### PR TITLE
8369038: Parallel: Use NMethodMarkingScope and ThreadsClaimTokenScope in psParallelCompact

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -28,6 +28,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "code/codeCache.hpp"
+#include "code/nmethod.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/parallel/objectStartArray.inline.hpp"
 #include "gc/parallel/parallelArguments.hpp"
@@ -61,7 +62,6 @@
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/referenceProcessorPhaseTimes.hpp"
 #include "gc/shared/spaceDecorator.hpp"
-#include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/taskTerminator.hpp"
 #include "gc/shared/weakProcessor.inline.hpp"
 #include "gc/shared/workerPolicy.hpp"
@@ -1085,7 +1085,8 @@ void steal_marking_work(TaskTerminator& terminator, uint worker_id) {
 }
 
 class MarkFromRootsTask : public WorkerTask {
-  StrongRootsScope _strong_roots_scope; // needed for Threads::possibly_parallel_threads_do
+  NMethodMarkingScope _nmethod_marking_scope;
+  ThreadsClaimTokenScope _threads_claim_token_scope;
   OopStorageSetStrongParState<false /* concurrent */, false /* is_const */> _oop_storage_set_par_state;
   TaskTerminator _terminator;
   uint _active_workers;
@@ -1093,7 +1094,8 @@ class MarkFromRootsTask : public WorkerTask {
 public:
   MarkFromRootsTask(uint active_workers) :
       WorkerTask("MarkFromRootsTask"),
-      _strong_roots_scope(active_workers),
+      _nmethod_marking_scope(),
+      _threads_claim_token_scope(),
       _terminator(active_workers, ParCompactionManager::marking_stacks()),
       _active_workers(active_workers) {}
 


### PR DESCRIPTION
Replace `StrongRootsScope` with `ThreadsClaimTokenScope` in `MarkFromRootsTask ` to be more precise with what is needed and why.

- `MarkFromRootsTask` uses `MarkingNMethodClosure` (in `PCAddThreadRootsMarkingTaskClosure`), so we also need `NMethodMarkingScope`.
- `active_workers ` is guaranteed to be `> 0`

Passes tier1 and tier2 (fastdebug).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369038](https://bugs.openjdk.org/browse/JDK-8369038): Parallel: Use NMethodMarkingScope and ThreadsClaimTokenScope in psParallelCompact (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27607/head:pull/27607` \
`$ git checkout pull/27607`

Update a local copy of the PR: \
`$ git checkout pull/27607` \
`$ git pull https://git.openjdk.org/jdk.git pull/27607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27607`

View PR using the GUI difftool: \
`$ git pr show -t 27607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27607.diff">https://git.openjdk.org/jdk/pull/27607.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27607#issuecomment-3360987776)
</details>
