### PR TITLE
8291986: ProcessBuilder.redirectErrorStream(true) leaves error stream available

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
+++ b/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,32 +21,46 @@
  * questions.
  */
 
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
-import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.Writer;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.lang.ProcessHandle;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /*
  * @test
- * @bug 8289643 8291760
- * @requires (os.family == "linux" & !vm.musl)
+ * @bug 8289643 8291760 8291986
+ * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
  * @summary File descriptor leak detection with ProcessBuilder.startPipeline
- * @run testng/othervm PipelineLeaksFD
+ * @run junit/othervm PipelineLeaksFD
  */
 
-@Test
+/*
+ * @test
+ * @bug 8289643 8291986
+ * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
+ * @summary File descriptor leak detection with ProcessBuilder.startPipeline
+ * @run junit/othervm -Xint PipelineLeaksFD
+ */
+
 public class PipelineLeaksFD {
-    @DataProvider
-    public Object[][] builders() {
+
+    private static final String OS_NAME = System.getProperty("os.name", "Unknown");
+
+    private static final long MY_PID =  ProcessHandle.current().pid();
+
+    // Test cases for pipelines with a number of pipeline sequences
+    public static Object[][] builders() {
         return new Object[][]{
                 {List.of(new ProcessBuilder("cat"))},
                 {List.of(new ProcessBuilder("cat"),
@@ -59,20 +73,22 @@ public class PipelineLeaksFD {
         };
     }
 
-    @Test(dataProvider = "builders")
+    @ParameterizedTest
+    @MethodSource("builders")
     void checkForLeaks(List<ProcessBuilder> builders) throws IOException {
 
-        Set<PipeRecord> pipesBefore = myPipes();
+        Set<PipeRecord> pipesBefore = pipesForPid(MY_PID);
         if (pipesBefore.size() < 3) {
-            System.out.println(pipesBefore);
-            Assert.fail("There should be at least 3 pipes before, (0, 1, 2)");
+            System.err.println(pipesBefore);
+            fail("There should be at least 3 pipes before, (0, 1, 2)");
         }
+        printPipes(pipesBefore, "Before start");
 
         List<Process> processes = ProcessBuilder.startPipeline(builders);
 
         // Write something through the pipeline
         final String text = "xyz";
-        try (Writer out = processes.get(0).outputWriter()) {
+        try (Writer out = processes.getFirst().outputWriter()) {
             out.write(text);
         }
 
@@ -84,16 +100,16 @@ public class PipelineLeaksFD {
             try (BufferedReader inputStream = p.inputReader();
                  BufferedReader errorStream = p.errorReader()) {
                 String outActual = inputStream.readLine();
-                Assert.assertEquals(outActual, expectedOut, "stdout, process[ " + i + "]: " + p);
+                assertEquals(expectedOut, outActual, "stdout, process[ " + i + "]: " + p);
 
                 String errActual = errorStream.readLine();
-                Assert.assertEquals(errActual, expectedErr, "stderr, process[ " + i + "]: " + p);
+                assertEquals(expectedErr, errActual, "stderr, process[ " + i + "]: " + p);
             }
         }
 
-        processes.forEach(p -> waitForQuiet(p));
+        processes.forEach(PipelineLeaksFD::waitForQuiet);
 
-        Set<PipeRecord> pipesAfter = myPipes();
+        Set<PipeRecord> pipesAfter = pipesForPid(MY_PID);
         if (!pipesBefore.equals(pipesAfter)) {
             Set<PipeRecord> missing = new HashSet<>(pipesBefore);
             missing.removeAll(pipesAfter);
@@ -101,46 +117,157 @@ public class PipelineLeaksFD {
             Set<PipeRecord> extra = new HashSet<>(pipesAfter);
             extra.removeAll(pipesBefore);
             printPipes(extra, "Extra pipes in pipesAfter");
-            Assert.fail("More or fewer pipes than expected");
+            fail("More or fewer pipes than expected");
+        }
+    }
+
+    // Test redirectErrorStream, both true and false
+    public static Object[][] redirectCases() {
+        return new Object[][] {
+                {true},
+                {false},
+        };
+    }
+
+    // Test redirectErrorStream  (true/false) has the right number of pipes in use
+    @ParameterizedTest()
+    @MethodSource("redirectCases")
+    void checkRedirectErrorStream(boolean redirectError) throws IOException {
+        try (Process p = new ProcessBuilder("cat")
+                .redirectErrorStream(redirectError)
+                .start()) {
+            System.err.printf("Parent PID; %d, Child Pid: %d\n", MY_PID, p.pid());
+            final Set<PipeRecord> pipes = pipesForPid(p.pid());
+            printPipes(pipes, "Parent and waiting child pipes");
+            int uniquePipes = redirectError ? 8 : 9;
+            assertEquals(uniquePipes, pipes.size(),
+                    "wrong number of pipes for redirect: " + redirectError);
+        } catch (IOException ioe) {
+            fail("Process start", ioe);
         }
     }
 
     static void printPipes(Set<PipeRecord> pipes, String label) {
-        System.out.printf("%s: [%d]%n", label, pipes.size());
-        pipes.forEach(r -> System.out.printf("%-20s: %s%n", r.fd(), r.link()));
+        System.err.printf("%s: [%d]%n", label, pipes.size());
+        pipes.forEach(System.err::println);
     }
 
     static void waitForQuiet(Process p) {
         try {
             int st = p.waitFor();
             if (st != 0) {
-                System.out.println("non-zero exit status: " + p);
+                System.err.println("non-zero exit status: " + p);
             }
         } catch (InterruptedException ie) {
         }
     }
 
     /**
-     * Collect a Set of pairs of /proc fd paths and the symbol links that are pipes.
+     * Collect a Set of file descriptors and identifying information.
+     * To identify the pipes in use the `lsof` command is invoked and output scrapped for
+     * fd's, pids, unique identities of the pipes (to match with parent).
+     * The pipes used by invoking the `lsof` process are removed from set captured
+     * for the parent (this test) and the child (waiting).
      * @return A set of PipeRecords, possibly empty
      */
-    static Set<PipeRecord> myPipes() {
-        Path path = Path.of("/proc/" + ProcessHandle.current().pid() + "/fd");
-        Set<PipeRecord> pipes = new HashSet<>();
-        File[] files = path.toFile().listFiles(f -> Files.isSymbolicLink(f.toPath()));
-        if (files != null) {
-            for (File file : files) {
-                try {
-                    Path link = Files.readSymbolicLink(file.toPath());
-                    if (link.toString().startsWith("pipe:")) {
-                        pipes.add(new PipeRecord(file.toPath(), link));
-                    }
-                } catch (IOException ioe) {
-                }
-            }
+    static Set<PipeRecord> pipesForPid(long pid) throws IOException {
+        try (Process p = new ProcessBuilder("lsof")
+                .redirectErrorStream(true)
+                .start()) {
+            long lsofPid = p.pid();
+            List<String> lines = p.inputReader().readAllLines();
+
+            // Collect all the pipes for the three processes (parent, waiting child, lsof)
+            Set<PipeRecord> pipes = lines.stream()
+                    .map(PipelineLeaksFD::pipeFromLSOF)
+                    .filter(pr -> pr != null &&
+                            (pr.pid() == pid || pr.pid() == MY_PID || pr.pid() == lsofPid))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            // Extract the `lsof` pipe keys and remove those pipes from the set
+            List<KeyedString> lsofPipeNames = pipes.stream()
+                    .filter(pr1 -> pr1.pid() == lsofPid)
+                    .map(PipeRecord::myKey)
+                    .toList();
+            pipes.removeIf(p1 -> lsofPipeNames.contains(p1.myKey()));
+            return pipes;
         }
-        return pipes;
     }
 
-    record PipeRecord(Path fd, Path link) { };
+    // Return pipe records by parsing the appropriate platform specific `lsof` output.
+    static PipeRecord pipeFromLSOF(String s) {
+        return switch (OS_NAME) {
+            case "Linux" -> pipeFromLinuxLSOF(s);
+            case "Mac OS X" -> pipeFromMacLSOF(s);
+            default -> throw new RuntimeException("lsof not supported on platform: " + OS_NAME);
+        };
+    }
+
+    // Return Pipe from lsof output put, or null (on Mac OS X)
+    // lsof      55221 rriggs    0      PIPE 0xc76402237956a5cb      16384  ->0xfcb0c07ae447908c
+    // lsof      55221 rriggs    1      PIPE 0xb486e02f86da463e      16384  ->0xf94eacc85896b4e6
+    static PipeRecord pipeFromMacLSOF(String s) {
+        String[] fields = s.split("\\s+");
+        if ("PIPE".equals(fields[4])) {
+            final int pid = Integer.parseInt(fields[1]);
+            final String myKey = (fields.length > 5) ? fields[5] : "";
+            final String otherKey = (fields.length > 7) ? fields[7].substring(2) : "";
+            return PipeRecord.lookup(Integer.parseInt(fields[3]), myKey, otherKey, pid);
+        }
+        return null;
+    }
+
+    // Return Pipe from lsof output put, or null (on Linux)
+    // java    7612 rriggs   14w  FIFO   0,12       0t0   117662267 pipe
+    // java    7612 rriggs   15r  FIFO   0,12       0t0   117662268 pipe
+    static PipeRecord pipeFromLinuxLSOF(String s) {
+        String[] fields = s.split("\\s+");
+        if ("FIFO".equals(fields[4])) {
+            final int pid = Integer.parseInt(fields[1]);
+            final String key = (fields.length > 7) ? fields[7] : "";
+            final int fdNum = Integer.parseInt(fields[3].substring(0, fields[3].length() - 1));
+            return PipeRecord.lookup(fdNum, key, null, pid);
+        }
+        return null;
+    }
+
+    // Identify a pipe by pid, fd, and a key (unique across processes)
+    // Mac OS X has separate keys for read and write sides, both are matched to the same "name"
+    record PipeRecord(long pid, int fd, KeyedString myKey) {
+        static PipeRecord lookup(int fd, String myKey, String otherKey, int pid) {
+            return new PipeRecord(pid, fd, KeyedString.getKey(myKey, otherKey));
+        }
+    }
+
+    // A unique name for a string with a count of uses
+    // Used to associate pipe between parent and child.
+    static class KeyedString {
+        private static final HashMap<String, KeyedString> map = new HashMap<>();
+        private static int nextInt = 1;
+        private final String key;
+        private final String name;
+        private int count;
+        KeyedString(String key, String name) {
+            this.key = key;
+            this.name = name;
+            this.count = 0;
+        }
+
+        KeyedString(String s) {
+            String k = "p" + nextInt++;
+            this(s, k);
+        }
+
+        static KeyedString getKey(String key, String otherKey) {
+            var k = map.computeIfAbsent(key, KeyedString::new);
+            k.count++;
+            if (otherKey != null) {
+                map.putIfAbsent(otherKey, k);
+            }
+            return k;
+        }
+
+        public String toString() {
+            return name + "(" + count + ")";
+        }
+    }
 }

--- a/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
+++ b/test/jdk/java/lang/ProcessBuilder/PipelineLeaksFD.java
@@ -46,14 +46,6 @@ import java.util.stream.Collectors;
  * @run junit/othervm PipelineLeaksFD
  */
 
-/*
- * @test
- * @bug 8289643 8291986
- * @requires os.family == "mac" | (os.family == "linux" & !vm.musl)
- * @summary File descriptor leak detection with ProcessBuilder.startPipeline
- * @run junit/othervm -Xint PipelineLeaksFD
- */
-
 public class PipelineLeaksFD {
 
     private static final String OS_NAME = System.getProperty("os.name", "Unknown");

--- a/test/jdk/java/lang/ProcessBuilder/TEST.properties
+++ b/test/jdk/java/lang/ProcessBuilder/TEST.properties
@@ -1,0 +1,1 @@
+maxOutputSize=6000000


### PR DESCRIPTION
On Linux and Mac, when a process is started, pipes are created to communicate with the child.
In the case where the stderr is redirected to stdout using `ProcessBuilder.redirectErrorStream()`, the pipe is not needed and should not be created.

Added a test to check pipe creation when spawning with and without `redirectErrorStream(t/f)`. 
Rewrote the extraction of pipes to use `lsof` available on Mac and Linux. (previously used Linux /proc/pid/fd/...)
Converted PipelineLeaksFD test to JUnit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291986](https://bugs.openjdk.org/browse/JDK-8291986): ProcessBuilder.redirectErrorStream(true) leaves error stream available (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29143/head:pull/29143` \
`$ git checkout pull/29143`

Update a local copy of the PR: \
`$ git checkout pull/29143` \
`$ git pull https://git.openjdk.org/jdk.git pull/29143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29143`

View PR using the GUI difftool: \
`$ git pr show -t 29143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29143.diff">https://git.openjdk.org/jdk/pull/29143.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29143#issuecomment-3729984776)
</details>
