### PR TITLE
8368752: Serial: Remove unused arg of DefNewGeneration::gc_epilogue

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -807,7 +807,7 @@ void DefNewGeneration::reset_scratch() {
   }
 }
 
-void DefNewGeneration::gc_epilogue(bool full) {
+void DefNewGeneration::gc_epilogue() {
   assert(!GCLocker::is_active(), "We should not be executing here");
   // update the generation and space performance counters
   update_counters();

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -187,7 +187,7 @@ class DefNewGeneration: public Generation {
   HeapWord* allocate(size_t word_size);
   HeapWord* par_allocate(size_t word_size);
 
-  void gc_epilogue(bool full);
+  void gc_epilogue();
 
   // For Old collection (part of running Full GC), the DefNewGeneration can
   // contribute the free part of "to-space" as the scratch space.

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -779,7 +779,7 @@ void SerialHeap::gc_epilogue(bool full) {
 
   resize_all_tlabs();
 
-  _young_gen->gc_epilogue(full);
+  _young_gen->gc_epilogue();
   _old_gen->gc_epilogue();
 
   if (_is_heap_almost_full) {


### PR DESCRIPTION
Trivial removing dead code.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368752](https://bugs.openjdk.org/browse/JDK-8368752): Serial: Remove unused arg of DefNewGeneration::gc_epilogue (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27516/head:pull/27516` \
`$ git checkout pull/27516`

Update a local copy of the PR: \
`$ git checkout pull/27516` \
`$ git pull https://git.openjdk.org/jdk.git pull/27516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27516`

View PR using the GUI difftool: \
`$ git pr show -t 27516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27516.diff">https://git.openjdk.org/jdk/pull/27516.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27516#issuecomment-3337482271)
</details>
