### PR TITLE
8367717: Cleanup atomic_copy64

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -38,6 +38,7 @@
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
@@ -521,10 +522,6 @@ void os::current_thread_enable_wx(WXMode mode) {
 }
 #endif
 
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  *(jlong *) dst = *(const jlong *) src;
-}
-
 extern "C" {
   int SpinPause() {
     // We don't use StubRoutines::aarch64::spin_wait stub in order to
@@ -588,14 +585,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end)
-        atomic_copy64(from++, to++);
+        AtomicAccess::store(to++, AtomicAccess::load(from++));
     }
     else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        atomic_copy64(from--, to--);
+        AtomicAccess::store(to--, AtomicAccess::load(from--));
     }
   }
 

--- a/src/hotspot/os_cpu/bsd_zero/atomicAccess_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/atomicAccess_bsd_zero.hpp
@@ -125,13 +125,6 @@ inline T AtomicAccess::PlatformCmpxchg<8>::operator()(T volatile* dest,
   return value;
 }
 
-// Atomically copy 64 bits of data
-inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  int64_t tmp;
-  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
-  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
-}
-
 template<>
 template<typename T>
 inline T AtomicAccess::PlatformLoad<8>::operator()(T const volatile* src) const {

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -240,13 +240,6 @@ void os::print_register_info(outputStream *st, const void *context, int& continu
 // Stubs for things that would be in bsd_zero.s if it existed.
 // You probably want to disassemble these monkeys to check they're ok.
 
-// Atomically copy 64 bits of data
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  int64_t tmp;
-  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
-  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
-}
-
 extern "C" {
   int SpinPause() {
     return 1;
@@ -284,14 +277,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end)
-        atomic_copy64(from++, to++);
+        AtomicAccess::store(to++, AtomicAccess::load(from++));
     }
     else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        atomic_copy64(from--, to--);
+        AtomicAccess::store(to--, AtomicAccess::load(from--));
     }
   }
 

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -240,6 +240,13 @@ void os::print_register_info(outputStream *st, const void *context, int& continu
 // Stubs for things that would be in bsd_zero.s if it existed.
 // You probably want to disassemble these monkeys to check they're ok.
 
+// Atomically copy 64 bits of data
+static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
+  int64_t tmp;
+  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
+  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
+}
+
 extern "C" {
   int SpinPause() {
     return 1;

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -36,6 +36,7 @@
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
@@ -383,10 +384,6 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  *(jlong *) dst = *(const jlong *) src;
-}
-
 extern "C" {
   int SpinPause() {
     using spin_wait_func_ptr_t = void (*)();
@@ -438,14 +435,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end)
-        atomic_copy64(from++, to++);
+        AtomicAccess::store(to++, AtomicAccess::load(from++));
     }
     else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        atomic_copy64(from--, to--);
+        AtomicAccess::store(to--, AtomicAccess::load(from--));
     }
   }
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -36,6 +36,7 @@
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
@@ -450,10 +451,6 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  *(jlong *) dst = *(const jlong *) src;
-}
-
 extern "C" {
   int SpinPause() {
     if (UseZihintpause) {
@@ -502,14 +499,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end) {
-        atomic_copy64(from++, to++);
+        AtomicAccess::store(to++, AtomicAccess::load(from++));
       }
     } else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end) {
-        atomic_copy64(from--, to--);
+        AtomicAccess::store(to--, AtomicAccess::load(from--));
       }
     }
   }

--- a/src/hotspot/os_cpu/linux_zero/atomicAccess_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomicAccess_linux_zero.hpp
@@ -125,13 +125,6 @@ inline T AtomicAccess::PlatformCmpxchg<8>::operator()(T volatile* dest,
   return value;
 }
 
-// Atomically copy 64 bits of data
-inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  int64_t tmp;
-  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
-  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
-}
-
 template<>
 template<typename T>
 inline T AtomicAccess::PlatformLoad<8>::operator()(T const volatile* src) const {

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -388,6 +388,13 @@ void os::print_register_info(outputStream *st, const void *context, int& continu
 // Stubs for things that would be in linux_zero.s if it existed.
 // You probably want to disassemble these monkeys to check they're ok.
 
+// Atomically copy 64 bits of data
+static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
+  int64_t tmp;
+  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
+  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
+}
+
 extern "C" {
   int SpinPause() {
       return -1; // silence compile warnings

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -388,13 +388,6 @@ void os::print_register_info(outputStream *st, const void *context, int& continu
 // Stubs for things that would be in linux_zero.s if it existed.
 // You probably want to disassemble these monkeys to check they're ok.
 
-// Atomically copy 64 bits of data
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  int64_t tmp;
-  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
-  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
-}
-
 extern "C" {
   int SpinPause() {
       return -1; // silence compile warnings
@@ -433,14 +426,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end)
-        atomic_copy64(from++, to++);
+        AtomicAccess::store(to++, AtomicAccess::load(from++));
     }
     else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        atomic_copy64(from--, to--);
+        AtomicAccess::store(to--, AtomicAccess::load(from--));
     }
   }
 


### PR DESCRIPTION
related jira issue: https://bugs.openjdk.org/browse/JDK-8367717

## Changes
- deleted all definitions of atomic_copy64
- replaced all calls to `atomic_copy64` with `AtomicAccess::store(dst, AtomicAccess::load(src))`

## Verification
- Verified by running:
  - `make run-test TEST="gtest:StubRoutines*"`
  - `make run-test TEST="gtest:AtomicAccess*"`

Please let me know if there are any additional or more appropriate verification steps I should perform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367717](https://bugs.openjdk.org/browse/JDK-8367717): Cleanup atomic_copy64 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27642/head:pull/27642` \
`$ git checkout pull/27642`

Update a local copy of the PR: \
`$ git checkout pull/27642` \
`$ git pull https://git.openjdk.org/jdk.git pull/27642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27642`

View PR using the GUI difftool: \
`$ git pr show -t 27642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27642.diff">https://git.openjdk.org/jdk/pull/27642.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27642#issuecomment-3369940824)
</details>
