### PR TITLE
JDK-8368522

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <limits.h>
 #include <fcntl.h>
@@ -70,19 +71,12 @@
 // by defining binary compatible statx structs in this file and
 // not relying on included headers.
 
-#ifndef __GLIBC__
-// Alpine doesn't know these types, define them
-typedef unsigned int       __uint32_t;
-typedef unsigned short     __uint16_t;
-typedef unsigned long int  __uint64_t;
-#endif
-
 /*
  * Timestamp structure for the timestamps in struct statx.
  */
 struct my_statx_timestamp {
         int64_t   tv_sec;
-        __uint32_t  tv_nsec;
+        uint32_t  tv_nsec;
         int32_t   __reserved;
 };
 
@@ -92,27 +86,27 @@ struct my_statx_timestamp {
  */
 struct my_statx
 {
-  __uint32_t stx_mask;
-  __uint32_t stx_blksize;
-  __uint64_t stx_attributes;
-  __uint32_t stx_nlink;
-  __uint32_t stx_uid;
-  __uint32_t stx_gid;
-  __uint16_t stx_mode;
-  __uint16_t __statx_pad1[1];
-  __uint64_t stx_ino;
-  __uint64_t stx_size;
-  __uint64_t stx_blocks;
-  __uint64_t stx_attributes_mask;
+  uint32_t stx_mask;
+  uint32_t stx_blksize;
+  uint64_t stx_attributes;
+  uint32_t stx_nlink;
+  uint32_t stx_uid;
+  uint32_t stx_gid;
+  uint16_t stx_mode;
+  uint16_t __statx_pad1[1];
+  uint64_t stx_ino;
+  uint64_t stx_size;
+  uint64_t stx_blocks;
+  uint64_t stx_attributes_mask;
   struct my_statx_timestamp stx_atime;
   struct my_statx_timestamp stx_btime;
   struct my_statx_timestamp stx_ctime;
   struct my_statx_timestamp stx_mtime;
-  __uint32_t stx_rdev_major;
-  __uint32_t stx_rdev_minor;
-  __uint32_t stx_dev_major;
-  __uint32_t stx_dev_minor;
-  __uint64_t __statx_pad2[14];
+  uint32_t stx_rdev_major;
+  uint32_t stx_rdev_minor;
+  uint32_t stx_dev_major;
+  uint32_t stx_dev_minor;
+  uint64_t __statx_pad2[14];
 };
 
 // statx masks, flags, constants

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #if defined(__linux__)
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -44,19 +45,13 @@
 #define AT_FDCWD -100
 #endif
 
-#ifndef __GLIBC__
-// Alpine doesn't know these types, define them
-typedef unsigned int       __uint32_t;
-typedef unsigned short     __uint16_t;
-typedef unsigned long int  __uint64_t;
-#endif
 
 /*
  * Timestamp structure for the timestamps in struct statx.
  */
 struct my_statx_timestamp {
         int64_t   tv_sec;
-        __uint32_t  tv_nsec;
+        uint32_t  tv_nsec;
         int32_t   __reserved;
 };
 
@@ -66,27 +61,27 @@ struct my_statx_timestamp {
  */
 struct my_statx
 {
-  __uint32_t stx_mask;
-  __uint32_t stx_blksize;
-  __uint64_t stx_attributes;
-  __uint32_t stx_nlink;
-  __uint32_t stx_uid;
-  __uint32_t stx_gid;
-  __uint16_t stx_mode;
-  __uint16_t __statx_pad1[1];
-  __uint64_t stx_ino;
-  __uint64_t stx_size;
-  __uint64_t stx_blocks;
-  __uint64_t stx_attributes_mask;
+  uint32_t stx_mask;
+  uint32_t stx_blksize;
+  uint64_t stx_attributes;
+  uint32_t stx_nlink;
+  uint32_t stx_uid;
+  uint32_t stx_gid;
+  uint16_t stx_mode;
+  uint16_t __statx_pad1[1];
+  uint64_t stx_ino;
+  uint64_t stx_size;
+  uint64_t stx_blocks;
+  uint64_t stx_attributes_mask;
   struct my_statx_timestamp stx_atime;
   struct my_statx_timestamp stx_btime;
   struct my_statx_timestamp stx_ctime;
   struct my_statx_timestamp stx_mtime;
-  __uint32_t stx_rdev_major;
-  __uint32_t stx_rdev_minor;
-  __uint32_t stx_dev_major;
-  __uint32_t stx_dev_minor;
-  __uint64_t __statx_pad2[14];
+  uint32_t stx_rdev_major;
+  uint32_t stx_rdev_minor;
+  uint32_t stx_dev_major;
+  uint32_t stx_dev_minor;
+  uint64_t __statx_pad2[14];
 };
 
 typedef int statx_func(int dirfd, const char *restrict pathname, int flags,


### PR DESCRIPTION
This cleanup replaces #ifdefs with a standard #include <stdint.h>. Using standard types is more prone to errors.

JDK-8368522 was reported on ARM32 with musl libc, which is not a supported configuration, but I still believe this code cleanup is worth it.

After the introduction of statx with musl 1.2.5, a buffer overflow issue with statx() call handling started happening on ARM32. The root cause is incorrect size of __uint64_t type definition in the JDK for musl libc, where it was defined as 4 bytes (unsigned long int) for 32-bit systems instead of 8 bytes (unsigned long long).

The mismatch between JDK's my_statx structure and kernel's statx structure causes stack corruption when statx() writes beyond the statx_buf boundaries, overwriting adjacent variables, including the 'attrs' argument that was later passed to copy_statx_attributes() function and caused a segfault there.

Built and ran jtreg on standard OpenJDK platforms with no regressions, including the altered test.