### PR TITLE
8369123: Still more small Float16 refactorings

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -97,19 +97,26 @@ import jdk.internal.vm.vector.Float16Math;
  *      <cite>IEEE Standard for Floating-Point Arithmetic</cite></a>
  */
 
-// Currently Float16 is a value-based class and in future it is
+// Currently Float16 is a value-based class and in the future it is
 // expected to be aligned with Value Classes and Object as described in
 // JEP-401 (https://openjdk.org/jeps/401).
 @jdk.internal.ValueBased
 public final class Float16
     extends Number
     implements Comparable<Float16> {
-    /** @serial */
+
+    /**
+     * Primitive {@code short} field to hold the bits of the {@code Float16}.
+     * @serial
+     */
     private final short value;
+
     private static final long serialVersionUID = 16; // May not be needed when a value class?
 
     // Functionality for future consideration:
-    // IEEEremainder / remainder operator remainder
+    // IEEEremainder and separate % operator remainder (which are
+    // defined to use different rounding modes, see JLS sections 15.4
+    // and 15.17.3).
 
     // Do *not* define any public constructors
    /**
@@ -149,8 +156,14 @@ public final class Float16
      */
     public static final Float16 NaN = valueOf(Float.NaN);
 
+    /**
+     * A constant holding a zero (0.0) of type {@code Float16}.
+     */
     private static final Float16 ZERO = valueOf(0);
 
+    /**
+     * A constant holding a one (1.0) of type {@code Float16}.
+     */
     private static final Float16 ONE  = valueOf(1);
 
     /**
@@ -1567,7 +1580,7 @@ public final class Float16
         case MAX_EXPONENT + 1 -> abs(f16);  // NaN or infinity
         case MIN_EXPONENT - 1 -> MIN_VALUE; // zero or subnormal
         default -> {
-            assert exp <= MAX_EXPONENT && exp >= MIN_EXPONENT;
+            assert exp <= MAX_EXPONENT && exp >= MIN_EXPONENT: "Out of range exponent";
             // ulp(x) is usually 2^(SIGNIFICAND_WIDTH-1)*(2^ilogb(x))
             // Let float -> float16 conversion handle encoding issues.
             yield scalb(ONE, exp - (PRECISION - 1));


### PR DESCRIPTION
Upon further inspection, found a few more opportunities to refine the use of constants in the Float16 implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369123](https://bugs.openjdk.org/browse/JDK-8369123): Still more small Float16 refactorings (**Enhancement** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27625/head:pull/27625` \
`$ git checkout pull/27625`

Update a local copy of the PR: \
`$ git checkout pull/27625` \
`$ git pull https://git.openjdk.org/jdk.git pull/27625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27625`

View PR using the GUI difftool: \
`$ git pr show -t 27625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27625.diff">https://git.openjdk.org/jdk/pull/27625.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27625#issuecomment-3366399492)
</details>
