### PR TITLE
8371130: Remove String template leftovers

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -2046,42 +2046,6 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         return value;
     }
 
-    /**
-     * Used by StringConcatHelper via JLA. Adds the current builder count to the
-     * accumulation of items being concatenated. If the coder for the builder is
-     * UTF16 then upgrade the whole concatenation to UTF16.
-     *
-     * @param lengthCoder running accumulation of length and coder
-     *
-     * @return updated accumulation of length and coder
-     */
-    long mix(long lengthCoder) {
-        return (lengthCoder + count) | ((long)coder << 32);
-    }
-
-    /**
-     * Used by StringConcatHelper via JLA. Adds the characters in the builder value to the
-     * concatenation buffer and then updates the running accumulation of length.
-     *
-     * @param lengthCoder running accumulation of length and coder
-     * @param buffer      concatenation buffer
-     *
-     * @return running accumulation of length and coder minus the number of characters added
-     */
-    long prepend(long lengthCoder, byte[] buffer) {
-        lengthCoder -= count;
-
-        if (lengthCoder < ((long)UTF16 << 32)) {
-            System.arraycopy(value, 0, buffer, (int)lengthCoder, count);
-        } else if (isLatin1(coder)) {
-            StringUTF16.inflate(value, 0, buffer, (int)lengthCoder, count);
-        } else {
-            System.arraycopy(value, 0, buffer, (int)lengthCoder << 1, count << 1);
-        }
-
-        return lengthCoder;
-    }
-
     private AbstractStringBuilder repeat(char c, int count) {
         byte coder = this.coder;
         int prevCount = this.count;


### PR DESCRIPTION
Hi all,

This is a trivial removal of methods that is no longer needed due since the String template function is now removed [JDK-8329948](https://bugs.openjdk.org/browse/JDK-8329948).

Testing: tier1-2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8371130](https://bugs.openjdk.org/browse/JDK-8371130): Remove String template leftovers (**Enhancement** - P5)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28125/head:pull/28125` \
`$ git checkout pull/28125`

Update a local copy of the PR: \
`$ git checkout pull/28125` \
`$ git pull https://git.openjdk.org/jdk.git pull/28125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28125`

View PR using the GUI difftool: \
`$ git pr show -t 28125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28125.diff">https://git.openjdk.org/jdk/pull/28125.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28125#issuecomment-3485860088)
</details>
