### PR TITLE
8369242: Rename URL variables in devkit/Tools.gmk

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -117,13 +117,13 @@ dependencies := gcc binutils ccache mpfr gmp mpc gdb
 
 $(foreach dep,$(dependencies),$(eval $(dep)_ver := $(dep)-$($(dep)_ver_only)))
 
-GCC := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
-BINUTILS := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
-CCACHE := https://github.com/ccache/ccache/releases/download/v$(ccache_ver_only)/$(ccache_ver).tar.xz
-MPFR := https://www.mpfr.org/$(mpfr_ver)/$(mpfr_ver).tar.bz2
-GMP := http://ftp.gnu.org/pub/gnu/gmp/$(gmp_ver).tar.bz2
-MPC := http://ftp.gnu.org/pub/gnu/mpc/$(mpc_ver).tar.gz
-GDB := http://ftp.gnu.org/gnu/gdb/$(gdb_ver).tar.xz
+GCC_URL := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
+BINUTILS_URL := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
+CCACHE_URL := https://github.com/ccache/ccache/releases/download/v$(ccache_ver_only)/$(ccache_ver).tar.xz
+MPFR_URL := https://www.mpfr.org/$(mpfr_ver)/$(mpfr_ver).tar.bz2
+GMP_URL := http://ftp.gnu.org/pub/gnu/gmp/$(gmp_ver).tar.bz2
+MPC_URL := http://ftp.gnu.org/pub/gnu/mpc/$(mpc_ver).tar.gz
+GDB_URL := http://ftp.gnu.org/gnu/gdb/$(gdb_ver).tar.xz
 
 REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
 ifneq ($(REQUIRED_MIN_MAKE_MAJOR_VERSION),)
@@ -201,7 +201,7 @@ download-rpms:
 # Generate downloading + unpacking of sources.
 define Download
   # Allow override
-  $(1)_DIRNAME ?= $(basename $(basename $(notdir $($(1)))))
+  $(1)_DIRNAME ?= $(basename $(basename $(notdir $($(1)_URL))))
   $(1)_DIR = $(abspath $(SRCDIR)/$$($(1)_DIRNAME))
   ifeq ($$($(1)_CMAKE_BASED),)
     $(1)_CFG = $$($(1)_DIR)/configure
@@ -212,7 +212,7 @@ define Download
     $(1)_SRC_MARKER = $$($(1)_DIR)/CMakeLists.txt
     $(1)_CONFIG = $$(CMAKE_CONFIG) $$($(1)_DIR)
   endif
-  $(1)_FILE = $(DOWNLOAD)/$(notdir $($(1)))
+  $(1)_FILE = $(DOWNLOAD)/$(notdir $($(1)_URL))
 
   $$($(1)_SRC_MARKER) : $$($(1)_FILE)
 	mkdir -p $$(SRCDIR)
@@ -224,7 +224,7 @@ define Download
 	touch $$@
 
   $$($(1)_FILE) :
-	wget -P $(DOWNLOAD) $$($(1))
+	wget -P $(DOWNLOAD) $$($(1)_URL)
 endef
 
 # Download and unpack all source packages


### PR DESCRIPTION
Background (from JBS):

To keep us on our toes the source bundle URL variables in Tools.gmk are simply named after the corresponding dependency. For example (from Tools.gmk):

```
GCC := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
```

There's also a lower case variable set up for the "done" marker file for each dependency (from Tools.gmk):

```
# Define marker files for each source package to be compiled
$(foreach dep,$(dependencies),$(eval $(dep) = $(TARGETDIR)/$($(dep)_ver).done))
```

Will do something equivalent to:

```
gcc = target/dir/gcc-14.2.0.done
```

Let's rename the former variable to make it clearer that is, in fact, a URL.


Description:

The change renames the variables in question to include a `_URL` suffix and updates the uses accordingly.

Testing:

* Built devkit on linux-x64
* Verified that the JDK builds with the new devkit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369242](https://bugs.openjdk.org/browse/JDK-8369242): Rename URL variables in devkit/Tools.gmk (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27661/head:pull/27661` \
`$ git checkout pull/27661`

Update a local copy of the PR: \
`$ git checkout pull/27661` \
`$ git pull https://git.openjdk.org/jdk.git pull/27661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27661`

View PR using the GUI difftool: \
`$ git pr show -t 27661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27661.diff">https://git.openjdk.org/jdk/pull/27661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27661#issuecomment-3374365510)
</details>
