### PR TITLE
8372704: ThreadMXBean.getThreadUserTime may return total time

### DIFF
--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2216,7 +2216,7 @@ JVM_ENTRY(jlong, jmm_GetThreadCpuTimeWithKind(JNIEnv *env, jlong thread_id, jboo
     THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
                "Invalid thread ID", -1);
   }
-  fprintf(stderr, "user_sys_cpu_time != 0: %d\n", user_sys_cpu_time != 0);
+
   JavaThread* java_thread = nullptr;
   if (thread_id == 0) {
     // current thread

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2216,7 +2216,7 @@ JVM_ENTRY(jlong, jmm_GetThreadCpuTimeWithKind(JNIEnv *env, jlong thread_id, jboo
     THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
                "Invalid thread ID", -1);
   }
-
+  fprintf(stderr, "user_sys_cpu_time != 0: %d\n", user_sys_cpu_time != 0);
   JavaThread* java_thread = nullptr;
   if (thread_id == 0) {
     // current thread

--- a/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -308,7 +308,7 @@ public class ThreadImpl implements ThreadMXBean {
                 long id = ids[0];
                 Thread thread = Thread.currentThread();
                 if (id == thread.threadId()) {
-                    times[0] = thread.isVirtual() ? -1L : getThreadTotalCpuTime0(0);
+                    times[0] = thread.isVirtual() ? -1L : getThreadUserCpuTime0(0);
                 } else {
                     times[0] = getThreadUserCpuTime0(id);
                 }


### PR DESCRIPTION
getThreadUserTime will return total (system + user) time if called with e.g. ManagementFactory.getThreadMXBean().getThreadUserTime(Thread.currentThread().threadId()).

The specification for this methods states that only user-level CPU time would ever be returned on success.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372704](https://bugs.openjdk.org/browse/JDK-8372704): ThreadMXBean.getThreadUserTime may return total time (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [4fdfbaf6](https://git.openjdk.org/jdk/pull/28545/files/4fdfbaf679184ef5805bf003573e05548bbf56a7)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28545/head:pull/28545` \
`$ git checkout pull/28545`

Update a local copy of the PR: \
`$ git checkout pull/28545` \
`$ git pull https://git.openjdk.org/jdk.git pull/28545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28545`

View PR using the GUI difftool: \
`$ git pr show -t 28545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28545.diff">https://git.openjdk.org/jdk/pull/28545.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28545#issuecomment-3587378595)
</details>
