### PR TITLE
8369230

### DIFF
--- a/test/jdk/com/sun/jdi/SimulResumerTest.java
+++ b/test/jdk/com/sun/jdi/SimulResumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g SimulResumerTest.java
- * @run driver SimulResumerTest
+ * @run driver/timeout=180 SimulResumerTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;


### PR DESCRIPTION
The test needs a longer timeout due to the recent timeout factor change. Test runs pushing close to 2 minutes seem common on windows, although the failure reported in the CR is the only case I see of it taking more than 2 minutes (and just barely more). Because of this I think 180 seconds should be plenty.

I'd like to push this as a trivial change.