### PR TITLE
JDK-8368621: In ASAN builds, attached non-main threads should have meaningful native names

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3847,6 +3847,17 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
     return JNI_ERR;
   }
 
+#ifdef ADDRESS_SANITIZER
+  // Make the thread name visible at the OS level, but only for ASAN builds. Otherwise,
+  // we deliberately avoid interfering with the properties of attached threads.
+  if (thread_name != nullptr) {
+    thread->set_native_thread_name(thread_name);
+  } else {
+    ResourceMark rm;
+    thread->set_native_thread_name(thread->name());
+  }
+#endif // ADDRESS_SANITIZER
+
   // Update the _monitor_owner_id with the tid value.
   thread->set_monitor_owner_id(java_lang_Thread::thread_id(thread->threadObj()));
 


### PR DESCRIPTION
See issue description and discussion. We set the thread name at the OS level, but only for ASAN builds, since outside of that narrow use case we consider attached threads to be owned by the application, not us, so we don't interfere with it.

