### PR TITLE
8245234: Still seeing missing mixed stack traces, even after JDK-8234624

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,17 +145,12 @@ public final class LinuxAMD64CFrame extends BasicCFrame {
      }
 
      DwarfParser nextDwarf = null;
-
-     if ((dwarf != null) && dwarf.isIn(nextPC)) {
-       nextDwarf = dwarf;
-     } else {
-       Address libptr = dbg.findLibPtrByAddress(nextPC);
-       if (libptr != null) {
-         try {
-           nextDwarf = new DwarfParser(libptr);
-         } catch (DebuggerException e) {
-           // Bail out to Java frame
-         }
+     Address libptr = dbg.findLibPtrByAddress(nextPC);
+     if (libptr != null) {
+       try {
+         nextDwarf = new DwarfParser(libptr);
+       } catch (DebuggerException e) {
+         // Bail out to Java frame
        }
      }
 


### PR DESCRIPTION
We haven't yet been able to unwind native frames in mixed mode jhsdb in some case even though we implement DWARF parser in [JDK-8234624](https://bugs.openjdk.org/browse/JDK-8234624). The cause is that `DwarfParser` would be reused.

DWARF is encoded as a state machine, so we have to initialize when we try to find new frame via DWARF. So I made change to create new `DwarfParser` instance everytime in `LinuxAMD64CFrame::sender`.