### PR TITLE
8368954: G1: Document why G1 uses TLS storage for the current card table reference

### DIFF
--- a/src/hotspot/share/gc/g1/g1ThreadLocalData.hpp
+++ b/src/hotspot/share/gc/g1/g1ThreadLocalData.hpp
@@ -42,9 +42,9 @@ private:
   //
   // Tests showed that embedding this value in the TLS block is the cheapest
   // way for fast access to this value in the barrier.
-  // E.g. embedding an address to that value directly into the code stream similar
-  // to Serial/Parallel and then loading from that was found to be slower at least
-  // on non-x64, and increases code size a lot.
+  // E.g. embedding an address to that value directly into the code stream and
+  // then loading from that was found to be slower on non-x64 architectures.
+  // Additionally it increases code size a lot.
   G1CardTable::CardValue* _byte_map_base;
 
   // Per-thread cache of pinned object count to reduce atomic operation traffic


### PR DESCRIPTION
Hi all,

  please review some documentation update why G1 now uses TLS storage to get the current card table base value for the card mark.

TLDR: it's the overall fastest currently available way.

Testing: local compilation, this is just a trivial documentation change.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368954](https://bugs.openjdk.org/browse/JDK-8368954): G1: Document why G1 uses TLS storage for the current card table reference (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**) Review applies to [bf0f553e](https://git.openjdk.org/jdk/pull/27573/files/bf0f553e532f60d0dff724acc3c7fa90244a1d90)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) Review applies to [bf0f553e](https://git.openjdk.org/jdk/pull/27573/files/bf0f553e532f60d0dff724acc3c7fa90244a1d90)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27573/head:pull/27573` \
`$ git checkout pull/27573`

Update a local copy of the PR: \
`$ git checkout pull/27573` \
`$ git pull https://git.openjdk.org/jdk.git pull/27573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27573`

View PR using the GUI difftool: \
`$ git pr show -t 27573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27573.diff">https://git.openjdk.org/jdk/pull/27573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27573#issuecomment-3351587052)
</details>
