### PR TITLE
8369051: More small Float16 refactorings

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -34,6 +34,7 @@ import java.math.BigInteger;
 import static jdk.incubator.vector.Float16Consts.SIGN_BIT_MASK;
 import static jdk.incubator.vector.Float16Consts.EXP_BIT_MASK;
 import static jdk.incubator.vector.Float16Consts.SIGNIF_BIT_MASK;
+import static jdk.incubator.vector.Float16Consts.MAG_BIT_MASK;
 
 import static java.lang.Float.float16ToFloat;
 import static java.lang.Float.floatToFloat16;
@@ -396,7 +397,7 @@ public final class Float16
         }
         long f_signif_bits = doppel & 0x000f_ffff_ffff_ffffL | msb;
 
-        int PRECISION_DIFF = Double.PRECISION - PRECISION; // 42
+        final int PRECISION_DIFF = Double.PRECISION - PRECISION; // 42
         // Significand bits as if using rounding to zero (truncation).
         short signif_bits = (short)(f_signif_bits >> (PRECISION_DIFF + expdelta));
 
@@ -774,7 +775,7 @@ public final class Float16
      * @see Double#isFinite(double)
      */
     public static boolean isFinite(Float16 f16) {
-        return (float16ToRawShortBits(f16) & (EXP_BIT_MASK | SIGNIF_BIT_MASK)) <=
+        return (float16ToRawShortBits(f16) & MAG_BIT_MASK) <=
             float16ToRawShortBits(MAX_VALUE);
      }
 
@@ -1093,7 +1094,7 @@ public final class Float16
      * 2) performing the operation in the wider format
      * 3) converting the result from 2) to the narrower format
      *
-     * For example, this property hold between the formats used for the
+     * For example, this property holds between the formats used for the
      * float and double types. Therefore, the following is a valid
      * implementation of a float addition:
      *
@@ -1477,7 +1478,7 @@ public final class Float16
         // operation. Therefore, in this case do _not_ use the float
         // unary minus as an implementation as that is not guaranteed
         // to flip the sign bit of a NaN.
-        return shortBitsToFloat16((short)(f16.value ^ (short)0x0000_8000));
+        return shortBitsToFloat16((short)(f16.value ^ SIGN_BIT_MASK));
     }
 
     /**
@@ -1495,7 +1496,7 @@ public final class Float16
     public static Float16 abs(Float16 f16) {
         // Zero out sign bit. Per IEE 754-2019 section 5.5.1, abs is a
         // bit-level operation and not a logical operation.
-        return shortBitsToFloat16((short)(f16.value & (short)0x0000_7FFF));
+        return shortBitsToFloat16((short)(f16.value & MAG_BIT_MASK));
     }
 
     /**


### PR DESCRIPTION
As a follow-up to https://git.openjdk.org/jdk/pull/27587, I went through the code of Float16.java and found a few more cases where hex integer constants could be replaced by symbolic constants. A few other small changes included too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369051](https://bugs.openjdk.org/browse/JDK-8369051): More small Float16 refactorings (**Enhancement** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27610/head:pull/27610` \
`$ git checkout pull/27610`

Update a local copy of the PR: \
`$ git checkout pull/27610` \
`$ git pull https://git.openjdk.org/jdk.git pull/27610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27610`

View PR using the GUI difftool: \
`$ git pr show -t 27610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27610.diff">https://git.openjdk.org/jdk/pull/27610.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27610#issuecomment-3362085679)
</details>
