### PR TITLE
8369152: Problem list new tests from JDK-8316694

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,6 +79,11 @@ compiler/c2/TestVerifyConstraintCasts.java 8355574 generic-all
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 linux-aarch64,macosx-aarch64
 
+compiler/whitebox/DeoptimizeRelocatedNMethod.java 8369147 generic-all
+compiler/whitebox/RelocateNMethod.java 8369147 generic-all
+compiler/whitebox/StressNMethodRelocation.java 8369147,8369148,8369149 generic-all
+serviceability/jvmti/NMethodRelocation/NMethodRelocationTest.java 8369150,8369151 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Most new tests from [JDK-8316694](https://bugs.openjdk.org/browse/JDK-8316694) failed in tier3. Problem list them until they are fixed.
