### PR TITLE
8368885: NMT CommandLine tests can check for error better

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/CommandLineDetail.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class CommandLineDetail {
 
-  public static void main(String args[]) throws Exception {
-
-    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-      "-XX:NativeMemoryTracking=detail",
-      "-version");
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotContain("error");
-    output.shouldHaveExitValue(0);
-  }
+    public static void main(String args[]) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+            "-Xlog:nmt=warning",
+            "-XX:NativeMemoryTracking=detail",
+            "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain("NMT initialization failed");
+        output.shouldNotContain("Could not create the Java Virtual Machine.");
+        output.shouldHaveExitValue(0);
+    }
 }

--- a/test/hotspot/jtreg/runtime/NMT/CommandLineSummary.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class CommandLineSummary {
 
-  public static void main(String args[]) throws Exception {
-
-    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-      "-XX:NativeMemoryTracking=summary",
-      "-version");
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotContain("error");
-    output.shouldHaveExitValue(0);
-  }
+    public static void main(String args[]) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+            "-Xlog:nmt=warning",
+            "-XX:NativeMemoryTracking=summary",
+            "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain("NMT initialization failed");
+        output.shouldNotContain("Could not create the Java Virtual Machine.");
+        output.shouldHaveExitValue(0);
+    }
 }


### PR DESCRIPTION
We can check for more specific error text when running the command line tests, the current 'error' string check misses NMT parsing succeeding but NMT initialization failure.

We also fix the indentation of the test files, let's use 4 spaces in the Java source files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368885](https://bugs.openjdk.org/browse/JDK-8368885): NMT CommandLine tests can check for error better (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Author)
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27554/head:pull/27554` \
`$ git checkout pull/27554`

Update a local copy of the PR: \
`$ git checkout pull/27554` \
`$ git pull https://git.openjdk.org/jdk.git pull/27554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27554`

View PR using the GUI difftool: \
`$ git pr show -t 27554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27554.diff">https://git.openjdk.org/jdk/pull/27554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27554#issuecomment-3348069479)
</details>
