### PR TITLE
8372460: Use EnumMap instead of HashMap for DateTimeFormatter parsing to improve performance

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1493,6 +1493,14 @@ public final class DateTimeFormatter {
         this.resolverStyle = Objects.requireNonNull(resolverStyle, "resolverStyle");
         this.chrono = chrono;
         this.zone = zone;
+        if (resolverFields != null) {
+            for (TemporalField resolverField : resolverFields) {
+                if (!(resolverField instanceof ChronoField)) {
+                    onlyChronoField = false;
+                    break;
+                }
+            }
+        }
         this.onlyChronoField = onlyChronoField;
     }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1493,14 +1493,6 @@ public final class DateTimeFormatter {
         this.resolverStyle = Objects.requireNonNull(resolverStyle, "resolverStyle");
         this.chrono = chrono;
         this.zone = zone;
-        if (resolverFields != null) {
-            for (TemporalField resolverField : resolverFields) {
-                if (!(resolverField instanceof ChronoField)) {
-                    onlyChronoField = false;
-                    break;
-                }
-            }
-        }
         this.onlyChronoField = onlyChronoField;
     }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1480,11 +1480,12 @@ public final class DateTimeFormatter {
      * @param resolverFields  the fields to use during resolving, null for all fields
      * @param chrono  the chronology to use, null for no override
      * @param zone  the zone to use, null for no override
+     * @param onlyChronoField  flag indicating whether this formatter only uses ChronoField instances
      */
     DateTimeFormatter(CompositePrinterParser printerParser,
             Locale locale, DecimalStyle decimalStyle,
             ResolverStyle resolverStyle, Set<TemporalField> resolverFields,
-            Chronology chrono, ZoneId zone) {
+            Chronology chrono, ZoneId zone, boolean onlyChronoField) {
         this.printerParser = Objects.requireNonNull(printerParser, "printerParser");
         this.resolverFields = resolverFields;
         this.locale = Objects.requireNonNull(locale, "locale");
@@ -1492,7 +1493,7 @@ public final class DateTimeFormatter {
         this.resolverStyle = Objects.requireNonNull(resolverStyle, "resolverStyle");
         this.chrono = chrono;
         this.zone = zone;
-        this.onlyChronoField = printerParser.onlyChronoField();
+        this.onlyChronoField = onlyChronoField;
     }
 
     //-----------------------------------------------------------------------
@@ -1530,7 +1531,7 @@ public final class DateTimeFormatter {
         if (this.locale.equals(locale)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     /**
@@ -1576,7 +1577,7 @@ public final class DateTimeFormatter {
                 Objects.equals(z, zone)) {
             return this;
         } else {
-            return new DateTimeFormatter(printerParser, locale, ds, resolverStyle, resolverFields, c, z);
+            return new DateTimeFormatter(printerParser, locale, ds, resolverStyle, resolverFields, c, z, onlyChronoField);
         }
     }
 
@@ -1602,7 +1603,7 @@ public final class DateTimeFormatter {
         if (this.decimalStyle.equals(decimalStyle)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1656,7 +1657,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.chrono, chrono)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1713,7 +1714,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.zone, zone)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1755,7 +1756,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.resolverStyle, resolverStyle)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1821,7 +1822,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.resolverFields, fields)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, fields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, fields, chrono, zone, onlyChronoField);
     }
 
     /**
@@ -1870,7 +1871,7 @@ public final class DateTimeFormatter {
         if (resolverFields != null) {
             resolverFields = Collections.unmodifiableSet(new HashSet<>(resolverFields));
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -544,6 +544,12 @@ public final class DateTimeFormatter {
      */
     private final ZoneId zone;
 
+    /**
+     * Flag indicating whether this formatter only uses ChronoField instances.
+     * This is used to optimize the storage of parsed field values in the Parsed class.
+     */
+    final boolean onlyChronoField;
+
     //-----------------------------------------------------------------------
     /**
      * Creates a formatter using the specified pattern.
@@ -1486,6 +1492,7 @@ public final class DateTimeFormatter {
         this.resolverStyle = Objects.requireNonNull(resolverStyle, "resolverStyle");
         this.chrono = chrono;
         this.zone = zone;
+        this.onlyChronoField = printerParser.onlyChronoField();
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2590,6 +2590,7 @@ public final class DateTimeFormatterBuilder {
         boolean onlyChronoField() {
             for (DateTimePrinterParser pp : printerParsers) {
                 if ((pp instanceof NumberPrinterParser    npp && !(npp.field instanceof ChronoField))
+                 || (pp instanceof TextPrinterParser      tpp && !(tpp.field instanceof ChronoField))
                  || (pp instanceof CompositePrinterParser cpp && !cpp.onlyChronoField())) {
                     return false;
                 }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -709,7 +709,6 @@ public final class DateTimeFormatterBuilder {
             }
             // Replace the modified parser with the updated one
             active.printerParsers.set(activeValueParser, basePP);
-            checkField(basePP);
         } else {
             // The new Parser becomes the active parser
             active.valueParserIndex = appendInternal(pp);

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -709,6 +709,7 @@ public final class DateTimeFormatterBuilder {
             }
             // Replace the modified parser with the updated one
             active.printerParsers.set(activeValueParser, basePP);
+            checkField(basePP);
         } else {
             // The new Parser becomes the active parser
             active.valueParserIndex = appendInternal(pp);
@@ -2379,20 +2380,31 @@ public final class DateTimeFormatterBuilder {
         }
 
         // Update the onlyChronoField flag if the printer/parser uses non-ChronoField instances
-        TemporalField field = null;
+        checkField(pp);
+        active.printerParsers.add(pp);
+        active.valueParserIndex = -1;
+        return active.printerParsers.size() - 1;
+    }
+
+    /**
+     * Update the onlyChronoField flag if the printer/parser uses non-ChronoField instances
+     * @param pp the printer-parser
+     */
+    private void checkField(DateTimePrinterParser pp) {
+        TemporalField field;
         if (pp instanceof NumberPrinterParser npp) {
             field = npp.field;
         } else if (pp instanceof TextPrinterParser tpp) {
             field = tpp.field;
         } else if (pp instanceof DefaultValueParser dvp) {
             field = dvp.field;
+        } else {
+            return;
         }
-        if (field != null && !(field instanceof ChronoField)) {
+
+        if (!(field instanceof ChronoField)) {
             active.onlyChronoField = false;
         }
-        active.printerParsers.add(pp);
-        active.valueParserIndex = -1;
-        return active.printerParsers.size() - 1;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2580,6 +2580,23 @@ public final class DateTimeFormatterBuilder {
             }
         }
 
+        /**
+         * Checks whether this composite printer parser only uses ChronoField instances.
+         * This is used to optimize the storage of parsed field values in the Parsed class.
+         *
+         * @return true if all printer parsers in this composite only use ChronoField instances,
+         *         false otherwise
+         */
+        boolean onlyChronoField() {
+            for (DateTimePrinterParser pp : printerParsers) {
+                if ((pp instanceof NumberPrinterParser    npp && !(npp.field instanceof ChronoField))
+                 || (pp instanceof CompositePrinterParser cpp && !cpp.onlyChronoField())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         @Override
         public String toString() {
             StringBuilder buf = new StringBuilder();

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
@@ -120,7 +120,7 @@ final class DateTimeParseContext {
     DateTimeParseContext(DateTimeFormatter formatter) {
         super();
         this.formatter = formatter;
-        parsed.add(new Parsed());
+        parsed.add(new Parsed(formatter.onlyChronoField));
     }
 
     /**

--- a/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -126,21 +126,10 @@ import java.util.Set;
 final class Parsed implements TemporalAccessor {
     // some fields are accessed using package scope from DateTimeParseContext
 
-    final boolean onlyChronoField;
-    @SuppressWarnings("unchecked")
-    private Map<TemporalField, Long> createFieldValuesMap() {
-        if (onlyChronoField) {
-            return new HashMap<>();
-        } else {
-            // Create the EnumMap with raw types and cast it appropriately
-            // This is safe because ChronoField implements TemporalField
-            return (Map<TemporalField, Long>) (Map) new EnumMap<>(ChronoField.class);
-        }
-    }
     /**
      * The parsed fields.
      */
-    final Map<TemporalField, Long> fieldValues = createFieldValuesMap();
+    final Map<TemporalField, Long> fieldValues;
     /**
      * The parsed zone.
      */
@@ -181,8 +170,12 @@ final class Parsed implements TemporalAccessor {
     /**
      * Creates an instance.
      */
+    @SuppressWarnings("unchecked")
     Parsed(boolean onlyChronoField) {
-        this.onlyChronoField = onlyChronoField;
+        // Create the EnumMap with raw types and cast it appropriately
+        // This is safe because ChronoField implements TemporalField
+        fieldValues = onlyChronoField ? (Map<TemporalField, Long>) (Map) new EnumMap<>(ChronoField.class)
+                                      : new HashMap<>();
     }
 
     /**
@@ -190,7 +183,7 @@ final class Parsed implements TemporalAccessor {
      */
     Parsed copy() {
         // only copy fields used in parsing stage
-        Parsed cloned = new Parsed(onlyChronoField);
+        Parsed cloned = new Parsed(fieldValues instanceof EnumMap);
         cloned.fieldValues.putAll(this.fieldValues);
         cloned.zone = this.zone;
         cloned.zoneNameType = this.zoneNameType;

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -98,6 +98,7 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.TemporalQuery;
 import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -125,10 +126,21 @@ import java.util.Set;
 final class Parsed implements TemporalAccessor {
     // some fields are accessed using package scope from DateTimeParseContext
 
+    final boolean onlyChronoField;
+    @SuppressWarnings("unchecked")
+    private Map<TemporalField, Long> createFieldValuesMap() {
+        if (onlyChronoField) {
+            return new HashMap<>();
+        } else {
+            // Create the EnumMap with raw types and cast it appropriately
+            // This is safe because ChronoField implements TemporalField
+            return (Map<TemporalField, Long>) (Map) new EnumMap<>(ChronoField.class);
+        }
+    }
     /**
      * The parsed fields.
      */
-    final Map<TemporalField, Long> fieldValues = new HashMap<>();
+    final Map<TemporalField, Long> fieldValues = createFieldValuesMap();
     /**
      * The parsed zone.
      */
@@ -169,7 +181,8 @@ final class Parsed implements TemporalAccessor {
     /**
      * Creates an instance.
      */
-    Parsed() {
+    Parsed(boolean onlyChronoField) {
+        this.onlyChronoField = onlyChronoField;
     }
 
     /**
@@ -177,7 +190,7 @@ final class Parsed implements TemporalAccessor {
      */
     Parsed copy() {
         // only copy fields used in parsing stage
-        Parsed cloned = new Parsed();
+        Parsed cloned = new Parsed(onlyChronoField);
         cloned.fieldValues.putAll(this.fieldValues);
         cloned.zone = this.zone;
         cloned.zoneNameType = this.zoneNameType;

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time.format;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Locale;
+import java.util.Random;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Thread)
+public class DateTimeFormatterParse {
+    static final DateTimeFormatter formatterLocalTime = DateTimeFormatter.ofPattern("HH:mm:ss");
+    static final DateTimeFormatter formatterLocalTimeWithNano = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+    static final DateTimeFormatter formatterLocalDate = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    static final DateTimeFormatter formatterLocalDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    static final DateTimeFormatter formatterLocalDateTimeWithNano = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    static final DateTimeFormatter formatterOffsetDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ");
+    static final DateTimeFormatter formatterZonedDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ'['VV']'");
+
+    static final String STR_LOCALTIME = "21:11:48";
+    static final String STR_LOCALTIME_WITH_NANO = "21:11:48.456";
+    static final String STR_LOCALDATE = "2024-08-01";
+    static final String STR_LOCALDATETIME = "2024-08-01T21:11:48";
+    static final String STR_LOCALDATETIME_WITH_NANO = "2024-08-01T21:11:48.456";
+    static final String STR_INSTANT = "2024-08-12T03:25:54.980339Z";
+    static final String STR_OFFSETDATETIME = "2024-08-12T11:50:46.731509+08:00";
+    static final String STR_ZONEDDATETIME = "2024-08-12T11:50:46.731509+08:00[Asia/Shanghai]";
+
+    @Benchmark
+    public LocalTime parseLocalTime() {
+        return LocalTime.parse(STR_LOCALTIME, formatterLocalTime);
+    }
+
+    @Benchmark
+    public LocalTime parseLocalTimeWithNano() {
+        return LocalTime.parse(STR_LOCALTIME_WITH_NANO, formatterLocalTimeWithNano);
+    }
+
+    @Benchmark
+    public LocalDate parseLocalDate() {
+        return LocalDate.parse(STR_LOCALDATE, formatterLocalDate);
+    }
+
+    @Benchmark
+    public LocalDateTime parseLocalDateTime() {
+        return LocalDateTime.parse(STR_LOCALDATETIME, formatterLocalDateTime);
+    }
+
+    @Benchmark
+    public LocalDateTime parseLocalDateTimeWithNano() {
+        return LocalDateTime.parse(STR_LOCALDATETIME_WITH_NANO, formatterLocalDateTimeWithNano);
+    }
+
+    @Benchmark
+    public OffsetDateTime parseOffsetDateTime() {
+        return OffsetDateTime.parse(STR_OFFSETDATETIME, formatterOffsetDateTime);
+    }
+
+    @Benchmark
+    public ZonedDateTime parseZonedDateTime() {
+        return ZonedDateTime.parse(STR_ZONEDDATETIME, formatterZonedDateTime);
+    }
+
+    @Benchmark
+    public Instant parseInstant() {
+        return Instant.parse(STR_INSTANT);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR optimizes the parsing performance of DateTimeFormatter by replacing HashMap with EnumMap in scenarios where the keys are exclusively ChronoField enum values.

When parsing date/time strings, DateTimeFormatter creates HashMaps to store intermediate parsed values. HashMap has more overhead for operations compared to specialized map implementations.

Since ChronoField is an enum and all keys in these maps are ChronoField instances, we can use EnumMap instead, which provides better performance for enum keys due to its optimized internal structure.

Parsing scenarios show improvements from 12% to 95%

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/crisubn.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/trusted.jks)

### Issue
 * [JDK-8372460](https://bugs.openjdk.org/browse/JDK-8372460): Use EnumMap instead of HashMap for DateTimeFormatter parsing to improve performance (**Enhancement** - P4)


### Reviewers without OpenJDK IDs
 * @khanbilal732 (no known openjdk.org user name / role) 🔄 Re-review required (review applies to [9a13e51e](https://git.openjdk.org/jdk/pull/28471/files/9a13e51e492e3809681a7cad7317f53ca329b0c4))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28471/head:pull/28471` \
`$ git checkout pull/28471`

Update a local copy of the PR: \
`$ git checkout pull/28471` \
`$ git pull https://git.openjdk.org/jdk.git pull/28471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28471`

View PR using the GUI difftool: \
`$ git pr show -t 28471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28471.diff">https://git.openjdk.org/jdk/pull/28471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28471#issuecomment-3573969408)
</details>
