### PR TITLE
8369080: Use uname -m for devkit cpu detection

### DIFF
--- a/make/devkit/Makefile
+++ b/make/devkit/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@
 COMMA := ,
 
 os := $(shell uname -o)
-cpu := $(shell uname -p)
+cpu := $(shell uname -m)
 
 # Figure out what platform this is building on.
 me := $(cpu)-$(if $(findstring Linux,$(os)),linux-gnu)


### PR DESCRIPTION
The devkit creation uses uname -p for detection the cpu architecture. uname -p is non-portable and no longer works on recent Linux/distributions (e.g. OL10). It should be changed to uname -m which is portable and works.

Testing: manual verification on ol{7,8,9,10}-{aarch64,x86_64}