### PR TITLE
8368890: open/test/jdk/tools/jpackage/macosx/NameWithSpaceTest.java fails randomly

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -74,10 +75,23 @@ public final class MacHelper {
 
         Path mountPoint = null;
         try {
-            // The first "dict" item of "system-entities" array property contains "mount-point" string property.
-            var plist = readPList(attachExecutor.getOutput()).queryArrayValue("system-entities", false).findFirst().map(PListReader.class::cast).orElseThrow();
-            mountPoint = Path.of(plist.queryValue("mount-point"));
+            // One of "dict" items of "system-entities" array property should contain "mount-point" string property.
+            mountPoint = readPList(attachExecutor.getOutput()).queryArrayValue("system-entities", false).map(PListReader.class::cast).map(dict -> {
+                try {
+                    return dict.queryValue("mount-point");
+                } catch (NoSuchElementException ex) {
+                    return (String)null;
+                }
+            }).filter(Objects::nonNull).map(Path::of).findFirst().orElseThrow();
+        } finally {
+            if (mountPoint == null) {
+                TKit.trace("Unexpected plist file missing `system-entities` array:");
+                attachExecutor.getOutput().forEach(TKit::trace);
+                TKit.trace("Done");
+            }
+        }
 
+        try {
             // code here used to copy just <runtime name> or <app name>.app
             // We now have option to include arbitrary content, so we copy
             // everything in the mounted image.


### PR DESCRIPTION
Fix regression from [JDK-8358723](https://bugs.openjdk.org/browse/JDK-8358723).

Without the fix, the test failed 3 times out of 100 executions. With the fix, it didn't fail after 200 executions in the same environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368890](https://bugs.openjdk.org/browse/JDK-8368890): open/test/jdk/tools/jpackage/macosx/NameWithSpaceTest.java fails randomly (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27555/head:pull/27555` \
`$ git checkout pull/27555`

Update a local copy of the PR: \
`$ git checkout pull/27555` \
`$ git pull https://git.openjdk.org/jdk.git pull/27555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27555`

View PR using the GUI difftool: \
`$ git pr show -t 27555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27555.diff">https://git.openjdk.org/jdk/pull/27555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27555#issuecomment-3349001014)
</details>
