### PR TITLE
8369226: GHA: Switch to MacOS 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -327,8 +327,8 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      runs-on: 'macos-13'
-      xcode-toolset-version: '14.3.1'
+      runs-on: 'macos-15-intel'
+      xcode-toolset-version: '16.4'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
@@ -340,8 +340,8 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      runs-on: 'macos-14'
-      xcode-toolset-version: '15.4'
+      runs-on: 'macos-15'
+      xcode-toolset-version: '16.4'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
@@ -432,9 +432,9 @@ jobs:
     with:
       platform: macos-aarch64
       bootjdk-platform: macos-aarch64
-      runs-on: macos-14
+      runs-on: macos-15
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
-      xcode-toolset-version: '15.4'
+      xcode-toolset-version: '16.4'
       debug-suffix: -debug
 
   test-windows-x64:


### PR DESCRIPTION
Current GHA workflows for MacOS are running with:
 - x86_64: macos-13, builds only
 - aarch64: macos-14, builds+tests

GitHub is deprecating MacOS 13 runner on December 4th, 2025, the brownouts are starting in a month: https://github.com/actions/runner-images/issues/13046. Additionally, GHA phases out MacOS x86_64, and MacOS 15 would be the last runner for x86_64. We have already disabled testing jobs for MacOS x86_64. GitHub recommends migrating to MacOS 15 at this time.

We can switch to MacOS 15 runner for both x86 and AArch64 to keep pipelines green in the coming months.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369226](https://bugs.openjdk.org/browse/JDK-8369226): GHA: Switch to MacOS 15 (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27655/head:pull/27655` \
`$ git checkout pull/27655`

Update a local copy of the PR: \
`$ git checkout pull/27655` \
`$ git pull https://git.openjdk.org/jdk.git pull/27655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27655`

View PR using the GUI difftool: \
`$ git pr show -t 27655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27655.diff">https://git.openjdk.org/jdk/pull/27655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27655#issuecomment-3373040945)
</details>
