### PR TITLE
8372008: TestGetTotalGcCpuTime test failures on Windows (Some GC CPU time must have been reported)

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/TestGetTotalGcCpuTime.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/TestGetTotalGcCpuTime.java
@@ -101,7 +101,7 @@ public class TestGetTotalGcCpuTime {
 
         // Add some tracing work to ensure OSs with slower update rates would report usage
         for (int i = 0; i < 200; i++) {
-            ArrayList<Object> objs = new ArrayList<Object>();
+            objs = new ArrayList<Object>();
             for (int j = 0; j < 5000; j++) {
                 objs.add(new Object());
             }

--- a/test/jdk/java/lang/management/MemoryMXBean/TestGetTotalGcCpuTime.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/TestGetTotalGcCpuTime.java
@@ -78,6 +78,7 @@
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
 
 public class TestGetTotalGcCpuTime {
     static final ThreadMXBean mxThreadBean = ManagementFactory.getThreadMXBean();
@@ -96,7 +97,15 @@ public class TestGetTotalGcCpuTime {
             return;
         }
 
-        System.gc();
+        // Add some tracing work to ensure OSs with slower update rates would report usage
+        for (int i = 0; i < 200; i++) {
+          ArrayList<Object> objs = new ArrayList<Object>();
+          for (int j = 0; j < 5000; j++) {
+            objs.add(new Object());
+          }
+          System.gc();
+        }
+
         long gcCpuTimeFromThread = mxMemoryBean.getTotalGcCpuTime();
 
         if (usingEpsilonGC) {

--- a/test/jdk/java/lang/management/MemoryMXBean/TestGetTotalGcCpuTime.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/TestGetTotalGcCpuTime.java
@@ -85,6 +85,8 @@ public class TestGetTotalGcCpuTime {
     static final MemoryMXBean mxMemoryBean = ManagementFactory.getMemoryMXBean();
     static final boolean usingEpsilonGC = ManagementFactory.getRuntimeMXBean().getInputArguments().stream().anyMatch(p -> p.contains("-XX:+UseEpsilonGC"));
 
+    private static ArrayList<Object> objs = null;
+
     public static void main(String[] args) throws Exception {
         try {
             if (!mxThreadBean.isThreadCpuTimeEnabled()) {
@@ -99,11 +101,11 @@ public class TestGetTotalGcCpuTime {
 
         // Add some tracing work to ensure OSs with slower update rates would report usage
         for (int i = 0; i < 200; i++) {
-          ArrayList<Object> objs = new ArrayList<Object>();
-          for (int j = 0; j < 5000; j++) {
-            objs.add(new Object());
-          }
-          System.gc();
+            ArrayList<Object> objs = new ArrayList<Object>();
+            for (int j = 0; j < 5000; j++) {
+                objs.add(new Object());
+            }
+            System.gc();
         }
 
         long gcCpuTimeFromThread = mxMemoryBean.getTotalGcCpuTime();


### PR DESCRIPTION
Current trivial test for `TestGetTotalGcCpuTime` fails as some OSs may have a slower update rate for the underlying CPU time thread counters than the code anticipated, causing the test to fail which assumes that some work have been performed and the count should be non-zero.

Solution: All GCs we are testing are tracing GCs. Therefore, add some marking job to inflate the GC CPU time such that we can guarantee to observe a non-zero value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372008](https://bugs.openjdk.org/browse/JDK-8372008): TestGetTotalGcCpuTime test failures on Windows (Some GC CPU time must have been reported) (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [f6d3a127](https://git.openjdk.org/jdk/pull/28362/files/f6d3a127a2583b41a851908956d7f1ed5bd434f5)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [f6d3a127](https://git.openjdk.org/jdk/pull/28362/files/f6d3a127a2583b41a851908956d7f1ed5bd434f5)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28362/head:pull/28362` \
`$ git checkout pull/28362`

Update a local copy of the PR: \
`$ git checkout pull/28362` \
`$ git pull https://git.openjdk.org/jdk.git pull/28362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28362`

View PR using the GUI difftool: \
`$ git pr show -t 28362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28362.diff">https://git.openjdk.org/jdk/pull/28362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28362#issuecomment-3544010414)
</details>
