### PR TITLE
8373625: CPUTimeCounters creates a total counter for unsupported GCs

### DIFF
--- a/src/hotspot/share/runtime/cpuTimeCounters.hpp
+++ b/src/hotspot/share/runtime/cpuTimeCounters.hpp
@@ -28,6 +28,7 @@
 #define SHARE_RUNTIME_CPUTIMECOUNTERS_HPP
 
 
+#include "gc/shared/gc_globals.hpp"
 #include "memory/iterator.hpp"
 #include "runtime/os.hpp"
 #include "runtime/perfData.hpp"
@@ -83,7 +84,9 @@ public:
     assert(_instance == nullptr, "we can only allocate one CPUTimeCounters object");
     if (UsePerfData && os::is_thread_cpu_time_supported()) {
       _instance = new CPUTimeCounters();
-      create_counter(SUN_THREADS, CPUTimeGroups::CPUTimeType::gc_total);
+      if (UseG1GC || UseParallelGC) {
+        create_counter(SUN_THREADS, CPUTimeGroups::CPUTimeType::gc_total);
+      }
     }
   }
 


### PR DESCRIPTION
`CPUTimeCounters` unconditionally creates `CPUTimeGroups::CPUTimeType::gc_total`. Since only Parallel and G1 are supported by this framework/class, this leads to publishing a counter that always resolves to 0. This may be contradictory for an end-user especially so as we now support logging GC CPU time for any GC inside Hotspot. For an example using `-XX:+UseZGC -Xlog:cpu` we get

```
[7.907s][info][cpu] === CPU time Statistics =============================================================
[7.907s][info][cpu]                                                                             CPUs
[7.907s][info][cpu]                                                                s       %  utilized
[7.907s][info][cpu]    Process
[7.907s][info][cpu]      Total                                              186.9562  100.00      23.6
[7.907s][info][cpu]      Garbage Collection                                   0.6700    0.36       0.1
[7.907s][info][cpu]        GC Threads                                         0.6692    0.36       0.1
[7.907s][info][cpu]        VM Thread                                          0.0008    0.00       0.0
[7.907s][info][cpu] =====================================================================================
```

But `jcmd $(pgrep -n java) PerfCounter.print | grep -E "sun.threads.total_gc_cpu_time"` prints: `sun.threads.total_gc_cpu_time=0`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373625](https://bugs.openjdk.org/browse/JDK-8373625): CPUTimeCounters creates a total counter for unsupported GCs (**Bug** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28803/head:pull/28803` \
`$ git checkout pull/28803`

Update a local copy of the PR: \
`$ git checkout pull/28803` \
`$ git pull https://git.openjdk.org/jdk.git pull/28803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28803`

View PR using the GUI difftool: \
`$ git pr show -t 28803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28803.diff">https://git.openjdk.org/jdk/pull/28803.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28803#issuecomment-3648233049)
</details>
