### PR TITLE
8366968: Exhaustive switch expression rejected by for not covering al…

### DIFF
--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215 8333169 8327368 8364991
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215 8333169 8327368 8364991 8366968
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2274,6 +2274,32 @@ public class Exhaustiveness extends TestRunner {
                """,
                "Test.java:4:16: compiler.err.not.exhaustive",
                "1 error");
+    }
+
+    @Test //JDK-8366968
+    public void testNonSealed(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               class Demo {
+
+                   sealed interface Base permits Special, Value {}
+
+                   non-sealed interface Value extends Base {}
+
+                   sealed interface Special extends Base permits SpecialValue {}
+
+                   non-sealed interface SpecialValue extends Value, Special {}
+
+                   static int demo(final Base base) {
+                       return switch (base) {
+                           case Value value -> 0;
+                       };
+
+                   }
+
+               }
+               """);
     }
 
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {


### PR DESCRIPTION
Consider case like (from the bug):
```
class Demo {

    sealed interface Base permits Special, Value {}

    non-sealed interface Value extends Base {}

    sealed interface Special extends Base permits SpecialValue {}

    non-sealed interface SpecialValue extends Value, Special {}

    static int demo(final Base base) {
        return switch (base) {
            case final Value value -> 0;
            // Uncommenting the following line will make javac accept this program
            //case final Special value -> throw new AssertionError();
        };

    }

}
```

This fails to compile:
```
/tmp/Demo.java:12: error: the switch expression does not cover all possible input values
        return switch (base) {
               ^
1 error
```

Note there is no instance of `Special` that would not be an instance of `Value` as well. I.e. covering `Value` will catch all input.

Also, note that if `case Value` is replaced with `case SpecialValue`, javac also compile the code:
```
            case final Value value -> 0;
=>
            case final SpecialValue value -> 0;

$ ~/tools/jdk/jdk-25/bin/javac /tmp/Demo.java
$
```

Which shows the problem: replacing a type with a super type should not cause the switch to stop to be exhaustive (i.e. the switch is exhaustive for `SpecialValue`, but replacing it with its super type `Value`, the switch is no longer exhaustive for javac).

javac contains a piece of code that searches through subtypes to handle diamond class hierarchies like the one above. But, when it searches for subtypes, it does a search through permitted subtypes of the type. And since `Value` is not sealed, this search will not find `SpecialValue`, and javac won't see the switch to be exhaustive.

The proposal herein is to broaden the search, and consider all transitive permitted subtypes of the selector type, and filter subtypes of the current type from this set (if the current type is abstract, if it is not abstract, we can't do the subtype search at all). This should, I think, include all relevant subtypes.
