### PR TITLE
8364929: Assign unique id to each AdapterBlob stored in AOTCodeCache

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2999,6 +2999,12 @@ void AdapterHandlerEntry::link() {
 void AdapterHandlerLibrary::link_aot_adapters() {
   uint max_id = 0;
   assert(AOTCodeCache::is_using_adapter(), "AOT adapters code should be available");
+  /* It is possible that some adapters generated in assembly phase are not stored in the cache.
+   * That implies adapter ids of the adapters in the cache may not be contiguous.
+   * If the size of the _aot_adapter_handler_table is used to initialize _id_counter, then it may
+   * result in collision of adapter ids between AOT stored handlers and runtime generated handlers.
+   * To avoid such situation, initialize the _id_counter with the largest adapter id among the AOT stored handlers.
+   */
   _aot_adapter_handler_table.iterate([&](AdapterHandlerEntry* entry) {
     assert(!entry->is_linked(), "AdapterHandlerEntry is already linked!");
     entry->link();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2602,7 +2602,7 @@ void AdapterHandlerLibrary::initialize() {
 
 AdapterHandlerEntry* AdapterHandlerLibrary::new_entry(AdapterFingerPrint* fingerprint) {
   uint id = (uint)AtomicAccess::add((int*)&_id_counter, 1);
-  guarantee(id > 0, "id_counter overflow");
+  assert(id > 0, "we can never overflow because AOT cache cannot contain more than 2^32 methods");
   return AdapterHandlerEntry::allocate(id, fingerprint);
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3011,6 +3011,7 @@ void AdapterHandlerLibrary::link_aot_adapters() {
     max_id = MAX2(max_id, entry->id());
   });
   // Set adapter id to the maximum id found in the AOTCache
+  assert(_id_counter == 0, "Did not expect new AdapterHandlerEntry to be created at this stage");
   _id_counter = max_id;
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2602,10 +2602,7 @@ void AdapterHandlerLibrary::initialize() {
 
 AdapterHandlerEntry* AdapterHandlerLibrary::new_entry(AdapterFingerPrint* fingerprint) {
   uint id = (uint)AtomicAccess::add((int*)&_id_counter, 1);
-  if (id == 0) {
-    // id_counter overflow
-    return nullptr;
-  }
+  guarantee(id > 0, "id_counter overflow");
   return AdapterHandlerEntry::allocate(id, fingerprint);
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2520,6 +2520,7 @@ ArchivedAdapterTable AdapterHandlerLibrary::_aot_adapter_handler_table;
 #endif // INCLUDE_CDS
 static const int AdapterHandlerLibrary_size = 16*K;
 BufferBlob* AdapterHandlerLibrary::_buffer = nullptr;
+volatile uint AdapterHandlerLibrary::_id_counter = 0;
 
 BufferBlob* AdapterHandlerLibrary::buffer_blob() {
   assert(_buffer != nullptr, "should be initialized");
@@ -2600,7 +2601,12 @@ void AdapterHandlerLibrary::initialize() {
 }
 
 AdapterHandlerEntry* AdapterHandlerLibrary::new_entry(AdapterFingerPrint* fingerprint) {
-  return AdapterHandlerEntry::allocate(fingerprint);
+  uint id = (uint)AtomicAccess::add((int*)&_id_counter, 1);
+  if (id == 0) {
+    // id_counter overflow
+    return nullptr;
+  }
+  return AdapterHandlerEntry::allocate(id, fingerprint);
 }
 
 AdapterHandlerEntry* AdapterHandlerLibrary::get_simple_adapter(const methodHandle& method) {
@@ -2754,8 +2760,8 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
 
 void AdapterHandlerLibrary::lookup_aot_cache(AdapterHandlerEntry* handler) {
   ResourceMark rm;
-  const char* name = AdapterHandlerLibrary::name(handler->fingerprint());
-  const uint32_t id = AdapterHandlerLibrary::id(handler->fingerprint());
+  const char* name = AdapterHandlerLibrary::name(handler);
+  const uint32_t id = AdapterHandlerLibrary::id(handler);
 
   CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::Adapter, id, name);
   if (blob != nullptr) {
@@ -2850,8 +2856,8 @@ bool AdapterHandlerLibrary::generate_adapter_code(AdapterHandlerEntry* handler,
   handler->set_adapter_blob(adapter_blob);
   if (!is_transient && AOTCodeCache::is_dumping_adapter()) {
     // try to save generated code
-    const char* name = AdapterHandlerLibrary::name(handler->fingerprint());
-    const uint32_t id = AdapterHandlerLibrary::id(handler->fingerprint());
+    const char* name = AdapterHandlerLibrary::name(handler);
+    const uint32_t id = AdapterHandlerLibrary::id(handler);
     bool success = AOTCodeCache::store_code_blob(*adapter_blob, AOTCodeEntry::Adapter, id, name);
     assert(success || !AOTCodeCache::is_dumping_adapter(), "caching of adapter must be disabled");
   }
@@ -2991,11 +2997,15 @@ void AdapterHandlerEntry::link() {
 }
 
 void AdapterHandlerLibrary::link_aot_adapters() {
+  uint max_id = 0;
   assert(AOTCodeCache::is_using_adapter(), "AOT adapters code should be available");
-  _aot_adapter_handler_table.iterate([](AdapterHandlerEntry* entry) {
+  _aot_adapter_handler_table.iterate([&](AdapterHandlerEntry* entry) {
     assert(!entry->is_linked(), "AdapterHandlerEntry is already linked!");
     entry->link();
+    max_id = MAX2(max_id, entry->id());
   });
+  // Set adapter id to the maximum id found in the AOTCache
+  _id_counter = max_id;
 }
 
 // This method is called during production run to lookup simple adapters
@@ -3360,13 +3370,12 @@ bool AdapterHandlerLibrary::contains(const CodeBlob* b) {
   return found;
 }
 
-const char* AdapterHandlerLibrary::name(AdapterFingerPrint* fingerprint) {
-  return fingerprint->as_basic_args_string();
+const char* AdapterHandlerLibrary::name(AdapterHandlerEntry* handler) {
+  return handler->fingerprint()->as_basic_args_string();
 }
 
-uint32_t AdapterHandlerLibrary::id(AdapterFingerPrint* fingerprint) {
-  unsigned int hash = fingerprint->compute_hash();
-  return hash;
+uint32_t AdapterHandlerLibrary::id(AdapterHandlerEntry* handler) {
+  return handler->id();
 }
 
 void AdapterHandlerLibrary::print_handler_on(outputStream* st, const CodeBlob* b) {

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -684,9 +684,9 @@ class AdapterHandlerEntry : public MetaspaceObj {
   static const int ENTRIES_COUNT = 4;
 
  private:
-  uint _id;
   AdapterFingerPrint* _fingerprint;
   AdapterBlob* _adapter_blob;
+  uint _id;
   bool _linked;
 
   static const char *_entry_names[];
@@ -699,9 +699,9 @@ class AdapterHandlerEntry : public MetaspaceObj {
 #endif
 
   AdapterHandlerEntry(int id, AdapterFingerPrint* fingerprint) :
-    _id(id),
     _fingerprint(fingerprint),
     _adapter_blob(nullptr),
+    _id(id),
     _linked(false)
 #ifdef ASSERT
     , _saved_code(nullptr),

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -684,6 +684,7 @@ class AdapterHandlerEntry : public MetaspaceObj {
   static const int ENTRIES_COUNT = 4;
 
  private:
+  uint _id;
   AdapterFingerPrint* _fingerprint;
   AdapterBlob* _adapter_blob;
   bool _linked;
@@ -697,7 +698,8 @@ class AdapterHandlerEntry : public MetaspaceObj {
   int            _saved_code_length;
 #endif
 
-  AdapterHandlerEntry(AdapterFingerPrint* fingerprint) :
+  AdapterHandlerEntry(int id, AdapterFingerPrint* fingerprint) :
+    _id(id),
     _fingerprint(fingerprint),
     _adapter_blob(nullptr),
     _linked(false)
@@ -720,8 +722,8 @@ class AdapterHandlerEntry : public MetaspaceObj {
   }
 
  public:
-  static AdapterHandlerEntry* allocate(AdapterFingerPrint* fingerprint) {
-    return new(0) AdapterHandlerEntry(fingerprint);
+  static AdapterHandlerEntry* allocate(uint id, AdapterFingerPrint* fingerprint) {
+    return new(0) AdapterHandlerEntry(id, fingerprint);
   }
 
   static void deallocate(AdapterHandlerEntry *handler) {
@@ -772,6 +774,7 @@ class AdapterHandlerEntry : public MetaspaceObj {
   AdapterBlob* adapter_blob() const { return _adapter_blob; }
   bool is_linked() const { return _linked; }
 
+  uint id() const { return _id; }
   AdapterFingerPrint* fingerprint() const { return _fingerprint; }
 
 #ifdef ASSERT
@@ -798,6 +801,7 @@ class ArchivedAdapterTable;
 class AdapterHandlerLibrary: public AllStatic {
   friend class SharedRuntime;
  private:
+  static volatile uint _id_counter; // counter for generating unique adapter ids, range = [1,UINT_MAX]
   static BufferBlob* _buffer; // the temporary code buffer in CodeCache
   static AdapterHandlerEntry* _no_arg_handler;
   static AdapterHandlerEntry* _int_arg_handler;
@@ -837,8 +841,8 @@ class AdapterHandlerLibrary: public AllStatic {
   static void print_handler(const CodeBlob* b) { print_handler_on(tty, b); }
   static void print_handler_on(outputStream* st, const CodeBlob* b);
   static bool contains(const CodeBlob* b);
-  static const char* name(AdapterFingerPrint* fingerprint);
-  static uint32_t id(AdapterFingerPrint* fingerprint);
+  static const char* name(AdapterHandlerEntry* handler);
+  static uint32_t id(AdapterHandlerEntry* handler);
 #ifndef PRODUCT
   static void print_statistics();
 #endif // PRODUCT


### PR DESCRIPTION
This patch assigns unique id to each AdapterHandlerEntry so as to avoid using hash computed from AdapterFingerPrint which may not be unique. Unique id allows AOTCodeCache to locate the AdapterBlob being requested to be loaded.

Testing:
Before this patch `runtime/cds/appcds/aotClassLinking/StringConcatStress.java` emits warning messages in the production run:
```
[0.009s][warning][aot,codecache,stubs] Saved blob's name 'LIIDIIIDL' is different from the expected name 'LIIDIIDL'
[0.009s][warning][aot                ] Failed to link AdapterHandlerEntry (fp=LIIDIIDL) to its code in the AOT code cache
[0.009s][warning][aot,codecache,stubs] Saved blob's name 'IILLLLIIIIII' is different from the expected name 'IILLLLLILIII'
[0.009s][warning][aot                ] Failed to link AdapterHandlerEntry (fp=IILLLLLILIII) to its code in the AOT code cache
```
With this patch, such warnings are not seen at all

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364929](https://bugs.openjdk.org/browse/JDK-8364929): Assign unique id to each AdapterBlob stored in AOTCodeCache (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27553/head:pull/27553` \
`$ git checkout pull/27553`

Update a local copy of the PR: \
`$ git checkout pull/27553` \
`$ git pull https://git.openjdk.org/jdk.git pull/27553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27553`

View PR using the GUI difftool: \
`$ git pr show -t 27553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27553.diff">https://git.openjdk.org/jdk/pull/27553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27553#issuecomment-3347959350)
</details>
