### PR TITLE
8370315: [IR-Framework] Allow scenarios to be run in parallel

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -189,6 +189,7 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10s) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
 - `-DIgnoreCompilerControls=true`: Ignore all compiler controls applied in the framework. This includes any compiler control annotations (`@DontCompile`, `@DontInline`, `@ForceCompile`, `@ForceInline`, `@ForceCompileStaticInitializer`), the exclusion of `@Run` and `@Check` methods from compilation, and the directive to not inline `@Test` annotated methods.
 - `-DPreferCommandLineFlags=true`: Prefer flags set via the command line over flags specified by the tests.
+- `-DForceSequentialScenarios=true`: Forces scenarios to be run sequentially.
 
 ## 3. Test Framework Execution
 This section gives an overview of how the framework is executing a JTreg test that calls the framework from within its `main()` method.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -427,10 +427,11 @@ public class TestFramework {
 
     /**
      * Start the testing of the implicitly (by {@link #TestFramework()}) or explicitly (by {@link #TestFramework(Class)})
-     * set test class. Scenarios are run in parallel.
+     * set test class. Scenarios are run in parallel. Note: scenarios could still be run sequentially if flag
+     *  {@code -DForceSequentialScenarios=true} is given.
      */
     public void startParallel() {
-        start(true);
+        start(!FORCE_SEQUENTIAL_SCENARIOS);
     }
 
     private void start(boolean parallel) {
@@ -453,7 +454,7 @@ public class TestFramework {
                 throw e;
             }
         } else {
-            startWithScenarios(!FORCE_SEQUENTIAL_SCENARIOS && parallel);
+            startWithScenarios(parallel);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -161,6 +161,7 @@ public class TestFramework {
     public static final boolean PRINT_RULE_MATCHING_TIME = Boolean.getBoolean("PrintRuleMatchingTime");
     public static final boolean TESTLIST = !System.getProperty("Test", "").isEmpty();
     public static final boolean EXCLUDELIST = !System.getProperty("Exclude", "").isEmpty();
+    private static final boolean FORCE_SEQUENTIAL_SCENARIOS = Boolean.getBoolean("ForceSequentialScenarios");
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     // Only used for internal testing and should not be used for normal user testing.
 
@@ -452,7 +453,7 @@ public class TestFramework {
                 throw e;
             }
         } else {
-            startWithScenarios(parallel);
+            startWithScenarios(!FORCE_SEQUENTIAL_SCENARIOS && parallel);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -729,6 +729,16 @@ public class TestFramework {
     }
 
     /**
+     * Get the VM output of the test VM. Use {@code -DVerbose=true} to enable more debug information. If scenarios
+     * were run, use {@link Scenario#getTestVMOutput()}.
+     *
+     * @return the last test VM output.
+     */
+    public static String getLastTestVMOutput() {
+        return TestVMProcess.getLastTestVMOutput();
+    }
+
+    /**
      * For scenarios: Run the tests with the scenario settings and collect all exceptions to be able to run all
      * scenarios without prematurely throwing an exception. Format violations, however, are wrong for all scenarios
      * and thus is reported immediately on the first scenario execution.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -516,6 +516,16 @@ public class TestFramework {
         return this;
     }
 
+    /**
+     * Get the VM output of the test VM. Use {@code -DVerbose=true} to enable more debug information. If scenarios
+     * were run, use {@link Scenario#getTestVMOutput()}.
+     *
+     * @return the last test VM output.
+     */
+    public static String getLastTestVMOutput() {
+        return TestVMProcess.getLastTestVMOutput();
+    }
+
     /*
      * The following methods are only intended to be called from actual @Test methods and not from the main() method of
      * a JTreg test. Calling these methods from main() results in a linking exception (Whitebox not yet loaded and enabled).
@@ -726,16 +736,6 @@ public class TestFramework {
         }
 
         System.out.println("");
-    }
-
-    /**
-     * Get the VM output of the test VM. Use {@code -DVerbose=true} to enable more debug information. If scenarios
-     * were run, use {@link Scenario#getTestVMOutput()}.
-     *
-     * @return the last test VM output.
-     */
-    public static String getLastTestVMOutput() {
-        return TestVMProcess.getLastTestVMOutput();
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -918,9 +918,7 @@ public class TestFramework {
     }
 
     private void runTestVM(TestVMProcess testVMProcess, List<String> additionalFlags, PrintStream printStream) {
-        if (testVMProcess == null) {
-            throw new TestFrameworkException("TestVMProcess is null");
-        }
+        TestFramework.check(testVMProcess != null, "TestVMProcess is null");
         testVMProcess.runProcess(additionalFlags, testClass, helperClasses, defaultWarmup,
                                  isAllowNotCompilable, testClassesOnBootClassPath, printStream);
         if (shouldVerifyIR) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -430,7 +430,7 @@ public class TestFramework {
     /**
      * Start the testing of the implicitly (by {@link #TestFramework()}) or explicitly (by {@link #TestFramework(Class)})
      * set test class. Scenarios are run in parallel. Note: scenarios could still be run sequentially if flag
-     *  {@code -DForceSequentialScenarios=true} is given.
+     *  {@code -DForceSequentialScenarios=true} is used.
      */
     public void startParallel() {
         start(!FORCE_SEQUENTIAL_SCENARIOS);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -746,6 +746,7 @@ public class TestFramework {
      * For scenarios: Run the tests with the scenario settings and collect all exceptions to be able to run all
      * scenarios without prematurely throwing an exception. Format violations, however, are wrong for all scenarios
      * and thus is reported immediately on the first scenario execution.
+     * 
      * @param parallel Run tests concurrently
      */
     private void startWithScenarios(boolean parallel) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -746,7 +746,7 @@ public class TestFramework {
      * For scenarios: Run the tests with the scenario settings and collect all exceptions to be able to run all
      * scenarios without prematurely throwing an exception. Format violations, however, are wrong for all scenarios
      * and thus is reported immediately on the first scenario execution.
-     * 
+     *
      * @param parallel Run tests concurrently
      */
     private void startWithScenarios(boolean parallel) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -750,7 +750,6 @@ public class TestFramework {
      */
     private void startWithScenarios(boolean parallel) {
         Map<Scenario, Exception> exceptionMap = new ConcurrentSkipListMap<>(Comparator.comparingInt(Scenario::getIndex));
-        record Outcome(Scenario scenario, Exception other) {}
         final Object printLock = new Object();
         AtomicReference<TestFormatException> testFormatException = new AtomicReference<>();
         Stream<Scenario> stream = parallel ? scenarios.parallelStream() : scenarios.stream();

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -56,8 +56,6 @@ public class TestVMProcess {
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     private static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
 
-    private static String lastTestVMOutput = "";
-
     private final ArrayList<String> cmds;
     private String hotspotPidFileName;
     private String commandLine;
@@ -89,8 +87,8 @@ public class TestVMProcess {
         return hotspotPidFileName;
     }
 
-    public static String getLastTestVMOutput() {
-        return lastTestVMOutput;
+    public String getTestVMOutput() {
+        return oa.getOutput();
     }
 
     private void prepareTestVMFlags(List<String> additionalFlags, TestFrameworkSocket socket, Class<?> testClass,
@@ -173,7 +171,6 @@ public class TestVMProcess {
         commandLine = "Command Line:" + System.lineSeparator() + String.join(" ", process.command())
                       + System.lineSeparator();
         hotspotPidFileName = String.format("hotspot_pid%d.log", oa.pid());
-        lastTestVMOutput = oa.getOutput();
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -57,6 +57,7 @@ public class TestVMProcess {
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     private static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
 
+    private static String lastTestVMOutput = "";
     private final ArrayList<String> cmds;
     private String hotspotPidFileName;
     private String commandLine;
@@ -89,6 +90,10 @@ public class TestVMProcess {
 
     public String getHotspotPidFileName() {
         return hotspotPidFileName;
+    }
+
+    public static String getLastTestVMOutput() {
+        return lastTestVMOutput;
     }
 
     public String getTestVMOutput() {
@@ -175,6 +180,7 @@ public class TestVMProcess {
         commandLine = "Command Line:" + System.lineSeparator() + String.join(" ", process.command())
                       + System.lineSeparator();
         hotspotPidFileName = String.format("hotspot_pid%d.log", oa.pid());
+        lastTestVMOutput = oa.getOutput();
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -58,6 +58,7 @@ public class TestVMProcess {
     private static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
 
     private static String lastTestVMOutput = "";
+
     private final ArrayList<String> cmds;
     private String hotspotPidFileName;
     private String commandLine;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormat.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,11 @@ import java.util.List;
  * Utility class to report a {@link TestFormatException}.
  */
 public class TestFormat {
-    private static final List<String> FAILURES = new ArrayList<>();
+    private static final ThreadLocal<List<String>> threadLocalFailures = ThreadLocal.withInitial(ArrayList<String>::new);
 
     public static void checkAndReport(boolean test, String failureMessage) {
         if (!test) {
-            FAILURES.add(failureMessage);
+            threadLocalFailures.get().add(failureMessage);
             throwIfAnyFailures();
         }
     }
@@ -58,30 +58,30 @@ public class TestFormat {
     }
 
     public static void fail(String failureMessage) {
-        FAILURES.add(failureMessage);
+        threadLocalFailures.get().add(failureMessage);
         throw new TestFormatException(failureMessage);
     }
 
     public static void failNoThrow(String failureMessage) {
-        FAILURES.add(failureMessage);
+        threadLocalFailures.get().add(failureMessage);
     }
 
     public static void throwIfAnyFailures() {
-        if (FAILURES.isEmpty()) {
+        if (threadLocalFailures.get().isEmpty()) {
             // No format violation detected.
             return;
         }
         StringBuilder builder = new StringBuilder();
         builder.append(System.lineSeparator()).append("One or more format violations have been detected:")
                .append(System.lineSeparator()).append(System.lineSeparator());
-        builder.append("Violations (").append(FAILURES.size()).append(")").append(System.lineSeparator());
-        builder.append("-------------").append("-".repeat(String.valueOf(FAILURES.size()).length()))
+        builder.append("Violations (").append(threadLocalFailures.get().size()).append(")").append(System.lineSeparator());
+        builder.append("-------------").append("-".repeat(String.valueOf(threadLocalFailures.get().size()).length()))
                .append(System.lineSeparator());
-        for (String failure : FAILURES) {
+        for (String failure : threadLocalFailures.get()) {
             builder.append(" - ").append(failure).append(System.lineSeparator());
         }
         builder.append("/============/");
-        FAILURES.clear();
+        threadLocalFailures.get().clear();
         throw new TestFormatException(builder.toString());
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormat.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormat.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Utility class to report a {@link TestFormatException}.
  */
 public class TestFormat {
-    private static final ThreadLocal<List<String>> threadLocalFailures = ThreadLocal.withInitial(ArrayList<String>::new);
+    private static final ThreadLocal<List<String>> threadLocalFailures = ThreadLocal.withInitial(ArrayList::new);
 
     public static void checkAndReport(boolean test, String failureMessage) {
         if (!test) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -25,10 +25,7 @@ package compiler.lib.ir_framework.shared;
 
 import compiler.lib.ir_framework.TestFramework;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -59,7 +56,7 @@ public class TestFrameworkSocket implements AutoCloseable {
     private final ServerSocket serverSocket;
     private boolean receivedStdOut = false;
 
-    public TestFrameworkSocket() {
+    public TestFrameworkSocket(PrintStream printStream) {
         try {
             serverSocket = new ServerSocket();
             serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
@@ -68,7 +65,7 @@ public class TestFrameworkSocket implements AutoCloseable {
         }
         int port = serverSocket.getLocalPort();
         if (TestFramework.VERBOSE) {
-            System.out.println("TestFramework server socket uses port " + port);
+            printStream.println("TestFramework server socket uses port " + port);
         }
         serverPortPropertyFlag = "-D" + SERVER_PORT_PROPERTY + "=" + port;
         start();

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -25,7 +25,11 @@ package compiler.lib.ir_framework.shared;
 
 import compiler.lib.ir_framework.TestFramework;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,6 +124,8 @@ public class TestBadFormat {
     }
 
     private static void expectTestFormatException(Class<?> clazz, Class<?>... helpers) {
+        // Single test
+        boolean exceptionCatched = false;
         try {
             if (helpers == null) {
                 TestFramework.run(clazz);
@@ -132,9 +134,25 @@ public class TestBadFormat {
             }
         } catch (Exception e) {
             checkException(clazz, e, helpers);
-            return;
+            exceptionCatched = true;
         }
-        throw new RuntimeException("Should catch an exception");
+        Asserts.assertTrue(exceptionCatched, "Should catch an exception");\
+
+        // Parallel scenarios
+        exceptionCatched = false;
+        try {
+            if (helpers == null) {
+                new TestFramework(clazz).addScenarios(new Scenario(1), new Scenario(2), new Scenario(3))
+                                        .startParallel();
+            } else {
+                new TestFramework(clazz).addScenarios(new Scenario(1), new Scenario(2), new Scenario(3))
+                                        .addHelperClasses(helpers).startParallel();
+            }
+        } catch (Exception e) {
+            checkException(clazz, e, helpers);
+            exceptionCatched = true;
+        }
+        Asserts.assertTrue(exceptionCatched, "Should catch an exception");
     }
 
     private static void checkException(Class<?> clazz, Exception e, Class<?>[] helpers) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -136,7 +136,7 @@ public class TestBadFormat {
             checkException(clazz, e, helpers);
             exceptionCatched = true;
         }
-        Asserts.assertTrue(exceptionCatched, "Should catch an exception");\
+        Asserts.assertTrue(exceptionCatched, "Should catch an exception");
 
         // Parallel scenarios
         exceptionCatched = false;

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -125,7 +125,7 @@ public class TestBadFormat {
 
     private static void expectTestFormatException(Class<?> clazz, Class<?>... helpers) {
         // Single test
-        boolean exceptionCatched = false;
+        boolean exceptionCaught = false;
         try {
             if (helpers == null) {
                 TestFramework.run(clazz);
@@ -134,12 +134,12 @@ public class TestBadFormat {
             }
         } catch (Exception e) {
             checkException(clazz, e, helpers);
-            exceptionCatched = true;
+            exceptionCaught = true;
         }
-        Asserts.assertTrue(exceptionCatched, "Should catch an exception");
+        Asserts.assertTrue(exceptionCaught, "Should catch an exception");
 
         // Parallel scenarios
-        exceptionCatched = false;
+        exceptionCaught = false;
         try {
             if (helpers == null) {
                 new TestFramework(clazz).addScenarios(new Scenario(1), new Scenario(2), new Scenario(3))
@@ -150,9 +150,9 @@ public class TestBadFormat {
             }
         } catch (Exception e) {
             checkException(clazz, e, helpers);
-            exceptionCatched = true;
+            exceptionCaught = true;
         }
-        Asserts.assertTrue(exceptionCatched, "Should catch an exception");
+        Asserts.assertTrue(exceptionCaught, "Should catch an exception");
     }
 
     private static void checkException(Class<?> clazz, Exception e, Class<?>[] helpers) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDFlags.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDFlags.java
@@ -35,12 +35,12 @@ import compiler.lib.ir_framework.TestFramework;
  * @library /test/lib /
  * @run main/othervm -DFlipC1C2=true -DExcludeRandom=true -DVerifyVM=true -DDumpReplay=true -DVerbose=true
  *                   -DShuffleTests=false -DReproduce=true -DReportStdout=true -DGCAfter=true -DPrintTimes=true
- *                   -DIgnoreCompilerControls=true -DExcludeRandom=true -DVerifyIR=true
- *                   -DPreferCommandLineFlags=true -DPrintRuleMatchingTime=true ir_framework.tests.TestDFlags
+ *                   -DIgnoreCompilerControls=true -DExcludeRandom=true -DVerifyIR=true -DPreferCommandLineFlags=true
+ *                   -DPrintRuleMatchingTime=true -DForceSequentialScenarios=true ir_framework.tests.TestDFlags
  * @run main/othervm -DFlipC1C2=true -DExcludeRandom=true -DVerifyVM=true -DDumpReplay=true -DVerbose=true
  *                   -DShuffleTests=false -DReproduce=true -DReportStdout=true -DGCAfter=true -DPrintTimes=true
- *                   -DIgnoreCompilerControls=true -DExcludeRandom=true -DVerifyIR=false
- *                   -DPreferCommandLineFlags=true -DPrintRuleMatchingTime=true ir_framework.tests.TestDFlags
+ *                   -DIgnoreCompilerControls=true -DExcludeRandom=true -DVerifyIR=false -DPreferCommandLineFlags=true
+ *                   -DPrintRuleMatchingTime=true -DForceSequentialScenarios=true ir_framework.tests.TestDFlags
  */
 
 public class TestDFlags {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDForceSequentialScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDForceSequentialScenarios.java
@@ -47,13 +47,12 @@ public class TestDForceSequentialScenarios {
                 Scenario s3 = new Scenario(10);
                 new TestFramework().addScenarios(s1, s2, s3).startParallel();
         } else {
-            OutputAnalyzer oa;
             ProcessBuilder process = ProcessTools.createLimitedTestJavaProcessBuilder(
                     "-Dtest.jdk=" + Utils.TEST_JDK,
                     "-DForceSequentialScenarios=true",
                     "ir_framework.tests.TestDForceSequentialScenarios",
                     "test");
-            oa = ProcessTools.executeProcess(process);
+            OutputAnalyzer oa = ProcessTools.executeProcess(process);
             oa.shouldHaveExitValue(0);
             System.out.println(oa.getOutput());
             Asserts.assertTrue(oa.getOutput().matches("(?s).*Scenario #1.*Scenario #5.*Scenario #10.*"));

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDForceSequentialScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDForceSequentialScenarios.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.Scenario;
+import compiler.lib.ir_framework.Test;
+import compiler.lib.ir_framework.TestFramework;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @requires vm.debug == true & vm.flagless
+ * @summary Test -DForceSequentialScenarios property flag.
+ * @library /test/lib /
+ * @run driver ir_framework.tests.TestDForceSequentialScenarios
+ */
+
+public class TestDForceSequentialScenarios {
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+                Scenario s1 = new Scenario(1);
+                Scenario s2 = new Scenario(5);
+                Scenario s3 = new Scenario(10);
+                new TestFramework().addScenarios(s1, s2, s3).startParallel();
+        } else {
+            OutputAnalyzer oa;
+            ProcessBuilder process = ProcessTools.createLimitedTestJavaProcessBuilder(
+                    "-Dtest.jdk=" + Utils.TEST_JDK,
+                    "-DForceSequentialScenarios=true",
+                    "ir_framework.tests.TestDForceSequentialScenarios",
+                    "test");
+            oa = ProcessTools.executeProcess(process);
+            oa.shouldHaveExitValue(0);
+            System.out.println(oa.getOutput());
+            Asserts.assertTrue(oa.getOutput().matches("(?s).*Scenario #1.*Scenario #5.*Scenario #10.*"));
+        }
+    }
+
+    @Test
+    public void test() {
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -67,7 +67,8 @@ public class TestPhaseIRMatching {
         List<String> noAdditionalFlags = new ArrayList<>();
         FlagVMProcess flagVMProcess = new FlagVMProcess(testClass, noAdditionalFlags);
         List<String> testVMFlags = flagVMProcess.getTestVMFlags();
-        TestVMProcess testVMProcess = new TestVMProcess(testVMFlags, testClass, null, -1, false, false);
+        TestVMProcess testVMProcess = new TestVMProcess();
+        testVMProcess.runProcess(testVMFlags, testClass, null, -1, false, false, System.out);
         TestClassParser testClassParser = new TestClassParser(testClass, false);
         Matchable testClassMatchable = testClassParser.parse(testVMProcess.getHotspotPidFileName(),
                                                              testVMProcess.getIrEncoding());

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
@@ -128,7 +128,3 @@ class MyExceptionTest {
 }
 
 class MyScenarioException extends RuntimeException {}
-
-
-public class TestScenarios {
-

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
@@ -49,7 +49,6 @@ import java.util.function.Consumer;
 
 public class TestScenarios {
     public static void main(String[] args) {
-        TestFramework testFramework;
         Consumer<TestFramework> startMethod =
                 args.length > 0 && args[0].equals("parallel") ? TestFramework::startParallel : TestFramework::start;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
## Issue
Today, the only practical ways to run IR Framework scenarios in parallel seems to be:
* spawning threads manually in a single test, or
* letting jtreg treat each scenario as a separate test (the only way to potentially distribute across hosts).

This makes it a bit cumbersome to use host CPU cores efficiently when running multiple scenarios within the same test.

## Change
This change introduces a method `TestFramework::startParallel` to execute multiple scenarios concurrently. The implementation:
* launches one task per scenario and runs them in parallel (by default, the maximum concurrency should match the host’s available cores)
* captures each task’s `System.out` into a dedicated buffer and flushes it when the task completes to avoid interleaved output between scenarios (Note: only call paths within the `compile.lib.ir_framework` package are modified to per-task output streams. `ProcessTools` methods still write directly to `stdout`, so their output may interleave).
* adds an option `-DForceSequentialScenarios=true` to force all scenarios to be run sequentially.

## Testing
* Tier 1-3+
* explicit `ir_framework.tests` runs
  * added IR-Framework test `TestDForceSequentialScenarios.java` to test forcing sequential testing (checkin the output order) and added a parallel run to `TestScenatios.java` (as well as adding `ForceSequentialScenarios` flag to `TestDFlags.java`)

As reference: a comparison of the execution time between sequential and parallel of all IR-Framework tests using scenarios on our machines (linux x64/aarch64, macosx x64/aarch64, windows x64 with different number of cores, so the results for a single test might not be relevant) gave me an average speedup of 1.9.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt76b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/crisubn.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/trusted.jks)

### Issue
 * [JDK-8370315](https://bugs.openjdk.org/browse/JDK-8370315): [IR-Framework] Allow scenarios to be run in parallel (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28065/head:pull/28065` \
`$ git checkout pull/28065`

Update a local copy of the PR: \
`$ git checkout pull/28065` \
`$ git pull https://git.openjdk.org/jdk.git pull/28065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28065`

View PR using the GUI difftool: \
`$ git pr show -t 28065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28065.diff">https://git.openjdk.org/jdk/pull/28065.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28065#issuecomment-3473940783)
</details>
