### PR TITLE
8373243: EnumSet.spliterator() should specify and document its characteristics

### DIFF
--- a/src/java.base/share/classes/java/util/EnumSet.java
+++ b/src/java.base/share/classes/java/util/EnumSet.java
@@ -504,17 +504,17 @@ public abstract sealed class EnumSet<E extends Enum<E>> extends AbstractSet<E>
 
     /**
      * Creates a <em><a href="Spliterator.html#binding">late-binding</a></em>
-     * and <em>fail-fast</em> {@code Spliterator} over the elements in this set.
+     * and <em>non-fail-fast</em> {@code Spliterator} over the elements in this set.
      *
      * <p>The {@code Spliterator} reports {@link Spliterator#SIZED},
      * {@link Spliterator#DISTINCT}, {@link Spliterator#SORTED},
      * {@link Spliterator#NONNULL}, and {@link Spliterator#ORDERED}.
      *
-     * @implNote
+     * @implSpec
      * The implementation creates a
      * <em><a href="Spliterator.html#binding">late-binding</a></em> spliterator
      * from the set's {@code Iterator}.  The spliterator inherits the
-     * <em>fail-fast</em> properties of the set's iterator.
+     * <em>non-fail-fast</em> properties of the set's iterator.
      * The created {@code Spliterator} additionally reports
      * {@link Spliterator#SUBSIZED}.
      *

--- a/src/java.base/share/classes/java/util/EnumSet.java
+++ b/src/java.base/share/classes/java/util/EnumSet.java
@@ -502,6 +502,25 @@ public abstract sealed class EnumSet<E extends Enum<E>> extends AbstractSet<E>
         throw new java.io.InvalidObjectException("Proxy required");
     }
 
+    /**
+     * Creates a <em><a href="Spliterator.html#binding">late-binding</a></em>
+     * and <em>fail-fast</em> {@code Spliterator} over the elements in this set.
+     *
+     * <p>The {@code Spliterator} reports {@link Spliterator#SIZED},
+     * {@link Spliterator#DISTINCT}, {@link Spliterator#SORTED},
+     * {@link Spliterator#NONNULL}, and {@link Spliterator#ORDERED}.
+     * Implementations should document the reporting of additional characteristic values.
+     *
+     * @implNote
+     * The implementation creates a
+     * <em><a href="Spliterator.html#binding">late-binding</a></em> spliterator
+     * from the set's {@code Iterator}.  The spliterator inherits the
+     * <em>fail-fast</em> properties of the set's iterator.
+     * The created {@code Spliterator} additionally reports
+     * {@link Spliterator#SUBSIZED}.
+     *
+     * @return a {@code Spliterator} over the elements in this set
+     */
     @Override
     public Spliterator<E> spliterator() {
         return Spliterators.spliterator(this,

--- a/src/java.base/share/classes/java/util/EnumSet.java
+++ b/src/java.base/share/classes/java/util/EnumSet.java
@@ -509,7 +509,6 @@ public abstract sealed class EnumSet<E extends Enum<E>> extends AbstractSet<E>
      * <p>The {@code Spliterator} reports {@link Spliterator#SIZED},
      * {@link Spliterator#DISTINCT}, {@link Spliterator#SORTED},
      * {@link Spliterator#NONNULL}, and {@link Spliterator#ORDERED}.
-     * Implementations should document the reporting of additional characteristic values.
      *
      * @implNote
      * The implementation creates a
@@ -522,7 +521,7 @@ public abstract sealed class EnumSet<E extends Enum<E>> extends AbstractSet<E>
      * @return a {@code Spliterator} over the elements in this set
      */
     @Override
-    public Spliterator<E> spliterator() {
+    public final Spliterator<E> spliterator() {
         return Spliterators.spliterator(this,
                 Spliterator.DISTINCT | Spliterator.SORTED | Spliterator.ORDERED | Spliterator.NONNULL);
     }


### PR DESCRIPTION
Addresses https://bugs.openjdk.org/browse/JDK-8373243 by copying and adapting the specification from https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/LinkedHashSet.java#L186-L204

Since EnumSet is sealed and only permits two final classes, the verbiage around "Implementations should document the reporting of additional characteristic values." may be considered to get removed from this PR. Kept, for now, for symmetry reasons.

---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change requires a CSR request matching fixVersion 28 to be approved (needs to be created)
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8373243](https://bugs.openjdk.org/browse/JDK-8373243): EnumSet.spliterator() should specify and document its characteristics (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28696/head:pull/28696` \
`$ git checkout pull/28696`

Update a local copy of the PR: \
`$ git checkout pull/28696` \
`$ git pull https://git.openjdk.org/jdk.git pull/28696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28696`

View PR using the GUI difftool: \
`$ git pr show -t 28696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28696.diff">https://git.openjdk.org/jdk/pull/28696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28696#issuecomment-3626466212)
</details>
