### PR TITLE
8365630: jdk/jfr/tool/TestPrintContextual.java fails with wrong spanId

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintContextual.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintContextual.java
@@ -25,6 +25,7 @@ package jdk.jfr.tool;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -265,6 +266,7 @@ public class TestPrintContextual {
     }
 
     private static void span(int depth) {
+        awaitUniqueTimestamp();
         SpanEvent span = new SpanEvent();
         span.name = "span";
         span.spanId = depth;
@@ -275,6 +277,17 @@ public class TestPrintContextual {
         }
         span(depth - 1);
         span.commit();
+    }
+
+    private static void awaitUniqueTimestamp() {
+        Instant timestamp = Instant.now();
+        while (timestamp.equals(Instant.now())) {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
     }
 
     // Tests that context values are only inhjected into events in the same thread.

--- a/test/jdk/jdk/jfr/tool/TestPrintContextual.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintContextual.java
@@ -265,7 +265,7 @@ public class TestPrintContextual {
         }
     }
 
-    private static void span(int depth) {
+    private static void span(int depth) throws InterruptedException {
         awaitUniqueTimestamp();
         SpanEvent span = new SpanEvent();
         span.name = "span";
@@ -279,14 +279,10 @@ public class TestPrintContextual {
         span.commit();
     }
 
-    private static void awaitUniqueTimestamp() {
+    private static void awaitUniqueTimestamp() throws InterruptedException {
         Instant timestamp = Instant.now();
         while (timestamp.equals(Instant.now())) {
-            try {
-                Thread.sleep(1);
-            } catch (InterruptedException e) {
-                // ignore
-            }
+            Thread.sleep(1);
         }
     }
 


### PR DESCRIPTION
Could I get a review of a test fix that emits events with unique timestamps, so the contextual information is printed in chronological order?

Testing: 500 *  jdk/jfr/tool/TestPrintContextual.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365630](https://bugs.openjdk.org/browse/JDK-8365630): jdk/jfr/tool/TestPrintContextual.java fails with wrong spanId (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27626/head:pull/27626` \
`$ git checkout pull/27626`

Update a local copy of the PR: \
`$ git checkout pull/27626` \
`$ git pull https://git.openjdk.org/jdk.git pull/27626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27626`

View PR using the GUI difftool: \
`$ git pr show -t 27626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27626.diff">https://git.openjdk.org/jdk/pull/27626.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27626#issuecomment-3367242365)
</details>
