### PR TITLE
8369039: JDK-8348611 caused regression in Javac-Hot-Generate

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/LintMapper.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/LintMapper.java
@@ -25,10 +25,10 @@
 
 package com.sun.tools.javac.code;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -180,7 +180,7 @@ public class LintMapper {
     private static class FileInfo {
 
         final LintRange rootRange;                              // the root LintRange (covering the entire source file)
-        final List<Span> unmappedDecls = new LinkedList<>();    // unmapped top-level declarations awaiting attribution
+        final List<Span> unmappedDecls = new ArrayList<>();     // unmapped top-level declarations awaiting attribution
 
         // After parsing: Add top-level declarations to our "unmappedDecls" list
         FileInfo(Lint rootLint, JCCompilationUnit tree) {
@@ -252,12 +252,12 @@ public class LintMapper {
 
         // Create a node representing the entire file, using the root lint configuration
         LintRange(Lint rootLint) {
-            this(Span.MAXIMAL, rootLint, new LinkedList<>());
+            this(Span.MAXIMAL, rootLint, new ArrayList<>());
         }
 
         // Create a node representing the given declaration and its corresponding Lint configuration
         LintRange(JCTree tree, EndPosTable endPositions, Lint lint) {
-            this(new Span(tree, endPositions), lint, new LinkedList<>());
+            this(new Span(tree, endPositions), lint, new ArrayList<>());
         }
 
         // Find the most specific node in this tree (including me) that contains the given position, if any

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/LintMapper.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/LintMapper.java
@@ -25,10 +25,10 @@
 
 package com.sun.tools.javac.code;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -180,7 +180,7 @@ public class LintMapper {
     private static class FileInfo {
 
         final LintRange rootRange;                              // the root LintRange (covering the entire source file)
-        final List<Span> unmappedDecls = new ArrayList<>();     // unmapped top-level declarations awaiting attribution
+        final List<Span> unmappedDecls = new LinkedList<>();    // unmapped top-level declarations awaiting attribution
 
         // After parsing: Add top-level declarations to our "unmappedDecls" list
         FileInfo(Lint rootLint, JCCompilationUnit tree) {
@@ -252,17 +252,18 @@ public class LintMapper {
 
         // Create a node representing the entire file, using the root lint configuration
         LintRange(Lint rootLint) {
-            this(Span.MAXIMAL, rootLint, new ArrayList<>());
+            this(Span.MAXIMAL, rootLint, new LinkedList<>());
         }
 
         // Create a node representing the given declaration and its corresponding Lint configuration
         LintRange(JCTree tree, EndPosTable endPositions, Lint lint) {
-            this(new Span(tree, endPositions), lint, new ArrayList<>());
+            this(new Span(tree, endPositions), lint, new LinkedList<>());
         }
 
         // Find the most specific node in this tree (including me) that contains the given position, if any
         LintRange bestMatch(DiagnosticPosition pos) {
             return children.stream()
+              .filter(child -> child.span.contains(pos))    // don't recurse unless necessary
               .map(child -> child.bestMatch(pos))
               .filter(Objects::nonNull)
               .reduce((a, b) -> a.span.contains(b.span) ? b : a)


### PR DESCRIPTION
The refactoring in [JDK-8348611](https://bugs.openjdk.org/browse/JDK-8348611) caused a regression in compiler performance. In the the refactoring there were a couple of simple optimizations that were missed. When put in place, these seem to (mostly) address the performance issue.