### PR TITLE
8368781: PerfMemory - make issues more transparent

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -72,7 +72,7 @@ static char* create_standard_memory(size_t size) {
 
   // commit memory
   if (!os::commit_memory(mapAddress, size, !ExecMem)) {
-    log_debug(perf)("Could not commit PerfData memory");
+    log_debug(perf)("could not commit PerfData memory");
     os::release_memory(mapAddress, size);
     return nullptr;
   }
@@ -674,7 +674,7 @@ static void remove_file(const char* path) {
   RESTARTABLE(::unlink(path), result);
   if (log_is_enabled(Debug, perf) && result == OS_ERR) {
     if (errno != ENOENT) {
-      log_debug(perf)("Could not unlink shared memory backing store file %s : %s",
+      log_debug(perf)("could not unlink shared memory backing store file %s : %s",
                       path, os::strerror(errno));
     }
   }
@@ -1039,7 +1039,7 @@ static char* mmap_create_shared(size_t size) {
   assert(result != OS_ERR, "could not close file");
 
   if (mapAddress == MAP_FAILED) {
-    log_debug(perf)("mmap failed -  %s", os::strerror(errno));
+    log_debug(perf)("mmap failed - %s", os::strerror(errno));
     remove_file(filename);
     FREE_C_HEAP_ARRAY(char, filename);
     return nullptr;

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -63,7 +63,7 @@ static char* create_standard_memory(size_t size) {
 
   // commit memory
   if (!os::commit_memory(mapAddress, size, !ExecMem)) {
-    log_debug(perf)("Could not commit PerfData memory");
+    log_debug(perf)("could not commit PerfData memory");
     os::release_memory(mapAddress, size);
     return nullptr;
   }
@@ -89,20 +89,20 @@ static void delete_standard_memory(char* addr, size_t size) {
 static void save_memory_to_file(char* addr, size_t size) {
 
   const char* destfile = PerfMemory::get_perfdata_file_path();
-  assert(destfile[0] != '\0', "invalid Perfdata file path");
+  assert(destfile[0] != '\0', "invalid PerfData file path");
 
   int fd = ::_open(destfile, _O_BINARY|_O_CREAT|_O_WRONLY|_O_TRUNC,
                    _S_IREAD|_S_IWRITE);
 
   if (fd == OS_ERR) {
-    log_debug(perf)("Could not create Perfdata save file: %s: %s",
+    log_debug(perf)("could not create PerfData save file: %s: %s",
                     destfile, os::strerror(errno));
   } else {
     for (size_t remaining = size; remaining > 0;) {
 
       int nbytes = ::_write(fd, addr, (unsigned int)remaining);
       if (nbytes == OS_ERR) {
-        log_debug(perf)("Could not write Perfdata save file: %s: %s",
+        log_debug(perf)("could not write PerfData save file: %s: %s",
                         destfile, os::strerror(errno));
         break;
       }
@@ -113,7 +113,7 @@ static void save_memory_to_file(char* addr, size_t size) {
 
     int result = ::_close(fd);
     if (result == OS_ERR) {
-      log_debug(perf)("Could not close %s: %s", destfile, os::strerror(errno));
+      log_debug(perf)("could not close %s: %s", destfile, os::strerror(errno));
     }
   }
 
@@ -242,7 +242,7 @@ static bool is_directory_secure(const char* path) {
     // this is either a regular file or some other type of file,
     // any of which are unexpected and therefore insecure.
     //
-    log_debug(perf)("%s is not a directory, file attributes = "
+    log_debug(perf)("%s is not a directory, file attributes : "
                     INTPTR_FORMAT, path, fa);
     return false;
   }
@@ -480,7 +480,7 @@ static void remove_file(const char* dirname, const char* filename) {
 
   if (::unlink(path) == OS_ERR) {
     if (errno != ENOENT) {
-      log_debug(perf)("Could not unlink shared memory backing store file %s : %s",
+      log_debug(perf)("could not unlink shared memory backing store file %s : %s",
                       path, os::strerror(errno));
     }
   }
@@ -1173,7 +1173,7 @@ static bool make_user_tmp_dir(const char* dirname) {
       SECURITY_INFORMATION secInfo = DACL_SECURITY_INFORMATION;
       if (!SetFileSecurity(dirname, secInfo, pDirSA->lpSecurityDescriptor)) {
         lasterror = GetLastError();
-        log_debug(perf)("SetFileSecurity failed for %s directory. lasterror %d", dirname, lasterror);
+        log_debug(perf)("SetFileSecurity failed for %s directory. lasterror = %d", dirname, lasterror);
       }
     } else {
       log_debug(perf)("CreateDirectory failed: %d", GetLastError());
@@ -1269,7 +1269,7 @@ static HANDLE create_sharedmem_resources(const char* dirname, const char* filena
     struct stat statbuf;
     int ret_code = ::stat(filename, &statbuf);
     if (ret_code == OS_ERR) {
-      log_debug(perf)("Could not get status information from file %s: %s",
+      log_debug(perf)("could not get status information from file %s: %s",
                       filename, os::strerror(errno));
       CloseHandle(fmh);
       CloseHandle(fh);

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -114,7 +114,7 @@ void PerfMemory::initialize() {
     // the warning is issued only in debug mode in order to avoid
     // additional output to the stdout or stderr output streams.
     //
-    log_debug(perf)("Could not create PerfData Memory region, reverting to malloc");
+    log_debug(perf)("could not create PerfData Memory region, reverting to malloc");
 
     _prologue = NEW_C_HEAP_OBJ(PerfDataPrologue, mtInternal);
   }
@@ -248,7 +248,7 @@ char* PerfMemory::get_perfdata_file_path() {
     if(!Arguments::copy_expand_pid(PerfDataSaveFile, strlen(PerfDataSaveFile),
                                    dest_file, JVM_MAXPATHLEN)) {
       FREE_C_HEAP_ARRAY(char, dest_file);
-      log_debug(perf)("Invalid performance data file path name specified, fall back to a default name");
+      log_debug(perf)("invalid performance data file path name specified, fall back to a default name");
     } else {
       return dest_file;
     }


### PR DESCRIPTION
Currently issues with perfMemory like problems with the secure tmp subdirectory creation are not very transparent in release JVMs.

There exists some warnings traces but they are behind develop flags like Verbose so only available in debug JVMs.
We could (in case of issues) store some information and write it later into hsinfo/hserr files ; or make the existing warnings available too in release JVMs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368781](https://bugs.openjdk.org/browse/JDK-8368781): PerfMemory - make issues more transparent (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27602/head:pull/27602` \
`$ git checkout pull/27602`

Update a local copy of the PR: \
`$ git checkout pull/27602` \
`$ git pull https://git.openjdk.org/jdk.git pull/27602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27602`

View PR using the GUI difftool: \
`$ git pr show -t 27602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27602.diff">https://git.openjdk.org/jdk/pull/27602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27602#issuecomment-3359868697)
</details>
