### PR TITLE
8368702: [macosx] Printing text with composite fonts loses font transform

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTextPipe.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTextPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTextPipe.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTextPipe.java
@@ -97,8 +97,14 @@ public class CTextPipe implements TextPipe {
         if (f2d instanceof CFont) {
             CompositeFont cf = ((CFont)f2d).getCompositeFont2D();
             PhysicalFont pf = cf.getSlotFont(slot);
-            Font f = new Font(pf.getFontName(null),
-                              font.getStyle(), font.getSize());
+            String name = pf.getFontName(null);
+            Font f = new Font(name, font.getStyle(), font.getSize());
+            if (font.isTransformed()) {
+                f = f.deriveFont(font.getTransform());
+            }
+            if (font.hasLayoutAttributes()) {
+                f = f.deriveFont(font.getAttributes());
+            }
             return f;
         }
         return null;

--- a/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6425068 7156751 7157659 8029204 8132890 8148334 8344637
+ * @bug 6425068 7156751 7157659 8029204 8132890 8148334 8344637 8368702
  * @key printer
  * @summary Confirm that text prints where we expect to the length we expect.
  * @library /java/awt/regtesthelpers


### PR DESCRIPTION
When printing text on macOS, if the text uses a composite font (a logical font composed of more than one physical font) with a custom affine transform, the transform can be lost, and the text printed without the transform applied.

This is one of a few issues affecting the problem listed manual test `java/awt/print/PrinterJob/PrintTextTest.java` on macOS, and can be observed on page 10, on the last line ("TextLayout 2"). Without the fix, the text on this line is not stretched across the x-axis, resulting in large gaps of white space between runs of different script types.