### PR TITLE
Proof of concept: Leverage profiled compiled size to avoid aggressive inlining and code growth

### DIFF
--- a/extract_size_to_directives.py
+++ b/extract_size_to_directives.py
@@ -1,0 +1,74 @@
+#  Copyright 2025 Arm Limited and/or its affiliates.
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+#  This code is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 2 only, as
+#  published by the Free Software Foundation.
+
+#  This code is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  version 2 for more details (a copy is included in the LICENSE file that
+#  accompanied this code).
+
+#  You should have received a copy of the GNU General Public License version
+#  2 along with this work; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+#  or visit www.oracle.com if you need additional information or have any
+#  questions.
+
+import re
+import json
+import sys
+
+INPUT_FILE = sys.argv[1]
+OUTPUT_FILE = sys.argv[2]
+
+# Pattern to match log lines with inline instruction size data
+pattern = re.compile(
+    r"Collecting method size\s*\{class_name} &apos;([^\{]+)&apos;\s*"
+    r"\{method_name} &apos;([^\{]+)&apos;\s*"
+    r"\{signature} &apos;([^\{]+)&apos;\s*"
+    r"\{Inline instruction size: (\d+)}",
+    re.MULTILINE | re.DOTALL
+)
+
+def extract_and_generate_directives(input_file, output_file):
+    directives = {
+        "match": "*::*",
+        "inline": []
+    }
+    seen = {}
+    with open(input_file, 'r') as infile:
+        content = infile.read()
+        matches = pattern.findall(content)
+        allcount = 0
+        for match in matches:
+            class_name, method_name, signature, inline_size = match
+            allcount = allcount + 1
+            if "LambdaForm" in class_name:
+                continue  # Exclude LambdaForm methods
+            if "print" == method_name:
+                continue  # Exclude method_name pointing to an option type or option name
+            key = (class_name, method_name, signature)
+            size = int(inline_size)
+            if key not in seen or size < seen[key]:
+                # Conservatively keep the smallest size
+                seen[key] = size
+        for (class_name, method_name, signature), size in seen.items():
+            dotted_class_name = class_name.replace("/", ".")
+            record = f"{dotted_class_name}::{method_name}{signature}:{size}"
+            directives["inline"].append(record)
+
+    with open(output_file, 'w') as outfile:
+        json.dump(directives, outfile, indent=2)
+
+    print(f"Directive file written to: {output_file}")
+    count = len(directives["inline"])
+    print(f"Generating {count} entries from {allcount} records")
+
+if __name__ == "__main__":
+    extract_and_generate_directives(INPUT_FILE, OUTPUT_FILE)
+

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1175,9 +1176,8 @@ int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
       nmethod* code = get_Method()->code();
-      if (code != nullptr && (code->comp_level() == CompLevel_full_optimization)) {
-        int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
-        _inline_instructions_size = isize > 0 ? isize : 0;
+      if (code != nullptr) {
+        _inline_instructions_size = code->inline_instructions_size();
       } else {
         _inline_instructions_size = 0;
       }

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -655,6 +656,14 @@ public:
   int dependencies_size  () const { return int(          dependencies_end () -           dependencies_begin ()); }
   int handler_table_size () const { return int(          handler_table_end() -           handler_table_begin()); }
   int nul_chk_table_size () const { return int(          nul_chk_table_end() -           nul_chk_table_begin()); }
+  int inline_instructions_size() const {
+    int isize = 0;
+    if (comp_level() == CompLevel_full_optimization) {
+      isize = insts_end() - verified_entry_point() - skipped_instructions_size();
+    }
+    return isize > 0 ? isize : 0;
+  }
+
 #if INCLUDE_JVMCI
   int speculations_size  () const { return int(          speculations_end () -           speculations_begin ()); }
   int jvmci_data_size    () const { return int(          jvmci_data_end   () -           jvmci_data_begin   ()); }

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -557,6 +558,19 @@ bool DirectiveSet::should_not_inline(ciMethod* inlinee) {
   }
   if (!CompilerDirectivesIgnoreCompileCommandsOption) {
     return CompilerOracle::should_not_inline(mh);
+  }
+  return false;
+}
+
+bool DirectiveSet::is_estimated_size_bigger_than(ciMethod* inlinee, const int threshold) {
+  inlinee->check_is_loaded();
+  VM_ENTRY_MARK;
+  methodHandle mh(THREAD, inlinee->get_Method());
+
+  if (_inlinematchers != nullptr) {
+    if (_inlinematchers->match_if_bigger_than(mh, threshold)) {
+      return true;
+    }
   }
   return false;
 }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,6 +143,7 @@ public:
   void append_inline(InlineMatcher* m);
   bool should_inline(ciMethod* inlinee);
   bool should_not_inline(ciMethod* inlinee);
+  bool is_estimated_size_bigger_than(ciMethod* inlinee, const int threshold);
   void print_inline(outputStream* st);
   DirectiveSet* compilecommand_compatibility_init(const methodHandle& method);
   bool is_exclusive_copy() { return _directive == nullptr; }

--- a/src/hotspot/share/compiler/methodMatcher.cpp
+++ b/src/hotspot/share/compiler/methodMatcher.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,7 +422,7 @@ void InlineMatcher::print(outputStream* st) {
   print_base(st);
 }
 
-InlineMatcher* InlineMatcher::parse_method_pattern(char* line, const char*& error_msg) {
+InlineMatcher* InlineMatcher::parse_method_pattern(char*& line, const char*& error_msg) {
   assert(error_msg == nullptr, "Dont call here with error_msg already set");
   InlineMatcher* im = new InlineMatcher();
   MethodMatcher::parse_method_pattern(line, error_msg, im);
@@ -441,21 +442,44 @@ bool InlineMatcher::match(const methodHandle& method, int inline_action) {
   return false;
 }
 
+bool InlineMatcher::match_if_bigger_than(const methodHandle& method, const int threshold) {
+  for (InlineMatcher* current = this; current != nullptr; current = current->next()) {
+    if (current->matches(method)) {
+      return (current->_inline_instructions_size > threshold);
+    }
+  }
+  return false;
+}
+
 InlineMatcher* InlineMatcher::parse_inline_pattern(char* str, const char*& error_msg) {
+  // Reuse the existing `inline` directive attribute for inlining control:
+  //
+  // - Prefix with '+' to force inlining of any matching Java method:
+  //     e.g., inline: ["+java/lang*.*"]
+  //
+  // - Prefix with '-' to prevent inlining of any matching Java method:
+  //     e.g., inline: ["-sun*.*"]
+  //
+  // - Suffix with ':<size>' to specify cached compiled size for a matching method:
+  //     e.g., inline: ["java.lang.StringCoding::countPositives([BII)I:408"]
+  //
+  // Note: If multiple inline rules match the same method, only the first match is effective.
+
   // check first token is +/-
   InlineType _inline_action;
    switch (str[0]) {
    case '-':
      _inline_action = InlineMatcher::dont_inline;
+     str++;
      break;
    case '+':
      _inline_action = InlineMatcher::force_inline;
+     str++;
      break;
    default:
-     error_msg = "Missing leading inline type (+/-)";
-     return nullptr;
+    _inline_action = InlineMatcher::unknown_inline;
+     break;
    }
-   str++;
 
    assert(error_msg == nullptr, "error_msg must not be set yet");
    InlineMatcher* im = InlineMatcher::parse_method_pattern(str, error_msg);
@@ -464,6 +488,26 @@ InlineMatcher* InlineMatcher::parse_inline_pattern(char* str, const char*& error
      return nullptr;
    }
    im->set_action(_inline_action);
+
+  // Parse method size
+  bool set_size = false;
+  if (str[0] != '\0') {
+    // Skip any leading spaces
+    int whitespace_read = 0;
+    sscanf(str, "%*[ \t]%n", &whitespace_read);
+    str += whitespace_read;
+    int size = 0;
+    if (str[0] >= '0' && str[0] <= '9') {
+      sscanf(str, "%d", &size);
+      im->set_size(size);
+      set_size = true;
+    }
+  }
+  // TODO: More logic to detect and handle incorrectly formatted input to this function
+  if (_inline_action == InlineMatcher::unknown_inline && !set_size) {
+    error_msg = "Missing leading inline type (+/-) or missing method size";
+    return nullptr;
+  }
    return im;
 }
 

--- a/src/hotspot/share/compiler/methodMatcher.hpp
+++ b/src/hotspot/share/compiler/methodMatcher.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,20 +106,26 @@ public:
 
 private:
   InlineType _inline_action;
+  int _inline_instructions_size;
   InlineMatcher * _next;
 
   InlineMatcher() : MethodMatcher(),
-    _inline_action(unknown_inline), _next(nullptr) {
+    _inline_action(unknown_inline), _inline_instructions_size(0), _next(nullptr) {
   }
 
 public:
-  static InlineMatcher* parse_method_pattern(char* line, const char*& error_msg);
+  static InlineMatcher* parse_method_pattern(char*& line, const char*& error_msg);
   bool match(const methodHandle& method, int inline_action);
+  bool match_if_bigger_than(const methodHandle& method, const int threshold);
   void print(outputStream* st);
   void set_next(InlineMatcher* next) { _next = next; }
   InlineMatcher* next() { return _next; }
   void set_action(InlineType inline_action) { _inline_action = inline_action; }
+  void set_size(const int size) { _inline_instructions_size = size; }
   int inline_action() { return _inline_action; }
+  // The attribute stores the estimated inlined size of a method, obtained
+  // from a compilerDirective JSON file generated in a previous profiling run.
+  int inline_instructions_size() { return _inline_instructions_size; }
   static InlineMatcher* parse_inline_pattern(char* line, const char*& error_msg);
   InlineMatcher* clone();
 };

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,6 +237,16 @@ void Method::print_external_name(outputStream *os, Klass* klass, Symbol* method_
   os->print(" %s.%s(", klass->external_name(), method_name->as_C_string());
   signature->print_as_signature_external_parameters(os);
   os->print(")");
+}
+
+void Method::print_opto_method_size(int size) {
+  tty->print("Collecting method size {class_name} ");
+  method_holder()->name()->print_value_on(tty);
+  tty->print("{method_name} ");
+  name()->print_value_on(tty);
+  tty->print("{signature} ");
+  signature()->print_value_on(tty);
+  tty->print_cr("{Inline instruction size: %d}", size);
 }
 
 int Method::fast_exception_handler_bci_for(const methodHandle& mh, Klass* ex_klass, int throw_bci, TRAPS) {

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -468,6 +469,7 @@ public:
   void print_codes(int flags = 0) const { print_codes_on(tty, flags); }
   void print_codes_on(outputStream* st, int flags = 0) const;
   void print_codes_on(int from, int to, outputStream* st, int flags = 0) const;
+  void print_opto_method_size(int size);
 
   // method parameters
   bool has_method_parameters() const

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,6 +180,13 @@ bool InlineTree::should_inline(ciMethod* callee_method, ciMethod* caller_method,
         callee_method->inline_instructions_size() > inline_small_code_size) {
       set_msg("already compiled into a medium method");
       return false;
+    } else if (!callee_method->has_compiled_code()) {
+      // Look up profiled compiled size to avoid aggressive inlining of large methods
+      if (callee_method->was_executed_more_than(CompilationPolicy::min_invocations()) &&
+          C->directive()->is_estimated_size_bigger_than(callee_method, inline_small_code_size)) {
+        set_msg("Directive info: might be compiled into a medium method");
+        return false;
+      }
     }
   }
   if (size > max_inline_size) {
@@ -275,6 +283,13 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
       callee_method->inline_instructions_size() > InlineSmallCode) {
     set_msg("already compiled into a big method");
     return true;
+  } else if (!callee_method->has_compiled_code()) {
+    // Look up profiled compiled size to avoid aggressive inlining of large methods
+    if (callee_method->was_executed_more_than(CompilationPolicy::min_invocations()) &&
+        C->directive()->is_estimated_size_bigger_than(callee_method, InlineSmallCode)) {
+      set_msg("Directive info: might be compiled into a big method");
+      return true;
+    }
   }
 
   // don't inline exception code unless the top method belongs to an

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3294,7 +3295,7 @@ static bool use_vm_log() {
   if (LogCompilation || !FLAG_IS_DEFAULT(LogFile) ||
       PrintCompilation || PrintInlining || PrintDependencies || PrintNativeNMethods ||
       PrintDebugInfo || PrintRelocations || PrintNMethods || PrintExceptionHandlers ||
-      PrintAssembly || TraceDeoptimization ||
+      PrintAssembly || TraceDeoptimization || PrintOptoMethodSize ||
       (VerifyDependencies && FLAG_IS_CMDLINE(VerifyDependencies))) {
     return true;
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -632,6 +633,10 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, PrintNMethods, false, DIAGNOSTIC,                           \
           "Print assembly code for nmethods when generated")                \
+                                                                            \
+  product(bool, PrintOptoMethodSize, false, DIAGNOSTIC,                     \
+          "Print estimated inlined instruction size for nmethods compiled"  \
+          "by C2")                                                          \
                                                                             \
   product(bool, PrintNativeNMethods, false, DIAGNOSTIC,                     \
           "Print assembly code for native nmethods when generated")         \


### PR DESCRIPTION
**TL;DR**

I proposed a PoC that explores leveraging profiled compiled sizes to improve C2 inlining decisions and mitigate code bloat. The approach records method sizes during a pre-run and feeds them back via compiler directives, helping to reduce aggressive inlining of large methods.

Testing on Renaissance and SPECjbb2015 showed clear code size differences but no significant performance impact on either AArch64 or x86. An alternative AOT-cache-based approach was also evaluated but did not produce meaningful code size changes.

Open questions remain about the long-term value of profiling given Project Leyden's direction of caching compiled code in AOT, and whether global profiling information could help C2 make better inlining decisions.

**1. Motivation**

In the current C2 behavior, the inliner only considers the estimated inlined size [1] [2] of a callee if the method has already been compiled by C2. In particular, C2 will explicitly reject inlining in the following cases:
    Hot methods with bytecode size > FreqInlineSize (325) [3]
    Cold methods with bytecode size > MaxInlineSize (35)

However, a common situation arises where a method's bytecode size is below 325, yet once compiled by C2 it produces a very large machine code body. If this method has not been compiled at the time its caller is being compiled, the inliner may aggressively inline it, potentially bloating the caller, even though an independent compiled copy might eventually exist.

To mitigate such cases, we can make previously profiled compiled sizes available early, allowing the inliner to make more informed decisions and reduce excessive code growth.

[1] https://github.com/openjdk/jdk/blob/0ba4141cb12414c08be88b37ea2a163aacbfa7de/src/hotspot/share/opto/bytecodeInfo.cpp#L180
[2] https://github.com/openjdk/jdk/blob/0ba4141cb12414c08be88b37ea2a163aacbfa7de/src/hotspot/share/opto/bytecodeInfo.cpp#L274
[3] https://github.com/openjdk/jdk/blob/0ba4141cb12414c08be88b37ea2a163aacbfa7de/src/hotspot/share/opto/bytecodeInfo.cpp#L184

**2. Proof of Concept**

To validate this idea, I created a proof-of-concept. In this PoC:

1) A dumping interface was added to record C2-compiled method sizes, enabled via the `-XX:+PrintOptoMethodSize` flag.

2) A new attribute was introduced in InlineMatcher: _inline_instructions_size. This attribute stores the estimated inlined size of a method, sourced from a compiler directive JSON file generated during a prior profiling run.

3) The inliner was updated to use these previously profiled method sizes to prevent aggressive inlining of large methods.

**3. How to Use**

To apply this approach to any workload, the workload must be run twice: 1) Pre-run: collect inlined sizes for all C2-compiled methods. 2) Product run: use the profiled method sizes to improve C2 inlining.

Step 1 Profile method size (pre-run)

Log the compiled method size:
`-XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:+PrintOptoMethodSize -XX:LogFile=logmethodsize.out` This will generate a log containing method size information from C2.

Step 2 Generate the compiler directive file

Use the provided Python script to extract method size info and generate a JSON file:
`python3 extract_size_to_directives.py logmethodsize.out output_directives.json`

This file contains estimated inlined sizes to guide inlining decisions in product run. If the same method is compiled multiple times, the script conservatively retains the smallest observed size. Note: Methods that are not accepted by the CompilerDirective format need to be excluded.

Step 3 Use the compiler directive in a product run

Pass the generated JSON to the JVM as a directive: `-XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=output_directives.json` This enables the inliner to make decisions using previously profiled method sizes, potentially avoiding aggressive inlining of large methods. Note: The patch reuses the existing `inline` directive attribute for inlining control. If multiple inline rules match the same method, only the first match is effective.

**4. Testing**

I tested the following workloads using the method above and measured the code cache size with `-XX:+PrintCodeCache`. The results are shown below, compared against the mainline code. All statistics (min, max, median, mean) are based on three runs.

(patch - mainline) / mainline

1) Renaissance.dotty

Code size change:

AArch64:

```
used           min      max      median   mean
non-profiled   -9.88%   -8.13%   -8.92%   -8.98%
profiled       -0.73%   -0.21%   -0.40%   -0.45%
non-nmethods   -15.20%  -0.02%   -14.92%   -10.32%
codecache      -2.82%   -2.88%   -2.97%   -2.89%
max_used       min      max      median   mean
non-profiled   -9.88%   -8.13%   -8.92%   -8.98%
profiled       2.37%    1.41%    1.50%    1.76%
non-nmethods   -0.95%   -1.73%   -0.93%   -1.21%
codecache      -0.35%   -1.00%   -0.95%   -0.77%
```

X86:

```
used            min      max      median   mean
non-profiled    -9.72%   -9.61%   -9.36%   -9.56%
profiled        -0.81%   -0.90%   -1.15%   -0.95%
non-nmethods    -0.04%   0.04%    -0.02%   -0.01%
codecache       -2.94%   -2.96%   -3.11%   -3.00%
max_used        min      max      median   mean
non-profiled    -9.72%   -9.61%   -9.36%   -9.56%
profiled        2.32%    2.60%    2.51%    2.48%
non-nmethods    -0.63%   -2.25%   -1.28%   -1.39%
codecache       -0.68%   -0.59%   -0.70%   -0.66%
```

No significant performance changes were observed on either platform.

2) SPECjbb 2015

Code size change:

AArch64:

```
used           min      max       median    mean
non-profiled   -1.00%   -11.68%   -12.73%   -8.62%
profiled       9.07%    -6.93%    -2.34%    -0.29%
non-nmethods   0.02%    -0.02%    0.00%     0.00%
codecache      2.98%    -7.18%    -5.35%    -3.28%
max_used       min      max       median    mean
non-profiled   -10.85%  -11.68%   -12.73%   -11.76%
profiled       -2.09%   -11.65%   -1.26%   -5.62%
non-nmethods   0.13%    -1.21%    -0.16%   -0.41%
codecache      -6.42%   -6.33%    -6.10%   -6.29%
```

On the AArch64 platform, no significant performance changes were observed for either high-bound IR or max jOPS.

For critical jOPS:
```
Min      Median   Mean     Max     Var%
-2.45%   -1.87%   -2.45%   -3.00%  1.9%
```

X86:

```
used           min      max      median   mean
non-profiled   -9.02%   -9.65%   -7.93%   -8.87%
profiled       -6.09%   -3.18%   -4.52%   -4.61%
non-nmethods   -0.02%   0.25%    0.04%    0.09%
codecache      -5.36%   -4.75%   -4.58%   -4.90%
max_used       min      max      median   mean
non-profiled   -4.03%   -9.65%   -7.93%   -7.23%
profiled       -2.86%   1.16%    -1.03%   -0.93%
non-nmethods   0.02%    -0.08%   0.08%    0.01%
codecache      -0.23%   -4.20%   -3.70%   -2.73%
```

No significant performance change was observed on x86 platform.

**5. AOT cache**

The current procedure above requires three steps: a pre-run to record method sizes, a separate step to process the JSON file, and finally a product run using the profiled method sizes. This workflow may add extra burden to workload deployment.

With JEP 515 [4], we can instead store the estimated inlined size in the AOT cache when ciMethod::inline_instructions_size() is called during the premain run, and later load this size from the AOT cache during the product run [5].

The store-load mechanism for inlined size can help reduce the overhead of recomputing actual sizes, but it does not provide the inliner with much additional information about the callee, since the compilation order in the product run generally follows that of the premain run, even if not exactly.

To give the inliner more profiled information about callees, I tried another simple draft that records inlined sizes for more C2-compiled methods:
https://github.com/openjdk/jdk/pull/27519/commits/ef5e61f3d68ad565ee11e2cc6aa57b6e2697ae6d

However, with this draft using the AOT cache, I did not observe any significant code size changes for any workloads. This may require further investigation.

[4] https://openjdk.org/jeps/515
[5] https://github.com/openjdk/jdk/blob/0ba4141cb12414c08be88b37ea2a163aacbfa7de/src/hotspot/share/ci/ciMethod.cpp#L1152

**6 Questions**

1) Relation to Project Leyden

Project Leyden aims to enhance the AOT cache to store compiled code from training runs [6]. This suggests that we may eventually prefer to cache compiled code directly from the AOT cache rather than rely solely on JIT compilation.

Given this direction, is it still worthwhile to invest further in using profiled method sizes as a means to improve inlining heuristics?

Could such profiling provide complementary benefits even if compiled code is cached?

2. Global profiling information for C2

Should we consider leveraging profiled information stored in the AOT cache to give the C2 inliner a broader, more global view of methods, enabling better inlining decisions?

For example, could global visibility into method sizes and call sites help address pathological cases of code bloat or missed optimization opportunities? [7]

[6] https://openjdk.org/jeps/8335368
[7] https://wiki.openjdk.org/display/hotspot/inlining

I'd greatly appreciate any feedback. Thank you for your time and consideration.