### PR TITLE
8368675: IGV: nodes are wrongly marked as changed in the difference view

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputNode.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,9 @@ import java.util.Objects;
  */
 public class InputNode extends Properties.Entity {
 
+    public static final String LABEL_PROPERTY = "label";
+    public static final String COLOR_PROPERTY = "color";
+
     private int id;
 
     public InputNode(InputNode n) {
@@ -49,6 +52,17 @@ public class InputNode extends Properties.Entity {
 
     public int getId() {
         return id;
+    }
+
+    // Return the node properties that are present in the input graph, excluding
+    // properties computed by IGV itself. This is useful e.g. to produce the
+    // difference view, where nodes should be compared based only on their
+    // intrinsic characteristics.
+    public Properties getPrimaryProperties() {
+        Properties primaryProperties = new Properties(getProperties());
+        primaryProperties.setProperty(LABEL_PROPERTY, null);
+        primaryProperties.setProperty(COLOR_PROPERTY, null);
+        return primaryProperties;
     }
 
     @Override
@@ -72,14 +86,14 @@ public class InputNode extends Properties.Entity {
     public void setCustomColor(Color color) {
         if (color != null) {
             String hexColor = String.format("#%08X", color.getRGB());
-            getProperties().setProperty("color", hexColor);
+            getProperties().setProperty(COLOR_PROPERTY, hexColor);
         } else {
-            getProperties().setProperty("color", null);
+            getProperties().setProperty(COLOR_PROPERTY, null);
         }
     }
 
     public Color getCustomColor() {
-        String hexColor = getProperties().get("color");
+        String hexColor = getProperties().get(COLOR_PROPERTY);
         if (hexColor != null) {
             try {
                 String hex = hexColor.startsWith("#") ? hexColor.substring(1) : hexColor;

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Parser.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Parser.java
@@ -81,7 +81,7 @@ public class Parser implements GraphParser {
     public static final String FROM_INDEX_PROPERTY = "fromIndex";
     public static final String TO_INDEX_PROPERTY = "toIndex";
     public static final String TO_INDEX_ALT_PROPERTY = "index";
-    public static final String LABEL_PROPERTY = "label";
+    public static final String EDGE_LABEL_PROPERTY = "label";
     public static final String METHOD_ELEMENT = "method";
     public static final String INLINE_ELEMENT = "inline";
     public static final String BYTECODES_ELEMENT = "bytecodes";
@@ -655,7 +655,7 @@ public class Parser implements GraphParser {
                     toIndex = Integer.parseInt(toIndexString);
                 }
 
-                label = readAttribute(LABEL_PROPERTY);
+                label = readAttribute(EDGE_LABEL_PROPERTY);
                 type = readAttribute(TYPE_PROPERTY);
 
                 from = lookupID(readRequiredAttribute(FROM_PROPERTY));

--- a/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
+++ b/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
@@ -356,7 +356,7 @@ public class Difference {
     private static void markAsChanged(InputNode n, InputNode firstNode, InputNode otherNode) {
 
         boolean difference = false;
-        for (Property p : otherNode.getProperties()) {
+        for (Property p : otherNode.getPrimaryProperties()) {
             String s = firstNode.getProperties().get(p.getName());
             if (!p.getValue().equals(s)) {
                 difference = true;
@@ -364,7 +364,7 @@ public class Difference {
             }
         }
 
-        for (Property p : firstNode.getProperties()) {
+        for (Property p : firstNode.getPrimaryProperties()) {
             String s = otherNode.getProperties().get(p.getName());
             if (s == null && p.getValue().length() > 0) {
                 difference = true;

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Figure.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Figure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,7 +371,7 @@ public class Figure extends Properties.Entity implements Vertex {
         // search is done on the node label (without line breaks). See also
         // class NodeQuickSearch in the View module.
         String label = inputNode.getProperties().resolveString(diagram.getNodeText());
-        inputNode.getProperties().setProperty("label", label.replaceAll("\\R", " "));
+        inputNode.getProperties().setProperty(InputNode.LABEL_PROPERTY, label.replaceAll("\\R", " "));
 
         // Update figure dimensions, as these are affected by the node text.
         updateWidth();

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -48,8 +48,6 @@ import org.openide.NotifyDescriptor.Message;
  */
 public class NodeQuickSearch implements SearchProvider {
 
-    private static final String DEFAULT_PROPERTY = "label";
-
     /**
      * Method is called by infrastructure when search operation was requested.
      * Implementors should evaluate given request and fill response object with
@@ -72,7 +70,7 @@ public class NodeQuickSearch implements SearchProvider {
         String value;
 
         if (parts.length == 1) {
-            name = DEFAULT_PROPERTY;
+            name = InputNode.LABEL_PROPERTY;
             rawValue = parts[0];
             value = ".*" + Pattern.quote(rawValue) + ".*";
         } else {


### PR DESCRIPTION
This changeset refines IGV's node difference analysis to ignore changes in node properties that are derived by IGV, as opposed to generated by HotSpot. Derived properties include the label and color of each node. Ignoring changes in these properties prevents IGV from wrongly marking equal nodes as "changed" (colored in yellow) when showing the difference between two graphs:

<img width="2323" height="651" alt="before-after" src="https://github.com/user-attachments/assets/ea51c86d-4719-45c0-b615-e6e4b8aec023" />

**Testing:** tier1 and manual testing on a few graphs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368675](https://bugs.openjdk.org/browse/JDK-8368675): IGV: nodes are wrongly marked as changed in the difference view (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Tobias Holenstein](https://openjdk.org/census#tholenstein) (@tobiasholenstein - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27515/head:pull/27515` \
`$ git checkout pull/27515`

Update a local copy of the PR: \
`$ git checkout pull/27515` \
`$ git pull https://git.openjdk.org/jdk.git pull/27515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27515`

View PR using the GUI difftool: \
`$ git pr show -t 27515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27515.diff">https://git.openjdk.org/jdk/pull/27515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27515#issuecomment-3337493237)
</details>
