### PR TITLE
8369138: New test compiler/loopstripmining/MissingStoreAfterOuterStripMinedLoop.java fails

### DIFF
--- a/test/hotspot/jtreg/compiler/loopstripmining/MissingStoreAfterOuterStripMinedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/MissingStoreAfterOuterStripMinedLoop.java
@@ -29,7 +29,8 @@
  *          leading to wrong results.
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
- *      -Xcomp -XX:-UseLoopPredicate -XX:-UseAutoVectorizationPredicate
+ *      -Xcomp -XX:-UseLoopPredicate
+ *      -XX:+UnlockDiagnosticVMOptions -XX:-UseAutoVectorizationPredicate
  *      -XX:CompileCommand=compileonly,compiler.loopstripmining.MissingStoreAfterOuterStripMinedLoop::test*
  *      compiler.loopstripmining.MissingStoreAfterOuterStripMinedLoop
  * @run main compiler.loopstripmining.MissingStoreAfterOuterStripMinedLoop


### PR DESCRIPTION
A trivial fix to allow new test compiler/loopstripmining/MissingStoreAfterOuterStripMinedLoop.java
to execute with release bits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369138](https://bugs.openjdk.org/browse/JDK-8369138): New test compiler/loopstripmining/MissingStoreAfterOuterStripMinedLoop.java fails (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27630/head:pull/27630` \
`$ git checkout pull/27630`

Update a local copy of the PR: \
`$ git checkout pull/27630` \
`$ git pull https://git.openjdk.org/jdk.git pull/27630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27630`

View PR using the GUI difftool: \
`$ git pr show -t 27630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27630.diff">https://git.openjdk.org/jdk/pull/27630.diff</a>

</details>
