### PR TITLE
8365782: Remove unnecessary inclusion of <stdlib.h> in jfrOSInterface.cpp

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrOSInterface.cpp
@@ -32,8 +32,6 @@
 #include "runtime/vm_version.hpp"
 #include "utilities/ostream.hpp"
 
-#include <stdlib.h> // for environment variables
-
 static JfrOSInterface* _instance = nullptr;
 
 JfrOSInterface& JfrOSInterface::instance() {
@@ -81,10 +79,7 @@ class JfrOSInterface::JfrOSInterfaceImpl : public JfrCHeapObj {
   // os information
   int os_version(char** os_version) const;
 
-  // environment information
-  void generate_environment_variables_events();
-
-   // system processes information
+  // system processes information
   int system_processes(SystemProcess** system_processes, int* no_of_sys_processes);
 
   int network_utilization(NetworkInterface** network_interfaces);


### PR DESCRIPTION
related jira issue: https://bugs.openjdk.org/browse/JDK-8365782

---

### Changes

As described in the issue, I have removed the unnecessary inclusion of `stdlib.h`.

This was first discussed in [this comment](https://github.com/openjdk/jdk/pull/26800#discussion_r2278998210).

As noted in the discussion, `generate_environment_variables_events` also appears to be unimplemented, so it has been removed as well.

---

### Verification

- Checked that no functions from `stdlib.h` are called in the file.
- Checked that the `generate_environment_variables_events` function is not implemented anywhere in the codebase.
- Ran the `tier1` tests after the changes and confirmed that there were no issues.

Please let me know if there are any additional or more appropriate verification steps I should perform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365782](https://bugs.openjdk.org/browse/JDK-8365782): Remove unnecessary inclusion of &lt;stdlib.h&gt; in jfrOSInterface.cpp (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27639/head:pull/27639` \
`$ git checkout pull/27639`

Update a local copy of the PR: \
`$ git checkout pull/27639` \
`$ git pull https://git.openjdk.org/jdk.git pull/27639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27639`

View PR using the GUI difftool: \
`$ git pr show -t 27639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27639.diff">https://git.openjdk.org/jdk/pull/27639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27639#issuecomment-3369211948)
</details>
