### PR TITLE
8371647: 7 Integer overflows in mlib_malloc of mlib_sys.c:85

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageConvMxN_Fp.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageConvMxN_Fp.c
@@ -76,6 +76,7 @@
 #include "mlib_ImageCheck.h"
 #include "mlib_SysMath.h"
 #include "mlib_ImageConv.h"
+#include "safe_math.h"
 
 /***************************************************************/
 static void mlib_ImageConvMxNMulAdd_F32(mlib_f32       *dst,
@@ -271,6 +272,13 @@ mlib_status mlib_convMxNext_f32(mlib_image       *dst,
   mlib_s32 dh = mlib_ImageGetHeight(dst);
   mlib_s32 nch = mlib_ImageGetChannels(dst);
   mlib_s32 i, j, j1, k;
+
+  if (!SAFE_TO_ADD(wid_e, m) ||
+      !SAFE_TO_MULT(3, wid_e + m) ||
+      !SAFE_TO_MULT((3 * wid_e + m),
+      (mlib_d64)sizeof(mlib_d64))) {
+    return MLIB_FAILURE;
+  }
 
   if (3 * wid_e + m > 1024) {
     dsa = mlib_malloc((3 * wid_e + m) * sizeof(mlib_d64));
@@ -628,6 +636,13 @@ mlib_status mlib_convMxNext_d64(mlib_image       *dst,
   mlib_s32 dh = mlib_ImageGetHeight(dst);
   mlib_s32 nch = mlib_ImageGetChannels(dst);
   mlib_s32 i, j, j1, k;
+
+  if (!SAFE_TO_ADD(wid_e, m) ||
+      !SAFE_TO_MULT(3, wid_e + m) ||
+      !SAFE_TO_MULT((3 * wid_e + m),
+      (mlib_d64)sizeof(mlib_d64))) {
+    return MLIB_FAILURE;
+  }
 
   if (3 * wid_e + m > 1024) {
     dsa = mlib_malloc((3 * wid_e + m) * sizeof(mlib_d64));

--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageConvMxN_ext.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageConvMxN_ext.c
@@ -82,6 +82,7 @@
 
 #include "mlib_image.h"
 #include "mlib_ImageConv.h"
+#include "safe_math.h"
 
 /***************************************************************/
 static void mlib_ImageConvMxNMulAdd_S32(mlib_d64       *dst,
@@ -228,6 +229,13 @@ mlib_status mlib_convMxNext_s32(mlib_image       *dst,
   mlib_s32 i, j, j1, k, mn;
 
   /* internal buffer */
+
+  if (!SAFE_TO_ADD(wid_e, m) ||
+      !SAFE_TO_MULT(3, wid_e + m) ||
+      !SAFE_TO_MULT((3 * wid_e + m),
+      (mlib_d64)sizeof(mlib_d64))) {
+    return MLIB_FAILURE;
+  }
 
   if (3 * wid_e + m > 1024) {
     dsa = mlib_malloc((3 * wid_e + m) * sizeof(mlib_d64));

--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageConv_16ext.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageConv_16ext.c
@@ -33,6 +33,7 @@
 #include "mlib_image.h"
 #include "mlib_ImageConv.h"
 #include "mlib_c_ImageConv.h"
+#include "safe_math.h"
 
 /*
  * This define switches between functions of different data types
@@ -265,6 +266,8 @@ static mlib_status mlib_ImageConv1xN_ext(mlib_image       *dst,
   bsize = 2 * (smax_hsize + 1);
 
   if (bsize > BUFF_SIZE) {
+    if (!SAFE_TO_MULT(bsize, (mlib_s32)sizeof(FTYPE))) return MLIB_FAILURE;
+
     pbuff = mlib_malloc(sizeof(FTYPE)*bsize);
 
     if (pbuff == NULL) return MLIB_FAILURE;
@@ -495,6 +498,8 @@ mlib_status CONV_FUNC_MxN
   mn = m*n;
 
   if (mn > 256) {
+    if (!SAFE_TO_MULT(mn, (mlib_d64)sizeof(mlib_d64))) return MLIB_FAILURE;
+
     k = mlib_malloc(mn*sizeof(mlib_d64));
 
     if (k == NULL) return MLIB_FAILURE;

--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageConv_8ext.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageConv_8ext.c
@@ -33,6 +33,7 @@
 #include "mlib_image.h"
 #include "mlib_ImageConv.h"
 #include "mlib_c_ImageConv.h"
+#include "safe_math.h"
 
 /*
  * This define switches between functions of different data types
@@ -918,6 +919,12 @@ mlib_status CONV_FUNC_MxN_I
   for (l = 0; l < (n + 1); l++) buffs[l] = pbuff + l*swid;
   for (l = 0; l < (n + 1); l++) buffs[l + (n + 1)] = buffs[l];
   buffd = buffs[n] + swid;
+
+  if (!SAFE_TO_MULT(m, n) ||
+      !SAFE_TO_MULT((m * n),
+      (mlib_s32)sizeof(mlib_s32))) {
+    return MLIB_FAILURE;
+  }
 
   if (m*n > MAX_N*MAX_N) {
     k = mlib_malloc(sizeof(mlib_s32)*(m*n));

--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageConv_u16ext.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageConv_u16ext.c
@@ -33,6 +33,7 @@
 #include "mlib_image.h"
 #include "mlib_ImageConv.h"
 #include "mlib_c_ImageConv.h"
+#include "safe_math.h"
 
 /*
  * This define switches between functions of different data types
@@ -941,6 +942,12 @@ mlib_status CONV_FUNC_MxN_I
   for (l = 0; l < (n + 1); l++) buffs[l] = pbuff + l*swid;
   for (l = 0; l < (n + 1); l++) buffs[l + (n + 1)] = buffs[l];
   buffd = buffs[n] + swid;
+
+  if (!SAFE_TO_MULT(m, n) ||
+      !SAFE_TO_MULT((m * n),
+      (mlib_s32)sizeof(mlib_s32))) {
+    return MLIB_FAILURE;
+  }
 
   if (m*n > MAX_N*MAX_N) {
     k = mlib_malloc(sizeof(mlib_s32)*(m*n));


### PR DESCRIPTION
There is a possible overflow when using `mlib_alloc()`. For example, `mlib_alloc(sizeof(mlib_s32) * (m * n))` may overflow if m and n are greater than 46430, since this would be greater than the max value for a signed 32 bit integer. I have added `SAFE_TO_ADD` and `SAFE_TO_MULT` in an attempt to amend this issue. CI testing shows all green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/crisubn.jks)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/net/ssl/HttpsURLConnection/trusted.jks)

### Issue
 * [JDK-8371647](https://bugs.openjdk.org/browse/JDK-8371647): 7 Integer overflows in mlib_malloc of mlib_sys.c:85 (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28560/head:pull/28560` \
`$ git checkout pull/28560`

Update a local copy of the PR: \
`$ git checkout pull/28560` \
`$ git pull https://git.openjdk.org/jdk.git pull/28560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28560`

View PR using the GUI difftool: \
`$ git pr show -t 28560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28560.diff">https://git.openjdk.org/jdk/pull/28560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28560#issuecomment-3590614998)
</details>
