### PR TITLE
8356202: Cleanup Source code in String Implementation Classes

### DIFF
--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -364,7 +364,7 @@ final class StringLatin1 {
         return new String(result, LATIN1);
     }
 
-    // case in-sensitive
+    // case insensitive
     static boolean regionMatchesCI(byte[] value, int toffset,
                                           byte[] other, int ooffset, int len) {
         int last = toffset + len;

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -237,7 +237,7 @@ final class StringLatin1 {
     }
 
     static int lastIndexOf(byte[] src, int srcCount,
-                                  byte[] tgt, int tgtCount, int fromIndex) {
+                           byte[] tgt, int tgtCount, int fromIndex) {
         int min = tgtCount - 1;
         int i = min + fromIndex;
         int strLastIndex = tgtCount - 1;
@@ -315,7 +315,7 @@ final class StringLatin1 {
     }
 
     static String replace(byte[] value, int valLen, byte[] targ,
-                                 int targLen, byte[] repl, int replLen)
+                          int targLen, byte[] repl, int replLen)
     {
         assert targLen > 0;
         int i, j, p = 0;
@@ -366,7 +366,7 @@ final class StringLatin1 {
 
     // case insensitive
     static boolean regionMatchesCI(byte[] value, int toffset,
-                                          byte[] other, int ooffset, int len) {
+                                   byte[] other, int ooffset, int len) {
         int last = toffset + len;
         while (toffset < last) {
             byte b1 = value[toffset++];
@@ -380,7 +380,7 @@ final class StringLatin1 {
     }
 
     static boolean regionMatchesCI_UTF16(byte[] value, int toffset,
-                                                byte[] other, int ooffset, int len) {
+                                         byte[] other, int ooffset, int len) {
         int last = toffset + len;
         while (toffset < last) {
             char c1 = (char)(value[toffset++] & 0xff);

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -41,61 +41,61 @@ import static java.lang.String.checkIndex;
 import static java.lang.String.checkOffset;
 
 final class StringLatin1 {
-    public static char charAt(byte[] value, int index) {
+    static char charAt(byte[] value, int index) {
         checkIndex(index, value.length);
         return (char)(value[index] & 0xff);
     }
 
-    public static boolean canEncode(char cp) {
+    static boolean canEncode(char cp) {
         return cp <= 0xff;
     }
 
-    public static boolean canEncode(int cp) {
+    static boolean canEncode(int cp) {
         return cp >=0 && cp <= 0xff;
     }
 
-    public static byte coderFromChar(char cp) {
+    static byte coderFromChar(char cp) {
         return (byte)((0xff - cp) >>> (Integer.SIZE - 1));
     }
 
-    public static int length(byte[] value) {
+    static int length(byte[] value) {
         return value.length;
     }
 
-    public static int codePointAt(byte[] value, int index, int end) {
+    static int codePointAt(byte[] value, int index, int end) {
         return value[index] & 0xff;
     }
 
-    public static int codePointBefore(byte[] value, int index) {
+    static int codePointBefore(byte[] value, int index) {
         return value[index - 1] & 0xff;
     }
 
-    public static int codePointCount(byte[] value, int beginIndex, int endIndex) {
+    static int codePointCount(byte[] value, int beginIndex, int endIndex) {
         return endIndex - beginIndex;
     }
 
-    public static char[] toChars(byte[] value) {
+    static char[] toChars(byte[] value) {
         char[] dst = new char[value.length];
         inflate(value, 0, dst, 0, value.length);
         return dst;
     }
 
-    public static byte[] inflate(byte[] value, int off, int len) {
+    static byte[] inflate(byte[] value, int off, int len) {
         byte[] ret = StringUTF16.newBytesFor(len);
         inflate(value, off, ret, 0, len);
         return ret;
     }
 
-    public static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
+    static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
         inflate(value, srcBegin, dst, dstBegin, srcEnd - srcBegin);
     }
 
-    public static void getBytes(byte[] value, int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
+    static void getBytes(byte[] value, int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
         System.arraycopy(value, srcBegin, dst, dstBegin, srcEnd - srcBegin);
     }
 
     @IntrinsicCandidate
-    public static boolean equals(byte[] value, byte[] other) {
+    static boolean equals(byte[] value, byte[] other) {
         if (value.length == other.length) {
             for (int i = 0; i < value.length; i++) {
                 if (value[i] != other[i]) {
@@ -108,20 +108,20 @@ final class StringLatin1 {
     }
 
     @IntrinsicCandidate
-    public static int compareTo(byte[] value, byte[] other) {
+    static int compareTo(byte[] value, byte[] other) {
         int len1 = value.length;
         int len2 = other.length;
         return compareTo(value, other, len1, len2);
     }
 
-    public static int compareTo(byte[] value, byte[] other, int len1, int len2) {
+    static int compareTo(byte[] value, byte[] other, int len1, int len2) {
         int lim = Math.min(len1, len2);
         int k = ArraysSupport.mismatch(value, other, lim);
         return (k < 0) ? len1 - len2 : getChar(value, k) - getChar(other, k);
     }
 
     @IntrinsicCandidate
-    public static int compareToUTF16(byte[] value, byte[] other) {
+    static int compareToUTF16(byte[] value, byte[] other) {
         int len1 = length(value);
         int len2 = StringUTF16.length(other);
         return compareToUTF16Values(value, other, len1, len2);
@@ -130,7 +130,7 @@ final class StringLatin1 {
     /*
      * Checks the boundary and then compares the byte arrays.
      */
-    public static int compareToUTF16(byte[] value, byte[] other, int len1, int len2) {
+    static int compareToUTF16(byte[] value, byte[] other, int len1, int len2) {
         checkOffset(len1, length(value));
         checkOffset(len2, StringUTF16.length(other));
 
@@ -149,7 +149,7 @@ final class StringLatin1 {
         return len1 - len2;
     }
 
-    public static int compareToCI(byte[] value, byte[] other) {
+    static int compareToCI(byte[] value, byte[] other) {
         int len1 = value.length;
         int len2 = other.length;
         int lim = Math.min(len1, len2);
@@ -169,7 +169,7 @@ final class StringLatin1 {
         return len1 - len2;
     }
 
-    public static int compareToCI_UTF16(byte[] value, byte[] other) {
+    static int compareToCI_UTF16(byte[] value, byte[] other) {
         int len1 = length(value);
         int len2 = StringUTF16.length(other);
         int lim = Math.min(len1, len2);
@@ -191,12 +191,12 @@ final class StringLatin1 {
         return len1 - len2;
     }
 
-    public static int hashCode(byte[] value) {
+    static int hashCode(byte[] value) {
         return ArraysSupport.hashCodeOfUnsigned(value, 0, value.length, 0);
     }
 
     // Caller must ensure that from- and toIndex are within bounds
-    public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
+    static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
         if (!canEncode(ch)) {
             return -1;
         }
@@ -215,7 +215,7 @@ final class StringLatin1 {
     }
 
     @IntrinsicCandidate
-    public static int indexOf(byte[] value, byte[] str) {
+    static int indexOf(byte[] value, byte[] str) {
         if (str.length == 0) {
             return 0;
         }
@@ -226,7 +226,7 @@ final class StringLatin1 {
     }
 
     @IntrinsicCandidate
-    public static int indexOf(byte[] value, int valueCount, byte[] str, int strCount, int fromIndex) {
+    static int indexOf(byte[] value, int valueCount, byte[] str, int strCount, int fromIndex) {
         byte first = str[0];
         int max = (valueCount - strCount);
         for (int i = fromIndex; i <= max; i++) {
@@ -248,7 +248,7 @@ final class StringLatin1 {
         return -1;
     }
 
-    public static int lastIndexOf(byte[] src, int srcCount,
+    static int lastIndexOf(byte[] src, int srcCount,
                                   byte[] tgt, int tgtCount, int fromIndex) {
         int min = tgtCount - 1;
         int i = min + fromIndex;
@@ -276,7 +276,7 @@ final class StringLatin1 {
         }
     }
 
-    public static int lastIndexOf(final byte[] value, int ch, int fromIndex) {
+    static int lastIndexOf(final byte[] value, int ch, int fromIndex) {
         if (!canEncode(ch)) {
             return -1;
         }
@@ -289,7 +289,7 @@ final class StringLatin1 {
         return -1;
     }
 
-    public static String replace(byte[] value, char oldChar, char newChar) {
+    static String replace(byte[] value, char oldChar, char newChar) {
         if (canEncode(oldChar)) {
             int len = value.length;
             int i = -1;
@@ -326,7 +326,7 @@ final class StringLatin1 {
         return null; // for string to return this;
     }
 
-    public static String replace(byte[] value, int valLen, byte[] targ,
+    static String replace(byte[] value, int valLen, byte[] targ,
                                  int targLen, byte[] repl, int replLen)
     {
         assert targLen > 0;
@@ -377,7 +377,7 @@ final class StringLatin1 {
     }
 
     // case insensitive
-    public static boolean regionMatchesCI(byte[] value, int toffset,
+    static boolean regionMatchesCI(byte[] value, int toffset,
                                           byte[] other, int ooffset, int len) {
         int last = toffset + len;
         while (toffset < last) {
@@ -391,7 +391,7 @@ final class StringLatin1 {
         return true;
     }
 
-    public static boolean regionMatchesCI_UTF16(byte[] value, int toffset,
+    static boolean regionMatchesCI_UTF16(byte[] value, int toffset,
                                                 byte[] other, int ooffset, int len) {
         int last = toffset + len;
         while (toffset < last) {
@@ -413,7 +413,7 @@ final class StringLatin1 {
         return true;
     }
 
-    public static String toLowerCase(String str, byte[] value, Locale locale) {
+    static String toLowerCase(String str, byte[] value, Locale locale) {
         if (locale == null) {
             throw new NullPointerException();
         }
@@ -480,7 +480,7 @@ final class StringLatin1 {
         return StringUTF16.newString(result, 0, resultOffset);
     }
 
-    public static String toUpperCase(String str, byte[] value, Locale locale) {
+    static String toUpperCase(String str, byte[] value, Locale locale) {
         if (locale == null) {
             throw new NullPointerException();
         }
@@ -560,7 +560,7 @@ final class StringLatin1 {
         return StringUTF16.newString(result, 0, resultOffset);
     }
 
-    public static String trim(byte[] value) {
+    static String trim(byte[] value) {
         int len = value.length;
         int st = 0;
         while ((st < len) && ((value[st] & 0xff) <= ' ')) {
@@ -573,7 +573,7 @@ final class StringLatin1 {
             newString(value, st, len - st) : null;
     }
 
-    public static int indexOfNonWhitespace(byte[] value) {
+    static int indexOfNonWhitespace(byte[] value) {
         int length = value.length;
         int left = 0;
         while (left < length) {
@@ -586,7 +586,7 @@ final class StringLatin1 {
         return left;
     }
 
-    public static int lastIndexOfNonWhitespace(byte[] value) {
+    static int lastIndexOfNonWhitespace(byte[] value) {
         int length = value.length;
         int right = length;
         while (0 < right) {
@@ -599,7 +599,7 @@ final class StringLatin1 {
         return right;
     }
 
-    public static String strip(byte[] value) {
+    static String strip(byte[] value) {
         int left = indexOfNonWhitespace(value);
         if (left == value.length) {
             return "";
@@ -609,12 +609,12 @@ final class StringLatin1 {
         return ifChanged ? newString(value, left, right - left) : null;
     }
 
-    public static String stripLeading(byte[] value) {
+    static String stripLeading(byte[] value) {
         int left = indexOfNonWhitespace(value);
         return (left != 0) ? newString(value, left, value.length - left) : null;
     }
 
-    public static String stripTrailing(byte[] value) {
+    static String stripTrailing(byte[] value) {
         int right = lastIndexOfNonWhitespace(value);
         return (right != value.length) ? newString(value, 0, right) : null;
     }
@@ -713,14 +713,14 @@ final class StringLatin1 {
         return StreamSupport.stream(LinesSpliterator.spliterator(value), false);
     }
 
-    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
+    static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
         value[i] = (byte)c1;
         value[i + 1] = (byte)c2;
         value[i + 2] = (byte)c3;
         value[i + 3] = (byte)c4;
     }
 
-    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
+    static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
         value[i] = (byte)c1;
         value[i + 1] = (byte)c2;
         value[i + 2] = (byte)c3;
@@ -728,32 +728,15 @@ final class StringLatin1 {
         value[i + 4] = (byte)c5;
     }
 
-    public static void putChar(byte[] val, int index, int c) {
-        //assert (canEncode(c));
-        val[index] = (byte)(c);
-    }
-
-    public static char getChar(byte[] val, int index) {
+    static char getChar(byte[] val, int index) {
         return (char)(val[index] & 0xff);
     }
 
-    public static byte[] toBytes(int[] val, int off, int len) {
-        byte[] ret = new byte[len];
-        for (int i = 0; i < len; i++) {
-            int cp = val[off++];
-            if (!canEncode(cp)) {
-                return null;
-            }
-            ret[i] = (byte)cp;
-        }
-        return ret;
-    }
-
-    public static byte[] toBytes(char c) {
+    static byte[] toBytes(char c) {
         return new byte[] { (byte)c };
     }
 
-    public static String newString(byte[] val, int index, int len) {
+    static String newString(byte[] val, int index, int len) {
         if (len == 0) {
             return "";
         }
@@ -763,7 +746,7 @@ final class StringLatin1 {
 
     // inflatedCopy byte[] -> char[]
     @IntrinsicCandidate
-    public static void inflate(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
+    static void inflate(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
         for (int i = 0; i < len; i++) {
             dst[dstOff++] = (char)(src[srcOff++] & 0xff);
         }
@@ -771,7 +754,7 @@ final class StringLatin1 {
 
     // inflatedCopy byte[] -> byte[]
     @IntrinsicCandidate
-    public static void inflate(byte[] src, int srcOff, byte[] dst, int dstOff, int len) {
+    static void inflate(byte[] src, int srcOff, byte[] dst, int dstOff, int len) {
         StringUTF16.inflate(src, srcOff, dst, dstOff, len);
     }
 

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -62,18 +62,6 @@ final class StringLatin1 {
         return value.length;
     }
 
-    static int codePointAt(byte[] value, int index, int end) {
-        return value[index] & 0xff;
-    }
-
-    static int codePointBefore(byte[] value, int index) {
-        return value[index - 1] & 0xff;
-    }
-
-    static int codePointCount(byte[] value, int beginIndex, int endIndex) {
-        return endIndex - beginIndex;
-    }
-
     static char[] toChars(byte[] value) {
         char[] dst = new char[value.length];
         inflate(value, 0, dst, 0, value.length);
@@ -376,7 +364,7 @@ final class StringLatin1 {
         return new String(result, LATIN1);
     }
 
-    // case insensitive
+    // case in-sensitive
     static boolean regionMatchesCI(byte[] value, int toffset,
                                           byte[] other, int ooffset, int len) {
         int last = toffset + len;
@@ -587,8 +575,7 @@ final class StringLatin1 {
     }
 
     static int lastIndexOfNonWhitespace(byte[] value) {
-        int length = value.length;
-        int right = length;
+        int right = value.length;
         while (0 < right) {
             char ch = getChar(value, right - 1);
             if (ch != ' ' && ch != '\t' && !CharacterDataLatin1.instance.isWhitespace(ch)) {
@@ -807,7 +794,7 @@ final class StringLatin1 {
         }
 
         @Override
-        public long estimateSize() { return (long)(fence - index); }
+        public long estimateSize() { return fence - index; }
 
         @Override
         public int characteristics() {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -539,7 +539,7 @@ final class StringUTF16 {
         return tlen - olen;
     }
 
-    // Case in-sensitive comparison of two code points
+    // Case insensitive comparison of two code points
     private static int compareCodePointCI(int cp1, int cp2) {
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -731,7 +731,7 @@ final class StringUTF16 {
 
     // srcCoder == UTF16 && tgtCoder == UTF16
     static int lastIndexOf(byte[] src, int srcCount,
-                                  byte[] tgt, int tgtCount, int fromIndex) {
+                           byte[] tgt, int tgtCount, int fromIndex) {
         assert fromIndex >= 0;
         assert tgtCount > 0;
         assert tgtCount <= length(tgt);
@@ -830,8 +830,8 @@ final class StringUTF16 {
     }
 
     static String replace(byte[] value, int valLen, boolean valLat1,
-                                 byte[] targ, int targLen, boolean targLat1,
-                                 byte[] repl, int replLen, boolean replLat1)
+                          byte[] targ, int targLen, boolean targLat1,
+                          byte[] repl, int replLen, boolean replLat1)
     {
         assert targLen > 0;
         assert !valLat1 || !targLat1 || !replLat1;
@@ -945,13 +945,13 @@ final class StringUTF16 {
     }
 
     static boolean regionMatchesCI(byte[] value, int toffset,
-                                          byte[] other, int ooffset, int len) {
+                                   byte[] other, int ooffset, int len) {
         return compareToCIImpl(value, toffset, len, other, ooffset, len) == 0;
     }
 
     static boolean regionMatchesCI_Latin1(byte[] value, int toffset,
-                                                 byte[] other, int ooffset,
-                                                 int len) {
+                                          byte[] other, int ooffset,
+                                          int len) {
         return StringLatin1.regionMatchesCI_UTF16(other, ooffset, value, toffset, len);
     }
 

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -512,8 +512,8 @@ final class StringUTF16 {
         assert olast <= length(other);
 
         for (int k1 = toffset, k2 = ooffset; k1 < tlast && k2 < olast; k1++, k2++) {
-            int cp1 = (int)getChar(value, k1);
-            int cp2 = (int)getChar(other, k2);
+            int cp1 = getChar(value, k1);
+            int cp2 = getChar(other, k2);
 
             if (cp1 == cp2 || compareCodePointCI(cp1, cp2) == 0) {
                 continue;
@@ -539,7 +539,7 @@ final class StringUTF16 {
         return tlen - olen;
     }
 
-    // Case insensitive comparison of two code points
+    // Case in-sensitive comparison of two code points
     private static int compareCodePointCI(int cp1, int cp2) {
         // try converting both characters to uppercase.
         // If the results match, then the comparison scan should
@@ -965,7 +965,7 @@ final class StringUTF16 {
 
         // Now check if there are any characters that need to be changed, or are surrogate
         for (first = 0 ; first < len; first++) {
-            int cp = (int)getChar(value, first);
+            int cp = getChar(value, first);
             if (Character.isSurrogate((char)cp)) {
                 hasSurr = true;
                 break;
@@ -988,7 +988,7 @@ final class StringUTF16 {
         }
         int bits = 0;
         for (int i = first; i < len; i++) {
-            int cp = (int)getChar(value, i);
+            int cp = getChar(value, i);
             if (cp == '\u03A3' ||                       // GREEK CAPITAL LETTER SIGMA
                 Character.isSurrogate((char)cp)) {
                 return toLowerCaseEx(str, value, result, i, locale, false);
@@ -1003,7 +1003,7 @@ final class StringUTF16 {
             bits |= cp;
             putChar(result, i, cp);
         }
-        if (bits < 0 || bits > 0xff) {
+        if (bits > 0xff) {
             return new String(result, UTF16);
         } else {
             return newString(result, 0, len);
@@ -1069,7 +1069,7 @@ final class StringUTF16 {
 
         // Now check if there are any characters that need to be changed, or are surrogate
         for (first = 0 ; first < len; first++) {
-            int cp = (int)getChar(value, first);
+            int cp = getChar(value, first);
             if (Character.isSurrogate((char)cp)) {
                 hasSurr = true;
                 break;
@@ -1093,7 +1093,7 @@ final class StringUTF16 {
         }
         int bits = 0;
         for (int i = first; i < len; i++) {
-            int cp = (int)getChar(value, i);
+            int cp = getChar(value, i);
             if (Character.isSurrogate((char)cp)) {
                 return toUpperCaseEx(str, value, result, i, locale, false);
             }
@@ -1104,7 +1104,7 @@ final class StringUTF16 {
             bits |= cp;
             putChar(result, i, cp);
         }
-        if (bits < 0 || bits > 0xff) {
+        if (bits > 0xff) {
             return new String(result, UTF16);
         } else {
             return newString(result, 0, len);
@@ -1193,8 +1193,7 @@ final class StringUTF16 {
     }
 
     static int lastIndexOfNonWhitespace(byte[] value) {
-        int length = value.length >>> 1;
-        int right = length;
+        int right = value.length >>> 1;
         while (0 < right) {
             int codepoint = codePointBefore(value, right);
             if (codepoint != ' ' && codepoint != '\t' && !Character.isWhitespace(codepoint)) {
@@ -1322,12 +1321,6 @@ final class StringUTF16 {
         return StreamSupport.stream(LinesSpliterator.spliterator(value), false);
     }
 
-    private static void putChars(byte[] val, int index, char[] str, int off, int end) {
-        while (off < end) {
-            putChar(val, index++, str[off++]);
-        }
-    }
-
     public static String newString(byte[] val, int index, int len) {
         if (len == 0) {
             return "";
@@ -1394,7 +1387,7 @@ final class StringUTF16 {
         }
 
         @Override
-        public long estimateSize() { return (long)(fence - index); }
+        public long estimateSize() { return fence - index; }
 
         @Override
         public int characteristics() {
@@ -1479,7 +1472,7 @@ final class StringUTF16 {
         }
 
         @Override
-        public long estimateSize() { return (long)(fence - index); }
+        public long estimateSize() { return fence - index; }
 
         @Override
         public int characteristics() {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1321,7 +1321,7 @@ final class StringUTF16 {
         return StreamSupport.stream(LinesSpliterator.spliterator(value), false);
     }
 
-    public static String newString(byte[] val, int index, int len) {
+    static String newString(byte[] val, int index, int len) {
         if (len == 0) {
             return "";
         }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -54,13 +54,13 @@ final class StringUTF16 {
 
     // Return a new byte array for a UTF16-coded string for len chars
     // Throw an exception if out of range
-    public static byte[] newBytesFor(int len) {
+    static byte[] newBytesFor(int len) {
         return new byte[newBytesLength(len)];
     }
 
     // Check the size of a UTF16-coded string
     // Throw an exception if out of range
-    public static int newBytesLength(int len) {
+    static int newBytesLength(int len) {
         if (len < 0) {
             throw new NegativeArraySizeException();
         }
@@ -89,7 +89,7 @@ final class StringUTF16 {
                       ((val[index]   & 0xff) << LO_BYTE_SHIFT));
     }
 
-    public static int length(byte[] value) {
+    static int length(byte[] value) {
         return value.length >> 1;
     }
 
@@ -111,7 +111,7 @@ final class StringUTF16 {
         return c1;
     }
 
-    public static int codePointAt(byte[] value, int index, int end) {
+    static int codePointAt(byte[] value, int index, int end) {
        return codePointAt(value, index, end, false /* unchecked */);
     }
 
@@ -134,7 +134,7 @@ final class StringUTF16 {
         return c2;
     }
 
-    public static int codePointBefore(byte[] value, int index) {
+    static int codePointBefore(byte[] value, int index) {
         return codePointBefore(value, index, false /* unchecked */);
     }
 
@@ -155,11 +155,11 @@ final class StringUTF16 {
         return count;
     }
 
-    public static int codePointCount(byte[] value, int beginIndex, int endIndex) {
+    static int codePointCount(byte[] value, int beginIndex, int endIndex) {
         return codePointCount(value, beginIndex, endIndex, false /* unchecked */);
     }
 
-    public static char[] toChars(byte[] value) {
+    static char[] toChars(byte[] value) {
         char[] dst = new char[value.length >> 1];
         getChars(value, 0, dst.length, dst, 0);
         return dst;
@@ -173,7 +173,7 @@ final class StringUTF16 {
      * @param len a length
      */
     @IntrinsicCandidate
-    public static byte[] toBytes(char[] value, int off, int len) {
+    static byte[] toBytes(char[] value, int off, int len) {
         byte[] val = newBytesFor(len);
         for (int i = 0; i < len; i++) {
             putChar(val, i, value[off]);
@@ -218,7 +218,7 @@ final class StringUTF16 {
      * @param count count of chars to be compressed, {@code count} > 0
      */
     @ForceInline
-    public static byte[] compress(final char[] val, final int off, final int count) {
+    static byte[] compress(final char[] val, final int off, final int count) {
         byte[] latin1 = new byte[count];
         int ndx = compress(val, off, latin1, 0, count);
         if (ndx != count) {
@@ -245,7 +245,7 @@ final class StringUTF16 {
      * @param off   starting offset
      * @param count count of chars to be compressed, {@code count} > 0
      */
-    public static byte[] compress(final byte[] val, final int off, final int count) {
+    static byte[] compress(final byte[] val, final int off, final int count) {
         byte[] latin1 = new byte[count];
         int ndx = compress(val, off, latin1, 0, count);
         if (ndx != count) {// Switch to UTF16
@@ -279,7 +279,7 @@ final class StringUTF16 {
      * @param off   starting offset
      * @param count length of code points to be compressed, length > 0
      */
-    public static byte[] compress(final int[] val, int off, final int count) {
+    static byte[] compress(final int[] val, int off, final int count) {
         // Optimistically copy all latin1 code points to the destination
         byte[] latin1 = new byte[count];
         final int end = off + count;
@@ -389,7 +389,7 @@ final class StringUTF16 {
 
     // compressedCopy char[] -> byte[]
     @IntrinsicCandidate
-    public static int compress(char[] src, int srcOff, byte[] dst, int dstOff, int len) {
+    static int compress(char[] src, int srcOff, byte[] dst, int dstOff, int len) {
         for (int i = 0; i < len; i++) {
             char c = src[srcOff];
             if (c > 0xff) {
@@ -404,7 +404,7 @@ final class StringUTF16 {
 
     // compressedCopy byte[] -> byte[]
     @IntrinsicCandidate
-    public static int compress(byte[] src, int srcOff, byte[] dst, int dstOff, int len) {
+    static int compress(byte[] src, int srcOff, byte[] dst, int dstOff, int len) {
         // We need a range check here because 'getChar' has no checks
         checkBoundsOffCount(srcOff, len, src);
         for (int i = 0; i < len; i++) {
@@ -420,7 +420,7 @@ final class StringUTF16 {
     }
 
     // Create the UTF16 buffer for !COMPACT_STRINGS
-    public static byte[] toBytes(int[] val, int index, int len) {
+    static byte[] toBytes(int[] val, int index, int len) {
         final int end = index + len;
         int n = computeCodePointSize(val, index, end);
 
@@ -428,7 +428,7 @@ final class StringUTF16 {
         return extractCodepoints(val, index, end, buf, 0);
      }
 
-    public static byte[] toBytes(char c) {
+    static byte[] toBytes(char c) {
         byte[] result = new byte[2];
         putChar(result, 0, c);
         return result;
@@ -442,7 +442,7 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
+    static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
         // We need a range check here because 'getChar' has no checks
         if (srcBegin < srcEnd) {
             checkBoundsOffCount(srcBegin, srcEnd - srcBegin, value);
@@ -453,7 +453,7 @@ final class StringUTF16 {
     }
 
     /* @see java.lang.String.getBytes(int, int, byte[], int) */
-    public static void getBytes(byte[] value, int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
+    static void getBytes(byte[] value, int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
         srcBegin <<= 1;
         srcEnd <<= 1;
         for (int i = srcBegin + (1 >> LO_BYTE_SHIFT); i < srcEnd; i += 2) {
@@ -462,7 +462,7 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static int compareTo(byte[] value, byte[] other) {
+    static int compareTo(byte[] value, byte[] other) {
         int len1 = length(value);
         int len2 = length(other);
         return compareValues(value, other, len1, len2);
@@ -471,7 +471,7 @@ final class StringUTF16 {
     /*
      * Checks the boundary and then compares the byte arrays.
      */
-    public static int compareTo(byte[] value, byte[] other, int len1, int len2) {
+    static int compareTo(byte[] value, byte[] other, int len1, int len2) {
         checkOffset(len1, value);
         checkOffset(len2, other);
 
@@ -491,15 +491,15 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static int compareToLatin1(byte[] value, byte[] other) {
+    static int compareToLatin1(byte[] value, byte[] other) {
         return -StringLatin1.compareToUTF16(other, value);
     }
 
-    public static int compareToLatin1(byte[] value, byte[] other, int len1, int len2) {
+    static int compareToLatin1(byte[] value, byte[] other, int len1, int len2) {
         return -StringLatin1.compareToUTF16(other, value, len2, len1);
     }
 
-    public static int compareToCI(byte[] value, byte[] other) {
+    static int compareToCI(byte[] value, byte[] other) {
         return compareToCIImpl(value, 0, length(value), other, 0, length(other));
     }
 
@@ -588,16 +588,16 @@ final class StringUTF16 {
         return cp;
     }
 
-    public static int compareToCI_Latin1(byte[] value, byte[] other) {
+    static int compareToCI_Latin1(byte[] value, byte[] other) {
         return -StringLatin1.compareToCI_UTF16(other, value);
     }
 
-    public static int hashCode(byte[] value) {
+    static int hashCode(byte[] value) {
         return ArraysSupport.hashCodeOfUTF16(value, 0, value.length >> 1, 0);
     }
 
     // Caller must ensure that from- and toIndex are within bounds
-    public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
+    static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
         if (ch < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
             // handle most cases here (ch is a BMP code point or a
             // negative value (invalid code point))
@@ -608,7 +608,7 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static int indexOf(byte[] value, byte[] str) {
+    static int indexOf(byte[] value, byte[] str) {
         if (str.length == 0) {
             return 0;
         }
@@ -619,7 +619,7 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static int indexOf(byte[] value, int valueCount, byte[] str, int strCount, int fromIndex) {
+    static int indexOf(byte[] value, int valueCount, byte[] str, int strCount, int fromIndex) {
         checkBoundsBeginEnd(fromIndex, valueCount, value);
         checkBoundsBeginEnd(0, strCount, str);
         return indexOfUnsafe(value, valueCount, str, strCount, fromIndex);
@@ -657,7 +657,7 @@ final class StringUTF16 {
      * Handles indexOf Latin1 substring in UTF16 string.
      */
     @IntrinsicCandidate
-    public static int indexOfLatin1(byte[] value, byte[] str) {
+    static int indexOfLatin1(byte[] value, byte[] str) {
         if (str.length == 0) {
             return 0;
         }
@@ -668,13 +668,13 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static int indexOfLatin1(byte[] src, int srcCount, byte[] tgt, int tgtCount, int fromIndex) {
+    static int indexOfLatin1(byte[] src, int srcCount, byte[] tgt, int tgtCount, int fromIndex) {
         checkBoundsBeginEnd(fromIndex, srcCount, src);
         String.checkBoundsBeginEnd(0, tgtCount, tgt.length);
         return indexOfLatin1Unsafe(src, srcCount, tgt, tgtCount, fromIndex);
     }
 
-    public static int indexOfLatin1Unsafe(byte[] src, int srcCount, byte[] tgt, int tgtCount, int fromIndex) {
+    static int indexOfLatin1Unsafe(byte[] src, int srcCount, byte[] tgt, int tgtCount, int fromIndex) {
         assert fromIndex >= 0;
         assert tgtCount > 0;
         assert tgtCount <= tgt.length;
@@ -730,7 +730,7 @@ final class StringUTF16 {
     }
 
     // srcCoder == UTF16 && tgtCoder == UTF16
-    public static int lastIndexOf(byte[] src, int srcCount,
+    static int lastIndexOf(byte[] src, int srcCount,
                                   byte[] tgt, int tgtCount, int fromIndex) {
         assert fromIndex >= 0;
         assert tgtCount > 0;
@@ -765,7 +765,7 @@ final class StringUTF16 {
         }
     }
 
-    public static int lastIndexOf(byte[] value, int ch, int fromIndex) {
+    static int lastIndexOf(byte[] value, int ch, int fromIndex) {
         if (ch < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
             // handle most cases here (ch is a BMP code point or a
             // negative value (invalid code point))
@@ -798,7 +798,7 @@ final class StringUTF16 {
         return -1;
     }
 
-    public static String replace(byte[] value, char oldChar, char newChar) {
+    static String replace(byte[] value, char oldChar, char newChar) {
         int len = value.length >> 1;
         int i = -1;
         while (++i < len) {
@@ -829,7 +829,7 @@ final class StringUTF16 {
         return null;
     }
 
-    public static String replace(byte[] value, int valLen, boolean valLat1,
+    static String replace(byte[] value, int valLen, boolean valLat1,
                                  byte[] targ, int targLen, boolean targLat1,
                                  byte[] repl, int replLen, boolean replLat1)
     {
@@ -944,18 +944,18 @@ final class StringUTF16 {
         return new String(result, UTF16);
     }
 
-    public static boolean regionMatchesCI(byte[] value, int toffset,
+    static boolean regionMatchesCI(byte[] value, int toffset,
                                           byte[] other, int ooffset, int len) {
         return compareToCIImpl(value, toffset, len, other, ooffset, len) == 0;
     }
 
-    public static boolean regionMatchesCI_Latin1(byte[] value, int toffset,
+    static boolean regionMatchesCI_Latin1(byte[] value, int toffset,
                                                  byte[] other, int ooffset,
                                                  int len) {
         return StringLatin1.regionMatchesCI_UTF16(other, ooffset, value, toffset, len);
     }
 
-    public static String toLowerCase(String str, byte[] value, Locale locale) {
+    static String toLowerCase(String str, byte[] value, Locale locale) {
         if (locale == null) {
             throw new NullPointerException();
         }
@@ -1059,7 +1059,7 @@ final class StringUTF16 {
         return newString(result, 0, resultOffset);
     }
 
-    public static String toUpperCase(String str, byte[] value, Locale locale) {
+    static String toUpperCase(String str, byte[] value, Locale locale) {
         if (locale == null) {
             throw new NullPointerException();
         }
@@ -1164,7 +1164,7 @@ final class StringUTF16 {
         return newString(result, 0, resultOffset);
     }
 
-    public static String trim(byte[] value) {
+    static String trim(byte[] value) {
         int length = value.length >> 1;
         int len = length;
         int st = 0;
@@ -1179,7 +1179,7 @@ final class StringUTF16 {
             null;
     }
 
-    public static int indexOfNonWhitespace(byte[] value) {
+    static int indexOfNonWhitespace(byte[] value) {
         int length = value.length >> 1;
         int left = 0;
         while (left < length) {
@@ -1192,7 +1192,7 @@ final class StringUTF16 {
         return left;
     }
 
-    public static int lastIndexOfNonWhitespace(byte[] value) {
+    static int lastIndexOfNonWhitespace(byte[] value) {
         int length = value.length >>> 1;
         int right = length;
         while (0 < right) {
@@ -1205,7 +1205,7 @@ final class StringUTF16 {
         return right;
     }
 
-    public static String strip(byte[] value) {
+    static String strip(byte[] value) {
         int length = value.length >>> 1;
         int left = indexOfNonWhitespace(value);
         if (left == length) {
@@ -1216,13 +1216,13 @@ final class StringUTF16 {
         return ifChanged ? newString(value, left, right - left) : null;
     }
 
-    public static String stripLeading(byte[] value) {
+    static String stripLeading(byte[] value) {
         int length = value.length >>> 1;
         int left = indexOfNonWhitespace(value);
         return (left != 0) ? newString(value, left, length - left) : null;
     }
 
-    public static String stripTrailing(byte[] value) {
+    static String stripTrailing(byte[] value) {
         int length = value.length >>> 1;
         int right = lastIndexOfNonWhitespace(value);
         return (right != length) ? newString(value, 0, right) : null;
@@ -1320,6 +1320,12 @@ final class StringUTF16 {
 
     static Stream<String> lines(byte[] value) {
         return StreamSupport.stream(LinesSpliterator.spliterator(value), false);
+    }
+
+    private static void putChars(byte[] val, int index, char[] str, int off, int end) {
+        while (off < end) {
+            putChar(val, index++, str[off++]);
+        }
     }
 
     public static String newString(byte[] val, int index, int len) {
@@ -1483,12 +1489,12 @@ final class StringUTF16 {
 
     ////////////////////////////////////////////////////////////////
 
-    public static void putCharSB(byte[] val, int index, int c) {
+    static void putCharSB(byte[] val, int index, int c) {
         checkIndex(index, val);
         putChar(val, index, c);
     }
 
-    public static void putCharsSB(byte[] val, int index, char[] ca, int off, int end) {
+    static void putCharsSB(byte[] val, int index, char[] ca, int off, int end) {
         checkBoundsBeginEnd(index, index + end - off, val);
         String.checkBoundsBeginEnd(off, end, ca.length);
         Unsafe.getUnsafe().copyMemory(
@@ -1499,26 +1505,26 @@ final class StringUTF16 {
                 (long) (end - off) << 1);
     }
 
-    public static void putCharsSB(byte[] val, int index, CharSequence s, int off, int end) {
+    static void putCharsSB(byte[] val, int index, CharSequence s, int off, int end) {
         checkBoundsBeginEnd(index, index + end - off, val);
         for (int i = off; i < end; i++) {
             putChar(val, index++, s.charAt(i));
         }
     }
 
-    public static int codePointAtSB(byte[] val, int index, int end) {
+    static int codePointAtSB(byte[] val, int index, int end) {
         return codePointAt(val, index, end, true /* checked */);
     }
 
-    public static int codePointBeforeSB(byte[] val, int index) {
+    static int codePointBeforeSB(byte[] val, int index) {
         return codePointBefore(val, index, true /* checked */);
     }
 
-    public static int codePointCountSB(byte[] val, int beginIndex, int endIndex) {
+    static int codePointCountSB(byte[] val, int beginIndex, int endIndex) {
         return codePointCount(val, beginIndex, endIndex, true /* checked */);
     }
 
-    public static boolean contentEquals(byte[] v1, byte[] v2, int len) {
+    static boolean contentEquals(byte[] v1, byte[] v2, int len) {
         checkBoundsOffCount(0, len, v2);
         for (int i = 0; i < len; i++) {
             if ((char)(v1[i] & 0xff) != getChar(v2, i)) {
@@ -1528,7 +1534,7 @@ final class StringUTF16 {
         return true;
     }
 
-    public static boolean contentEquals(byte[] value, CharSequence cs, int len) {
+    static boolean contentEquals(byte[] value, CharSequence cs, int len) {
         checkOffset(len, value);
         for (int i = 0; i < len; i++) {
             if (getChar(value, i) != cs.charAt(i)) {
@@ -1538,7 +1544,7 @@ final class StringUTF16 {
         return true;
     }
 
-    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
+    static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
         int end = i + 4;
         checkBoundsBeginEnd(i, end, value);
         putChar(value, i, c1);
@@ -1547,7 +1553,7 @@ final class StringUTF16 {
         putChar(value, i + 3, c4);
     }
 
-    public static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
+    static void putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
         int end = i + 5;
         checkBoundsBeginEnd(i, end, value);
         putChar(value, i, c1);
@@ -1557,12 +1563,12 @@ final class StringUTF16 {
         putChar(value, i + 4, c5);
     }
 
-    public static char charAt(byte[] value, int index) {
+    static char charAt(byte[] value, int index) {
         checkIndex(index, value);
         return getChar(value, index);
     }
 
-    public static void reverse(byte[] val, int count) {
+    static void reverse(byte[] val, int count) {
         checkOffset(count, val);
         int n = count - 1;
         boolean hasSurrogates = false;
@@ -1597,7 +1603,7 @@ final class StringUTF16 {
     }
 
     // inflatedCopy byte[] -> byte[]
-    public static void inflate(byte[] src, int srcOff, byte[] dst, int dstOff, int len) {
+    static void inflate(byte[] src, int srcOff, byte[] dst, int dstOff, int len) {
         // We need a range check here because 'putChar' has no checks
         checkBoundsOffCount(dstOff, len, dst);
         for (int i = 0; i < len; i++) {
@@ -1606,7 +1612,7 @@ final class StringUTF16 {
     }
 
     // srcCoder == UTF16 && tgtCoder == LATIN1
-    public static int lastIndexOfLatin1(byte[] src, int srcCount,
+    static int lastIndexOfLatin1(byte[] src, int srcCount,
                                         byte[] tgt, int tgtCount, int fromIndex) {
         assert fromIndex >= 0;
         assert tgtCount > 0;
@@ -1659,19 +1665,19 @@ final class StringUTF16 {
 
     static final int MAX_LENGTH = Integer.MAX_VALUE >> 1;
 
-    public static void checkIndex(int off, byte[] val) {
+    static void checkIndex(int off, byte[] val) {
         String.checkIndex(off, length(val));
     }
 
-    public static void checkOffset(int off, byte[] val) {
+    static void checkOffset(int off, byte[] val) {
         String.checkOffset(off, length(val));
     }
 
-    public static void checkBoundsBeginEnd(int begin, int end, byte[] val) {
+    static void checkBoundsBeginEnd(int begin, int end, byte[] val) {
         String.checkBoundsBeginEnd(begin, end, length(val));
     }
 
-    public static void checkBoundsOffCount(int offset, int count, byte[] val) {
+    static void checkBoundsOffCount(int offset, int count, byte[] val) {
         String.checkBoundsOffCount(offset, count, length(val));
     }
 


### PR DESCRIPTION
Code cleanup in java.lang.StringLatin1 and StringUTF16.
Remove the `public` qualifier from methods where it is not needed.
Remove an unused toBytes method.
Remove unused codePointXXX methods.
Remove unnecessary casts of primitive types.

Some of these are suggested by IntelliJ, if the advice should not be taken, I'll revert and update the IDE settings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356202](https://bugs.openjdk.org/browse/JDK-8356202): Cleanup Source code in String Implementation Classes (**Bug** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**) Review applies to [06822b94](https://git.openjdk.org/jdk/pull/27609/files/06822b94e42cc1c429a0540e8e05d7af51485a41)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [06822b94](https://git.openjdk.org/jdk/pull/27609/files/06822b94e42cc1c429a0540e8e05d7af51485a41)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27609/head:pull/27609` \
`$ git checkout pull/27609`

Update a local copy of the PR: \
`$ git checkout pull/27609` \
`$ git pull https://git.openjdk.org/jdk.git pull/27609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27609`

View PR using the GUI difftool: \
`$ git pr show -t 27609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27609.diff">https://git.openjdk.org/jdk/pull/27609.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27609#issuecomment-3361942649)
</details>
