### PR TITLE
8368520: TLS 1.3 KeyUpdate fails with SunPKCS11 provider

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
@@ -210,9 +210,7 @@ enum SSLTrafficKeyDerivation implements SSLKeyDerivationGenerator {
         }
 
         String getAlgorithm(CipherSuite cs, String algorithm) {
-            if (this == TlsKey)
-                return cs.bulkCipher.algorithm;
-            return algorithm;
+            return this == TlsKey ? cs.bulkCipher.algorithm : algorithm;
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
@@ -29,13 +29,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.ProviderException;
-import java.security.spec.AlgorithmParameterSpec;
 import javax.crypto.KDF;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.HKDFParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.SSLHandshakeException;
 import sun.security.internal.spec.TlsKeyMaterialParameterSpec;
 import sun.security.internal.spec.TlsKeyMaterialSpec;
@@ -191,22 +189,22 @@ enum SSLTrafficKeyDerivation implements SSLKeyDerivationGenerator {
 
     private enum KeySchedule {
         // Note that we use enum name as the key name.
-        TlsKey              ("key", false),
-        TlsIv               ("iv",  true),
-        TlsUpdateNplus1     ("traffic upd", false);
+        TlsKey              ("key"),
+        TlsIv               ("iv"),
+        TlsUpdateNplus1     ("traffic upd");
 
         private final byte[] label;
-        private final boolean isIv;
 
-        KeySchedule(String label, boolean isIv) {
+        KeySchedule(String label) {
             this.label = ("tls13 " + label).getBytes();
-            this.isIv = isIv;
         }
 
         int getKeyLength(CipherSuite cs) {
-            if (this == KeySchedule.TlsUpdateNplus1)
-                return cs.hashAlg.hashLength;
-            return isIv ? cs.bulkCipher.ivSize : cs.bulkCipher.keySize;
+            return switch (this) {
+                case TlsUpdateNplus1 -> cs.hashAlg.hashLength;
+                case TlsIv -> cs.bulkCipher.ivSize;
+                case TlsKey -> cs.bulkCipher.keySize;
+            };
         }
 
         String getAlgorithm(CipherSuite cs, String algorithm) {

--- a/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
@@ -210,7 +210,9 @@ enum SSLTrafficKeyDerivation implements SSLKeyDerivationGenerator {
         }
 
         String getAlgorithm(CipherSuite cs, String algorithm) {
-            return isIv ? algorithm : cs.bulkCipher.algorithm;
+            if (this == TlsKey)
+                return cs.bulkCipher.algorithm;
+            return algorithm;
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/tls/fips/FipsModeTLS.java
+++ b/test/jdk/sun/security/pkcs11/tls/fips/FipsModeTLS.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8029661 8325164 8368073 8368514
+ * @bug 8029661 8325164 8368073 8368514 8368520
  * @summary Test TLS 1.2 and TLS 1.3
  * @modules java.base/sun.security.internal.spec
  *          java.base/sun.security.util
@@ -88,6 +88,9 @@ public final class FipsModeTLS extends SecmodTest {
     private static PublicKey publicKey;
 
     public static void main(String[] args) throws Exception {
+        // reduce the limit to trigger a key update later
+        Security.setProperty("jdk.tls.keyLimits",
+                "AES/GCM/NoPadding KeyUpdate 10000");
         try {
             initialize();
         } catch (Exception e) {
@@ -305,10 +308,11 @@ public final class FipsModeTLS extends SecmodTest {
                 cTOs = ByteBuffer.allocateDirect(netBufferMax);
                 sTOc = ByteBuffer.allocateDirect(netBufferMax);
 
+                // big enough to trigger a key update
                 clientOut = ByteBuffer.wrap(
-                        "Hi Server, I'm Client".getBytes());
+                        "a".repeat(16000).getBytes());
                 serverOut = ByteBuffer.wrap(
-                        "Hello Client, I'm Server".getBytes());
+                        "b".repeat(16000).getBytes());
 
                 SSLEngineResult clientResult;
                 SSLEngineResult serverResult;


### PR DESCRIPTION
Change SunJSSE to use `TlsUpdateNplus1` instead of `AES` as the key algorithm when deriving the next application traffic secret.

SunPKCS11 provider checks the key length when creating an `AES` key, and since 384 bits is not a valid AES key length, the key creation fails.

`TlsUpdateNplus1` is [already recognized](https://github.com/openjdk/jdk/blob/3c9fd7688f4d73067db9b128c329ca7603a60578/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java#L287) as a standard TLS generic key by SunPKCS11.

Key update is now exercised by the FipsModeTLS test. The test passes with the changes, fails without them. Other tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368520](https://bugs.openjdk.org/browse/JDK-8368520): TLS 1.3 KeyUpdate fails with SunPKCS11 provider (**Bug** - P4)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27498/head:pull/27498` \
`$ git checkout pull/27498`

Update a local copy of the PR: \
`$ git checkout pull/27498` \
`$ git pull https://git.openjdk.org/jdk.git pull/27498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27498`

View PR using the GUI difftool: \
`$ git pr show -t 27498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27498.diff">https://git.openjdk.org/jdk/pull/27498.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27498#issuecomment-3335801253)
</details>
