### PR TITLE
Speed up DateTime parse & format

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/IsoChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/IsoChronology.java
@@ -589,8 +589,8 @@ public final class IsoChronology extends AbstractChronology implements Serializa
 
     @Override  // override for better proleptic algorithm
     void resolveProlepticMonth(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
-        Long pMonth = fieldValues.remove(PROLEPTIC_MONTH);
-        if (pMonth != null) {
+        if (fieldValues.containsKey(PROLEPTIC_MONTH)) {
+            long pMonth = fieldValues.remove(PROLEPTIC_MONTH);
             if (resolverStyle != ResolverStyle.LENIENT) {
                 PROLEPTIC_MONTH.checkValidValue(pMonth);
             }
@@ -601,8 +601,8 @@ public final class IsoChronology extends AbstractChronology implements Serializa
 
     @Override  // override for enhanced behaviour
     LocalDate resolveYearOfEra(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
-        Long yoeLong = fieldValues.remove(YEAR_OF_ERA);
-        if (yoeLong != null) {
+        if (fieldValues.containsKey(YEAR_OF_ERA)) {
+            long yoeLong = fieldValues.remove(YEAR_OF_ERA);
             if (resolverStyle != ResolverStyle.LENIENT) {
                 YEAR_OF_ERA.checkValidValue(yoeLong);
             }

--- a/src/java.base/share/classes/java/time/format/ChronoFieldMap.java
+++ b/src/java.base/share/classes/java/time/format/ChronoFieldMap.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.time.format;
+
+import java.time.temporal.ChronoField;
+import java.util.*;
+
+final class ChronoFieldMap implements Map<ChronoField, Long> {
+    private static final ChronoField[] FIELDS = ChronoField.values();
+    private static final int MAX_SIZE = FIELDS.length;
+    private final long[] values = new long[MAX_SIZE];
+    private int bitSet;
+
+    static {
+        assert MAX_SIZE <= Integer.SIZE :
+                "Too many ChronoField values. MAX_SIZE=" + MAX_SIZE + " exceeds Integer.SIZE=" + Integer.SIZE;
+    }
+
+    @Override
+    public int size() {
+        return Integer.bitCount(bitSet);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return bitSet == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return (bitSet & (1 << ((ChronoField) key).ordinal())) != 0;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        if (value instanceof Long) {
+            long v = (Long) value;
+            for (long l : values) {
+                if (l == v) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Long get(Object key) {
+        int ordinal = ((ChronoField) key).ordinal();
+        if ((bitSet & (1 << ordinal)) != 0) {
+            return values[ordinal];
+        }
+        return null;
+    }
+
+    @Override
+    public Long put(ChronoField key, Long value) {
+        int ordinal = key.ordinal();
+        long oldValue = values[ordinal];
+        values[ordinal] = value;
+        int mask = 1 << ordinal;
+        if ((bitSet & mask) == 0) {
+            bitSet |= mask;
+            return null;
+        } else {
+            return oldValue;
+        }
+    }
+
+    @Override
+    public Long remove(Object key) {
+        int ordinal = ((ChronoField) key).ordinal();
+        long oldValue = values[ordinal];
+        int mask = 1 << ordinal;
+        if ((bitSet & mask) != 0) {
+            bitSet &= ~(1 << ordinal);
+            return oldValue;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void putAll(Map<? extends ChronoField, ? extends Long> m) {
+        for (Entry<? extends ChronoField, ? extends Long> e : m.entrySet()) {
+            put(e.getKey(), e.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        bitSet = 0;
+        Arrays.fill(values, 0);
+    }
+
+    private abstract class ChronoFieldMapIterator<T> implements Iterator<T> {
+        int index = 0;
+        int lastReturnedIndex = -1;
+
+        @Override
+        public boolean hasNext() {
+            while(this.index < MAX_SIZE && (bitSet & (1 << this.index)) == 0) {
+                ++this.index;
+            }
+
+            return this.index != MAX_SIZE;
+        }
+
+        public void remove() {
+            this.checkLastReturnedIndex();
+            bitSet &= ~(1 << this.lastReturnedIndex);
+
+            this.lastReturnedIndex = -1;
+        }
+
+        private void checkLastReturnedIndex() {
+            if (this.lastReturnedIndex < 0) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    @Override
+    public Set<ChronoField> keySet() {
+        return new AbstractSet<>() {
+            @Override
+            public int size() {
+                return ChronoFieldMap.this.size();
+            }
+
+            @Override
+            public Iterator<ChronoField> iterator() {
+                return new KeyIterator();
+            }
+        };
+    }
+
+    @Override
+    public Collection<Long> values() {
+        return new AbstractCollection<>() {
+            @Override
+            public Iterator<Long> iterator() {
+                return new ValueIterator();
+            }
+
+            @Override
+            public int size() {
+                return ChronoFieldMap.this.size();
+            }
+        };
+    }
+
+    @Override
+    public Set<Entry<ChronoField, Long>> entrySet() {
+        return new AbstractSet<>() {
+            @Override
+            public int size() {
+                return ChronoFieldMap.this.size();
+            }
+            @Override
+            public Iterator<Entry<ChronoField, Long>> iterator() {
+                return new EntryIterator();
+            }
+        };
+    }
+
+    final class ValueIterator extends ChronoFieldMapIterator<Long> {
+        public Long next() {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            lastReturnedIndex = index++;
+            return values[lastReturnedIndex];
+        }
+    }
+
+    final class KeyIterator extends ChronoFieldMapIterator<ChronoField> {
+        public ChronoField next() {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            lastReturnedIndex = index++;
+            return FIELDS[lastReturnedIndex];
+        }
+    }
+
+    final class EntryIterator extends ChronoFieldMapIterator<Entry<ChronoField, Long>> {
+        public Entry<ChronoField, Long> next() {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            lastReturnedIndex = index++;
+            return new AbstractMap.SimpleEntry<>(FIELDS[lastReturnedIndex], values[lastReturnedIndex]);
+        }
+    }
+}

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -2109,19 +2109,27 @@ public final class DateTimeFormatter {
         if (context == null || pos.getErrorIndex() >= 0 || (position == null && pos.getIndex() < text.length())) {
             String abbr;
             if (text.length() > 64) {
-                abbr = text.subSequence(0, 64).toString() + "...";
+                abbr = text.subSequence(0, 64).toString().concat("...");
             } else {
                 abbr = text.toString();
             }
             if (pos.getErrorIndex() >= 0) {
-                throw new DateTimeParseException("Text '" + abbr + "' could not be parsed at index " +
-                        pos.getErrorIndex(), text, pos.getErrorIndex());
+                throw errorIndex(text, abbr, pos);
             } else {
-                throw new DateTimeParseException("Text '" + abbr + "' could not be parsed, unparsed text found at index " +
-                        pos.getIndex(), text, pos.getIndex());
+                throw error(text, abbr, pos);
             }
         }
         return context.toResolved(resolverStyle, resolverFields);
+    }
+
+    private static DateTimeParseException error(CharSequence text, String abbr, ParsePosition pos) {
+        return new DateTimeParseException("Text '" + abbr + "' could not be parsed, unparsed text found at index " +
+                pos.getIndex(), text, pos.getIndex());
+    }
+
+    private static DateTimeParseException errorIndex(CharSequence text, String abbr, ParsePosition pos) {
+        return new DateTimeParseException("Text '" + abbr + "' could not be parsed at index " +
+                pos.getErrorIndex(), text, pos.getErrorIndex());
     }
 
     /**

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -544,6 +544,12 @@ public final class DateTimeFormatter {
      */
     private final ZoneId zone;
 
+    /**
+     * Flag indicating whether this formatter only uses ChronoField instances.
+     * This is used to optimize the storage of parsed field values in the Parsed class.
+     */
+    final boolean onlyChronoField;
+
     //-----------------------------------------------------------------------
     /**
      * Creates a formatter using the specified pattern.
@@ -1474,11 +1480,12 @@ public final class DateTimeFormatter {
      * @param resolverFields  the fields to use during resolving, null for all fields
      * @param chrono  the chronology to use, null for no override
      * @param zone  the zone to use, null for no override
+     * @param onlyChronoField  flag indicating whether this formatter only uses ChronoField instances
      */
     DateTimeFormatter(CompositePrinterParser printerParser,
             Locale locale, DecimalStyle decimalStyle,
             ResolverStyle resolverStyle, Set<TemporalField> resolverFields,
-            Chronology chrono, ZoneId zone) {
+            Chronology chrono, ZoneId zone, boolean onlyChronoField) {
         this.printerParser = Objects.requireNonNull(printerParser, "printerParser");
         this.resolverFields = resolverFields;
         this.locale = Objects.requireNonNull(locale, "locale");
@@ -1486,6 +1493,7 @@ public final class DateTimeFormatter {
         this.resolverStyle = Objects.requireNonNull(resolverStyle, "resolverStyle");
         this.chrono = chrono;
         this.zone = zone;
+        this.onlyChronoField = onlyChronoField;
     }
 
     //-----------------------------------------------------------------------
@@ -1523,7 +1531,7 @@ public final class DateTimeFormatter {
         if (this.locale.equals(locale)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     /**
@@ -1569,7 +1577,7 @@ public final class DateTimeFormatter {
                 Objects.equals(z, zone)) {
             return this;
         } else {
-            return new DateTimeFormatter(printerParser, locale, ds, resolverStyle, resolverFields, c, z);
+            return new DateTimeFormatter(printerParser, locale, ds, resolverStyle, resolverFields, c, z, onlyChronoField);
         }
     }
 
@@ -1595,7 +1603,7 @@ public final class DateTimeFormatter {
         if (this.decimalStyle.equals(decimalStyle)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1649,7 +1657,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.chrono, chrono)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1706,7 +1714,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.zone, zone)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1748,7 +1756,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.resolverStyle, resolverStyle)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------
@@ -1814,7 +1822,7 @@ public final class DateTimeFormatter {
         if (Objects.equals(this.resolverFields, fields)) {
             return this;
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, fields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, fields, chrono, zone, onlyChronoField);
     }
 
     /**
@@ -1863,7 +1871,7 @@ public final class DateTimeFormatter {
         if (resolverFields != null) {
             resolverFields = Collections.unmodifiableSet(new HashSet<>(resolverFields));
         }
-        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone);
+        return new DateTimeFormatter(printerParser, locale, decimalStyle, resolverStyle, resolverFields, chrono, zone, onlyChronoField);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -62,74 +62,38 @@
  */
 package java.time.format;
 
-import static java.time.temporal.ChronoField.DAY_OF_MONTH;
-import static java.time.temporal.ChronoField.HOUR_OF_DAY;
-import static java.time.temporal.ChronoField.INSTANT_SECONDS;
-import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
-import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
-import static java.time.temporal.ChronoField.NANO_OF_SECOND;
-import static java.time.temporal.ChronoField.OFFSET_SECONDS;
-import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
-import static java.time.temporal.ChronoField.YEAR;
-import static java.time.temporal.ChronoField.ERA;
+import jdk.internal.misc.VM;
+import jdk.internal.util.DateTimeHelper;
+import jdk.internal.util.DecimalDigits;
+import jdk.internal.vm.annotation.Stable;
+import sun.text.spi.JavaTimeDateTimePatternProvider;
+import sun.util.locale.provider.CalendarDataUtility;
+import sun.util.locale.provider.LocaleProviderAdapter;
+import sun.util.locale.provider.LocaleResources;
+import sun.util.locale.provider.TimeZoneNameUtility;
 
 import java.lang.ref.SoftReference;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.ParsePosition;
-import java.time.DateTimeException;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.chrono.ChronoLocalDate;
 import java.time.chrono.Chronology;
 import java.time.chrono.Era;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeTextProvider.LocaleStore;
-import java.time.temporal.ChronoField;
-import java.time.temporal.IsoFields;
-import java.time.temporal.JulianFields;
-import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
-import java.time.temporal.TemporalQueries;
-import java.time.temporal.TemporalQuery;
-import java.time.temporal.ValueRange;
-import java.time.temporal.WeekFields;
+import java.time.temporal.*;
 import java.time.zone.ZoneRulesProvider;
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.internal.util.DateTimeHelper;
-import jdk.internal.util.DecimalDigits;
-
-import sun.text.spi.JavaTimeDateTimePatternProvider;
-import sun.util.locale.provider.CalendarDataUtility;
-import sun.util.locale.provider.LocaleProviderAdapter;
-import sun.util.locale.provider.LocaleResources;
-import sun.util.locale.provider.TimeZoneNameUtility;
+import static java.time.temporal.ChronoField.*;
 
 /**
  * Builder to create date-time formatters.
@@ -163,6 +127,11 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * @since 1.8
  */
 public final class DateTimeFormatterBuilder {
+    private static final boolean UNROLLING_PRINTERS_BY_CLASS_FILE;
+    static {
+        String property = VM.getSavedProperty("java.time.format.DateTimeFormatter.UnrollingByClassFile");
+        UNROLLING_PRINTERS_BY_CLASS_FILE = property == null || Boolean.parseBoolean(property);
+    }
     /**
      * Query for a time-zone that is region-only.
      */
@@ -438,14 +407,14 @@ public final class DateTimeFormatterBuilder {
      * The parser for a variable width value such as this normally behaves greedily,
      * requiring one digit, but accepting as many digits as possible.
      * This behavior can be affected by 'adjacent value parsing'.
-     * See {@link #appendValue(java.time.temporal.TemporalField, int)} for full details.
+     * See {@link #appendValue(TemporalField, int)} for full details.
      *
      * @param field  the field to append, not null
      * @return this, for chaining, not null
      */
     public DateTimeFormatterBuilder appendValue(TemporalField field) {
         Objects.requireNonNull(field, "field");
-        appendValue(new NumberPrinterParser(field, 1, 19, SignStyle.NORMAL));
+        appendValue(NumberPrinterParser.of(field, 1, 19, SignStyle.NORMAL));
         return this;
     }
 
@@ -502,7 +471,7 @@ public final class DateTimeFormatterBuilder {
         if (width < 1 || width > 19) {
             throw new IllegalArgumentException("The width must be from 1 to 19 inclusive but was " + width);
         }
-        NumberPrinterParser pp = new NumberPrinterParser(field, width, width, SignStyle.NOT_NEGATIVE);
+        NumberPrinterParser pp = NumberPrinterParser.of(field, width, width, SignStyle.NOT_NEGATIVE);
         appendValue(pp);
         return this;
     }
@@ -520,7 +489,7 @@ public final class DateTimeFormatterBuilder {
      * The parser for a variable width value such as this normally behaves greedily,
      * accepting as many digits as possible.
      * This behavior can be affected by 'adjacent value parsing'.
-     * See {@link #appendValue(java.time.temporal.TemporalField, int)} for full details.
+     * See {@link #appendValue(TemporalField, int)} for full details.
      * <p>
      * In strict parsing mode, the minimum number of parsed digits is {@code minWidth}
      * and the maximum is {@code maxWidth}.
@@ -555,7 +524,7 @@ public final class DateTimeFormatterBuilder {
             throw new IllegalArgumentException("The maximum width must exceed or equal the minimum width but " +
                     maxWidth + " < " + minWidth);
         }
-        NumberPrinterParser pp = new NumberPrinterParser(field, minWidth, maxWidth, signStyle);
+        NumberPrinterParser pp = NumberPrinterParser.of(field, minWidth, maxWidth, signStyle);
         appendValue(pp);
         return this;
     }
@@ -728,7 +697,7 @@ public final class DateTimeFormatterBuilder {
      * the minimum and maximum width. In strict mode, if the minimum and maximum widths
      * are equal and there is no decimal point then the parser will
      * participate in adjacent value parsing, see
-     * {@link #appendValue(java.time.temporal.TemporalField, int)}. When parsing in lenient mode,
+     * {@link #appendValue(TemporalField, int)}. When parsing in lenient mode,
      * the minimum width is considered to be zero and the maximum is nine.
      * <p>
      * If the value cannot be obtained then an exception will be thrown.
@@ -751,9 +720,9 @@ public final class DateTimeFormatterBuilder {
         if (field == NANO_OF_SECOND) {
             if (minWidth == maxWidth && decimalPoint == false) {
                 // adjacent parsing
-                appendValue(new NanosPrinterParser(minWidth, maxWidth, decimalPoint));
+                appendValue(NanosPrinterParser.of(minWidth, maxWidth, decimalPoint));
             } else {
-                appendInternal(new NanosPrinterParser(minWidth, maxWidth, decimalPoint));
+                appendInternal(NanosPrinterParser.of(minWidth, maxWidth, decimalPoint));
             }
         } else {
             if (minWidth == maxWidth && decimalPoint == false) {
@@ -2470,7 +2439,6 @@ public final class DateTimeFormatterBuilder {
     }
 
     interface DateTimeParser {
-
         /**
          * Parses text into date-time information.
          * <p>
@@ -2522,6 +2490,7 @@ public final class DateTimeFormatterBuilder {
      * Composite printer and parser.
      */
     static final class CompositePrinterParser implements DateTimePrinterParser {
+        @Stable
         private final DateTimePrinterParser[] printerParsers;
         private final boolean optional;
         private final DateTimePrinter formatter;
@@ -2557,7 +2526,6 @@ public final class DateTimeFormatterBuilder {
             boolean effectiveOptional = optional | this.optional;
             if (!formatter.format(context, buf, effectiveOptional)) {
                 buf.setLength(length);  // reset buffer
-                return true;
             }
             return true;
         }
@@ -2733,8 +2701,8 @@ public final class DateTimeFormatterBuilder {
      * Prints or parses a character literal.
      */
     static final class CharLiteralPrinterParser implements DateTimePrinterParser {
-        private final char literal;
-        private final boolean isSpaceSeparator;
+        final char literal;
+        final boolean isSpaceSeparator;
 
         private CharLiteralPrinterParser(char literal) {
             this.literal = literal;
@@ -2842,7 +2810,7 @@ public final class DateTimeFormatterBuilder {
         final TemporalField field;
         final int minWidth;
         final int maxWidth;
-        private final SignStyle signStyle;
+        final SignStyle signStyle;
         final int subsequentWidth;
 
         /**
@@ -2872,7 +2840,7 @@ public final class DateTimeFormatterBuilder {
          * @param subsequentWidth  the width of subsequent non-negative numbers, 0 or greater,
          *  -1 if fixed width due to active adjacent parsing
          */
-        protected NumberPrinterParser(TemporalField field, int minWidth, int maxWidth, SignStyle signStyle, int subsequentWidth) {
+        private NumberPrinterParser(TemporalField field, int minWidth, int maxWidth, SignStyle signStyle, int subsequentWidth) {
             // validated by caller
             this.field = field;
             this.minWidth = minWidth;
@@ -2890,7 +2858,7 @@ public final class DateTimeFormatterBuilder {
             if (subsequentWidth == -1) {
                 return this;
             }
-            return new NumberPrinterParser(field, minWidth, maxWidth, signStyle, -1);
+            return NumberPrinterParser.of(field, minWidth, maxWidth, signStyle, -1);
         }
 
         /**
@@ -2900,16 +2868,16 @@ public final class DateTimeFormatterBuilder {
          * @return a new updated printer-parser, not null
          */
         NumberPrinterParser withSubsequentWidth(int subsequentWidth) {
-            return new NumberPrinterParser(field, minWidth, maxWidth, signStyle, this.subsequentWidth + subsequentWidth);
+            return NumberPrinterParser.of(field, minWidth, maxWidth, signStyle, this.subsequentWidth + subsequentWidth);
         }
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long valueLong = context.getValue(field, optional);
-            if (valueLong == null) {
+            if (notSupported(context, optional)) {
                 return false;
             }
-            long value = getValue(context, valueLong);
+
+            long value = getLong(context);
             DecimalStyle decimalStyle = context.getDecimalStyle();
             int size = DecimalDigits.stringSize(value);
             if (value < 0) {
@@ -2917,9 +2885,7 @@ public final class DateTimeFormatterBuilder {
             }
 
             if (size > maxWidth) {
-                throw new DateTimeException("Field " + field +
-                    " cannot be printed as the value " + value +
-                    " exceeds the maximum print width of " + maxWidth);
+                throw maxWidthError(value);
             }
 
             if (value >= 0) {
@@ -2936,9 +2902,7 @@ public final class DateTimeFormatterBuilder {
             } else {
                 switch (signStyle) {
                     case NORMAL, EXCEEDS_PAD, ALWAYS -> buf.append(decimalStyle.getNegativeSign());
-                    case NOT_NEGATIVE -> throw new DateTimeException("Field " + field +
-                                             " cannot be printed as the value " + value +
-                                             " cannot be negative according to the SignStyle");
+                    case NOT_NEGATIVE -> throw notNegativeError(value);
                 }
             }
             char zeroDigit = decimalStyle.getZeroDigit();
@@ -2955,15 +2919,42 @@ public final class DateTimeFormatterBuilder {
             return true;
         }
 
+        private DateTimeException notNegativeError(long value) {
+            return new DateTimeException("Field " + field +
+                    " cannot be printed as the value " + value +
+                    " cannot be negative according to the SignStyle");
+        }
+
+        private DateTimeException maxWidthError(long value) {
+            return new DateTimeException("Field " + field +
+                    " cannot be printed as the value " + value +
+                    " exceeds the maximum print width of " + maxWidth);
+        }
+
+        boolean notSupported(DateTimePrintContext context, boolean optional) {
+            return optional && !context.isSupported(field);
+        }
+
         /**
-         * Gets the value to output.
+         * Gets the long value to output.
          *
          * @param context  the context
          * @param value  the value of the field, not null
          * @return the value
          */
-        long getValue(DateTimePrintContext context, long value) {
-            return value;
+        long getLong(DateTimePrintContext context) {
+            return context.getLong(field);
+        }
+
+        /**
+         * Gets the int value to output.
+         *
+         * @param context  the context
+         * @param value  the value of the field, not null
+         * @return the value
+         */
+        int getInt(DateTimePrintContext context) {
+            return context.get(field);
         }
 
         /**
@@ -2971,7 +2962,7 @@ public final class DateTimeFormatterBuilder {
          * minWidth, maxWidth, signStyle and whether subsequent fields are fixed.
          * @param context the context
          * @return true if the field is fixed width
-         * @see DateTimeFormatterBuilder#appendValue(java.time.temporal.TemporalField, int)
+         * @see DateTimeFormatterBuilder#appendValue(TemporalField, int)
          */
         boolean isFixedWidth(DateTimeParseContext context) {
             return subsequentWidth == -1 ||
@@ -3103,6 +3094,199 @@ public final class DateTimeFormatterBuilder {
             }
             return "Value(" + field + "," + minWidth + "," + maxWidth + "," + signStyle + ")";
         }
+
+        /**
+         * Constructor.
+         *
+         * @param field  the field to format, not null
+         * @param minWidth  the minimum field width, from 1 to 19
+         * @param maxWidth  the maximum field width, from minWidth to 19
+         * @param signStyle  the positive/negative sign style, not null
+         */
+        static NumberPrinterParser of(TemporalField field, int minWidth, int maxWidth, SignStyle signStyle) {
+            return of(field, minWidth, maxWidth, signStyle, 0);
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param field  the field to format, not null
+         * @param minWidth  the minimum field width, from 1 to 19
+         * @param maxWidth  the maximum field width, from minWidth to 19
+         * @param signStyle  the positive/negative sign style, not null
+         */
+        static NumberPrinterParser of(TemporalField field, int minWidth, int maxWidth, SignStyle signStyle, int subsequentWidth) {
+            // validated by caller
+            if (subsequentWidth == 0) {
+                if (minWidth == 2 && maxWidth == 2 && signStyle == SignStyle.NOT_NEGATIVE) {
+                    if (field instanceof ChronoField chronoField) {
+                        switch (chronoField) {
+                            case MONTH_OF_YEAR:
+                                return FixWidth2NotNegative.PP_MONTH;
+                            case DAY_OF_MONTH:
+                                return FixWidth2NotNegative.PP_DAY_OF_MONTH;
+                            case HOUR_OF_DAY:
+                                return FixWidth2NotNegative.PP_HOUR;
+                            case MINUTE_OF_HOUR:
+                                return FixWidth2NotNegative.PP_MINUTE;
+                            case SECOND_OF_MINUTE:
+                                return FixWidth2NotNegative.PP_SECOND;
+                            default:
+                                break;
+                        }
+                    }
+                } else if (minWidth == 4 && maxWidth == 4 && signStyle == SignStyle.EXCEEDS_PAD) {
+                    if (field instanceof ChronoField chronoField) {
+                        switch (chronoField) {
+                            case YEAR:
+                                return FixWidth4ExceedsPad.PP_YEAR;
+                            case YEAR_OF_ERA:
+                                return FixWidth4ExceedsPad.PP_YEAR_OF_ERA;
+                            default:
+                                break;
+                        }
+                    }
+                } else if (minWidth == 4 && maxWidth == 19 && signStyle == SignStyle.EXCEEDS_PAD) {
+                    if (field instanceof ChronoField chronoField) {
+                        switch (chronoField) {
+                            case YEAR:
+                                return FixWidth49ExceedsPad.PP_YEAR;
+                            case YEAR_OF_ERA:
+                                return FixWidth49ExceedsPad.PP_YEAR_OF_ERA;
+                            default:
+                                break;
+                        }
+                    }
+                }
+            }
+
+            return new NumberPrinterParser(field, minWidth, maxWidth, signStyle, subsequentWidth);
+        }
+
+        static abstract class FixWidth4ExceedsPad extends NumberPrinterParser {
+            FixWidth4ExceedsPad(ChronoField field) {
+                super(field, 4, 4, SignStyle.EXCEEDS_PAD);
+            }
+
+            @Override
+            public final boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
+                if (notSupported(context, optional)) {
+                    return false;
+                }
+                if (context.getDecimalStyle() != DecimalStyle.STANDARD) {
+                    return super.format(context, buf, optional);
+                }
+                int value = getInt(context);
+                if (value < 0) {
+                    buf.append('-');
+                    value = -value;
+                }
+                DecimalDigits.appendQuad(buf, value);
+                return true;
+            }
+
+            static final FixWidth4ExceedsPad PP_YEAR = new FixWidth4ExceedsPad(ChronoField.YEAR) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportYear();}
+                @Override
+                protected int getInt(DateTimePrintContext context) {return context.getYear();}
+            };
+            static final FixWidth4ExceedsPad PP_YEAR_OF_ERA = new FixWidth4ExceedsPad(YEAR_OF_ERA) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportYearOfEra();}
+                @Override
+                protected int getInt(DateTimePrintContext context) {return context.getYearOfEra();}
+            };
+        }
+
+        static abstract class FixWidth49ExceedsPad extends NumberPrinterParser {
+            FixWidth49ExceedsPad(ChronoField field) {
+                super(field, 4, 19, SignStyle.EXCEEDS_PAD);
+            }
+
+            @Override
+            public final boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
+                if (notSupported(context, optional)) {
+                    return false;
+                }
+                if (context.getDecimalStyle() != DecimalStyle.STANDARD) {
+                    return super.format(context, buf, optional);
+                }
+                int value = getInt(context);
+                if (value < 0) {
+                    buf.append('-');
+                    value = -value;
+                }
+                if (value < 10000) {
+                    DecimalDigits.appendQuad(buf, value);
+                } else {
+                    buf.append(value);
+                }
+                return true;
+            }
+
+            static final FixWidth49ExceedsPad PP_YEAR = new FixWidth49ExceedsPad(ChronoField.YEAR) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportYear();}
+                @Override
+                protected int getInt(DateTimePrintContext context) {return context.getYear();}
+            };
+            static final FixWidth49ExceedsPad PP_YEAR_OF_ERA = new FixWidth49ExceedsPad(YEAR_OF_ERA) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportYearOfEra();}
+                @Override
+                protected int getInt(DateTimePrintContext context) {return context.getYearOfEra();}
+            };
+        }
+
+        static abstract class FixWidth2NotNegative extends NumberPrinterParser {
+            FixWidth2NotNegative(ChronoField field) {
+                super(field, 2, 2, SignStyle.NOT_NEGATIVE);
+            }
+
+            @Override
+            public final boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
+                if (context.getDecimalStyle() != DecimalStyle.STANDARD) {
+                    return super.format(context, buf, optional);
+                }
+                if (notSupported(context, optional)) {
+                    return false;
+                }
+                DecimalDigits.appendPair(buf, getInt(context));
+                return true;
+            }
+
+            static final FixWidth2NotNegative PP_MONTH = new FixWidth2NotNegative(MONTH_OF_YEAR) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportMonth();}
+                @Override
+                int getInt(DateTimePrintContext context) {return context.getMonthValue();}
+            };
+            static final FixWidth2NotNegative PP_DAY_OF_MONTH = new FixWidth2NotNegative(DAY_OF_MONTH) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportDayOfMonth();}
+                @Override
+                int getInt(DateTimePrintContext context) {return context.getDayOfMonth();}
+            };
+            static final FixWidth2NotNegative PP_HOUR = new FixWidth2NotNegative(HOUR_OF_DAY) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportHour();}
+                @Override
+                int getInt(DateTimePrintContext context) {return context.getHour();}
+            };
+            static final FixWidth2NotNegative PP_MINUTE = new FixWidth2NotNegative(MINUTE_OF_HOUR) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportMinute();}
+                @Override
+                int getInt(DateTimePrintContext context) {return context.getMinute();}
+            };
+            static final FixWidth2NotNegative PP_SECOND = new FixWidth2NotNegative(SECOND_OF_MINUTE) {
+                @Override
+                boolean notSupported(DateTimePrintContext context, boolean optional) {return optional && !context.isSupportSecond();}
+                @Override
+                int getInt(DateTimePrintContext context) {return context.getSecond();}
+            };
+        }
     }
 
     //-----------------------------------------------------------------------
@@ -3169,7 +3353,8 @@ public final class DateTimeFormatterBuilder {
         }
 
         @Override
-        long getValue(DateTimePrintContext context, long value) {
+        long getLong(DateTimePrintContext context) {
+            long value = context.getLong(field);
             long absValue = Math.abs(value);
             int baseValue = this.baseValue;
             if (baseDate != null) {
@@ -3249,7 +3434,7 @@ public final class DateTimeFormatterBuilder {
          * otherwise it is set as for NumberPrinterParser.
          * @param context the context
          * @return if the field is fixed width
-         * @see DateTimeFormatterBuilder#appendValueReduced(java.time.temporal.TemporalField, int, int, int)
+         * @see DateTimeFormatterBuilder#appendValueReduced(TemporalField, int, int, int)
          */
         @Override
         boolean isFixedWidth(DateTimeParseContext context) {
@@ -3270,7 +3455,7 @@ public final class DateTimeFormatterBuilder {
     /**
      * Prints and parses a NANO_OF_SECOND field with optional padding.
      */
-    static final class NanosPrinterParser extends NumberPrinterParser {
+    static class NanosPrinterParser extends NumberPrinterParser {
         private final boolean decimalPoint;
 
         /**
@@ -3280,8 +3465,7 @@ public final class DateTimeFormatterBuilder {
          * @param maxWidth  the maximum width to output, from 0 to 9
          * @param decimalPoint  whether to output the localized decimal point symbol
          */
-        private NanosPrinterParser(int minWidth, int maxWidth, boolean decimalPoint) {
-            this(minWidth, maxWidth, decimalPoint, 0);
+        static NanosPrinterParser of(int minWidth, int maxWidth, boolean decimalPoint) {
             if (minWidth < 0 || minWidth > 9) {
                 throw new IllegalArgumentException("Minimum width must be from 0 to 9 inclusive but was " + minWidth);
             }
@@ -3292,6 +3476,10 @@ public final class DateTimeFormatterBuilder {
                 throw new IllegalArgumentException("Maximum width must exceed or equal the minimum width but " +
                         maxWidth + " < " + minWidth);
             }
+            if (minWidth == 3 && maxWidth == 3 && !decimalPoint) {
+                return PP_FIX_3;
+            }
+            return new NanosPrinterParser(minWidth, maxWidth, decimalPoint, 0);
         }
 
         /**
@@ -3336,7 +3524,7 @@ public final class DateTimeFormatterBuilder {
          * minWidth equal to maxWidth and decimalpoint is absent.
          * @param context the context
          * @return if the field is fixed width
-         * @see #appendFraction(java.time.temporal.TemporalField, int, int, boolean)
+         * @see #appendFraction(TemporalField, int, int, boolean)
          */
         @Override
         boolean isFixedWidth(DateTimeParseContext context) {
@@ -3359,12 +3547,17 @@ public final class DateTimeFormatterBuilder {
         };
 
         @Override
-        public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long value = context.getValue(field, optional);
-            if (value == null) {
+        public final boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
+            if (optional && !context.isSupportNano()) {
                 return false;
             }
-            int val = field.range().checkValidIntValue(value, field);
+
+            int val = context.getNano();
+            format(context, buf, val);
+            return true;
+        }
+
+        void format(DateTimePrintContext context, StringBuilder buf, int val) {
             DecimalStyle decimalStyle = context.getDecimalStyle();
             int stringSize = DecimalDigits.stringSize(val);
             char zero = decimalStyle.getZeroDigit();
@@ -3405,7 +3598,6 @@ public final class DateTimeFormatterBuilder {
                     buf.append(decimalStyle.convertNumberToI18N(Integer.toString(val)));
                 }
             }
-            return true;
         }
 
         @Override
@@ -3454,6 +3646,22 @@ public final class DateTimeFormatterBuilder {
             String decimal = (decimalPoint ? ",DecimalPoint" : "");
             return "Fraction(" + field + "," + minWidth + "," + maxWidth + decimal + ")";
         }
+
+        static final NanosPrinterParser PP_FIX_3 = new NanosPrinterParser(3, 3, false, 0) {
+            @Override
+            void format(DateTimePrintContext context, StringBuilder buf, int val) {
+                if (context.getDecimalStyle() != DecimalStyle.STANDARD) {
+                    super.format(context, buf, val);
+                    return;
+                }
+
+                val /= 1_000_000;
+                int d0 = val / 100;
+                int d12 = val - d0 * 100;
+                buf.append('0' + d0);
+                DecimalDigits.appendPair(buf, d12);
+            }
+        };
     }
 
     //-----------------------------------------------------------------------
@@ -3537,7 +3745,7 @@ public final class DateTimeFormatterBuilder {
          * minWidth equal to maxWidth and decimalpoint is absent.
          * @param context the context
          * @return if the field is fixed width
-         * @see #appendFraction(java.time.temporal.TemporalField, int, int, boolean)
+         * @see #appendFraction(TemporalField, int, int, boolean)
          */
         @Override
         boolean isFixedWidth(DateTimeParseContext context) {
@@ -3549,10 +3757,11 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long value = context.getValue(field, optional);
-            if (value == null) {
+            if(notSupported(context, optional)) {
                 return false;
             }
+
+            long value = getLong(context);
             DecimalStyle decimalStyle = context.getDecimalStyle();
             BigDecimal fraction = convertToFraction(value);
             if (fraction.scale() == 0) {  // scale is zero if value is zero
@@ -3619,7 +3828,7 @@ public final class DateTimeFormatterBuilder {
          * Converts a value for this field to a fraction between 0 and 1.
          * <p>
          * The fractional value is between 0 (inclusive) and 1 (exclusive).
-         * It can only be returned if the {@link java.time.temporal.TemporalField#range() value range} is fixed.
+         * It can only be returned if the {@link TemporalField#range() value range} is fixed.
          * The fraction is obtained by calculation from the field range using 9 decimal
          * places and a rounding mode of {@link RoundingMode#FLOOR FLOOR}.
          * The calculation is inaccurate if the values do not run continuously from smallest to largest.
@@ -3643,7 +3852,7 @@ public final class DateTimeFormatterBuilder {
          * Converts a fraction from 0 to 1 for this field to a value.
          * <p>
          * The fractional value must be between 0 (inclusive) and 1 (exclusive).
-         * It can only be returned if the {@link java.time.temporal.TemporalField#range() value range} is fixed.
+         * It can only be returned if the {@link TemporalField#range() value range} is fixed.
          * The value is obtained by calculation from the field range and a rounding
          * mode of {@link RoundingMode#FLOOR FLOOR}.
          * The calculation is inaccurate if the values do not run continuously from smallest to largest.
@@ -3697,10 +3906,12 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long value = context.getValue(field, optional);
-            if (value == null) {
+            if(optional && !context.isSupported(field)) {
                 return false;
             }
+
+            long value = context.getLong(field);
+
             String text;
             Chronology chrono = context.getTemporal().query(TemporalQueries.chronology());
             if (chrono == null || chrono == IsoChronology.INSTANCE) {
@@ -3760,7 +3971,7 @@ public final class DateTimeFormatterBuilder {
          */
         private NumberPrinterParser numberPrinterParser() {
             if (numberPrinterParser == null) {
-                numberPrinterParser = new NumberPrinterParser(field, 1, 19, SignStyle.NORMAL);
+                numberPrinterParser = NumberPrinterParser.of(field, 1, 19, SignStyle.NORMAL);
             }
             return numberPrinterParser;
         }
@@ -3793,16 +4004,12 @@ public final class DateTimeFormatterBuilder {
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
             // use INSTANT_SECONDS, thus this code is not bound by Instant.MAX
-            Long inSecs = context.getValue(INSTANT_SECONDS, optional);
-            Long inNanos = null;
-            if (context.getTemporal().isSupported(NANO_OF_SECOND)) {
-                inNanos = context.getTemporal().getLong(NANO_OF_SECOND);
-            }
-            if (inSecs == null) {
+            if (optional && !context.isSupported(INSTANT_SECONDS)) {
                 return false;
             }
-            long inSec = inSecs;
-            int inNano = NANO_OF_SECOND.checkValidIntValue(inNanos != null ? inNanos : 0);
+
+            long inSec = context.getLong(INSTANT_SECONDS);
+            int inNano = context.isSupported(NANO_OF_SECOND) ? context.get(NANO_OF_SECOND) : 0;
             if (fractionalDigits == 0) {
                 inNano = 0;
             }
@@ -3891,7 +4098,7 @@ public final class DateTimeFormatterBuilder {
             }
             // parser restricts most fields to 2 digits, so definitely int
             // correctly parsed nano is also guaranteed to be valid
-            long yearParsed = newContext.getParsed(YEAR);
+            long yearParsed = newContext.getParsed(ChronoField.YEAR);
             int month = newContext.getParsed(MONTH_OF_YEAR).intValue();
             int day = newContext.getParsed(DAY_OF_MONTH).intValue();
             int hour = newContext.getParsed(HOUR_OF_DAY).intValue();
@@ -3978,11 +4185,11 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long offsetSecs = context.getValue(OFFSET_SECONDS, optional);
-            if (offsetSecs == null) {
+            if (optional && !context.isSupported(OFFSET_SECONDS)) {
                 return false;
             }
-            int totalSecs = Math.toIntExact(offsetSecs);
+
+            int totalSecs = context.get(OFFSET_SECONDS);
             if (totalSecs == 0) {
                 buf.append(noOffsetText);
             } else {
@@ -4277,17 +4484,17 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long offsetSecs = context.getValue(OFFSET_SECONDS, optional);
-            if (offsetSecs == null) {
+            if (optional && !context.isSupported(OFFSET_SECONDS)) {
                 return false;
             }
+
+            int totalSecs = context.get(OFFSET_SECONDS);
             String key = "timezone.gmtZeroFormat";
             String gmtText = DateTimeTextProvider.getLocalizedResource(key, context.getLocale());
             if (gmtText == null) {
                 gmtText = "GMT";  // Default to "GMT"
             }
             buf.append(gmtText);
-            int totalSecs = Math.toIntExact(offsetSecs);
             if (totalSecs != 0) {
                 int absHours = Math.abs((totalSecs / 3600) % 100);  // anything larger than 99 silently dropped
                 int absMinutes = Math.abs((totalSecs / 60) % 60);
@@ -5271,7 +5478,7 @@ public final class DateTimeFormatterBuilder {
                         return new ReducedPrinterParser(field, 2, 2, 0, ReducedPrinterParser.BASE_DATE,
                                 this.subsequentWidth);
                     } else {
-                        return new NumberPrinterParser(field, count, 19,
+                        return NumberPrinterParser.of(field, count, 19,
                                 (count < 4) ? SignStyle.NORMAL : SignStyle.EXCEEDS_PAD,
                                 this.subsequentWidth);
                     }
@@ -5288,7 +5495,7 @@ public final class DateTimeFormatterBuilder {
                 default:
                     throw new IllegalStateException("unreachable");
             }
-            return new NumberPrinterParser(field, minWidth, maxWidth, SignStyle.NOT_NEGATIVE,
+            return NumberPrinterParser.of(field, minWidth, maxWidth, SignStyle.NOT_NEGATIVE,
                     this.subsequentWidth);
         }
 
@@ -5350,12 +5557,13 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            Long hod = context.getValue(HOUR_OF_DAY, optional);
-            if (hod == null) {
+            if(optional && !context.isSupported(HOUR_OF_DAY)) {
                 return false;
             }
-            Long moh = context.getValue(MINUTE_OF_HOUR, optional);
-            long value = Math.floorMod(hod, 24) * 60 + (moh != null ? Math.floorMod(moh, 60) : 0);
+
+            long hod = context.getLong(HOUR_OF_DAY);
+            long moh = optional && !context.isSupported(MINUTE_OF_HOUR) ? 0 : context.getLong(MINUTE_OF_HOUR);
+            long value = Math.floorMod(hod, 24) * 60 + Math.floorMod(moh, 60);
             Locale locale = context.getLocale();
             LocaleStore store = findDayPeriodStore(locale);
             final long val = value;

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2447,6 +2447,47 @@ public final class DateTimeFormatterBuilder {
     }
 
     //-----------------------------------------------------------------------
+    interface DateTimePrinter {
+        /**
+         * Prints the date-time object to the buffer.
+         * <p>
+         * The context holds information to use during the format.
+         * It also contains the date-time information to be printed.
+         * <p>
+         * The buffer must not be mutated beyond the content controlled by the implementation.
+         *
+         * @param context  the context to format using, not null
+         * @param buf  the buffer to append to, not null
+         * @param optional  whether the enclosing formatter is optional.
+         *                  If true and this formatter is nested in an optional formatter
+         *                  and the data is not available, then no error is returned and
+         *                  nothing is appended to the buffer. If false and the data is not available
+         *                  then an exception is thrown or false is returned as appropriate.
+         * @return false if unable to query the value from the date-time, true otherwise
+         * @throws DateTimeException if the date-time cannot be printed successfully
+         */
+        boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional);
+    }
+
+    interface DateTimeParser {
+
+        /**
+         * Parses text into date-time information.
+         * <p>
+         * The context holds information to use during the parse.
+         * It is also used to store the parsed date-time information.
+         *
+         * @param context  the context to use and parse into, not null
+         * @param text  the input text to parse, not null
+         * @param position  the position to start parsing at, from 0 to the text length
+         * @return the new parse position, where negative means an error with the
+         *  error position encoded using the complement ~ operator
+         * @throws NullPointerException if the context or text is null
+         * @throws IndexOutOfBoundsException if the position is invalid
+         */
+        int parse(DateTimeParseContext context, CharSequence text, int position);
+    }
+
     /**
      * Strategy for formatting/parsing date-time information.
      * <p>
@@ -2473,43 +2514,7 @@ public final class DateTimeFormatterBuilder {
      * for each format that occurs. The context must not be stored in an instance
      * variable or shared with any other threads.
      */
-    interface DateTimePrinterParser {
-
-        /**
-         * Prints the date-time object to the buffer.
-         * <p>
-         * The context holds information to use during the format.
-         * It also contains the date-time information to be printed.
-         * <p>
-         * The buffer must not be mutated beyond the content controlled by the implementation.
-         *
-         * @param context  the context to format using, not null
-         * @param buf  the buffer to append to, not null
-         * @param optional  whether the enclosing formatter is optional.
-         *                  If true and this formatter is nested in an optional formatter
-         *                  and the data is not available, then no error is returned and
-         *                  nothing is appended to the buffer. If false and the data is not available
-         *                  then an exception is thrown or false is returned as appropriate.
-         * @return false if unable to query the value from the date-time, true otherwise
-         * @throws DateTimeException if the date-time cannot be printed successfully
-         */
-        boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional);
-
-        /**
-         * Parses text into date-time information.
-         * <p>
-         * The context holds information to use during the parse.
-         * It is also used to store the parsed date-time information.
-         *
-         * @param context  the context to use and parse into, not null
-         * @param text  the input text to parse, not null
-         * @param position  the position to start parsing at, from 0 to the text length
-         * @return the new parse position, where negative means an error with the
-         *  error position encoded using the complement ~ operator
-         * @throws NullPointerException if the context or text is null
-         * @throws IndexOutOfBoundsException if the position is invalid
-         */
-        int parse(DateTimeParseContext context, CharSequence text, int position);
+    interface DateTimePrinterParser extends DateTimePrinter, DateTimeParser {
     }
 
     //-----------------------------------------------------------------------
@@ -2519,6 +2524,8 @@ public final class DateTimeFormatterBuilder {
     static final class CompositePrinterParser implements DateTimePrinterParser {
         private final DateTimePrinterParser[] printerParsers;
         private final boolean optional;
+        private final DateTimePrinter formatter;
+        private final DateTimeParser parser;
 
         private CompositePrinterParser(List<DateTimePrinterParser> printerParsers, boolean optional) {
             this(printerParsers.toArray(new DateTimePrinterParser[0]), optional);
@@ -2527,6 +2534,8 @@ public final class DateTimeFormatterBuilder {
         private CompositePrinterParser(DateTimePrinterParser[] printerParsers, boolean optional) {
             this.printerParsers = printerParsers;
             this.optional = optional;
+            this.formatter = DateTimePrinterParserFactory.createFormatter(printerParsers, optional);
+            this.parser = DateTimePrinterParserFactory.createParser(printerParsers, optional);
         }
 
         /**
@@ -2546,38 +2555,16 @@ public final class DateTimeFormatterBuilder {
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
             int length = buf.length();
             boolean effectiveOptional = optional | this.optional;
-            for (DateTimePrinterParser pp : printerParsers) {
-                if (!pp.format(context, buf, effectiveOptional)) {
-                    buf.setLength(length);  // reset buffer
-                    return true;
-                }
+            if (!formatter.format(context, buf, effectiveOptional)) {
+                buf.setLength(length);  // reset buffer
+                return true;
             }
             return true;
         }
 
         @Override
         public int parse(DateTimeParseContext context, CharSequence text, int position) {
-            if (optional) {
-                context.startOptional();
-                int pos = position;
-                for (DateTimePrinterParser pp : printerParsers) {
-                    pos = pp.parse(context, text, pos);
-                    if (pos < 0) {
-                        context.endOptional(false);
-                        return position;  // return original position
-                    }
-                }
-                context.endOptional(true);
-                return pos;
-            } else {
-                for (DateTimePrinterParser pp : printerParsers) {
-                    position = pp.parse(context, text, position);
-                    if (position < 0) {
-                        break;
-                    }
-                }
-                return position;
-            }
+            return parser.parse(context, text, position);
         }
 
         @Override

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4089,7 +4089,7 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
-            if(optional && !context.isSupported(field)) {
+            if (optional && !context.isSupported(field)) {
                 return false;
             }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeParseContext.java
@@ -120,7 +120,7 @@ final class DateTimeParseContext {
     DateTimeParseContext(DateTimeFormatter formatter) {
         super();
         this.formatter = formatter;
-        parsed.add(new Parsed());
+        parsed.add(new Parsed(formatter.onlyChronoField));
     }
 
     /**

--- a/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
@@ -176,7 +176,8 @@ final class DateTimePrinterParserFactory {
                .withMethodBody("format", MTD_format, ACC_PUBLIC | ACC_FINAL, cb -> {
                    int thisSlot    = cb.receiverSlot(),
                        contextSlot = cb.parameterSlot(0),
-                       bufSlot     = cb.parameterSlot(1);
+                       bufSlot     = cb.parameterSlot(1),
+                       parserSlot  = cb.allocateLocal(TypeKind.REFERENCE);
                    /*
                     * return printers[0].format(context, buf, optional)
                     *     && printers[1].format(context, buf, optional)
@@ -184,9 +185,11 @@ final class DateTimePrinterParserFactory {
                     *        ...
                     */
                    Label L0 = cb.newLabel(), L1 = cb.newLabel();
+                   cb.aload(thisSlot)
+                           .getfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                           .astore(parserSlot);
                    for (int i = 0; i < printers.length; ++i) {
-                       cb.aload(thisSlot)
-                         .getfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                       cb.aload(parserSlot)
                          .bipush(i)
                          .aaload()
                          .aload(contextSlot)
@@ -281,8 +284,10 @@ final class DateTimePrinterParserFactory {
                         int thisSlot     = cb.receiverSlot(),
                             contextSlot  = cb.parameterSlot(0),
                             textSlot     = cb.parameterSlot(1),
-                            positionSlot = cb.parameterSlot(2);
+                            positionSlot = cb.parameterSlot(2),
+                            parserSlot   = cb.allocateLocal(TypeKind.REFERENCE);
                         /*
+                         *  var printerParsers = this.printerParsers;
                          *  if ((position = printerParsers[0].parse(context, text, position)) >= 0) {
                          *      if ((position = printerParsers[1].parse(context, text, position)) >= 0) {
                          *          if ((position = printerParsers[2].parse(context, text, position)) >= 0) {
@@ -293,9 +298,11 @@ final class DateTimePrinterParserFactory {
                          * return position;
                          */
                         var L0 = cb.newLabel();
+                        cb.aload(thisSlot)
+                          .getfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                          .astore(parserSlot);
                         for (int i = 0; i < printers.length; ++i) {
-                            cb.aload(thisSlot)
-                              .getfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                            cb.aload(parserSlot)
                               .bipush(i)
                               .aaload()
                               .aload(contextSlot)

--- a/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.time.format;
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.constant.ConstantUtils;
+
+import java.lang.classfile.*;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.time.DateTimeException;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import static java.lang.classfile.ClassFile.*;
+import static java.lang.constant.ConstantDescs.*;
+import static java.time.format.DateTimeFormatterBuilder.DateTimePrinter;
+import static java.time.format.DateTimeFormatterBuilder.DateTimePrinterParser;
+import static java.time.format.DateTimeFormatterBuilder.DateTimeParser;
+
+/**
+ * A factory for creating specialized DateTimePrinter and DateTimeParser instances.
+ * This class generates optimized implementations of DateTimePrinter and DateTimeParser
+ * by dynamically creating classes at runtime using the ClassFile API to avoid loops
+ * when processing multiple DateTimePrinterParser instances.
+ *
+ * <p>The generated classes implement efficient formatting and parsing operations
+ * by unrolling loops into explicit sequences of calls, which allows the JVM's
+ * TypeProfile optimizer to be more effective.</p>
+ *
+ * <p>For small numbers of printer parsers, specialized classes are generated to
+ * provide optimal performance. For larger numbers, fallback implementations using
+ * loops are provided.</p>
+ *
+ */
+final class DateTimePrinterParserFactory {
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+    private static final AtomicReferenceArray<Constructor<?>> DATETIME_PRINTER_CONSTRUCTORS = new AtomicReferenceArray<>(32);
+    private static final AtomicReferenceArray<Constructor<?>> DATETIME_PARSER_CONSTRUCTORS = new AtomicReferenceArray<>(32);
+
+    private static final ClassDesc
+            CD_StringBuilder               = ClassDesc.ofDescriptor("Ljava/lang/StringBuilder;"),
+            CD_DateTimePrinter             = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$DateTimePrinter;"),
+            CD_DateTimePrintContext        = ClassDesc.ofDescriptor("Ljava/time/format/DateTimePrintContext;"),
+            CD_DateTimeParser              = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$DateTimeParser;"),
+            CD_DateTimeParseContext        = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeParseContext;"),
+            CD_DateTimePrinterParser       = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$DateTimePrinterParser;"),
+            CD_DateTimePrinterParser_array = ClassDesc.ofDescriptor("[Ljava/time/format/DateTimeFormatterBuilder$DateTimePrinterParser;"),
+            CD_CharSequence                = ClassDesc.ofDescriptor("Ljava/lang/CharSequence;");
+
+    private static final MethodTypeDesc
+            MTD_format                     = MethodTypeDesc.of(CD_boolean, CD_DateTimePrintContext, CD_StringBuilder, CD_boolean),
+            MTD_parse                      = MethodTypeDesc.of(CD_int, CD_DateTimeParseContext, CD_CharSequence, CD_int),
+            MTD_constructor                = MethodTypeDesc.of(CD_void, CD_DateTimePrinterParser_array);
+
+    private DateTimePrinterParserFactory() {
+    }
+
+    /**
+     * Creates a DateTimePrinter instance based on the provided printer parsers.
+     * For small numbers of printer parsers (up to 32), this method attempts to
+     * create a specialized class that unrolls the loop for better performance.
+     * For larger numbers, it creates a fallback implementation using a traditional loop.
+     *
+     * @param printers an array of DateTimePrinterParser instances to format
+     * @param optional whether the formatters are optional
+     * @return a DateTimePrinter that formats according to the provided printer parsers
+     * @throws DateTimeException if there's an issue instantiating the generated class
+     */
+    static DateTimePrinter createFormatter(DateTimePrinterParser[] printers, boolean optional) {
+        int length = printers.length;
+        if (length > DATETIME_PRINTER_CONSTRUCTORS.length()) {
+            return (context, buf, opt) -> {
+                for (var pp : printers) {
+                    if (!pp.format(context, buf, opt)) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+        }
+        var printerConstructor = DATETIME_PRINTER_CONSTRUCTORS.get(length - 1);
+        try {
+            if (printerConstructor == null) {
+                printerConstructor = generateFormatterClass(printers, optional)
+                        .getDeclaredConstructor(DateTimePrinterParser[].class);
+                DATETIME_PRINTER_CONSTRUCTORS.set(length - 1, printerConstructor);
+            }
+            return (DateTimePrinter) printerConstructor.newInstance(new Object[]{printers});
+        } catch (Exception e) {
+            throw new DateTimeException("Exception while instantiating the DateTimePrinter class", e);
+        }
+    }
+
+    /**
+     * Generates a specialized DateTimePrinter class based on the provided printer parsers.
+     * This method creates a dynamic class that unrolls the formatting loop for optimal
+     * performance. The generated class implements the format method by chaining calls
+     * to each individual printer parser using explicit conditional logic instead of loops.
+     *
+     * <p>The following is an example of the generated class structure:</p>
+     *
+     * <blockquote><pre>
+     *  class DateTimeFormatterBuilder$$Printer extends DateTimePrinter {
+     *      private final DateTimePrinterParser[] printerParsers;
+
+     *      public DateTimeFormatterBuilder$$Printer(DateTimePrinterParser[] printerParsers) {
+     *          this.printerParsers = printerParsers;
+     *      }
+     *
+     *      public boolean format(DateTimePrintContext context, StringBuilder buf, boolean optional) {
+     *          return printerParsers[0].format(context, buf, optional)
+     *              && printerParsers[1].format(context, buf, optional)
+     *              && printerParsers[2].format(context, buf, optional)
+     *                 ...;
+     *      }
+     *  }
+     *
+     * </pre></blockquote>
+     *
+     * @param printers an array of DateTimePrinterParser instances to format
+     * @param optional whether the formatters are optional
+     * @return a Class object representing the generated DateTimePrinter implementation
+     * @throws DateTimeException if there's an issue generating the class
+     */
+    static Class<?> generateFormatterClass(DateTimePrinterParser[] printers, boolean optional) {
+        var className = "java.time.format.DateTimeFormatterBuilder$$Printer";
+        var classDesc = ConstantUtils.binaryNameToDesc(className);
+        byte[] classBytes = ClassFile.of().build(classDesc, clb -> {
+            String fieldName = "printerParsers";
+            clb.withFlags(ACC_FINAL | ACC_SUPER | ACC_SYNTHETIC)
+               .withSuperclass(CD_Object)
+               .withInterfaces(clb.constantPool().classEntry(CD_DateTimePrinter))
+               .withField(fieldName, CD_DateTimePrinterParser_array, ACC_FINAL | ACC_PRIVATE)
+               .withMethodBody(INIT_NAME, MTD_constructor, ACC_PUBLIC, cb -> {
+                   int thisSlot    = cb.receiverSlot(),
+                       printerSlot = cb.parameterSlot(0);
+                   /*
+                    * super()
+                    */
+                   cb.aload(thisSlot)
+                     .invokespecial(CD_Object, INIT_NAME, MTD_void)
+                     /*
+                      * this.printerParser = printerParsers;
+                      */
+                     .aload(thisSlot)
+                     .aload(printerSlot)
+                     .putfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                     .return_();
+               })
+               .withMethodBody("format", MTD_format, ACC_PUBLIC | ACC_FINAL, cb -> {
+                   int thisSlot    = cb.receiverSlot(),
+                       contextSlot = cb.parameterSlot(0),
+                       bufSlot     = cb.parameterSlot(1);
+                   /*
+                    * return printers[0].format(context, buf, optional)
+                    *     && printers[1].format(context, buf, optional)
+                    *     && printers[2].format(context, buf, optional)
+                    *        ...
+                    */
+                   Label L0 = cb.newLabel(), L1 = cb.newLabel();
+                   for (int i = 0; i < printers.length; ++i) {
+                       cb.aload(thisSlot)
+                         .getfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                         .bipush(i)
+                         .aaload()
+                         .aload(contextSlot)
+                         .aload(bufSlot);
+                       if (optional) {
+                           cb.iconst_1();
+                       } else {
+                           cb.iconst_0();
+                       }
+                       cb.invokeinterface(CD_DateTimePrinterParser, "format", MTD_format)
+                         .ifeq(L0);
+                   }
+                   cb.iconst_1()
+                     .goto_(L1)
+                     .labelBinding(L0)
+                     .iconst_0()
+                     .labelBinding(L1)
+                     .ireturn();
+               });
+        });
+        try {
+            var lookupClass = MethodHandles.lookup().lookupClass();
+            var loader      = lookupClass.getClassLoader();
+            var pd          = (loader != null) ? JLA.protectionDomain(lookupClass) : null;
+            return JLA.defineClass(loader, lookupClass, className, classBytes, pd, true, ACC_FINAL | ACC_PRIVATE | ACC_STATIC, null);
+        } catch (Exception e) {
+            throw new DateTimeException("Exception while spinning the DateTimePrinter class", e);
+        }
+    }
+
+    /**
+     * Generates a specialized DateTimeParser class based on the provided printer parsers.
+     * This method creates a dynamic class that unrolls the parsing loop for optimal
+     * performance. The generated class implements the parse method by chaining calls
+     * to each individual printer parser using explicit conditional logic instead of loops.
+     *
+     * <p>The following is an example of the generated class structure:</p>
+     *
+     * <blockquote><pre>
+     *  class DateTimeFormatterBuilder$$Parser extends DateTimeParser {
+     *      private final DateTimePrinterParser[] printerParsers;
+     *
+     *      public DateTimeFormatterBuilder$$Parser(DateTimePrinterParser[] printerParsers) {
+     *          this.printerParsers = printerParsers;
+     *      }
+     *
+     *      public int parse(DateTimeParseContext context, CharSequence text, int position) {
+     *          if ((position = printerParsers[0].parse(context, text, position)) >= 0) {
+     *              if ((position = printerParsers[1].parse(context, text, position)) >= 0) {
+     *                  if ((position = printerParsers[2].parse(context, text, position)) >= 0) {
+     *                      ...
+     *                  }
+     *              }
+     *          }
+     *          return position;
+     *      }
+     *  }
+     *
+     * </pre></blockquote>
+     *
+     * @param printers an array of DateTimePrinterParser instances to parse
+     * @param optional whether the parsers are optional
+     * @return a Class object representing the generated DateTimeParser implementation
+     * @throws DateTimeException if there's an issue generating the class
+     */
+    static Class<?> generateParserClass(DateTimePrinterParser[] printers, boolean optional) {
+        var className = "java.time.format.DateTimeFormatterBuilder$$Parser";
+        var classDesc = ConstantUtils.binaryNameToDesc(className);
+        byte[] classBytes = ClassFile.of().build(classDesc, clb -> {
+            String fieldName = "printerParsers";
+            clb.withFlags(ACC_FINAL | ACC_SUPER | ACC_SYNTHETIC)
+               .withSuperclass(CD_Object)
+               .withInterfaces(clb.constantPool().classEntry(CD_DateTimeParser))
+               .withField(fieldName, CD_DateTimePrinterParser_array, ACC_FINAL | ACC_PRIVATE)
+               .withMethodBody(INIT_NAME, MTD_constructor, ACC_PUBLIC, cb -> {
+                    int thisSlot    = cb.receiverSlot(),
+                        parsersSlot = cb.parameterSlot(0);
+                    /*
+                     * super()
+                     */
+                    cb.aload(thisSlot)
+                      .invokespecial(CD_Object, INIT_NAME, MTD_void)
+                      /*
+                       * this.printerParser = printerParsers;
+                       */
+                      .aload(thisSlot)
+                      .aload(parsersSlot)
+                      .putfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                      .return_();
+               })
+               .withMethodBody("parse", MTD_parse, ACC_PUBLIC | ACC_FINAL, cb -> {
+                        int thisSlot     = cb.receiverSlot(),
+                            contextSlot  = cb.parameterSlot(0),
+                            textSlot     = cb.parameterSlot(1),
+                            positionSlot = cb.parameterSlot(2);
+                        /*
+                         *  if ((position = printerParsers[0].parse(context, text, position)) >= 0) {
+                         *      if ((position = printerParsers[1].parse(context, text, position)) >= 0) {
+                         *          if ((position = printerParsers[2].parse(context, text, position)) >= 0) {
+                         *              ...
+                         *          }
+                         *      }
+                         * }
+                         * return position;
+                         */
+                        var L0 = cb.newLabel();
+                        for (int i = 0; i < printers.length; ++i) {
+                            cb.aload(thisSlot)
+                              .getfield(classDesc, fieldName, CD_DateTimePrinterParser_array)
+                              .bipush(i)
+                              .aaload()
+                              .aload(contextSlot)
+                              .aload(textSlot)
+                              .iload(positionSlot)
+                              .invokeinterface(CD_DateTimePrinterParser, "parse", MTD_parse)
+                              .dup()
+                              .istore(positionSlot)
+                              .iflt(L0);
+                        }
+                        cb.labelBinding(L0)
+                          .iload(positionSlot)
+                          .ireturn();
+                    });
+        });
+        try {
+            var lookupClass = MethodHandles.lookup().lookupClass();
+            var loader      = lookupClass.getClassLoader();
+            var pd          = (loader != null) ? JLA.protectionDomain(lookupClass) : null;
+            return JLA.defineClass(loader, lookupClass, className, classBytes, pd, true, ACC_FINAL | ACC_PRIVATE | ACC_STATIC, null);
+        } catch (Exception e) {
+            throw new DateTimeException("Exception while spinning the DateTimePrinter class", e);
+        }
+    }
+
+    /**
+     * Creates a DateTimeParser instance based on the provided printer parsers.
+     * For small numbers of printer parsers (up to 32), this method attempts to
+     * create a specialized class that unrolls the loop for better performance.
+     * For larger numbers, it creates a fallback implementation using a traditional loop.
+     * If the optional flag is true, the returned parser is wrapped with optional handling logic.
+     *
+     * @param printerParsers an array of DateTimePrinterParser instances to parse
+     * @param optional whether the parsers are optional
+     * @return a DateTimeParser that parses according to the provided printer parsers
+     * @throws DateTimeException if there's an issue instantiating the generated class
+     */
+    static DateTimeParser createParser(DateTimePrinterParser[] printerParsers, boolean optional) {
+        int length = printerParsers.length;
+        DateTimeParser parser;
+        if (length > DATETIME_PRINTER_CONSTRUCTORS.length()) {
+            parser = (context, text, position) -> {
+                for (var pp : printerParsers) {
+                    position = pp.parse(context, text, position);
+                    if (position < 0) {
+                        break;
+                    }
+                }
+                return position;
+            };
+        } else {
+            var parserConstructor = DATETIME_PARSER_CONSTRUCTORS.get(length - 1);
+            try {
+                if (parserConstructor == null) {
+                    parserConstructor = generateParserClass(printerParsers, optional)
+                            .getDeclaredConstructor(DateTimePrinterParser[].class);
+                    DATETIME_PARSER_CONSTRUCTORS.set(length - 1, parserConstructor);
+                }
+                parser = (DateTimeParser) parserConstructor.newInstance(new Object[]{printerParsers});
+            } catch (Exception e) {
+                throw new DateTimeException("Exception while instantiating the DateTimeParser class", e);
+            }
+        }
+
+        if (!optional) {
+            return parser;
+        }
+        // Wrap the parser with optional handling logic
+        return (context, text, position) -> {
+            context.startOptional();
+            int pos = position;
+            pos = parser.parse(context, text, pos);
+            if (pos < 0) {
+                context.endOptional(false);
+                return position;  // return original position
+            }
+            context.endOptional(true);
+            return pos;
+        };
+    }
+}

--- a/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
@@ -94,7 +94,7 @@ final class DateTimePrinterParserFactory {
      */
     static DateTimePrinter createFormatter(DateTimePrinterParser[] printers, boolean optional) {
         int length = printers.length;
-        if (length > DATETIME_PRINTER_CONSTRUCTORS.length()) {
+        if (length == 0 || length > DATETIME_PRINTER_CONSTRUCTORS.length()) {
             return (context, buf, opt) -> {
                 for (var pp : printers) {
                     if (!pp.format(context, buf, opt)) {
@@ -174,10 +174,11 @@ final class DateTimePrinterParserFactory {
                      .return_();
                })
                .withMethodBody("format", MTD_format, ACC_PUBLIC | ACC_FINAL, cb -> {
-                   int thisSlot    = cb.receiverSlot(),
-                       contextSlot = cb.parameterSlot(0),
-                       bufSlot     = cb.parameterSlot(1),
-                       parserSlot  = cb.allocateLocal(TypeKind.REFERENCE);
+                   int thisSlot     = cb.receiverSlot(),
+                       contextSlot  = cb.parameterSlot(0),
+                       bufSlot      = cb.parameterSlot(1),
+                       optionalSlot = cb.parameterSlot(2),
+                       parserSlot   = cb.allocateLocal(TypeKind.REFERENCE);
                    /*
                     * return printers[0].format(context, buf, optional)
                     *     && printers[1].format(context, buf, optional)
@@ -193,13 +194,9 @@ final class DateTimePrinterParserFactory {
                          .bipush(i)
                          .aaload()
                          .aload(contextSlot)
-                         .aload(bufSlot);
-                       if (optional) {
-                           cb.iconst_1();
-                       } else {
-                           cb.iconst_0();
-                       }
-                       cb.invokeinterface(CD_DateTimePrinterParser, "format", MTD_format)
+                         .aload(bufSlot)
+                         .iload(optionalSlot)
+                         .invokeinterface(CD_DateTimePrinterParser, "format", MTD_format)
                          .ifeq(L0);
                    }
                    cb.iconst_1()
@@ -344,7 +341,7 @@ final class DateTimePrinterParserFactory {
     static DateTimeParser createParser(DateTimePrinterParser[] printerParsers, boolean optional) {
         int length = printerParsers.length;
         DateTimeParser parser;
-        if (length > DATETIME_PRINTER_CONSTRUCTORS.length()) {
+        if (length == 0 || length > DATETIME_PRINTER_CONSTRUCTORS.length()) {
             parser = (context, text, position) -> {
                 for (var pp : printerParsers) {
                     position = pp.parse(context, text, position);

--- a/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrinterParserFactory.java
@@ -211,13 +211,17 @@ final class DateTimePrinterParserFactory {
                });
         });
         try {
-            var lookupClass = MethodHandles.lookup().lookupClass();
-            var loader      = lookupClass.getClassLoader();
-            var pd          = (loader != null) ? JLA.protectionDomain(lookupClass) : null;
-            return JLA.defineClass(loader, lookupClass, className, classBytes, pd, true, ACC_FINAL | ACC_PRIVATE | ACC_STATIC, null);
+            return defineClass(className, classBytes);
         } catch (Exception e) {
             throw new DateTimeException("Exception while spinning the DateTimePrinter class", e);
         }
+    }
+
+    private static Class<?> defineClass(String className, byte[] classBytes) {
+        var lookupClass = MethodHandles.lookup().lookupClass();
+        var loader      = lookupClass.getClassLoader();
+        var pd          = (loader != null) ? JLA.protectionDomain(lookupClass) : null;
+        return JLA.defineClass(loader, lookupClass, className, classBytes, pd, true, ACC_FINAL | ACC_PRIVATE | ACC_STATIC, null);
     }
 
     /**
@@ -319,10 +323,7 @@ final class DateTimePrinterParserFactory {
                     });
         });
         try {
-            var lookupClass = MethodHandles.lookup().lookupClass();
-            var loader      = lookupClass.getClassLoader();
-            var pd          = (loader != null) ? JLA.protectionDomain(lookupClass) : null;
-            return JLA.defineClass(loader, lookupClass, className, classBytes, pd, true, ACC_FINAL | ACC_PRIVATE | ACC_STATIC, null);
+            return defineClass(className, classBytes);
         } catch (Exception e) {
             throw new DateTimeException("Exception while spinning the DateTimePrinter class", e);
         }

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -750,9 +750,9 @@ final class Parsed implements TemporalAccessor {
     }
 
     private void resolveInstant0() {
-        Long offsetSecs = fieldValues.get(OFFSET_SECONDS);
-        if (offsetSecs != null) {
-            ZoneOffset offset = ZoneOffset.ofTotalSeconds(offsetSecs.intValue());
+        if (fieldValues.containsKey(OFFSET_SECONDS)) {
+            long offsetSecs = fieldValues.get(OFFSET_SECONDS);
+            ZoneOffset offset = ZoneOffset.ofTotalSeconds((int) offsetSecs);
             long instant = date.atTime(time).atZone(offset).toEpochSecond();
             fieldValues.put(INSTANT_SECONDS, instant);
         } else {
@@ -800,7 +800,7 @@ final class Parsed implements TemporalAccessor {
         }
         if (time != null) {
             crossCheck(time);
-            if (date != null && fieldValues.size() > 0) {
+            if (date != null && !fieldValues.isEmpty()) {
                 crossCheck(date.atTime(time));
             }
         }

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +129,7 @@ final class Parsed implements TemporalAccessor {
     /**
      * The parsed fields.
      */
-    final Map<TemporalField, Long> fieldValues = new HashMap<>();
+    final Map<TemporalField, Long> fieldValues;
     /**
      * The parsed zone.
      */
@@ -169,7 +170,12 @@ final class Parsed implements TemporalAccessor {
     /**
      * Creates an instance.
      */
-    Parsed() {
+    @SuppressWarnings("unchecked")
+    Parsed(boolean onlyChronoField) {
+        // Create the EnumMap with raw types and cast it appropriately
+        // This is safe because ChronoField implements TemporalField
+        fieldValues = onlyChronoField ? (Map<TemporalField, Long>) (Map) new ChronoFieldMap()
+                : new HashMap<>();
     }
 
     /**
@@ -177,7 +183,7 @@ final class Parsed implements TemporalAccessor {
      */
     Parsed copy() {
         // only copy fields used in parsing stage
-        Parsed cloned = new Parsed();
+        Parsed cloned = new Parsed((Map) fieldValues instanceof ChronoFieldMap);
         cloned.fieldValues.putAll(this.fieldValues);
         cloned.zone = this.zone;
         cloned.zoneNameType = this.zoneNameType;

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time.format;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Locale;
+import java.util.Random;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Thread)
+public class DateTimeFormatterParse {
+    static final DateTimeFormatter formatterLocalTime = DateTimeFormatter.ofPattern("HH:mm:ss");
+    static final DateTimeFormatter formatterLocalTimeWithNano = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+    static final DateTimeFormatter formatterLocalDate = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    static final DateTimeFormatter formatterLocalDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    static final DateTimeFormatter formatterLocalDateTimeWithNano = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    static final DateTimeFormatter formatterOffsetDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ");
+    static final DateTimeFormatter formatterZonedDateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ'['VV']'");
+
+    static final String STR_LOCALTIME = "21:11:48";
+    static final String STR_LOCALTIME_WITH_NANO = "21:11:48.456";
+    static final String STR_LOCALDATE = "2024-08-01";
+    static final String STR_LOCALDATETIME = "2024-08-01T21:11:48";
+    static final String STR_LOCALDATETIME_WITH_NANO = "2024-08-01T21:11:48.456";
+    static final String STR_INSTANT = "2024-08-12T03:25:54.980339Z";
+    static final String STR_OFFSETDATETIME = "2024-08-12T11:50:46.731509+08:00";
+    static final String STR_ZONEDDATETIME = "2024-08-12T11:50:46.731509+08:00[Asia/Shanghai]";
+
+    @Benchmark
+    public LocalTime parseLocalTime() {
+        return LocalTime.parse(STR_LOCALTIME, formatterLocalTime);
+    }
+
+    @Benchmark
+    public LocalTime parseLocalTimeWithNano() {
+        return LocalTime.parse(STR_LOCALTIME_WITH_NANO, formatterLocalTimeWithNano);
+    }
+
+    @Benchmark
+    public LocalDate parseLocalDate() {
+        return LocalDate.parse(STR_LOCALDATE, formatterLocalDate);
+    }
+
+    @Benchmark
+    public LocalDateTime parseLocalDateTime() {
+        return LocalDateTime.parse(STR_LOCALDATETIME, formatterLocalDateTime);
+    }
+
+    @Benchmark
+    public LocalDateTime parseLocalDateTimeWithNano() {
+        return LocalDateTime.parse(STR_LOCALDATETIME_WITH_NANO, formatterLocalDateTimeWithNano);
+    }
+
+    @Benchmark
+    public OffsetDateTime parseOffsetDateTime() {
+        return OffsetDateTime.parse(STR_OFFSETDATETIME, formatterOffsetDateTime);
+    }
+
+    @Benchmark
+    public ZonedDateTime parseZonedDateTime() {
+        return ZonedDateTime.parse(STR_ZONEDDATETIME, formatterZonedDateTime);
+    }
+
+    @Benchmark
+    public Instant parseInstant() {
+        return Instant.parse(STR_INSTANT);
+    }
+}


### PR DESCRIPTION
This PR demonstrates the potential for performance optimizations in java.time.format.DateTimeFormatter parse and format.

It will be submitted as multiple smaller PRs. includes #28471

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28790/head:pull/28790` \
`$ git checkout pull/28790`

Update a local copy of the PR: \
`$ git checkout pull/28790` \
`$ git pull https://git.openjdk.org/jdk.git pull/28790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28790`

View PR using the GUI difftool: \
`$ git pr show -t 28790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28790.diff">https://git.openjdk.org/jdk/pull/28790.diff</a>

</details>
