### PR TITLE
8369291

### DIFF
--- a/test/jdk/java/net/httpclient/BasicHTTP2Test.java
+++ b/test/jdk/java/net/httpclient/BasicHTTP2Test.java
@@ -166,7 +166,6 @@ public class BasicHTTP2Test implements HttpServerAdapters {
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .executor(executor)
                 .sslContext(sslContext)
-                .connectTimeout(Duration.ofSeconds(10))
                 .build();
         return TRACKER.track(client);
     }

--- a/test/jdk/java/net/httpclient/BasicHTTP3Test.java
+++ b/test/jdk/java/net/httpclient/BasicHTTP3Test.java
@@ -216,7 +216,6 @@ public class BasicHTTP3Test implements HttpServerAdapters {
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .executor(executor)
                 .sslContext(sslContext)
-                .connectTimeout(Duration.ofSeconds(10))
                 .build();
         return TRACKER.track(client);
     }

--- a/test/jdk/java/net/httpclient/http3/H3DataLimitsTest.java
+++ b/test/jdk/java/net/httpclient/http3/H3DataLimitsTest.java
@@ -164,7 +164,6 @@ public class H3DataLimitsTest implements HttpServerAdapters {
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .executor(executor)
                 .sslContext(sslContext)
-                .connectTimeout(Duration.ofSeconds(10))
                 .build();
         return client;
     }

--- a/test/jdk/java/net/httpclient/http3/H3HeaderSizeLimitTest.java
+++ b/test/jdk/java/net/httpclient/http3/H3HeaderSizeLimitTest.java
@@ -103,8 +103,6 @@ public class H3HeaderSizeLimitTest implements HttpServerAdapters {
         final HttpClient client = newClientBuilderForH3()
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .version(Version.HTTP_3)
-                // the server drops 1 packet out of two!
-                .connectTimeout(Duration.ofSeconds(Utils.adjustTimeout(10)))
                 .sslContext(sslContext).build();
         final URI reqURI = new URI(requestURIBase + "/hello");
         final HttpRequest.Builder reqBuilder = HttpRequest.newBuilder(reqURI)

--- a/test/jdk/java/net/httpclient/http3/H3InsertionsLimitTest.java
+++ b/test/jdk/java/net/httpclient/http3/H3InsertionsLimitTest.java
@@ -155,8 +155,6 @@ public class H3InsertionsLimitTest implements HttpServerAdapters {
         final HttpClient client = newClientBuilderForH3()
                 .proxy(HttpClient.Builder.NO_PROXY)
                 .version(Version.HTTP_3)
-                // the server drops 1 packet out of two!
-                .connectTimeout(Duration.ofSeconds(Utils.adjustTimeout(10)))
                 .sslContext(sslContext).build();
         final URI reqURI = new URI(requestURIBase + "/insertions");
         final HttpRequest.Builder reqBuilder = HttpRequest.newBuilder(reqURI)


### PR DESCRIPTION
Remove connectTimeout setting from all tests that set it without a good reason. It causes occasional test failures, especially on machines running tests with artificially inflated level of parallelism.

The tests continue to pass.