### PR TITLE
8368861: [TEST] compiler/floatingpoint/ScalarFPtoIntCastTest.java expects x86 IR on non-x86 platforms

### DIFF
--- a/test/hotspot/jtreg/compiler/floatingpoint/ScalarFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/ScalarFPtoIntCastTest.java
@@ -87,6 +87,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_F2I, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_F2I, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_F2I_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2int() {
@@ -100,6 +103,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_F2L, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_F2L, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_F2L_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2long() {
@@ -113,6 +119,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_F2I, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_F2I, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_F2I_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2short() {
@@ -126,6 +135,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_F2I, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_F2I, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_F2I_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void float2byte() {
@@ -139,6 +151,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_D2I, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_D2I, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_D2I_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2int() {
@@ -152,6 +167,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_D2L, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_D2L, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_D2L_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2long() {
@@ -165,6 +183,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_D2I, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_D2I, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_D2I_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2short() {
@@ -178,6 +199,9 @@ public class ScalarFPtoIntCastTest {
 
     @Test
     @IR(counts = {IRNode.CONV_D2I, "> 0"})
+    @IR(counts = {IRNode.X86_SCONV_D2I, "> 0"},
+        applyIfPlatform = {"x64", "true"},
+        applyIfCPUFeature = {"avx10_2", "false"})
     @IR(counts = {IRNode.X86_SCONV_D2I_AVX10, "> 0"},
         applyIfCPUFeature = {"avx10_2", "true"})
     public void double2byte() {


### PR DESCRIPTION
This removes X86 specific IR checks that are applied if the X86 specific feature *avx10_2* is not present.

We could make the checks dependent on the platform being X86 if we wanted to keep them but I don't see a value in doing so.

Tested on X86 and PPC64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368861](https://bugs.openjdk.org/browse/JDK-8368861): [TEST] compiler/floatingpoint/ScalarFPtoIntCastTest.java expects x86 IR on non-x86 platforms (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) Review applies to [00db7b16](https://git.openjdk.org/jdk/pull/27546/files/00db7b16389e7609d5c026c67f90b4e687cbff43)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27546/head:pull/27546` \
`$ git checkout pull/27546`

Update a local copy of the PR: \
`$ git checkout pull/27546` \
`$ git pull https://git.openjdk.org/jdk.git pull/27546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27546`

View PR using the GUI difftool: \
`$ git pr show -t 27546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27546.diff">https://git.openjdk.org/jdk/pull/27546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27546#issuecomment-3346802962)
</details>
