### PR TITLE
8374544: Add SleepyCat diagnostics for all platforms

### DIFF
--- a/test/jdk/java/lang/RuntimeTests/exec/SleepyCat.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/SleepyCat.java
@@ -66,26 +66,19 @@ public class SleepyCat {
      * @param pids the processes to dump status for
      */
     static void dumpState(Process... pids) {
-        if (!System.getProperty("os.name").contains("SunOS")) {
-            return;
-        }
         try {
             String[] psArgs = {"ps", "-elf"};
-            Process ps = new ProcessBuilder(psArgs).inheritIO().start();
-            ps.waitFor();
-            String[] sfiles = {"pfiles", "self"};
-            Process fds = new ProcessBuilder(sfiles).inheritIO().start();
-            fds.waitFor();
+            try (Process ps = new ProcessBuilder(psArgs).inheritIO().start()) {
+                ps.waitFor();
+            }
 
             for (Process p : pids) {
                 if (p == null)
                     continue;
-                String[] pfiles = {"pfiles", Long.toString(p.pid())};
-                fds = new ProcessBuilder(pfiles).inheritIO().start();
-                fds.waitFor();
-                String[] pstack = {"pstack", Long.toString(p.pid())};
-                fds = new ProcessBuilder(pstack).inheritIO().start();
-                fds.waitFor();
+                String[] pfiles = {"lsof", "-p", Long.toString(p.pid())};
+                try (Process fds = new ProcessBuilder(pfiles).inheritIO().start()) {
+                    fds.waitFor();
+                }
             }
         } catch (IOException | InterruptedException i) {
             i.printStackTrace();

--- a/test/jdk/java/lang/RuntimeTests/exec/SleepyCat.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/SleepyCat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/RuntimeTests/exec/TEST.properties
+++ b/test/jdk/java/lang/RuntimeTests/exec/TEST.properties
@@ -1,0 +1,1 @@
+maxOutputSize=6000000


### PR DESCRIPTION
To aid diagnosis of these intermittent failures, add diagnostic information to the test failures.
On timeout, show ps and lsof commands for processes under test Add TEST.properties to increase jtreg maxOutputSize=6000000

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374544](https://bugs.openjdk.org/browse/JDK-8374544): Add SleepyCat diagnostics for all platforms (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29047/head:pull/29047` \
`$ git checkout pull/29047`

Update a local copy of the PR: \
`$ git checkout pull/29047` \
`$ git pull https://git.openjdk.org/jdk.git pull/29047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29047`

View PR using the GUI difftool: \
`$ git pr show -t 29047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29047.diff">https://git.openjdk.org/jdk/pull/29047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29047#issuecomment-3711958882)
</details>
