### PR TITLE
8369434: java/net/httpclient/AltServiceUsageTest.java fails intermittently

### DIFF
--- a/test/jdk/java/net/httpclient/AltServiceUsageTest.java
+++ b/test/jdk/java/net/httpclient/AltServiceUsageTest.java
@@ -23,16 +23,12 @@
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.channels.DatagramChannel;
-import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -47,6 +43,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.net.http.HttpClient.Version.HTTP_3;
+import static java.net.http.HttpOption.H3_DISCOVERY;
+import static java.net.http.HttpOption.Http3DiscoveryMode.ALT_SVC;
 import static java.net.http.HttpOption.Http3DiscoveryMode.HTTP_3_URI_ONLY;
 
 /*
@@ -258,9 +256,10 @@ public class AltServiceUsageTest implements HttpServerAdapters {
         // send a HTTP3 request to a server which is expected to respond back
         // with a 200 response and an alt-svc header pointing to another/different H3 server
         final URI reqURI = URI.create("https://" + toHostPort(originServer) + "/foo/");
-        final HttpRequest request = HttpRequest.newBuilder()
+        final HttpRequest request = HttpRequest.newBuilder(reqURI)
                 .GET()
-                .uri(reqURI).build();
+                .setOption(H3_DISCOVERY, ALT_SVC)
+                .build();
         System.out.println("Issuing request " + reqURI);
         final HttpResponse<String> response = client.send(request,
                 HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
@@ -304,7 +303,10 @@ public class AltServiceUsageTest implements HttpServerAdapters {
                 .version(HTTP_3)
                 .build();
         final URI reqURI = URI.create("https://" + toHostPort(originServer) + "/foo421/");
-        final HttpRequest request = HttpRequest.newBuilder().GET().uri(reqURI).build();
+        final HttpRequest request = HttpRequest.newBuilder(reqURI)
+                .GET()
+                .setOption(H3_DISCOVERY, ALT_SVC)
+                .build();
         System.out.println("Issuing request " + reqURI);
         final HttpResponse<String> response = client.send(request,
                 HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
@@ -352,7 +354,10 @@ public class AltServiceUsageTest implements HttpServerAdapters {
         // send a HTTP3 request to a server which is expected to respond back
         // with a 200 response and an alt-svc header pointing to another/different H3 server
         final URI reqURI = URI.create("https://" + toHostPort(originServer) + "/bar/");
-        final HttpRequest request = HttpRequest.newBuilder().GET().uri(reqURI).build();
+        final HttpRequest request = HttpRequest.newBuilder(reqURI)
+                .GET()
+                .setOption(H3_DISCOVERY, ALT_SVC)
+                .build();
         System.out.println("Issuing request " + reqURI);
         final HttpResponse<String> response = client.send(request,
                 HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
@@ -404,7 +409,10 @@ public class AltServiceUsageTest implements HttpServerAdapters {
         // send a HTTP3 request to a server which is expected to respond back
         // with a 200 response and an alt-svc header pointing to another/different H3 server
         final URI reqURI = URI.create("https://" + toHostPort(originServer) + "/maxAgeAltSvc/");
-        final HttpRequest request = HttpRequest.newBuilder().GET().uri(reqURI).build();
+        final HttpRequest request = HttpRequest.newBuilder(reqURI)
+                .GET()
+                .setOption(H3_DISCOVERY, ALT_SVC)
+                .build();
         System.out.println("Issuing request " + reqURI);
         final HttpResponse<String> response = client.send(request,
                 HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));


### PR DESCRIPTION
The test expects that the first request will go to the HTTP/2 server and the next will go to HTTP/3. But since the default config is to use Http3DiscoveryMode.ANY it can manage to send the first request with HTTP/3 instead.

Requests should be explicitly configured with Http3DiscoveryMode.ALT_SVC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369434](https://bugs.openjdk.org/browse/JDK-8369434): java/net/httpclient/AltServiceUsageTest.java fails intermittently (**Bug** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/27696/head:pull/27696` \
`$ git checkout pull/27696`

Update a local copy of the PR: \
`$ git checkout pull/27696` \
`$ git pull https://git.openjdk.org/jdk.git pull/27696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27696`

View PR using the GUI difftool: \
`$ git pr show -t 27696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/27696.diff">https://git.openjdk.org/jdk/pull/27696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/27696#issuecomment-3382152091)
</details>
