### PR TITLE
8369236: testlibrary_tests/ir_framework/tests/TestCompileThreshold.java timed out

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompileThreshold.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompileThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import jdk.test.lib.Asserts;
  * @summary Test that CompileThreshold flag is ignored when passed as Java/VM option to the framework.
  *          Normally, the framework should be called with driver.
  * @library /test/lib /testlibrary_tests /
- * @run main/othervm -XX:CompileThreshold=12 -XX:+UseG1GC ir_framework.tests.TestCompileThreshold
+ * @run main/othervm -XX:CompileThreshold=3000 -XX:+UseG1GC ir_framework.tests.TestCompileThreshold
  */
 
 public class TestCompileThreshold {
@@ -42,10 +42,10 @@ public class TestCompileThreshold {
 
     public static void main(String[] args) throws Exception {
         try {
-            // CompileThreshold=12 passed to the JTreg test is ignored even though we prefer command line flags.
-            // CompileThreshold=10 is user defined and passed directly to the framework and thus not ignored.
-            // InterpreterProfilePercentage=0 ensures that we compile exactly after 10 invocations.
-            TestFramework.runWithFlags("-XX:CompileThreshold=10", "-XX:InterpreterProfilePercentage=0",
+            // CompileThreshold=3000 passed to the JTreg test is ignored even though we prefer command line flags.
+            // CompileThreshold=2000 is user defined and passed directly to the framework and thus not ignored.
+            // InterpreterProfilePercentage=0 ensures that we compile exactly after 2000 invocations.
+            TestFramework.runWithFlags("-XX:CompileThreshold=2000", "-XX:InterpreterProfilePercentage=0",
                                        "-XX:-TieredCompilation", "-DTest=testWithCompileThreshold",
                                        "-DPreferCommandLineFlags=true");
         } catch (IRViolationException e) {
@@ -71,12 +71,12 @@ public class TestCompileThreshold {
     }
 
     @Run(test = "testWithCompileThreshold")
-    @Warmup(20)
+    @Warmup(2010)
     public void runTestWithCompileThreshold(RunInfo info) {
-        if (iFld == 10) {
+        if (iFld == 2000) {
             TestFramework.assertNotCompiled(info.getTest());
-        } else if (iFld == 11) {
-            // CompileThreshold=10 is passed directly as a flag to the framework.
+        } else if (iFld == 2001) {
+            // CompileThreshold=2000 is passed directly as a flag to the framework.
             // Therefore, testWithCompileThreshold() must be compiled by now.
             TestFramework.assertCompiled(info.getTest());
         }
@@ -91,12 +91,12 @@ public class TestCompileThreshold {
     }
 
     @Run(test = "testWithoutCompileThreshold")
-    @Warmup(20)
+    @Warmup(2010)
     public void runTestWithoutCompileThreshold(RunInfo info) {
         testWithCompileThreshold();
         if (info.isWarmUp()) {
-            // CompileThreshold=12 is passed to the JTreg test but not directly to the framework.
-            // Therefore, it is ignored and we do not trigger a compilation until the framework does.
+            // CompileThreshold=3000 is passed to the JTreg test but not directly to the framework.
+            // Therefore, it is ignored, and we do not trigger a compilation until the framework does.
             TestFramework.assertNotCompiled(info.getTest());
         }
     }


### PR DESCRIPTION
The test `testlibrary_tests/ir_framework/tests/TestCompileThreshold.java` times out intermittently after the timeout factor change (taking more than 120s). On my local machine, I measured around ~105-115s.

The test uses `CompileThreshold=10` which is almost like `Xcomp` and thus quite slow. However, the purpose of this test is not to stress the compiler but actually to verify that passing `CompileThreshold` to the IR framework over jtreg options is properly ignored. Therefore, we can use higher `CompileThreshold` values and achieve the same goal. With the proposed changes, the test finishes in ~10-15s on my local machine.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369236](https://bugs.openjdk.org/browse/JDK-8369236): testlibrary_tests/ir_framework/tests/TestCompileThreshold.java timed out (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27667/head:pull/27667` \
`$ git checkout pull/27667`

Update a local copy of the PR: \
`$ git checkout pull/27667` \
`$ git pull https://git.openjdk.org/jdk.git pull/27667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27667`

View PR using the GUI difftool: \
`$ git pr show -t 27667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27667.diff">https://git.openjdk.org/jdk/pull/27667.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27667#issuecomment-3375623712)
</details>
