### PR TITLE
8368818: Remove duplicate dtrace macros

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -63,53 +63,6 @@
 #include "jfr/support/jfrFlush.hpp"
 #endif
 
-#ifdef DTRACE_ENABLED
-
-// Only bother with this argument setup if dtrace is available
-// TODO-FIXME: probes should not fire when caller is _blocked.  assert() accordingly.
-
-
-#define DTRACE_MONITOR_PROBE_COMMON(obj, thread)                           \
-  char* bytes = nullptr;                                                   \
-  int len = 0;                                                             \
-  jlong jtid = SharedRuntime::get_java_tid(thread);                        \
-  Symbol* klassname = obj->klass()->name();                                \
-  if (klassname != nullptr) {                                              \
-    bytes = (char*)klassname->bytes();                                     \
-    len = klassname->utf8_length();                                        \
-  }
-
-#define DTRACE_MONITOR_WAIT_PROBE(monitor, obj, thread, millis)            \
-  {                                                                        \
-    if (DTraceMonitorProbes) {                                             \
-      DTRACE_MONITOR_PROBE_COMMON(obj, thread);                            \
-      HOTSPOT_MONITOR_WAIT(jtid,                                           \
-                           (monitor), bytes, len, (millis));               \
-    }                                                                      \
-  }
-
-#define HOTSPOT_MONITOR_contended__enter HOTSPOT_MONITOR_CONTENDED_ENTER
-#define HOTSPOT_MONITOR_contended__entered HOTSPOT_MONITOR_CONTENDED_ENTERED
-#define HOTSPOT_MONITOR_contended__exit HOTSPOT_MONITOR_CONTENDED_EXIT
-#define HOTSPOT_MONITOR_notify HOTSPOT_MONITOR_NOTIFY
-#define HOTSPOT_MONITOR_notifyAll HOTSPOT_MONITOR_NOTIFYALL
-
-#define DTRACE_MONITOR_PROBE(probe, monitor, obj, thread)                  \
-  {                                                                        \
-    if (DTraceMonitorProbes) {                                             \
-      DTRACE_MONITOR_PROBE_COMMON(obj, thread);                            \
-      HOTSPOT_MONITOR_##probe(jtid,                                        \
-                              (uintptr_t)(monitor), bytes, len);           \
-    }                                                                      \
-  }
-
-#else //  ndef DTRACE_ENABLED
-
-#define DTRACE_MONITOR_WAIT_PROBE(obj, thread, millis, mon)    {;}
-#define DTRACE_MONITOR_PROBE(probe, obj, thread, mon)          {;}
-
-#endif // ndef DTRACE_ENABLED
-
 DEBUG_ONLY(static volatile bool InitDone = false;)
 
 OopStorage* ObjectMonitor::_oop_storage = nullptr;

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -59,7 +59,7 @@ class ContinuationWrapper;
     if (DTraceMonitorProbes) {                                             \
       DTRACE_MONITOR_PROBE_COMMON(obj, thread);                            \
       HOTSPOT_MONITOR_WAIT(jtid,                                           \
-                           (monitor), bytes, len, (millis));               \
+                           (uintptr_t) monitor, bytes, len, millis);       \
     }                                                                      \
   }
 
@@ -75,7 +75,7 @@ class ContinuationWrapper;
     if (DTraceMonitorProbes) {                                             \
       DTRACE_MONITOR_PROBE_COMMON(obj, thread);                            \
       HOTSPOT_MONITOR_##probe(jtid,                                        \
-                              (uintptr_t)(monitor), bytes, len);           \
+                              (uintptr_t) monitor, bytes, len);            \
     }                                                                      \
   }
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -39,6 +39,52 @@ class ParkEvent;
 class BasicLock;
 class ContinuationWrapper;
 
+#ifdef DTRACE_ENABLED
+
+// Only bother with this argument setup if dtrace is available
+// TODO-FIXME: probes should not fire when caller is _blocked.  assert() accordingly.
+
+#define DTRACE_MONITOR_PROBE_COMMON(obj, thread)                           \
+  char* bytes = nullptr;                                                   \
+  int len = 0;                                                             \
+  jlong jtid = SharedRuntime::get_java_tid(thread);                        \
+  Symbol* klassname = obj->klass()->name();                                \
+  if (klassname != nullptr) {                                              \
+    bytes = (char*)klassname->bytes();                                     \
+    len = klassname->utf8_length();                                        \
+  }
+
+#define DTRACE_MONITOR_WAIT_PROBE(monitor, obj, thread, millis)            \
+  {                                                                        \
+    if (DTraceMonitorProbes) {                                             \
+      DTRACE_MONITOR_PROBE_COMMON(obj, thread);                            \
+      HOTSPOT_MONITOR_WAIT(jtid,                                           \
+                           (monitor), bytes, len, (millis));               \
+    }                                                                      \
+  }
+
+#define HOTSPOT_MONITOR_contended__enter HOTSPOT_MONITOR_CONTENDED_ENTER
+#define HOTSPOT_MONITOR_contended__entered HOTSPOT_MONITOR_CONTENDED_ENTERED
+#define HOTSPOT_MONITOR_contended__exit HOTSPOT_MONITOR_CONTENDED_EXIT
+#define HOTSPOT_MONITOR_notify HOTSPOT_MONITOR_NOTIFY
+#define HOTSPOT_MONITOR_notifyAll HOTSPOT_MONITOR_NOTIFYALL
+#define HOTSPOT_MONITOR_waited HOTSPOT_MONITOR_WAITED
+
+#define DTRACE_MONITOR_PROBE(probe, monitor, obj, thread)                  \
+  {                                                                        \
+    if (DTraceMonitorProbes) {                                             \
+      DTRACE_MONITOR_PROBE_COMMON(obj, thread);                            \
+      HOTSPOT_MONITOR_##probe(jtid,                                        \
+                              (uintptr_t)(monitor), bytes, len);           \
+    }                                                                      \
+  }
+
+#else //  ndef DTRACE_ENABLED
+
+#define DTRACE_MONITOR_WAIT_PROBE(obj, thread, millis, mon)    {;}
+#define DTRACE_MONITOR_PROBE(probe, obj, thread, mon)          {;}
+
+#endif // ndef DTRACE_ENABLED
 
 class ObjectWaiter : public CHeapObj<mtThread> {
  public:


### PR DESCRIPTION
I propose to move the following macros and constants definition to `objectMonitor.hpp`:
```
DTRACE_MONITOR_PROBE_COMMON
DTRACE_MONITOR_WAIT_PROBE
DTRACE_MONITOR_PROBE
HOTSPOT_MONITOR_notify
HOTSPOT_MONITOR_notifyAll
```
They are defined both in `objectMonitor.cpp` and `synchronizer.cpp`.

Passes tier1 (fastdebug) with `--enable-jvm-feature-dtrace`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368818](https://bugs.openjdk.org/browse/JDK-8368818): Remove duplicate dtrace macros (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27538/head:pull/27538` \
`$ git checkout pull/27538`

Update a local copy of the PR: \
`$ git checkout pull/27538` \
`$ git pull https://git.openjdk.org/jdk.git pull/27538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27538`

View PR using the GUI difftool: \
`$ git pr show -t 27538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27538.diff">https://git.openjdk.org/jdk/pull/27538.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27538#issuecomment-3342907735)
</details>
