### PR TITLE
8367646: [GenShen] Control thread may overwrite gc cancellation cause set by mutator

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -110,10 +110,9 @@ void ShenandoahGenerationalControlThread::check_for_request(ShenandoahGCRequest&
     // failure (degenerated cycle), or old marking was cancelled to run a young collection.
     // In either case, the correct generation for the next cycle can be determined by
     // the cancellation cause.
-    request.cause = _heap->cancelled_cause();
+    request.cause = _heap->clear_cancellation(GCCause::_shenandoah_concurrent_gc);
     if (request.cause == GCCause::_shenandoah_concurrent_gc) {
       request.generation = _heap->young_generation();
-      _heap->clear_cancelled_gc(false);
     }
   } else {
     request.cause = _requested_gc_cause;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -460,6 +460,10 @@ public:
   // old mark does _not_ touch the oom handler).
   inline void clear_cancelled_gc(bool clear_oom_handler = true);
 
+  // Clears the cancellation cause iff the current cancellation reason equals the given
+  // expected cancellation cause. Does not reset the oom handler.
+  inline GCCause::Cause clear_cancellation(GCCause::Cause expected);
+
   void cancel_concurrent_mark();
 
   // Returns true if and only if this call caused a gc to be cancelled.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -31,6 +31,7 @@
 
 #include "classfile/javaClasses.inline.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
+#include "gc/shared/gcCause.hpp"
 #include "gc/shared/markBitMap.inline.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/shared/threadLocalAllocBuffer.inline.hpp"
@@ -278,6 +279,10 @@ inline void ShenandoahHeap::clear_cancelled_gc(bool clear_oom_handler) {
   if (clear_oom_handler) {
     _oom_evac_handler.clear();
   }
+}
+
+inline GCCause::Cause ShenandoahHeap::clear_cancellation(GCCause::Cause expected) {
+  return _cancelled_gc.cmpxchg(GCCause::_no_gc, expected);
 }
 
 inline HeapWord* ShenandoahHeap::allocate_from_gclab(Thread* thread, size_t size) {


### PR DESCRIPTION
I believe the following events could lead to this assertion failure:
1. Control thread reads the heap's gc cancellation cause as `shenandoah_concurrent_gc` 
2. Mutator thread has an allocation failure and sets the heap's gc cancellation cause to `shenandoah_alloc_failure`
3. Control thread uses stale value from `1` and decides to unconditionally clear the cancellation cause
4. Mutator thread assert that gc is still cancelled

The proposed fix here has the control thread use a CAS operation to only clear the gc if the existing value if `shenandoah_concurrent_gc`. This will stop the control thread from erroneously changing the value if a mutator has already set it to `shenandoah_alloc_failure`. A mutator thread may still have an allocation failure after the control thread has cleared the cancellation, but this is normal and expected.