### PR TITLE
8375297: ZGC: Remove obsolete O_CLOEXEC definition

### DIFF
--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -66,9 +66,6 @@
 #endif
 
 // open(2) flags
-#ifndef O_CLOEXEC
-#define O_CLOEXEC                        02000000
-#endif
 #ifndef O_TMPFILE
 #define O_TMPFILE                        (020000000 | O_DIRECTORY)
 #endif


### PR DESCRIPTION
With [JDK-8375006](https://bugs.openjdk.org/browse/JDK-8375006) integrated we are no longer supporting building with on a system with kernel headers < 2.6.23 and glibc < 2.7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8375297](https://bugs.openjdk.org/browse/JDK-8375297): ZGC: Remove obsolete O_CLOEXEC definition (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29230/head:pull/29230` \
`$ git checkout pull/29230`

Update a local copy of the PR: \
`$ git checkout pull/29230` \
`$ git pull https://git.openjdk.org/jdk.git pull/29230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29230`

View PR using the GUI difftool: \
`$ git pr show -t 29230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29230.diff">https://git.openjdk.org/jdk/pull/29230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29230#issuecomment-3749854790)
</details>
