### PR TITLE
8368670: Deadlock in JFR on event register + class load

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -291,7 +291,7 @@ public final class MetadataRepository {
         }
     }
 
-    synchronized boolean isEnabled(String eventName) {
+    boolean isEnabled(String eventName) {
         return settingsManager.isEnabled(eventName);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -130,10 +130,12 @@ final class SettingsManager {
     }
 
    private Map<String, InternalSetting> availableSettings = new LinkedHashMap<>();
+   private Set<String> enabled = HashSet.newHashSet(0);
 
     void setSettings(List<Map<String, String>> activeSettings, boolean writeSettingEvents) {
         // store settings so they are available if a new event class is loaded
         availableSettings = createSettingsMap(activeSettings);
+        createEnabled();
         List<EventControl> eventControls = MetadataRepository.getInstance().getEventControls();
         if (!JVM.isRecording()) {
             for (EventControl ec : eventControls) {
@@ -151,6 +153,16 @@ final class SettingsManager {
         if (JVM.getAllowedToDoEventRetransforms()) {
             updateRetransform(JVM.getAllEventClasses());
         }
+    }
+
+    private synchronized void createEnabled() {
+        Set<String> set = HashSet.newHashSet(availableSettings.size());
+        for (var entry : availableSettings.entrySet()) {
+            if (entry.getValue().isEnabled()) {
+                set.add(entry.getKey());
+            }
+        }
+        enabled = set;
     }
 
     public void updateRetransform(List<Class<? extends jdk.internal.event.Event>> eventClasses) {
@@ -290,11 +302,7 @@ final class SettingsManager {
         return sb.toString();
     }
 
-    boolean isEnabled(String eventName) {
-        InternalSetting is = availableSettings.get(eventName);
-        if (is == null) {
-            return false;
-        }
-        return is.isEnabled();
+    synchronized boolean isEnabled(String eventName) {
+        return enabled.contains(eventName);
     }
 }


### PR DESCRIPTION
Could I have review of PR that prevents a deadlock. The MetadataRepository::isEnabled is an optimization that delays instrumenting a JFR event class that is disabled. There are multiple ways this can be addressed:

- **Remove the MetadataRepository::isEnabled check all together**
Con: The JIT would not be able to remove dead code if disabled events get instrumented

- **Use ReentrantLock instead of synchronized, so ReentrantLock::tryLock could be used.**
Con: It's rather large change and not that suitable for a backport. The code would be harder to read.

Testing: jdk/jdk/jfr

Thanks
Erik