### PR TITLE
8371419: IGV: Add view to visualise dominator tree and dominator information

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -83,7 +83,8 @@ const char *IdealGraphPrinter::DIFFERENCE_VALUE_PROPERTY = "value";
 const char *IdealGraphPrinter::VISIBLE_NODES_ELEMENT = "visibleNodes";
 const char *IdealGraphPrinter::ALL_PROPERTY = "all";
 const char *IdealGraphPrinter::BLOCK_NAME_PROPERTY = "name";
-const char *IdealGraphPrinter::BLOCK_DOMINATOR_PROPERTY = "dom";
+const char *IdealGraphPrinter::BLOCK_IMMEDIATE_DOMINATOR_PROPERTY = "idom";
+const char *IdealGraphPrinter::BLOCK_DOMINATOR_DEPTH_PROPERTY = "domDepth";
 const char *IdealGraphPrinter::BLOCK_ELEMENT = "block";
 const char *IdealGraphPrinter::SUCCESSORS_ELEMENT = "successors";
 const char *IdealGraphPrinter::SUCCESSOR_ELEMENT = "successor";
@@ -469,10 +470,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
         print_prop("block", C->cfg()->get_block(0)->_pre_order);
       } else {
         print_prop("block", block->_pre_order);
-        if (node == block->head()) {
-          if (block->_idom != nullptr) {
-            print_prop("idom", block->_idom->_pre_order);
-          }
+        if (block->_idom != nullptr) {
+          print_prop("idom", block->_idom->_pre_order);
           print_prop("dom_depth", block->_dom_depth);
         }
         // Print estimated execution frequency, normalized within a [0,1] range.
@@ -1041,6 +1040,10 @@ void IdealGraphPrinter::print(const char* name, Node* node, GrowableArray<const 
       Block* block = C->cfg()->get_block(i);
       begin_head(BLOCK_ELEMENT);
       print_attr(BLOCK_NAME_PROPERTY, block->_pre_order);
+      if (block->_idom != nullptr) {
+        print_attr(BLOCK_IMMEDIATE_DOMINATOR_PROPERTY, block->_idom->_pre_order);
+      }
+      print_attr(BLOCK_DOMINATOR_DEPTH_PROPERTY, block->_dom_depth);
       end_head();
 
       head(SUCCESSORS_ELEMENT);

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -77,7 +77,8 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   static const char *COMPILATION_THREAD_ID_PROPERTY;
   static const char *METHOD_NAME_PROPERTY;
   static const char *BLOCK_NAME_PROPERTY;
-  static const char *BLOCK_DOMINATOR_PROPERTY;
+  static const char *BLOCK_IMMEDIATE_DOMINATOR_PROPERTY;
+  static const char *BLOCK_DOMINATOR_DEPTH_PROPERTY;
   static const char *BLOCK_ELEMENT;
   static const char *SUCCESSORS_ELEMENT;
   static const char *SUCCESSOR_ELEMENT;

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlock.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlock.java
@@ -33,6 +33,7 @@ public class InputBlock {
 
     private List<InputNode> nodes;
     private final String name;
+    private final String iDom;
     private final InputGraph graph;
     private final Set<InputBlock> successors;
     private Set<Integer> liveOut;
@@ -83,9 +84,10 @@ public class InputBlock {
         return true;
     }
 
-    InputBlock(InputGraph graph, String name) {
+    InputBlock(InputGraph graph, String name, String iDom) {
         this.graph = graph;
         this.name = name;
+        this.iDom = iDom;
         nodes = new ArrayList<>();
         successors = new LinkedHashSet<>(2);
         liveOut = new HashSet<Integer>(0);
@@ -95,6 +97,7 @@ public class InputBlock {
     public String getName() {
         return name;
     }
+    public String getIDom() { return iDom; }
 
     public List<InputNode> getNodes() {
         return Collections.unmodifiableList(nodes);

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlock.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlock.java
@@ -33,7 +33,8 @@ public class InputBlock {
 
     private List<InputNode> nodes;
     private final String name;
-    private final String iDom;
+    private String iDom;
+    private int domDepth;
     private final InputGraph graph;
     private final Set<InputBlock> successors;
     private Set<Integer> liveOut;
@@ -92,12 +93,14 @@ public class InputBlock {
         successors = new LinkedHashSet<>(2);
         liveOut = new HashSet<Integer>(0);
         artificial = false;
+        domDepth = 1;
     }
 
     public String getName() {
         return name;
     }
     public String getIDom() { return iDom; }
+    public int getDomDepth() { return domDepth; }
 
     public List<InputNode> getNodes() {
         return Collections.unmodifiableList(nodes);
@@ -144,5 +147,13 @@ public class InputBlock {
 
     public boolean isArtificial() {
         return artificial;
+    }
+
+    public void setIDom(String iDom) {
+        this.iDom = iDom;
+    }
+
+    public void setDomDepth(int domDepth) {
+        this.domDepth = domDepth;
     }
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlockEdge.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlockEdge.java
@@ -83,4 +83,14 @@ public class InputBlockEdge {
         hash = 59 * hash + to.hashCode();
         return hash;
     }
+
+    @Override
+    public String toString() {
+        return "InputBlockEdge{" +
+                "from=" + from +
+                ", to=" + to +
+                ", state=" + state +
+                ", label='" + label + '\'' +
+                '}';
+    }
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlockEdge.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputBlockEdge.java
@@ -83,14 +83,4 @@ public class InputBlockEdge {
         hash = 59 * hash + to.hashCode();
         return hash;
     }
-
-    @Override
-    public String toString() {
-        return "InputBlockEdge{" +
-                "from=" + from +
-                ", to=" + to +
-                ", state=" + state +
-                ", label='" + label + '\'' +
-                '}';
-    }
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -37,6 +37,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     private Group parentGroup;
     private final Map<String, InputBlock> blocks;
     private final List<InputBlockEdge> blockEdges;
+    private final List<InputBlockEdge> blockDominatorEdges;
     private final Map<Integer, InputBlock> nodeToBlock;
     private final Map<Integer, InputLiveRange> liveRanges;
     private Map<Integer, LivenessInfo> livenessInfo;
@@ -47,6 +48,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     private final InputGraph firstGraph;
     private final InputGraph secondGraph;
     private final ChangedEvent<InputGraph> displayNameChangedEvent = new ChangedEvent<>(this);
+    private boolean isScheduled;
 
     public InputGraph(InputGraph firstGraph, InputGraph secondGraph) {
         this(firstGraph.getName() + " Δ " + secondGraph.getName(), firstGraph, secondGraph);
@@ -69,6 +71,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         defNodes = new LinkedHashMap<>();
         useNodes = new LinkedHashMap<>();
         blockEdges = new ArrayList<>();
+        blockDominatorEdges = new ArrayList<>();
         nodeToBlock = new LinkedHashMap<>();
         isDiffGraph = firstGraph != null && secondGraph != null;
         this.firstGraph = firstGraph;
@@ -77,6 +80,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
             this.firstGraph.getDisplayNameChangedEvent().addListener(l -> displayNameChangedEvent.fire());
             this.secondGraph.getDisplayNameChangedEvent().addListener(l -> displayNameChangedEvent.fire());
         }
+        this.isScheduled = false;
     }
 
     public boolean isDiffGraph() {
@@ -111,6 +115,12 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         InputBlockEdge edge = new InputBlockEdge(left, right, label);
         blockEdges.add(edge);
         left.addSuccessor(right);
+        return edge;
+    }
+
+    public InputBlockEdge addDominatorBlockEdge(InputBlock dominator, InputBlock dominated) {
+        InputBlockEdge edge = new InputBlockEdge(dominator, dominated, null);
+        blockDominatorEdges.add(edge);
         return edge;
     }
 
@@ -191,6 +201,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     public void clearBlocks() {
         blocks.clear();
         blockEdges.clear();
+        blockDominatorEdges.clear();
         nodeToBlock.clear();
     }
 
@@ -399,7 +410,11 @@ public class InputGraph extends Properties.Entity implements FolderElement {
     }
 
     public InputBlock addBlock(String name) {
-        final InputBlock b = new InputBlock(this, name);
+        return addBlock(name, null);
+    }
+
+    public InputBlock addBlock(String name, String iDom) {
+        final InputBlock b = new InputBlock(this, name, iDom);
         blocks.put(b.getName(), b);
         return b;
     }
@@ -412,8 +427,20 @@ public class InputGraph extends Properties.Entity implements FolderElement {
         return Collections.unmodifiableList(blockEdges);
     }
 
+    public Collection<InputBlockEdge> getBlockDominatorEdges() {
+        return Collections.unmodifiableList(blockDominatorEdges);
+    }
+
     @Override
     public Folder getParent() {
         return parent;
+    }
+
+    public void setScheduled(boolean isScheduled) {
+        this.isScheduled = isScheduled;
+    }
+
+    public boolean isScheduled() {
+        return isScheduled;
     }
 }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Parser.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Parser.java
@@ -90,6 +90,7 @@ public class Parser implements GraphParser {
     public static final String CONTROL_FLOW_ELEMENT = "controlFlow";
     public static final String BLOCK_NAME_PROPERTY = "name";
     public static final String BLOCK_ELEMENT = "block";
+    public static final String BLOCK_DOMINATOR_PROPERTY = "idom";
     public static final String SUCCESSORS_ELEMENT = "successors";
     public static final String SUCCESSOR_ELEMENT = "successor";
     public static final String LIVEOUT_ELEMENT = "liveOut";
@@ -208,7 +209,8 @@ public class Parser implements GraphParser {
         protected InputBlock start() throws SAXException {
             InputGraph graph = getParentObject();
             String name = readRequiredAttribute(BLOCK_NAME_PROPERTY);
-            InputBlock b = graph.addBlock(name);
+            String iDom = readAttribute(BLOCK_DOMINATOR_PROPERTY);
+            InputBlock b = graph.addBlock(name, iDom);
             for (InputNode n : b.getNodes()) {
                 assert graph.getBlock(n).equals(b);
             }
@@ -433,9 +435,12 @@ public class Parser implements GraphParser {
             if (!graph.getBlocks().isEmpty()) {
                 boolean blocksContainNodes = false;
                 for (InputBlock b : graph.getBlocks()) {
-                    if (!b.getNodes().isEmpty()) {
+                    // Add block immediate dominator edge
+                    if (b.getIDom() != null) {
+                        graph.addDominatorBlockEdge(graph.getBlock(b.getIDom()), b);
+                    }
+                    if (!blocksContainNodes && !b.getNodes().isEmpty()) {
                         blocksContainNodes = true;
-                        break;
                     }
                 }
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Printer.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/Printer.java
@@ -152,7 +152,11 @@ public class Printer {
 
         writer.startTag(Parser.CONTROL_FLOW_ELEMENT);
         for (InputBlock b : graph.getBlocks()) {
-            writer.startTag(Parser.BLOCK_ELEMENT, new Properties(Parser.BLOCK_NAME_PROPERTY, b.getName()));
+            Properties properties = new Properties(Parser.BLOCK_NAME_PROPERTY, b.getName());
+            if (b.getIDom() != null) {
+                properties.setProperty(Parser.BLOCK_DOMINATOR_PROPERTY, b.getIDom());
+            }
+            writer.startTag(Parser.BLOCK_ELEMENT, properties);
 
             if (!b.getSuccessors().isEmpty()) {
                 writer.startTag(Parser.SUCCESSORS_ELEMENT);

--- a/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
+++ b/src/utils/IdealGraphVisualizer/Difference/src/main/java/com/sun/hotspot/igv/difference/Difference.java
@@ -157,6 +157,33 @@ public class Difference {
             edge.setState(InputBlockEdge.State.DELETED);
         }
 
+        // Difference between dominator block edges
+        aEdges.clear();
+        for (InputBlockEdge edge : a.getBlockDominatorEdges()) {
+            aEdges.add(new Pair<>(edge.getFrom().getName(), edge.getTo().getName()));
+        }
+        for (InputBlockEdge bEdge : b.getBlockDominatorEdges()) {
+            InputBlock from = bEdge.getFrom();
+            InputBlock to = bEdge.getTo();
+            Pair<String, String> pair = new Pair<>(from.getName(), to.getName());
+            if (aEdges.contains(pair)) {
+                // same
+                graph.addDominatorBlockEdge(blocksMap.get(from), blocksMap.get(to));
+                aEdges.remove(pair);
+            } else {
+                // added
+                InputBlockEdge edge = graph.addDominatorBlockEdge(blocksMap.get(from), blocksMap.get(to));
+                edge.setState(InputBlockEdge.State.NEW);
+            }
+        }
+        for (Pair<String, String> deleted : aEdges) {
+            // removed
+            InputBlock from = graph.getBlock(deleted.getLeft());
+            InputBlock to = graph.getBlock(deleted.getRight());
+            InputBlockEdge edge = graph.addDominatorBlockEdge(from, to);
+            edge.setState(InputBlockEdge.State.DELETED);
+        }
+
         Set<InputNode> nodesA = new HashSet<>(a.getNodes());
         Set<InputNode> nodesB = new HashSet<>(b.getNodes());
 

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/BlockConnection.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/BlockConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/BlockConnection.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/BlockConnection.java
@@ -35,19 +35,31 @@ public class BlockConnection implements Connection {
     private final Block destinationBlock;
     private final String label;
     private List<Point> controlPoints;
+    private ConnectionStyle style;
+    private Color color;
 
     public BlockConnection(Block src, Block dst, String label) {
         this.sourceBlock = src;
         this.destinationBlock = dst;
         this.label = label;
+        this.style = ConnectionStyle.NORMAL;
+        this.color = Color.BLUE;
     }
 
     public Color getColor() {
-        return Color.BLUE;
+        return color;
+    }
+
+    public void setColor(Color color) {
+         this.color = color;
     }
 
     public ConnectionStyle getStyle() {
-        return ConnectionStyle.BOLD;
+        return style;
+    }
+
+    public void setStyle(ConnectionStyle s) {
+        style = s;
     }
 
     @Override

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Diagram.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Diagram.java
@@ -25,7 +25,6 @@ package com.sun.hotspot.igv.graph;
 
 import com.sun.hotspot.igv.data.Properties;
 import com.sun.hotspot.igv.data.*;
-
 import java.awt.*;
 import java.util.*;
 import java.util.List;

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -529,6 +529,14 @@ public class ServerCompilerScheduler implements Scheduler {
             }
         }
 
+        // Add dominator properties to nodes
+        for (InputBlock block : blocks) {
+            for (InputNode node : block.getNodes()) {
+                node.getProperties().setProperty("block", block.getName());
+                node.getProperties().setProperty("idom", block.getIDom());
+                node.getProperties().setProperty("dom_depth", String.valueOf(block.getDomDepth()));
+            }
+        }
     }
 
     // Recompute the input array of the given node, including empty slots.
@@ -665,7 +673,19 @@ public class ServerCompilerScheduler implements Scheduler {
             dominatorMap.put(b, idom);
             if (idom != null) {
                 graph.addDominatorBlockEdge(idom, b);
+                b.setIDom(idom.getName());
             }
+        }
+        if (root != null) {
+            setBlockDepth(D.dominatorTree(), root, 1);
+        }
+    }
+
+    private void setBlockDepth(Graph<InputBlock> domTree, InputBlock block, int depth) {
+        block.setDomDepth(depth);
+        for (Iterator<InputBlock> it = domTree.getSuccNodes(block); it.hasNext(); ) {
+            InputBlock child = it.next();
+            setBlockDepth(domTree, child, depth + 1);
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -663,6 +663,9 @@ public class ServerCompilerScheduler implements Scheduler {
                 idom = root;
             }
             dominatorMap.put(b, idom);
+            if (idom != null) {
+                graph.addDominatorBlockEdge(idom, b);
+            }
         }
     }
 

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
@@ -1079,9 +1079,7 @@ public class DiagramScene extends ObjectScene implements DiagramViewer, DoubleCl
 
     private void doCFGLayout(Set<Figure> visibleFigures, Set<Connection> visibleConnections, List<LiveRangeSegment> segments) {
         layoutMover = null;
-        Set<Connection> visibleBlockConnections = getVisibleBlockConnections();
-        HierarchicalCFGLayoutManager cfgLayoutManager =
-                new HierarchicalCFGLayoutManager(visibleBlockConnections, getVisibleBlocks());
+        HierarchicalCFGLayoutManager cfgLayoutManager = new HierarchicalCFGLayoutManager(getVisibleBlockConnections(), getVisibleBlocks());
         cfgLayoutManager.setCutEdges(model.getCutEdges());
         cfgLayoutManager.setSegments(new ArrayList<>(segments));
         cfgLayoutManager.doLayout(new LayoutGraph(visibleConnections, visibleFigures));

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
@@ -1327,29 +1327,6 @@ public class DiagramScene extends ObjectScene implements DiagramViewer, DoubleCl
         }
     }
 
-    private void processBlockDominatorConnection(BlockConnection blockDominatorConnection) {
-        boolean isDashed = blockDominatorConnection.getStyle() == Connection.ConnectionStyle.DASHED;
-        boolean isBold = blockDominatorConnection.getStyle() == Connection.ConnectionStyle.BOLD;
-        boolean isVisible = blockDominatorConnection.getStyle() != Connection.ConnectionStyle.INVISIBLE;
-        Point lastPoint = null;
-        LineWidget predecessor = null;
-        for (Point currentPoint : blockDominatorConnection.getControlPoints()) {
-            if (currentPoint == null) { // Long connection, has been cut vertically.
-                currentPoint = specialNullPoint;
-            } else if (lastPoint != specialNullPoint && lastPoint != null) {
-                List<BlockConnection> connectionList = Collections.singletonList(blockDominatorConnection);
-                Point src = new Point(lastPoint);
-                Point dest = new Point(currentPoint);
-                predecessor = new LineWidget(this, null, connectionList, src, dest, predecessor, isBold, isDashed);
-                predecessor.setVisible(isVisible);
-                connectionLayer.addChild(predecessor);
-                addObject(new ConnectionSet(connectionList), predecessor);
-                predecessor.getActions().addAction(hoverAction);
-            }
-            lastPoint = currentPoint;
-        }
-    }
-
     @Override
     public void setInteractionMode(InteractionMode mode) {
         panAction.setEnabled(mode == InteractionMode.PANNING);
@@ -1576,10 +1553,12 @@ public class DiagramScene extends ObjectScene implements DiagramViewer, DoubleCl
         }
 
         if (getModel().getShowCFG()) {
-            Set<BlockConnection> connections = getModel().getShowDominatorTree() ? getModel().getDiagram().getBlockDominatorConnections() : getModel().getDiagram().getBlockConnections();
+            Set<BlockConnection> connections = getModel().getShowDominatorTree() ?
+                    getModel().getDiagram().getBlockDominatorConnections() :
+                    getModel().getDiagram().getBlockConnections();
             for (BlockConnection blockConnection : connections) {
                 if (isVisibleBlockConnection(blockConnection)) {
-                    processBlockDominatorConnection(blockConnection);
+                    processBlockConnection(blockConnection);
                 }
             }
         }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -75,6 +75,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
     private boolean showNodeHull;
     private boolean showEmptyBlocks;
     private boolean showLiveRanges;
+    private boolean showDominatorTree;
     private static boolean globalSelection = false;
     private static boolean cutEdges = false;
 
@@ -200,6 +201,15 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
         diagramChangedEvent.fire();
     }
 
+    public boolean getShowDominatorTree() {
+        return showDominatorTree;
+    }
+
+    public void setShowDominatorTree(boolean b) {
+        showDominatorTree = b;
+        diagramChangedEvent.fire();
+    }
+
     private void initGroup() {
         group.getChangedEvent().addListener(g -> {
             assert g == group;
@@ -240,6 +250,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
         showNodeHull = model.getShowNodeHull();
         showEmptyBlocks = model.getShowEmptyBlocks();
         showLiveRanges = model.getShowLiveRanges();
+        showDominatorTree = model.getShowDominatorTree();
 
         hiddenNodes = new HashSet<>(model.getHiddenNodes());
         selectedNodes = new HashSet<>();
@@ -267,6 +278,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
         showNodeHull = true;
         showEmptyBlocks = true;
         showLiveRanges = true;
+        showDominatorTree = false;
 
         hiddenNodes = new HashSet<>();
         selectedNodes = new HashSet<>();
@@ -441,6 +453,7 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
             graph.clearBlocks();
             s.schedule(graph);
             graph.ensureNodesInBlocks();
+            graph.setScheduled(true);
         }
         PreProcessor p = Lookup.getDefault().lookup(PreProcessor.class);
         p.preProcess(graph);

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/EditorTopComponent.java
@@ -215,6 +215,7 @@ public final class EditorTopComponent extends TopComponent implements TopCompone
         toolBar.add(new JToggleButton(new PredSuccAction(diagramViewModel.getShowNodeHull())));
         toolBar.add(new JToggleButton(new ShowEmptyBlocksAction(cfgLayoutAction, diagramViewModel.getShowEmptyBlocks())));
         toolBar.add(new JToggleButton(new ShowLiveRangesAction(cfgLayoutAction, diagramViewModel.getShowLiveRanges())));
+        toolBar.add(new JToggleButton(new ShowDominatorTreeAction(cfgLayoutAction, diagramViewModel.getShowDominatorTree())));
 
         toolBar.addSeparator();
         UndoAction undoAction = UndoAction.get(UndoAction.class);

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ShowDominatorTreeAction.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/actions/ShowDominatorTreeAction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package com.sun.hotspot.igv.view.actions;
+
+import com.sun.hotspot.igv.view.EditorTopComponent;
+import org.openide.util.ImageUtilities;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public class ShowDominatorTreeAction extends AbstractAction implements PropertyChangeListener {
+
+    private boolean selected;
+    private AbstractAction parentAction;
+
+    public ShowDominatorTreeAction(AbstractAction action, boolean select) {
+        this.parentAction = action;
+        this.selected = select;
+        this.parentAction.addPropertyChangeListener(this);
+        putValue(SELECTED_KEY, this.selected);
+        putValue(SMALL_ICON, new ImageIcon(ImageUtilities.loadImage(iconResource())));
+        putValue(SHORT_DESCRIPTION, "Toggle dominator tree / control-flow graph view");
+        enableIfParentSelected();
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent ev) {
+        this.selected = isSelected();
+        EditorTopComponent editor = EditorTopComponent.getActive();
+        if (editor != null) {
+            editor.getModel().setShowDominatorTree(this.selected);
+        }
+    }
+
+    protected String iconResource() {
+        return "com/sun/hotspot/igv/view/images/domtree.svg";
+    }
+
+    private boolean isSelected() {
+        return (Boolean)getValue(SELECTED_KEY);
+    }
+
+    private void enableIfParentSelected() {
+        boolean enable = parentAction.isEnabled() && (Boolean)parentAction.getValue(SELECTED_KEY);
+        if (enable != this.isEnabled()) {
+            if (enable) {
+                putValue(SELECTED_KEY, this.selected);
+            } else {
+                this.selected = isSelected();
+                putValue(SELECTED_KEY, false);
+            }
+        }
+        this.setEnabled(enable);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getSource() == this.parentAction) {
+            enableIfParentSelected();
+        }
+    }
+}

--- a/src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/domtree.svg
+++ b/src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/domtree.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#0000FF" stroke-width="0.75"
+     stroke-linecap="round" stroke-linejoin="round" role="img" aria-labelledby="title desc">
+    <path d="M12 5.5 L12 8.5 M12 5.5 L20.9 8.5 M12 12.5 L3.1 18 M12 12.5 L12 18 M20.9 12.5 L20.9 18" />
+    <rect x="10.4" y="1.5" width="3.2" height="4.0" fill="#D0D0FF" />
+    <rect x="10.4" y="8.5" width="3.2" height="4.0" fill="#D0D0FF" />
+    <rect x="19.3" y="8.5" width="3.2" height="4.0" fill="#D0D0FF" />
+    <rect x="1.5" y="18.0" width="3.2" height="4.0" fill="#D0D0FF" />
+    <rect x="10.4" y="18.0" width="3.2" height="4.0" fill="#D0D0FF" />
+    <rect x="19.3" y="18.0" width="3.2" height="4.0" fill="#D0D0FF" />
+</svg>


### PR DESCRIPTION
This change introduces a dominator tree view in IGV’s CFG panel, enabling users to toggle between the control flow graph and the dominator tree. This makes dominator relationships easier to inspect than the current stdout-based output (`-XX:+PrintDominators`).

## Motivation
* Today, dominator information is difficult to access (e.g. via `-XX:+PrintDominators`, which is hard to read and correlate with the graph).
* IGV already computes dominators for some phases but does not visualize them.
* Comparing dominator trees across graphs/phases was not supported.
 
## What’s New
1. Toggle in the CFG view (toolbar button (<img width="34" height="30" alt="image" src="https://github.com/user-attachments/assets/d215d018-dbb6-4ef0-8129-2fab60999acf" />) to switch between:
   * Control Flow Graph (CFG)
   * Dominator Tree
2. Dominator edge coloring to indicate provenance:
   * Blue: dominator info provided by C2 (from GCM phase onward for now, a follow RFE will handle loop optimization dominator information)
   * Red: dominator info computed by IGV (pre-GCM)
3. Graph comparison enhancements:
   * Compare dominator trees between graphs (new)
   * Compare CFG differences between graphs (previously missing)
4. Node annotations:
   * `idom`: immediate dominator
   * `dom_depth`: dominator depth
   * `block`: numeric block ID for all nodes in a block
 
The resulting main view looks like this:
<img width="1415" height="1051" alt="Screenshot 2025-11-13 at 15 04 12" src="https://github.com/user-attachments/assets/2aedca80-45d6-40ba-8726-50d5b8fd68df" />

## Testing
* Tier 1-3
* Manual testing in IGV

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8371419](https://bugs.openjdk.org/browse/JDK-8371419): IGV: Add view to visualise dominator tree and dominator information (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28293/head:pull/28293` \
`$ git checkout pull/28293`

Update a local copy of the PR: \
`$ git checkout pull/28293` \
`$ git pull https://git.openjdk.org/jdk.git pull/28293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28293`

View PR using the GUI difftool: \
`$ git pr show -t 28293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28293.diff">https://git.openjdk.org/jdk/pull/28293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28293#issuecomment-3528241226)
</details>
