### PR TITLE
8368775: Remove outdated comment in OutlineTextRenderer

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/pipe/OutlineTextRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/OutlineTextRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,8 +73,8 @@ public class OutlineTextRenderer implements TextPipe {
 
     public void drawString(SunGraphics2D g2d, String str, double x, double y) {
 
-        if ("".equals(str)) {
-            return; // TextLayout constructor throws IAE on "".
+        if (str.length() == 0) {
+            return;
         }
         TextLayout tl = new TextLayout(str, g2d.getFont(),
                                        g2d.getFontRenderContext());


### PR DESCRIPTION
Until [JDK-4138921](https://bugs.openjdk.org/browse/JDK-4138921), `TextLayout` did not accept empty strings in the constructor. This limitation has been removed. However, there is a guard condition in `OutlineTextRenderer` which checks for an empty string before trying to use `TextLayout` which explicitly calls out this limitation in a code comment. We should remove the out-of-date comment but leave the check in as an optimization (see discussion in PR #26947).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368775](https://bugs.openjdk.org/browse/JDK-8368775): Remove outdated comment in OutlineTextRenderer (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27523/head:pull/27523` \
`$ git checkout pull/27523`

Update a local copy of the PR: \
`$ git checkout pull/27523` \
`$ git pull https://git.openjdk.org/jdk.git pull/27523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27523`

View PR using the GUI difftool: \
`$ git pr show -t 27523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27523.diff">https://git.openjdk.org/jdk/pull/27523.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27523#issuecomment-3338241491)
</details>
