### PR TITLE
8369432: Add Support for JDBC 4.5 MR

### DIFF
--- a/src/java.sql/share/classes/java/sql/Array.java
+++ b/src/java.sql/share/classes/java/sql/Array.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,13 +61,19 @@ package java.sql;
  * If the connection's type map or a type map supplied to a method has no entry
  * for the base type, the elements are mapped according to the standard mapping.
  * <p>
+ * To release resources used by the {@code Array} object, applications must call
+ * either the {@link #free()} or the {@link #close()} method.  Any attempt to
+ * invoke a method other than {@link #free()} or {@link #close()} after the
+ * {@code Array} object has been closed, will result in a {@link SQLException}
+ * being thrown.
+ * <P>
  * All methods on the {@code Array} interface must be fully implemented if the
  * JDBC driver supports the data type.
  *
  * @since 1.2
  */
 
-public interface Array {
+public interface Array  extends AutoCloseable {
 
   /**
    * Retrieves the SQL type name of the elements in
@@ -345,21 +351,35 @@ public interface Array {
                           java.util.Map<String,Class<?>> map)
     throws SQLException;
     /**
-     * This method frees the {@code Array} object and releases the resources that
-     * it holds. The object is invalid once the {@code free}
-     * method is called.
+     * Closes and releases the resources held by this {@code Array} object.
      * <p>
-     * After {@code free} has been called, any attempt to invoke a
-     * method other than {@code free} will result in a {@code SQLException}
-     * being thrown.  If {@code free} is called multiple times, the subsequent
-     * calls to {@code free} are treated as a no-op.
+     * If the {@code Array} object is already closed, then invoking this method
+     * has no effect.
      *
      * @throws SQLException if an error occurs releasing
      * the Array's resources
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      * this method
      * @since 1.6
+     * @see #close()
      */
     void free() throws SQLException;
 
+  /**
+   * Closes and releases the resources held by this {@code Array} object.
+   * <p>
+   * If the {@code Array} object is already closed, then invoking this method
+   * has no effect.
+   *
+   * @throws SQLException                    if an error occurs releasing
+   *                                         the Array's resources
+   * @throws SQLFeatureNotSupportedException if the JDBC driver
+   *                                         does not support this method
+   * @implSpec The default implementation calls the {@link #free()} method.
+   * @see #free()
+   * @since 26
+   */
+  default void close() throws SQLException {
+    free();
+  };
 }

--- a/src/java.sql/share/classes/java/sql/Blob.java
+++ b/src/java.sql/share/classes/java/sql/Blob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.io.InputStream;
  * the Java programming language of an SQL
  * {@code BLOB} value.  An SQL {@code BLOB} is a built-in type
  * that stores a Binary Large Object as a column value in a row of
- * a database table. By default drivers implement {@code Blob} using
+ * a database table. By default, drivers implement {@code Blob} using
  * an SQL {@code locator(BLOB)}, which means that a
  * {@code Blob} object contains a logical pointer to the
  * SQL {@code BLOB} data rather than the data itself.
@@ -50,13 +50,19 @@ import java.io.InputStream;
  * {@code BLOB} value. In addition, this interface has methods for updating
  * a {@code BLOB} value.
  * <p>
+ * To release resources used by the {@code Blob} object, applications must call
+ * either the {@link #free()} or the {@link #close()} method.  Any attempt to
+ * invoke a method other than {@link #free()} or {@link #close()} after the
+ * {@code Blob} object has been closed, will result in a {@link SQLException}
+ * being thrown.
+ * <P>
  * All methods on the {@code Blob} interface must be fully implemented if the
  * JDBC driver supports the data type.
  *
  * @since 1.2
  */
 
-public interface Blob {
+public interface Blob extends AutoCloseable {
 
   /**
    * Returns the number of bytes in the {@code BLOB} value
@@ -266,20 +272,17 @@ public interface Blob {
     void truncate(long len) throws SQLException;
 
     /**
-     * This method frees the {@code Blob} object and releases the resources that
-     * it holds. The object is invalid once the {@code free}
-     * method is called.
+     * Closes and releases the resources held by this {@code Blob} object.
      * <p>
-     * After {@code free} has been called, any attempt to invoke a
-     * method other than {@code free} will result in an {@code SQLException}
-     * being thrown.  If {@code free} is called multiple times, the subsequent
-     * calls to {@code free} are treated as a no-op.
+     * If the {@code Blob} object is already closed, then invoking this method
+     * has no effect.
      *
      * @throws SQLException if an error occurs releasing
      *         the Blob's resources
      * @throws SQLFeatureNotSupportedException if the JDBC driver
      *         does not support this method
      * @since 1.6
+     * @see #close()
      */
     void free() throws SQLException;
 
@@ -303,4 +306,23 @@ public interface Blob {
      * @since 1.6
      */
     InputStream getBinaryStream(long pos, long length) throws SQLException;
+
+  /**
+   * Closes and releases the resources held by this {@code Blob} object.
+   * <p>
+   * If the {@code Blob} object is already closed, then invoking this method
+   * has no effect.
+   *
+   * @implSpec The default implementation calls the {@link #free()} method.
+   *
+   * @throws SQLException if an error occurs releasing
+   *         the Blob's resources
+   * @throws SQLFeatureNotSupportedException if the JDBC driver
+   *         does not support this method
+   * @since 26
+   * @see #free()
+   */
+  default void close() throws SQLException {
+    free();
+  };
 }

--- a/src/java.sql/share/classes/java/sql/Clob.java
+++ b/src/java.sql/share/classes/java/sql/Clob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.io.Reader;
  * An SQL {@code CLOB} is a built-in type
  * that stores a Character Large Object as a column value in a row of
  * a database table.
- * By default drivers implement a {@code Clob} object using an SQL
+ * By default, drivers implement a {@code Clob} object using an SQL
  * {@code locator(CLOB)}, which means that a {@code Clob} object
  * contains a logical pointer to the SQL {@code CLOB} data rather than
  * the data itself. A {@code Clob} object is valid for the duration
@@ -49,13 +49,19 @@ import java.io.Reader;
  * access an SQL {@code CLOB} value.  In addition, this interface
  * has methods for updating a {@code CLOB} value.
  * <p>
+ * To release resources used by the {@code Clob} object, applications must call
+ * either the {@link #free()} or the {@link #close()} method.  Any attempt to
+ * invoke a method other than {@link #free()} or {@link #close()} after the
+ * {@code Clob} object has been closed, will result in a {@link SQLException}
+ * being thrown.
+ * <P>
  * All methods on the {@code Clob} interface must be
  * fully implemented if the JDBC driver supports the data type.
  *
  * @since 1.2
  */
 
-public interface Clob {
+public interface Clob extends AutoCloseable {
 
   /**
    * Retrieves the number of characters
@@ -310,14 +316,10 @@ public interface Clob {
     void truncate(long len) throws SQLException;
 
     /**
-     * This method releases the resources that the {@code Clob} object
-     * holds.  The object is invalid once the {@code free} method
-     * is called.
+     * Closes and releases the resources held by this {@code Clob} object.
      * <p>
-     * After {@code free} has been called, any attempt to invoke a
-     * method other than {@code free} will result in a {@code SQLException}
-     * being thrown.  If {@code free} is called multiple times, the subsequent
-     * calls to {@code free} are treated as a no-op.
+     * If the {@code Clob} object is already closed, then invoking this method
+     * has no effect.
      *
      * @throws SQLException if an error occurs releasing
      *         the Clob's resources
@@ -325,6 +327,7 @@ public interface Clob {
      * @throws SQLFeatureNotSupportedException if the JDBC driver
      *         does not support this method
      * @since 1.6
+     * @see #close()
      */
     void free() throws SQLException;
 
@@ -350,4 +353,21 @@ public interface Clob {
      */
     Reader getCharacterStream(long pos, long length) throws SQLException;
 
+  /**
+   * Closes and releases the resources held by this {@code Clob} object.
+   * <p>
+   * If the {@code Clob} object is already closed, then invoking this method
+   * has no effect.
+   *
+   * @throws SQLException                    if an error occurs releasing
+   *                                         the Clob's resources
+   * @throws SQLFeatureNotSupportedException if the JDBC driver
+   *                                         does not support this method
+   * @implSpec The default implementation calls the {@link #free()} method.
+   * @see #free()
+   * @since 26
+   */
+  default void close() throws SQLException {
+    free();
+  };
 }

--- a/src/java.sql/share/classes/java/sql/DriverPropertyInfo.java
+++ b/src/java.sql/share/classes/java/sql/DriverPropertyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,13 @@
 
 package java.sql;
 
+import java.util.Properties;
+
 /**
  * <p>Driver properties for making a connection. The
- * {@code DriverPropertyInfo} class is of interest only to advanced programmers
- * who need to interact with a Driver via the method
- * {@code getDriverProperties} to discover
- * and supply properties for connections.
+ * {@code DriverPropertyInfo} class is of interest only to advanced programmers.
+ * The method {@linkplain Driver#getPropertyInfo(String, Properties)} may be used
+ * to discover Driver properties.
  *
  * @since 1.1
  */

--- a/src/java.sql/share/classes/java/sql/JDBCType.java
+++ b/src/java.sql/share/classes/java/sql/JDBCType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,7 +200,17 @@ public enum JDBCType implements SQLType {
     /**
      * Identifies the generic SQL type {@code TIMESTAMP_WITH_TIMEZONE}.
      */
-    TIMESTAMP_WITH_TIMEZONE(Types.TIMESTAMP_WITH_TIMEZONE);
+    TIMESTAMP_WITH_TIMEZONE(Types.TIMESTAMP_WITH_TIMEZONE),
+
+    /**
+     * Identifies the generic SQL type {@code DECFLOAT}.
+     */
+    DECFLOAT(Types.DECFLOAT),
+
+    /**
+     * Identifies the generic SQL type {@code DECFLOAT}.
+     */
+    JSON(Types.JSON);
 
     /**
      * The Integer value for the JDBCType.  It maps to a value in

--- a/src/java.sql/share/classes/java/sql/NClob.java
+++ b/src/java.sql/share/classes/java/sql/NClob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,8 @@ package java.sql;
  * An SQL {@code NCLOB} is a built-in type
  * that stores a Character Large Object using the National Character Set
  *  as a column value in a row of  a database table.
- * <P>The {@code NClob} interface extends the {@code Clob} interface
+ * <P>
+ * The {@code NClob} interface extends the {@code Clob} interface
  * which provides methods for getting the
  * length of an SQL {@code NCLOB} value,
  * for materializing a {@code NCLOB} value on the client, and for
@@ -44,6 +45,12 @@ package java.sql;
  * access an SQL {@code NCLOB} value.  In addition, this interface
  * has methods for updating a {@code NCLOB} value.
  * <p>
+ * To release resources used by the {@code NClob} object, applications must call
+ * either the {@link #free()} or the {@link #close()} method.  Any attempt to
+ * invoke a method other than {@link #free()} or {@link #close()} after the
+ * {@code NClob} object has been closed, will result in a {@link SQLException}
+ * being thrown.
+ * <P>
  * All methods on the {@code NClob} interface must be fully implemented if the
  * JDBC driver supports the data type.
  *

--- a/src/java.sql/share/classes/java/sql/SQLPermission.java
+++ b/src/java.sql/share/classes/java/sql/SQLPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,30 +29,14 @@ package java.sql;
 import java.security.*;
 
 /**
- * A {@code SQLPermission} object contains
- * a name (also referred to as a "target name") but no actions
- * list; there is either a named permission or there is not.
- * The target name is the name of the permission. The
- * naming convention follows the  hierarchical property naming convention.
- * In addition, an asterisk
- * may appear at the end of the name, following a ".", or by itself, to
- * signify a wildcard match. For example: {@code loadLibrary.*}
- * and {@code *} signify a wildcard match,
- * while {@code *loadLibrary} and {@code a*b} do not.
- *
- * @apiNote
- * This permission cannot be used for controlling access to resources
- * as the Security Manager is no longer supported.
+ *This class was only useful in conjunction with the {@link java.lang.SecurityManager},
+ * which is no longer supported. There is no replacement for this class.
  *
  * @since 1.3
- * @see java.security.BasicPermission
- * @see java.security.Permission
- * @see java.security.Permissions
- * @see java.security.PermissionCollection
- * @see java.lang.SecurityManager
  *
+ * @deprecated There is no replacement for this class.
  */
-
+@Deprecated(since="26", forRemoval=true)
 public final class SQLPermission extends BasicPermission {
 
     /**

--- a/src/java.sql/share/classes/java/sql/SQLXML.java
+++ b/src/java.sql/share/classes/java/sql/SQLXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,15 +170,20 @@ import javax.xml.transform.Source;
  * The conceptual states of writable and not writable determine if one
  * of the writing APIs will set a value or throw an exception.
  * <p>
- * The state moves from readable to not readable once free() or any of the
+ * The state moves from readable to not readable once close(), free() or any of the
  * reading APIs are called: getBinaryStream(), getCharacterStream(), getSource(), and getString().
  * Implementations may also change the state to not writable when this occurs.
  * <p>
- * The state moves from writable to not writable once free() or any of the
+ * The state moves from writable to not writable once close(), free() or any of the
  * writing APIs are called: setBinaryStream(), setCharacterStream(), setResult(), and setString().
  * Implementations may also change the state to not readable when this occurs.
- *
- * <p>
+ *<p>
+ * To release resources used by the {@code SQLXML} object, applications must call
+ * either the {@link #free()} or the {@link #close()} method.  Any attempt to
+ * invoke a method other than {@link #free()} or {@link #close()} after the
+ * {@code SQLXML} object has been closed, will result in a {@link SQLException}
+ * being thrown.
+ * <P>
  * All methods on the {@code SQLXML} interface must be fully implemented if the
  * JDBC driver supports the data type.
  *
@@ -188,21 +193,19 @@ import javax.xml.transform.Source;
  * @see javax.xml.xpath
  * @since 1.6
  */
-public interface SQLXML
+public interface SQLXML extends AutoCloseable
 {
   /**
-   * This method closes this object and releases the resources that it held.
-   * The SQL XML object becomes invalid and neither readable or writable
-   * when this method is called.
+   * Closes and releases the resources held by this {@code SQLXML} object.
+   * <p>
+   * If the {@code SQLXML} object is already closed, then invoking this method
+   * has no effect.
    *
-   * After {@code free} has been called, any attempt to invoke a
-   * method other than {@code free} will result in a {@code SQLException}
-   * being thrown.  If {@code free} is called multiple times, the subsequent
-   * calls to {@code free} are treated as a no-op.
    * @throws SQLException if there is an error freeing the XML value.
    * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
    * this method
    * @since 1.6
+   * @see #close()
    */
   void free() throws SQLException;
 
@@ -424,4 +427,21 @@ public interface SQLXML
    */
   <T extends Result> T setResult(Class<T> resultClass) throws SQLException;
 
+  /**
+   * Closes and releases the resources held by this {@code SQLXML} object.
+   * <p>
+   * If the {@code SQLXML} object is already closed, then invoking this method
+   * has no effect.
+   *
+   * @throws SQLException                    if an error occurs releasing
+   *                                         the SQLXML's resources
+   * @throws SQLFeatureNotSupportedException if the JDBC driver
+   *                                         does not support this method
+   * @implSpec The default implementation calls the {@link #free()} method.
+   * @see #free()
+   * @since 26
+   */
+  default void close() throws SQLException {
+    free();
+  };
 }

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -54,10 +54,7 @@ import java.time.LocalDateTime;
  * because the nanos component of a date is unknown.
  * As a result, the {@code Timestamp.equals(Object)}
  * method is not symmetric with respect to the
- * {@code java.util.Date.equals(Object)}
- * method.  Also, the {@code hashCode} method uses the underlying
- * {@code java.util.Date}
- * implementation and therefore does not include nanos in its computation.
+ * {@code java.util.Date.equals(Object)} method.
  * <P>
  * Due to the differences between the {@code Timestamp} class
  * and the {@code java.util.Date}
@@ -465,10 +462,15 @@ public class Timestamp extends java.util.Date {
     }
 
     /**
-     * {@inheritDoc}
+     * Returns a hash code value for this Timestamp. The result is the
+     * exclusive OR of the two halves of the primitive {@code long}
+     * value returned by the {@link #getTime} method. That is,
+     * the hash code is the value of the expression:
+     * {@snippet :
+     *   (int)(this.getTime()^(this.getTime() >>> 32))
+     * }
      *
-     * The {@code hashCode} method uses the underlying {@code java.util.Date}
-     * implementation and therefore does not include nanos in its computation.
+     * @return  a hash code value for this Timestamp.
      *
      */
     @Override

--- a/src/java.sql/share/classes/java/sql/Types.java
+++ b/src/java.sql/share/classes/java/sql/Types.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -338,6 +338,27 @@ public class Types {
      * @since 1.8
      */
     public static final int TIMESTAMP_WITH_TIMEZONE = 2014;
+
+
+    //--------------------------JDBC 4.5 -----------------------------
+
+    /**
+     * The constant in the Java programming language, sometimes referred to
+     * as a type code, that identifies the generic SQL type
+     * {@code DECFLOAT}.
+     *
+     * @since 26
+     */
+    public static final int DECFLOAT = 2015;
+
+    /**
+     * The constant in the Java programming language, sometimes referred to
+     * as a type code, that identifies the generic SQL type
+     * {@code JSON}.
+     *
+     * @since 26
+     */
+    public static final int JSON = 2016;
 
     // Prevent instantiation
     private Types() {}

--- a/src/java.sql/share/classes/java/sql/package-info.java
+++ b/src/java.sql/share/classes/java/sql/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,20 +38,22 @@
  * use and update data from a spread sheet, flat file, or any other tabular
  * data source.
  *
- * <h2>What the JDBC 4.3 API Includes</h2>
- * The JDBC 4.3 API includes both
+ * <h2>What the JDBC 4.5 API Includes</h2>
+ * The JDBC 4.5 API includes both
  * the {@code java.sql} package, referred to as the JDBC core API,
  * and the {@code javax.sql} package, referred to as the JDBC Optional
  * Package API. This complete JDBC API
- * is included in the Java Standard Edition (Java SE), version 7.
+ * is included in the Java Standard Edition (Java SE).
  * The {@code javax.sql} package extends the functionality of the JDBC API
  * from a client-side API to a server-side API, and it is an essential part
  * of the Java  Enterprise Edition
  * (Java EE) technology.
  *
  * <h2>Versions</h2>
- * The JDBC 4.3 API incorporates all of the previous JDBC API versions:
+ * The JDBC 4.5 API incorporates all the previous JDBC API versions:
  * <UL>
+ *     <LI> The JDBC 4.4 API</li>
+ *     <LI> The JDBC 4.3 API</li>
  *     <LI> The JDBC 4.2 API</li>
  *     <LI> The JDBC 4.1 API</li>
  *     <LI> The JDBC 4.0 API</li>
@@ -70,6 +72,10 @@
  * Javadoc comments for the JDBC API,
  * they indicate the following:
  * <UL>
+ *     <LI>Since 26 -- new in the JDBC 4.5 API and part of the Java SE platform,
+ *         version 26</li>
+ *      <LI>Since 24 -- new in the JDBC 4.4 API and part of the Java SE platform,
+ *         version 24</li>
  *     <LI>Since 9 -- new in the JDBC 4.3 API and part of the Java SE platform,
  *         version 9</li>
  *     <LI>Since 1.8 -- new in the JDBC 4.2 API and part of the Java SE platform,
@@ -126,6 +132,7 @@
  *       <LI>{@code Blob} interface -- mapping for SQL {@code BLOB}
  *       <LI>{@code Clob} interface -- mapping for SQL {@code CLOB}
  *       <LI>{@code Date} class -- mapping for SQL {@code DATE}
+ *       <LI>{@code JDBCType} class -- provides enum constants for SQL types
  *       <LI>{@code NClob} interface -- mapping for SQL {@code NCLOB}
  *       <LI>{@code Ref} interface -- mapping for SQL {@code REF}
  *       <LI>{@code RowId} interface -- mapping for SQL {@code ROWID}
@@ -166,6 +173,26 @@
  *      </UL>
  * </UL>
  *
+ *     <h3>{@code java.sql} and {@code javax.sql} Features Introduced in the JDBC 4.5 API</h3>
+ *  <UL>
+ *      <LI>The interfaces {@code Array}, {@code Blob}, {@code Clob}, {@code NClob}
+ *      and  {@code SQLXML} now extend the {@code AutoCloseable} interface and
+ *      include a default {@code close} method implentation</LI>
+ *     <LI>Added support to {@code Connection} for enquoting literals
+ *     and simple identifiers</LI>
+ *      <LI> {@code SQLPermissions} has been deprecated for removal</LI>
+ *      <LI> The SQL Types {@code JSON} and {@code DECFLOAT} have been added to
+ *           {@code JDBCType} and {@code Types}</LI>
+ *  </UL>
+ *     <h3>{@code java.sql} and {@code javax.sql} Features Introduced in the JDBC 4.4 API</h3>
+ *  <UL>
+ *      <LI>Remove mention of {@code SecurityManager} and {@code SecurityException}
+ *            as the {@code SecurityManager} is no longer supported</LI>
+ *      <LI> {@code SQLPermissions} can no longer be used to control access to
+ *            resources as the {@code SecurityManager} is no longer supported</LI>
+ *     <LI>Added support to {@code Connection} for enquoting literals
+ *     and simple identifiers</LI>
+ *  </UL>
  *     <h3>{@code java.sql} and {@code javax.sql} Features Introduced in the JDBC 4.3 API</h3>
  * <UL>
  *     <LI>Added {@code Sharding} support</LI>
@@ -317,7 +344,7 @@
  * <h2>Package Specification</h2>
  *
  * <ul>
- *   <li><a href="https://jcp.org/en/jsr/detail?id=221">JDBC 4.3 Specification</a>
+ *   <li><a href="https://jcp.org/en/jsr/detail?id=221">JDBC 4.5 Specification</a>
  * </ul>
  *
  * <h2>Related Documentation</h2>
@@ -326,7 +353,6 @@
  *   <li><a href="http://docs.oracle.com/javase/tutorial/jdbc/basics/index.html">
  *           Lesson:JDBC Basics(The Java Tutorials &gt; JDBC Database Access)</a>
  *
- *  <li>&ldquo;<i>JDBC API Tutorial and Reference, Third Edition</i>&rdquo;
  * </ul>
  * @since 1.1
  */

--- a/test/jdk/java/sql/testng/test/sql/ConnectionTests.java
+++ b/test/jdk/java/sql/testng/test/sql/ConnectionTests.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.sql;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import util.BaseTest;
+import util.StubConnection;
+
+import java.sql.SQLException;
+
+import static org.testng.Assert.assertEquals;
+
+public class ConnectionTests extends BaseTest {
+
+    protected StubConnection conn;
+    protected static String maxIdentifier;
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+        conn = new StubConnection();
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        int maxLen = 128;
+        StringBuilder s = new StringBuilder(maxLen);
+        for (int i = 0; i < maxLen; i++) {
+            s.append('a');
+        }
+        maxIdentifier = s.toString();
+    }
+    /*
+     * Verify that enquoteLiteral creates a  valid literal and converts every
+     * single quote to two single quotes
+     */
+
+    @Test(dataProvider = "validEnquotedLiteralValues")
+    public void test00(String s, String expected) throws SQLException {
+        assertEquals(conn.enquoteLiteral(s), expected);
+    }
+
+    /*
+     * Validate a NullPointerException is thrown if the string passed to
+     * enquoteLiteral is null
+     */
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test01() throws SQLException {
+        conn.enquoteLiteral(null);
+
+    }
+
+    /*
+     * Validate that enquoteIdentifier returns the expected value
+     */
+    @Test(dataProvider = "validIdentifierValues")
+    public void test02(String s, boolean alwaysQuote, String expected) throws SQLException {
+        assertEquals(conn.enquoteIdentifier(s, alwaysQuote), expected);
+
+    }
+
+    /*
+     * Validate that a SQLException is thrown for values that are not valid
+     * for a SQL identifier
+     */
+    @Test(dataProvider = "invalidIdentifierValues",
+            expectedExceptions = SQLException.class)
+    public void test03(String s, boolean alwaysQuote) throws SQLException {
+        conn.enquoteIdentifier(s, alwaysQuote);
+
+    }
+
+    /*
+     * Validate a NullPointerException is thrown is the string passed to
+     * enquoteIdentiifer is null
+     */
+    @Test(dataProvider = "trueFalse",
+            expectedExceptions = NullPointerException.class)
+    public void test04(boolean alwaysQuote) throws SQLException {
+        conn.enquoteIdentifier(null, alwaysQuote);
+    }
+
+    /*
+     * Validate that isSimpleIdentifier returns the expected value
+     */
+    @Test(dataProvider = "simpleIdentifierValues")
+    public void test05(String s, boolean expected) throws SQLException {
+        assertEquals(conn.isSimpleIdentifier(s), expected);
+    }
+
+    /*
+     * Validate a NullPointerException is thrown if the string passed to
+     * isSimpleIdentifier is null
+     */
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test06() throws SQLException {
+        conn.isSimpleIdentifier(null);
+    }
+
+    /*
+     * Verify that enquoteLiteral creates a  valid literal and converts every
+     * single quote to two single quotes
+     */
+    @Test(dataProvider = "validEnquotedNCharLiteralValues")
+    public void test07(String s, String expected) throws SQLException {
+        assertEquals(conn.enquoteNCharLiteral(s), expected);
+    }
+
+    /*
+     * Validate a NullPointerException is thrown if the string passed to
+     * enquoteNCharLiteral is null
+     */
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test08() throws SQLException {
+        conn.enquoteNCharLiteral(null);
+    }
+
+    /*
+     * DataProvider used to provide strings that will be used to validate
+     * that enquoteLiteral converts a string to a literal and every instance of
+     * a single quote will be converted into two single quotes in the literal.
+     */
+    @DataProvider(name = "validEnquotedLiteralValues")
+    protected Object[][] validEnquotedLiteralValues() {
+        return new Object[][]{
+            {"Hello", "'Hello'"},
+            {"G'Day", "'G''Day'"},
+            {"'G''Day'", "'''G''''Day'''"},
+            {"I'''M", "'I''''''M'"},
+            {"The Dark Knight", "'The Dark Knight'"}
+        };
+    }
+
+    /*
+     * DataProvider used to provide strings that will be used to validate
+     * that enqouteIdentifier returns a simple SQL Identifier or a double
+     * quoted identifier
+     */
+    @DataProvider(name = "validIdentifierValues")
+    protected Object[][] validEnquotedIdentifierValues() {
+        return new Object[][]{
+            {"b", false, "b"},
+            {"b", true, "\"b\""},
+            {maxIdentifier, false, maxIdentifier},
+            {maxIdentifier, true, "\"" + maxIdentifier + "\""},
+            {"Hello", false, "Hello"},
+            {"Hello", true, "\"Hello\""},
+            {"G'Day", false, "\"G'Day\""},
+            {"G'Day", true, "\"G'Day\""},
+            {"Bruce Wayne", false, "\"Bruce Wayne\""},
+            {"Bruce Wayne", true, "\"Bruce Wayne\""},
+            {"GoodDay$", false, "\"GoodDay$\""},
+            {"GoodDay$", true, "\"GoodDay$\""},};
+    }
+
+    /*
+     * DataProvider used to provide strings are invalid for enquoteIdentifier
+     * resulting in a SQLException being thrown
+     */
+    @DataProvider(name = "invalidIdentifierValues")
+    protected Object[][] invalidEnquotedIdentifierValues() {
+        return new Object[][]{
+            {"Hel\"lo", false},
+            {"\"Hel\"lo\"", true},
+            {"Hello" + '\0', false},
+            {"", false},
+            {maxIdentifier + 'a', false},};
+    }
+
+    /*
+     * DataProvider used to provide strings that will be used to validate
+     * that isSimpleIdentifier returns the correct value based on the
+     * identifier specified.
+     */
+    @DataProvider(name = "simpleIdentifierValues")
+    protected Object[][] simpleIdentifierValues() {
+        return new Object[][]{
+            {"b", true},
+            {"Hello", true},
+            {"\"Gotham\"", false},
+            {"G'Day", false},
+            {"Bruce Wayne", false},
+            {"GoodDay$", false},
+            {"Dick_Grayson", true},
+            {"Batmobile1966", true},
+            {maxIdentifier, true},
+            {maxIdentifier + 'a', false},
+            {"", false},};
+    }
+
+    /*
+     * DataProvider used to provide strings that will be used to validate
+     * that enquoteNCharLiteral converts a string to a National Character
+     * literal and every instance of
+     * a single quote will be converted into two single quotes in the literal.
+     */
+    @DataProvider(name = "validEnquotedNCharLiteralValues")
+    protected Object[][] validEnquotedNCharLiteralValues() {
+        return new Object[][]{
+            {"Hello", "N'Hello'"},
+            {"G'Day", "N'G''Day'"},
+            {"'G''Day'", "N'''G''''Day'''"},
+            {"I'''M", "N'I''''''M'"},
+            {"N'Hello'", "N'N''Hello'''"},
+            {"The Dark Knight", "N'The Dark Knight'"}
+        };
+    }
+}

--- a/test/jdk/java/sql/testng/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/testng/test/sql/TimestampTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -665,6 +665,44 @@ public class TimestampTests extends BaseTest {
 
         // The earliest possible Instant will certainly overflow.
         expectThrows(IllegalArgumentException.class, () -> Timestamp.from(Instant.MIN));
+    }
+
+    /*
+     * Validate that two Timestamp hashCode values are equal when
+     * the Timestamp values match, including the nanos.
+     */
+    @Test
+    public void test54() {
+        long t = System.currentTimeMillis();
+        Timestamp ts1 = new Timestamp(t);
+        Timestamp ts2 = new Timestamp(t);
+        ts1.setNanos(123456789);
+        ts2.setNanos(123456789);
+        assertTrue(ts1.equals(ts1));
+        assertTrue(ts2.equals(ts2));
+        assertTrue(ts1.equals(ts2));
+        // As the Timestamp values, including the nanos are the same, the hashCode's
+        // should be equal
+        assertEquals(ts1.hashCode(), ts2.hashCode());
+    }
+
+    /*
+     * Validate that two Timestamp hashCode values are not equal when only
+     * the nanos value for the Timestamp differ.
+     */
+    @Test
+    public void test55() {
+        long t = System.currentTimeMillis();
+        Timestamp ts1 = new Timestamp(t);
+        Timestamp ts2 = new Timestamp(t);
+        // Modify the nanos so that the Timestamp values differ
+        ts1.setNanos(123456789);
+        ts2.setNanos(987654321);
+        assertTrue(ts1.equals(ts1));
+        assertTrue(ts2.equals(ts2));
+        assertFalse(ts1.equals(ts2));
+        // As the nanos differ, the hashCode values should differ
+        assertNotEquals(ts1.hashCode(), ts2.hashCode());
     }
 
     /*

--- a/test/jdk/java/sql/testng/util/BaseTest.java
+++ b/test/jdk/java/sql/testng/util/BaseTest.java
@@ -93,13 +93,6 @@ public class BaseTest {
     }
 
     /*
-     * Utility Method used to set the current Policy
-     */
-    protected static void setPolicy(Policy p) {
-        Policy.setPolicy(p);
-    }
-
-    /*
      * DataProvider used to specify the value to set and check for
      * methods using boolean values
      */


### PR DESCRIPTION
This PR adds support for the upcoming JDBC 4.5 MR which provides the following  updates to the JDBC specification:

- Deprecate SQLPermission for removal
- Enhance the Blob/Clob/Array/SQLXML/NClob interfaces to extend/support AutoClosable
- Add the SQL types DECFLOAT, JSON to Types.Java and JDBCType.java
- Add the quoted identifier methods that **were added previously to the Statement interface in JDK 9** to the Connection interface
  - It is the exact same verbiage & default methods used when these methods were added to the Statement interface
- Clarify the Timestamp::hashCode method which incorrectly indicates that nanos are not used when calculating the hash

Tiers 1-3 have been run
