### PR TITLE
8369257: PPC: compiler/whitebox/RelocateNMethodMultiplePaths.java fails with assertion

### DIFF
--- a/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
@@ -402,7 +402,7 @@ void NativePostCallNop::make_deopt() {
 bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset) {
   int32_t i2, i1;
   assert(is_aligned(cb_offset, 4), "cb offset alignment does not match instruction alignment");
-  assert(!decode(i1, i2), "already patched");
+  assert(!decode(i1, i2) || NMethodRelocation, "already patched");
 
   cb_offset = cb_offset >> 2;
   if (((oopmap_slot & ppc_oopmap_slot_mask) != oopmap_slot) || ((cb_offset & ppc_cb_offset_mask) != cb_offset)) {


### PR DESCRIPTION
Relax assertion in NativePostCallNop::patch(). With NMethodRelocation (see [JDK-8369257](https://bugs.openjdk.org/browse/JDK-8369257)) it cannot be expected that the post call nop to be patched is still clean.

compiler/whitebox/RelocateNMethodMultiplePaths.java succeeds in local testing on PPC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369257](https://bugs.openjdk.org/browse/JDK-8369257): PPC: compiler/whitebox/RelocateNMethodMultiplePaths.java fails with assertion (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27669/head:pull/27669` \
`$ git checkout pull/27669`

Update a local copy of the PR: \
`$ git checkout pull/27669` \
`$ git pull https://git.openjdk.org/jdk.git pull/27669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27669`

View PR using the GUI difftool: \
`$ git pr show -t 27669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27669.diff">https://git.openjdk.org/jdk/pull/27669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27669#issuecomment-3379778351)
</details>
