### PR TITLE
8368846: java/io/File/createTempFile/TargetDirectory fails when run by root user

### DIFF
--- a/test/jdk/java/io/File/createTempFile/TargetDirectory.java
+++ b/test/jdk/java/io/File/createTempFile/TargetDirectory.java
@@ -26,10 +26,11 @@
  * @bug 4847239
  * @summary Verify directory parameter behavior in File.createTempFile(String,String,File)
  * @library /test/lib
- * @run junit/othervm TargetDirectory
+ * @run junit TargetDirectory
  */
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.condition.DisabledIf;
 
 import java.io.File;
@@ -47,11 +48,12 @@ import java.util.List;
 import java.util.Set;
 import jdk.test.lib.Platform;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TargetDirectory {
 
-    @TempDir
+    @TempDir(cleanup = CleanupMode.ALWAYS)
     Path tempDir;
 
     @Test


### PR DESCRIPTION
The test checks whether writing to a read-only directory throws a `IOException`. This test is not applicable when the user running the test is root. Thus, I propose to skip it.

I converted the class to several JUnit tests, so we can use `@DisabledIf`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368846](https://bugs.openjdk.org/browse/JDK-8368846): java/io/File/createTempFile/TargetDirectory fails when run by root user (**Enhancement** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27542/head:pull/27542` \
`$ git checkout pull/27542`

Update a local copy of the PR: \
`$ git checkout pull/27542` \
`$ git pull https://git.openjdk.org/jdk.git pull/27542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27542`

View PR using the GUI difftool: \
`$ git pr show -t 27542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27542.diff">https://git.openjdk.org/jdk/pull/27542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27542#issuecomment-3345688617)
</details>
