### PR TITLE
8354894: java/lang/Thread/virtual/Starvation.java timeout on server with high CPUs

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/Starvation.java
+++ b/test/jdk/java/lang/Thread/virtual/Starvation.java
@@ -25,7 +25,7 @@
  * @requires vm.continuations
  * @library /test/lib
  * @bug 8345294
- * @run main/othervm/timeout=800/native --enable-native-access=ALL-UNNAMED Starvation 100000
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED Starvation
  */
 
 import java.time.Duration;
@@ -37,9 +37,16 @@ import jdk.test.lib.thread.VThreadPinner;
 
 public class Starvation {
     public static void main(String[] args) throws Exception {
-        int iterations = Integer.parseInt(args[0]);
+        int iterations;
+        if (args.length > 0) {
+            iterations = Integer.parseInt(args[0]);
+        } else {
+            int nprocs = Runtime.getRuntime().availableProcessors();
+            iterations = 40_000 / nprocs;
+        }
 
-        for (int i = 0; i < iterations; i++) {
+        for (int i = 1; i <= iterations; i++) {
+            System.out.format("%s iteration %d of %d ...%n", Instant.now(), i, iterations);
             var exRef = new AtomicReference<Exception>();
             Thread thread =  Thread.startVirtualThread(() -> {
                 try {


### PR DESCRIPTION
Hi all,

We observed java/lang/Thread/virtual/Starvation.java intermittent timed out on server with many CPU core number. The more CPU core number the 'runTest' will create more pinned virtual threads. This PR compute an iteration count which divide the CPU core number will make test run passed steady on server with high CPUs.

Before apply the proposed patch, test run finish 257 seconds, after apply the proposed patch test run finish 1.2 seconds on the 2 sockets system with Intel(R) Xeon(R) Platinum 8480+. So I remove the 'timeout=800', I think the default timeout 120 will be enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354894](https://bugs.openjdk.org/browse/JDK-8354894): java/lang/Thread/virtual/Starvation.java timeout on server with high CPUs (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Contributors
 * Alan Bateman `<alanb@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27543/head:pull/27543` \
`$ git checkout pull/27543`

Update a local copy of the PR: \
`$ git checkout pull/27543` \
`$ git pull https://git.openjdk.org/jdk.git pull/27543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27543`

View PR using the GUI difftool: \
`$ git pr show -t 27543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27543.diff">https://git.openjdk.org/jdk/pull/27543.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27543#issuecomment-3345798202)
</details>
