### PR TITLE
JDK-8368982: Test sun/security/tools/jarsigner/EC.java completed and timed out

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/EC.java
+++ b/test/jdk/sun/security/tools/jarsigner/EC.java
@@ -26,6 +26,7 @@
  * @bug 6870812
  * @summary enhance security tools to use ECC algorithm
  * @library /test/lib
+ * @run main/timeout=300 EC
  */
 
 import jdk.test.lib.SecurityTools;


### PR DESCRIPTION
Increased a timeout from default 120. Each test runs 25 commands with 5 sec spent on each, so this made it likely that 120 would timeout. I think changing it to 300 would be a nice buffer.