### PR TITLE
8373021: aarch64: MacroAssembler::arrays_equals reads out of bounds

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5782,6 +5782,9 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     //      return false;
     bind(A_IS_NOT_NULL);
     ldrw(cnt1, Address(a1, length_offset));
+    ldrw(tmp5, Address(a2, length_offset));
+    cmp(cnt1, tmp5);
+    br(NE, DONE); // If lengths differ, return false
     // Increase loop counter by diff between base- and actual start-offset.
     addw(cnt1, cnt1, extra_length);
     lea(a1, Address(a1, start_offset));
@@ -5848,6 +5851,9 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     cbz(a1, DONE);
     ldrw(cnt1, Address(a1, length_offset));
     cbz(a2, DONE);
+    ldrw(tmp5, Address(a2, length_offset));
+    cmp(cnt1, tmp5);
+    br(NE, DONE); // If lengths differ, return false
     // Increase loop counter by diff between base- and actual start-offset.
     addw(cnt1, cnt1, extra_length);
 


### PR DESCRIPTION
Please review this PR to add back array-length comparison to AArch64 array-equals intrinsic.

[JDK-8331098](https://bugs.openjdk.org/browse/JDK-8331098) removed the direct comparison of both arrays' length but doing so will cause the code to index out of bounds of the array payload. The root cause of the problem is: 1) the main comparison loops only compare the array lengths (indirectly) after reading at least 16 bytes from _both_ arrays; 2) only the length of the first array, `a1`, is checked before the main comparison loop. Consequently, we code may read past the end of the array payload if the second array is shorter than 16 bytes. The result of indexing out of the array bounds is dependent on where the array is allocated and what comes after it: the VM may crash because of segment violation if the object is at the end of the heap (or Eden?) and there is no padding after the object or it can cause the array comparison to be incorrect.

Testing:

- [x] tier1 (+CCP)
- [x] tier1 (-CCP)
- [x] tier2 (+CCP)
- [x] tier2 (-CCP)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373021](https://bugs.openjdk.org/browse/JDK-8373021): aarch64: MacroAssembler::arrays_equals reads out of bounds (**Bug** - P3)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29372/head:pull/29372` \
`$ git checkout pull/29372`

Update a local copy of the PR: \
`$ git checkout pull/29372` \
`$ git pull https://git.openjdk.org/jdk.git pull/29372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29372`

View PR using the GUI difftool: \
`$ git pr show -t 29372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29372.diff">https://git.openjdk.org/jdk/pull/29372.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29372#issuecomment-3786275298)
</details>
