### PR TITLE
8357809: Test jdk/jshell/JdiListeningExecutionControlTest.java failed with com.sun.jdi.connect.TransportTimeoutException

### DIFF
--- a/test/langtools/jdk/jshell/JdiBadOptionListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiBadOptionListenExecutionControlTest.java
@@ -47,7 +47,7 @@ public class JdiBadOptionListenExecutionControlTest {
             // turn on logging of launch failures
             Logger.getLogger("jdk.jshell.execution").setLevel(Level.ALL);
             JShell.builder()
-                    .executionEngine("jdi")
+                    .executionEngine(Presets.TEST_JDI_EXECUTION)
                     .remoteVMOptions("-BadBadOption")
                     .build();
         } catch (IllegalStateException ex) {

--- a/test/langtools/jdk/jshell/JdiListeningExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiListeningExecutionControlTest.java
@@ -39,6 +39,6 @@ public class JdiListeningExecutionControlTest extends ExecutionControlTestBase {
     @BeforeEach
     @Override
     public void setUp() {
-        setUp(builder -> builder.executionEngine("jdi"));
+        setUp(builder -> builder.executionEngine(Presets.TEST_JDI_EXECUTION));
     }
 }

--- a/test/langtools/jdk/jshell/Presets.java
+++ b/test/langtools/jdk/jshell/Presets.java
@@ -39,7 +39,7 @@ public class Presets {
                                  "2(jdi:timeout(" + TEST_TIMEOUT + "))," +
                                  "3(local)";
         TEST_STANDARD_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
-                                  "1(jdi:launch(true))" +
+                                  "1(jdi:launch(true))," +
                                   "2(jdi:timeout(" + TEST_TIMEOUT + "))";
         TEST_JDI_EXECUTION = "jdi:timeout(" + TEST_TIMEOUT + ")";
     }

--- a/test/langtools/jdk/jshell/Presets.java
+++ b/test/langtools/jdk/jshell/Presets.java
@@ -25,16 +25,23 @@ import java.net.InetAddress;
 import java.util.*;
 
 public class Presets {
+    private static final int TEST_TIMEOUT = 20_000;
+
     public static final String TEST_DEFAULT_EXECUTION;
     public static final String TEST_STANDARD_EXECUTION;
+    public static final String TEST_JDI_EXECUTION;
 
     static {
         String loopback = InetAddress.getLoopbackAddress().getHostAddress();
 
         TEST_DEFAULT_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
-                                 "1(jdi:launch(true)), 2(jdi), 3(local)";
+                                 "1(jdi:launch(true))," +
+                                 "2(jdi:timeout(" + TEST_TIMEOUT + "))," +
+                                 "3(local)";
         TEST_STANDARD_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
-                                  "1(jdi:launch(true)), 2(jdi)";
+                                  "1(jdi:launch(true))" +
+                                  "2(jdi:timeout(" + TEST_TIMEOUT + "))";
+        TEST_JDI_EXECUTION = "jdi:timeout(" + TEST_TIMEOUT + ")";
     }
 
     public static String[] addExecutionIfMissing(String[] args) {


### PR DESCRIPTION
The test timed-out while connecting to the remote agent over JDI. This PR proposes to try to increase the JDI connection timeout.