### PR TITLE
8368780: IGV: Upgrade to Netbeans Platform 27

### DIFF
--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -78,8 +78,8 @@
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                      <version>[17,22)</version>
-                                      <message>IGV requires a JDK version between 17 and 21</message>
+                                        <version>[17,26)</version>
+                                        <message>IGV requires a JDK version between 17 and 25</message>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -58,6 +58,9 @@
                     <version>${mvncompilerplugin.version}</version>
                     <configuration>
                         <release>17</release>
+                        <compilerArgs>
+                            <arg>-proc:full</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -109,7 +112,7 @@
         <module>View</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE200</netbeans.version>
+        <netbeans.version>RELEASE270</netbeans.version>
         <swinglayouts.version>1.0.2</swinglayouts.version>
         <nbmmvnplugin.version>3.7</nbmmvnplugin.version>
         <mvncompilerplugin.version>3.12.1</mvncompilerplugin.version>


### PR DESCRIPTION
This PR upgrades IGV and its dependencies to the newest Netbeans Platform 27, released on August 21, 2025. It also supports running the latest (LTS) JDK 25. 

It has been tested that IGV still behaves as expected after the upgrade.