### PR TITLE
8304811: vmTestbase/vm/mlvm/indy/func/jvmti/stepBreakPopReturn/INDIFY_Test.java fails with JVMTI_ERROR_TYPE_MISMATCH

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/stepBreakPopReturn/stepBreakPopReturn.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/stepBreakPopReturn/stepBreakPopReturn.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ MethodEntry(jvmtiEnv *jvmti_env,
             gIsMethodEntryWorking = JNI_TRUE;
 
             if (!gIsBreakpointSet)
-                NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, nullptr));
+                NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thread));
         }
     }
 
@@ -116,7 +116,7 @@ SingleStep(jvmtiEnv *jvmti_env,
         free(locStr);
     }
 
-    NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, nullptr));
+    NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, thread));
 
     if (!gIsDebuggerCompatible) {
         if (!NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(method, location)))


### PR DESCRIPTION
The change fixes the test which intermittently fails.

The test requests MethodEntry. SingleStep and Breakpoint events globally (from all threads).
MethodEntry handler checks location (to be expected test method);
Breakpoint request specifies location in the testes method, only test threads calls the method;
SingleStep handler has no checks for thread or location. So once SingleStep event is enabled, event from other thread can be posted first (or several events from different threads).
The fix enables SingleStep event only for test thread (we get it in MethodEntry)

testing: tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304811](https://bugs.openjdk.org/browse/JDK-8304811): vmTestbase/vm/mlvm/indy/func/jvmti/stepBreakPopReturn/INDIFY_Test.java fails with JVMTI_ERROR_TYPE_MISMATCH (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27598/head:pull/27598` \
`$ git checkout pull/27598`

Update a local copy of the PR: \
`$ git checkout pull/27598` \
`$ git pull https://git.openjdk.org/jdk.git pull/27598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27598`

View PR using the GUI difftool: \
`$ git pr show -t 27598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27598.diff">https://git.openjdk.org/jdk/pull/27598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27598#issuecomment-3358461073)
</details>
