### PR TITLE
8368754: runtime/cds/appcds/SignedJar.java log regex is too strict

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
@@ -50,8 +50,8 @@ public class SignedJar {
 
         String skipMsg = "Skipping Hello: Signed JAR";
         String lambdaInArchive = "klasses.*=.*app.*Hello[$][$]Lambda.*hidden";
-        String loadFromJar = ".class,load. Hello source: file:.*signed_hello.jar";
-        String lambdaLoadFromHello = ".class.load. Hello[$][$]Lambda.*/0x.*source.*Hello";
+        String loadFromJar = ".class,load\s*. Hello source: file:.*signed_hello.jar";
+        String lambdaLoadFromHello = ".class.load\s*. Hello[$][$]Lambda.*/0x.*source.*Hello";
 
         for (String mainArg : mainArgs) {
             output = TestCommon.dump(signedJar, TestCommon.list(mainClass),


### PR DESCRIPTION
Any logging which gets enabled (via `-verbose:class` which the test uses, or externally from JTREG) and logs before the line this test is checking for with a tag set which is longer than `class,load` makes the test fail.
Example:
Test expects: 
 * `"[class,load] Hello source: [...]"`
 
What it gets when logging with `class,unload` prior to this specific log line: 
 * `"[class,load ] Hello source: [...]"`

I suggest we simply allow for any whitespace after the log tags and before the `.`. Unclear why we use `.` and not `]`. But think it works just as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368754](https://bugs.openjdk.org/browse/JDK-8368754): runtime/cds/appcds/SignedJar.java log regex is too strict (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27517/head:pull/27517` \
`$ git checkout pull/27517`

Update a local copy of the PR: \
`$ git checkout pull/27517` \
`$ git pull https://git.openjdk.org/jdk.git pull/27517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27517`

View PR using the GUI difftool: \
`$ git pr show -t 27517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27517.diff">https://git.openjdk.org/jdk/pull/27517.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27517#issuecomment-3337547910)
</details>
