### PR TITLE
8369286: Parallel: Assertion failure in mutableNUMASpace

### DIFF
--- a/src/hotspot/share/gc/parallel/psYoungGen.cpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.cpp
@@ -250,6 +250,12 @@ void PSYoungGen::space_invariants() {
 bool PSYoungGen::try_expand_to_hold(size_t word_size) {
   assert(eden_space()->free_in_words() < word_size, "precondition");
 
+  if (UseNUMA && !_eden_space->is_empty()) {
+    // Eden expansion is not supported with NUMA, when eden is not empty.
+    // See also MutableNUMASpace::initialize.
+    return false;
+  }
+
   // For logging purpose
   size_t original_committed_size = virtual_space()->committed_size();
 


### PR DESCRIPTION
Parallel will try to expand eden to satisfy allocation request. However, the current NUMA implementation in Parallel requires a space to be empty on resizing so that the memory inside the space can be freely distributed among all NUMA nodes.

Add an early-return to `PSYoungGen::try_expand_to_hold` if NUMA is enabled and eden is not empty.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369286](https://bugs.openjdk.org/browse/JDK-8369286): Parallel: Assertion failure in mutableNUMASpace (**Bug** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27675/head:pull/27675` \
`$ git checkout pull/27675`

Update a local copy of the PR: \
`$ git checkout pull/27675` \
`$ git pull https://git.openjdk.org/jdk.git pull/27675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27675`

View PR using the GUI difftool: \
`$ git pr show -t 27675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27675.diff">https://git.openjdk.org/jdk/pull/27675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27675#issuecomment-3376861336)
</details>
