### PR TITLE
8369428: Include method name in 'does not override or implement' diagnostics

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2080,7 +2080,7 @@ public class Check {
                 }
             }
             log.error(pos,
-                      explicitOverride ? (m.isStatic() ? Errors.StaticMethodsCannotBeAnnotatedWithOverride : Errors.MethodDoesNotOverrideSuperclass) :
+                      explicitOverride ? (m.isStatic() ? Errors.StaticMethodsCannotBeAnnotatedWithOverride : Errors.MethodDoesNotOverrideSuperclass(m)) :
                                 Errors.AnonymousDiamondMethodDoesNotOverrideSuperclass(Fragments.DiamondAnonymousMethodsImplicitlyOverride));
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -905,8 +905,9 @@ compiler.err.limit.string.overflow=\
 compiler.err.malformed.fp.lit=\
     malformed floating-point literal
 
+# 0: symbol
 compiler.err.method.does.not.override.superclass=\
-    method does not override or implement a method from a supertype
+    {0} does not override or implement a method from a supertype
 
 compiler.err.static.methods.cannot.be.annotated.with.override=\
     static methods cannot be annotated with @Override

--- a/test/langtools/tools/javac/OverrideChecks/Private.out
+++ b/test/langtools/tools/javac/OverrideChecks/Private.out
@@ -1,2 +1,2 @@
-Private.java:14:5: compiler.err.method.does.not.override.superclass
+Private.java:14:5: compiler.err.method.does.not.override.superclass: m()
 1 error

--- a/test/langtools/tools/javac/annotations/neg/OverrideNo.out
+++ b/test/langtools/tools/javac/annotations/neg/OverrideNo.out
@@ -1,2 +1,2 @@
-OverrideNo.java:16:5: compiler.err.method.does.not.override.superclass
+OverrideNo.java:16:5: compiler.err.method.does.not.override.superclass: f()
 1 error

--- a/test/langtools/tools/javac/lvti/BadLocalVarInferenceTest.out
+++ b/test/langtools/tools/javac/lvti/BadLocalVarInferenceTest.out
@@ -5,7 +5,7 @@ BadLocalVarInferenceTest.java:22:13: compiler.err.cant.infer.local.var.type: g, 
 BadLocalVarInferenceTest.java:23:13: compiler.err.cant.infer.local.var.type: d, (compiler.misc.local.self.ref)
 BadLocalVarInferenceTest.java:24:13: compiler.err.cant.infer.local.var.type: k, (compiler.misc.local.array.missing.target)
 BadLocalVarInferenceTest.java:25:29: compiler.err.does.not.override.abstract: compiler.misc.anonymous.class: BadLocalVarInferenceTest$1, m(java.lang.Object), BadLocalVarInferenceTest.Foo
-BadLocalVarInferenceTest.java:26:13: compiler.err.method.does.not.override.superclass
+BadLocalVarInferenceTest.java:26:13: compiler.err.method.does.not.override.superclass: m(java.lang.String)
 BadLocalVarInferenceTest.java:29:27: compiler.err.cant.resolve.location.args: kindname.method, charAt, , int, (compiler.misc.location.1: kindname.variable, x, java.lang.Object)
 BadLocalVarInferenceTest.java:30:13: compiler.err.cant.infer.local.var.type: t, (compiler.misc.local.cant.infer.void)
 10 errors


### PR DESCRIPTION
Hi,

Please consider this small improvement to `compiler.err.method.does.not.override.superclass` diagnostics, to include the method name.

Before:

```
T.java:2: error: method does not override or implement a method from a supertype
  @Override
  ^
```

After:

```
T.java:2: error: f() does not override or implement a method from a supertype
  @Override
  ^
1 error
```