### PR TITLE
JDK-8369078: Fix faulty test conversion in IllegalCharsetName.java

### DIFF
--- a/test/jdk/java/nio/charset/Charset/IllegalCharsetName.java
+++ b/test/jdk/java/nio/charset/Charset/IllegalCharsetName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class IllegalCharsetName {
         assertThrows(IllegalCharsetNameException.class,
                 () -> Charset.forName(name));
         assertThrows(IllegalCharsetNameException.class,
-                () -> Charset.forName(name));
+                () -> Charset.isSupported(name));
     }
 
     // Charset.forName, Charset.isSupported, and the Charset constructor should
@@ -60,7 +60,7 @@ public class IllegalCharsetName {
         assertThrows(IllegalCharsetNameException.class,
                 () -> Charset.forName(""));
         assertThrows(IllegalCharsetNameException.class,
-                () -> Charset.forName(""));
+                () -> Charset.isSupported(""));
         assertThrows(IllegalCharsetNameException.class,
                 () -> new Charset("", new String[]{}) {
                     @Override


### PR DESCRIPTION
This PR corrects two instances of `Charset.isSupported` which were inadvertently converted to `Charset.forName` in _test/jdk/java/nio/charset/Charset/IllegalCharsetName.java_ during [JDK-8369078](https://bugs.openjdk.org/browse/JDK-8369078).