### PR TITLE
8368715: Serial: Add GCTraceTime for marking from roots subphases during full gc marking

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -482,6 +482,8 @@ void SerialFullGC::phase1_mark(bool clear_all_softrefs) {
   ref_processor()->start_discovery(clear_all_softrefs);
 
   {
+    GCTraceTime(Debug, gc, phases) tm_m("Marking From Roots", gc_timer());
+
     // Start tracing from roots, there are 3 kinds of roots in full-gc.
     //
     // 1. CLD. This method internally takes care of whether class loading is


### PR DESCRIPTION
Add a scoped timer for the first subphase of marking, to be aligned with other counterparts.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368715](https://bugs.openjdk.org/browse/JDK-8368715): Serial: Add GCTraceTime for marking from roots subphases during full gc marking (**Enhancement** - P4)


### Reviewers
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27499/head:pull/27499` \
`$ git checkout pull/27499`

Update a local copy of the PR: \
`$ git checkout pull/27499` \
`$ git pull https://git.openjdk.org/jdk.git pull/27499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27499`

View PR using the GUI difftool: \
`$ git pr show -t 27499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27499.diff">https://git.openjdk.org/jdk/pull/27499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27499#issuecomment-3335795804)
</details>
