### PR TITLE
8371903: HttpClient: improve handling of HTTP/2 GOAWAY frames with error code

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1477,11 +1477,11 @@ class Http2Connection implements Closeable {
                 debug.log("%d stream(s) marked as unprocessed, processed streams will be closed by termination",
                         numUnprocessed.get());
             }
-
-            close(cause);
         } finally {
             stateLock.unlock();
         }
+
+        close(cause);
     }
 
     /**

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1463,21 +1463,17 @@ class Http2Connection implements Closeable {
         final Http2TerminationCause cause = Http2TerminationCause.forH2Error(errorCode, errorMsg);
 
         final AtomicInteger numUnprocessed = new AtomicInteger();
-        final AtomicInteger numFailed = new AtomicInteger();
 
         streams.forEach((id, stream) -> {
             if (id > lastProcessedStream) {
                 stream.closeAsUnprocessed();
                 numUnprocessed.incrementAndGet();
-            } else {
-                stream.connectionClosing(cause.getCloseCause());
-                numFailed.incrementAndGet();
             }
         });
 
         if (debug.on()) {
-            debug.log("%d stream(s) marked as unprocessed, %d stream(s) failed due to GOAWAY error",
-                    numUnprocessed.get(), numFailed.get());
+            debug.log("%d stream(s) marked as unprocessed, processed streams will be closed by termination",
+                    numUnprocessed.get());
         }
 
         close(cause);

--- a/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
+++ b/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.http2.Http2Handler;
+import jdk.httpclient.test.lib.http2.Http2TestExchange;
+import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
+import jdk.httpclient.test.lib.http2.Http2TestServer;
+import jdk.internal.net.http.frame.ErrorFrame;
+import jdk.test.lib.net.SimpleSSLContext;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static java.net.http.HttpClient.Version.HTTP_2;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8371903
+ * @summary Verify that HTTP/2 client properly handles GOAWAY frames with error codes
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.test.lib.net.SimpleSSLContext
+ *        jdk.httpclient.test.lib.http2.Http2TestServer
+ *        jdk.httpclient.test.lib.http2.Http2TestExchange
+ *        jdk.httpclient.test.lib.http2.Http2TestExchangeImpl
+ * @run junit GoAwayWithErrorTest
+ */
+
+public class GoAwayWithErrorTest {
+
+    static final int PROTOCOL_ERROR = ErrorFrame.PROTOCOL_ERROR;
+    static final String DEBUG_MESSAGE = "Test GOAWAY error from server";
+    static final byte[] DEBUG_DATA = DEBUG_MESSAGE.getBytes(UTF_8);
+    static SSLContext sslContext;
+    static Http2TestServer server;
+    static int port;
+    static AtomicBoolean firstRequestHandled;
+    static AtomicBoolean secondRequestHandled;
+    static AtomicReference<String> allowedConnectionKey;
+    static CountDownLatch goAwaySentLatch;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        firstRequestHandled = new AtomicBoolean(false);
+        secondRequestHandled = new AtomicBoolean(false);
+        allowedConnectionKey = new AtomicReference<>();
+        goAwaySentLatch = new CountDownLatch(1);
+        sslContext = new SimpleSSLContext().get();
+        server = new Http2TestServer(true, 0, null, sslContext);
+        server.setRequestApprover(key -> {
+            String allowed = allowedConnectionKey.get();
+            return allowed == null || allowed.equals(key);
+        });
+        server.addHandler(new GoAwayHandler(), "/");
+        server.start();
+        port = server.getAddress().getPort();
+        System.out.println("Server started on port: " + port);
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testGoAwayWithProtocolError() throws Exception {
+        HttpClient client = HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .version(HTTP_2)
+                .build();
+
+        URI uri = URI.create("https://localhost:" + port + "/test");
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .GET()
+                .build();
+
+        CompletableFuture<HttpResponse<String>> first = client.sendAsync(
+                request, HttpResponse.BodyHandlers.ofString());
+
+        if (!goAwaySentLatch.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("GOAWAY not sent in time");
+        }
+
+        CompletableFuture<HttpResponse<String>> second = client.sendAsync(
+                request, HttpResponse.BodyHandlers.ofString());
+
+        CompletableFuture.allOf(first, second)
+                .orTimeout(20, TimeUnit.SECONDS)
+                .exceptionally(ex -> null)
+                .join();
+
+        List<Throwable> failures = List.of(first, second).stream()
+                .map(f -> f.handle((r, ex) -> ex).join())
+                .map(ex -> {
+                    if (ex instanceof CompletionException ce && ce.getCause() != null) {
+                        return ce.getCause();
+                    }
+                    return ex;
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        assertFalse(failures.isEmpty(), "At least one request should fail due to GOAWAY");
+
+        boolean hasGoAwayInfo = failures.stream()
+                .map(Throwable::getMessage)
+                .filter(Objects::nonNull)
+                .peek(msg -> System.out.println("Failure message: " + msg))
+                .anyMatch(msg ->
+                        msg.contains("GOAWAY")
+                                && msg.contains("Protocol error")
+                                && msg.contains("0x1")
+                                && msg.contains(DEBUG_MESSAGE));
+
+        assertTrue(hasGoAwayInfo,
+                "Exception message should contain GOAWAY error code and debug data: " + failures);
+
+        assertFalse(secondRequestHandled.get(), "Second request should not reach server after GOAWAY");
+    }
+
+    static class GoAwayHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            System.out.println("Handler: received request for " + exchange.getRequestURI());
+
+            Http2TestExchangeImpl impl = (Http2TestExchangeImpl) exchange;
+
+            if (!firstRequestHandled.getAndSet(true)) {
+                allowedConnectionKey.compareAndSet(null, impl.getConnectionKey());
+                System.out.println("Handler: sending GOAWAY(PROTOCOL_ERROR) and closing connection");
+
+                impl.getServerConnection().sendGoAway(Integer.MAX_VALUE, PROTOCOL_ERROR, DEBUG_DATA);
+                impl.getServerConnection().close(PROTOCOL_ERROR);
+                goAwaySentLatch.countDown();
+                return;
+            }
+
+            secondRequestHandled.set(true);
+            throw new IOException("Second request should not have reached server after GOAWAY");
+        }
+    }
+}

--- a/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
+++ b/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
@@ -176,10 +176,9 @@ public class GoAwayWithErrorTest {
 
             if (!firstRequestHandled.getAndSet(true)) {
                 int lastStreamId = impl.getStreamId();
-                System.out.println("Handler: sending GOAWAY(PROTOCOL_ERROR, lastStreamId=" + lastStreamId + ") and closing connection");
+                System.out.println("Handler: sending GOAWAY(PROTOCOL_ERROR, lastStreamId=" + lastStreamId + ")");
 
                 impl.getServerConnection().sendGoAway(lastStreamId, PROTOCOL_ERROR, DEBUG_DATA);
-                impl.getServerConnection().close(PROTOCOL_ERROR);
                 goAwaySentLatch.countDown();
                 return;
             }

--- a/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
+++ b/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
@@ -40,6 +40,7 @@ import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.internal.net.http.frame.ErrorFrame;
 import jdk.test.lib.net.SimpleSSLContext;
+import jdk.test.lib.Utils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -109,7 +110,7 @@ public class GoAwayWithErrorTest {
         CompletableFuture<HttpResponse<String>> first = client.sendAsync(
                 request, HttpResponse.BodyHandlers.ofString());
 
-        if (!goAwaySentLatch.await(5, TimeUnit.SECONDS)) {
+        if (!goAwaySentLatch.await(Utils.adjustTimeout(5), TimeUnit.SECONDS)) {
             throw new AssertionError("GOAWAY not sent in time");
         }
 
@@ -120,7 +121,7 @@ public class GoAwayWithErrorTest {
                 request, HttpResponse.BodyHandlers.ofString());
 
         CompletableFuture.allOf(first, second, third)
-                .orTimeout(20, TimeUnit.SECONDS)
+                .orTimeout(Utils.adjustTimeout(20), TimeUnit.SECONDS)
                 .exceptionally(ex -> null)
                 .join();
 

--- a/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
+++ b/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
@@ -109,15 +109,15 @@ public class GoAwayWithErrorTest {
         CompletableFuture<HttpResponse<String>> first = client.sendAsync(
                 request, HttpResponse.BodyHandlers.ofString());
 
+        if (!goAwaySentLatch.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("GOAWAY not sent in time");
+        }
+
         CompletableFuture<HttpResponse<String>> second = client.sendAsync(
                 request, HttpResponse.BodyHandlers.ofString());
 
         CompletableFuture<HttpResponse<String>> third = client.sendAsync(
                 request, HttpResponse.BodyHandlers.ofString());
-
-        if (!goAwaySentLatch.await(5, TimeUnit.SECONDS)) {
-            throw new AssertionError("GOAWAY not sent in time");
-        }
 
         CompletableFuture.allOf(first, second, third)
                 .orTimeout(20, TimeUnit.SECONDS)

--- a/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
+++ b/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
@@ -135,6 +135,7 @@ public class GoAwayWithErrorTest {
                 assertEquals(200, response.statusCode(), "unexpected status code");
             } catch (CompletionException e) {
                 failureCount++;
+                e.printStackTrace();
                 if (goawayError == null) {
                     Throwable cause = e.getCause();
                     if (cause != null) {

--- a/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
+++ b/test/jdk/java/net/httpclient/http2/GoAwayWithErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
@@ -244,6 +244,10 @@ public class Http2TestExchangeImpl implements Http2TestExchange {
         return conn.connectionKey();
     }
 
+    public Http2TestServerConnection getServerConnection() {
+        return conn;
+    }
+
     private boolean isHeadRequest() {
         return HEAD.equalsIgnoreCase(getRequestMethod());
     }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
@@ -248,6 +248,10 @@ public class Http2TestExchangeImpl implements Http2TestExchange {
         return conn;
     }
 
+    public int getStreamId() {
+        return streamid;
+    }
+
     private boolean isHeadRequest() {
         return HEAD.equalsIgnoreCase(getRequestMethod());
     }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -251,24 +251,7 @@ public class Http2TestServerConnection {
         if (maxProcessedStreamId == -1) {
             maxProcessedStreamId = 0;
         }
-        boolean send = false;
-        int currentGoAwayReqStrmId = goAwayRequestStreamId.get();
-        // update the last processed stream id and send a goaway frame if the new last processed
-        // stream id is lesser than the last processed stream id sent in
-        // a previous goaway frame (if any)
-        while (currentGoAwayReqStrmId == -1 || maxProcessedStreamId < currentGoAwayReqStrmId) {
-            if (goAwayRequestStreamId.compareAndSet(currentGoAwayReqStrmId, maxProcessedStreamId)) {
-                send = true;
-                break;
-            }
-            currentGoAwayReqStrmId = goAwayRequestStreamId.get();
-        }
-        if (!send) {
-            return;
-        }
-        final GoAwayFrame frame = new GoAwayFrame(maxProcessedStreamId, error);
-        outputQ.put(frame);
-        System.err.println(server.name + ": Sending GOAWAY frame " + frame + " from server connection " + this);
+        sendGoAway(maxProcessedStreamId, error, new byte[0]);
     }
 
     /**


### PR DESCRIPTION
### Problem

  When the HTTP/2 client receives a GOAWAY frame with a non-zero error code, the current implementation discards both the error code and debug data. Users only see generic "Connection closed by peer" errors without any information about why the server terminated the connection.

  ### Solution

  Per [RFC 9113 §5.4.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-5.4.1), a GOAWAY frame with a non-zero error code indicates a connection error requiring immediate closure. This fix:

  1. **Distinguishes** graceful shutdown (NO_ERROR) from connection errors
  2. **Preserves** error code and debug data in exception messages
  3. **Categorizes** streams based on `lastStreamId`:
     - Streams with ID > `lastStreamId`: Marked as unprocessed for automatic retry
     - Streams with ID ≤ `lastStreamId`: Failed with detailed error information

  ### Changes

  **Core Implementation** (`Http2Connection.java`):
  - Modified `handleGoAway()` to check error code and route appropriately
  - Added `handleGoAwayWithError()` method that:
    - Extracts error code and debug data from GOAWAY frame
    - Creates meaningful error messages with error name, hex code, and debug data
    - Properly categorizes streams for retry or failure

  **Test Infrastructure**:
  - `Http2TestServerConnection.sendGoAway(int, int, byte[])`: Supports custom error codes
  - `Http2TestExchangeImpl.getServerConnection()`: Accessor for test handlers
  - `GoAwayWithErrorTest`: Verifies proper error propagation

  ### Example

  **Before:**
  IOException: Connection closed by peer

  **After:**
  IOException: Received GOAWAY with error code Protocol error (0x1): Invalid HEADERS frame

  ### Testing

  - New `GoAwayWithErrorTest` passes
  - Existing HTTP/2 tests unaffected (NO_ERROR path unchanged)
  - Backward compatible (no public API changes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8371903](https://bugs.openjdk.org/browse/JDK-8371903): HttpClient: improve handling of HTTP/2 GOAWAY frames with error code (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) 🔄 Re-review required (review applies to [6dc77e1b](https://git.openjdk.org/jdk/pull/28632/files/6dc77e1b266e30aa2e0b4c0bcf0067e06b65df0f))
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) 🔄 Re-review required (review applies to [6068c1f9](https://git.openjdk.org/jdk/pull/28632/files/6068c1f9710bde3545c91faa5045b3a650bdba38))
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) 🔄 Re-review required (review applies to [566dfe23](https://git.openjdk.org/jdk/pull/28632/files/566dfe235ae29ae3028c639d55b6c90886c298c5))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28632/head:pull/28632` \
`$ git checkout pull/28632`

Update a local copy of the PR: \
`$ git checkout pull/28632` \
`$ git pull https://git.openjdk.org/jdk.git pull/28632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28632`

View PR using the GUI difftool: \
`$ git pr show -t 28632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28632.diff">https://git.openjdk.org/jdk/pull/28632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28632#issuecomment-3606587679)
</details>
