### PR TITLE
8368968: FloatingDecimal: Clean up unused code

### DIFF
--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -1549,8 +1549,7 @@ public class FloatingDecimal{
         // Discover obvious special cases of NaN and Infinity.
         if ( binExp == (int)(DoubleConsts.EXP_BIT_MASK>>EXP_SHIFT) ) {
             if ( fractBits == 0L ){
-                throw new IllegalArgumentException((isNegative ? "-" : "+") + INFINITY_REP
-                );
+                throw new IllegalArgumentException((isNegative ? "-" : "") + INFINITY_REP);
             } else {
                 throw new IllegalArgumentException(NAN_REP);
             }


### PR DESCRIPTION
This is a followup to https://github.com/openjdk/jdk/pull/27118, to clean up resulting unused code.
- remove `getChars`, `isExceptional` and `isNegative` 
- remove `ExceptionalBinaryToASCIIBuffer`; throws `IllegalArgumentException` instead of returning an instance of that.(Caller already asserts non-exceptional arg)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368968](https://bugs.openjdk.org/browse/JDK-8368968): FloatingDecimal: Clean up unused code (**Enhancement** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27581/head:pull/27581` \
`$ git checkout pull/27581`

Update a local copy of the PR: \
`$ git checkout pull/27581` \
`$ git pull https://git.openjdk.org/jdk.git pull/27581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27581`

View PR using the GUI difftool: \
`$ git pr show -t 27581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27581.diff">https://git.openjdk.org/jdk/pull/27581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27581#issuecomment-3353080283)
</details>
