### PR TITLE
8368809: JFR: Remove events from testSettingConfiguration in TestActiveSettingEvent

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -245,28 +245,6 @@ public final class TestActiveSettingEvent {
         System.out.println("Testing configuration " + configurationName);
         Configuration c = Configuration.getConfiguration(configurationName);
         Map<String, String> settingValues = c.getSettings();
-        // Don't want to add these settings to the jfc-files we ship since they
-        // are not useful to configure. They are however needed to make the test
-        // pass.
-        settingValues.put(EventNames.ActiveSetting + "#stackTrace", "false");
-        settingValues.put(EventNames.ActiveSetting + "#threshold", "0 ns");
-        settingValues.put(EventNames.ActiveRecording + "#stackTrace", "false");
-        settingValues.put(EventNames.ActiveRecording + "#threshold", "0 ns");
-        settingValues.put(EventNames.InitialSecurityProperty + "#threshold", "0 ns");
-        settingValues.put(EventNames.JavaExceptionThrow + "#threshold", "0 ns");
-        settingValues.put(EventNames.JavaErrorThrow + "#threshold", "0 ns");
-        settingValues.put(EventNames.SecurityProperty + "#threshold", "0 ns");
-        settingValues.put(EventNames.TLSHandshake + "#threshold", "0 ns");
-        settingValues.put(EventNames.X509Certificate + "#threshold", "0 ns");
-        settingValues.put(EventNames.X509Validation + "#threshold", "0 ns");
-        settingValues.put(EventNames.ProcessStart + "#threshold", "0 ns");
-        settingValues.put(EventNames.Deserialization + "#threshold", "0 ns");
-        settingValues.put(EventNames.VirtualThreadStart + "#threshold", "0 ns");
-        settingValues.put(EventNames.VirtualThreadEnd + "#stackTrace", "false");
-        settingValues.put(EventNames.VirtualThreadEnd + "#threshold", "0 ns");
-        settingValues.put(EventNames.VirtualThreadSubmitFailed + "#threshold", "0 ns");
-        settingValues.put(EventNames.SecurityProviderService + "#threshold", "0 ns");
-
         try (Recording recording = new Recording(c)) {
             Map<Long, EventType> eventTypes = new HashMap<>();
             for (EventType et : FlightRecorder.getFlightRecorder().getEventTypes()) {
@@ -279,7 +257,11 @@ public final class TestActiveSettingEvent {
                     String settingName = type.getName() + "#" + s.getName();
                     String value = settingValues.get(settingName);
                     if (value == null) {
-                        throw new Exception("Could not find setting with name " + settingName);
+                        String message = "Could not find setting with name " + settingName;
+                        if (settingName.equals("duration") || settingName.equals("stackTrace")) {
+                            message +=". Use @RemoveField(\"" + settingName + "\") to drop the field";
+                        }
+                        throw new Exception(message);
                     }
                     // Prefer to have ms unit in jfc file
                     if (value.equals("0 ms")) {

--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -259,7 +259,7 @@ public final class TestActiveSettingEvent {
                     if (value == null) {
                         String message = "Could not find setting with name " + settingName + ".";
                         if (settingName.equals("duration") || settingName.equals("stackTrace")) {
-                            message += " Use @RemoveField(\"" + settingName + "\") to drop the field.";
+                            message += " Use @RemoveFields(\"" + settingName + "\") to drop the field.";
                         }
                         throw new Exception(message);
                     }

--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -257,9 +257,9 @@ public final class TestActiveSettingEvent {
                     String settingName = type.getName() + "#" + s.getName();
                     String value = settingValues.get(settingName);
                     if (value == null) {
-                        String message = "Could not find setting with name " + settingName;
+                        String message = "Could not find setting with name " + settingName + ".";
                         if (settingName.equals("duration") || settingName.equals("stackTrace")) {
-                            message +=". Use @RemoveField(\"" + settingName + "\") to drop the field";
+                            message += " Use @RemoveField(\"" + settingName + "\") to drop the field.";
                         }
                         throw new Exception(message);
                     }


### PR DESCRIPTION
Could I have a review of a PR that removes an old test hack that is no longer needed. 

Testing: jdk/jfr/event/runtime/TestActiveSettingEvent.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368809](https://bugs.openjdk.org/browse/JDK-8368809): JFR: Remove events from testSettingConfiguration in TestActiveSettingEvent (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27565/head:pull/27565` \
`$ git checkout pull/27565`

Update a local copy of the PR: \
`$ git checkout pull/27565` \
`$ git pull https://git.openjdk.org/jdk.git pull/27565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27565`

View PR using the GUI difftool: \
`$ git pr show -t 27565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27565.diff">https://git.openjdk.org/jdk/pull/27565.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27565#issuecomment-3349327934)
</details>
