### PR TITLE
8374519: assert((!inside_attrs()) || VMError::is_error_reported()) failed: cannot print tag inside attrs with "-XX:+LogCompilation -XX:-SerializeVMOutput"

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -854,8 +854,9 @@ intx defaultStream::hold(intx writer_id) {
       // can't grab a lock if current Thread isn't set
       Thread::current_or_null() == nullptr ||
 
-      // developer hook
-      !SerializeVMOutput ||
+      // developer hook: when SerializeVMOutput is off, we normally don't lock.
+      // But xtty is stateful and must not be interleaved.
+      (!SerializeVMOutput && xtty == nullptr) ||
 
       // VM already unhealthy
       VMError::is_error_reported() ||

--- a/test/hotspot/jtreg/compiler/codegen/TestLogCompilationNoSerializeVMOutput.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestLogCompilationNoSerializeVMOutput.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /**
+ * @test
+ * @bug 8374519
+ * @summary Regression test for -XX:+LogCompilation -XX:-SerializeVMOutput crash
+ * @requires vm.debug
+ * @run main/othervm -XX:+LogCompilation -XX:-SerializeVMOutput compiler.codegen.TestLogCompilationNoSerializeVMOutput
+ */
+
+package compiler.codegen;
+
+public class TestLogCompilationNoSerializeVMOutput {
+
+    public static void main(String[] args) {
+        System.out.println("passed");
+    }
+}


### PR DESCRIPTION
Please review this change. Thanks!

**Description:**

The compilation logging is written as structured XML through the global xtty. With SerializeVMOutput turned off, multiple threads can write to the same xmlStream concurrently. This allows XML fragments (especially the tag/attribute header state) to interleave, corrupting the xmlStream markup state machine and triggering the inside_attrs() assertion.

**Fix:**

Ensure xtty remains serialized even when -XX:-SerializeVMOutput is specified.

**Test:**

GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374519](https://bugs.openjdk.org/browse/JDK-8374519): assert((!inside_attrs()) || VMError::is_error_reported()) failed: cannot print tag inside attrs with "-XX:+LogCompilation -XX:-SerializeVMOutput" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29337/head:pull/29337` \
`$ git checkout pull/29337`

Update a local copy of the PR: \
`$ git checkout pull/29337` \
`$ git pull https://git.openjdk.org/jdk.git pull/29337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29337`

View PR using the GUI difftool: \
`$ git pr show -t 29337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29337.diff">https://git.openjdk.org/jdk/pull/29337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29337#issuecomment-3775864452)
</details>
