### PR TITLE
8368698: runtime/cds/appcds/aotCache/OldClassSupport.java assert(can_add()) failed: Cannot add TrainingData objects

### DIFF
--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -328,7 +328,9 @@ void CompileTrainingData::notice_jit_observation(ciEnv* env, ciBaseObject* what)
         // This JIT task is (probably) requesting that ik be initialized,
         // so add him to my _init_deps list.
         TrainingDataLocker l;
-        add_init_dep(ktd);
+        if (l.can_add()) {
+          add_init_dep(ktd);
+        }
       }
     }
   }


### PR DESCRIPTION
That's a bit of a bug trail from [JDK-8366948](https://bugs.openjdk.org/browse/JDK-8366948). We need to check if the TD snapshot has happened before attempting to modify the data.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368698](https://bugs.openjdk.org/browse/JDK-8368698): runtime/cds/appcds/aotCache/OldClassSupport.java assert(can_add()) failed: Cannot add TrainingData objects (**Bug** - P4)


### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27593/head:pull/27593` \
`$ git checkout pull/27593`

Update a local copy of the PR: \
`$ git checkout pull/27593` \
`$ git pull https://git.openjdk.org/jdk.git pull/27593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27593`

View PR using the GUI difftool: \
`$ git pr show -t 27593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27593.diff">https://git.openjdk.org/jdk/pull/27593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27593#issuecomment-3357774903)
</details>
