### PR TITLE
8373697: AArch64: Remove deoptimization stub code for nmethods with small stack frames

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -228,7 +228,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
     nmethod* nm = sender_blob->as_nmethod_or_null();
     if (nm != nullptr) {
-      if (nm->is_deopt_entry(sender_pc) || nm->method()->is_method_handle_intrinsic()) {
+      if (nm->is_deopt_pc(sender_pc) || nm->method()->is_method_handle_intrinsic()) {
         return false;
       }
     }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -123,11 +123,7 @@ inline void frame::setup(address pc) {
     assert(_cb == nullptr || _cb->as_nmethod()->insts_contains_inclusive(_pc),
            "original PC must be in the main code section of the compiled method (or must be immediately following it)");
   } else {
-    if (_cb == SharedRuntime::deopt_blob()) {
-      _deopt_state = is_deoptimized;
-    } else {
-      _deopt_state = not_deoptimized;
-    }
+    _deopt_state = not_deoptimized;
   }
   _sp_is_trusted = false;
 }

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -315,7 +315,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  assert(!is_compiled_frame() || !_cb->as_nmethod()->is_deopt_entry(_pc), "must be");
+  assert(!is_compiled_frame() || !_cb->as_nmethod()->is_deopt_pc(_pc), "must be");
 
 #ifdef ASSERT
   {

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -217,7 +217,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
     nmethod* nm = sender_blob->as_nmethod_or_null();
     if (nm != nullptr) {
-      if (nm->is_deopt_entry(sender_pc) || nm->method()->is_method_handle_intrinsic()) {
+      if (nm->is_deopt_pc(sender_pc) || nm->method()->is_method_handle_intrinsic()) {
         return false;
       }
     }

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -280,7 +280,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  assert(!is_compiled_frame() || !_cb->as_nmethod()->is_deopt_entry(_pc), "must be");
+  assert(!is_compiled_frame() || !_cb->as_nmethod()->is_deopt_pc(_pc), "must be");
 
   #ifdef ASSERT
   {

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -219,7 +219,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
     nmethod* nm = sender_blob->as_nmethod_or_null();
     if (nm != nullptr) {
-        if (nm->is_deopt_entry(sender_pc) || nm->method()->is_method_handle_intrinsic()) {
+        if (nm->is_deopt_pc(sender_pc) || nm->method()->is_method_handle_intrinsic()) {
             return false;
         }
     }
@@ -294,7 +294,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  assert(!is_compiled_frame() || !_cb->as_nmethod()->is_deopt_entry(_pc), "must be");
+  assert(!is_compiled_frame() || !_cb->as_nmethod()->is_deopt_pc(_pc), "must be");
 
 #ifdef ASSERT
   {

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -101,11 +101,11 @@ class Compilation: public StackObj {
   void build_hir();
   void emit_lir();
 
-  void emit_code_epilog(LIR_Assembler* assembler);
+  void emit_code_epilog(LIR_Assembler* assembler, int frame_size_in_bytes);
   int  emit_code_body();
 
   int  compile_java_method();
-  void install_code(int frame_size);
+  void install_code(ByteSize frame_size);
   void compile_method();
 
   void generate_exception_handler_table();

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1056,7 +1056,13 @@ void ciEnv::register_method(ciMethod* target,
       return;
     }
 
-    assert(offsets->value(CodeOffsets::Deopt) != -1, "must have deopt entry");
+    if (AlwaysEmitDeoptStubCode
+        || frame_words >= DeoptimizationBlob::UNPACK_SUBENTRY_COUNT
+        || compiler->type() == compiler_jvmci) {
+      assert(offsets->value(CodeOffsets::Deopt) != -1, "must have deopt entry");
+    } else {
+      assert(offsets->value(CodeOffsets::Deopt) == -1, "must not have a deopt entry");
+    }
 
     assert(compiler->type() == compiler_c2 ||
            offsets->value(CodeOffsets::Exceptions) != -1, "must have exception entry");

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -617,7 +617,9 @@ DeoptimizationBlob::DeoptimizationBlob(
   CodeBuffer* cb,
   int         size,
   OopMapSet*  oop_maps,
-  int         unpack_offset,
+  int         unpack_subentries_offset,
+  int         unpack_subentry_size,
+  int         unpack_generic_offset,
   int         unpack_with_exception_offset,
   int         unpack_with_reexecution_offset,
   int         frame_size
@@ -625,9 +627,11 @@ DeoptimizationBlob::DeoptimizationBlob(
 : SingletonBlob("DeoptimizationBlob", CodeBlobKind::Deoptimization, cb,
                 size, sizeof(DeoptimizationBlob), frame_size, oop_maps)
 {
-  _unpack_offset           = unpack_offset;
-  _unpack_with_exception   = unpack_with_exception_offset;
-  _unpack_with_reexecution = unpack_with_reexecution_offset;
+  _unpack_subentries_offset = unpack_subentries_offset;
+  _unpack_subentry_size     = unpack_subentry_size;
+  _unpack_offset            = unpack_generic_offset;
+  _unpack_with_exception    = unpack_with_exception_offset;
+  _unpack_with_reexecution  = unpack_with_reexecution_offset;
 #ifdef COMPILER1
   _unpack_with_exception_in_tls   = -1;
 #endif
@@ -637,10 +641,24 @@ DeoptimizationBlob::DeoptimizationBlob(
 DeoptimizationBlob* DeoptimizationBlob::create(
   CodeBuffer* cb,
   OopMapSet*  oop_maps,
-  int        unpack_offset,
-  int        unpack_with_exception_offset,
-  int        unpack_with_reexecution_offset,
-  int        frame_size)
+  int         unpack_generic_offset,
+  int         unpack_with_exception_offset,
+  int         unpack_with_reexecution_offset,
+  int         frame_size)
+{
+  return create(cb, oop_maps, -1, 0, unpack_generic_offset, unpack_with_exception_offset,
+                unpack_with_reexecution_offset, frame_size);
+}
+
+DeoptimizationBlob* DeoptimizationBlob::create(
+  CodeBuffer* cb,
+  OopMapSet*  oop_maps,
+  int         unpack_subentries_offset,
+  int         unpack_subentry_size,
+  int         unpack_generic_offset,
+  int         unpack_with_exception_offset,
+  int         unpack_with_reexecution_offset,
+  int         frame_size)
 {
   DeoptimizationBlob* blob = nullptr;
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(DeoptimizationBlob));
@@ -650,7 +668,9 @@ DeoptimizationBlob* DeoptimizationBlob::create(
     blob = new (size) DeoptimizationBlob(cb,
                                          size,
                                          oop_maps,
-                                         unpack_offset,
+                                         unpack_subentries_offset,
+                                         unpack_subentry_size,
+                                         unpack_generic_offset,
                                          unpack_with_exception_offset,
                                          unpack_with_reexecution_offset,
                                          frame_size);

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -167,6 +167,9 @@ class CodeCache : AllStatic {
   static int find_oopmap_slot_fast(void* start);        // Returns a fast oopmap slot if there is any; -1 otherwise
   static nmethod*  find_nmethod(void* start);           // Returns the nmethod containing the given address
 
+  static bool is_deopt_pc(address pc, bool strictly_compiled, CodeBlob* input_cb); // Returns whether pc is a deoptimization handler entry point
+  static address get_deopt_original_pc_and_cb(intptr_t* unextended_sp, address pc, CodeBlob* cb, CodeBlob*& out_cb); // Returns original PC and code blob
+
   static int       blob_count();                        // Returns the total number of CodeBlobs in the cache
   static int       blob_count(CodeBlobType code_blob_type);
   static int       adapter_count();                     // Returns the total number of Adapters in the cache

--- a/src/hotspot/share/code/codeCache.inline.hpp
+++ b/src/hotspot/share/code/codeCache.inline.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +29,7 @@
 #include "code/codeCache.hpp"
 
 #include "code/nativeInst.hpp"
+#include "runtime/sharedRuntime.hpp"
 
 inline CodeBlob* CodeCache::find_blob_fast(void* pc) {
   int slot = 0;
@@ -57,6 +59,83 @@ inline int CodeCache::find_oopmap_slot_fast(void* pc) {
     return oopmap_slot;
   }
   return -1;
+}
+
+inline bool CodeCache::is_deopt_pc(address pc, bool strictly_compiled,
+                                   CodeBlob* input_cb) {
+  const DeoptimizationBlob* deopt_blob = SharedRuntime::deopt_blob();
+  int subentry_index = -1;
+  if (deopt_blob->get_unpack_subentry(pc, subentry_index)) {
+    return true;
+  }
+
+  assert(input_cb == nullptr || input_cb == CodeCache::find_blob(pc),
+         "Inconsistent input_cb");
+  CodeBlob* cb = (input_cb != nullptr) ? input_cb : CodeCache::find_blob(pc);
+  nmethod* nm = nullptr;
+  if (cb != nullptr) {
+    nm = cb->as_nmethod_or_null();
+  }
+
+  if (nm != nullptr) {
+    return nm->is_deopt_pc(pc);
+  } else {
+    assert(!strictly_compiled, "this is not an nmethod");
+  }
+
+  return false;
+}
+
+inline address CodeCache::get_deopt_original_pc_and_cb(intptr_t* unextended_sp,
+                                                       address pc,
+                                                       CodeBlob* input_cb,
+                                                       CodeBlob*& out_cb) {
+  const DeoptimizationBlob* deopt_blob = SharedRuntime::deopt_blob();
+
+  out_cb = nullptr;
+
+  address original_pc = nullptr;
+  if (deopt_blob->get_original_pc(unextended_sp, pc, original_pc)) {
+    if (input_cb != nullptr && input_cb->is_nmethod()) {
+      nmethod* nm = input_cb->as_nmethod();
+      assert(nm->is_deopt_pc(pc), "mismatched deopt PC");
+      out_cb = input_cb;
+    } else {
+      assert(input_cb == nullptr || input_cb == deopt_blob,
+             "pc is expected to be of the sub entry points");
+      out_cb = CodeCache::find_blob_fast(original_pc);
+    }
+    assert(out_cb != nullptr, "corrupted stack frame");
+  } else {
+#ifdef ASSERT
+    if (input_cb != nullptr) {
+      assert(input_cb == CodeCache::find_blob_fast(pc),
+             "unexpected input_cb");
+    }
+#endif
+
+    CodeBlob *cb = (input_cb != nullptr) ?
+      input_cb : CodeCache::find_blob_fast(pc);
+    if (cb != nullptr) {
+      out_cb = cb;
+
+      nmethod* nm = cb->as_nmethod_or_null();
+      if (nm != nullptr && nm->is_deopt_pc(pc)) {
+        address orig_pc_slot = (address) unextended_sp + nm->orig_pc_offset();
+        original_pc = *(address*)orig_pc_slot;
+      }
+    }
+  }
+
+#ifdef ASSERT
+  if (original_pc != nullptr) {
+    nmethod* nm = CodeCache::find_nmethod(original_pc);
+    assert(nm == out_cb, "mismatched code blob");
+    assert(nm != nullptr && nm->is_deopt_pc(pc), "mismatched deopt PC");
+  }
+#endif
+
+  return original_pc;
 }
 
 #endif // SHARE_VM_COMPILER_CODECACHE_INLINE_HPP

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -833,7 +833,6 @@ public:
   // Deopt
   // Return true is the PC is one would expect if the frame is being deopted.
   inline bool is_deopt_pc(address pc);
-  inline bool is_deopt_entry(address pc);
 
   // Accessor/mutator for the original pc of a frame before a frame was deopted.
   address get_original_pc(const frame* fr) { return *orig_pc_addr(fr); }

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -30,6 +30,7 @@
 #include "oops/metadata.hpp"
 #include "oops/method.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/sharedRuntime.hpp"
 
 class AbstractCompiler;
 class CompiledDirectCall;
@@ -620,7 +621,6 @@ public:
   address stub_begin            () const { return           header_begin() + _stub_offset             ; }
   address stub_end              () const { return           code_end()     ; }
   address exception_begin       () const { return           header_begin() + _exception_offset        ; }
-  address deopt_handler_entry   () const { return           header_begin() + _deopt_handler_entry_offset    ; }
   address unwind_handler_begin  () const { return _unwind_handler_offset != -1 ? (insts_end() - _unwind_handler_offset) : nullptr; }
   oop*    oops_begin            () const { return (oop*)    data_begin(); }
   oop*    oops_end              () const { return (oop*)    data_end(); }
@@ -832,7 +832,9 @@ public:
 
   // Deopt
   // Return true is the PC is one would expect if the frame is being deopted.
-  inline bool is_deopt_pc(address pc);
+  inline bool is_deopt_pc(address pc) const;
+  address deopt_handler_entry() const;
+  int orig_pc_offset() const;
 
   // Accessor/mutator for the original pc of a frame before a frame was deopted.
   address get_original_pc(const frame* fr) { return *orig_pc_addr(fr); }
@@ -999,8 +1001,6 @@ public:
   // copying of debugging information
   void copy_scopes_pcs(PcDesc* pcs, int count);
   void copy_scopes_data(address buffer, int size);
-
-  int orig_pc_offset() { return _orig_pc_offset; }
 
   // Post successful compilation
   void post_compiled_method(CompileTask* task);

--- a/src/hotspot/share/code/nmethod.inline.hpp
+++ b/src/hotspot/share/code/nmethod.inline.hpp
@@ -31,9 +31,7 @@
 #include "runtime/atomicAccess.hpp"
 #include "runtime/frame.hpp"
 
-inline bool nmethod::is_deopt_pc(address pc) { return is_deopt_entry(pc); }
-
-inline bool nmethod::is_deopt_entry(address pc) {
+inline bool nmethod::is_deopt_pc(address pc) {
   return pc == deopt_handler_entry();
 }
 

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1790,8 +1790,11 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
     if (C->failing()) {
       return; // CodeBuffer::expand failed
     }
-    // Emit the deopt handler code.
-    _code_offsets.set_value(CodeOffsets::Deopt, HandlerImpl::emit_deopt_handler(masm));
+    // Emit the deopt handler code if needed.
+    if (AlwaysEmitDeoptStubCode
+        || frame_size_in_words() >= DeoptimizationBlob::UNPACK_SUBENTRY_COUNT) {
+      _code_offsets.set_value(CodeOffsets::Deopt, HandlerImpl::emit_deopt_handler(masm));
+    }
   }
 
   // One last check for failed CodeBuffer::expand:

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1901,39 +1901,41 @@ JRT_ENTRY_NO_ASYNC(address, OptoRuntime::handle_exception_C_helper(JavaThread* c
   // exceptions from compiled java methods are handled in compiled code
   // using rethrow node
 
-  nm = CodeCache::find_nmethod(pc);
-  assert(nm != nullptr, "No NMethod found");
+  if (JvmtiExport::can_post_on_exceptions()) {
+    // "Full-speed catching" is not necessary here,
+    // since we're notifying the VM on every catch.
+    // Force deoptimization and the rest of the lookup
+    // will be fine.
+    deoptimize_caller_frame(current);
+  }
+
+  CodeBlob* cb = CodeCache::find_blob(pc);
+  bool is_deopt_pc = CodeCache::is_deopt_pc(pc, /*strictly_compiled = */true, cb);
+  // Check the stack guard pages.  If enabled, look for handler in this frame;
+  // otherwise, forcibly unwind the frame.
+  //
+  // 4826555: use default current sp for reguard_stack instead of &nm: it's more accurate.
+  bool force_unwind = !current->stack_overflow_state()->reguard_stack();
+  bool deopting = false;
+  if (is_deopt_pc) {
+    deopting = true;
+    RegisterMap map(current,
+                    RegisterMap::UpdateMap::skip,
+                    RegisterMap::ProcessFrames::include,
+                    RegisterMap::WalkContinuation::skip);
+    frame deoptee = current->last_frame().sender(&map);
+    assert(deoptee.is_deoptimized_frame(), "must be deopted");
+    // Adjust the pc back to the original throwing pc
+    pc = deoptee.pc();
+    cb = deoptee.cb();
+  }
+  nm = cb->as_nmethod();
+
   if (nm->is_native_method()) {
     fatal("Native method should not have path to exception handling");
   } else {
     // we are switching to old paradigm: search for exception handler in caller_frame
     // instead in exception handler of caller_frame.sender()
-
-    if (JvmtiExport::can_post_on_exceptions()) {
-      // "Full-speed catching" is not necessary here,
-      // since we're notifying the VM on every catch.
-      // Force deoptimization and the rest of the lookup
-      // will be fine.
-      deoptimize_caller_frame(current);
-    }
-
-    // Check the stack guard pages.  If enabled, look for handler in this frame;
-    // otherwise, forcibly unwind the frame.
-    //
-    // 4826555: use default current sp for reguard_stack instead of &nm: it's more accurate.
-    bool force_unwind = !current->stack_overflow_state()->reguard_stack();
-    bool deopting = false;
-    if (nm->is_deopt_pc(pc)) {
-      deopting = true;
-      RegisterMap map(current,
-                      RegisterMap::UpdateMap::skip,
-                      RegisterMap::ProcessFrames::include,
-                      RegisterMap::WalkContinuation::skip);
-      frame deoptee = current->last_frame().sender(&map);
-      assert(deoptee.is_deoptimized_frame(), "must be deopted");
-      // Adjust the pc back to the original throwing pc
-      pc = deoptee.pc();
-    }
 
     // If we are forcing an unwind because of stack overflow then deopt is
     // irrelevant since we are throwing the frame away anyway.

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1136,6 +1136,7 @@ void frame::oops_upcall_do(OopClosure* f, const RegisterMap* map) const {
 bool frame::is_deoptimized_frame() const {
   assert(_deopt_state != unknown, "not answerable");
   if (_deopt_state == is_deoptimized) {
+    AARCH64_ONLY(assert(is_compiled_frame(), "only compiled methods can be deoptimized");)
     return true;
   }
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -125,6 +125,7 @@ class frame {
   // (a) the given PC belongs to an nmethod and
   // (b) it is a deopt PC
   address get_deopt_original_pc() const;
+  address get_deopt_original_pc_and_cb(CodeBlob*& out_cb) const;
 
   void set_pc(address newpc);
   void adjust_pc(address newpc);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1244,6 +1244,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, TraceDeoptimization, false, DIAGNOSTIC,                     \
           "Trace deoptimization")                                           \
                                                                             \
+  product(bool, AlwaysEmitDeoptStubCode, false, DIAGNOSTIC,                 \
+          "Emit deoptimization stub code independently "                    \
+          "of method's stack frame size")                                   \
+                                                                            \
   develop(bool, PrintDeoptimizationDetails, false,                          \
           "Print more information about deoptimization")                    \
                                                                             \

--- a/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationAllTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationAllTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test UnexpectedDeoptimizationAllTest
+ * @test id=UnexpectedDeoptimizationAllTest
  * @key stress
  * @summary stressing code cache by forcing unexpected deoptimizations of all methods
  * @library /test/lib /
@@ -52,6 +52,46 @@
  *                   compiler.codecache.stress.UnexpectedDeoptimizationAllTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:+SegmentedCodeCache
+ *                   -DhelperVirtualThread=true
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationAllTest
+ */
+
+/*
+ * @test id=UnexpectedDeoptimizationAllTest-with-deopt-stub-code
+ * @key stress
+ * @summary stressing code cache by forcing unexpected deoptimizations of all methods
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires os.arch=="aarch64"
+ *
+ * @build jdk.test.whitebox.WhiteBox compiler.codecache.stress.Helper compiler.codecache.stress.TestCaseImpl
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:-SegmentedCodeCache
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationAllTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:+SegmentedCodeCache
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationAllTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:-SegmentedCodeCache
+ *                   -DhelperVirtualThread=true
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationAllTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:+SegmentedCodeCache

--- a/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test UnexpectedDeoptimizationTest
+ * @test id=UnexpectedDeoptimizationTest
  * @key stress randomness
  * @summary stressing code cache by forcing unexpected deoptimizations
  * @library /test/lib /
@@ -52,6 +52,46 @@
  *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
  * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:+SegmentedCodeCache
+ *                   -DhelperVirtualThread=true
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
+ */
+
+/*
+ * @test id=UnexpectedDeoptimizationTest-with-deopt-stub-code
+ * @key stress randomness
+ * @summary stressing code cache by forcing unexpected deoptimizations
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires os.arch=="aarch64"
+ *
+ * @build jdk.test.whitebox.WhiteBox compiler.codecache.stress.Helper compiler.codecache.stress.TestCaseImpl
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:-SegmentedCodeCache
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:+SegmentedCodeCache
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:-SegmentedCodeCache
+ *                   -DhelperVirtualThread=true
+ *                   compiler.codecache.stress.UnexpectedDeoptimizationTest
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:+SegmentedCodeCache

--- a/test/hotspot/jtreg/compiler/exceptions/TestDeoptExceptionState.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestDeoptExceptionState.java
@@ -22,13 +22,23 @@
  */
 
 /**
-* @test
+* @test id=default
 * @bug 8316422
 * @summary Test exception state used for deoptimization.
 * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack -XX:+DeoptimizeALot
 *      -Xcomp -XX:TieredStopAtLevel=1 -XX:CompileOnly=compiler.exceptions.TestDeoptExceptionState::test
 *      compiler.exceptions.TestDeoptExceptionState
 */
+
+/**
+ * @test id=with-deopt-stub-code
+ * @summary Test exception state used for deoptimization.
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack -XX:+DeoptimizeALot
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysEmitDeoptStubCode
+ *      -Xcomp -XX:TieredStopAtLevel=1 -XX:CompileOnly=compiler.exceptions.TestDeoptExceptionState::test
+ *      compiler.exceptions.TestDeoptExceptionState
+ */
 
 package compiler.exceptions;
 

--- a/test/hotspot/jtreg/compiler/interpreter/TestVerifyStackAfterDeopt.java
+++ b/test/hotspot/jtreg/compiler/interpreter/TestVerifyStackAfterDeopt.java
@@ -23,7 +23,7 @@
 
 
 /*
- * @test TestVerifyStackAfterDeopt
+ * @test id=TestVerifyStackAfterDeopt
  * @bug 8148871
  * @bug 8209825
  * @summary Checks VerifyStack after deoptimization of array allocation slow call
@@ -31,6 +31,18 @@
  *                   -XX:AllocatePrefetchLines=1 -XX:AllocateInstancePrefetchLines=1 -XX:AllocatePrefetchStepSize=16 -XX:AllocatePrefetchDistance=1
  *                   -XX:MinTLABSize=1k -XX:TLABSize=1k
  *                   -XX:+DeoptimizeALot -XX:+VerifyStack
+ *                   compiler.interpreter.TestVerifyStackAfterDeopt
+ */
+
+/*
+ * @test id=TestVerifyStackAfterDeopt-with-deopt-stub-code
+ * @summary Checks VerifyStack after deoptimization of array allocation slow call
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:TieredStopAtLevel=1
+ *                   -XX:AllocatePrefetchLines=1 -XX:AllocateInstancePrefetchLines=1 -XX:AllocatePrefetchStepSize=16 -XX:AllocatePrefetchDistance=1
+ *                   -XX:MinTLABSize=1k -XX:TLABSize=1k
+ *                   -XX:+DeoptimizeALot -XX:+VerifyStack
+ *                   -XX:+AlwaysEmitDeoptStubCode
  *                   compiler.interpreter.TestVerifyStackAfterDeopt
  */
 

--- a/test/hotspot/jtreg/compiler/intrinsics/SortingDeoptimizationTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/SortingDeoptimizationTest.java
@@ -22,9 +22,17 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8318306
  * @run main/othervm/timeout=200 -XX:+IgnoreUnrecognizedVMOptions -Xcomp -ea -esa -XX:CompileThreshold=100 -XX:+UnlockExperimentalVMOptions -server -XX:-TieredCompilation -XX:+DeoptimizeALot SortingDeoptimizationTest 1e-2 100 50
+ * @summary Exercise Arrays.parallelSort when -XX:+DeoptimizeALot is enabled
+ *
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ * @requires os.arch=="aarch64"
+ * @run main/othervm/timeout=200 -XX:+IgnoreUnrecognizedVMOptions -Xcomp -ea -esa -XX:CompileThreshold=100 -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysEmitDeoptStubCode -XX:+UnlockExperimentalVMOptions -server -XX:-TieredCompilation -XX:+DeoptimizeALot SortingDeoptimizationTest 1e-2 100 50
  * @summary Exercise Arrays.parallelSort when -XX:+DeoptimizeALot is enabled
  *
  */

--- a/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
@@ -30,12 +30,22 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 
 /*
- * @test
+ * @test id=default
  * @bug 8336042
  * @library /test/lib /
  *
  * @run main/bootclasspath/othervm -Xbatch -XX:-TieredCompilation compiler.jsr292.MHDeoptTest
  *
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ * @library /test/lib /
+ *
+ * @requires os.arch=="aarch64"
+ * @run main/bootclasspath/othervm -Xbatch -XX:-TieredCompilation
+ *                                 -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysEmitDeoptStubCode
+ *                                 compiler.jsr292.MHDeoptTest
  */
 public class MHDeoptTest {
 

--- a/test/hotspot/jtreg/compiler/uncommontrap/DeoptReallocFailure.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/DeoptReallocFailure.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8146416
  * @library /test/lib /
  *
@@ -32,7 +32,20 @@
  *      -XX:+WhiteBoxAPI -Xbatch -Xmx100m
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.DeoptReallocFailure::main
  *      compiler.uncommontrap.DeoptReallocFailure
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ * @library /test/lib /
  *
+ * @requires os.arch=="aarch64"
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI -Xbatch -Xmx100m
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.DeoptReallocFailure::main
+ *      -XX:+AlwaysEmitDeoptStubCode
+ *      compiler.uncommontrap.DeoptReallocFailure
  */
 
 package compiler.uncommontrap;

--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 6898462 8198826
  * @summary failed reallocations of scalar replaced objects during deoptimization causes crash
  *
@@ -42,6 +42,32 @@
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
  *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+UseZGC -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
+ *      compiler.uncommontrap.TestDeoptOOM
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ * @summary failed reallocations of scalar replaced objects during deoptimization causes crash
+ *
+ * @requires !vm.graal.enabled
+ * @requires os.arch=="aarch64"
+ * @run main/othervm/timeout=480 -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysEmitDeoptStubCode
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
+ *      compiler.uncommontrap.TestDeoptOOM
+ */
+
+/*
+ * @test id=Z-with-deopt-stub-code
+ * @summary Test that ttyLock is ranked above StackWatermark_lock
+ * @requires !vm.graal.enabled & vm.gc.Z
+ * @requires os.arch=="aarch64"
+ * @run main/othervm/timeout=480 -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysEmitDeoptStubCode
  *      -XX:+UseZGC -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
  *      compiler.uncommontrap.TestDeoptOOM
  */

--- a/test/hotspot/jtreg/compiler/uncommontrap/TraceDeoptimizationNoRealloc.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TraceDeoptimizationNoRealloc.java
@@ -22,12 +22,23 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8067144
  * @summary -XX:+TraceDeoptimization tries to print realloc'ed objects even when there are none
  *
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+TraceDeoptimization
+ *                   compiler.uncommontrap.TraceDeoptimizationNoRealloc
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ * @summary -XX:+TraceDeoptimization tries to print realloc'ed objects even when there are none
+ *
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+TraceDeoptimization
+ *                   -XX:+AlwaysEmitDeoptStubCode
  *                   compiler.uncommontrap.TraceDeoptimizationNoRealloc
  */
 

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeAllTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeAllTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test DeoptimizeAllTest
+ * @test id=DeoptimizeAllTest
  * @bug 8006683 8007288 8022832
  * @summary testing of WB::deoptimizeAll()
  * @library /test/lib /
@@ -35,6 +35,24 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
+ *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
+ *                   compiler.whitebox.DeoptimizeAllTest
+ */
+
+/*
+ * @test id=DeoptimizeAllTest-with-deopt-stub-code
+ * @summary testing of WB::deoptimizeAll()
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ * @requires os.arch=="aarch64"
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
  *                   compiler.whitebox.DeoptimizeAllTest
  */

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeFramesTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeFramesTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test DeoptimizeFramesTest
+ * @test id=DeoptimizeFramesTest
  * @bug 8028595
  * @summary testing of WB::deoptimizeFrames()
  * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
@@ -40,6 +40,34 @@
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom -XX:-DeoptimizeALot
  *                   compiler.whitebox.DeoptimizeFramesTest true
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xmixed
+ *                   -XX:CompileCommand=compileonly,compiler.whitebox.DeoptimizeFramesTest$TestCaseImpl::method
+ *                   -XX:CompileCommand=dontinline,java.util.concurrent.Phaser::*
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom -XX:-DeoptimizeALot
+ *                   compiler.whitebox.DeoptimizeFramesTest false
+ */
+
+/*
+ * @test id=DeoptimizeFramesTest-with-deopt-stub-code
+ * @summary testing of WB::deoptimizeFrames()
+ * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ * @requires os.arch=="aarch64"
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   -XX:+WhiteBoxAPI -Xmixed
+ *                   -XX:CompileCommand=compileonly,compiler.whitebox.DeoptimizeFramesTest$TestCaseImpl::method
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-DeoptimizeRandom -XX:-DeoptimizeALot
+ *                   compiler.whitebox.DeoptimizeFramesTest true
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
  *                   -XX:+WhiteBoxAPI -Xmixed
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.DeoptimizeFramesTest$TestCaseImpl::method
  *                   -XX:CompileCommand=dontinline,java.util.concurrent.Phaser::*

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMethodTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMethodTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test DeoptimizeMethodTest
+ * @test id=DeoptimizeMethodTest
  * @bug 8006683 8007288 8022832
  * @summary testing of WB::deoptimizeMethod()
  * @library /test/lib /
@@ -32,6 +32,21 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
+ *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
+ *                   compiler.whitebox.DeoptimizeMethodTest
+ */
+
+/*
+ * @test id=DeoptimizeMethodTest-with-deopt-stub-code
+ * @summary testing of WB::deoptimizeMethod()
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @requires os.arch=="aarch64"
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
  *                   compiler.whitebox.DeoptimizeMethodTest
  */

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeMultipleOSRTest.java
@@ -23,7 +23,7 @@
 
 
 /*
- * @test DeoptimizeMultipleOSRTest
+ * @test id=DeoptimizeMultipleOSRTest
  * @bug 8061817
  * @summary testing of WB::deoptimizeMethod()
  * @library /test/lib /
@@ -35,6 +35,24 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:CompileCommand=compileonly,compiler.whitebox.DeoptimizeMultipleOSRTest::triggerOSR
+ *                   compiler.whitebox.DeoptimizeMultipleOSRTest
+ */
+
+/*
+ * @test id=DeoptimizeMultipleOSRTest-with-deopt-stub-code
+ * @summary testing of WB::deoptimizeMethod()
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires vm.opt.DeoptimizeALot != true
+ * @requires os.arch=="aarch64"
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+AlwaysEmitDeoptStubCode
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.DeoptimizeMultipleOSRTest::triggerOSR
  *                   compiler.whitebox.DeoptimizeMultipleOSRTest
  */

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeRelocatedNMethod.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeRelocatedNMethod.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8316694
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc java.management
@@ -33,6 +33,21 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch -XX:+SegmentedCodeCache
+ * -XX:+UnlockExperimentalVMOptions -XX:+NMethodRelocation compiler.whitebox.DeoptimizeRelocatedNMethod
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc java.management
+ * @requires vm.opt.DeoptimizeALot != true
+ * @requires os.arch=="aarch64"
+ * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires !vm.emulatedClient
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch -XX:+SegmentedCodeCache
+ * -XX:+AlwaysEmitDeoptStubCode
  * -XX:+UnlockExperimentalVMOptions -XX:+NMethodRelocation compiler.whitebox.DeoptimizeRelocatedNMethod
  */
 

--- a/test/hotspot/jtreg/runtime/vthread/Deoptimization.java
+++ b/test/hotspot/jtreg/runtime/vthread/Deoptimization.java
@@ -52,6 +52,40 @@
  *                   Deoptimization
  */
 
+/**
+ * @test id=vthread-deopt-c1-with-deopt-stub-code
+ * @summary Deoptimization test for virtual threads (C1)
+ * @requires vm.continuations
+ * @requires vm.compiler1.enabled
+ * @requires vm.opt.TieredStopAtLevel != 0
+ * @requires os.arch=="aarch64"
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-BackgroundCompilation
+ *                   -XX:TieredStopAtLevel=1
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   Deoptimization
+ */
+
+/**
+ * @test id=vthread-deopt-c2-with-deopt-stub-code
+ * @summary Deoptimization test for virtual threads (C2)
+ * @requires vm.continuations
+ * @requires vm.compiler2.enabled
+ * @requires os.arch=="aarch64"
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-BackgroundCompilation
+ *                   -XX:-TieredCompilation
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   Deoptimization
+ */
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.BrokenBarrierException;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test01/test01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test01/test01.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=default
  *
  * @summary converted from VM Testbase jit/deoptimization/test01.
  * VM Testbase keywords: [jit, quick]
@@ -30,6 +30,18 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm jit.deoptimization.test01.test01
+ */
+
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test01.test01
  */
 
 package jit.deoptimization.test01;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test02/test02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test02/test02.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test02.test02
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test02.test02
+ */
+
 package jit.deoptimization.test02;
 
 import nsk.share.TestFailure;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test03/test03.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test03/test03.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test03.test03
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test03.test03
+ */
+
 package jit.deoptimization.test03;
 
 import nsk.share.TestFailure;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test04/test04.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test04/test04.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test04.test04
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test04.test04
+ */
+
 package jit.deoptimization.test04;
 
 import nsk.share.TestFailure;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test05/test05.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test05/test05.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test05.test05
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test05.test05
+ */
+
 package jit.deoptimization.test05;
 
 import nsk.share.TestFailure;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test06/test06.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test06/test06.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test06.test06
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test06.test06
+ */
+
 package jit.deoptimization.test06;
 
 import nsk.share.TestFailure;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test07/test07.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test07/test07.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test07.test07
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test07.test07
+ */
+
 package jit.deoptimization.test07;
 
 import nsk.share.TestFailure;

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test08/test08.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test08/test08.java
@@ -32,6 +32,18 @@
  * @run main/othervm jit.deoptimization.test08.test08
  */
 
+/*
+ * @test id=with-deopt-stub-code
+ *
+ * @summary Ensure the same works with per-method deoptimization entry point.
+ * @library /vmTestbase
+ *          /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AlwaysEmitDeoptStubCode
+ *                   jit.deoptimization.test08.test08
+ */
+
 package jit.deoptimization.test08;
 
 import nsk.share.TestFailure;


### PR DESCRIPTION
Removal of deoptimization stub codes improves density of compiled code.
It is possible at least for methods with relatively small stack frames.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Issue
 * [JDK-8373697](https://bugs.openjdk.org/browse/JDK-8373697): AArch64: Remove deoptimization stub code for nmethods with small stack frames (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28857/head:pull/28857` \
`$ git checkout pull/28857`

Update a local copy of the PR: \
`$ git checkout pull/28857` \
`$ git pull https://git.openjdk.org/jdk.git pull/28857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28857`

View PR using the GUI difftool: \
`$ git pr show -t 28857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28857.diff">https://git.openjdk.org/jdk/pull/28857.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28857#issuecomment-3662861228)
</details>
