### PR TITLE
8368097: [asan] heap-buffer-overflow reported in ClassFileParser::skip_over_field_signature

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4678,12 +4678,14 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
       return signature + 1;
     case JVM_SIGNATURE_CLASS: {
       if (_major_version < JAVA_1_5_VERSION) {
-        signature++; length--;
+        signature++;
+        length--;
         // Skip over the class name if one is there
         const char* const p = skip_over_field_name(signature, true, length);
+        assert(p == nullptr || p > signature, "must parse one character at least");
         // The next character better be a semicolon
         if (p != nullptr               && // Parse of field name succeeded.
-            signature + length > p     && // There is at least one character left to parse.
+            p - signature < length     && // There is at least one character left to parse.
             p[0] == JVM_SIGNATURE_ENDCLASS) {
           return p + 1;
         }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4680,9 +4680,11 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
       if (_major_version < JAVA_1_5_VERSION) {
         // Skip over the class name if one is there
         const char* const p = skip_over_field_name(signature + 1, true, --length);
-
         // The next character better be a semicolon
-        if (p && (p - signature) > 1 && p[0] == JVM_SIGNATURE_ENDCLASS) {
+        if (p != nullptr               && // Parse succeeded
+            signature < p              && // p is in range [ signature,
+            signature + length > p     && //                 signature + length )
+            p[0] == JVM_SIGNATURE_ENDCLASS) {
           return p + 1;
         }
       }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4684,8 +4684,8 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
         const char* const p = skip_over_field_name(signature, true, length);
         assert(p == nullptr || p > signature, "must parse one character at least");
         // The next character better be a semicolon
-        if (p != nullptr                                 && // Parse of field name succeeded.
-            p - signature < static_cast<int>(length)     && // There is at least one character left to parse.
+        if (p != nullptr                             && // Parse of field name succeeded.
+            p - signature < static_cast<int>(length) && // There is at least one character left to parse.
             p[0] == JVM_SIGNATURE_ENDCLASS) {
           return p + 1;
         }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4684,8 +4684,8 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
         const char* const p = skip_over_field_name(signature, true, length);
         assert(p == nullptr || p > signature, "must parse one character at least");
         // The next character better be a semicolon
-        if (p != nullptr               && // Parse of field name succeeded.
-            p - signature < length     && // There is at least one character left to parse.
+        if (p != nullptr                                 && // Parse of field name succeeded.
+            p - signature < static_cast<int>(length)     && // There is at least one character left to parse.
             p[0] == JVM_SIGNATURE_ENDCLASS) {
           return p + 1;
         }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4678,12 +4678,12 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
       return signature + 1;
     case JVM_SIGNATURE_CLASS: {
       if (_major_version < JAVA_1_5_VERSION) {
+        signature++; length--;
         // Skip over the class name if one is there
-        const char* const p = skip_over_field_name(signature + 1, true, --length);
+        const char* const p = skip_over_field_name(signature, true, length);
         // The next character better be a semicolon
-        if (p != nullptr               && // Parse succeeded
-            signature < p              && // p is in range [ signature,
-            signature + length > p     && //                 signature + length )
+        if (p != nullptr               && // Parse of field name succeeded.
+            signature + length > p     && // There is at least one character left to parse.
             p[0] == JVM_SIGNATURE_ENDCLASS) {
           return p + 1;
         }


### PR DESCRIPTION
Hi,

`skip_over_field_name` may produce a pointer which is exactly one `char` of bounds, which is the dereferenced by `skip_over_field_signature` when it looks for a semi-colon. This causes an out-of-bounds read, which ASAN caught. The fix is to check whether it's OK to dereference `p` or not.

We keep the semantics the same other than that, so `skip_over_field_signature` and `skip_over_field_name` can both return a pointer which is one past the valid memory range. Creating such a pointer is explicitly not UB, but dereferencing it is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368097](https://bugs.openjdk.org/browse/JDK-8368097): [asan] heap-buffer-overflow reported in ClassFileParser::skip_over_field_signature (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [75709361](https://git.openjdk.org/jdk/pull/27528/files/757093618d9f997c7d6b19fdf330cb7007c484b8)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27528/head:pull/27528` \
`$ git checkout pull/27528`

Update a local copy of the PR: \
`$ git checkout pull/27528` \
`$ git pull https://git.openjdk.org/jdk.git pull/27528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27528`

View PR using the GUI difftool: \
`$ git pr show -t 27528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27528.diff">https://git.openjdk.org/jdk/pull/27528.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27528#issuecomment-3350668523)
</details>
