### PR TITLE
8372584: [Linux]: Replace reading proc to get thread user CPU time with clock_gettime

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4958,7 +4958,7 @@ int os::open(const char *path, int oflag, int mode) {
   return fd;
 }
 
-// Since kernel v2.6.12 the Linux ABI have had support for encoding the clock types
+// Since kernel v2.6.12 the Linux ABI has had support for encoding the clock types
 // in the last three bits. Setting bit to 001 (CPUCLOCK_VIRT) will result in the kernel
 // returning only user time. POSIX compliant implementations of pthread_getcpuclockid
 // for the Linux kernel defaults to construct a clockid with 010 (CPUCLOCK_SCHED)

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4303,7 +4303,7 @@ OSReturn os::get_native_priority(const Thread* const thread,
 // For reference, please, see IEEE Std 1003.1-2004:
 //   http://www.unix.org/single_unix_specification
 
-jlong os::Linux::total_thread_cpu_time(clockid_t clockid) {
+jlong os::Linux::thread_cpu_time(clockid_t clockid) {
   struct timespec tp;
   int status = clock_gettime(clockid, &tp);
   assert(status == 0, "clock_gettime error: %s", os::strerror(errno));
@@ -4958,20 +4958,35 @@ int os::open(const char *path, int oflag, int mode) {
   return fd;
 }
 
+// Since kernel v2.6.12 the Linux ABI have had support for encoding the clock types
+// in the last three bits. Setting bit to 001 (CPUCLOCK_VIRT) will result in the kernel
+// returning only user time. POSIX compliant implementations of pthread_getcpuclockid
+// for the Linux kernel defaults to construct a clockid that with 010 (CPUCLOCK_SCHED)
+// set, which return system+user time, which is what the POSIX standard mandates, see
+// POSIX.1-2024/IEEE Std 1003.1-2024 §3.90.
+static clockid_t get_thread_clockid(Thread* thread, bool full, bool* success) {
+  constexpr clockid_t CPUCLOCK_VIRT = 1;
+
+  clockid_t clockid;
+  int rc = pthread_getcpuclockid(thread->osthread()->pthread_id(), &clockid);
+  if (rc == 0) {
+    clockid = full ? clockid : (clockid & ~3) | CPUCLOCK_VIRT;
+  } else {
+    // It's possible to encounter a terminated native thread that failed
+    // to detach itself from the VM - which should result in ESRCH.
+    assert_status(rc == ESRCH, rc, "pthread_getcpuclockid failed");
+    *success = false;
+  }
+  return clockid;
+}
+
 static jlong user_thread_cpu_time(Thread *thread);
 
 static jlong total_thread_cpu_time(Thread *thread) {
-    clockid_t clockid;
-    int rc = pthread_getcpuclockid(thread->osthread()->pthread_id(),
-                                              &clockid);
-    if (rc == 0) {
-      return os::Linux::total_thread_cpu_time(clockid);
-    } else {
-      // It's possible to encounter a terminated native thread that failed
-      // to detach itself from the VM - which should result in ESRCH.
-      assert_status(rc == ESRCH, rc, "pthread_getcpuclockid failed");
-      return -1;
-    }
+  bool success = true;
+  clockid_t clockid = get_thread_clockid(thread, true, &success);
+
+  return success ? os::Linux::thread_cpu_time(clockid) : -1;
 }
 
 // current_thread_cpu_time(bool) and thread_cpu_time(Thread*, bool)
@@ -4982,7 +4997,7 @@ static jlong total_thread_cpu_time(Thread *thread) {
 // the fast estimate available on the platform.
 
 jlong os::current_thread_cpu_time() {
-  return os::Linux::total_thread_cpu_time(CLOCK_THREAD_CPUTIME_ID);
+  return os::Linux::thread_cpu_time(CLOCK_THREAD_CPUTIME_ID);
 }
 
 jlong os::thread_cpu_time(Thread* thread) {
@@ -4991,7 +5006,7 @@ jlong os::thread_cpu_time(Thread* thread) {
 
 jlong os::current_thread_cpu_time(bool user_sys_cpu_time) {
   if (user_sys_cpu_time) {
-    return os::Linux::total_thread_cpu_time(CLOCK_THREAD_CPUTIME_ID);
+    return os::Linux::thread_cpu_time(CLOCK_THREAD_CPUTIME_ID);
   } else {
     return user_thread_cpu_time(Thread::current());
   }
@@ -5005,46 +5020,11 @@ jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
   }
 }
 
-//  -1 on error.
 static jlong user_thread_cpu_time(Thread *thread) {
-  pid_t  tid = thread->osthread()->thread_id();
-  char *s;
-  char stat[2048];
-  size_t statlen;
-  char proc_name[64];
-  int count;
-  long sys_time, user_time;
-  char cdummy;
-  int idummy;
-  long ldummy;
-  FILE *fp;
+  bool success = true;
+  clockid_t clockid = get_thread_clockid(thread, false, &success);
 
-  os::snprintf_checked(proc_name, 64, "/proc/self/task/%d/stat", tid);
-  fp = os::fopen(proc_name, "r");
-  if (fp == nullptr) return -1;
-  statlen = fread(stat, 1, 2047, fp);
-  stat[statlen] = '\0';
-  fclose(fp);
-
-  // Skip pid and the command string. Note that we could be dealing with
-  // weird command names, e.g. user could decide to rename java launcher
-  // to "java 1.4.2 :)", then the stat file would look like
-  //                1234 (java 1.4.2 :)) R ... ...
-  // We don't really need to know the command string, just find the last
-  // occurrence of ")" and then start parsing from there. See bug 4726580.
-  s = strrchr(stat, ')');
-  if (s == nullptr) return -1;
-
-  // Skip blank chars
-  do { s++; } while (s && isspace((unsigned char) *s));
-
-  count = sscanf(s,"%c %d %d %d %d %d %lu %lu %lu %lu %lu %lu %lu",
-                 &cdummy, &idummy, &idummy, &idummy, &idummy, &idummy,
-                 &ldummy, &ldummy, &ldummy, &ldummy, &ldummy,
-                 &user_time, &sys_time);
-  if (count != 13) return -1;
-
-  return (jlong)user_time * (1000000000 / os::Posix::clock_tics_per_second());
+  return success ? os::Linux::thread_cpu_time(clockid) : -1;
 }
 
 void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -142,7 +142,7 @@ class os::Linux {
   static bool manually_expand_stack(JavaThread * t, address addr);
   static void expand_stack_to(address bottom);
 
-  static jlong total_thread_cpu_time(clockid_t clockid);
+  static jlong thread_cpu_time(clockid_t clockid);
 
   static jlong sendfile(int out_fd, int in_fd, jlong* offset, jlong count);
 

--- a/test/micro/org/openjdk/bench/vm/runtime/CPUTime.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/CPUTime.java
@@ -22,28 +22,17 @@
  */
 package org.openjdk.bench.vm.runtime;
 
-import java.lang.invoke.*;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
-import java.lang.reflect.Constructor;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
-
 import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;

--- a/test/micro/org/openjdk/bench/vm/runtime/CPUTime.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/CPUTime.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.runtime;
+
+import java.lang.invoke.*;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.lang.reflect.Constructor;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 10)
+@Measurement(iterations = 5, time = 10)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Threads(1)
+@Fork(value = 5)
+public class CPUTime {
+    static final ThreadMXBean mxThreadBean = ManagementFactory.getThreadMXBean();
+    static long user; // To avoid dead-code elimination
+
+    @Benchmark
+    public void execute() throws Throwable {
+        user = mxThreadBean.getCurrentThreadUserTime();
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/runtime/ThreadMXBeanBench.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/ThreadMXBeanBench.java
@@ -38,18 +38,18 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 5, time = 10)
-@Measurement(iterations = 5, time = 10)
+@Warmup(iterations = 2, time = 5)
+@Measurement(iterations = 5, time = 5)
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Threads(1)
-@Fork(value = 5)
-public class CPUTime {
+@Fork(value = 10)
+public class ThreadMXBeanBench {
     static final ThreadMXBean mxThreadBean = ManagementFactory.getThreadMXBean();
     static long user; // To avoid dead-code elimination
 
     @Benchmark
-    public void execute() throws Throwable {
+    public void getCurrentThreadUserTime() throws Throwable {
         user = mxThreadBean.getCurrentThreadUserTime();
     }
 }


### PR DESCRIPTION
Since kernel v2.6.12 the Linux ABI have had support for encoding the clock types in the last three bits. Setting bit to 001 (CPUCLOCK_VIRT) will result in the kernel returning only user time. POSIX compliant implementations of pthread_getcpuclockid for the Linux kernel defaults to construct a clockid that with 010 (CPUCLOCK_SCHED) set, which return system+user time, which is what the POSIX standard mandates, see POSIX.1-2024/IEEE Std 1003.1-2024 §3.90. This patch joins the family of glibc, musl etc.  that utilities this bit pattern.

This PR also results in improved performance and thus a reduced observer effect, especially for the 100th percentile (max).

Before patch:
```
Benchmark                  Mode      Cnt  Score    Error  Units
CPUTime.execute          sample  7506555  0.008 ±  0.001  ms/op
CPUTime.execute:p0.00    sample           0.008           ms/op
CPUTime.execute:p0.50    sample           0.008           ms/op
CPUTime.execute:p0.90    sample           0.008           ms/op
CPUTime.execute:p0.95    sample           0.008           ms/op
CPUTime.execute:p0.99    sample           0.012           ms/op
CPUTime.execute:p0.999   sample           0.015           ms/op
CPUTime.execute:p0.9999  sample           0.021           ms/op
CPUTime.execute:p1.00    sample           1.030           ms/op
```

After patch:
```
Benchmark                  Mode      Cnt   Score    Error  Units
CPUTime.execute          sample  8984189  ≈ 10⁻³           ms/op
CPUTime.execute:p0.00    sample           ≈ 10⁻³           ms/op
CPUTime.execute:p0.50    sample           ≈ 10⁻³           ms/op
CPUTime.execute:p0.90    sample           ≈ 10⁻³           ms/op
CPUTime.execute:p0.95    sample           ≈ 10⁻³           ms/op
CPUTime.execute:p0.99    sample            0.001           ms/op
CPUTime.execute:p0.999   sample            0.001           ms/op
CPUTime.execute:p0.9999  sample            0.006           ms/op
CPUTime.execute:p1.00    sample            0.054           ms/op
```

Testing: `java/lang/management/ThreadMXBean/ThreadUserTime.java` and the added microbenchmark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372584](https://bugs.openjdk.org/browse/JDK-8372584): [Linux]: Replace reading proc to get thread user CPU time with clock_gettime (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) Review applies to [345ba380](https://git.openjdk.org/jdk/pull/28556/files/345ba3809c6ebfee72eebc12b7ff507ab4c6af4b)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28556/head:pull/28556` \
`$ git checkout pull/28556`

Update a local copy of the PR: \
`$ git checkout pull/28556` \
`$ git pull https://git.openjdk.org/jdk.git pull/28556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28556`

View PR using the GUI difftool: \
`$ git pr show -t 28556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28556.diff">https://git.openjdk.org/jdk/pull/28556.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28556#issuecomment-3589091429)
</details>
