### PR TITLE
JDK-8368625: com/sun/net/httpserver/ServerStopTerminationTest.java fails intermittently in tier7

### DIFF
--- a/test/jdk/com/sun/net/httpserver/ServerStopTerminationTest.java
+++ b/test/jdk/com/sun/net/httpserver/ServerStopTerminationTest.java
@@ -128,7 +128,7 @@ public class ServerStopTerminationTest {
         log("Complete Exchange triggered");
 
         // Time the shutdown sequence
-        final Duration delayDuration = Duration.ofSeconds(Utils.adjustTimeout(5));
+        final Duration delayDuration = Duration.ofSeconds(Utils.adjustTimeout(20));
         log("Shutdown triggered with the delay of " + delayDuration.getSeconds());
         final long elapsed = timeShutdown(delayDuration);
         log("Shutdown complete");


### PR DESCRIPTION
I believe that increasing the timeout might help, as it seems to be happening due to the machine load. I'm going to make a pr increasing the timeout to 20 from 5 (similar to what it was when timeout factor was 4).