### PR TITLE
8367026: Reorder the timeout failure handler commands to have jstack run before the rest

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,13 @@ args=%p
 ################################################################################
 # process info to gather
 ################################################################################
+# It's important to retain the order of these actions and run the thread dump
+# generating commands before the rest, to allow for capturing the test
+# process' call stack as soon as the timeout has occurred. That reduces the chances
+# of the test completing and thus missing crucial details from the thread dump
+# while these timeout actions were being run.
 onTimeout=\
+  thread_dump \
   jinfo \
   jcmd.compiler.codecache jcmd.compiler.codelist \
         jcmd.compiler.queue \
@@ -63,9 +69,13 @@ jcmd.thread.dump_to_file.params.successArtifacts=JavaThread.dump.%p.%iterCount
 
 jcmd.thread.vthread_scheduler.args=%p Thread.vthread_scheduler
 
+# use jstack to generate one thread dump
+thread_dump.app=jstack
+thread_dump.args=-e -l %p
+
 jstack.app=jstack
 jstack.args=-e -l %p
-jstack.params.repeat=6
+jstack.params.repeat=5
 
 jhsdb.app=jhsdb
 jhsdb.jstack.live.default.args=jstack --pid %p


### PR DESCRIPTION
Can I please get a review of this change to a jtreg failure handler configured in the JDK?

The change proposes to generate a thread dump much sooner than previously whenever a test times out. This should thus capture a much more accurate state of the test process when the test is considered timed out.

Due to the recent changes in the default timeout factor, we have noticed some tests which timeout and the jtreg failure handler actions start execution. While those are being executed the test sometimes completes. So by the time the "jstack" failure handler action is executed (can be several seconds later), the test's state will no longer be accurate.

The change here generates a thread dump using jstack as the first action in the set of failure handler actions. It does it only once and then moves to the rest of the actions, one of which subsequent "jstack" which generates thread dumps more than once.

I have verified that this change works as expected when a test times out. The action is named "thread_dump" instead of just reusing the "jstack" name because the current HTML rendering of the processes.html runs into trouble if there are more than one action with the same name.

I wanted to reorder some of the other commands in that set, but it causes some trouble in the rendering of the HTML and would require some changes to that part. So I decided to keep this simple and have it done sooner to help investigating timeout failures in our CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367026](https://bugs.openjdk.org/browse/JDK-8367026): Reorder the timeout failure handler commands to have jstack run before the rest (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27574/head:pull/27574` \
`$ git checkout pull/27574`

Update a local copy of the PR: \
`$ git checkout pull/27574` \
`$ git pull https://git.openjdk.org/jdk.git pull/27574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27574`

View PR using the GUI difftool: \
`$ git pr show -t 27574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27574.diff">https://git.openjdk.org/jdk/pull/27574.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27574#issuecomment-3351626158)
</details>
