### PR TITLE
8369263: Parallel: Inline PSPromotionManager::push_depth

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -102,8 +102,6 @@ class PSPromotionManager {
   void process_array_chunk(PartialArrayState* state, bool stolen);
   void push_objArray(oop old_obj, oop new_obj);
 
-  void push_depth(ScannerTask task);
-
   inline void promotion_trace_event(oop new_obj, Klass* klass, size_t obj_size,
                                     uint age, bool tenured,
                                     const PSPromotionLAB* lab);

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -50,10 +50,6 @@ inline PSPromotionManager* PSPromotionManager::manager_array(uint index) {
   return &_manager_array[index];
 }
 
-inline void PSPromotionManager::push_depth(ScannerTask task) {
-  claimed_stack_depth()->push(task);
-}
-
 template <class T>
 inline void PSPromotionManager::claim_or_forward_depth(T* p) {
   assert(ParallelScavengeHeap::heap()->is_in(p), "pointer outside heap");
@@ -62,7 +58,7 @@ inline void PSPromotionManager::claim_or_forward_depth(T* p) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(!PSScavenge::is_obj_in_to_space(obj), "revisiting object?");
     Prefetch::write(obj->base_addr(), oopDesc::mark_offset_in_bytes());
-    push_depth(ScannerTask(p));
+    claimed_stack_depth()->push(ScannerTask(p));
   }
 }
 


### PR DESCRIPTION
Trivial inlining a method to its single caller.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369263](https://bugs.openjdk.org/browse/JDK-8369263): Parallel: Inline PSPromotionManager::push_depth (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Francesco Andreuzzi](https://openjdk.org/census#fandreuzzi) (@fandreuz - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27668/head:pull/27668` \
`$ git checkout pull/27668`

Update a local copy of the PR: \
`$ git checkout pull/27668` \
`$ git pull https://git.openjdk.org/jdk.git pull/27668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27668`

View PR using the GUI difftool: \
`$ git pr show -t 27668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27668.diff">https://git.openjdk.org/jdk/pull/27668.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27668#issuecomment-3375742495)
</details>
