### PR TITLE
8374945: Avoid fstat in os::open

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4882,13 +4882,14 @@ int os::open(const char *path, int oflag, int mode) {
   oflag |= O_CLOEXEC;
 
   int fd = ::open(path, oflag, mode);
-  // No further checking is needed if the file is not a
-  // directory or open returned an error
-  if (fd == -1 || ((oflag & O_ACCMODE) != O_RDONLY) != 0) {
+  // No further checking is needed if open() returned an error or
+  // access mode is not read only
+  if (fd == -1 || (oflag & O_ACCMODE) != O_RDONLY) {
     return fd;
   }
 
-  //If the open succeeded, the file might still be a directory
+  // If the open succeeded and is read only, the file might be a directory
+  // which the JVM don't allow to be read
   {
     struct stat buf;
     int ret = ::fstat(fd, &buf);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4887,7 +4887,7 @@ int os::open(const char *path, int oflag, int mode) {
   if (fd == -1 || ((oflag & O_ACCMODE) != O_RDONLY) != 0) {
     return fd;
   }
-  
+
   //If the open succeeded, the file might still be a directory
   {
     struct stat buf;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4882,8 +4882,12 @@ int os::open(const char *path, int oflag, int mode) {
   oflag |= O_CLOEXEC;
 
   int fd = ::open(path, oflag, mode);
-  if (fd == -1) return -1;
-
+  // No further checking is needed if the file is not a
+  // directory or open returned an error
+  if (fd == -1 || ((oflag & O_ACCMODE) != O_RDONLY) != 0) {
+    return fd;
+  }
+  
   //If the open succeeded, the file might still be a directory
   {
     struct stat buf;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4883,13 +4883,13 @@ int os::open(const char *path, int oflag, int mode) {
 
   int fd = ::open(path, oflag, mode);
   // No further checking is needed if open() returned an error or
-  // access mode is not read only
+  // access mode is not read only.
   if (fd == -1 || (oflag & O_ACCMODE) != O_RDONLY) {
     return fd;
   }
 
   // If the open succeeded and is read only, the file might be a directory
-  // which the JVM don't allow to be read
+  // which the JVM doesn't allow to be read.
   {
     struct stat buf;
     int ret = ::fstat(fd, &buf);


### PR DESCRIPTION
Eliminate unnecessary calls to fstat in os::open akin to JDK-8373647. This optimization reduces system overhead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374945](https://bugs.openjdk.org/browse/JDK-8374945): Avoid fstat in os::open (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) Review applies to [dfc44a6b](https://git.openjdk.org/jdk/pull/29152/files/dfc44a6bde0a9aeadb5a60639849d1721b18fc97)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) Review applies to [dfc44a6b](https://git.openjdk.org/jdk/pull/29152/files/dfc44a6bde0a9aeadb5a60639849d1721b18fc97)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29152/head:pull/29152` \
`$ git checkout pull/29152`

Update a local copy of the PR: \
`$ git checkout pull/29152` \
`$ git pull https://git.openjdk.org/jdk.git pull/29152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29152`

View PR using the GUI difftool: \
`$ git pr show -t 29152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29152.diff">https://git.openjdk.org/jdk/pull/29152.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29152#issuecomment-3734494173)
</details>
