### PR TITLE
8368683: [process] Increase jtreg debug output maxOutputSize for TreeTest

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/TEST.properties
+++ b/test/jdk/java/lang/ProcessHandle/TEST.properties
@@ -1,0 +1,1 @@
+maxOutputSize=6000000


### PR DESCRIPTION
TreeTest failure is intermittent, getting the complete output may help with the diagnosis.

Add maxOutputSize for ProcessHandle TEST.properties for the directory of ProcessHandle tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368683](https://bugs.openjdk.org/browse/JDK-8368683): [process] Increase jtreg debug output maxOutputSize for TreeTest (**Sub-task** - P4)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27501/head:pull/27501` \
`$ git checkout pull/27501`

Update a local copy of the PR: \
`$ git checkout pull/27501` \
`$ git pull https://git.openjdk.org/jdk.git pull/27501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27501`

View PR using the GUI difftool: \
`$ git pr show -t 27501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27501.diff">https://git.openjdk.org/jdk/pull/27501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27501#issuecomment-3335857652)
</details>
