### PR TITLE
8362598: [macos] Add tests for custom info plist files

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/util/PListWriter.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/util/PListWriter.java
@@ -90,11 +90,13 @@ public final class PListWriter {
 
     public static void writePList(XMLStreamWriter xml, XmlConsumer content)
             throws XMLStreamException, IOException {
-        xml.writeDTD("plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\"");
+        xml.writeStartDocument();
+        xml.writeDTD("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\">");
         xml.writeStartElement("plist");
         xml.writeAttribute("version", "1.0");
         content.accept(xml);
         xml.writeEndElement();
+        xml.writeEndDocument();
     }
 
     public static void writeKey(XMLStreamWriter xml, String key)

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -128,6 +128,10 @@ public final class MacHelper {
         return readPList(appImage.resolve("Contents/Info.plist"));
     }
 
+    public static PListReader readPListFromEmbeddedRuntime(Path appImage) {
+        return readPList(appImage.resolve("Contents/runtime/Contents/Info.plist"));
+    }
+
     public static PListReader readPList(Path path) {
         TKit.assertReadableFileExists(path);
         return ThrowingSupplier.toSupplier(() -> readPList(Files.readAllLines(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -175,6 +175,29 @@ public final class MacHelper {
         return (cmd.hasArgument("--mac-signing-key-user-name") || cmd.hasArgument("--mac-app-image-sign-identity"));
     }
 
+    public static Path createInputRuntimeImage() throws IOException {
+
+        final Path runtimeImageDir;
+
+        if (JPackageCommand.DEFAULT_RUNTIME_IMAGE != null) {
+            runtimeImageDir = JPackageCommand.DEFAULT_RUNTIME_IMAGE;
+        } else {
+            runtimeImageDir = TKit.createTempDirectory("runtime-image").resolve("data");
+
+            new Executor().setToolProvider(JavaTool.JLINK)
+                    .dumpOutput()
+                    .addArguments(
+                            "--output", runtimeImageDir.toString(),
+                            "--add-modules", "java.desktop",
+                            "--strip-debug",
+                            "--no-header-files",
+                            "--no-man-pages")
+                    .execute();
+        }
+
+        return runtimeImageDir;
+    }
+
     static PackageHandlers createDmgPackageHandlers() {
         return new PackageHandlers(MacHelper::installDmg, MacHelper::uninstallDmg, MacHelper::unpackDmg);
     }

--- a/test/jdk/tools/jpackage/macosx/CustomInfoPListTest.java
+++ b/test/jdk/tools/jpackage/macosx/CustomInfoPListTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /**
+ * Test --resource-dir with custom "Info.plist" for the top-level bundle
+ * and "Runtime-Info.plist" for the embedded runtime bundle
+ */
+
+/*
+ * @test
+ * @summary jpackage with --type image --resource-dir "Info.plist" and "Runtime-Info.plist"
+ * @library /test/jdk/tools/jpackage/helpers
+ * @key jpackagePlatformPackage
+ * @build jdk.jpackage.test.*
+ * @build CustomInfoPListTest
+ * @requires (os.family == "mac")
+ * @run main/othervm/timeout=1440 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=CustomInfoPListTest
+ */
+
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.MacHelper;
+import jdk.jpackage.test.JPackageCommand;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.stream.XMLOutputFactory;
+
+import jdk.jpackage.test.Annotations.Test;
+
+import static jdk.jpackage.internal.util.PListWriter.writePList;
+import static jdk.jpackage.internal.util.PListWriter.writeDict;
+import static jdk.jpackage.internal.util.PListWriter.writeString;
+import static jdk.jpackage.internal.util.XmlUtils.toXmlConsumer;
+import static jdk.jpackage.internal.util.function.ThrowingSupplier.toSupplier;
+
+public class CustomInfoPListTest {
+
+    private static final String BUNDLE_NAME_APP = "CustomAppName";
+    private static final String BUNDLE_NAME_RUNTIME = "CustomRuntimeName";
+
+    // We do not need full Info.plist for testing
+    private static String getInfoPListXML(String bundleName) {
+        return toSupplier(() -> {
+            var buf = new StringWriter();
+            var xml = XMLOutputFactory.newInstance().createXMLStreamWriter(buf);
+            writePList(xml, toXmlConsumer(() -> {
+                writeDict(xml, toXmlConsumer(() -> {
+                    writeString(xml, "CFBundleName", bundleName);
+                    writeString(xml, "CFBundleIdentifier", "CustomInfoPListTest");
+                    writeString(xml, "CFBundleVersion", "1.0");
+                }));
+            }));
+            xml.flush();
+            xml.close();
+            return buf.toString();
+        }).get();
+    }
+
+    private static String getResourceDirWithCustomInfoPList() {
+        final Path resources = TKit.createTempDirectory("resources");
+        try {
+            Files.writeString(resources.resolve("Info.plist"),
+                    getInfoPListXML(BUNDLE_NAME_APP));
+            Files.writeString(resources.resolve("Runtime-Info.plist"),
+                    getInfoPListXML(BUNDLE_NAME_RUNTIME));
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+
+        return resources.toString();
+    }
+
+    @Test
+    public void test() {
+        JPackageCommand cmd = JPackageCommand.helloAppImage()
+                .addArguments("--resource-dir",
+                        getResourceDirWithCustomInfoPList());
+
+        cmd.executeAndAssertHelloAppImageCreated();
+
+        var appPList = MacHelper.readPListFromAppImage(cmd.outputBundle());
+        TKit.assertEquals(BUNDLE_NAME_APP, appPList.queryValue("CFBundleName"), String.format(
+                "Check value of %s plist key", "CFBundleName"));
+
+        var runtimePList = MacHelper.readPListFromEmbeddedRuntime(cmd.outputBundle());
+        TKit.assertEquals(BUNDLE_NAME_RUNTIME, runtimePList.queryValue("CFBundleName"), String.format(
+                "Check value of %s plist key", "CFBundleName"));
+    }
+}

--- a/test/jdk/tools/jpackage/macosx/SigningRuntimeImagePackageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningRuntimeImagePackageTest.java
@@ -94,32 +94,9 @@ public class SigningRuntimeImagePackageTest {
         return cmd;
     }
 
-    private static Path createInputRuntimeImage() throws IOException {
-
-        final Path runtimeImageDir;
-
-        if (JPackageCommand.DEFAULT_RUNTIME_IMAGE != null) {
-            runtimeImageDir = JPackageCommand.DEFAULT_RUNTIME_IMAGE;
-        } else {
-            runtimeImageDir = TKit.createTempDirectory("runtime-image").resolve("data");
-
-            new Executor().setToolProvider(JavaTool.JLINK)
-                    .dumpOutput()
-                    .addArguments(
-                            "--output", runtimeImageDir.toString(),
-                            "--add-modules", "java.desktop",
-                            "--strip-debug",
-                            "--no-header-files",
-                            "--no-man-pages")
-                    .execute();
-        }
-
-        return runtimeImageDir;
-    }
-
     private static Path createInputRuntimeBundle(int certIndex) throws IOException {
 
-        final var runtimeImage = createInputRuntimeImage();
+        final var runtimeImage = MacHelper.createInputRuntimeImage();
 
         final var runtimeBundleWorkDir = TKit.createTempDirectory("runtime-bundle");
 


### PR DESCRIPTION
- Added test for custom info plist to cover app image including embedded runtime and runtime installer.
- Fixed bug in `writePList`. It was missing `writeStartDocument()/writeEndDocument()` and `DOCTYPE` should be full xml string.