### PR TITLE
8367899: compiler/c2/gvn/TestBitCompressValueTransform.java intermittent timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/gvn/TestBitCompressValueTransform.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/TestBitCompressValueTransform.java
@@ -77,7 +77,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test1")
     public void run1(RunInfo info) {
         long res = 0;
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             res |= test1(field_L);
         }
         Asserts.assertEQ(res, gold_L);
@@ -93,7 +93,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test2")
     public void run2(RunInfo info) {
         int res = 0;
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             res |= test2(field_I);
         }
         Asserts.assertEQ(res, gold_I);
@@ -113,7 +113,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test3")
     public void run3(RunInfo info) {
         int res = 0;
-        for (int i = 1; i < 10000; i++) {
+        for (int i = 1; i < 100; i++) {
             res |= test3(i);
         }
         Asserts.assertLTE(0, res);
@@ -133,7 +133,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test4")
     public void run4(RunInfo info) {
         long res = 0;
-        for (long i = 1; i < 10000; i++) {
+        for (long i = 1; i < 100; i++) {
             res |= test4(i);
         }
         Asserts.assertLTE(0L, res);
@@ -151,7 +151,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test5")
     public void run5(RunInfo info) {
         long res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test5((long)i);
         }
         Asserts.assertEQ(-1L, res);
@@ -169,7 +169,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test6")
     public void run6(RunInfo info) {
         long res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test6((long)i);
         }
         Asserts.assertLTE(0L, res);
@@ -188,7 +188,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test7")
     public void run7(RunInfo info) {
         long res = Long.MIN_VALUE;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res = Long.max(test7((long)i), res);
         }
         Asserts.assertGTE(10000L, res);
@@ -206,7 +206,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test8")
     public void run8(RunInfo info) {
         int res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test8(i);
         }
         Asserts.assertEQ(-1, res);
@@ -224,7 +224,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test9")
     public void run9(RunInfo info) {
         int res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test9(i);
         }
         Asserts.assertLTE(0, res);
@@ -243,10 +243,10 @@ public class TestBitCompressValueTransform {
     @Run(test = "test10")
     public void run10(RunInfo info) {
         int res = Integer.MIN_VALUE;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res = Integer.max(test10(i), res);
         }
-        Asserts.assertGTE(10000, res);
+        Asserts.assertGTE(100, res);
     }
 
     @Test
@@ -260,7 +260,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test11")
     public void run11(RunInfo info) {
         int res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test11(i);
         }
         Asserts.assertEQ(0, res);
@@ -277,7 +277,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test12")
     public void run12(RunInfo info) {
         long res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test12(i);
         }
         Asserts.assertEQ(0L, res);
@@ -294,7 +294,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test13")
     public void run13(RunInfo info) {
         int res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test13(i);
         }
         Asserts.assertEQ(0, res);
@@ -311,7 +311,7 @@ public class TestBitCompressValueTransform {
     @Run(test = "test14")
     public void run14(RunInfo info) {
         long res = 0;
-        for (int i = -10000; i < 10000; i++) {
+        for (int i = -100; i < 100; i++) {
             res |= test14(i);
         }
         Asserts.assertEQ(0L, res);
@@ -328,7 +328,7 @@ public class TestBitCompressValueTransform {
     @Run (test = "test15")
     public void run15(RunInfo info) {
         int res = 0;
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             res |= test15(0, 0);
         }
         Asserts.assertEQ(0, res);
@@ -408,7 +408,7 @@ public class TestBitCompressValueTransform {
         int actual = 0;
         int expected = 0;
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             int arg1 = GEN_I.next();
             int arg2 = GEN_I.next();
 
@@ -492,7 +492,7 @@ public class TestBitCompressValueTransform {
         int actual = 0;
         int expected = 0;
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             int arg1 = GEN_I.next();
             int arg2 = GEN_I.next();
 
@@ -576,7 +576,7 @@ public class TestBitCompressValueTransform {
         long actual = 0;
         long expected = 0;
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             long arg1 = GEN_L.next();
             long arg2 = GEN_L.next();
 
@@ -660,7 +660,7 @@ public class TestBitCompressValueTransform {
         long actual = 0;
         long expected = 0;
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100; i++) {
             long arg1 = GEN_L.next();
             long arg2 = GEN_L.next();
 

--- a/test/hotspot/jtreg/compiler/c2/gvn/TestBitCompressValueTransform.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/TestBitCompressValueTransform.java
@@ -76,10 +76,7 @@ public class TestBitCompressValueTransform {
 
     @Run(test = "test1")
     public void run1(RunInfo info) {
-        long res = 0;
-        for (int i = 0; i < 100; i++) {
-            res |= test1(field_L);
-        }
+        long res = test1(field_L);
         Asserts.assertEQ(res, gold_L);
     }
 
@@ -92,10 +89,7 @@ public class TestBitCompressValueTransform {
 
     @Run(test = "test2")
     public void run2(RunInfo info) {
-        int res = 0;
-        for (int i = 0; i < 100; i++) {
-            res |= test2(field_I);
-        }
+        int res = test2(field_I);
         Asserts.assertEQ(res, gold_I);
     }
 
@@ -327,10 +321,7 @@ public class TestBitCompressValueTransform {
 
     @Run (test = "test15")
     public void run15(RunInfo info) {
-        int res = 0;
-        for (int i = 0; i < 100; i++) {
-            res |= test15(0, 0);
-        }
+        int res = test15(0, 0);
         Asserts.assertEQ(0, res);
     }
 


### PR DESCRIPTION
Hi all,

After JDK-8260555 change the timeout factor from 4 to 1, make test compiler/c2/gvn/TestBitCompressValueTransform.java intermittent timed out.

There are 20 10k/20k loop count of loops in this test, this cause test need many CPU cycles to finish. If I reduce the loop count from 10k/20k to 100/200, the test failures descripted in [JDK-8350896](https://bugs.openjdk.org/browse/JDK-8350896) also reproduced when the tested jdk is jdk25u. So it seems that there no need so many loop count for these tests.

Without the proposed change, the driver action finish about 65 sencods on linux-x64, with the proposed change the driver action finish about 1.5 seconds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367899](https://bugs.openjdk.org/browse/JDK-8367899): compiler/c2/gvn/TestBitCompressValueTransform.java intermittent timed out (**Bug** - P4)


### Reviewers
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27548/head:pull/27548` \
`$ git checkout pull/27548`

Update a local copy of the PR: \
`$ git checkout pull/27548` \
`$ git pull https://git.openjdk.org/jdk.git pull/27548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27548`

View PR using the GUI difftool: \
`$ git pr show -t 27548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27548.diff">https://git.openjdk.org/jdk/pull/27548.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27548#issuecomment-3347141159)
</details>
