### PR TITLE
8368753: IGV: improve CFG view of difference graphs

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlock.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlock.java
@@ -135,7 +135,7 @@ public class InputBlock {
         successors.add(b);
     }
 
-    void setArtificial() {
+    public void setArtificial() {
         this.artificial = true;
     }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/Scheduler.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/services/Scheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,7 @@
  */
 package com.sun.hotspot.igv.data.services;
 
-import com.sun.hotspot.igv.data.InputBlock;
 import com.sun.hotspot.igv.data.InputGraph;
-import java.util.Collection;
 
 /**
  *
@@ -34,5 +32,9 @@ import java.util.Collection;
  */
 public interface Scheduler {
 
-    public Collection<InputBlock> schedule(InputGraph graph);
+    // Compute a set of scheduled blocks for the given graph, creating new
+    // blocks if these are not found in the graph.
+    public void schedule(InputGraph graph);
+    // Schedule locally the set of blocks in the given graph.
+    public void scheduleLocally(InputGraph graph);
 }

--- a/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
+++ b/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
@@ -114,12 +114,18 @@ public class Difference {
         Map<InputBlock, InputBlock> blocksMap = new HashMap<>();
         for (InputBlock blk : a.getBlocks()) {
             InputBlock diffblk = graph.addBlock(blk.getName());
+            if (blk.isArtificial()) {
+                diffblk.setArtificial();
+            }
             blocksMap.put(blk, diffblk);
         }
         for (InputBlock blk : b.getBlocks()) {
             InputBlock diffblk = graph.getBlock(blk.getName());
             if (diffblk == null) {
                 diffblk = graph.addBlock(blk.getName());
+            }
+            if (blk.isArtificial()) {
+                diffblk.setArtificial();
             }
             blocksMap.put(blk, diffblk);
         }
@@ -248,6 +254,9 @@ public class Difference {
                 }
             }
         }
+
+        Scheduler s = Lookup.getDefault().lookup(Scheduler.class);
+        s.scheduleLocally(graph);
 
         return graph;
     }

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -296,10 +296,25 @@ public class ServerCompilerScheduler implements Scheduler {
         return n.getProperties().get("block");
     }
 
+    private boolean initialize(InputGraph graph) {
+        nodes = new ArrayList<>();
+        inputNodeToNode = new HashMap<>(graph.getNodes().size());
+        this.graph = graph;
+        if (!hasCategoryInformation()) {
+            ErrorManager.getDefault().log(ErrorManager.WARNING,
+                "Cannot find node category information in the input graph. " +
+                "The control-flow graph will not be approximated.");
+            return false;
+        }
+        buildUpGraph();
+        markCFGNodes();
+        return true;
+    }
+
     @Override
-    public Collection<InputBlock> schedule(InputGraph graph) {
+    public void schedule(InputGraph graph) {
         if (graph.getNodes().isEmpty()) {
-            return Collections.emptyList();
+            return;
         }
 
         if (graph.getBlocks().size() > 0) {
@@ -311,20 +326,11 @@ public class ServerCompilerScheduler implements Scheduler {
                     assert graph.getBlock(n) != null;
                 }
             }
-            return graph.getBlocks();
+            return;
         } else {
-            nodes = new ArrayList<>();
-            inputNodeToNode = new HashMap<>(graph.getNodes().size());
-
-            this.graph = graph;
-            if (!hasCategoryInformation()) {
-                ErrorManager.getDefault().log(ErrorManager.WARNING,
-                    "Cannot find node category information in the input graph. " +
-                    "The control-flow graph will not be approximated.");
-                return null;
+            if (!initialize(graph)) {
+                return;
             }
-            buildUpGraph();
-            markCFGNodes();
             buildBlocks();
             schedulePinned();
             buildDominators();
@@ -333,8 +339,24 @@ public class ServerCompilerScheduler implements Scheduler {
             check();
             reportWarnings();
 
-            return blocks;
+            return;
         }
+    }
+
+    @Override
+    public void scheduleLocally(InputGraph graph) {
+        if (!initialize(graph)) {
+            return;
+        }
+        // Import global schedule from the given graph.
+        blocks = new Vector<>();
+        for (InputBlock block : graph.getBlocks()) {
+            blocks.add(block);
+            for (InputNode in : block.getNodes()) {
+                inputNodeToNode.get(in).block = block;
+            }
+        }
+        scheduleLocal();
     }
 
     private void scheduleLocal() {


### PR DESCRIPTION
This changeset improves the control-flow graph view of difference graphs by:

1. ensuring that nodes are scheduled locally within each block, and
2. hiding internal, artificial blocks containing nodes that remain in the graph even if they are dead, such as the top constant node.

The following screenshot illustrates the effect of scheduling nodes locally:

<img width="3853" height="1033" alt="JDK-8368753" src="https://github.com/user-attachments/assets/bdc0f6de-3d28-4615-9e0d-221de2ad4770" />

For example, before this changeset (left) the `Return` node in B9 is scheduled at the beginning of the block. After the changeset (right), this node is scheduled last, as expected.

**Testing:** tier1 and manual testing on a few graphs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368753](https://bugs.openjdk.org/browse/JDK-8368753): IGV: improve CFG view of difference graphs (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer) Review applies to [a35f357b](https://git.openjdk.org/jdk/pull/27520/files/a35f357b927900038f878217b345712f9bfe5c74)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer) Review applies to [a35f357b](https://git.openjdk.org/jdk/pull/27520/files/a35f357b927900038f878217b345712f9bfe5c74)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27520/head:pull/27520` \
`$ git checkout pull/27520`

Update a local copy of the PR: \
`$ git checkout pull/27520` \
`$ git pull https://git.openjdk.org/jdk.git pull/27520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27520`

View PR using the GUI difftool: \
`$ git pr show -t 27520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27520.diff">https://git.openjdk.org/jdk/pull/27520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27520#issuecomment-3337899099)
</details>
