### PR TITLE
8276966: Improve diagnostic output for the mismatching parts of a hybrid snippet

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -462,6 +462,7 @@ public class SnippetTaglet extends BaseTaglet {
                %s
                ----------------- external -----------------
                %s
+               --------------------------------------------
                """.formatted(inline, external);
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266666 8275788 8276964 8299080
+ * @bug 8266666 8275788 8276964 8299080 8276966
  * @summary Implementation for snippets
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2208,8 +2208,16 @@ public class TestSnippetTag extends SnippetTester {
                 "pkg");
         checkExit(Exit.ERROR);
         checkOutput(Output.OUT, true,
-                    """
-                    A.java:4: error: contents mismatch""");
+                """
+                    A.java:4: error: contents mismatch""",
+                """
+                      ----------------- inline -------------------
+                      Hello, Snippet! ...more
+                    \s\s
+                      ----------------- external -----------------
+                      Hello, Snippet!
+                    \s\s
+                      --------------------------------------------""");
         checkOutput("pkg/A.html", true, """
                         <details class="invalid-tag">
                         <summary>invalid @snippet</summary>

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2166,6 +2166,7 @@ public class TestSnippetTag extends SnippetTester {
                         Hello, Snippet!
                         ----------------- external -----------------
                         Hello, Snippet!...more
+                        --------------------------------------------
                         </pre>
                         </details>
                         """);
@@ -2219,6 +2220,7 @@ public class TestSnippetTag extends SnippetTester {
                         ----------------- external -----------------
                         Hello, Snippet!
 
+                        --------------------------------------------
                         </pre>
                         </details>
                         """);


### PR DESCRIPTION
Please review a trivial change to improve the error output for hybrid snippets with mismatching inline and external snippet text.

Since the logging code drops trailing blank lines, differences in trailing whitespace were not displayed properly. See [JDK-8304408](https://bugs.openjdk.org/browse/JDK-8304408) for an example where this occurs. By adding a terminal separator we make sure trailing blank lines are not discarded. This makes it also easier to see where the snippet diff ends. 

Old output:

```
  ----------------- inline -------------------
  inline snippet
  ----------------- external -----------------
  external snippet
```

New output:

```
  ----------------- inline -------------------
  inline snippet
  ----------------- external -----------------
  external snippet
  -------------------------------------------- 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276966](https://bugs.openjdk.org/browse/JDK-8276966): Improve diagnostic output for the mismatching parts of a hybrid snippet (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27621/head:pull/27621` \
`$ git checkout pull/27621`

Update a local copy of the PR: \
`$ git checkout pull/27621` \
`$ git pull https://git.openjdk.org/jdk.git pull/27621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27621`

View PR using the GUI difftool: \
`$ git pr show -t 27621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27621.diff">https://git.openjdk.org/jdk/pull/27621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27621#issuecomment-3365295451)
</details>
