### PR TITLE
8369423: Reduce execution time of testlibrary_tests/ir_framework/tests/TestDFlags.java

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -178,7 +178,7 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DVerbose=true`: Enable more fain-grained logging (slows the execution down).
 - `-DReproduce=true`: Flag to use when directly running a test VM to bypass dependencies to the driver VM state (for example, when reproducing an issue).
 - `-DPrintTimes=true`: Print the execution time measurements of each executed test.
-- `-DPrintRuleMatchingTime=true`: Print the time of matching IR rules per method. Slows down the execution as the rules are warmed up before meassurement.
+- `-DPrintRuleMatchingTime=true`: Print the time of matching IR rules per method. Slows down the execution as the rules are warmed up before measurement.
 - `-DVerifyVM=true`: The framework runs the test VM with additional verification flags (slows the execution down).
 - `-DExcluceRandom=true`: The framework randomly excludes some methods from compilation. IR verification is disabled completely with this flag.
 - `-DFlipC1C2=true`: The framework compiles all `@Test` annotated method with C1 if a C2 compilation would have been applied and vice versa. IR verification is disabled completely with this flag.

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDFlags.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDFlags.java
@@ -23,24 +23,24 @@
 
 package ir_framework.tests;
 
+import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.Test;
 import compiler.lib.ir_framework.TestFramework;
 /*
  * @test
  * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
- * @summary Sanity test remaining framework property flags.
+ * @summary Sanity test remaining framework property/D flags with non-default values. We do two runs, one time with
+ *          VerifyIR=false and one time with VerifyIR=true.
  * @library /test/lib /
- * @run main/othervm -DFlipC1C2=true ir_framework.tests.TestDFlags
- * @run main/othervm -DExcludeRandom=true ir_framework.tests.TestDFlags
- * @run main/othervm -DVerifyVM=true ir_framework.tests.TestDFlags
- * @run main/othervm -DDumpReplay=true ir_framework.tests.TestDFlags
- * @run main/othervm -DVerbose=true ir_framework.tests.TestDFlags
- * @run main/othervm -DShuffleTests=false ir_framework.tests.TestDFlags
- * @run main/othervm -DReproduce=true ir_framework.tests.TestDFlags
- * @run main/othervm -DReportStdout=true ir_framework.tests.TestDFlags
- * @run main/othervm -DGCAfter=true ir_framework.tests.TestDFlags
- * @run main/othervm -DPrintTimes=true ir_framework.tests.TestDFlags
- * @run main/othervm -DVerifyIR=false ir_framework.tests.TestDFlags
+ * @run main/othervm -DFlipC1C2=true -DExcludeRandom=true -DVerifyVM=true -DDumpReplay=true -DVerbose=true
+ *                   -DShuffleTests=false -DReproduce=true -DReportStdout=true -DGCAfter=true -DPrintTimes=true
+ *                   -DIgnoreCompilerControls=true -DExcludeRandom=true -DVerifyIR=true
+ *                   -DPreferCommandLineFlags=true -DPrintRuleMatchingTime=true ir_framework.tests.TestDFlags
+ * @run main/othervm -DFlipC1C2=true -DExcludeRandom=true -DVerifyVM=true -DDumpReplay=true -DVerbose=true
+ *                   -DShuffleTests=false -DReproduce=true -DReportStdout=true -DGCAfter=true -DPrintTimes=true
+ *                   -DIgnoreCompilerControls=true -DExcludeRandom=true -DVerifyIR=false
+ *                   -DPreferCommandLineFlags=true -DPrintRuleMatchingTime=true ir_framework.tests.TestDFlags
  */
 
 public class TestDFlags {
@@ -49,24 +49,28 @@ public class TestDFlags {
     }
 
     @Test
+    @IR(failOn = IRNode.STORE)
     public int c1() {
         return 34;
     }
 
 
     @Test
+    @IR(failOn = IRNode.STORE)
     public void c2() {
         for (int i = 0; i < 100; i++) {
         }
     }
 
     @Test
+    @IR(failOn = IRNode.STORE)
     public void c2_2() {
         for (int i = 0; i < 100; i++) {
         }
     }
 
     @Test
+    @IR(failOn = IRNode.STORE)
     public void c2_3() {
         for (int i = 0; i < 100; i++) {
         }


### PR DESCRIPTION
The test `testlibrary_tests/ir_framework/tests/TestDFlags.java` runs 11 separate IR framework runs by enabling only a single property/D flag in each run. This seems like a waste of resources for just a sanity run (we don't do any additional verification). Moreover, some newer property flags are missing.

I suggest to cut it down to 2 runs: 
- IR verification enabled (i.e. -DVerifyIR=true, which is the default) 
- IR verification disabled (i.e. -DVerifyIR=false)

In both runs we simultaneously set all property flags to some non-default value as a sanity test.

This reduces the test execution time from around 20-30s down to 3-4s.

Thanks,
Christian