### PR TITLE
8335646: Nimbus : JLabel not painted with LAF defined foreground color on Ubuntu 24.04

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicHTML/bug4248210.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicHTML/bug4248210.java
@@ -71,8 +71,7 @@ public class bug4248210 {
             UIManager.getDefaults().put("Label.foreground", labelColor);
         }
 
-        JLabel label = new JLabel("<html><body>WWWWWWWWWMMMMMMM?</body></html>");
-        label.setFont(new java.awt.Font("Dialog", java.awt.Font.BOLD, 20));
+        JLabel label = new JLabel("<html><body>\u2588 \u2588 \u2588 \u2588</body></html>");
         label.setSize(150, 30);
 
         BufferedImage img = paintToImage(label);

--- a/test/jdk/javax/swing/plaf/basic/BasicHTML/bug4248210.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicHTML/bug4248210.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,8 @@ public class bug4248210 {
             UIManager.getDefaults().put("Label.foreground", labelColor);
         }
 
-        JLabel label = new JLabel("<html><body>Can You Read This?</body></html>");
+        JLabel label = new JLabel("<html><body>WWWWWWWWWMMMMMMM?</body></html>");
+        label.setFont(new java.awt.Font("Dialog", java.awt.Font.BOLD, 20));
         label.setSize(150, 30);
 
         BufferedImage img = paintToImage(label);


### PR DESCRIPTION
Test fails to pick red color from JLabel in ubuntu24.04 even though it passes is ubuntu 22.04.
Seems like the red pixel from the font is not being picked up despite the fact that label foreground color actually is rendered in red.

It is seen in ubuntu 22.04 the font used for JLabel is "family=DejaVu Sans,name=DejaVu Sans,style=plain,size=12"
while in ubuntu 24.04 the font used for JLabel is "family=Noto Sans,name=Noto Sans,style=plain,size=12"

I have made it consistent across version using same font and made it larger and bold and using such text for easier pickup of redpixel.
It passes in all platforms including ubuntu24.04

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335646](https://bugs.openjdk.org/browse/JDK-8335646): Nimbus : JLabel not painted with LAF defined foreground color on Ubuntu 24.04 (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27635/head:pull/27635` \
`$ git checkout pull/27635`

Update a local copy of the PR: \
`$ git checkout pull/27635` \
`$ git pull https://git.openjdk.org/jdk.git pull/27635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27635`

View PR using the GUI difftool: \
`$ git pr show -t 27635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27635.diff">https://git.openjdk.org/jdk/pull/27635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27635#issuecomment-3368772859)
</details>
