### PR TITLE
8368501: Shenandoah: GC progress evaluation does not use generation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -115,8 +115,7 @@ void ShenandoahDegenGC::op_degenerated() {
   }
 #endif
 
-  ShenandoahMetricsSnapshot metrics(_generation);
-  metrics.snap_before();
+  ShenandoahMetricsSnapshot metrics(heap->free_set());
 
   switch (_degen_point) {
     // The cases below form the Duff's-like device: it describes the actual GC cycle,
@@ -307,8 +306,6 @@ void ShenandoahDegenGC::op_degenerated() {
   if (VerifyAfterGC) {
     Universe::verify();
   }
-
-  metrics.snap_after();
 
   // Decide if this cycle made good progress, and, if not, should it upgrade to a full GC.
   const bool progress = metrics.is_good_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -106,8 +106,7 @@ void ShenandoahFullGC::entry_full(GCCause::Cause cause) {
 void ShenandoahFullGC::op_full(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
 
-  ShenandoahMetricsSnapshot metrics(heap->global_generation());
-  metrics.snap_before();
+  ShenandoahMetricsSnapshot metrics(heap->free_set());
 
   // Perform full GC
   do_it(cause);
@@ -115,8 +114,6 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
   if (heap->mode()->is_generational()) {
     ShenandoahGenerationalFullGC::handle_completion(heap);
   }
-
-  metrics.snap_after();
 
   if (metrics.is_good_progress()) {
     heap->notify_gc_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahMetrics.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMetrics.cpp
@@ -28,45 +28,21 @@
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahMetrics.hpp"
 
-ShenandoahMetricsSnapshot::ShenandoahMetricsSnapshot(ShenandoahGeneration* generation)
-: _generation(generation), _used_before(0), _used_after(0), _if_before(0), _if_after(0), _ef_before(0), _ef_after(0) {
+ShenandoahMetricsSnapshot::ShenandoahMetricsSnapshot(ShenandoahFreeSet* free_set)
+  : _free_set(free_set)
+  , _used_before(free_set->used())
+  , _if_before(free_set->internal_fragmentation())
+  , _ef_before(free_set->external_fragmentation()) {
 }
-
-void ShenandoahMetricsSnapshot::snap_before() {
-  const ShenandoahHeap* heap = ShenandoahHeap::heap();
-  _used_before = _generation->used();
-  _if_before = heap->free_set()->internal_fragmentation();
-  _ef_before = heap->free_set()->external_fragmentation();
-}
-void ShenandoahMetricsSnapshot::snap_after() {
-  const ShenandoahHeap* heap = ShenandoahHeap::heap();
-  _used_after = _generation->used();
-  _if_after = heap->free_set()->internal_fragmentation();
-  _ef_after = heap->free_set()->external_fragmentation();
-}
-
-// For degenerated GC, generation is Young in generational mode, Global in non-generational mode.
-// For full GC, generation is always Global.
-//
-// Note that the size of the chosen collection set is proportional to the relevant generation's collection set.
-// Note also that the generation size may change following selection of the collection set, as a side effect
-// of evacuation.  Evacuation may promote objects, causing old to grow and young to shrink.  Or this may be a
-// mixed evacuation.  When old regions are evacuated, this typically allows young to expand.  In all of these
-// various scenarios, the purpose of asking is_good_progress() is to determine if there is enough memory available
-// within young generation to justify making an attempt to perform a concurrent collection.  For this reason, we'll
-// use the current size of the generation (which may not be different than when the collection set was chosen) to
-// assess how much free memory we require in order to consider the most recent GC to have had good progress.
 
 bool ShenandoahMetricsSnapshot::is_good_progress() const {
   // Under the critical threshold?
-  const ShenandoahHeap* heap = ShenandoahHeap::heap();
-  const ShenandoahFreeSet* free_set = heap->free_set();
-  const size_t free_actual   = free_set->available();
+  const size_t free_actual = _free_set->available();
   assert(free_actual != ShenandoahFreeSet::FreeSetUnderConstruction, "Avoid this race");
 
-  // ShenandoahCriticalFreeThreshold is expressed as a percentage.  We multiple this percentage by 1/100th
-  // of the generation capacity to determine whether the available memory within the generation exceeds the
-  // critical threshold.
+  // ShenandoahCriticalFreeThreshold is expressed as a percentage.  We multiply this percentage by 1/100th
+  // of the soft max capacity to determine whether the available memory within the mutator partition of the
+  // freeset exceeds the critical threshold.
   const size_t free_expected = (ShenandoahHeap::heap()->soft_max_capacity() / 100) * ShenandoahCriticalFreeThreshold;
   const bool prog_free = free_actual >= free_expected;
   log_info(gc, ergo)("%s progress for free space: " PROPERFMT ", need " PROPERFMT,
@@ -76,7 +52,8 @@ bool ShenandoahMetricsSnapshot::is_good_progress() const {
   }
 
   // Freed up enough?
-  const size_t progress_actual   = (_used_before > _used_after) ? _used_before - _used_after : 0;
+  const size_t used_after = _free_set->used();
+  const size_t progress_actual   = (_used_before > used_after) ? _used_before - used_after : 0;
   const size_t progress_expected = ShenandoahHeapRegion::region_size_bytes();
   const bool prog_used = progress_actual >= progress_expected;
   log_info(gc, ergo)("%s progress for used space: " PROPERFMT ", need " PROPERFMT,
@@ -86,7 +63,8 @@ bool ShenandoahMetricsSnapshot::is_good_progress() const {
   }
 
   // Internal fragmentation is down?
-  const double if_actual = _if_before - _if_after;
+  const double if_after = _free_set->internal_fragmentation();
+  const double if_actual = _if_before - if_after;
   const double if_expected = 0.01; // 1% should be enough
   const bool prog_if = if_actual >= if_expected;
   log_info(gc, ergo)("%s progress for internal fragmentation: %.1f%%, need %.1f%%",
@@ -97,7 +75,8 @@ bool ShenandoahMetricsSnapshot::is_good_progress() const {
   }
 
   // External fragmentation is down?
-  const double ef_actual = _ef_before - _ef_after;
+  const double ef_after = _free_set->external_fragmentation();
+  const double ef_actual = _ef_before - ef_after;
   const double ef_expected = 0.01; // 1% should be enough
   const bool prog_ef = ef_actual >= ef_expected;
   log_info(gc, ergo)("%s progress for external fragmentation: %.1f%%, need %.1f%%",

--- a/src/hotspot/share/gc/shenandoah/shenandoahMetrics.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMetrics.hpp
@@ -25,21 +25,19 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHMETRICS_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHMETRICS_HPP
 
-#include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahFreeSet.hpp"
 
 class ShenandoahMetricsSnapshot : public StackObj {
 private:
-  ShenandoahGeneration* _generation;
-  size_t _used_before, _used_after;
-  double _if_before, _if_after;
-  double _ef_before, _ef_after;
+  ShenandoahFreeSet* _free_set;
+  size_t _used_before;
+  double _if_before;
+  double _ef_before;
 
 public:
-  explicit ShenandoahMetricsSnapshot(ShenandoahGeneration* generation);
+  explicit ShenandoahMetricsSnapshot(ShenandoahFreeSet* free_set);
 
-  void snap_before();
-  void snap_after();
-
+  // Decide if the GC made "good" progress (i.e., reduced fragmentation, freed up sufficient memory).
   bool is_good_progress() const;
 };
 


### PR DESCRIPTION
Remove unused `generation` parameter from stop-the-world GC progress evaluation. Also, have `shMetrics` use the freeset for `usage`  details. This is a follow up to a comment from an unrelated PR: https://github.com/openjdk/jdk/pull/27456#issuecomment-3325724362.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368501](https://bugs.openjdk.org/browse/JDK-8368501): Shenandoah: GC progress evaluation does not use generation (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27561/head:pull/27561` \
`$ git checkout pull/27561`

Update a local copy of the PR: \
`$ git checkout pull/27561` \
`$ git pull https://git.openjdk.org/jdk.git pull/27561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27561`

View PR using the GUI difftool: \
`$ git pr show -t 27561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27561.diff">https://git.openjdk.org/jdk/pull/27561.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27561#issuecomment-3349126337)
</details>
