### PR TITLE
8327246: Add a jcmd diagnostic command to list the jar files loaded by a process

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2356,6 +2356,8 @@ void PrintClassClosure::do_klass(Klass* k)  {
   _st->print("%4d  ", k->size());
   // initialization state
 
+  assert(!k->is_instance_klass(), "not InstanceKlass!");
+
   InstanceKlass *ik = k->is_instance_klass() ? InstanceKlass::cast(k) : nullptr;
 
   if (ik != nullptr) {
@@ -2383,6 +2385,8 @@ void PrintClassClosure::do_klass(Klass* k)  {
 
     oop pd = java_lang_Class::protection_domain(k->java_mirror());
 
+    assert(pd != nullptr && !pd->klass()->is_instance_klass(), "pd klass is not InstanceKlass");
+
     if (pd != nullptr && (ik = pd->klass()->is_instance_klass() ? InstanceKlass::cast(pd->klass()) : nullptr) != nullptr) {
 
       TempNewSymbol css  = SymbolTable::new_symbol("codesource");
@@ -2394,6 +2398,8 @@ void PrintClassClosure::do_klass(Klass* k)  {
 
         oop cs = pd->obj_field(csfd.offset());
 
+        assert(cs !=nullptr && !cs->klass()->is_instance_klass(), "cs klass is not InstanceKlass");
+
         if (cs != nullptr && (ik = cs->klass()->is_instance_klass() ? InstanceKlass::cast(cs->klass()) : nullptr) != nullptr) {
           fieldDescriptor locfd;
 
@@ -2403,12 +2409,14 @@ void PrintClassClosure::do_klass(Klass* k)  {
           if (ik->find_field(csls, cslss, &locfd)) {
             oop loc = cs->obj_field(locfd.offset());
 
+            assert(loc != nullptr && loc->klass() != vmClasses::String_klass(), "locationNoFragString field is not a String");
+
             if (loc != nullptr && loc->klass() == vmClasses::String_klass()) {
               java_lang_String::print(loc, _st, MAXPATHLEN);
             }
           }
-        }
-      }
+        } else assert(true, "failed to find locationNoFragString field in CodeSource");
+      } else assert(true, "failed to find codeSource field in ProtectionDomain");
     }
   }
   // end

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2338,7 +2338,7 @@ Method* InstanceKlass::lookup_method_in_all_interfaces(Symbol* name,
 }
 
 PrintClassClosure::PrintClassClosure(outputStream* st, bool verbose, bool location)
-  :_st(st), _verbose(verbose), _location(location) {
+  :_st(st), _verbose(verbose), _location(location), _aot_statics(0), _aot_dynamics(0) {
   ResourceMark rm;
   _st->print("%-18s  ", "KlassAddr");
   _st->print("%-4s  ", "Size");
@@ -2383,7 +2383,6 @@ void PrintClassClosure::do_klass(Klass* k)  {
         if (_location) buf[i++] = 'd';
       }
     }
-
   }
   buf[i++] = '\0';
   _st->print("%-7s  ", buf);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2355,7 +2355,10 @@ void PrintClassClosure::do_klass(Klass* k)  {
   // klass size
   _st->print("%4d  ", k->size());
   // initialization state
-  if (k->is_instance_klass()) {
+
+  InstanceKlass *ik = k->is_instance_klass() ? InstanceKlass::cast(k) : nullptr;
+
+  if (ik != nullptr) {
     _st->print("%-20s  ",InstanceKlass::cast(k)->init_state_name());
   } else {
     _st->print("%-20s  ","");
@@ -2364,8 +2367,7 @@ void PrintClassClosure::do_klass(Klass* k)  {
   char buf[10];
   int i = 0;
   if (k->has_finalizer()) buf[i++] = 'F';
-  if (k->is_instance_klass()) {
-    InstanceKlass* ik = InstanceKlass::cast(k);
+  if (ik != nullptr) {
     if (ik->has_final_method()) buf[i++] = 'f';
     if (ik->is_rewritten()) buf[i++] = 'W';
     if (ik->is_contended()) buf[i++] = 'C';
@@ -2377,13 +2379,11 @@ void PrintClassClosure::do_klass(Klass* k)  {
   // klass name
   _st->print("%-5s  ", k->external_name());
 
-  if (k->is_instance_klass() && _location) {
+  if (ik != nullptr && _location) {
 
     oop pd = java_lang_Class::protection_domain(k->java_mirror());
 
-    InstanceKlass* ik;
-
-    if (pd != nullptr && (ik = InstanceKlass::cast(pd->klass()))->is_instance_klass()) {
+    if (pd != nullptr && (ik = pd->klass()->is_instance_klass() ? InstanceKlass::cast(pd->klass()) : nullptr) != nullptr) {
 
       TempNewSymbol css  = SymbolTable::new_symbol("codesource");
       TempNewSymbol csss = SymbolTable::new_symbol("Ljava/security/CodeSource;");
@@ -2394,7 +2394,7 @@ void PrintClassClosure::do_klass(Klass* k)  {
 
         oop cs = pd->obj_field(csfd.offset());
 
-        if (cs != nullptr && (ik = InstanceKlass::cast(cs->klass()))->is_instance_klass()) {
+        if (cs != nullptr && (ik = cs->klass()->is_instance_klass() ? InstanceKlass::cast(cs->klass()) : nullptr) != nullptr) {
           fieldDescriptor locfd;
 
           TempNewSymbol csls  = SymbolTable::new_symbol("locationNoFragString");

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2372,7 +2372,18 @@ void PrintClassClosure::do_klass(Klass* k)  {
     if (ik->is_rewritten()) buf[i++] = 'W';
     if (ik->is_contended()) buf[i++] = 'C';
     if (ik->has_been_redefined()) buf[i++] = 'R';
-    if (ik->in_aot_cache()) buf[i++] = 'S';
+    if (ik->in_aot_cache()) {
+      buf[i++] = 'S';
+
+      if (AOTMetaspace::in_aot_cache_static_region((void*)k)) {
+        _aot_statics++;
+        if (_location) buf[i++] = 's';
+      } else if (AOTMetaspace::in_aot_cache_dynamic_region((void*)k)) {
+        _aot_dynamics++;
+        if (_location) buf[i++] = 'd';
+      }
+    }
+
   }
   buf[i++] = '\0';
   _st->print("%-7s  ", buf);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2375,12 +2375,14 @@ void PrintClassClosure::do_klass(Klass* k)  {
     if (ik->in_aot_cache()) {
       buf[i++] = 'S';
 
-      if (AOTMetaspace::in_aot_cache_static_region((void*)k)) {
-        _aot_statics++;
-        if (_location) buf[i++] = 's';
-      } else if (AOTMetaspace::in_aot_cache_dynamic_region((void*)k)) {
-        _aot_dynamics++;
-        if (_location) buf[i++] = 'd';
+      if (_location) {
+        if (AOTMetaspace::in_aot_cache_static_region((void*)k)) {
+          _aot_statics++;
+          buf[i++] = 's';
+        } else if (AOTMetaspace::in_aot_cache_dynamic_region((void*)k)) {
+          _aot_dynamics++;
+          buf[i++] = 'd';
+        }
       }
     }
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2383,9 +2383,9 @@ void PrintClassClosure::do_klass(Klass* k)  {
 
     oop pd = java_lang_Class::protection_domain(k->java_mirror());
 
-    assert(pd == nullptr || pd->klass()->is_instance_klass(), "pd klass is not InstanceKlass");
-
     if (pd != nullptr) {
+
+      assert(pd->klass()->is_instance_klass(), "pd klass is not InstanceKlass");
 
       TempNewSymbol css  = SymbolTable::new_symbol("codesource");
       TempNewSymbol csss = SymbolTable::new_symbol("Ljava/security/CodeSource;");
@@ -2396,9 +2396,9 @@ void PrintClassClosure::do_klass(Klass* k)  {
 
         oop cs = pd->obj_field(csfd.offset());
 
-        assert(cs == nullptr || cs->klass()->is_instance_klass(), "cs klass is not InstanceKlass");
-
         if (cs != nullptr) {
+          assert(cs->klass()->is_instance_klass(), "cs klass is not InstanceKlass");
+
           fieldDescriptor locfd;
 
           TempNewSymbol csls  = SymbolTable::new_symbol("locationNoFragString");
@@ -2410,7 +2410,7 @@ void PrintClassClosure::do_klass(Klass* k)  {
             assert(loc == nullptr || loc->klass() == vmClasses::String_klass(), "locationNoFragString field is not a String");
 
             if (loc != nullptr) {
-              java_lang_String::print(loc, _st, MAXPATHLEN);
+              java_lang_String::print(loc, _st, JVM_MAXPATHLEN);
             }
           }
         }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1211,6 +1211,9 @@ private:
   bool _verbose;
   bool _location;
 public:
+  unsigned int _aot_statics;
+  unsigned int _aot_dynamics;
+
   PrintClassClosure(outputStream* st, bool verbose, bool location);
 
   void do_klass(Klass* k);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1209,8 +1209,9 @@ class PrintClassClosure : public KlassClosure {
 private:
   outputStream* _st;
   bool _verbose;
+  bool _location;
 public:
-  PrintClassClosure(outputStream* st, bool verbose);
+  PrintClassClosure(outputStream* st, bool verbose, bool location);
 
   void do_klass(Klass* k);
 };

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -25,6 +25,7 @@
 #include "cds/aotMetaspace.hpp"
 #include "cds/cds_globals.hpp"
 #include "cds/cdsConfig.hpp"
+#include "cds/filemap.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/classLoaderHierarchyDCmd.hpp"
 #include "classfile/classLoaderStats.hpp"
@@ -957,9 +958,9 @@ ClassesDCmd::ClassesDCmd(outputStream* output, bool heap) :
            "W = methods rewritten, "
            "C = marked with @Contended annotation, "
            "R = has been redefined, "
-           "S = is shared class",
+           "S = is shared class (if -location then 's' indicates static 'd' indicates dynamic AOT cache)",
            "BOOLEAN", false, "false"),
-  _location("-location", "Print class file location url (if available)", "BOOLEAN", false, "false") {
+  _location("-location", "Print class file (and AOT cache) location url (if available)", "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_verbose);
   _dcmdparser.add_dcmd_option(&_location);
 }
@@ -977,6 +978,13 @@ public:
   virtual void doit() {
     PrintClassClosure closure(_out, _verbose, _location);
     ClassLoaderDataGraph::classes_do(&closure);
+
+    if (_location) {
+      if (closure._aot_statics > 0)
+        _out->print_cr("\n%d classes shared from static cache: %s", closure._aot_statics, FileMapInfo::current_info()->full_path());
+      if (closure._aot_dynamics > 0)
+        _out->print_cr("\n%d classes shared from dynamic cache: %s", closure._aot_dynamics, FileMapInfo::dynamic_info()->full_path());
+    }
   }
 };
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -958,27 +958,30 @@ ClassesDCmd::ClassesDCmd(outputStream* output, bool heap) :
            "C = marked with @Contended annotation, "
            "R = has been redefined, "
            "S = is shared class",
-           "BOOLEAN", false, "false") {
+           "BOOLEAN", false, "false"),
+  _location("-location", "print class file location url (if available)", "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_verbose);
+  _dcmdparser.add_dcmd_option(&_location);
 }
 
 class VM_PrintClasses : public VM_Operation {
 private:
   outputStream* _out;
   bool _verbose;
+  bool _location;
 public:
-  VM_PrintClasses(outputStream* out, bool verbose) : _out(out), _verbose(verbose) {}
+  VM_PrintClasses(outputStream* out, bool verbose, bool location) : _out(out), _verbose(verbose), _location(location) {}
 
   virtual VMOp_Type type() const { return VMOp_PrintClasses; }
 
   virtual void doit() {
-    PrintClassClosure closure(_out, _verbose);
+    PrintClassClosure closure(_out, _verbose, _location);
     ClassLoaderDataGraph::classes_do(&closure);
   }
 };
 
 void ClassesDCmd::execute(DCmdSource source, TRAPS) {
-  VM_PrintClasses vmop(output(), _verbose.value());
+  VM_PrintClasses vmop(output(), _verbose.value(), _location.value());
   VMThread::execute(&vmop);
 }
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -959,7 +959,7 @@ ClassesDCmd::ClassesDCmd(outputStream* output, bool heap) :
            "R = has been redefined, "
            "S = is shared class",
            "BOOLEAN", false, "false"),
-  _location("-location", "print class file location url (if available)", "BOOLEAN", false, "false") {
+  _location("-location", "Print class file location url (if available)", "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_verbose);
   _dcmdparser.add_dcmd_option(&_location);
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -952,13 +952,14 @@ ClassesDCmd::ClassesDCmd(outputStream* output, bool heap) :
                                      DCmdWithParser(output, heap),
   _verbose("-verbose",
            "Dump the detailed content of a Java class.\n"
-           "\t\tclasses are annotated with flags:\n"
-           "\t\tF = has, or inherits, a non-empty finalize method,\n"
-           "\t\tf = has final method,\n"
-           "\t\tW = methods rewritten,\n"
-           "\t\tC = marked with @Contended annotation,\n"
-           "\t\tR = has been redefined,\n"
-           "\t\tS = is an (App)CDS shared class (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, are appended)",
+           "\t\t   classes are annotated with flags:\n"
+           "\t\t   F = has, or inherits, a non-empty finalize method,\n"
+           "\t\t   f = has final method,\n"
+           "\t\t   W = methods rewritten,\n"
+           "\t\t   C = marked with @Contended annotation,\n"
+           "\t\t   R = has been redefined,\n"
+           "\t\t   S = is an (App)CDS shared class,\n"
+           "\t\t       (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, are appended)\n\t",
            "BOOLEAN", false, "false"),
   _location("-location", "Print class file location url (if available)", "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_verbose);

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -951,16 +951,16 @@ void ClassHierarchyDCmd::execute(DCmdSource source, TRAPS) {
 ClassesDCmd::ClassesDCmd(outputStream* output, bool heap) :
                                      DCmdWithParser(output, heap),
   _verbose("-verbose",
-           "Dump the detailed content of a Java class. "
-           "Some classes are annotated with flags: "
-           "F = has, or inherits, a non-empty finalize method, "
-           "f = has final method, "
-           "W = methods rewritten, "
-           "C = marked with @Contended annotation, "
-           "R = has been redefined, "
-           "S = is shared class (if -location then 's' indicates static 'd' indicates dynamic AOT cache)",
+           "Dump the detailed content of a Java class.\n"
+           "\t\tclasses are annotated with flags:\n"
+           "\t\tF = has, or inherits, a non-empty finalize method,\n"
+           "\t\tf = has final method,\n"
+           "\t\tW = methods rewritten,\n"
+           "\t\tC = marked with @Contended annotation,\n"
+           "\t\tR = has been redefined,\n"
+           "\t\tS = is an (App)CDS shared class (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, are appended)",
            "BOOLEAN", false, "false"),
-  _location("-location", "Print class file (and AOT cache) location url (if available)", "BOOLEAN", false, "false") {
+  _location("-location", "Print class file location url (if available)", "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_verbose);
   _dcmdparser.add_dcmd_option(&_location);
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -950,17 +950,7 @@ void ClassHierarchyDCmd::execute(DCmdSource source, TRAPS) {
 
 ClassesDCmd::ClassesDCmd(outputStream* output, bool heap) :
                                      DCmdWithParser(output, heap),
-  _verbose("-verbose",
-           "Dump the detailed content of a Java class.\n"
-           "\t\t   classes are annotated with flags:\n"
-           "\t\t   F = has, or inherits, a non-empty finalize method,\n"
-           "\t\t   f = has final method,\n"
-           "\t\t   W = methods rewritten,\n"
-           "\t\t   C = marked with @Contended annotation,\n"
-           "\t\t   R = has been redefined,\n"
-           "\t\t   S = is an (App)CDS shared class,\n"
-           "\t\t       (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, are appended)\n\t",
-           "BOOLEAN", false, "false"),
+  _verbose("-verbose", "Dump the detailed content of a Java class.", "BOOLEAN", false, "false"),
   _location("-location", "Print class file location url (if available)", "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_verbose);
   _dcmdparser.add_dcmd_option(&_location);

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -737,8 +737,9 @@ public:
 class ClassesDCmd : public DCmdWithParser {
 protected:
   DCmdArgument<bool> _verbose;
+  DCmdArgument<bool> _location;
 public:
-  static int num_arguments() { return 1; }
+  static int num_arguments() { return 2; }
   ClassesDCmd(outputStream* output, bool heap);
   static const char* name() {
     return "VM.classes";

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -735,6 +735,18 @@ public:
 };
 
 class ClassesDCmd : public DCmdWithParser {
+private:
+  static constexpr const char *desc = R"(
+Print all loaded classes, classes are annotated with flags:
+  F = has, or inherits, a non-empty finalize method,
+  f = has final method,
+  W = methods rewritten,
+  C = marked with @Contended annotation,
+  R = has been redefined,
+  S = is an (App)CDS shared class,
+      (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, is appended)
+  )";
+
 protected:
   DCmdArgument<bool> _verbose;
   DCmdArgument<bool> _location;
@@ -745,7 +757,7 @@ public:
     return "VM.classes";
   }
   static const char* description() {
-    return "Print all loaded classes";
+    return desc;
   }
   static const char* impact() {
       return "Medium: Depends on number of loaded classes.";

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -736,16 +736,7 @@ public:
 
 class ClassesDCmd : public DCmdWithParser {
 private:
-  static constexpr const char *desc = R"(
-Print all loaded classes, classes are annotated with flags:
-  F = has, or inherits, a non-empty finalize method,
-  f = has final method,
-  W = methods rewritten,
-  C = marked with @Contended annotation,
-  R = has been redefined,
-  S = is an (App)CDS shared class,
-      (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, is appended)
-  )";
+  static constexpr const char *desc = "Print all loaded classes,\nclasses are annotated with flags:\n F = has, or inherits, a non-empty finalize method,\n f = has final method,\n W = methods rewritten,\n C = marked with @Contended annotation,\n R = has been redefined,\n S = is an (App)CDS shared class,\n     (if -location is also specified, (either) 's' indicating static (or) 'd' indicating dynamic AOT cache locations, is appended)";
 
 protected:
   DCmdArgument<bool> _verbose;

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -804,6 +804,12 @@ The following commands are available:
         `f` = has final method, `W` = methods rewritten, `C` = marked with `@Contended` annotation,
         `R` = has been redefined, `S` = is shared class (BOOLEAN, false)
 
+    -   `-location`: (Optional) Print the location of the class file from which the class is loaded (if available)
+         If provided by its defining ClassLoader, this option will print a URL specifying the location of the 
+         class file (directory, jar or other URL location) from which this class was loaded.
+
+         Note: JDK (and other classes) loaded by a ClassLoader that does not provide a location URL to the JVM will omit this field.
+
 `VM.classloader_stats`
 :   Print statistics about all ClassLoaders.
 

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -806,7 +806,7 @@ The following commands are available:
           - `W` = methods rewritten,
           - `C` = marked with `@Contended` annotation,
           - `R` = has been redefined,
-          - `S` = is shared class (if -location 's' is static and 'd' is dynamic AOT cache location)
+          - `S` = is shared class (if -location is specified then either 's' (for static) or 'd' (for dynamic) AOT cache origin is appended)
         (BOOLEAN, false)
 
     -   `-location`: (Optional) Print the location of the class file from which the class is loaded (if available)
@@ -816,9 +816,11 @@ The following commands are available:
          Note: JDK (and other classes) loaded by a ClassLoader that does not provide a location URL to the JVM will omit this field.
 
          Note: if any classes are loaded from an AOT cache, their location reported is that of the original
-               url from which they were loaded at the time of the training run that created the AOT cache.
+               url from which they were loaded at the time of the training run that created the AOT cache,
+               additionally the flags will also be annotated to indicate the AOT cache origin (static or dynamic).
 
-               The total number of classes loaded from any AOT cache (and its name) are summarized. 
+               The total number of classes loaded (if any) from either AOT cache (and the associated cache filepath) are summarized. 
+
 `VM.classloader_stats`
 :   Print statistics about all ClassLoaders.
 

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -800,16 +800,25 @@ The following commands are available:
     *options*:
 
     -   `-verbose`: (Optional) Dump the detailed content of a Java class.
-        Some classes are annotated with flags: `F` = has, or inherits, a non-empty finalize method,
-        `f` = has final method, `W` = methods rewritten, `C` = marked with `@Contended` annotation,
-        `R` = has been redefined, `S` = is shared class (BOOLEAN, false)
+        Some classes are annotated with flags:
+          - `F` = has, or inherits, a non-empty finalize method,
+          - `f` = has final method,
+          - `W` = methods rewritten,
+          - `C` = marked with `@Contended` annotation,
+          - `R` = has been redefined,
+          - `S` = is shared class (if -location 's' is static and 'd' is dynamic AOT cache location)
+        (BOOLEAN, false)
 
     -   `-location`: (Optional) Print the location of the class file from which the class is loaded (if available)
          If provided by its defining ClassLoader, this option will print a URL specifying the location of the 
-         class file (directory, jar or other URL location) from which this class was loaded.
+         class file (directory, jar or other URL location) from which this class was initially loaded.
 
          Note: JDK (and other classes) loaded by a ClassLoader that does not provide a location URL to the JVM will omit this field.
 
+         Note: if any classes are loaded from an AOT cache, their location reported is that of the original
+               url from which they were loaded at the time of the training run that created the AOT cache.
+
+               The total number of classes loaded from any AOT cache (and its name) are summarized. 
 `VM.classloader_stats`
 :   Print statistics about all ClassLoaders.
 

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -810,7 +810,7 @@ The following commands are available:
         (BOOLEAN, false)
 
     -   `-location`: (Optional) Print the location of the class file from which the class is loaded (if available)
-         If provided by its defining ClassLoader, this option will print a URL specifying the location of the 
+         If provided by its defining ClassLoader, this option will print a URL specifying the location of the
          class file (directory, jar or other URL location) from which this class was initially loaded.
 
          Note: JDK (and other classes) loaded by a ClassLoader that does not provide a location URL to the JVM will omit this field.
@@ -819,7 +819,7 @@ The following commands are available:
                url from which they were loaded at the time of the training run that created the AOT cache,
                additionally the flags will also be annotated to indicate the AOT cache origin (static or dynamic).
 
-               The total number of classes loaded (if any) from either AOT cache (and the associated cache filepath) are summarized. 
+               The total number of classes loaded (if any) from either AOT cache (and the associated cache filepath) are summarized.
 
 `VM.classloader_stats`
 :   Print statistics about all ClassLoaders.

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -790,24 +790,23 @@ The following commands are available:
         no default value)
 
 `VM.classes` \[*options*\]
-:   Print all loaded classes
+:   Print all loaded classes.
 
-    Impact: Medium: Depends on number of loaded classes.
+    Some classes may be annotated with flags:
+        - `F` = has, or inherits, a non-empty finalize method,
+        - `f` = has final method,
+        - `W` = methods rewritten,
+        - `C` = marked with `@Contended` annotation,
+        - `R` = has been redefined,
+        - `S` = is shared class (if `-location` is specified then either 's' (for static) or 'd' (for dynamic) AOT cache origin is appended)
 
-    The following *options* must be specified using either *key* or
-    *key*`=`*value* syntax.
-
+    Impact: Medium: Depends on number of loaded classes. 
+        
+    The following *options* must be specified using either *key* or *key*`=`*value* syntax. 
+          
     *options*:
-
-    -   `-verbose`: (Optional) Dump the detailed content of a Java class.
-        Some classes are annotated with flags:
-          - `F` = has, or inherits, a non-empty finalize method,
-          - `f` = has final method,
-          - `W` = methods rewritten,
-          - `C` = marked with `@Contended` annotation,
-          - `R` = has been redefined,
-          - `S` = is shared class (if -location is specified then either 's' (for static) or 'd' (for dynamic) AOT cache origin is appended)
-        (BOOLEAN, false)
+        
+    -   `-verbose`: (Optional) Dump the detailed content of a Java class. (BOOLEAN, false)
 
     -   `-location`: (Optional) Print the location of the class file from which the class is loaded (if available)
          If provided by its defining ClassLoader, this option will print a URL specifying the location of the
@@ -819,7 +818,7 @@ The following commands are available:
                url from which they were loaded at the time of the training run that created the AOT cache,
                additionally the flags will also be annotated to indicate the AOT cache origin (static or dynamic).
 
-               The total number of classes loaded (if any) from either AOT cache (and the associated cache filepath) are summarized.
+               The total number of classes loaded (if any) from either AOT cache (and the associated cache path location) are summarized.
 
 `VM.classloader_stats`
 :   Print statistics about all ClassLoaders.

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -800,12 +800,12 @@ The following commands are available:
         - `R` = has been redefined,
         - `S` = is shared class (if `-location` is specified then either 's' (for static) or 'd' (for dynamic) AOT cache origin is appended)
 
-    Impact: Medium: Depends on number of loaded classes. 
-        
-    The following *options* must be specified using either *key* or *key*`=`*value* syntax. 
-          
+    Impact: Medium: Depends on number of loaded classes.
+
+    The following *options* must be specified using either *key* or *key*`=`*value* syntax.
+
     *options*:
-        
+
     -   `-verbose`: (Optional) Dump the detailed content of a Java class. (BOOLEAN, false)
 
     -   `-location`: (Optional) Print the location of the class file from which the class is loaded (if available)

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -59,5 +59,9 @@ public class PrintClasses {
 
     // Test for previous bug in misc flags printing
     output.shouldNotContain("##name");
+
+    pb.command(new PidJcmdExecutor().getCommandLine("VM.classes", "-location"));
+    output = new OutputAnalyzer(pb.start());
+    output.stdoutContains(".*(file:/|jar:).*");
   }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -62,6 +62,6 @@ public class PrintClasses {
 
     pb.command(new PidJcmdExecutor().getCommandLine("VM.classes", "-location"));
     output = new OutputAnalyzer(pb.start());
-    output.stdoutContains(".*(file:/|jar:).*");
+    output.stdoutShouldMatch("^.*(file:/|jar:).*$");
   }
 }


### PR DESCRIPTION
modified the pre-existing VM.classes jcmd to add a 'location' option, that when specified, will (natively) attempt to obtain the value (if non-null) of the location URL of the CodeSource of each classes ProtectionDomain.

effectively:

someObject.getClass().getProtectionDomain().getCodeSource().getLocation().toExternalForm()

(where interim oops are null-checked)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8377709](https://bugs.openjdk.org/browse/JDK-8377709) to be approved
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issues
 * [JDK-8327246](https://bugs.openjdk.org/browse/JDK-8327246): Add a jcmd diagnostic command to list the jar files loaded by a process (**Enhancement** - P4)
 * [JDK-8377709](https://bugs.openjdk.org/browse/JDK-8377709): Add a jcmd diagnostic command to list the jar files loaded by a process (**CSR**)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) 🔄 Re-review required (review applies to [22f27bee](https://git.openjdk.org/jdk/pull/29048/files/22f27bee7c78997638ff53cd9d67e7f351576448))
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) 🔄 Re-review required (review applies to [55d270dc](https://git.openjdk.org/jdk/pull/29048/files/55d270dcc3e8f18806699449fc243942844ff8d4))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29048/head:pull/29048` \
`$ git checkout pull/29048`

Update a local copy of the PR: \
`$ git checkout pull/29048` \
`$ git pull https://git.openjdk.org/jdk.git pull/29048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29048`

View PR using the GUI difftool: \
`$ git pr show -t 29048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29048.diff">https://git.openjdk.org/jdk/pull/29048.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29048#issuecomment-3711970656)
</details>
