### PR TITLE
JDK-8365424 : [macos26] java/awt/Frame/DisposeTest.java fails on macOS 26

### DIFF
--- a/test/jdk/java/awt/Frame/DisposeTest.java
+++ b/test/jdk/java/awt/Frame/DisposeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,13 @@ import java.io.IOException;
  * @bug 4127271
  * @summary Tests that disposing of a Frame with MenuBar removes all traces
  *          of the Frame from the screen.
+ * @run main/othervm -Dsun.java2d.uiScale=1 DisposeTest
  */
 
 public class DisposeTest {
     private static Frame backgroundFrame;
     private static Frame testedFrame;
+    private static final int PIXEL_OFFSET = 4;
 
     private static final Rectangle backgroundFrameBounds =
             new Rectangle(100, 100, 200, 200);
@@ -74,8 +76,8 @@ public class DisposeTest {
         BufferedImage bi = robot.createScreenCapture(backgroundFrameBounds);
         int redPix = Color.RED.getRGB();
 
-        for (int x = 0; x < bi.getWidth(); x++) {
-            for (int y = 0; y < bi.getHeight(); y++) {
+        for (int x = PIXEL_OFFSET; x < bi.getWidth() - PIXEL_OFFSET; x++) {
+            for (int y = PIXEL_OFFSET; y < bi.getHeight() - PIXEL_OFFSET; y++) {
                 if (bi.getRGB(x, y) != redPix) {
                     try {
                         ImageIO.write(bi, "png",

--- a/test/jdk/java/awt/Frame/DisposeTest.java
+++ b/test/jdk/java/awt/Frame/DisposeTest.java
@@ -39,7 +39,6 @@ import java.io.IOException;
  * @bug 4127271
  * @summary Tests that disposing of a Frame with MenuBar removes all traces
  *          of the Frame from the screen.
- * @run main/othervm -Dsun.java2d.uiScale=1 DisposeTest
  */
 
 public class DisposeTest {


### PR DESCRIPTION
This test fails on macOS 26 due to slight color mismatch at background frame edges. A offset of 4 pixels is added as fix.

CI testing passes on other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365424](https://bugs.openjdk.org/browse/JDK-8365424): [macos26] java/awt/Frame/DisposeTest.java fails on macOS 26 (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27585/head:pull/27585` \
`$ git checkout pull/27585`

Update a local copy of the PR: \
`$ git checkout pull/27585` \
`$ git pull https://git.openjdk.org/jdk.git pull/27585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27585`

View PR using the GUI difftool: \
`$ git pr show -t 27585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27585.diff">https://git.openjdk.org/jdk/pull/27585.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27585#issuecomment-3354157854)
</details>
