### PR TITLE
8368821: Test java/net/httpclient/http3/GetHTTP3Test.java intermittently fails with java.io.IOException: QUIC endpoint closed

### DIFF
--- a/test/jdk/java/net/httpclient/http3/GetHTTP3Test.java
+++ b/test/jdk/java/net/httpclient/http3/GetHTTP3Test.java
@@ -33,7 +33,6 @@ import java.net.http.HttpOption.Http3DiscoveryMode;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.net.ssl.SSLContext;
 
+import jdk.test.lib.Utils;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
@@ -74,8 +74,9 @@ import static java.lang.System.out;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.Utils
  * @compile ../ReferenceTracker.java
- * @run testng/othervm/timeout=60 -Djdk.internal.httpclient.debug=true
+ * @run testng/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.HttpClient.log=requests,responses,errors
  *                     GetHTTP3Test
  * @summary Basic HTTP/3 GET test
@@ -216,7 +217,6 @@ public class GetHTTP3Test implements HttpServerAdapters {
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .executor(executor)
                 .sslContext(sslContext)
-                .connectTimeout(Duration.ofSeconds(10))
                 .build();
         return TRACKER.track(client);
     }
@@ -348,7 +348,7 @@ public class GetHTTP3Test implements HttpServerAdapters {
             var tracker = TRACKER.getTracker(client);
             client = null;
             System.gc();
-            AssertionError error = TRACKER.check(tracker, 1000);
+            AssertionError error = TRACKER.check(tracker, Utils.adjustTimeout(1000));
             if (error != null) throw error;
         }
         System.out.println("test: DONE");
@@ -394,7 +394,7 @@ public class GetHTTP3Test implements HttpServerAdapters {
         var tracker = TRACKER.getTracker(client);
         client = null;
         System.gc();
-        AssertionError error = TRACKER.check(tracker, 1000);
+        AssertionError error = TRACKER.check(tracker, Utils.adjustTimeout(1000));
         if (error != null) throw error;
     }
 
@@ -423,7 +423,7 @@ public class GetHTTP3Test implements HttpServerAdapters {
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(Utils.adjustTimeout(1000));
         try {
             h3TestServer.stop();
         } finally {

--- a/test/jdk/java/net/httpclient/http3/PostHTTP3Test.java
+++ b/test/jdk/java/net/httpclient/http3/PostHTTP3Test.java
@@ -38,7 +38,6 @@ import java.net.http.HttpOption.Http3DiscoveryMode;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 
+import jdk.test.lib.Utils;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
@@ -79,6 +79,7 @@ import static java.lang.System.out;
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.Utils
  * @compile  ../ReferenceTracker.java
  * @run testng/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.HttpClient.log=requests,responses,errors
@@ -221,7 +222,6 @@ public class PostHTTP3Test implements HttpServerAdapters {
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .executor(executor)
                 .sslContext(sslContext)
-                .connectTimeout(Duration.ofSeconds(10))
                 .build();
         return TRACKER.track(client);
     }
@@ -375,7 +375,7 @@ public class PostHTTP3Test implements HttpServerAdapters {
             var tracker = TRACKER.getTracker(client);
             client = null;
             System.gc();
-            AssertionError error = TRACKER.check(tracker, 1000);
+            AssertionError error = TRACKER.check(tracker, Utils.adjustTimeout(1000));
             if (error != null) throw error;
         }
         System.out.println("test: DONE");
@@ -437,7 +437,7 @@ public class PostHTTP3Test implements HttpServerAdapters {
         var tracker = TRACKER.getTracker(client);
         client = null;
         System.gc();
-        AssertionError error = TRACKER.check(tracker, 1000);
+        AssertionError error = TRACKER.check(tracker, Utils.adjustTimeout(1000));
         if (error != null) throw error;
     }
 
@@ -466,7 +466,7 @@ public class PostHTTP3Test implements HttpServerAdapters {
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(Utils.adjustTimeout(1000));
         try {
             h3TestServer.stop();
         } finally {


### PR DESCRIPTION
Can I please get a review of this test-only change which addresses intermittent failures in `GetHTTP3Test` and `PostHTTP3Test`?

As noted in https://bugs.openjdk.org/browse/JDK-8368821, these two tests have been reported to fail intermittently, especially when the host on which it runs is under heavy resource usage or when run with JVM options like `-Xcomp`.

The commit in this PR removes the connection timeout that was enforced on the connection attempts by the test. As far as I can see, they aren't necessary for what this test is testing. The change also updates a few other places in this test which had specific values for timeouts when checking if the `HttpClient` had shutdown. These places have been updated to take into account the timeout factor when computing the timeout.

The changes have been verified by Matthias and SendaoYan who originally reported these issues. I will run this change in our CI too before integrating.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368821](https://bugs.openjdk.org/browse/JDK-8368821): Test java/net/httpclient/http3/GetHTTP3Test.java intermittently fails with java.io.IOException: QUIC endpoint closed (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27619/head:pull/27619` \
`$ git checkout pull/27619`

Update a local copy of the PR: \
`$ git checkout pull/27619` \
`$ git pull https://git.openjdk.org/jdk.git pull/27619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27619`

View PR using the GUI difftool: \
`$ git pr show -t 27619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27619.diff">https://git.openjdk.org/jdk/pull/27619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27619#issuecomment-3364572623)
</details>
