### PR TITLE
8360702: runtime/Thread/AsyncExceptionTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -90,6 +90,5 @@ vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.ja
 gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
 gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
-runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all
 runtime/handshake/HandshakeWalkStackTest.java 0000000 generic-all

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
@@ -44,9 +44,13 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
     public static native int exitRawMonitor();
     public static native void destroyRawMonitor();
 
+    // Avoid using CountDownLatch or similar objects that require unparking the
+    // main thread. Otherwise, if the main thread is run as a virtual thread, the
+    // async exception could be sent while the target is still executing FJP logic.
+    public volatile boolean started = false;
+    public volatile boolean gotMonitor = false;
+
     private static Object o1 = new Object();
-    private static boolean firstWorker = true;
-    private static Semaphore sem = new Semaphore(0);
 
     @Override
     public void run() {
@@ -59,11 +63,9 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
 
     public void testWithJavaMonitor() {
         try {
+            started = true;
             synchronized (o1) {
-                if (firstWorker) {
-                    firstWorker = false;
-                    sem.release();
-                }
+                gotMonitor = true;
                 Thread.sleep(1000);
             }
         } catch (ThreadDeath td) {
@@ -74,20 +76,16 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
 
 
     public void testWithJVMTIRawMonitor() {
-        boolean savedFirst = false;
+        started = true;
         try {
             int retCode = enterRawMonitor();
-            if (retCode != 0 && firstWorker) {
+            if (retCode != 0) {
                 throw new RuntimeException("error in JVMTI RawMonitorEnter: retCode=" + retCode);
             }
-            if (firstWorker) {
-                firstWorker = false;
-                savedFirst = true;
-                sem.release();
-            }
-            Thread.sleep(1000);
+            gotMonitor = true;
+            Thread.sleep(500);
             retCode = exitRawMonitor();
-            if (retCode != 0 && savedFirst) {
+            if (retCode != 0) {
                 throw new RuntimeException("error in JVMTI RawMonitorExit: retCode=" + retCode);
             }
         } catch (ThreadDeath td) {
@@ -133,15 +131,18 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
             AsyncExceptionOnMonitorEnter worker2 = new AsyncExceptionOnMonitorEnter();
 
             try {
-                // Start firstWorker worker and wait until monitor is acquired
-                firstWorker = true;
+                // Start first worker and wait until monitor is acquired
                 worker1.start();
-                sem.acquire();
+                while (!worker1.gotMonitor) {
+                    Thread.sleep(1);
+                }
 
                 // Start second worker and allow some time for target to block on monitorenter
                 // before executing Thread.stop()
                 worker2.start();
-                Thread.sleep(300);
+                while (!worker2.started) {
+                    Thread.sleep(10);
+                }
 
                 while (true) {
                     JVMTIUtils.stopThread(worker2);
@@ -150,6 +151,8 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
                         // not released worker2 will deadlock on enter
                         JVMTIUtils.stopThread(worker1);
                     }
+                    // Give time to throw exception
+                    Thread.sleep(10);
 
                     if (!worker1.isAlive() && !worker2.isAlive()) {
                         // Done with Thread.stop() calls since

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -49,9 +49,11 @@ public class AsyncExceptionTest extends Thread {
     private final static int DEF_TIME_MAX = 30;  // default max # secs to test
     private final static String PROG_NAME = "AsyncExceptionTest";
 
-    public CountDownLatch startSyncObj = new CountDownLatch(1);
+    // Avoid using CountDownLatch or similar objects that require unparking the
+    // main thread. Otherwise, if the main thread is run as a virtual thread, the
+    // async exception could be sent while the target is still executing FJP logic.
+    public volatile boolean started = false;
 
-    private boolean firstEntry = true;
     private boolean receivedThreadDeathinInternal1 = false;
     private boolean receivedThreadDeathinInternal2 = false;
     private volatile RuntimeException error = null;
@@ -76,6 +78,7 @@ public class AsyncExceptionTest extends Thread {
     }
 
     public void internalRun1() {
+        started = true;
         try {
             while (!receivedThreadDeathinInternal2) {
               internalRun2();
@@ -89,12 +92,6 @@ public class AsyncExceptionTest extends Thread {
         try {
             Integer myLocalCount = 1;
             Integer myLocalCount2 = 1;
-
-            if (firstEntry) {
-                // Tell main thread we have started.
-                startSyncObj.countDown();
-                firstEntry = false;
-            }
 
             while(myLocalCount > 0) {
                 myLocalCount2 = (myLocalCount % 3) / 2;
@@ -128,7 +125,9 @@ public class AsyncExceptionTest extends Thread {
             thread.start();
             try {
                 // Wait for the worker thread to get going.
-                thread.startSyncObj.await();
+                while (!thread.started) {
+                    Thread.sleep(1);
+                }
                 // Send async exception and wait until it is thrown
                 JVMTIUtils.stopThread(thread);
                 thread.join();


### PR DESCRIPTION
Please review this small test fix. To make sure the worker thread receives the async exception at a safe place, we should avoid using synchronization objects where the worker thread might need to unpark the main thread. Otherwise, if the main thread is virtual, the async exception might be set while the worker is still executing FJP code. See JBS comments for more detail.

I fixed test AsyncExceptionOnMonitorEnter.java too and removed it from test/hotspot/jtreg/ProblemList-Virtual.txt. The alternative was to problem list AsyncExceptionTest.java, but I think it’s better if we can just keep the tests for this mode too.

Thanks,
Patricio