### PR TITLE
8368848: JShell's code completion not always working for multi-snippet inputs

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/OuterWrapMap.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/OuterWrapMap.java
@@ -73,7 +73,11 @@ class OuterWrapMap {
 
     OuterWrap wrapInClass(Set<Key> except, Collection<Snippet> plus,
             List<Snippet> snippets, List<Wrap> wraps) {
-        String imports = state.maps.packageAndImportsExcept(except, plus);
+        List<String> extraImports =
+                plus.stream()
+                    .map(psi -> psi.importLine(state))
+                    .toList();
+        String imports = state.maps.packageAndImportsExcept(except, extraImports);
         // className is unique to the set of snippets and their version (seq)
         String className = REPL_CLASS_PREFIX + snippets.stream()
                 .sorted((sn1, sn2) -> sn1.key().index() - sn2.key().index())
@@ -86,9 +90,16 @@ class OuterWrapMap {
     }
 
     OuterWrap wrapInTrialClass(Wrap wrap) {
-        String imports = state.maps.packageAndImportsExcept(null, null);
+        return wrapInTrialClass(List.of(), List.of(), wrap);
+    }
+
+    OuterWrap wrapInTrialClass(List<String> extraImports, List<Wrap> preWraps, Wrap wrap) {
+        String imports = state.maps.packageAndImportsExcept(null, extraImports);
+        List<Wrap> allWraps = new ArrayList<>();
+        allWraps.addAll(preWraps);
+        allWraps.add(wrap);
         CompoundWrap w = wrappedInClass(REPL_DOESNOTMATTER_CLASS_NAME, imports,
-                Collections.singletonList(wrap));
+                allWraps);
         return new OuterWrap(w);
     }
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SnippetMaps.java
@@ -105,7 +105,7 @@ final class SnippetMaps {
         return new ArrayList<>(snippets);
     }
 
-    String packageAndImportsExcept(Set<Key> except, Collection<Snippet> plus) {
+    String packageAndImportsExcept(Set<Key> except, Collection<String> extraImports) {
         StringBuilder sb = new StringBuilder();
         sb.append("package ").append(REPL_PACKAGE).append(";\n");
         for (Snippet si : keyIndexToSnippet) {
@@ -113,9 +113,7 @@ final class SnippetMaps {
                 sb.append(si.importLine(state));
             }
         }
-        if (plus != null) {
-            plus.forEach(psi -> sb.append(psi.importLine(state)));
-        }
+        extraImports.forEach(sb::append);
         return sb.toString();
     }
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -300,17 +300,8 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                 identifier = m.group();
             }
         }
-        code = code.substring(0, cursor);
-        if (code.trim().isEmpty()) { //TODO: comment handling
-            code += ";";
-        }
-        boolean[] moduleImport = new boolean[1];
-        OuterWrap codeWrap = switch (guessKind(code, moduleImport)) {
-            case IMPORT -> moduleImport[0] ? proc.outerMap.wrapImport(Wrap.simpleWrap(code), null)
-                                           : proc.outerMap.wrapImport(Wrap.simpleWrap(code + "any.any"), null);
-            case CLASS, METHOD -> proc.outerMap.wrapInTrialClass(Wrap.classMemberWrap(code));
-            default -> proc.outerMap.wrapInTrialClass(Wrap.methodWrap(code));
-        };
+
+        OuterWrap codeWrap = wrapCodeForCompletion(code, cursor, true);
         String[] requiredPrefix = new String[] {identifier};
         return computeSuggestions(codeWrap, code, cursor, requiredPrefix, anchor).stream()
                 .filter(s -> filteringText(s).startsWith(requiredPrefix[0]) && !s.continuation().equals(REPL_DOESNOTMATTER_CLASS_NAME))
@@ -1740,15 +1731,11 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
     };
 
     private List<Documentation> documentationImpl(String code, int cursor, boolean computeJavadoc) {
-        code = code.substring(0, cursor);
-        if (code.trim().isEmpty()) { //TODO: comment handling
-            code += ";";
-        }
-
-        if (guessKind(code) == Kind.IMPORT)
+        OuterWrap codeWrap = wrapCodeForCompletion(code, cursor, false);
+        if (codeWrap == null) {
+            //import:
             return Collections.emptyList();
-
-        OuterWrap codeWrap = proc.outerMap.wrapInTrialClass(Wrap.methodWrap(code));
+        }
         return proc.taskFactory.analyze(codeWrap, List.of(keepParameterNames), at -> {
             SourcePositions sp = at.trees().getSourcePositions();
             CompilationUnitTree topLevel = at.firstCuTree();
@@ -2427,6 +2414,99 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
 
     public static void waitCurrentBackgroundTasksFinished() throws Exception {
         INDEXER.submit(() -> {}).get();
+    }
+
+    private OuterWrap wrapCodeForCompletion(String code, int cursor, boolean wrapImports) {
+        code = code.substring(0, cursor);
+        if (code.trim().isEmpty()) { //TODO: comment handling
+            code += ";";
+        }
+
+        List<String> imports = new ArrayList<>();
+        List<Wrap> declarationParts = new ArrayList<>();
+        String lastImport = null;
+        boolean lastImportIsModuleImport = false;
+        Wrap declarationWrap = null;
+        Wrap pendingWrap = null;
+        String input = code;
+        boolean cont = true;
+        int startOffset = 0;
+
+        while (cont) {
+            if (lastImport != null) {
+                imports.add(lastImport);
+                lastImport = null;
+            }
+            if (declarationWrap != null) {
+                declarationParts.add(declarationWrap);
+                declarationWrap = null;
+                pendingWrap = null;
+            }
+
+            String current;
+            SourceCodeAnalysis.CompletionInfo completeness = analyzeCompletion(input);
+            int newStartOffset;
+
+            if (completeness.completeness().isComplete() && !completeness.remaining().isBlank()) {
+                current = input.substring(0, input.length() - completeness.remaining().length());
+                newStartOffset = startOffset + input.length() - completeness.remaining().length();
+                input = completeness.remaining();
+                cont = true;
+            } else {
+                current = input;
+                cont = false;
+                newStartOffset = startOffset;
+            }
+
+            boolean[] moduleImport = new boolean[1];
+
+            switch (guessKind(current, moduleImport)) {
+                case IMPORT -> {
+                    lastImport = current;
+                    lastImportIsModuleImport = moduleImport[0];
+                }
+                case CLASS, METHOD -> {
+                    pendingWrap = declarationWrap = Wrap.classMemberWrap(whitespaces(code, startOffset) + current);
+                }
+                case VARIABLE -> {
+                    declarationWrap = Wrap.classMemberWrap(whitespaces(code, startOffset) + current);
+                    pendingWrap = Wrap.methodWrap(whitespaces(code, startOffset) + current);
+                }
+                default -> {
+                    pendingWrap = declarationWrap = Wrap.methodWrap(whitespaces(code, startOffset) + current);
+                }
+            }
+
+            startOffset = newStartOffset;
+        }
+
+        if (lastImport != null) {
+            if (wrapImports) {
+                return proc.outerMap.wrapImport(Wrap.simpleWrap(whitespaces(code, startOffset) + lastImport + (!lastImportIsModuleImport ? "any.any" : "")), null);
+            } else {
+                return null;
+            }
+        }
+
+        if (pendingWrap != null) {
+            return proc.outerMap.wrapInTrialClass(imports, declarationParts, pendingWrap);
+        }
+
+        throw new IllegalStateException("No pending wrap for: " + code);
+    }
+
+    private static String whitespaces(String input, int offset) {
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < offset; i++) {
+            if (input.charAt(i) == '\n') {
+                result.append('\n');
+            } else {
+                result.append(' ');
+            }
+        }
+
+        return result.toString();
     }
 
     /**

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -941,4 +941,14 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertEval("import static java.lang.annotation.RetentionPolicy.*;");
         assertCompletion("@AnnA(C|", true, "CLASS");
     }
+
+    @Test
+    public void testMultiSnippet() {
+        assertCompletion("String s = \"\"; s.len|", true, "length()");
+        assertCompletion("String s() { return \"\"; } s().len|", true, "length()");
+        assertCompletion("String s() { return \"\"; } import java.util.List; List.o|", true, "of(");
+        assertCompletion("String s() { return \"\"; } import java.ut| ", true, "util.");
+        assertCompletion("class S { public int length() { return 0; } } new S().len|", true, "length()");
+        assertSignature("void f() { } f(|", "void f()");
+    }
 }


### PR DESCRIPTION
Having a JShell input like:
```
jshell> String s() { return "";} s(). 
```

the code completion is not working for it. The reason is that the input is two snippets, but the code completion will interpret it as only one snippet, and a method declaration and method invocation cannot coexist inside one snippet (as one is a declaration that must appear outside of a method, and the invocation must be inside a method body or field initializer).

The proposal herein is for the JShell's code completion to split the input into snippets, and create a wrapper/compilation unit based on all the snippets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368848](https://bugs.openjdk.org/browse/JDK-8368848): JShell's code completion not always working for multi-snippet inputs (**Task** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27552/head:pull/27552` \
`$ git checkout pull/27552`

Update a local copy of the PR: \
`$ git checkout pull/27552` \
`$ git pull https://git.openjdk.org/jdk.git pull/27552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27552`

View PR using the GUI difftool: \
`$ git pr show -t 27552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27552.diff">https://git.openjdk.org/jdk/pull/27552.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27552#issuecomment-3347946298)
</details>
