### PR TITLE
8308027: GetThreadListStackTraces/OneGetThreadListStackTraces.java should be skipped when thread factory is used

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -25,7 +25,6 @@
 # Bugs
 
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-all
-serviceability/jvmti/GetThreadListStackTraces/OneGetThreadListStackTraces.java 8308027 generic-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all
 

--- a/test/hotspot/jtreg/serviceability/jvmti/GetThreadListStackTraces/OneGetThreadListStackTraces.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetThreadListStackTraces/OneGetThreadListStackTraces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +27,7 @@
  * @bug 8242428
  * @summary Verifies JVMTI GetThreadListStackTraces API with thread_count = 1
  * @requires vm.jvmti
+ * @requires test.thread.factory == null
  * @library /test/lib
  * @run main/othervm/native -agentlib:OneGetThreadListStackTraces OneGetThreadListStackTraces
  *


### PR DESCRIPTION
The test fails with virtual thread factory. 
There is no good way to adopt it for virtual thread factory. So let skip it's execution with it permanently.

The property support has been added to the jtregby
https://bugs.openjdk.org/browse/CODETOOLS-7903931

I use
`@requires test.thread.factory == null`
and not
`@requires test.thread.factory != "Virtual"`
because I don't think that it makes sense to run it with any potential test thread factory, like "VirtualStress"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308027](https://bugs.openjdk.org/browse/JDK-8308027): GetThreadListStackTraces/OneGetThreadListStackTraces.java should be skipped when thread factory is used (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27507/head:pull/27507` \
`$ git checkout pull/27507`

Update a local copy of the PR: \
`$ git checkout pull/27507` \
`$ git pull https://git.openjdk.org/jdk.git pull/27507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27507`

View PR using the GUI difftool: \
`$ git pr show -t 27507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27507.diff">https://git.openjdk.org/jdk/pull/27507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27507#issuecomment-3336558119)
</details>
