### PR TITLE
8373696: AArch64: Refine post-call NOPs

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -168,7 +168,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
     offset >>= 2;
     starti;
     f(0, 31), f(offset_lo, 30, 29), f(0b10000, 28, 24), sf(offset, 23, 5);
-    rf(Rd, 0);
+    zrf(Rd, 0);
   }
 
   void Assembler::_adrp(Register Rd, address adr) {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -356,6 +356,16 @@ void Assembler::wrap_label(Register r, Label &L,
   }
 }
 
+void Assembler::wrap_label(FloatRegister r, Label &L,
+                           fp_memory_access_insn insn) {
+  if (L.is_bound()) {
+    (this->*insn)(r, target(L));
+  } else {
+    L.add_patch_at(code(), locator());
+    (this->*insn)(r, pc());
+  }
+}
+
 void Assembler::wrap_label(Register r, int bitpos, Label &L,
                                  test_and_branch_insn insn) {
   if (L.is_bound()) {

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.hpp
@@ -33,13 +33,6 @@ friend class ArrayCopyStub;
 
   int array_element_size(BasicType type) const;
 
-  // helper functions which checks for overflow and sets bailout if it
-  // occurs.  Always returns a valid embeddable pointer but in the
-  // bailout case the pointer won't be to unique storage.
-  address float_constant(float f);
-  address double_constant(double d);
-
-  address int_constant(jlong n);
 
   bool is_literal_address(LIR_Address* addr);
 

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -127,6 +127,9 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Branch Protection to use: none, standard, pac-ret")          \
   product(bool, AlwaysMergeDMB, true, DIAGNOSTIC,                       \
           "Always merge DMB instructions in code emission")             \
+  product(bool, UsePostCallSequenceWithADRP, false,                     \
+          "Use ADRP/ADR to store metadata within post-call NOP "        \
+          "instruction sequences.")
 
 // end of ARCH_FLAGS
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -496,7 +496,10 @@ public:
   // first two private routines for loading 32 bit or 64 bit constants
 private:
 
-  void mov_immediate64(Register dst, uint64_t imm64);
+  template<bool count_only>
+  int mov_immediate64(Register dst, uint64_t imm64);
+  int mov_immediate64_insts_count(Register dst, uint64_t imm64);
+  int mov_immediate64(Register dst, uint64_t imm64);
   void mov_immediate32(Register dst, uint32_t imm32);
 
   int push(unsigned int bitset, Register stack);

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -394,23 +395,88 @@ void NativePostCallNop::make_deopt() {
   NativeDeoptInstruction::insert(addr_at(0));
 }
 
-bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset) {
-  if (((oopmap_slot & 0xff) != oopmap_slot) || ((cb_offset & 0xffffff) != cb_offset)) {
-    return false; // cannot encode
-  }
-  uint32_t data = ((uint32_t)oopmap_slot << 24) | cb_offset;
+template<typename Variant>
+bool NativePostCallNop::patch_helper(int32_t oopmap_slot, int32_t cb_offset) {
+  constexpr size_t block_size = HeapBlock::minimum_alignment();
+  const int32_t cb_offset_to_segment = cb_offset + CodeHeap::header_size();
+  const int32_t cb_blocks_offset = cb_offset_to_segment / block_size;
+
+  const uint32_t chunk1 = *(uint32_t*)addr_at(first_check_size);
+  uint32_t data1 = Variant::extract_metadata(chunk1);
+
+  const uint32_t chunks_count = Variant::two_chunks_flag.extract(data1) + 1;
 #ifdef ASSERT
-  assert(data != 0, "must be");
-  uint32_t insn1 = uint_at(4);
-  uint32_t insn2 = uint_at(8);
-  assert (is_movk_to_zr(insn1) && is_movk_to_zr(insn2), "must be");
+  const uint32_t req_chunks_count = metadata_chunks_count<Variant>(cb_offset);
+
+  assert(block_size <= CodeCacheSegmentSize, "incorrect block size value");
+
+  uintptr_t code_blob_address = (uintptr_t) this - cb_offset;
+  uint32_t code_blob_offset_from_segment = code_blob_address % block_size;
+  assert(CodeHeap::header_size() == code_blob_offset_from_segment, "unexpected offset value");
+
+  bool is_empty;
+
+  if (chunks_count == 1) {
+    is_empty = (data1 == 0);
+    assert(req_chunks_count == 1, "one metadata chunk is sufficient");
+  } else {
+    assert(req_chunks_count <= 2, "two metadata chunks are sufficient");
+    assert(chunks_count == 2, "unexpected number of chunks");
+
+    const uint32_t chunk2_offset = first_check_size + NativeInstruction::instruction_size;
+    const uint32_t chunk2 = *(uint32_t*)addr_at(chunk2_offset);
+    uint32_t data2 = Variant::extract_metadata(chunk2);
+
+    is_empty = (data1 == 1 && data2 == 0);
+  }
+
+  if (!is_empty) {
+    // If not empty, it can be a copy of the nmethod, in which case the
+    // contents should already match the values requested from this method.
+    verify(cb_offset, oopmap_slot);
+  }
 #endif
 
-  uint32_t lo = data & 0xffff;
-  uint32_t hi = data >> 16;
-  Instruction_aarch64::patch(addr_at(4), 20, 5, lo);
-  Instruction_aarch64::patch(addr_at(8), 20, 5, hi);
+  uint64_t data = Variant::two_chunks_flag.insert(0, chunks_count - 1);
+
+  if (chunks_count == 1) {
+    if (!pack<typename Variant::one_chunk>(/* output */ data,
+                                           oopmap_slot, cb_blocks_offset)) {
+      return false;
+    }
+  } else {
+    if (!pack<typename Variant::two_chunks>(/* output */ data,
+                                            oopmap_slot, cb_blocks_offset)) {
+      return false;
+    }
+  }
+
+#ifdef ASSERT
+  const uint32_t metadata_bits_count = chunks_count * Variant::metadata_chunk_width;
+  const uint64_t metadata_mask = (1ull << metadata_bits_count) - 1;
+  assert((data & metadata_mask) == data, "insufficient metadata bits");
+#endif
+
+  address addr = addr_at(first_check_size);
+
+  data = Variant::patch_chunk(addr, data);
+
+  if (chunks_count == 2) {
+    data = Variant::patch_chunk(addr + NativeInstruction::instruction_size, data);
+  }
+
+  verify(cb_offset, oopmap_slot);
+
   return true; // successfully encoded
+}
+
+bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset) {
+  const uint32_t chunk = *(uint32_t*)addr_at(first_check_size);
+  if (VariantADR::is_match(chunk)) {
+    return patch_helper<VariantADR>(oopmap_slot, cb_offset);
+  } else {
+    return patch_helper<VariantMOV>(oopmap_slot, cb_offset);
+  }
 }
 
 void NativeDeoptInstruction::verify() {

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2025, Red Hat Inc. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +28,7 @@
 #define CPU_AARCH64_NATIVEINST_AARCH64_HPP
 
 #include "asm/assembler.hpp"
+#include "memory/heap.hpp"
 #include "runtime/icache.hpp"
 #include "runtime/os.hpp"
 #include "runtime/os.hpp"
@@ -518,52 +520,313 @@ inline NativeLdSt* NativeLdSt_at(address addr) {
   return (NativeLdSt*)addr;
 }
 
-// A NativePostCallNop takes the form of three instructions:
-//     nop; movk zr, lo; movk zr, hi
+// A NativePostCallNop takes the form of NOP followed by one or two instruction
+// slots holding metadata chunks represented as instructions with no side
+// effects.
 //
-// The nop is patchable for a deoptimization trap. The two movk
-// instructions execute as nops but have a 16-bit payload in which we
-// can store an offset from the initial nop to the nmethod.
+// The options are:
+//   - variant MOV
+//     - nop; movk zr, metadata (18-bit payload)
+//     - nop; movz zr, metadata_lo; movk/movz zr, metadata_hi (37-bit payload)
+//   - variant ADR
+//     - nop; adr zr, metadata (21-bit payload)
+//     - nop; adrp zr, metadata_lo; adr/adrp zr, metadata_hi (43-bit payload)
+//
+// The nop is patchable for a deoptimization trap. The subsequent movk/movz/adr/adrp
+// execute as nops but contain metadata payload.
+//
+// The metadata layout is as follows:
+//  - 1-bit field indicating whether one or two metadata chunks are present;
+//  - cb_blocks_offset (9 or 19 bits for MOV variant; 11 or 22 bits for ADR variant)
+//   - offset from the start of the code heap's space allocated for the method,
+//     in HeapBlock::minimum_alignment() blocks.
+//  - oopmap_slot (9 or 18 bits for MOV variant; 10 or 21 bits for ADR variant)
+//
+// The metadata layout for these options is described via VariantMOV / VariantADR helpers,
+// which also provide variant-specific implementation for matching format, extracting and
+// patching metadata.
+class NativePostCallNopMetadataField {
+public:
+  constexpr NativePostCallNopMetadataField(uint32_t shift, uint32_t width)
+    : _shift(shift), _width(width), _mask((1ull << width) - 1) {
+    assert(_shift + _width <= sizeof(uint64_t) * BitsPerByte, "overflow");
+  }
+
+  constexpr NativePostCallNopMetadataField(NativePostCallNopMetadataField previous_field, uint32_t width)
+    : NativePostCallNopMetadataField(previous_field.end_pos(), width) {}
+
+  constexpr uint32_t end_pos() const {
+    return _shift + _width;
+  }
+
+  constexpr bool can_hold(int32_t value) const {
+    return (static_cast<int32_t>(value & _mask) == value);
+  }
+
+  constexpr uint64_t extract(uint64_t data) const {
+    return ((data >> _shift) & _mask);
+  }
+
+  constexpr uint64_t insert(uint64_t data, uint32_t value) const {
+    return data | ((uint64_t) value << _shift);
+  }
+
+private:
+  const uint32_t _shift;
+  const uint32_t _width;
+  const uint64_t _mask;
+};
 
 class NativePostCallNop: public NativeInstruction {
 private:
-  static bool is_movk_to_zr(uint32_t insn) {
-    return ((insn & 0xffe0001f) == 0xf280001f);
+  struct VariantADR {
+    static constexpr uint32_t metadata_chunk_width = 22;
+
+    static constexpr NativePostCallNopMetadataField two_chunks_flag { 0, 1 };
+
+    struct one_chunk {
+      static constexpr NativePostCallNopMetadataField cb_blocks_offset { two_chunks_flag, 11 };
+      static constexpr NativePostCallNopMetadataField oopmap_slot { cb_blocks_offset, 10 };
+      static_assert(oopmap_slot.end_pos() == metadata_chunk_width,
+                    "Should take exactly the width of one metadata chunk.");
+    };
+
+    struct two_chunks {
+      static constexpr NativePostCallNopMetadataField cb_blocks_offset { two_chunks_flag, 22 };
+      static constexpr NativePostCallNopMetadataField oopmap_slot { cb_blocks_offset, 21 };
+      static_assert(oopmap_slot.end_pos() == 2 * metadata_chunk_width,
+                    "Should take exactly the width of two metadata chunks.");
+    };
+
+    static bool is_match(uint32_t chunk, bool assertion = true) {
+      // Metadata chunks are in form of ADRP/ADR XZR, <data>.
+      bool matches = ((chunk & 0x1f00001f) == 0x1000001f);
+      if (assertion) {
+        assert(matches == UsePostCallSequenceWithADRP, "mismatch with configuration");
+      }
+      return matches;
+    }
+
+    static uint32_t extract_metadata(uint32_t chunk) {
+      uint32_t field1 = Instruction_aarch64::extract(chunk, 31, 31);
+      uint32_t field2 = Instruction_aarch64::extract(chunk, 30, 29);
+      uint32_t field3 = Instruction_aarch64::extract(chunk, 23, 5);
+
+      uint32_t data = field3;
+      data <<= 2;
+      data |= field2;
+      data <<= 1;
+      data |= field1;
+
+      return data;
+    }
+
+    static uint64_t patch_chunk(address addr, uint64_t data) {
+      uint32_t field1 = data & 1;
+      data >>= 1;
+      uint32_t field2 = data & 3;
+      data >>= 2;
+      uint32_t field3 = data & 0x7ffff;
+      data >>= 19;
+
+      Instruction_aarch64::patch(addr, 31, 31, field1);
+      Instruction_aarch64::patch(addr, 30, 29, field2);
+      Instruction_aarch64::patch(addr, 23, 5, field3);
+
+      return data;
+    }
+  };
+
+  struct VariantMOV {
+    static constexpr uint32_t metadata_chunk_width = 19;
+
+    static constexpr NativePostCallNopMetadataField two_chunks_flag { 0, 1 };
+
+    struct one_chunk {
+      static constexpr NativePostCallNopMetadataField cb_blocks_offset { two_chunks_flag, 9 };
+      static constexpr NativePostCallNopMetadataField oopmap_slot { cb_blocks_offset, 9 };
+      static_assert(oopmap_slot.end_pos() == metadata_chunk_width,
+                    "Should take exactly the width of one metadata chunk.");
+    };
+
+    struct two_chunks {
+      static constexpr NativePostCallNopMetadataField cb_blocks_offset { two_chunks_flag, 19 } ;
+      static constexpr NativePostCallNopMetadataField oopmap_slot { cb_blocks_offset, 18 };
+      static_assert(oopmap_slot.end_pos() == 2 * metadata_chunk_width,
+                    "Should take exactly the width of two metadata chunks.");
+    };
+
+    static bool is_match(uint32_t chunk, bool assertion = true) {
+      // Metadata chunks are in form of MOVK/MOVZ XZR, <data>.
+      bool matches = ((chunk & 0xdf80001f) == 0xd280001f);
+      if (assertion) {
+        assert(matches == !UsePostCallSequenceWithADRP, "mismatch with configuration");
+      }
+      return matches;
+    }
+
+    static uint32_t extract_metadata(uint32_t chunk) {
+      uint32_t field1 = Instruction_aarch64::extract(chunk, 29, 29) ^ 1;
+      uint32_t field2 = Instruction_aarch64::extract(chunk, 22, 21);
+      uint32_t field3 = Instruction_aarch64::extract(chunk, 20, 5);
+
+      uint32_t data = field3;
+      data <<= 2;
+      data |= field2;
+      data <<= 1;
+      data |= field1;
+
+      return data;
+    }
+
+    static uint64_t patch_chunk(address addr, uint64_t data) {
+      uint32_t field1 = data & 1;
+      data >>= 1;
+      uint32_t field2 = data & 3;
+      data >>= 2;
+      uint32_t field3 = data & 0xffff;
+      data >>= 16;
+
+      Instruction_aarch64::patch(addr, 29, 29, field1 ^ 1);
+      Instruction_aarch64::patch(addr, 22, 21, field2);
+      Instruction_aarch64::patch(addr, 20, 5, field3);
+
+      return data;
+    }
+  };
+
+  template<typename FieldsDescription>
+  static bool unpack(uint64_t data, int32_t& oopmap_slot, int32_t& cb_blocks_offset) {
+    oopmap_slot = FieldsDescription::oopmap_slot.extract(data);
+    cb_blocks_offset = FieldsDescription::cb_blocks_offset.extract(data);
+
+    if (cb_blocks_offset == 0) {
+      if (oopmap_slot == 0) {
+        return false; // no information stored
+      }
+
+      oopmap_slot--;
+    }
+
+    return true;
+  }
+
+  template<typename FieldsDescription>
+  static bool pack(uint64_t& data, int32_t oopmap_slot, int32_t cb_blocks_offset) {
+    if (!FieldsDescription::cb_blocks_offset.can_hold(cb_blocks_offset)) {
+      return false;
+    }
+
+    if (cb_blocks_offset == 0) {
+      // Distinguish from the case when the fields are empty.
+      oopmap_slot++;
+    }
+
+    if (!FieldsDescription::oopmap_slot.can_hold(oopmap_slot)) {
+      return false;
+    }
+
+    data = FieldsDescription::cb_blocks_offset.insert(data, cb_blocks_offset);
+    data = FieldsDescription::oopmap_slot.insert(data, oopmap_slot);
+
+    return true;
+  }
+
+  template<typename Variant>
+  bool patch_helper(int32_t oopmap_slot, int32_t cb_offset);
+
+  void verify(int32_t cb_offset, int32_t oopmap_slot) const {
+    int32_t test_oopmap_slot;
+    int32_t test_cb_offset;
+    assert(decode(test_oopmap_slot, test_cb_offset), "unpacking values failed");
+    assert(test_oopmap_slot == oopmap_slot, "oopmap_slot mismatch");
+    assert(test_cb_offset == cb_offset, "cb_offset mismatch");
   }
 
 public:
   enum AArch64_specific_constants {
     // The two parts should be checked separately to prevent out of bounds access in case
     // the return address points to the deopt handler stub code entry point which could be
-    // at the end of page.
+    // at the end of a page.
     first_check_size = instruction_size
   };
 
   bool check() const {
-    // Check the first instruction is NOP.
+    // Check for a NOP followed by a metadata chunk.
+    // This sequence only ever appears in a post-call
+    // NOP, so it's unnecessary to check whether there is
+    // a second metadata chunk following the sequence.
     if (is_nop()) {
-      uint32_t insn = *(uint32_t*)addr_at(first_check_size);
-      // Check next instruction is MOVK zr, xx.
-      // These instructions only ever appear together in a post-call
-      // NOP, so it's unnecessary to check that the third instruction is
-      // a MOVK as well.
-      return is_movk_to_zr(insn);
+      uint32_t chunk = *(uint32_t*)addr_at(first_check_size);
+      if (VariantADR::is_match(chunk, /* assertion = */false)) {
+        return true;
+      } else if (VariantMOV::is_match(chunk, /* assertion = */false)) {
+        return true;
+      }
     }
 
     return false;
   }
 
+  template<typename Variant>
   bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const {
-    uint64_t movk_insns = *(uint64_t*)addr_at(4);
-    uint32_t lo = (movk_insns >> 5) & 0xffff;
-    uint32_t hi = (movk_insns >> (5 + 32)) & 0xffff;
-    uint32_t data = (hi << 16) | lo;
-    if (data == 0) {
-      return false; // no information encoded
+    uint32_t chunk_offset = first_check_size;
+    const uint32_t chunk = *(uint32_t*)addr_at(chunk_offset);
+
+    assert(Variant::is_match(chunk), "unexpected format");
+
+    uint64_t data = Variant::extract_metadata(chunk);
+    const uint32_t chunks_count = Variant::two_chunks_flag.extract(data) + 1;
+
+    int32_t cb_blocks_offset;
+    if (chunks_count == 1) {
+      if (!unpack<typename Variant::one_chunk>(data, oopmap_slot, cb_blocks_offset)) {
+        return false;
+      }
+    } else {
+      assert(chunks_count == 2, "expected either one or two chunks");
+
+      chunk_offset += NativeInstruction::instruction_size;
+
+      uint64_t data2 = Variant::extract_metadata(*(uint32_t*)addr_at(chunk_offset));
+      data2 <<= Variant::metadata_chunk_width;
+      data |= data2;
+
+      if (!unpack<typename Variant::two_chunks>(data, oopmap_slot, cb_blocks_offset)) {
+        return false;
+      }
     }
-    cb_offset = (data & 0xffffff);
-    oopmap_slot = (data >> 24) & 0xff;
-    return true; // decoding succeeded
+
+    constexpr size_t block_size = HeapBlock::minimum_alignment();
+    cb_offset = cb_blocks_offset * block_size;
+    cb_offset += (uintptr_t) this % block_size;
+    cb_offset -= CodeHeap::header_size();
+
+    return true;
+  }
+
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const {
+    const uint32_t chunk = *(uint32_t*)addr_at(first_check_size);
+    if (VariantADR::is_match(chunk)) {
+      return decode<VariantADR>(oopmap_slot, cb_offset);
+    } else {
+      return decode<VariantMOV>(oopmap_slot, cb_offset);
+    }
+  }
+
+  template<typename Variant>
+  static uint32_t metadata_chunks_count(int32_t cb_offset) {
+    constexpr size_t block_size = HeapBlock::minimum_alignment();
+    uint32_t cb_blocks_offset = (cb_offset + CodeHeap::header_size()) / block_size;
+    return Variant::one_chunk::cb_blocks_offset.can_hold(cb_blocks_offset) ? 1 : 2;
+  }
+
+  static uint32_t metadata_chunks_count(int32_t cb_offset) {
+    if (UsePostCallSequenceWithADRP) {
+      return metadata_chunks_count<VariantADR>(cb_offset);
+    } else {
+      return metadata_chunks_count<VariantMOV>(cb_offset);
+    }
   }
 
   bool patch(int32_t oopmap_slot, int32_t cb_offset);

--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -44,6 +44,8 @@ class HeapBlock {
     bool      _used;                             // Used bit
   };
 
+  static constexpr size_t minimum_alignment() { return 16; }
+
  protected:
   union {
     Header _header;
@@ -174,7 +176,7 @@ class CodeHeap : public CHeapObj<mtCode> {
 
   void* find_start(void* p)     const;   // returns the block containing p or null
   CodeBlob* find_blob(void* start) const;
-  static size_t header_size()         { return sizeof(HeapBlock); } // returns the header size for each heap block
+  static constexpr size_t header_size() { return sizeof(HeapBlock); } // returns the header size for each heap block
 
   size_t segment_size()         const { return _segment_size; }  // for CodeHeapState
   HeapBlock* first_block() const;                                // for CodeHeapState

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -26,6 +26,7 @@
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "interpreter/invocationCounter.hpp"
+#include "memory/heap.hpp"
 #include "oops/metadata.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/flags/jvmFlag.hpp"
@@ -170,6 +171,14 @@ JVMFlag::Error CodeCacheSegmentSizeConstraintFunc(size_t value, bool verbose) {
                         "to align entry points\n",
                         CodeCacheSegmentSize, CodeEntryAlignment);
     return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+
+  if (CodeCacheSegmentSize < HeapBlock::minimum_alignment()) {
+      JVMFlag::printError(verbose,
+                          "CodeCacheSegmentSize (%zu) must be "
+                          "greater than or equal to %zu\n",
+                          CodeCacheSegmentSize, HeapBlock::minimum_alignment());
+      return JVMFlag::VIOLATES_CONSTRAINT;
   }
 
   if (CodeCacheSegmentSize < sizeof(jdouble)) {

--- a/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Fuzz.java
@@ -56,6 +56,25 @@
  *                                Fuzz
  */
 
+/*
+ * @test id=aarch64-post-call-nop-using-adr
+ * @key randomness
+ * @summary Fuzz tests for jdk.internal.vm.Continuation
+ * @requires os.arch == "aarch64"
+ * @requires vm.continuations
+ * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires vm.opt.TieredCompilation == null | vm.opt.TieredCompilation == true
+ * @modules java.base java.base/jdk.internal.vm.annotation java.base/jdk.internal.vm
+ * @library /test/lib
+ * @build java.base/java.lang.StackWalkerHelper
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=1200 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                                -XX:+UnlockExperimentalVMOptions -XX:+UsePostCallSequenceWithADRP
+ *                                Fuzz
+ */
+
 import jdk.internal.vm.Continuation;
 import jdk.internal.vm.ContinuationScope;
 


### PR DESCRIPTION
Extend MOVK-based scheme to MOVK/MOVZ allowing to store 19 bits of metadata.

Choose number of metadata slots in post-call NOP sequence between 1 and 2 depending on the offset from the CodeBlob header.

Additionally, implement ADR/ADRP-based metadata storage - that provides 22 bits instead of 16 bits to store metadata. This can be enabled via UsePostCallSequenceWithADRP option.


 Renaissance 0.15.0 benchmark results (MOVK-based scheme)
 Neoverse V1.
 The runs were limited to 16 cores.

 Number of runs:
   6 for baseline, 6 for the changes - interleaved pairs.

 Command line:
  java -jar renaissance-jmh-0.15.0.jar \
    -bm avgt -gc true -v extra \
    -jvmArgsAppend '-Xbatch -XX:-UseDynamicNumberOfCompilerThreads \
      -XX:-CICompilerCountPerCPU -XX:ActiveProcessorCount=16 \
      -XX:CICompilerCount=2 -Xms8g -Xmx8g -XX:+AlwaysPreTouch \
      -XX:+UseG1GC'

 The change is geometric mean of ratios across 6 the pairs of runs.

  |  Benchmark                                            |  Change  | 90% CI for the change |
  | ----------------------------------------------------- | -------- | --------------------- |
  | org.renaissance.actors.JmhAkkaUct.run                 |  -0.215% |    -2.652% to  1.357% |
  | org.renaissance.actors.JmhReactors.run                |  -0.166% |    -1.974% to  1.775% |
  | org.renaissance.jdk.concurrent.JmhFjKmeans.run        |   0.222% |    -0.492% to  0.933% |
  | org.renaissance.jdk.concurrent.JmhFutureGenetic.run   |  -1.880% |    -2.438% to -1.343% |
  | org.renaissance.jdk.streams.JmhMnemonics.run          |  -0.500% |    -1.032% to  0.089% |
  | org.renaissance.jdk.streams.JmhParMnemonics.run       |  -0.740% |    -2.092% to  0.639% |
  | org.renaissance.jdk.streams.JmhScrabble.run           |  -0.031% |    -0.353% to  0.310% |
  | org.renaissance.neo4j.JmhNeo4jAnalytics.run           |  -0.873% |    -2.323% to  0.427% |
  | org.renaissance.rx.JmhRxScrabble.run                  |  -0.512% |    -1.121% to  0.049% |
  | org.renaissance.scala.dotty.JmhDotty.run              |  -0.219% |    -1.108% to  0.708% |
  | org.renaissance.scala.sat.JmhScalaDoku.run            |  -2.750% |    -6.426% to -0.827% |
  | org.renaissance.scala.stdlib.JmhScalaKmeans.run       |   0.046% |    -0.383% to  0.408% |
  | org.renaissance.scala.stm.JmhPhilosophers.run         |   1.497% |    -0.955% to  3.923% |
  | org.renaissance.scala.stm.JmhScalaStmBench7.run       |  -0.096% |    -0.773% to  0.586% |
  | org.renaissance.twitter.finagle.JmhFinagleChirper.run |  -0.200% |    -1.143% to  0.698% |
  | org.renaissance.twitter.finagle.JmhFinagleHttp.run    |  -0.865% |    -1.328% to -0.251% |
  |------------------------------------------------------------------------------------------|
  | Overall geometric mean: -0.459% change (90% CI: [-0.839%, -0.097%])                      |
  |------------------------------------------------------------------------------------------|

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Issue
 * [JDK-8373696](https://bugs.openjdk.org/browse/JDK-8373696): AArch64: Refine post-call NOPs (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28855/head:pull/28855` \
`$ git checkout pull/28855`

Update a local copy of the PR: \
`$ git checkout pull/28855` \
`$ git pull https://git.openjdk.org/jdk.git pull/28855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28855`

View PR using the GUI difftool: \
`$ git pr show -t 28855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28855.diff">https://git.openjdk.org/jdk/pull/28855.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28855#issuecomment-3662769207)
</details>
