### PR TITLE
Draft: 8369246: Use https in make/devkit scripts

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -117,13 +117,13 @@ dependencies := gcc binutils ccache mpfr gmp mpc gdb
 
 $(foreach dep,$(dependencies),$(eval $(dep)_ver := $(dep)-$($(dep)_ver_only)))
 
-GCC_URL := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
-BINUTILS_URL := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
+GCC_URL := https://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
+BINUTILS_URL := https://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
 CCACHE_URL := https://github.com/ccache/ccache/releases/download/v$(ccache_ver_only)/$(ccache_ver).tar.xz
 MPFR_URL := https://www.mpfr.org/$(mpfr_ver)/$(mpfr_ver).tar.bz2
-GMP_URL := http://ftp.gnu.org/pub/gnu/gmp/$(gmp_ver).tar.bz2
-MPC_URL := http://ftp.gnu.org/pub/gnu/mpc/$(mpc_ver).tar.gz
-GDB_URL := http://ftp.gnu.org/gnu/gdb/$(gdb_ver).tar.xz
+GMP_URL := https://ftp.gnu.org/pub/gnu/gmp/$(gmp_ver).tar.bz2
+MPC_URL := https://ftp.gnu.org/pub/gnu/mpc/$(mpc_ver).tar.gz
+GDB_URL := https://ftp.gnu.org/gnu/gdb/$(gdb_ver).tar.xz
 
 REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
 ifneq ($(REQUIRED_MIN_MAKE_MAJOR_VERSION),)

--- a/make/devkit/createAutoconfBundle.sh
+++ b/make/devkit/createAutoconfBundle.sh
@@ -93,7 +93,7 @@ elif test "x$TARGET_PLATFORM" = xlinux_x64; then
   rpm2cpio $OUTPUT_ROOT/m4-$M4_VERSION.el6.x86_64.rpm | cpio -d -i
 elif test "x$TARGET_PLATFORM" = xlinux_x86; then
   M4_VERSION=1.4.13-5
-  wget http://yum.oracle.com/repo/OracleLinux/OL6/latest/i386/getPackage/m4-$M4_VERSION.el6.i686.rpm
+  wget https://yum.oracle.com/repo/OracleLinux/OL6/latest/i386/getPackage/m4-$M4_VERSION.el6.i686.rpm
   cd $IMAGE_DIR
   rpm2cpio $OUTPUT_ROOT/m4-$M4_VERSION.el6.i686.rpm | cpio -d -i
 else


### PR DESCRIPTION
Let's switch to https for URLs in the make/devkit files, where possible.

That's most places, apart from - it turns out from empirical testing - the `fedora.riscv.rocks` (RISC-V) URL in Tools.gmk.

Testing:

* Built devkit on linux-x64
* Verified that the JDK builds with the new devkit