### PR TITLE
8369277: Remove unused CodeCacheUnloadingTask::_num_workers

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2669,8 +2669,7 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(size_t allocation_
 }
 
 void G1CollectedHeap::complete_cleaning(bool class_unloading_occurred) {
-  uint num_workers = workers()->active_workers();
-  G1ParallelCleaningTask unlink_task(num_workers, class_unloading_occurred);
+  G1ParallelCleaningTask unlink_task(class_unloading_occurred);
   workers()->run_task(&unlink_task);
 }
 

--- a/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
+++ b/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
@@ -50,8 +50,7 @@ void JVMCICleaningTask::work(bool unloading_occurred) {
 }
 #endif // INCLUDE_JVMCI
 
-G1ParallelCleaningTask::G1ParallelCleaningTask(uint num_workers,
-                                               bool unloading_occurred) :
+G1ParallelCleaningTask::G1ParallelCleaningTask(bool unloading_occurred) :
   WorkerTask("G1 Parallel Cleaning"),
   _unloading_occurred(unloading_occurred),
   _code_cache_task(unloading_occurred),

--- a/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
+++ b/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
@@ -54,7 +54,7 @@ G1ParallelCleaningTask::G1ParallelCleaningTask(uint num_workers,
                                                bool unloading_occurred) :
   WorkerTask("G1 Parallel Cleaning"),
   _unloading_occurred(unloading_occurred),
-  _code_cache_task(num_workers, unloading_occurred),
+  _code_cache_task(unloading_occurred),
   JVMCI_ONLY(_jvmci_cleaning_task() COMMA)
   _klass_cleaning_task() {
 }

--- a/src/hotspot/share/gc/g1/g1ParallelCleaning.hpp
+++ b/src/hotspot/share/gc/g1/g1ParallelCleaning.hpp
@@ -54,8 +54,7 @@ private:
 
 public:
   // The constructor is run in the VMThread.
-  G1ParallelCleaningTask(uint num_workers,
-                         bool unloading_occurred);
+  G1ParallelCleaningTask(bool unloading_occurred);
 
   void work(uint worker_id);
 };

--- a/src/hotspot/share/gc/shared/parallelCleaning.cpp
+++ b/src/hotspot/share/gc/shared/parallelCleaning.cpp
@@ -30,9 +30,8 @@
 #include "oops/klass.inline.hpp"
 #include "runtime/atomicAccess.hpp"
 
-CodeCacheUnloadingTask::CodeCacheUnloadingTask(uint num_workers, bool unloading_occurred) :
+CodeCacheUnloadingTask::CodeCacheUnloadingTask(bool unloading_occurred) :
   _unloading_occurred(unloading_occurred),
-  _num_workers(num_workers),
   _first_nmethod(nullptr),
   _claimed_nmethod(nullptr) {
   // Get first alive nmethod

--- a/src/hotspot/share/gc/shared/parallelCleaning.hpp
+++ b/src/hotspot/share/gc/shared/parallelCleaning.hpp
@@ -33,14 +33,13 @@
 class CodeCacheUnloadingTask {
 
   const bool                _unloading_occurred;
-  const uint                _num_workers;
 
   // Variables used to claim nmethods.
   nmethod* _first_nmethod;
   nmethod* volatile _claimed_nmethod;
 
 public:
-  CodeCacheUnloadingTask(uint num_workers, bool unloading_occurred);
+  CodeCacheUnloadingTask(bool unloading_occurred);
   ~CodeCacheUnloadingTask();
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2259,8 +2259,7 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
       // Clean JVMCI metadata handles.
       JVMCI_ONLY(JVMCI::do_unloading(unloading_occurred));
 
-      uint num_workers = _workers->active_workers();
-      ShenandoahClassUnloadingTask unlink_task(phase, num_workers, unloading_occurred);
+      ShenandoahClassUnloadingTask unlink_task(phase, unloading_occurred);
       _workers->run_task(&unlink_task);
     }
     // Release unloaded nmethods's memory.

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.cpp
@@ -36,7 +36,7 @@ ShenandoahClassUnloadingTask::ShenandoahClassUnloadingTask(ShenandoahPhaseTiming
   WorkerTask("Shenandoah Class Unloading"),
   _phase(phase),
   _unloading_occurred(unloading_occurred),
-  _code_cache_task(num_workers, unloading_occurred),
+  _code_cache_task(unloading_occurred),
   _klass_cleaning_task() {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.cpp
@@ -31,7 +31,6 @@
 #include "runtime/safepoint.hpp"
 
 ShenandoahClassUnloadingTask::ShenandoahClassUnloadingTask(ShenandoahPhaseTimings::Phase phase,
-                                                           uint num_workers,
                                                            bool unloading_occurred) :
   WorkerTask("Shenandoah Class Unloading"),
   _phase(phase),

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.hpp
@@ -59,7 +59,6 @@ private:
   KlassCleaningTask                   _klass_cleaning_task;
 public:
   ShenandoahClassUnloadingTask(ShenandoahPhaseTimings::Phase phase,
-                               uint num_workers,
                                bool unloading_occurred);
 
   void work(uint worker_id);


### PR DESCRIPTION
Trivial removing dead code.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369277](https://bugs.openjdk.org/browse/JDK-8369277): Remove unused CodeCacheUnloadingTask::_num_workers (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27671/head:pull/27671` \
`$ git checkout pull/27671`

Update a local copy of the PR: \
`$ git checkout pull/27671` \
`$ git pull https://git.openjdk.org/jdk.git pull/27671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27671`

View PR using the GUI difftool: \
`$ git pr show -t 27671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27671.diff">https://git.openjdk.org/jdk/pull/27671.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27671#issuecomment-3376275905)
</details>
