### PR TITLE
8374150: Fix instruction for requirements on rpm-based for building with cross-compile

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -559,7 +559,9 @@ but you will most likely need to install developer packages.</p>
 <p>For apt-based distributions (Debian, Ubuntu, etc), try this:</p>
 <pre><code>sudo apt-get install build-essential autoconf</code></pre>
 <p>For rpm-based distributions (Fedora, Red Hat, etc), try this:</p>
-<pre><code>sudo yum groupinstall &quot;Development Tools&quot;</code></pre>
+<pre><code>sudo yum group install development-tools</code></pre>
+or
+<pre><code>sudo dnf group install development-tools</code></pre>
 <p>For Alpine Linux, aside from basic tooling, install the GNU versions
 of some programs:</p>
 <pre><code>sudo apk add build-base bash grep zip</code></pre>

--- a/doc/building.md
+++ b/doc/building.md
@@ -380,7 +380,13 @@ sudo apt-get install build-essential autoconf
 For rpm-based distributions (Fedora, Red Hat, etc), try this:
 
 ```
-sudo yum groupinstall "Development Tools"
+sudo yum group install development-tools
+```
+
+or
+
+```
+sudo dnf group install development-tools
 ```
 
 For Alpine Linux, aside from basic tooling, install the GNU versions of some


### PR DESCRIPTION
Previous instruction were leading to:
```
sudo dnf group install "Development Tools"
Updating and loading repositories:
Repositories loaded.
Failed to resolve the transaction:
No match for argument: Development Tools
You can try to add to command line:
  --skip-unavailable to skip unavailable packages
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8374150](https://bugs.openjdk.org/browse/JDK-8374150): Fix instruction for requirements on rpm-based for building with cross-compile (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28925/head:pull/28925` \
`$ git checkout pull/28925`

Update a local copy of the PR: \
`$ git checkout pull/28925` \
`$ git pull https://git.openjdk.org/jdk.git pull/28925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28925`

View PR using the GUI difftool: \
`$ git pr show -t 28925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28925.diff">https://git.openjdk.org/jdk/pull/28925.diff</a>

</details>
