### PR TITLE
8368756: Skip sun/security/provider/acvp/Launcher.java when ACVP-Server artifact isn't found

### DIFF
--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -26,6 +26,7 @@ import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.json.JSONValue;
 
 import java.io.InputStream;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.security.Provider;
 import java.security.Security;
@@ -113,8 +114,12 @@ public class Launcher {
     }
 
     public static void main(String[] args) throws Exception {
-
-        Path archivePath = ArtifactResolver.fetchOne(ACVP_SERVER_TESTS.class);
+        Path archivePath;
+        try {
+            archivePath = ArtifactResolver.fetchOne(ACVP_SERVER_TESTS.class);
+        } catch (IOException exception) {
+            throw new jtreg.SkippedException("ACVP-Server artifact not found", exception);
+        }
         System.out.println("Data path: " + archivePath);
 
         if (PROVIDER != null) {

--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -25,8 +25,8 @@ import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.json.JSONValue;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.Provider;
 import java.security.Security;


### PR DESCRIPTION
I propose to skip the test when the ACVP-Server artifact isn't found, instead of throwing the following exception:
```
java.io.IOException: Cannot find the artifact ACVP-Server
	at jdk.test.lib.artifacts.ArtifactResolver.fetchOne(ArtifactResolver.java:100)
	at Launcher.main(Launcher.java:117)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:335)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: jdk.test.lib.artifacts.ArtifactResolverException: Couldn't automatically resolve dependency for ACVP-Server
Please specify the location using jdk.test.lib.artifacts.ACVP-Server
	at jdk.test.lib.artifacts.DefaultArtifactManager.resolve(DefaultArtifactManager.java:39)
	at jdk.test.lib.artifacts.DefaultArtifactManager.resolve(DefaultArtifactManager.java:32)
	at jdk.test.lib.artifacts.ArtifactResolver.resolve(ArtifactResolver.java:61)
	at jdk.test.lib.artifacts.ArtifactResolver.fetchOne(ArtifactResolver.java:96)
	... 5 more
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368756](https://bugs.openjdk.org/browse/JDK-8368756): Skip sun/security/provider/acvp/Launcher.java when ACVP-Server artifact isn't found (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27518/head:pull/27518` \
`$ git checkout pull/27518`

Update a local copy of the PR: \
`$ git checkout pull/27518` \
`$ git pull https://git.openjdk.org/jdk.git pull/27518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27518`

View PR using the GUI difftool: \
`$ git pr show -t 27518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27518.diff">https://git.openjdk.org/jdk/pull/27518.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27518#issuecomment-3337760608)
</details>
