### PR TITLE
ProblemListing 1 test and disabling 2 other tests

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryDataRunner.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryDataRunner.java
@@ -29,6 +29,7 @@ package gc.g1;
  * @bug 8038423 8061715
  * @summary Checks that decommitment occurs for JVM with different ObjectAlignmentInBytes values
  * @requires vm.gc.G1
+ * @requires !vm.opt.final.UseLargePages
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/vmTestbase/gc/vector/CircularListLow/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/vector/CircularListLow/TestDescription.java
@@ -31,5 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @requires vm.gc != "Serial"
  * @run main/othervm/timeout=480 gc.vector.SimpleGC.SimpleGC -ms low -gp circularList(low)
  */

--- a/test/hotspot/jtreg/vmTestbase/gc/vector/LinearListLow/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/vector/LinearListLow/TestDescription.java
@@ -31,5 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @requires vm.gc != "Serial"
  * @run main/othervm gc.vector.SimpleGC.SimpleGC -ms low -gp linearList(low)
  */

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,3 +29,4 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/reflect/callerCache/ReflectionCallerCacheTest.java    8332028 generic-all
+jdk/jfr/event/profiling/TestCPUTimeSampleQueueAutoSizes.java    8367302 linux-all


### PR DESCRIPTION
In order to reduce noise in the JDK26 CI, I'm bundling the following three trivial fixes:

[JDK-8369128](https://bugs.openjdk.org/browse/JDK-8369128) ProblemList jdk/jfr/event/profiling/TestCPUTimeSampleQueueAutoSizes.java in Xcomp configs

[JDK-8369132](https://bugs.openjdk.org/browse/JDK-8369132) Disable vmTestbase/gc/vector/CircularListLow and LinearListLow with SerialGC

[JDK-8369133](https://bugs.openjdk.org/browse/JDK-8369133) Disable gc/g1/TestShrinkAuxiliaryDataRunner.java with UseLargePages option