### PR TITLE
8369037: Identify owning method for MethodData and MethodCounters in AOT map output

### DIFF
--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -348,6 +348,12 @@ void AOTMapLogger::log_metaspace_objects_impl(address region_base, address regio
     case MetaspaceObj::MethodType:
       log_method((Method*)src, requested_addr, type_name, bytes, current);
       break;
+    case MetaspaceObj::MethodCountersType:
+      log_method_counter((MethodCounters*)src, requested_addr, type_name, bytes, current);
+      break;
+    case MetaspaceObj::MethodDataType:
+      log_method_data((MethodData*)src, requested_addr, type_name, bytes, current);
+      break;
     case MetaspaceObj::SymbolType:
       log_symbol((Symbol*)src, requested_addr, type_name, bytes, current);
       break;
@@ -387,6 +393,18 @@ void AOTMapLogger::log_const_method(ConstMethod* cm, address requested_addr, con
                                     int bytes, Thread* current) {
   ResourceMark rm(current);
   log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  cm->method()->external_name());
+}
+
+void AOTMapLogger::log_method_counter(MethodCounters* mc, address requested_addr, const char* type_name,
+                                    int bytes, Thread* current) {
+  ResourceMark rm(current);
+  log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  mc->method()->external_name());
+}
+
+void AOTMapLogger::log_method_data(MethodData* md, address requested_addr, const char* type_name,
+                                    int bytes, Thread* current) {
+  ResourceMark rm(current);
+  log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  md->method()->external_name());
 }
 
 void AOTMapLogger::log_klass(Klass* k, address requested_addr, const char* type_name,

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -33,6 +33,8 @@
 #include "memory/metaspaceClosure.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/method.hpp"
+#include "oops/methodCounters.hpp"
+#include "oops/methodData.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/globals_extension.hpp"

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -398,13 +398,13 @@ void AOTMapLogger::log_const_method(ConstMethod* cm, address requested_addr, con
 }
 
 void AOTMapLogger::log_method_counter(MethodCounters* mc, address requested_addr, const char* type_name,
-                                    int bytes, Thread* current) {
+                                      int bytes, Thread* current) {
   ResourceMark rm(current);
   log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  mc->method()->external_name());
 }
 
 void AOTMapLogger::log_method_data(MethodData* md, address requested_addr, const char* type_name,
-                                    int bytes, Thread* current) {
+                                   int bytes, Thread* current) {
   ResourceMark rm(current);
   log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  md->method()->external_name());
 }

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -351,7 +351,7 @@ void AOTMapLogger::log_metaspace_objects_impl(address region_base, address regio
       log_method((Method*)src, requested_addr, type_name, bytes, current);
       break;
     case MetaspaceObj::MethodCountersType:
-      log_method_counter((MethodCounters*)src, requested_addr, type_name, bytes, current);
+      log_method_counters((MethodCounters*)src, requested_addr, type_name, bytes, current);
       break;
     case MetaspaceObj::MethodDataType:
       log_method_data((MethodData*)src, requested_addr, type_name, bytes, current);
@@ -397,7 +397,7 @@ void AOTMapLogger::log_const_method(ConstMethod* cm, address requested_addr, con
   log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  cm->method()->external_name());
 }
 
-void AOTMapLogger::log_method_counter(MethodCounters* mc, address requested_addr, const char* type_name,
+void AOTMapLogger::log_method_counters(MethodCounters* mc, address requested_addr, const char* type_name,
                                       int bytes, Thread* current) {
   ResourceMark rm(current);
   log_debug(aot, map)(_LOG_PREFIX " %s", p2i(requested_addr), type_name, bytes,  mc->method()->external_name());

--- a/src/hotspot/share/cds/aotMapLogger.hpp
+++ b/src/hotspot/share/cds/aotMapLogger.hpp
@@ -98,6 +98,10 @@ class AOTMapLogger : AllStatic {
   static void log_constant_pool_cache(ConstantPoolCache* cpc, address requested_addr,
                                       const char* type_name, int bytes, Thread* current);
   static void log_const_method(ConstMethod* cm, address requested_addr, const char* type_name, int bytes, Thread* current);
+  static void log_method_counter(MethodCounters* mc, address requested_addr, const char* type_name, int bytes,
+  Thread* current);
+  static void log_method_data(MethodData* md, address requested_addr, const char* type_name, int bytes,
+  Thread* current);
   static void log_klass(Klass* k, address requested_addr, const char* type_name, int bytes, Thread* current);
   static void log_method(Method* m, address requested_addr, const char* type_name, int bytes, Thread* current);
   static void log_symbol(Symbol* s, address requested_addr, const char* type_name, int bytes, Thread* current);

--- a/src/hotspot/share/cds/aotMapLogger.hpp
+++ b/src/hotspot/share/cds/aotMapLogger.hpp
@@ -98,7 +98,7 @@ class AOTMapLogger : AllStatic {
   static void log_constant_pool_cache(ConstantPoolCache* cpc, address requested_addr,
                                       const char* type_name, int bytes, Thread* current);
   static void log_const_method(ConstMethod* cm, address requested_addr, const char* type_name, int bytes, Thread* current);
-  static void log_method_counter(MethodCounters* mc, address requested_addr, const char* type_name, int bytes,
+  static void log_method_counters(MethodCounters* mc, address requested_addr, const char* type_name, int bytes,
   Thread* current);
   static void log_method_data(MethodData* md, address requested_addr, const char* type_name, int bytes,
   Thread* current);


### PR DESCRIPTION
Part of https://bugs.openjdk.org/browse/JDK-8369037
Provides part of fixes needed to resolve https://bugs.openjdk.org/browse/JDK-8363440

The AOT map file lists many objects without any kind of context of what they represent. For example, `MethodCounters` and `MethodData` do not show to what method they belong to. With this patch, now we can at least link the `MethodCounters` and `MethodData` to the `Method` they belong to.

Before:
```
$ cat aot.map | grep "@@ MethodCounters"
[...]
0x0000000801e4c280: @@ MethodCounters    64
```
``` bash
$ cat aot.map | grep "@@ MethodData"
[...]
0x0000000801e44448: @@ MethodData        584
```

After:
```
$ cat aot.map | grep "@@ MethodCounters"
[...]
0x0000000801f8b9a8: @@ MethodCounters    64 void jdk.internal.access.SharedSecrets.setJavaLangAccess(jdk.internal.access.JavaLangAccess)
0x0000000801f8be60: @@ MethodCounters    64 void java.lang.Object.notifyAll()
```
``` bash
$ cat aot.map | grep "@@ MethodData"
[...]
0x0000000801f700e0: @@ MethodData        728 int java.lang.module.ModuleDescriptor.hashCode()
0x0000000801f81af0: @@ MethodData        688 java.lang.String java.lang.Class.cannotCastMsg(java.lang.Object)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369037](https://bugs.openjdk.org/browse/JDK-8369037): Identify owning method for MethodData and MethodCounters in AOT map output (**Sub-task** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer) Review applies to [b36e4408](https://git.openjdk.org/jdk/pull/27603/files/b36e4408b328bba21cbfcaabe2a2b9c99a3380f2)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) Review applies to [b36e4408](https://git.openjdk.org/jdk/pull/27603/files/b36e4408b328bba21cbfcaabe2a2b9c99a3380f2)
 * [Mat Carter](https://openjdk.org/census#macarte) (@macarte - Author) Review applies to [76e3a5a0](https://git.openjdk.org/jdk/pull/27603/files/76e3a5a04f9453086b61ddec8eeaf564675d92ac)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27603/head:pull/27603` \
`$ git checkout pull/27603`

Update a local copy of the PR: \
`$ git checkout pull/27603` \
`$ git pull https://git.openjdk.org/jdk.git pull/27603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27603`

View PR using the GUI difftool: \
`$ git pr show -t 27603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27603.diff">https://git.openjdk.org/jdk/pull/27603.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27603#issuecomment-3359868365)
</details>
