### PR TITLE
8374307: Fix deoptimization storm caused by Action_none in GraphKit::uncommon_trap

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4479,7 +4479,7 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
   bool  layout_is_con = (layout_val == nullptr);
 
   if (!layout_is_con && !StressReflectiveCode &&
-      !too_many_traps(Deoptimization::Reason_class_check)) {
+      !too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
     // This is a reflective array creation site.
     // Optimistically assume that it is a subtype of Object[],
     // so that we can fold up all the address arithmetic.
@@ -4745,7 +4745,7 @@ InitializeNode* AllocateNode::initialization() {
 // Add a Parse Predicate with an uncommon trap on the failing/false path. Normal control will continue on the true path.
 void GraphKit::add_parse_predicate(Deoptimization::DeoptReason reason, const int nargs) {
   // Too many traps seen?
-  if (too_many_traps(reason)) {
+  if (too_many_traps_or_recompiles(reason)) {
 #ifdef ASSERT
     if (TraceLoopPredicate) {
       int tc = C->trap_count(reason);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1413,7 +1413,7 @@ Node* LibraryCallKit::make_indexOf_node(Node* src_start, Node* src_count, Node* 
 
 //-----------------------------inline_string_indexOfChar-----------------------
 bool LibraryCallKit::inline_string_indexOfChar(StrIntrinsicNode::ArgEnc ae) {
-  if (too_many_traps(Deoptimization::Reason_intrinsic)) {
+  if (too_many_traps_or_recompiles(Deoptimization::Reason_intrinsic)) {
     return false;
   }
   if (!Matcher::match_rule_supported(Op_StrIndexOfChar)) {
@@ -4615,7 +4615,7 @@ bool LibraryCallKit::inline_Class_cast() {
   }
 
   // Bailout intrinsic and do normal inlining if exception path is frequent.
-  if (too_many_traps(Deoptimization::Reason_intrinsic)) {
+  if (too_many_traps_or_recompiles(Deoptimization::Reason_intrinsic)) {
     return false;
   }
 
@@ -5138,7 +5138,7 @@ bool LibraryCallKit::inline_unsafe_newArray(bool uninitialized) {
 //----------------------inline_native_getLength--------------------------
 // public static native int java.lang.reflect.Array.getLength(Object array);
 bool LibraryCallKit::inline_native_getLength() {
-  if (too_many_traps(Deoptimization::Reason_intrinsic))  return false;
+  if (too_many_traps_or_recompiles(Deoptimization::Reason_intrinsic))  return false;
 
   Node* array = null_check(argument(0));
   // If array is dead, only null-path is taken.
@@ -5170,7 +5170,7 @@ bool LibraryCallKit::inline_native_getLength() {
 // public static <T,U> T[] java.util.Arrays.copyOf(     U[] original, int newLength,         Class<? extends T[]> newType);
 // public static <T,U> T[] java.util.Arrays.copyOfRange(U[] original, int from,      int to, Class<? extends T[]> newType);
 bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
-  if (too_many_traps(Deoptimization::Reason_intrinsic))  return false;
+  if (too_many_traps_or_recompiles(Deoptimization::Reason_intrinsic))  return false;
 
   // Get the arguments.
   Node* original          = argument(0);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -823,7 +823,7 @@ void Parse::do_tableswitch() {
       profile = (ciMultiBranchData*)data;
     }
   }
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps_or_recompiles(method(), bci(), Deoptimization::Reason_unstable_if);
 
   // generate decision tree, using trichotomy when possible
   int rnum = len+2;
@@ -897,7 +897,7 @@ void Parse::do_lookupswitch() {
       profile = (ciMultiBranchData*)data;
     }
   }
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps_or_recompiles(method(), bci(), Deoptimization::Reason_unstable_if);
 
   // generate decision tree, using trichotomy when possible
   jint* table = NEW_RESOURCE_ARRAY(jint, len*3);
@@ -1300,7 +1300,7 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
 //----------------------------jump_switch_ranges-------------------------------
 void Parse::jump_switch_ranges(Node* key_val, SwitchRange *lo, SwitchRange *hi, int switch_depth) {
   Block* switch_block = block();
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps_or_recompiles(method(), bci(), Deoptimization::Reason_unstable_if);
 
   if (switch_depth == 0) {
     // Do special processing for the top-level call.

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1145,7 +1145,7 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
   // Are jumptables supported
   if (!Matcher::has_match_rule(Op_Jump))  return false;
 
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps_or_recompiles(method(), bci(), Deoptimization::Reason_unstable_if);
 
   // Decide if a guard is needed to lop off big ranges at either (or
   // both) end(s) of the input set. We'll call this the default target

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2587,6 +2587,8 @@ bool Parse::path_is_suitable_for_uncommon_trap(float prob) const {
     return false;
   }
   return seems_never_taken(prob) &&
+         // Skip optimization if recompile limit is exceeded to avoid deopts without recompilation.
+         !C->too_many_recompiles(method(), bci(), Deoptimization::Reason_unstable_if) &&
          !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
 }
 

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2588,8 +2588,7 @@ bool Parse::path_is_suitable_for_uncommon_trap(float prob) const {
   }
   return seems_never_taken(prob) &&
          // Skip optimization if recompile limit is exceeded to avoid deopts without recompilation.
-         !C->too_many_recompiles(method(), bci(), Deoptimization::Reason_unstable_if) &&
-         !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+         !C->too_many_traps_or_recompiles(method(), bci(), Deoptimization::Reason_unstable_if);
 }
 
 void Parse::maybe_add_predicate_after_if(Block* path) {

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -173,13 +173,13 @@ Node* Parse::array_store_check(const Type*& elemtype) {
     Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
     // Try to cast the array to an exact type from profile data. First
     // check the speculative type.
-    if (ary_spec != nullptr && !too_many_traps(Deoptimization::Reason_speculate_class_check)) {
+    if (ary_spec != nullptr && !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
       extak = TypeKlassPtr::make(ary_spec)->is_aryklassptr();
       reason = Deoptimization::Reason_speculate_class_check;
     } else if (UseArrayLoadStoreProfile) {
       // No speculative type: check profile data at this bci.
       reason = Deoptimization::Reason_class_check;
-      if (!too_many_traps(reason)) {
+      if (!too_many_traps_or_recompiles(reason)) {
         ciKlass* array_type = nullptr;
         ciKlass* element_type = nullptr;
         ProfilePtrKind element_ptr = ProfileMaybeNull;
@@ -190,7 +190,7 @@ Node* Parse::array_store_check(const Type*& elemtype) {
           extak = TypeKlassPtr::make(array_type)->is_aryklassptr();
         }
       }
-    } else if (!too_many_traps(Deoptimization::Reason_array_check) && tak->isa_aryklassptr()) {
+    } else if (!too_many_traps_or_recompiles(Deoptimization::Reason_array_check) && tak->isa_aryklassptr()) {
       // If the compiler has determined that the type of array 'ary' (represented
       // by 'array_klass') is java/lang/Object, the compiler must not assume that
       // the array 'ary' is monomorphic.

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -922,7 +922,7 @@ bool StringConcat::validate_control_flow() {
   // safe to transform the graph as we would expect.
 
   // Check to see if this resulted in too many uncommon traps previously
-  if (Compile::current()->too_many_traps(_begin->jvms()->method(), _begin->jvms()->bci(),
+  if (Compile::current()->too_many_traps_or_recompiles(_begin->jvms()->method(), _begin->jvms()->bci(),
                         Deoptimization::Reason_intrinsic)) {
     return false;
   }

--- a/test/hotspot/jtreg/compiler/uncommontrap/DeoptStorm.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/DeoptStorm.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.uncommontrap;
+
+import java.util.List;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @bug 8374307
+ * @summary The change reproduces the unstable_if action_none deoptimization storm
+ * @library /test/lib
+ *
+ * @run main/othervm compiler.uncommontrap.DeoptStorm
+ */
+public class DeoptStorm {
+
+    private static final int MAX_DEOPT_LINES = 100;
+    private static final String DEOPT_TAG = "[debug][deoptimization]";
+
+    public static void main(String[] args) throws Exception {
+        if (args.length >= 1) {
+            // Child process: execute workload that produces deoptimizations.
+            new DeoptStorm().run();
+            return;
+        }
+
+        // Parent process: spawn child with deopt logging enabled and validate output.
+        String className = DeoptStorm.class.getName();
+        String[] procArgs = {
+            "-XX:PerMethodRecompilationCutoff=2",
+            "-XX:CompileCommand=dontinline,compiler.uncommontrap::*",
+            "-Xlog:deoptimization=debug",
+            className, "dummy"};
+        ProcessBuilder pb  = ProcessTools.createLimitedTestJavaProcessBuilder(procArgs);
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        List<String> lines = out.asLines();
+        long deoptCount = lines.stream().filter(l -> l.contains(DEOPT_TAG)).count();
+        if (deoptCount > MAX_DEOPT_LINES) {
+            System.out.println(out.getStdout());
+            throw new RuntimeException("Failed: too many deoptimization report lines: " + deoptCount + " > " + MAX_DEOPT_LINES);
+        }
+        out.shouldHaveExitValue(0);
+    }
+
+    private static int iteration;
+    private static char[] data;
+    private static int max_index;
+
+    public void run() {
+        max_index = 999_999;
+        data = new char[max_index + 1];
+        data[max_index] = 'a';
+        iteration = 0;
+        for (int i = 0; i < 100_000_000; i++) {
+            deoptStorm();
+        }
+    }
+
+    // Run with: -XX:PerMethodRecompilationCutoff=2
+    // Expect: the 3rd deoptimization reaches the recompilation cutoff;
+    //         the method is no longer recompiled or made non-entrant,
+    //         so each call repeatedly triggers the same [unstable_if trap -> deopt].
+    public int deoptStorm() {
+        iteration = (iteration < max_index) ? iteration + 1 : 0;
+
+        // First array pass: profiling makes C2 believe this condition is always true,
+        // so it compiles the false branch as an uncommon trap (action=reinterpret).
+        // When the false branch executes, it triggers uncommon_trap and deoptimizes.
+        if (data[iteration] == 'a') { data[iteration] = 'b'; return 1; }
+
+        // Second pass: we hit the unstable_if uncommon trap again (now with the recompiled nmethod).
+        if (data[iteration] == 'b') { data[iteration] = 'c'; return 2; }
+
+        // After reaching the recompilation cutoff, C2 may emit uncommon_trap with action=none,
+        // so deoptimization no longer triggers recompilation. If executed frequently, this can
+        // produce a deoptimization storm.
+        if (data[iteration] == 'c') { max_index = 1; data[max_index] = 'c'; return 3; }
+
+        return 0;
+    }
+}

--- a/test/hotspot/jtreg/compiler/uncommontrap/DeoptStorm.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/DeoptStorm.java
@@ -54,7 +54,7 @@ public class DeoptStorm {
             "-XX:CompileCommand=dontinline,compiler.uncommontrap::*",
             "-Xlog:deoptimization=debug",
             className, "dummy"};
-        ProcessBuilder pb  = ProcessTools.createLimitedTestJavaProcessBuilder(procArgs);
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(procArgs);
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         List<String> lines = out.asLines();
         long deoptCount = lines.stream().filter(l -> l.contains(DEOPT_TAG)).count();


### PR DESCRIPTION
We observed a deoptimization storm caused by GraphKit::uncommon_trap generator logic. GraphKit::uncommon_trap considers the too_many_recompiles metric. If the threshold is overflowed, it replaces Deoptimization::Action_reinterpret with Deoptimization::Action_none (see code snippet below).

This replacement changes the uncommon_trap logic: once execution hits a trap, the VM performs deoptimization but does not recompile the method anymore. In an "unlucky" case, when the code part calling this uncommon_trap becomes frequent, a deoptimization storm occurs (thousands of deoptimizations per second) causing a significant performance drop.

The original problematic method, which triggered repeated recompilations, is a high-performance compressed binary serialization algorithm with heavy use of conditional branches driven by bitmasks. See a standalone [synthetic benchmark](https://bugs.openjdk.org/secure/attachment/118045/UnstableIf.java) to reproduce the issue.

The issue arises when the method overcomes a global recompilation threshold before stabilizing specific trap counters.

Current thresholds:
- Recompilation Limit (too_many_recompiles):
  Condition: decompile_count() >= (PerMethodRecompilationCutoff / 2) + 1
  Default: 201 (derived from default PerMethodRecompilationCutoff = 400).
- Specific Trap Limits (too_many_traps):
  Checks if the trap count for a specific reason exceeds:
  PerMethodTrapLimit (Default: 100) - for Reason_unstable_if, Reason_unstable_fused_if, etc.
  PerMethodSpecTrapLimit (Default: 5000) - for Reason_speculate_class_check, Reason_speculate_null_check, etc.

With the gived defaults, if the only reason for the method recompilation is unstable_if, the system stabilizes after 100 traps (PerMethodTrapLimit). However, if the method experiences traps and recompilations for different reasons, the total number of recompilations can exceed 200 before hitting the limit for unstable_if traps. This triggers Action_none and causes the deopt storm.

The proposal is a minimal change in GraphKit::uncommon_trap: apply the same `too_many_recompiles` threshold inside `Parse::path_is_suitable_for_uncommon_trap` - this ensures that on the final recompilation C2 gets a hint not to speculate on untaken branches anymore.

As an alternative solution, we can revisit GraphKit::uncommon_trap. This "Temporary fix" has persisted in the codebase for 17 years, so it is probably time to change it as well. Any comments are welcome
```cpp
  case Deoptimization::Action_reinterpret:
    // Temporary fix for 6529811 to allow virtual calls to be sure they
    // get the chance to go from mono->bi->mega
    if (!keep_exact_action &&
        Deoptimization::trap_request_index(trap_request) < 0 &&
        too_many_recompiles(reason)) {
      // This BCI is causing too many recompilations.
      if (C->log() != nullptr) {
        C->log()->elem("observe that='trap_action_change' reason='%s' from='%s' to='none'",
                Deoptimization::trap_reason_name(reason),
                Deoptimization::trap_action_name(action));
      }
      action = Deoptimization::Action_none;
      trap_request = Deoptimization::make_trap_request(reason, action);
    } else {
      C->set_trap_can_recompile(true);
    }
```

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8374307](https://bugs.openjdk.org/browse/JDK-8374307): Fix deoptimization storm caused by Action_none in GraphKit::uncommon_trap (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/28966/head:pull/28966` \
`$ git checkout pull/28966`

Update a local copy of the PR: \
`$ git checkout pull/28966` \
`$ git pull https://git.openjdk.org/jdk.git pull/28966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28966`

View PR using the GUI difftool: \
`$ git pr show -t 28966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/28966.diff">https://git.openjdk.org/jdk/pull/28966.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/28966#issuecomment-3687555347)
</details>
