### PR TITLE
8369097

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -282,9 +282,23 @@ HeapWord* ParallelScavengeHeap::mem_allocate_cas_noexpand(size_t size, bool is_t
     return result;
   }
 
-  // Try allocating from the old gen for non-TLAB in certain scenarios.
+  // Try allocating from the old gen for non-TLAB and large allocations.
   if (!is_tlab) {
-    if (!should_alloc_in_eden(size) || _is_heap_almost_full) {
+    if (!should_alloc_in_eden(size)) {
+      result = old_gen()->cas_allocate_noexpand(size);
+      if (result != nullptr) {
+        return result;
+      }
+    }
+  }
+
+  // In extreme cases, try allocating in from space also.
+  if (_is_heap_almost_full) {
+    result = young_gen()->from_space()->cas_allocate(size);
+    if (result != nullptr) {
+      return result;
+    }
+    if (!is_tlab) {
       result = old_gen()->cas_allocate_noexpand(size);
       if (result != nullptr) {
         return result;


### PR DESCRIPTION
Support allocation in from-space of young-gen in extreme cases (heap is almost full), so that gc-log shows used-heap is almost at max-heap when OOM is thrown.

Test: tier1-5