### PR TITLE
8355631: The events might be generated after VM_DEATH event

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -769,6 +769,10 @@ void JvmtiExport::post_vm_death() {
 
   JvmtiTagMap::flush_all_object_free_events();
 
+  // It is needed to disable event generation before setting DEAD phase.
+  // The VM_DEATH should be the last posted event.
+  JvmtiEventController::vm_death();
+
   JvmtiEnvIterator it;
   for (JvmtiEnv* env = it.first(); env != nullptr; env = it.next(env)) {
     if (env->is_enabled(JVMTI_EVENT_VM_DEATH)) {
@@ -784,8 +788,7 @@ void JvmtiExport::post_vm_death() {
     }
   }
 
-  JvmtiEnvBase::set_phase(JVMTI_PHASE_DEAD);
-  JvmtiEventController::vm_death();
+ JvmtiEnvBase::set_phase(JVMTI_PHASE_DEAD);
 }
 
 char**


### PR DESCRIPTION
The JVMTI spec says: https://docs.oracle.com/en/java/javase/24/docs/specs/jvmti.html#VMDeath
`The VM death event notifies the agent of the termination of the VM. No events will occur after the VMDeath event.`

However, current implementation changes state and only after this start disabling events.  

It is not a conformance issue, because there is no way to get thread state in the very beginning of event. 
The main practical issue is that currently certain events are generated when VM is dead if not disabled explicitly. So any function in event should check error against JVMTI_PHASE_DEAD. We can easily trigger it by running tests with enabled https://bugs.openjdk.org/browse/JDK-8352654

The proposed fix to disable all event generation and then post the last (VMDeath) event. After this event is completed  change VM phase to death. It's guaranteed that no any events are generated after VMDeath completion.

After this fix the VMDeath callback also can't generate any events. 
The alternative is to disable events posting after VMDeath completion and before changing VM state. However, seems it is still a gap between vm death event completion and disabling events. So user can see events after VMDeath completion.

It might be still possible also to wait while all currently executing  events are completed. It is not required be specification, might add unneeded complexity. So  I want to apply this fix first and then to check if we still any problems.
Currently, I haven't seen problems with this fix and  https://bugs.openjdk.org/browse/JDK-8352654. 

 