### PR TITLE
RISC-V: Check if unaligned_access is enabled before use

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -158,7 +158,7 @@ void VM_Version::common_initialize() {
     }
   }
 
-  if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
+  if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses) && unaligned_access.enabled()) {
     FLAG_SET_DEFAULT(AvoidUnalignedAccesses,
       unaligned_access.value() != MISALIGNED_FAST);
   }
@@ -173,7 +173,7 @@ void VM_Version::common_initialize() {
 
   // See JDK-8026049
   // This machine has fast unaligned memory accesses
-  if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
+  if (FLAG_IS_DEFAULT(UseUnalignedAccesses) && unaligned_access.enabled()) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses,
       unaligned_access.value() == MISALIGNED_FAST);
   }


### PR DESCRIPTION
we can notice that the `unaligned_access.value()` can only be used when the `unaligned_access.enabled()` is true, so we add the check here before use