### PR TITLE
8369328: Use uppercase variable names in the devkit makefiles

### DIFF
--- a/make/devkit/Makefile
+++ b/make/devkit/Makefile
@@ -57,61 +57,61 @@
 
 COMMA := ,
 
-os := $(shell uname -o)
-cpu := $(shell uname -m)
+OS := $(shell uname -o)
+CPU := $(shell uname -m)
 
 # Figure out what platform this is building on.
-me := $(cpu)-$(if $(findstring Linux,$(os)),linux-gnu)
+ME := $(CPU)-$(if $(findstring Linux,$(OS)),linux-gnu)
 
-$(info Building on platform $(me))
+$(info Building on platform $(ME))
 
 #
 # By default just build for the current platform, which is assumed to be Linux
 #
 ifeq ($(TARGETS), )
-  platforms := $(me)
-  host_platforms := $(platforms)
+  PLATFORMS := $(ME)
+  HOST_PLATFORMS := $(PLATFORMS)
 else
-  platforms := $(subst $(COMMA), , $(TARGETS))
-  host_platforms := $(me)
+  PLATFORMS := $(subst $(COMMA), , $(TARGETS))
+  HOST_PLATFORMS := $(ME)
 endif
-target_platforms := $(platforms)
-$(info host_platforms $(host_platforms))
-$(info target_platforms $(target_platforms))
+TARGET_PLATFORMS := $(PLATFORMS)
+$(info HOST_PLATFORMS $(HOST_PLATFORMS))
+$(info TARGET_PLATFORMS $(TARGET_PLATFORMS))
 
-all compile : $(platforms)
+all compile : $(PLATFORMS)
 
 ifeq ($(SKIP_ME), )
-  $(foreach p,$(filter-out $(me),$(platforms)),$(eval $(p) : $$(me)))
+  $(foreach p,$(filter-out $(ME),$(PLATFORMS)),$(eval $(p) : $$(ME)))
 endif
 
 OUTPUT_ROOT = $(abspath ../../build/devkit)
 RESULT = $(OUTPUT_ROOT)/result
 
-submakevars = HOST=$@ BUILD=$(me) RESULT=$(RESULT) OUTPUT_ROOT=$(OUTPUT_ROOT)
+SUBMAKEVARS = HOST=$@ BUILD=$(ME) RESULT=$(RESULT) OUTPUT_ROOT=$(OUTPUT_ROOT)
 
-$(host_platforms) :
+$(HOST_PLATFORMS) :
 	@echo 'Building compilers for $@'
-	@echo 'Targets: $(target_platforms)'
-	for p in $(filter $@, $(target_platforms)) $(filter-out $@, $(target_platforms)); do \
-	  $(MAKE) -f Tools.gmk download-rpms $(submakevars) \
+	@echo 'Targets: $(TARGET_PLATFORMS)'
+	for p in $(filter $@, $(TARGET_PLATFORMS)) $(filter-out $@, $(TARGET_PLATFORMS)); do \
+	  $(MAKE) -f Tools.gmk download-rpms $(SUBMAKEVARS) \
               TARGET=$$p PREFIX=$(RESULT)/$@-to-$$p && \
-	  $(MAKE) -f Tools.gmk all $(submakevars) \
+	  $(MAKE) -f Tools.gmk all $(SUBMAKEVARS) \
               TARGET=$$p PREFIX=$(RESULT)/$@-to-$$p && \
-	  $(MAKE) -f Tools.gmk ccache $(submakevars) \
+	  $(MAKE) -f Tools.gmk ccache $(SUBMAKEVARS) \
               TARGET=$@ PREFIX=$(RESULT)/$@-to-$$p || exit 1 ; \
 	done
 	@echo 'All done"'
 
-today := $(shell date +%Y%m%d)
+TODAY := $(shell date +%Y%m%d)
 
 define Mktar
-  $(1)-to-$(2)_tar = $$(RESULT)/sdk-$(1)-to-$(2)-$$(today).tar.gz
+  $(1)-to-$(2)_tar = $$(RESULT)/sdk-$(1)-to-$(2)-$$(TODAY).tar.gz
   $$($(1)-to-$(2)_tar) : PLATFORM = $(1)-to-$(2)
   TARFILES += $$($(1)-to-$(2)_tar)
 endef
 
-$(foreach p,$(host_platforms),$(foreach t,$(target_platforms),$(eval $(call Mktar,$(p),$(t)))))
+$(foreach p,$(HOST_PLATFORMS),$(foreach t,$(TARGET_PLATFORMS),$(eval $(call Mktar,$(p),$(t)))))
 
 tars : all $(TARFILES)
 onlytars : $(TARFILES)
@@ -119,9 +119,9 @@ onlytars : $(TARFILES)
 	$(MAKE) -r -f Tars.gmk SRC_DIR=$(RESULT)/$(PLATFORM) TAR_FILE=$@
 
 clean :
-	rm -rf $(addprefix ../../build/devkit/, result $(host_platforms))
+	rm -rf $(addprefix ../../build/devkit/, result $(HOST_PLATFORMS))
 dist-clean: clean
 	rm -rf $(addprefix ../../build/devkit/, src download)
 
 FORCE :
-.PHONY : all compile tars $(configs) $(host_platforms) clean dist-clean
+.PHONY : all compile tars $(HOST_PLATFORMS) clean dist-clean

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -39,7 +39,7 @@
 # Fix this...
 #
 
-uppercase = $(shell echo $1 | tr a-z A-Z)
+lowercase = $(shell echo $1 | tr A-Z a-z)
 
 $(info TARGET=$(TARGET))
 $(info HOST=$(HOST))
@@ -104,26 +104,26 @@ endif
 ################################################################################
 # Define external dependencies
 
-gcc_ver_only := 14.2.0
-binutils_ver_only := 2.43
-ccache_ver_only := 4.10.2
+GCC_VER_ONLY := 14.2.0
+BINUTILS_VER_ONLY := 2.43
+CCACHE_VER_ONLY := 4.10.2
 CCACHE_CMAKE_BASED := 1
-mpfr_ver_only := 4.2.1
-gmp_ver_only := 6.3.0
-mpc_ver_only := 1.3.1
-gdb_ver_only := 15.2
+MPFR_VER_ONLY := 4.2.1
+GMP_VER_ONLY := 6.3.0
+MPC_VER_ONLY := 1.3.1
+GDB_VER_ONLY := 15.2
 
-dependencies := gcc binutils ccache mpfr gmp mpc gdb
+DEPENDENCIES := GCC BINUTILS CCACHE MPFR GMP MPC GDB
 
-$(foreach dep,$(dependencies),$(eval $(dep)_ver := $(dep)-$($(dep)_ver_only)))
+$(foreach dep,$(DEPENDENCIES),$(eval $(dep)_VER := $(call lowercase,$(dep)-$($(dep)_VER_ONLY))))
 
-GCC_URL := https://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
-BINUTILS_URL := https://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
-CCACHE_URL := https://github.com/ccache/ccache/releases/download/v$(ccache_ver_only)/$(ccache_ver).tar.xz
-MPFR_URL := https://www.mpfr.org/$(mpfr_ver)/$(mpfr_ver).tar.bz2
-GMP_URL := https://ftp.gnu.org/pub/gnu/gmp/$(gmp_ver).tar.bz2
-MPC_URL := https://ftp.gnu.org/pub/gnu/mpc/$(mpc_ver).tar.gz
-GDB_URL := https://ftp.gnu.org/gnu/gdb/$(gdb_ver).tar.xz
+GCC_URL := https://ftp.gnu.org/pub/gnu/gcc/$(GCC_VER)/$(GCC_VER).tar.xz
+BINUTILS_URL := https://ftp.gnu.org/pub/gnu/binutils/$(BINUTILS_VER).tar.gz
+CCACHE_URL := https://github.com/ccache/ccache/releases/download/v$(CCACHE_VER_ONLY)/$(CCACHE_VER).tar.xz
+MPFR_URL := https://www.mpfr.org/$(MPFR_VER)/$(MPFR_VER).tar.bz2
+GMP_URL := https://ftp.gnu.org/pub/gnu/gmp/$(GMP_VER).tar.bz2
+MPC_URL := https://ftp.gnu.org/pub/gnu/mpc/$(MPC_VER).tar.gz
+GDB_URL := https://ftp.gnu.org/gnu/gdb/$(GDB_VER).tar.xz
 
 REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
 ifneq ($(REQUIRED_MIN_MAKE_MAJOR_VERSION),)
@@ -180,10 +180,10 @@ DOWNLOAD_RPMS := $(DOWNLOAD)/rpms/$(TARGET)-$(LINUX_VERSION)
 SRCDIR := $(OUTPUT_ROOT)/src
 
 # Marker file for unpacking rpms
-rpms := $(SYSROOT)/rpms_unpacked
+RPMS := $(SYSROOT)/rpms_unpacked
 
 # Need to patch libs that are linker scripts to use non-absolute paths
-libs := $(SYSROOT)/libs_patched
+LIBS := $(SYSROOT)/libs_patched
 
 ################################################################################
 # Download RPMs
@@ -228,7 +228,7 @@ define Download
 endef
 
 # Download and unpack all source packages
-$(foreach dep,$(dependencies),$(eval $(call Download,$(call uppercase,$(dep)))))
+$(foreach dep,$(DEPENDENCIES),$(eval $(call Download,$(dep))))
 
 ################################################################################
 # Unpack RPMS
@@ -250,7 +250,7 @@ RPM_FILE_LIST := $(sort $(foreach a, $(RPM_ARCHS), \
 # Note. For building linux you should install rpm2cpio.
 define unrpm
   $(SYSROOT)/$(notdir $(1)).unpacked : $(1)
-  $$(rpms) : $(SYSROOT)/$(notdir $(1)).unpacked
+  $$(RPMS) : $(SYSROOT)/$(notdir $(1)).unpacked
 endef
 
 %.unpacked :
@@ -277,7 +277,7 @@ $(foreach p,$(RPM_FILE_LIST),$(eval $(call unrpm,$(p))))
 # have it anyway, but just to make sure...
 # Patch libc.so and libpthread.so to force linking against libraries in sysroot
 # and not the ones installed on the build machine.
-$(libs) : $(rpms)
+$(LIBS) : $(RPMS)
 	@echo Patching libc and pthreads
 	@(for f in `find $(SYSROOT) -name libc.so -o -name libpthread.so`; do \
 	  (cat $$f | sed -e 's|/usr/lib64/||g' \
@@ -293,10 +293,10 @@ $(libs) : $(rpms)
 # Create links for ffi header files so that they become visible by default when using the
 # devkit.
 ifeq ($(ARCH), x86_64)
-  $(SYSROOT)/usr/include/ffi.h: $(rpms)
+  $(SYSROOT)/usr/include/ffi.h: $(RPMS)
 	cd $(@D) && rm -f $(@F) && ln -s ../lib/libffi-*/include/$(@F) .
 
-  $(SYSROOT)/usr/include/ffitarget.h: $(rpms)
+  $(SYSROOT)/usr/include/ffitarget.h: $(RPMS)
 	cd $(@D) && rm -f $(@F) && ln -s ../lib/libffi-*/include/$(@F) .
 
   SYSROOT_LINKS += $(SYSROOT)/usr/include/ffi.h $(SYSROOT)/usr/include/ffitarget.h
@@ -305,7 +305,7 @@ endif
 ################################################################################
 
 # Define marker files for each source package to be compiled
-$(foreach dep,$(dependencies),$(eval $(dep) = $(TARGETDIR)/$($(dep)_ver).done))
+$(foreach dep,$(DEPENDENCIES),$(eval $(dep) = $(TARGETDIR)/$($(dep)_VER).done))
 
 ################################################################################
 
@@ -345,48 +345,48 @@ TOOLS ?= $(call declare_tools,_FOR_TARGET,$(TARGET)-)
 # CFLAG_<name> to most likely -m32.
 define mk_bfd
   $$(info Libs for $(1))
-  $$(BUILDDIR)/$$(binutils_ver)-$(subst /,-,$(1))/Makefile \
+  $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile \
       : CFLAGS += $$(CFLAGS_$(1))
-  $$(BUILDDIR)/$$(binutils_ver)-$(subst /,-,$(1))/Makefile \
+  $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile \
       : LIBDIRS = --libdir=$(TARGETDIR)/$(1)
 
-  bfdlib += $$(TARGETDIR)/$$(binutils_ver)-$(subst /,-,$(1)).done
-  bfdmakes += $$(BUILDDIR)/$$(binutils_ver)-$(subst /,-,$(1))/Makefile
+  BFDLIB += $$(TARGETDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1)).done
+  BFDMAKES += $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile
 endef
 
 # Create one set of bfds etc for each multilib arch
 $(foreach l,$(LIBDIRS),$(eval $(call mk_bfd,$(l))))
 
 # Only build these two libs.
-$(bfdlib) : MAKECMD = all-libiberty all-bfd
-$(bfdlib) : INSTALLCMD = install-libiberty install-bfd
+$(BFDLIB) : MAKECMD = all-libiberty all-bfd
+$(BFDLIB) : INSTALLCMD = install-libiberty install-bfd
 
 # Building targets libbfd + libiberty. HOST==TARGET, i.e not
 # for a cross env.
-$(bfdmakes) : CONFIG = --target=$(TARGET) \
+$(BFDMAKES) : CONFIG = --target=$(TARGET) \
     --host=$(TARGET) --build=$(BUILD) \
     --prefix=$(TARGETDIR) \
     --with-sysroot=$(SYSROOT) \
     $(LIBDIRS)
 
-$(bfdmakes) : TOOLS = $(call declare_tools,_FOR_TARGET,$(TARGET)-) $(call declare_tools,,$(TARGET)-)
+$(BFDMAKES) : TOOLS = $(call declare_tools,_FOR_TARGET,$(TARGET)-) $(call declare_tools,,$(TARGET)-)
 
 ################################################################################
 
-$(gcc) \
-    $(binutils) \
-    $(gmp) \
-    $(mpfr) \
-    $(mpc) \
-    $(bfdmakes) \
-    $(ccache) : ENVS += $(TOOLS)
+$(GCC) \
+    $(BINUTILS) \
+    $(GMP) \
+    $(MPFR) \
+    $(MPC) \
+    $(BFDMAKES) \
+    $(CCACHE) : ENVS += $(TOOLS)
 
 # libdir to work around hateful bfd stuff installing into wrong dirs...
 # ensure we have 64 bit bfd support in the HOST library. I.e our
 # compiler on i686 will know 64 bit symbols, BUT later
 # we build just the libs again for TARGET, then with whatever the arch
 # wants.
-$(BUILDDIR)/$(binutils_ver)/Makefile : CONFIG += --enable-64-bit-bfd --libdir=$(PREFIX)/$(word 1,$(LIBDIRS))
+$(BUILDDIR)/$(BINUTILS_VER)/Makefile : CONFIG += --enable-64-bit-bfd --libdir=$(PREFIX)/$(word 1,$(LIBDIRS))
 
 ifeq ($(filter $(ARCH), s390x riscv64 ppc64le), )
   # gold compiles but cannot link properly on s390x @ gcc 13.2 and Fedore 41
@@ -397,8 +397,8 @@ endif
 
 # Makefile creation. Simply run configure in build dir.
 # Setting CFLAGS to -O2 generates a much faster ld.
-$(bfdmakes) \
-$(BUILDDIR)/$(binutils_ver)/Makefile \
+$(BFDMAKES) \
+$(BUILDDIR)/$(BINUTILS_VER)/Makefile \
     : $(BINUTILS_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
@@ -417,7 +417,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-$(BUILDDIR)/$(mpfr_ver)/Makefile \
+$(BUILDDIR)/$(MPFR_VER)/Makefile \
     : $(MPFR_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
@@ -432,7 +432,7 @@ $(BUILDDIR)/$(mpfr_ver)/Makefile \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-$(BUILDDIR)/$(gmp_ver)/Makefile \
+$(BUILDDIR)/$(GMP_VER)/Makefile \
     : $(GMP_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
@@ -449,7 +449,7 @@ $(BUILDDIR)/$(gmp_ver)/Makefile \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-$(BUILDDIR)/$(mpc_ver)/Makefile \
+$(BUILDDIR)/$(MPC_VER)/Makefile \
     : $(MPC_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
@@ -468,11 +468,11 @@ $(BUILDDIR)/$(mpc_ver)/Makefile \
 # Only valid if glibc target -> linux
 # proper destructor handling for c++
 ifneq (,$(findstring linux,$(TARGET)))
-  $(BUILDDIR)/$(gcc_ver)/Makefile : CONFIG += --enable-__cxa_atexit
+  $(BUILDDIR)/$(GCC_VER)/Makefile : CONFIG += --enable-__cxa_atexit
 endif
 
 ifeq ($(ARCH), armhfp)
-  $(BUILDDIR)/$(gcc_ver)/Makefile : CONFIG +=  --with-float=hard
+  $(BUILDDIR)/$(GCC_VER)/Makefile : CONFIG +=  --with-float=hard
 endif
 
 ifneq ($(filter riscv64 ppc64le s390x, $(ARCH)), )
@@ -487,7 +487,7 @@ endif
 # skip native language.
 # and link and assemble with the binutils we created
 # earlier, so --with-gnu*
-$(BUILDDIR)/$(gcc_ver)/Makefile \
+$(BUILDDIR)/$(GCC_VER)/Makefile \
     : $(GCC_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	mkdir -p $(@D)
@@ -509,17 +509,17 @@ $(BUILDDIR)/$(gcc_ver)/Makefile \
 	@echo 'done'
 
 # need binutils for gcc
-$(gcc) : $(binutils)
+$(GCC) : $(BINUTILS)
 
 # as of 4.3 or so need these for doing config
-$(BUILDDIR)/$(gcc_ver)/Makefile : $(gmp) $(mpfr) $(mpc)
-$(mpfr) : $(gmp)
-$(mpc) : $(gmp) $(mpfr)
+$(BUILDDIR)/$(GCC_VER)/Makefile : $(GMP) $(MPFR) $(MPC)
+$(MPFR) : $(GMP)
+$(MPC) : $(GMP) $(MPFR)
 
 ################################################################################
 # Build gdb but only where host and target match
 ifeq ($(HOST), $(TARGET))
-  $(BUILDDIR)/$(gdb_ver)/Makefile: $(GDB_CFG)
+  $(BUILDDIR)/$(GDB_VER)/Makefile: $(GDB_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	mkdir -p $(@D)
 	( \
@@ -532,9 +532,9 @@ ifeq ($(HOST), $(TARGET))
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-  $(gdb): $(gcc)
+  $(GDB): $(GCC)
 else
-  $(BUILDDIR)/$(gdb_ver)/Makefile:
+  $(BUILDDIR)/$(GDB_VER)/Makefile:
 	$(info Faking $@, not used when cross-compiling)
 	mkdir -p $(@D)
 	echo "install:" > $@
@@ -543,7 +543,7 @@ endif
 
 ################################################################################
 # very straightforward. just build a ccache. it is only for host.
-$(BUILDDIR)/$(ccache_ver)/Makefile \
+$(BUILDDIR)/$(CCACHE_VER)/Makefile \
     : $(CCACHE_SRC_MARKER)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
@@ -554,12 +554,12 @@ $(BUILDDIR)/$(ccache_ver)/Makefile \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-gccpatch = $(TARGETDIR)/gcc-patched
+GCC_PATCHED = $(TARGETDIR)/gcc-patched
 
 ################################################################################
 # For some reason cpp is not created as a target-compiler
 ifeq ($(HOST),$(TARGET))
-  $(gccpatch) : $(gcc) link_libs
+  $(GCC_PATCHED) : $(GCC) link_libs
 	@echo -n 'Creating compiler symlinks...'
 	@for f in cpp; do \
 	  if [ ! -e $(PREFIX)/bin/$(TARGET)-$$f ]; \
@@ -587,7 +587,7 @@ ifeq ($(HOST),$(TARGET))
 	done;)
 	@echo 'done'
 else
-  $(gccpatch) :
+  $(GCC_PATCHED) :
 	@echo 'done'
 endif
 
@@ -615,7 +615,7 @@ $(PREFIX)/devkit.info:
 	echo '# This file describes to configure how to interpret the contents of this' >> $@
 	echo '# devkit' >> $@
 	echo '' >> $@
-	echo 'DEVKIT_NAME="$(gcc_ver) - $(LINUX_VERSION)"' >> $@
+	echo 'DEVKIT_NAME="$(GCC_VER) - $(LINUX_VERSION)"' >> $@
 	echo 'DEVKIT_TOOLCHAIN_PATH="$$DEVKIT_ROOT/bin"' >> $@
 	echo 'DEVKIT_SYSROOT="$$DEVKIT_ROOT/$(TARGET)/sysroot"' >> $@
 	echo 'DEVKIT_EXTRA_PATH="$$DEVKIT_ROOT/bin"' >> $@
@@ -651,32 +651,32 @@ ifeq ($(TARGET), $(HOST))
 	@echo 'Creating missing $* soft link'
 	ln -s $(TARGET)-$* $@
 
-  missing-links := $(addprefix $(PREFIX)/bin/, \
-      addr2line ar as c++ c++filt dwp elfedit g++ gcc gcc-$(gcc_ver_only) gprof ld ld.bfd \
+  MISSING_LINKS := $(addprefix $(PREFIX)/bin/, \
+      addr2line ar as c++ c++filt dwp elfedit g++ gcc gcc-$(GCC_VER_ONLY) gprof ld ld.bfd \
       ld.gold nm objcopy objdump ranlib readelf size strings strip)
 endif
 
 # Add link to work around "plugin needed to handle lto object" (JDK-8344272)
-$(PREFIX)/lib/bfd-plugins/liblto_plugin.so: $(PREFIX)/libexec/gcc/$(TARGET)/$(gcc_ver_only)/liblto_plugin.so
+$(PREFIX)/lib/bfd-plugins/liblto_plugin.so: $(PREFIX)/libexec/gcc/$(TARGET)/$(GCC_VER_ONLY)/liblto_plugin.so
 	@echo 'Creating missing $(@F) soft link'
 	@mkdir -p $(@D)
 	ln -s $$(realpath -s --relative-to=$(@D) $<) $@
 
-missing-links += $(PREFIX)/lib/bfd-plugins/liblto_plugin.so
+MISSING_LINKS += $(PREFIX)/lib/bfd-plugins/liblto_plugin.so
 
 ################################################################################
 
-bfdlib : $(bfdlib)
-binutils : $(binutils)
-rpms : $(rpms)
-libs : $(libs)
+bfdlib : $(BFDLIB)
+binutils : $(BINUTILS)
+rpms : $(RPMS)
+libs : $(LIBS)
 sysroot : rpms libs
-gcc : sysroot $(gcc) $(gccpatch)
-gdb : $(gdb)
-all : binutils gcc bfdlib $(PREFIX)/devkit.info $(missing-links) $(SYSROOT_LINKS) \
+gcc : sysroot $(GCC) $(GCC_PATCHED)
+gdb : $(GDB)
+all : binutils gcc bfdlib $(PREFIX)/devkit.info $(MISSING_LINKS) $(SYSROOT_LINKS) \
     $(THESE_MAKEFILES) gdb
 
 # this is only built for host. so separate.
-ccache : $(ccache)
+ccache : $(CCACHE)
 
 .PHONY : gcc all binutils bfdlib link_libs rpms libs sysroot


### PR DESCRIPTION
Bring the devkit makefiles closer to the naming convention used in the JDK build system by using uppercase variable names.

Testing:

* Built devkit on linux-x64
* Verified that the JDK builds with the new devkit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369328](https://bugs.openjdk.org/browse/JDK-8369328): Use uppercase variable names in the devkit makefiles (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27679/head:pull/27679` \
`$ git checkout pull/27679`

Update a local copy of the PR: \
`$ git checkout pull/27679` \
`$ git pull https://git.openjdk.org/jdk.git pull/27679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27679`

View PR using the GUI difftool: \
`$ git pr show -t 27679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27679.diff">https://git.openjdk.org/jdk/pull/27679.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27679#issuecomment-3378929893)
</details>
