### PR TITLE
8368793: java/lang/StringBuilder/RacingSBThreads.java timed out in Xcomp subtest

### DIFF
--- a/test/jdk/java/lang/StringBuilder/RacingSBThreads.java
+++ b/test/jdk/java/lang/StringBuilder/RacingSBThreads.java
@@ -28,7 +28,7 @@
  * @run main/othervm -esa RacingSBThreads read
  * @run main/othervm -esa RacingSBThreads insert
  * @run main/othervm -esa RacingSBThreads append
- * @run main/othervm -Xcomp RacingSBThreads
+ * @run main/othervm/timeout=240 -Xcomp RacingSBThreads
  */
 
 import java.nio.CharBuffer;


### PR DESCRIPTION
To avoid timeout in -Xcomp run of RacingSBThreads test raise the timeout to 240 on -Xcomp run.