### PR TITLE
8387276: Replace LinkedList with GrowableArray in shared trampolines

### DIFF
--- a/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBuffer_aarch64.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,7 +38,7 @@ void CodeBuffer::share_trampoline_for(address dest, int caller_offset) {
   if (created) {
     _shared_trampoline_requests->maybe_grow();
   }
-  offsets->add(caller_offset);
+  offsets->push(caller_offset);
   _finalize_stubs = true;
 }
 
@@ -50,16 +51,19 @@ static bool emit_shared_trampolines(CodeBuffer* cb, CodeBuffer::SharedTrampoline
 
   MacroAssembler masm(cb);
 
-  auto emit = [&](address dest, const CodeBuffer::Offsets &offsets) {
+  auto emit = [&](address dest, const CodeBuffer::Offsets& offsets) {
     assert(cb->stubs()->remaining() >= MacroAssembler::max_trampoline_stub_size(), "pre-allocated trampolines");
-    LinkedListIterator<int> it(offsets.head());
-    int offset = *it.next();
+    assert(offsets.length() > 0, "must be");
+    // We go backwards
+    const int offset_end = offsets.length() - 1;
+    int offset = offsets.at(offset_end);
     address stub = __ emit_trampoline_stub(offset, dest);
     assert(stub, "pre-allocated trampolines");
 
     address reloc_pc = cb->stubs()->end() - NativeCallTrampolineStub::instruction_size;
-    while (!it.is_empty()) {
-      offset = *it.next();
+    // Skip the first one
+    for (int i = offset_end - 1; i >= 0; i--) {
+      offset = offsets.at(i);
       address caller_pc = cb->insts()->start() + offset;
       cb->stubs()->relocate(reloc_pc, trampoline_stub_Relocation::spec(caller_pc));
     }

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -28,11 +28,11 @@
 #include "code/oopRecorder.hpp"
 #include "code/relocInfo.hpp"
 #include "compiler/compiler_globals.hpp"
+#include "nmt/memTag.hpp"
 #include "runtime/os.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/linkedlist.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/resizableHashTable.hpp"
 
@@ -538,7 +538,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     SECT_LIMIT, SECT_NONE = -1
   };
 
-  typedef LinkedListImpl<int> Offsets;
+  typedef GrowableArrayCHeap<int, mtCompiler> Offsets;
   typedef ResizeableHashTable<address, Offsets, AnyObj::C_HEAP, mtCompiler> SharedTrampolineRequests;
 
  private:


### PR DESCRIPTION
Get rid of the linked list in the shared trampoline code.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai)

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387276](https://bugs.openjdk.org/browse/JDK-8387276): Replace LinkedList with GrowableArray in shared trampolines (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28535/head:pull/28535` \
`$ git checkout pull/28535`

Update a local copy of the PR: \
`$ git checkout pull/28535` \
`$ git pull https://git.openjdk.org/jdk.git pull/28535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28535`

View PR using the GUI difftool: \
`$ git pr show -t 28535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28535.diff">https://git.openjdk.org/jdk/pull/28535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28535#issuecomment-4797047191)
</details>
