### PR TITLE
8368722: RISC-V: Several vector load/store tests fail on riscv without support for misaligned vector access

### DIFF
--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ByteVector av = ByteVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ByteVector av = ByteVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ByteVector av = ByteVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ByteVector av = ByteVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -618,7 +618,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -649,7 +649,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ByteVector av = ByteVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             DoubleVector av = DoubleVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             DoubleVector av = DoubleVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             DoubleVector av = DoubleVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             DoubleVector av = DoubleVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -618,7 +618,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -649,7 +649,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             DoubleVector av = DoubleVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             FloatVector av = FloatVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             FloatVector av = FloatVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             FloatVector av = FloatVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             FloatVector av = FloatVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -618,7 +618,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -649,7 +649,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             FloatVector av = FloatVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             IntVector av = IntVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             IntVector av = IntVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             IntVector av = IntVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             IntVector av = IntVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -618,7 +618,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -649,7 +649,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             IntVector av = IntVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             LongVector av = LongVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             LongVector av = LongVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             LongVector av = LongVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             LongVector av = LongVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -618,7 +618,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -649,7 +649,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             LongVector av = LongVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ShortVector av = ShortVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ShortVector av = ShortVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ShortVector av = ShortVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -611,7 +611,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -642,7 +642,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ShortVector av = ShortVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -618,7 +618,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -649,7 +649,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             ShortVector av = ShortVector.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -631,7 +631,7 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             fromMemorySegment(a, index, ByteOrder.nativeOrder(), vmask);
@@ -662,7 +662,7 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
             }
         }
 
-        int index = fi.apply((int) a.byteSize());
+        int index = fi.apply((int) a.byteSize()) & (~(SPECIES.elementSize() - 1));
         boolean shouldFail = isIndexOutOfBoundsForMask(mask, index, (int) a.byteSize(), SPECIES.elementSize() / 8);
         try {
             $abstractvectortype$ av = $abstractvectortype$.fromMemorySegment(SPECIES, a, 0, ByteOrder.nativeOrder());


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

In `*VectorLoadStoreTests.java`,  `loadMemorySegmentMaskIOOBE` and `storeMemorySegmentMaskIOOBE` may fail because `int index = fi.apply((int) a.byteSize())` can generate random indices that result in misaligned addresses, leading to SIGBUS on hardware that disallows misaligned vector accesses.

Some RISC-V hardware supports fast misaligned scalar accesses but not vector ones, which causes SIGBUS when executing these tests with misaligned vector memory operations.

So we should adjusted index to align with the element byte size in these tests.

### Test (fastdebug)
- [x] Run jdk_vector on k1
- [x] Run jdk_vector on x86_64 and arm64(kunpeng920)