### PR TITLE
8368955: Improve HttpExchange.sendResponseHeaders usability

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -71,6 +71,16 @@ import java.net.URI;
 
 public abstract class HttpExchange implements AutoCloseable, Request {
 
+     /**
+      * No response body is being sent with this response
+      */
+     public static final long RSPBODY_EMPTY = -1L;
+
+     /**
+      * The response body is unspecified and will be chunk encoded
+      */
+     public static final long RSPBODY_CHUNKED = 0;
+
     /**
      * Constructor for subclasses to call.
      */
@@ -165,17 +175,19 @@ public abstract class HttpExchange implements AutoCloseable, Request {
 
 
     /**
-     * Starts sending the response back to the client using the current set of
-     * response headers and the numeric response code as specified in this
+     * Starts sending the final response back to the client using the current set of
+     * response headers obtained from {@link #getResponseHeaders()} and the numeric
+     * response code as specified in this
      * method. The response body length is also specified as follows. If the
      * response length parameter is greater than {@code zero}, this specifies an
      * exact number of bytes to send and the application must send that exact
-     * amount of data. If the response length parameter is {@code zero}, then
-     * chunked transfer encoding is used and an arbitrary amount of data may be
+     * amount of data. If the response length parameter has the value
+     * {@link #RSPBODY_CHUNKED} then the response body uses
+     * chunked transfer encoding and an arbitrary amount of data may be
      * sent. The application terminates the response body by closing the
      * {@link OutputStream}.
-     * If response length has the value {@code -1} then no response body is
-     * being sent.
+     * If response length has the value {@link #RSPBODY_EMPTY} then no
+     * response body is being sent.
      *
      * <p> If the content-length response header has not already been set then
      * this is set to the appropriate value depending on the response length
@@ -193,9 +205,9 @@ public abstract class HttpExchange implements AutoCloseable, Request {
      * @param responseLength if {@literal > 0}, specifies a fixed response body
      *                       length and that exact number of bytes must be written
      *                       to the stream acquired from {@link #getResponseCode()}
-     *                       If {@literal == 0}, then chunked encoding is used,
+     *                       If equal to {@link #RSPBODY_CHUNKED}, then chunked encoding is used,
      *                       and an arbitrary number of bytes may be written.
-     *                       If {@literal <= -1}, then no response body length is
+     *                       If equal to {@link #RSPBODY_EMPTY}, then no response body length is
      *                       specified and no response body may be written.
      * @throws IOException   if the response headers have already been sent or an I/O error occurs
      * @see   HttpExchange#getResponseBody()

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -173,42 +173,40 @@ public abstract class HttpExchange implements AutoCloseable, Request {
      */
     public abstract OutputStream getResponseBody();
 
-
     /**
      * Starts sending the final response back to the client using the current set of
-     * response headers obtained from {@link #getResponseHeaders()} and the numeric
-     * response code as specified in this
-     * method. The response body length is also specified as follows. If the
-     * response length parameter is greater than {@code zero}, this specifies an
-     * exact number of bytes to send and the application must send that exact
-     * amount of data. If the response length parameter has the value
+     * response headers and the numeric response code {@code rCode}.
+     * <p>
+     * If the given {@code responseLength} is greater than {@code zero}, this
+     * specifies an exact number of bytes to send and the application must send
+     * that exact amount of data. If {@code responseLength} is
      * {@link #RSPBODY_CHUNKED} then the response body uses
      * chunked transfer encoding and an arbitrary amount of data may be
-     * sent. The application terminates the response body by closing the
+     * sent. If {@code responseLength} is {@link #RSPBODY_EMPTY} then no
+     * response body should be sent.
+     * <p>
+     * The application terminates the response body by closing the
      * {@link OutputStream}.
-     * If response length has the value {@link #RSPBODY_EMPTY} then no
-     * response body is being sent.
-     *
-     * <p> If the content-length response header has not already been set then
-     * this is set to the appropriate value depending on the response length
-     * parameter.
-     *
-     * <p> This method must be called prior to calling {@link #getResponseBody()}.
+     * <p>
+     * If the {@code content-length} response header has not already been set then
+     * this is set to the appropriate value depending on the {@code responseLength}.
+     * <p>
+     * This method must be called prior to calling {@link #getResponseBody()}.
      *
      * @implNote This implementation allows the caller to instruct the
      * server to force a connection close after the exchange terminates, by
-     * supplying a {@code Connection: close} header to the {@linkplain
+     * supplying a {@code Connection: close} header through {@linkplain
      * #getResponseHeaders() response headers} before {@code sendResponseHeaders}
      * is called.
      *
      * @param rCode          the response code to send
      * @param responseLength if {@literal > 0}, specifies a fixed response body
      *                       length and that exact number of bytes must be written
-     *                       to the stream acquired from {@link #getResponseCode()}
+     *                       to the stream acquired from {@link #getResponseBody()}
      *                       If equal to {@link #RSPBODY_CHUNKED}, then chunked encoding is used,
      *                       and an arbitrary number of bytes may be written.
-     *                       If equal to {@link #RSPBODY_EMPTY}, then no response body length is
-     *                       specified and no response body may be written.
+     *                       If equal to {@link #RSPBODY_EMPTY}, then the response will not
+     *                       have a body and no response body may be written.
      * @throws IOException   if the response headers have already been sent or an I/O error occurs
      * @see   HttpExchange#getResponseBody()
      */

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,12 +72,12 @@ import java.net.URI;
 public abstract class HttpExchange implements AutoCloseable, Request {
 
      /**
-      * No response body is being sent with this response
+      * No response body is sent with the response
       */
      public static final long RSPBODY_EMPTY = -1L;
 
      /**
-      * The response body is unspecified and will be chunk encoded
+      * The response body will be chunk encoded
       */
      public static final long RSPBODY_CHUNKED = 0;
 


### PR DESCRIPTION
As specified in [JDK-8368955](https://bugs.openjdk.org/browse/JDK-8368955?jql=project%20in%20(JDK)%20AND%20component%20in%20(core-libs)%20AND%20Subcomponent%20in%20(java.net)), adds some constants to HttpExchange to make `sendResponseHeaders` more usable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 26 to be approved (needs to be created)

### Issue
 * [JDK-8368955](https://bugs.openjdk.org/browse/JDK-8368955): Improve HttpExchange.sendResponseHeaders usability (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27613/head:pull/27613` \
`$ git checkout pull/27613`

Update a local copy of the PR: \
`$ git checkout pull/27613` \
`$ git pull https://git.openjdk.org/jdk.git pull/27613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27613`

View PR using the GUI difftool: \
`$ git pr show -t 27613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27613.diff">https://git.openjdk.org/jdk/pull/27613.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27613#issuecomment-3362769773)
</details>
