### PR TITLE
8368866: compiler/codecache/stress/UnexpectedDeoptimizationTest.java intermittent timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,26 +31,26 @@
  *
  * @build jdk.test.whitebox.WhiteBox compiler.codecache.stress.Helper compiler.codecache.stress.TestCaseImpl
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:-SegmentedCodeCache
  *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:+SegmentedCodeCache
  *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:-SegmentedCodeCache
  *                   -DhelperVirtualThread=true
  *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
@@ -75,7 +75,7 @@ public class UnexpectedDeoptimizationTest implements Runnable {
     public void run() {
         Helper.WHITE_BOX.deoptimizeFrames(rng.nextBoolean());
         // Sleep a short while to allow the stacks to grow - otherwise
-        //  we end up running almost all code in the interpreter
+        // we end up running almost all code in the interpreter
         try {
             Thread.sleep(10);
         } catch (Exception e) {


### PR DESCRIPTION
Hi all,

When I run test compiler/codecache/stress/UnexpectedDeoptimizationTest.java standalone, test occupy about 6 CPU threads.

The default timeout factor was change from 4 to 1 by [JDK-8260555](https://bugs.openjdk.org/browse/JDK-8260555). This make test compiler/codecache/stress/UnexpectedDeoptimizationTest.java intermittent timed out when this test run with other tests simultancely, because this is stress test which may affected by other tests.

So I want to change the default timeout value from 120 to 240, this will make this test run success steady.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368866](https://bugs.openjdk.org/browse/JDK-8368866): compiler/codecache/stress/UnexpectedDeoptimizationTest.java intermittent timed out (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27550/head:pull/27550` \
`$ git checkout pull/27550`

Update a local copy of the PR: \
`$ git checkout pull/27550` \
`$ git pull https://git.openjdk.org/jdk.git pull/27550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27550`

View PR using the GUI difftool: \
`$ git pr show -t 27550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27550.diff">https://git.openjdk.org/jdk/pull/27550.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27550#issuecomment-3347358107)
</details>
