### PR TITLE
JDK-8368997: AIX allows reading from address zero which leads to several ubsan findings

### DIFF
--- a/src/hotspot/os/posix/safefetch_sigjmp.cpp
+++ b/src/hotspot/os/posix/safefetch_sigjmp.cpp
@@ -67,6 +67,14 @@ ATTRIBUTE_NO_ASAN static bool _SafeFetchXX_internal(const T *adr, T* result) {
 
   T n = 0;
 
+#ifdef AIX
+  // AIX allows reading from nullptr without signalling
+  if (adr == nullptr) {
+    *result = 0;
+    return false;
+  }
+#endif
+
   // Set up a jump buffer. Anchor its pointer in TLS. Then read from the unsafe address.
   // If that address was invalid, we fault, and in the signal handler we will jump back
   // to the jump point.


### PR DESCRIPTION
In _SafeFetchXX_internal() a pointer is checked for readability before using. It returns false if this is not the case. The implementation tries to read from the pointer if this is not feasible the signal handler comes into place jumping back to the function via longjmp, so the _SafeFetchXX_internal() itself can return with a false and a null as pseudo content of the address. If the address was readable the function returns true and provides the content of the address.
Because AIX allows reading from address zero, _SafeFetchXX_internal() returns true and follow up functions using the address are called. All these functions end up in an UBSAN finding regarding reading from zero.
The solution could be to manually code that also AIX behaves like other operating systems and returns false and the content zero in case of address zero. Then no UBSAN finding occur.