### PR TITLE
8368984: Extra slashes in Cipher transformation leads to NSPE instead of NSAE

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20CipherUnitTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20CipherUnitTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8153029 8360463
+ * @bug 8153029 8360463 8368984
  * @library /test/lib
  * @run main ChaCha20CipherUnitTest
  * @summary Unit test for com.sun.crypto.provider.ChaCha20Cipher.
@@ -72,10 +72,12 @@ public class ChaCha20CipherUnitTest {
 
         checkTransformation("ChaCha20", null);
         checkTransformation("ChaCha20/None/NoPadding", null);
-        checkTransformation("ChaCha20-Poly1305", null);
-        checkTransformation("ChaCha20-Poly1305/None/NoPadding", null);
+        checkTransformation("ChaCha20/None//", NSAE);
         checkTransformation("ChaCha20/ECB/NoPadding", NSAE);
         checkTransformation("ChaCha20/None/PKCS5Padding", NSPE);
+        checkTransformation("ChaCha20-Poly1305", null);
+        checkTransformation("ChaCha20-Poly1305/None/NoPadding", null);
+        checkTransformation("ChaCha20-Poly1305/None//", NSAE);
         checkTransformation("ChaCha20-Poly1305/ECB/NoPadding", NSAE);
         checkTransformation("ChaCha20-Poly1305/None/PKCS5Padding", NSPE);
     }

--- a/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
+++ b/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8359388
+ * @bug 8359388 8368984
  * @summary test that the Cipher.getInstance() would reject improper
  *     transformations with empty mode and/or padding.
  */
@@ -67,6 +67,9 @@ public class TestEmptyModePadding {
             "PBEWithHmacSHA512/256AndAES_128/CBC/ ",
             "PBEWithHmacSHA512/256AndAES_128//PKCS5Padding",
             "PBEWithHmacSHA512/256AndAES_128/ /PKCS5Padding",
+            // 4 or more components transformations
+            "PBEWithHmacSHA512///PKCS5Padding",
+            "AES/GCM/NoPadding///",
         };
 
         for (String t : testTransformations) {


### PR DESCRIPTION
This PR updates the cipher transformation parsing and verification logic to be stricter and throws NoSuchAlgorithmException (NSAE) when additional slash(es) is found. With the existing parsing logic, the extra slash(es) is likely to end up in the last component, i.e. the padding scheme, and lead to NoSuchPaddingException (NSPE) from the underlying CipherSpi object. 

Out of the supported cipher algorithms for all JDK providers, PBES2 cipher algorithms and RSA cipher with OAEP paddings may contain truncated SHA-512 in their transformations. This proposed fix would check for truncated SHA in both algorithm and padding schemes and throws NSAE if any extra slash is found. 

Thanks in advance for the review~