### PR TITLE
8369349: Add missing CPE headers

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/Result.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/Result.java
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Adds missing classpath exception copyright headers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369349](https://bugs.openjdk.org/browse/JDK-8369349): Add missing CPE headers (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27687/head:pull/27687` \
`$ git checkout pull/27687`

Update a local copy of the PR: \
`$ git checkout pull/27687` \
`$ git pull https://git.openjdk.org/jdk.git pull/27687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27687`

View PR using the GUI difftool: \
`$ git pr show -t 27687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27687.diff">https://git.openjdk.org/jdk/pull/27687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27687#issuecomment-3380896915)
</details>
