### PR TITLE
8368938: Remove ObjectWaiter::badObjectWaiterPtr

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -32,6 +32,7 @@
 #include "oops/weakHandle.hpp"
 #include "runtime/javaThread.hpp"
 #include "utilities/checkedCast.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ObjectMonitor;
 class ObjectMonitorContentionMark;


### PR DESCRIPTION
There's apparently no reason against having the symbol shared for all instances. This saves a byte from the memory footprint of `ObjectWaiter`.

Passes tier1 and tier2 (fastdebug).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368938](https://bugs.openjdk.org/browse/JDK-8368938): Remove ObjectWaiter::badObjectWaiterPtr (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27571/head:pull/27571` \
`$ git checkout pull/27571`

Update a local copy of the PR: \
`$ git checkout pull/27571` \
`$ git pull https://git.openjdk.org/jdk.git pull/27571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27571`

View PR using the GUI difftool: \
`$ git pr show -t 27571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27571.diff">https://git.openjdk.org/jdk/pull/27571.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27571#issuecomment-3351156559)
</details>
