### PR TITLE
JDK-8369207: _Copy_conjoint_{jshorts,jints,jlongs}_atomic on Linux/BSD AArch64 do not prevent tearing

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -521,10 +521,6 @@ void os::current_thread_enable_wx(WXMode mode) {
 }
 #endif
 
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  *(jlong *) dst = *(const jlong *) src;
-}
-
 extern "C" {
   int SpinPause() {
     // We don't use StubRoutines::aarch64::spin_wait stub in order to
@@ -559,28 +555,28 @@ extern "C" {
     if (from > to) {
       const jshort *end = from + count;
       while (from < end)
-        *(to++) = *(from++);
+        *((volatile jshort*) to++) = *(from++);
     }
     else if (from < to) {
       const jshort *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        *(to--) = *(from--);
+        *((volatile jshort*) to--) = *(from--);
     }
   }
   void _Copy_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
     if (from > to) {
       const jint *end = from + count;
       while (from < end)
-        *(to++) = *(from++);
+        *((volatile jint*) to++) = *(from++);
     }
     else if (from < to) {
       const jint *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        *(to--) = *(from--);
+        *((volatile jint*) to--) = *(from--);
     }
   }
 
@@ -588,14 +584,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end)
-        atomic_copy64(from++, to++);
+        *((volatile jlong*) to++) = *(from++);
     }
     else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        atomic_copy64(from--, to--);
+        *((volatile jlong*) to--) = *(from--);
     }
   }
 

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -383,10 +383,6 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  *(jlong *) dst = *(const jlong *) src;
-}
-
 extern "C" {
   int SpinPause() {
     using spin_wait_func_ptr_t = void (*)();
@@ -409,28 +405,28 @@ extern "C" {
     if (from > to) {
       const jshort *end = from + count;
       while (from < end)
-        *(to++) = *(from++);
+        *((volatile jshort*) to++) = *(from++);
     }
     else if (from < to) {
       const jshort *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        *(to--) = *(from--);
+        *((volatile jshort*) to--) = *(from--);
     }
   }
   void _Copy_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
     if (from > to) {
       const jint *end = from + count;
       while (from < end)
-        *(to++) = *(from++);
+        *((volatile jint*) to++) = *(from++);
     }
     else if (from < to) {
       const jint *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        *(to--) = *(from--);
+        *((volatile jint*) to--) = *(from--);
     }
   }
 
@@ -438,14 +434,14 @@ extern "C" {
     if (from > to) {
       const jlong *end = from + count;
       while (from < end)
-        atomic_copy64(from++, to++);
+        *((volatile jlong*) to++) = *(from++);
     }
     else if (from < to) {
       const jlong *end = from;
       from += count - 1;
       to   += count - 1;
       while (from >= end)
-        atomic_copy64(from--, to--);
+        *((volatile jlong*) to--) = *(from--);
     }
   }
 


### PR DESCRIPTION
Ensure the compiler cannot optimize the copy loops by replacing them with `memcpy` which is allowed to copy byte by byte potentially introducing tearing. Currently there is nothing preventing the compiler from doing this. We add `volatile` which prevents the compiler from making this optimization in the future.

Currently the code generates to `ldp` and `stp`, this change does have the side affect of forcing it to do `ldr` and `str`. If that seems unacceptable from a performance standpoint we can hand-roll assembly to do `ldp` and `stp`.