### PR TITLE
8366244: TLS1.3 ChangeCipherSpec message received after the client's Finished message should trigger a connection abort with "unexpected message"

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ChangeCipherSpec.java
+++ b/src/java.base/share/classes/sun/security/ssl/ChangeCipherSpec.java
@@ -232,7 +232,8 @@ final class ChangeCipherSpec {
             tc.consumers.remove(ContentType.CHANGE_CIPHER_SPEC.id);
 
             // parse
-            if (message.remaining() != 1 || message.get() != 1) {
+            if (message.remaining() != 1 || message.get() != 1
+                    || tc.isNegotiated) {
                 throw tc.fatal(Alert.UNEXPECTED_MESSAGE,
                         "Malformed or unexpected ChangeCipherSpec message");
             }

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/TLS13ChangeCipherSpecAfterFinished.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/TLS13ChangeCipherSpecAfterFinished.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static jdk.test.lib.Asserts.assertEquals;
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Utils.runAndCheckException;
+
+import java.nio.ByteBuffer;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLProtocolException;
+
+/*
+ * @test
+ * @bug 8366244
+ * @summary TLS1.3 ChangeCipherSpec message received after the client's
+ *          Finished message should trigger a connection abort with
+ *          "unexpected message"
+ * @library /javax/net/ssl/templates
+ *          /test/lib
+ * @run main/othervm TLS13ChangeCipherSpecAfterFinished false
+ * @run main/othervm TLS13ChangeCipherSpecAfterFinished true
+ */
+
+public class TLS13ChangeCipherSpecAfterFinished extends SSLEngineTemplate {
+
+    private final String exMsg;
+
+    protected TLS13ChangeCipherSpecAfterFinished(String exMsg)
+            throws Exception {
+        super();
+        this.exMsg = exMsg;
+    }
+
+    @Override
+    protected ContextParameters getServerContextParameters() {
+        return new ContextParameters("TLSv1.3", "PKIX", "SunX509");
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new RuntimeException("Wrong number of arguments");
+        }
+
+        boolean useCompatibilityMode = Boolean.parseBoolean(args[0]);
+
+        if (useCompatibilityMode) {
+            // Use existing CCS rejection after Finished message with client's
+            // Middlebox Compatibility Mode on (which is the default).
+            new TLS13ChangeCipherSpecAfterFinished(
+                    "(unexpected_message) Unexpected content: 20").run();
+        } else {
+            // Switch off client Middlebox Compatibility Mode: do not send CCS
+            // immediately before the second flight. This is needed to reproduce
+            // the conditions for the issue to manifest itself.
+            System.setProperty("jdk.tls.client.useCompatibilityMode", "false");
+
+            // Test the fix.
+            new TLS13ChangeCipherSpecAfterFinished("(unexpected_message) "
+                    + "Malformed or unexpected ChangeCipherSpec "
+                    + "message").run();
+        }
+    }
+
+    protected void run() throws Exception {
+
+        // Complete handshake.
+        do {
+            clientEngine.wrap(clientOut, cTOs);
+            runDelegatedTasks(clientEngine);
+
+            serverEngine.wrap(serverOut, sTOc);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.flip();
+            sTOc.flip();
+
+            clientEngine.unwrap(sTOc, clientIn);
+            runDelegatedTasks(clientEngine);
+
+            serverEngine.unwrap(cTOs, serverIn);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.compact();
+            sTOc.compact();
+        } while (serverEngine.getHandshakeStatus()
+                != HandshakeStatus.NOT_HANDSHAKING);
+
+        // Send a valid CCS message after Finished.
+        ByteBuffer changeCipher = ByteBuffer.allocate(6);
+        //        ContentType type: change_cipher_spec(20)
+        //        ProtocolVersion:  0x0303
+        //        uint16 length:    0x0001
+        //        opaque fragment:  0x01
+        changeCipher.put(new byte[]{20, 3, 3, 0, 1, 1});
+        changeCipher.flip();
+
+        runAndCheckException(
+                () -> serverEngine.unwrap(changeCipher, serverIn),
+                ex -> {
+                    assertTrue(ex instanceof SSLProtocolException);
+                    assertEquals(ex.getMessage(), exMsg);
+                });
+    }
+}


### PR DESCRIPTION
According to the TLS specification, RFC 8446 section 5,
```
An implementation may receive an unencrypted record of type
   change_cipher_spec consisting of the single byte value 0x01 at any
   time after the first ClientHello message has been sent or received
   and before the peer's Finished message has been received and MUST
   simply drop it without further processing. Note that this record may
   appear at a point at the handshake where the implementation is
   expecting protected records, and so it is necessary to detect this
   condition prior to attempting to deprotect the record. An
   implementation which receives any other change_cipher_spec value or
   which receives a protected change_cipher_spec record MUST abort the
   handshake with an "unexpected_message" alert. If an implementation
   detects a change_cipher_spec record received before the first
   ClientHello message or after the peer's Finished message, it MUST be
   treated as an unexpected record type (though stateless servers may
   not be able to distinguish these cases from allowed cases).
```

However the TLS implementation ignores a CCS message received after the client's Finished, instead of sending an alert(fatal, unexpected_message) and aborting the connection.