### PR TITLE
8341039: compiler/cha/TypeProfileFinalMethod.java fails with assertEquals expected: 0 but was: 2

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -45,6 +45,4 @@ vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 829
 
 vmTestbase/nsk/stress/thread/thread006.java 8321476 linux-all
 
-compiler/cha/TypeProfileFinalMethod.java 8341039 generic-all
-
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64

--- a/test/hotspot/jtreg/compiler/cha/TypeProfileFinalMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/TypeProfileFinalMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary test c1 to record type profile with CHA optimization
- * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires vm.flavor == "server" & vm.flagless
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -48,6 +48,7 @@ public class TypeProfileFinalMethod {
            "-Xbatch", "-XX:-UseOnStackReplacement",
            "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
            "-XX:Tier3InvocationThreshold=200", "-XX:Tier4InvocationThreshold=5000",
+           "-XX:CompileCommand=CompileOnly," + Launcher.class.getName() + "::test*",
            Launcher.class.getName());
        OutputAnalyzer output = ProcessTools.executeProcess(pb);
        System.out.println("debug output");
@@ -61,7 +62,7 @@ public class TypeProfileFinalMethod {
        while (matcher.find()) {
          matchCnt++;
        }
-       Asserts.assertEquals(matchCnt, 2);  // inline Child1::m() twice
+       Asserts.assertEquals(2, matchCnt);  // inline Child1::m() twice
     }
 
     static class Launcher {
@@ -86,23 +87,22 @@ public class TypeProfileFinalMethod {
 
         static void addCompilerDirectives() {
             WhiteBox WB = WhiteBox.getWhiteBox();
-            // do not inline getInstance() for test1() and test2()
+            // Directive for test1
             String directive = "[{ match: [\"" + Launcher.class.getName() + "::test1\"]," +
-                "inline:[\"-" + Launcher.class.getName()+"::getInstance()\"] }]";
+                // Do not inline getInstance
+                "inline:[\"-" + Launcher.class.getName()+"::getInstance\"] }]";
             WB.addCompilerDirective(directive);
 
+            // Directive for test2
             directive = "[{ match: [\"" + Launcher.class.getName() + "::test2\"]," +
-                "inline:[\"-" + Launcher.class.getName()+"::getInstance()\"] }]";
-            WB.addCompilerDirective(directive);
-
-            // do not inline test1() for test2() in c1 compilation
-            directive = "[{ match: [\"" + Launcher.class.getName() + "::test2\"]," +
-                "c1: { inline:[\"-" + Launcher.class.getName()+"::test1()\"] } }]";
-            WB.addCompilerDirective(directive);
-
-            // print inline tree for checking
-            directive = "[{ match: [\"" + Launcher.class.getName() + "::test2\"]," +
-                "c2: { PrintInlining: true } }]";
+                // Do not inline getInstance
+                "inline:[\"-" + Launcher.class.getName()+"::getInstance\"]," +
+                // Do not inline test1 in C1 compilation
+                "c1: { inline:[\"-" + Launcher.class.getName()+"::test1\"] }," +
+                // Make sure to inline test1 in C2 compilation
+                "c2: { inline:[\"+" + Launcher.class.getName()+"::test1\"]," +
+                "      PrintInlining:true }" +
+                "}]";
             WB.addCompilerDirective(directive);
         }
 

--- a/test/hotspot/jtreg/compiler/cha/TypeProfileFinalMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/TypeProfileFinalMethod.java
@@ -101,6 +101,7 @@ public class TypeProfileFinalMethod {
                 "c1: { inline:[\"-" + Launcher.class.getName()+"::test1\"] }," +
                 // Make sure to inline test1 in C2 compilation
                 "c2: { inline:[\"+" + Launcher.class.getName()+"::test1\"]," +
+                // Print the inline tree for checking
                 "      PrintInlining:true }" +
                 "}]";
             WB.addCompilerDirective(directive);


### PR DESCRIPTION
### Issue Summary

The test `compiler/cha/TypeProfileFinalMethod.java` exercises a specific compilation pattern and easily breaks by setting various VM flags (e.g., `-Xcomp`).

### Changeset

- Make the test flagless.
- Ensure the test only compiles the intended methods.
- Fix problems with compiler directives used in the test (incorrect signatures and some directives getting unintentionally shadowed by other directives).
- Force C2 inlining of a method which the test author likely intended to always be inlined (based on source code comments in the test).
- Switch argument order in `assertEquals` to make error message correct.

Note for reviewers: A more fundamental rewrite of the test is beyond the scope of this changeset. The objective here is simply to ensure the test runs only in contexts intended by the test author.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/18972906513)
- `tier1` and HotSpot parts of `tier2` and `tier3` (and additional Oracle-internal testing) on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.
- Stress testing of the specific test on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341039](https://bugs.openjdk.org/browse/JDK-8341039): compiler/cha/TypeProfileFinalMethod.java fails with assertEquals expected: 0 but was: 2 (**Bug** - P3)


### Reviewers
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer) Review applies to [da0d3140](https://git.openjdk.org/jdk/pull/28200/files/da0d31406f6125977722a272cc4174f56f8b1571)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28200/head:pull/28200` \
`$ git checkout pull/28200`

Update a local copy of the PR: \
`$ git checkout pull/28200` \
`$ git pull https://git.openjdk.org/jdk.git pull/28200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28200`

View PR using the GUI difftool: \
`$ git pr show -t 28200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28200.diff">https://git.openjdk.org/jdk/pull/28200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28200#issuecomment-3503546384)
</details>
