### PR TITLE
8374441: (fs) FileSystemProvider.readAttributesIfExists throws "Not a directory" when element in path is not directory should return null for ENOTDIR (unix)

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
@@ -98,7 +98,8 @@ class UnixFileAttributes
                                                   path, flag, attrs);
         if (errno == 0)
             return attrs;
-        else if (errno == UnixConstants.ENOENT)
+        else if (errno == UnixConstants.ENOENT ||
+                 errno == UnixConstants.ENOTDIR)
             return null;
         else
             throw new UnixException(errno);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/file/Files/NotADirectory.java
+++ b/test/jdk/java/nio/file/Files/NotADirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/file/Files/NotADirectory.java
+++ b/test/jdk/java/nio/file/Files/NotADirectory.java
@@ -22,9 +22,10 @@
  */
 
 /* @test
- * @bug 8356678
+ * @bug 8356678 8374441
  * @requires (os.family != "windows")
- * @summary Test Files operations when a path component is not a directory
+ * @summary Test Files and FileSystemProvider operations when a path component
+ *          is not a directory
  * @run junit NotADirectory
  */
 
@@ -32,10 +33,12 @@ import java.io.IOException;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.FileSystemException;
+import java.nio.file.FileSystems;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -56,6 +59,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NotADirectory {
+    private static final FileSystemProvider PROVIDER =
+        FileSystems.getDefault().provider();
+
     private static final Path ROOT      = Path.of(".");
     private static final Path NOT_EXIST = ROOT.resolve("notExist");
     private static final Path DIR       = ROOT.resolve("dir");
@@ -147,15 +153,13 @@ public class NotADirectory {
     @Test
     public void readBasicIfExists() throws IOException {
         assertNull(
-            BOGUS.getFileSystem().provider().readAttributesIfExists(
-                BOGUS, BasicFileAttributes.class));
+            PROVIDER.readAttributesIfExists(BOGUS, BasicFileAttributes.class));
     }
 
     @Test
     public void readPosixIfExists() throws IOException {
         assertNull(
-            BOGUS.getFileSystem().provider().readAttributesIfExists(
-                BOGUS, PosixFileAttributes.class));
+            PROVIDER.readAttributesIfExists(BOGUS, PosixFileAttributes.class));
     }
 
     @Test

--- a/test/jdk/java/nio/file/Files/NotADirectory.java
+++ b/test/jdk/java/nio/file/Files/NotADirectory.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -141,6 +142,20 @@ public class NotADirectory {
     public void readPosix() throws IOException {
         assertThrows(NoSuchFileException.class,
                      () -> Files.readAttributes(BOGUS, PosixFileAttributes.class));
+    }
+
+    @Test
+    public void readBasicIfExists() throws IOException {
+        assertNull(
+            BOGUS.getFileSystem().provider().readAttributesIfExists(
+                BOGUS, BasicFileAttributes.class));
+    }
+
+    @Test
+    public void readPosixIfExists() throws IOException {
+        assertNull(
+            BOGUS.getFileSystem().provider().readAttributesIfExists(
+                BOGUS, PosixFileAttributes.class));
     }
 
     @Test


### PR DESCRIPTION
`FileSystemProvider.readAttributesIfExists` now returns `null` for a path with a true prefix that is not a directory rather than throwing `NotDirectoryException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374441](https://bugs.openjdk.org/browse/JDK-8374441): (fs) FileSystemProvider.readAttributesIfExists throws "Not a directory" when element in path is not directory should return null for ENOTDIR (unix) (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29013/head:pull/29013` \
`$ git checkout pull/29013`

Update a local copy of the PR: \
`$ git checkout pull/29013` \
`$ git pull https://git.openjdk.org/jdk.git pull/29013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29013`

View PR using the GUI difftool: \
`$ git pr show -t 29013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29013.diff">https://git.openjdk.org/jdk/pull/29013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29013#issuecomment-3703341032)
</details>
