### PR TITLE
Strict output validation

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/AppImageSigner.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/AppImageSigner.java
@@ -172,19 +172,19 @@ final class AppImageSigner {
         // "--app-content" can fail "codesign".
 
         if (!app.contentDirSources().isEmpty()) {
-            Log.info(I18N.getString("message.codesign.failed.reason.app.content"));
+            Log.fatalError(I18N.getString("message.codesign.failed.reason.app.content"));
         }
 
         // Signing might not work without Xcode with command line
         // developer tools. Show user if Xcode is missing as possible
         // reason.
         if (!isXcodeDevToolsInstalled()) {
-            Log.info(I18N.getString("message.codesign.failed.reason.xcode.tools"));
+            Log.fatalError(I18N.getString("message.codesign.failed.reason.xcode.tools"));
         }
 
         // Log "codesign" output
-        Log.info(I18N.format("error.tool.failed.with.output", "codesign"));
-        Log.info(Stream.of(ex.getOutput()).collect(joining("\n")).strip());
+        Log.fatalError(I18N.format("error.tool.failed.with.output", "codesign"));
+        Log.fatalError(Stream.of(ex.getOutput()).collect(joining("\n")).strip());
 
         return ex;
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -906,6 +906,11 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         return this;
     }
 
+    public JPackageCommand validateOutput(TKit.TextStreamVerifier.Group group) {
+        group.tryCreate().ifPresent(this::validateOutput);
+        return this;
+    }
+
     @FunctionalInterface
     public interface CannedArgument {
         public String value(JPackageCommand cmd);
@@ -947,11 +952,11 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
 
     public JPackageCommand validateOutput(CannedFormattedString... str) {
         // Will look up the given errors in the order they are specified.
-        Stream.of(str).map(this::getValue)
+        validateOutput(Stream.of(str).map(this::getValue)
                 .map(TKit::assertTextStream)
                 .reduce(TKit.TextStreamVerifier.group(),
                         TKit.TextStreamVerifier.Group::add,
-                        TKit.TextStreamVerifier.Group::add).tryCreate().ifPresent(this::validateOutput);
+                        TKit.TextStreamVerifier.Group::add));
         return this;
     }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -98,7 +98,8 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         verifyActions = new Actions(cmd.verifyActions);
         standardAsserts = cmd.standardAsserts;
         readOnlyPathAsserts = cmd.readOnlyPathAsserts;
-        outputValidators = cmd.outputValidators;
+        outValidators = cmd.outValidators;
+        errValidators = cmd.errValidators;
         executeInDirectory = cmd.executeInDirectory;
         winMsiLogFile = cmd.winMsiLogFile;
         unpackedPackageDirectory = cmd.unpackedPackageDirectory;
@@ -895,19 +896,38 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         return removeOldOutputBundle;
     }
 
-    public JPackageCommand validateOutput(TKit.TextStreamVerifier validator) {
-        return validateOutput(validator::apply);
-    }
-
-    public JPackageCommand validateOutput(Consumer<Iterator<String>> validator) {
-        Objects.requireNonNull(validator);
-        saveConsoleOutput(true);
-        outputValidators.add(validator);
+    public JPackageCommand validateOut(TKit.TextStreamVerifier validator) {
+        new JPackageOutputValidator().validator(validator).applyTo(this);
         return this;
     }
 
-    public JPackageCommand validateOutput(TKit.TextStreamVerifier.Group group) {
-        group.tryCreate().ifPresent(this::validateOutput);
+    public JPackageCommand validateOut(Consumer<Iterator<String>> validator) {
+        return validateOutput(validator, outValidators);
+    }
+
+    public JPackageCommand validateOut(TKit.TextStreamVerifier.Group group) {
+        new JPackageOutputValidator().validator(group).applyTo(this);
+        return this;
+    }
+
+    public JPackageCommand validateErr(TKit.TextStreamVerifier validator) {
+        new JPackageOutputValidator().stderr().validator(validator).applyTo(this);
+        return this;
+    }
+
+    public JPackageCommand validateErr(Consumer<Iterator<String>> validator) {
+        return validateOutput(validator, errValidators);
+    }
+
+    public JPackageCommand validateErr(TKit.TextStreamVerifier.Group group) {
+        new JPackageOutputValidator().stderr().validator(group).applyTo(this);
+        return this;
+    }
+
+    private JPackageCommand validateOutput(Consumer<Iterator<String>> validator, List<Consumer<Iterator<String>>> validators) {
+        Objects.requireNonNull(validator);
+        saveConsoleOutput(true);
+        validators.add(validator);
         return this;
     }
 
@@ -936,8 +956,16 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         return v.addPrefix("message.error-header");
     }
 
+    public static CannedFormattedString makeError(String key, Object ... args) {
+        return makeError(JPackageStringBundle.MAIN.cannedFormattedString(key, args));
+    }
+
     public static CannedFormattedString makeAdvice(CannedFormattedString v) {
         return v.addPrefix("message.advice-header");
+    }
+
+    public static CannedFormattedString makeAdvice(String key, Object ... args) {
+        return makeAdvice(JPackageStringBundle.MAIN.cannedFormattedString(key, args));
     }
 
     public String getValue(CannedFormattedString str) {
@@ -950,13 +978,13 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         }).toArray()).getValue();
     }
 
-    public JPackageCommand validateOutput(CannedFormattedString... str) {
-        // Will look up the given errors in the order they are specified.
-        validateOutput(Stream.of(str).map(this::getValue)
-                .map(TKit::assertTextStream)
-                .reduce(TKit.TextStreamVerifier.group(),
-                        TKit.TextStreamVerifier.Group::add,
-                        TKit.TextStreamVerifier.Group::add));
+    public JPackageCommand validateOut(CannedFormattedString... strings) {
+        new JPackageOutputValidator().expectMatchingStrings(strings).applyTo(this);
+        return this;
+    }
+
+    public JPackageCommand validateErr(CannedFormattedString... strings) {
+        new JPackageOutputValidator().stderr().expectMatchingStrings(strings).applyTo(this);
         return this;
     }
 
@@ -1055,8 +1083,12 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
             ConfigFilesStasher.INSTANCE.accept(this);
         }
 
-        for (final var outputValidator: outputValidators) {
-            outputValidator.accept(result.getOutput().iterator());
+        for (final var validator: outValidators) {
+            validator.accept(result.findStdout().orElseThrow().iterator());
+        }
+
+        for (final var validator: errValidators) {
+            validator.accept(result.findStderr().orElseThrow().iterator());
         }
 
         if (result.getExitCode() == 0 && expectedExitCode.isPresent()) {
@@ -1836,7 +1868,8 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
     private Path unpackedPackageDirectory;
     private Set<ReadOnlyPathAssert> readOnlyPathAsserts = Set.of(ReadOnlyPathAssert.values());
     private Set<StandardAssert> standardAsserts = Set.of(StandardAssert.values());
-    private List<Consumer<Iterator<String>>> outputValidators = new ArrayList<>();
+    private List<Consumer<Iterator<String>>> outValidators = new ArrayList<>();
+    private List<Consumer<Iterator<String>>> errValidators = new ArrayList<>();
 
     private enum DefaultToolProviderKey {
         VALUE

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageOutputValidator.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageOutputValidator.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jpackage.test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import jdk.jpackage.internal.util.function.ExceptionBox;
+
+public final class JPackageOutputValidator {
+
+    public JPackageOutputValidator stdout() {
+        stdout = true;
+        return this;
+    }
+
+    public JPackageOutputValidator stderr() {
+        stdout = false;
+        return this;
+    }
+
+    public JPackageOutputValidator matchTimestamps() {
+        matchTimestamps = true;
+        return this;
+    }
+
+    public JPackageOutputValidator stripTimestamps() {
+        stripTimestamps = true;
+        return this;
+    }
+
+    public void applyTo(JPackageCommand cmd) {
+        validators.stream().map(v -> {
+            return toStringIteratorConsumer(cmd, v);
+        }).flatMap(Optional::stream).reduce(Consumer::andThen).ifPresent(validator -> {
+
+            if (stripTimestamps) {
+                validator = stripTimestamps(validator, label());
+            }
+
+            if (matchTimestamps) {
+                validator = matchTimestamps(validator, label());
+            }
+
+            if (stdout) {
+                cmd.validateOut(validator);
+            } else {
+                cmd.validateErr(validator);
+            }
+        });
+    }
+
+    public JPackageOutputValidator validator(TKit.TextStreamVerifier validator) {
+        validators.add(validator);
+        return this;
+    }
+
+    public JPackageOutputValidator validator(Consumer<Iterator<String>> validator) {
+        validators.add(validator);
+        return this;
+    }
+
+    public JPackageOutputValidator validator(TKit.TextStreamVerifier.Group validator) {
+        validators.add(validator);
+        return this;
+    }
+
+    public JPackageOutputValidator expectMatchingStrings(CannedFormattedString... strings) {
+        validators.add(strings);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<Consumer<Iterator<String>>> toStringIteratorConsumer(JPackageCommand cmd, Object validator) {
+        switch (validator) {
+            case TKit.TextStreamVerifier tv -> {
+                return Optional.of(tv.copy().label(label())::apply);
+            }
+            case TKit.TextStreamVerifier.Group g -> {
+                return g.copy().label(label()).tryCreate();
+            }
+            case CannedFormattedString[] strings -> {
+                // Will look up the given strings in the order they are specified.
+                return toStringIteratorConsumer(cmd, Stream.of(strings)
+                        .map(cmd::getValue)
+                        .map(TKit::assertTextStream)
+                        .map(verifier -> {
+                            return verifier.predicate(String::equals);
+                        })
+                        .reduce(TKit.TextStreamVerifier.group(),
+                                TKit.TextStreamVerifier.Group::add,
+                                TKit.TextStreamVerifier.Group::add));
+            }
+            case Consumer<?> c -> {
+                return Optional.of((Consumer<Iterator<String>>)c);
+            }
+            default -> {
+                throw ExceptionBox.reachedUnreachable();
+            }
+        }
+    }
+
+    private String label() {
+        return stdout ? "'stdout'" : "'stderr'";
+    }
+
+    private static Consumer<Iterator<String>> stripTimestamps(Consumer<Iterator<String>> consumer, String label) {
+        Objects.requireNonNull(consumer);
+        Objects.requireNonNull(label);
+        return it -> {
+            Objects.requireNonNull(it);
+            TKit.trace(String.format("Strip timestamps in %s...", label));
+            consumer.accept(new Iterator<String>() {
+
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public String next() {
+                    var str = it.next();
+                    var strippedStr = JPackageCommand.stripTimestamp(str);
+                    if (str.length() == strippedStr.length()) {
+                        throw new IllegalArgumentException(String.format("String [%s] doesn't have a timestamp", str));
+                    } else {
+                        return strippedStr;
+                    }
+                }
+
+            });
+            TKit.trace("Done");
+        };
+    }
+
+    private static Consumer<Iterator<String>> matchTimestamps(Consumer<Iterator<String>> consumer, String label) {
+        Objects.requireNonNull(consumer);
+        Objects.requireNonNull(label);
+        return it -> {
+            Objects.requireNonNull(it);
+            TKit.trace(String.format("Match lines with timestamps in %s...", label));
+            consumer.accept(new FilteringIterator<>(it, JPackageCommand::withTimestamp));
+            TKit.trace("Done");
+        };
+    }
+
+    final static class FilteringIterator<T> implements Iterator<T> {
+
+        public FilteringIterator(Iterator<T> it, Predicate<T> predicate) {
+            this.it = Objects.requireNonNull(it);
+            this.predicate = Objects.requireNonNull(predicate);
+        }
+
+        @Override
+        public boolean hasNext() {
+            while (!nextReady && it.hasNext()) {
+                var v = it.next();
+                if (predicate.test(v)) {
+                    next = v;
+                    nextReady = true;
+                }
+            }
+            return nextReady;
+        }
+
+        @Override
+        public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            nextReady = false;
+            return next;
+        }
+
+        @Override
+        public void remove() {
+            it.remove();
+        }
+
+        private final Iterator<T> it;
+        private final Predicate<T> predicate;
+        private T next;
+        private boolean nextReady;
+    }
+
+    boolean stdout = true;
+    boolean matchTimestamps;
+    boolean stripTimestamps;
+    private final List<Object> validators = new ArrayList<>();
+}

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -782,6 +782,10 @@ public final class MacHelper {
             return sign(cmd);
         }
 
+        public Optional<Name> optionName() {
+            return type.mapOptionName(certRequest.type());
+        }
+
         public List<String> asCmdlineArgs() {
             String[] args = new String[2];
             applyTo((optionName, optionValue) -> {
@@ -789,6 +793,10 @@ public final class MacHelper {
                 args[1] = optionValue;
             });
             return List.of(args);
+        }
+
+        public Optional<Boolean> passThrough() {
+            return optionName().map(Name::passThrough);
         }
 
         private void applyTo(BiConsumer<String, String> sink) {
@@ -884,6 +892,14 @@ public final class MacHelper {
 
         public ResolvableCertificateRequest certRequest() {
             return signKeyOption.certRequest();
+        }
+
+        public Optional<SignKeyOption.Name> optionName() {
+            return signKeyOption.optionName();
+        }
+
+        public Optional<Boolean> passThrough() {
+            return signKeyOption.passThrough();
         }
 
         public JPackageCommand addTo(JPackageCommand cmd) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -1176,6 +1176,20 @@ public final class TKit {
         }
 
         public static final class Group {
+
+            public Group() {
+            }
+
+            public Group(Group other) {
+                Objects.requireNonNull(other);
+                this.label = other.label;
+                this.verifiers.addAll(other.verifiers);
+            }
+
+            public Group copy() {
+                return new Group(this);
+            }
+
             public Group add(TextStreamVerifier verifier) {
                 if (verifier.anotherVerifier != null) {
                     throw new IllegalArgumentException();
@@ -1186,6 +1200,11 @@ public final class TKit {
 
             public Group add(Group other) {
                 verifiers.addAll(other.verifiers);
+                return this;
+            }
+
+            public Group label(String v) {
+                label = v;
                 return this;
             }
 
@@ -1211,20 +1230,24 @@ public final class TKit {
                     throw new IllegalStateException();
                 }
 
-                if (verifiers.size() == 1) {
-                    return verifiers.getFirst()::apply;
-                }
+                final var theLabel = Optional.ofNullable(label);
 
-                final var head = new TextStreamVerifier(verifiers.getFirst());
-                var prev = head;
-                for (var verifier : verifiers.subList(1, verifiers.size())) {
-                    verifier = new TextStreamVerifier(verifier);
-                    prev.anotherVerifier = verifier::apply;
+                TextStreamVerifier head = null;
+                TextStreamVerifier prev = null;
+                for (var verifier : verifiers) {
+                    verifier = verifier.copy();
+                    theLabel.ifPresent(verifier::label);
+                    if (prev != null) {
+                        prev.anotherVerifier = verifier::apply;
+                    } else {
+                        head = verifier;
+                    }
                     prev = verifier;
                 }
                 return head::apply;
             }
 
+            private String label;
             private final List<TextStreamVerifier> verifiers = new ArrayList<>();
         }
 

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsValidationFailTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsValidationFailTest.java
@@ -99,7 +99,7 @@ public class OptionsValidationFailTest {
 
                 var errorReporter = new Main.ErrorReporter(ex -> {
                     ex.printStackTrace(err);
-                }, out::append);
+                }, err::println);
 
                 return parse(args).peekErrors(errors -> {
                     final var firstErr = errors.stream().findFirst().orElseThrow();

--- a/test/jdk/tools/jpackage/linux/LinuxResourceTest.java
+++ b/test/jdk/tools/jpackage/linux/LinuxResourceTest.java
@@ -28,7 +28,9 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.CannedFormattedString;
 import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JPackageOutputValidator;
 import jdk.jpackage.test.LinuxHelper;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
@@ -67,22 +69,26 @@ public class LinuxResourceTest {
             final var arhProp = property("Architecture", "bar");
 
             TKit.createTextFile(controlFile, List.of(
-                packageProp.format(),
-                verProp.format(),
-                "Section: APPLICATION_SECTION",
-                "Maintainer: APPLICATION_MAINTAINER",
-                "Priority: optional",
-                arhProp.format(),
-                "Provides: dont-install-me",
-                "Description: APPLICATION_DESCRIPTION",
-                "Installed-Size: APPLICATION_INSTALLED_SIZE",
-                "Depends: PACKAGE_DEFAULT_DEPENDENCIES"
+                    packageProp.format(),
+                    verProp.format(),
+                    "Section: APPLICATION_SECTION",
+                    "Maintainer: APPLICATION_MAINTAINER",
+                    "Priority: optional",
+                    arhProp.format(),
+                    "Provides: dont-install-me",
+                    "Description: APPLICATION_DESCRIPTION",
+                    "Installed-Size: APPLICATION_INSTALLED_SIZE",
+                    "Depends: PACKAGE_DEFAULT_DEPENDENCIES"
             ));
 
-            cmd.validateOutput(MAIN.cannedFormattedString(
-                    "message.using-custom-resource",
-                    String.format("[%s]", MAIN.cannedFormattedString("resource.deb-control-file").getValue()),
-                    controlFile.getFileName()));
+            new JPackageOutputValidator()
+                    .expectMatchingStrings(MAIN.cannedFormattedString(
+                            "message.using-custom-resource",
+                            String.format("[%s]", MAIN.cannedFormattedString("resource.deb-control-file").getValue()),
+                            controlFile.getFileName()))
+                    .matchTimestamps()
+                    .stripTimestamps()
+                    .applyTo(cmd);
 
             packageProp.expectedValue(LinuxHelper.getPackageName(cmd)).token("APPLICATION_PACKAGE").resourceDirFile(controlFile).validateOutput(cmd);
             verProp.expectedValue(cmd.version()).token("APPLICATION_VERSION_WITH_RELEASE").resourceDirFile(controlFile).validateOutput(cmd);
@@ -98,30 +104,34 @@ public class LinuxResourceTest {
             final var releaseProp = property("Release", "R2");
 
             TKit.createTextFile(specFile, List.of(
-                packageProp.format(),
-                verProp.format(),
-                releaseProp.format(),
-                "Summary: APPLICATION_SUMMARY",
-                "License: APPLICATION_LICENSE_TYPE",
-                "Prefix: %{dirname:APPLICATION_DIRECTORY}",
-                "Provides: dont-install-me",
-                "%define _build_id_links none",
-                "%description",
-                "APPLICATION_DESCRIPTION",
-                "%prep",
-                "%build",
-                "%install",
-                "rm -rf %{buildroot}",
-                "install -d -m 755 %{buildroot}APPLICATION_DIRECTORY",
-                "cp -r %{_sourcedir}APPLICATION_DIRECTORY/* %{buildroot}APPLICATION_DIRECTORY",
-                "%files",
-                "APPLICATION_DIRECTORY"
+                    packageProp.format(),
+                    verProp.format(),
+                    releaseProp.format(),
+                    "Summary: APPLICATION_SUMMARY",
+                    "License: APPLICATION_LICENSE_TYPE",
+                    "Prefix: %{dirname:APPLICATION_DIRECTORY}",
+                    "Provides: dont-install-me",
+                    "%define _build_id_links none",
+                    "%description",
+                    "APPLICATION_DESCRIPTION",
+                    "%prep",
+                    "%build",
+                    "%install",
+                    "rm -rf %{buildroot}",
+                    "install -d -m 755 %{buildroot}APPLICATION_DIRECTORY",
+                    "cp -r %{_sourcedir}APPLICATION_DIRECTORY/* %{buildroot}APPLICATION_DIRECTORY",
+                    "%files",
+                    "APPLICATION_DIRECTORY"
             ));
 
-            cmd.validateOutput(MAIN.cannedFormattedString(
-                    "message.using-custom-resource",
-                    String.format("[%s]", MAIN.cannedFormattedString("resource.rpm-spec-file").getValue()),
-                    specFile.getFileName()));
+            new JPackageOutputValidator()
+                    .expectMatchingStrings(MAIN.cannedFormattedString(
+                            "message.using-custom-resource",
+                            String.format("[%s]", MAIN.cannedFormattedString("resource.rpm-spec-file").getValue()),
+                            specFile.getFileName()))
+                    .matchTimestamps()
+                    .stripTimestamps()
+                    .applyTo(cmd);
 
             packageProp.expectedValue(LinuxHelper.getPackageName(cmd)).token("APPLICATION_PACKAGE").resourceDirFile(specFile).validateOutput(cmd);
             verProp.expectedValue(cmd.version()).token("APPLICATION_VERSION").resourceDirFile(specFile).validateOutput(cmd);
@@ -171,9 +181,15 @@ public class LinuxResourceTest {
             Objects.requireNonNull(resourceDirFile);
 
             final var customResourcePath = customResourcePath();
-            cmd.validateOutput(
-                    MAIN.cannedFormattedString("error.unexpected-package-property", name, expectedValue, customValue, customResourcePath),
-                    MAIN.cannedFormattedString("error.unexpected-package-property.advice", token, customValue, name, customResourcePath));
+
+            new JPackageOutputValidator()
+                    .expectMatchingStrings(
+                            MAIN.cannedFormattedString("error.unexpected-package-property", name, expectedValue, customValue, customResourcePath),
+                            MAIN.cannedFormattedString("error.unexpected-package-property.advice", token, customValue, name, customResourcePath)
+                    )
+                    .matchTimestamps()
+                    .stripTimestamps()
+                    .applyTo(cmd);
         }
 
         private Path customResourcePath() {

--- a/test/jdk/tools/jpackage/macosx/PkgScriptsTest.java
+++ b/test/jdk/tools/jpackage/macosx/PkgScriptsTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import jdk.jpackage.test.Annotations.ParameterSupplier;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JPackageOutputValidator;
 import jdk.jpackage.test.JPackageStringBundle;
 import jdk.jpackage.test.MacHelper;
 import jdk.jpackage.test.PackageTest;
@@ -94,7 +95,13 @@ public class PkgScriptsTest {
                             "message.no-default-resource",
                             String.format("[%s]", role.resourceCategory()),
                             role.scriptName());
-                }).forEach(cmd::validateOutput);
+                }).forEach(str -> {
+                    new JPackageOutputValidator()
+                            .expectMatchingStrings(str)
+                            .matchTimestamps()
+                            .stripTimestamps()
+                            .applyTo(cmd);
+                });
             }).addInstallVerifier(cmd -> {
                 customScripts.forEach(customScript -> {
                     customScript.verify(cmd);

--- a/test/jdk/tools/jpackage/macosx/SigningPackageTwoStepTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageTwoStepTest.java
@@ -212,9 +212,9 @@ public class SigningPackageTwoStepTest {
             }
         }
 
-        expected.ifPresent(cmd::validateOutput);
+        expected.ifPresent(cmd::validateOut);
         unexpected.forEach(str -> {
-            cmd.validateOutput(TKit.assertTextStream(cmd.getValue(str)).negate());
+            cmd.validateOut(TKit.assertTextStream(cmd.getValue(str)).negate());
         });
     }
 }

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -102,7 +102,7 @@ public class AppContentTest {
         JPackageCommand.helloAppImage()
             .addArguments("--app-content", appContentValue)
             .setFakeRuntime()
-            .validateOutput(expectedWarning)
+            .validateOut(expectedWarning)
             .executeIgnoreExitCode();
     }
 

--- a/test/jdk/tools/jpackage/share/AppImagePackageTest.java
+++ b/test/jdk/tools/jpackage/share/AppImagePackageTest.java
@@ -173,7 +173,7 @@ public class AppImagePackageTest {
 
         final var appImageDir = appImageCmd.outputBundle();
 
-        final var expectedError = JPackageStringBundle.MAIN.cannedFormattedString(
+        final var expectedError = JPackageCommand.makeError(
                 "error.invalid-app-image-file", AppImageFile.getPathInAppImage(Path.of("")), appImageDir);
 
         configureBadAppImage(appImageDir, expectedError).addRunOnceInitializer(() -> {
@@ -204,7 +204,7 @@ public class AppImagePackageTest {
     }
 
     private static PackageTest configureBadAppImage(Path appImageDir) {
-        return configureBadAppImage(appImageDir, JPackageStringBundle.MAIN.cannedFormattedString(
+        return configureBadAppImage(appImageDir, JPackageCommand.makeError(
                 "error.missing-app-image-file", AppImageFile.getPathInAppImage(Path.of("")), appImageDir));
     }
 
@@ -212,7 +212,7 @@ public class AppImagePackageTest {
         return new PackageTest().addInitializer(cmd -> {
             cmd.usePredefinedAppImage(appImageDir);
             cmd.ignoreDefaultVerbose(true); // no "--verbose" option
-            cmd.validateOutput(expectedError);
+            cmd.validateErr(expectedError);
         }).setExpectedExitCode(1);
     }
 

--- a/test/jdk/tools/jpackage/share/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/ErrorTest.java
@@ -51,7 +51,6 @@ import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.CannedArgument;
 import jdk.jpackage.test.CannedFormattedString;
 import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.JPackageStringBundle;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.TKit;
 
@@ -287,11 +286,11 @@ public final class ErrorTest {
             }
 
             Builder error(String key, Object ... args) {
-                return messages(makeError(JPackageStringBundle.MAIN.cannedFormattedString(key, args)));
+                return messages(makeError(key, args));
             }
 
             Builder advice(String key, Object ... args) {
-                return messages(makeAdvice(JPackageStringBundle.MAIN.cannedFormattedString(key, args)));
+                return messages(makeAdvice(key, args));
             }
 
             Builder invalidTypeArg(String arg, String... otherArgs) {
@@ -707,8 +706,7 @@ public final class ErrorTest {
         final var signingId = "foo";
 
         final List<CannedFormattedString> errorMessages = new ArrayList<>();
-        errorMessages.add(makeError(JPackageStringBundle.MAIN.cannedFormattedString(
-                "error.cert.not.found", "Developer ID Application: " + signingId, "")));
+        errorMessages.add(makeError("error.cert.not.found", "Developer ID Application: " + signingId, ""));
 
         final var cmd = JPackageCommand.helloAppImage()
                 .ignoreDefaultVerbose(true)
@@ -720,9 +718,9 @@ public final class ErrorTest {
             errorMessages.stream()
                     .map(CannedFormattedString::getValue)
                     .map(TKit::assertTextStream)
-                    .map(TKit.TextStreamVerifier::negate).forEach(cmd::validateOutput);
+                    .map(TKit.TextStreamVerifier::negate).forEach(cmd::validateErr);
         } else {
-            cmd.validateOutput(errorMessages.toArray(CannedFormattedString[]::new));
+            cmd.validateErr(errorMessages.toArray(CannedFormattedString[]::new));
         }
 
         cmd.execute(1);
@@ -750,12 +748,12 @@ public final class ErrorTest {
     }
 
     private static void macInvalidRuntime(Consumer<TestSpec> accumulator) {
-        var runtimeWithBinDirErr = makeError(JPackageStringBundle.MAIN.cannedFormattedString(
+        var runtimeWithBinDirErr = makeError(
                 "error.invalid-runtime-image-bin-dir", JPackageCommand.cannedArgument(cmd -> {
                     return Path.of(cmd.getArgumentValue("--runtime-image"));
-                }, Token.JAVA_HOME.token())));
-        var runtimeWithBinDirErrAdvice = makeAdvice(JPackageStringBundle.MAIN.cannedFormattedString(
-                "error.invalid-runtime-image-bin-dir.advice", "--mac-app-store"));
+                }, Token.JAVA_HOME.token()));
+        var runtimeWithBinDirErrAdvice = makeAdvice(
+                "error.invalid-runtime-image-bin-dir.advice", "--mac-app-store");
 
         Stream.of(
                 testSpec().nativeType().addArgs("--mac-app-store", "--runtime-image", Token.JAVA_HOME.token())
@@ -795,10 +793,10 @@ public final class ErrorTest {
         }
 
         private CannedFormattedString expectedErrorMsg() {
-            return makeError(JPackageStringBundle.MAIN.cannedFormattedString(
+            return makeError(
                     "error.invalid-runtime-image-missing-file", JPackageCommand.cannedArgument(cmd -> {
                         return Path.of(cmd.getArgumentValue("--runtime-image"));
-                    }, runtimeDir.token()), missingFile));
+                    }, runtimeDir.token()), missingFile);
         }
     }
 
@@ -880,7 +878,7 @@ public final class ErrorTest {
         // with jpackage arguments in this test.
         cmd.ignoreDefaultRuntime(true);
 
-        cmd.validateOutput(expectedMessages.toArray(CannedFormattedString[]::new));
+        cmd.validateErr(expectedMessages.toArray(CannedFormattedString[]::new));
     }
 
     private static <T> Collection<Object[]> toTestArgs(Stream<T> stream) {

--- a/test/jdk/tools/jpackage/share/FileAssociationsTest.java
+++ b/test/jdk/tools/jpackage/share/FileAssociationsTest.java
@@ -22,12 +22,9 @@
  */
 
 import static java.util.Map.entry;
-import static jdk.jpackage.test.JPackageStringBundle.MAIN;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.FileAssociations;
@@ -123,9 +120,9 @@ public class FileAssociationsTest {
             ));
         }).addInitializer(cmd -> {
             cmd.addArguments("--file-associations", propFile);
-            cmd.validateOutput(
-                    MAIN.cannedFormattedString("error.no-content-types-for-file-association", 1),
-                    MAIN.cannedFormattedString("error.no-content-types-for-file-association.advice", 1));
+            cmd.validateErr(
+                    JPackageCommand.makeError("error.no-content-types-for-file-association", 1),
+                    JPackageCommand.makeAdvice("error.no-content-types-for-file-association.advice", 1));
         }).run();
     }
 
@@ -141,9 +138,9 @@ public class FileAssociationsTest {
             ));
         }).addInitializer(cmd -> {
             cmd.addArguments("--file-associations", propFile);
-            cmd.validateOutput(
-                    MAIN.cannedFormattedString("error.too-many-content-types-for-file-association", 1),
-                    MAIN.cannedFormattedString("error.too-many-content-types-for-file-association.advice", 1));
+            cmd.validateErr(
+                    JPackageCommand.makeError("error.too-many-content-types-for-file-association", 1),
+                    JPackageCommand.makeAdvice("error.too-many-content-types-for-file-association.advice", 1));
         }).run();
     }
 

--- a/test/jdk/tools/jpackage/share/InstallDirTest.java
+++ b/test/jdk/tools/jpackage/share/InstallDirTest.java
@@ -30,7 +30,6 @@ import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.ParameterSupplier;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.JPackageStringBundle;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.RunnablePackageTest.Action;
@@ -106,7 +105,7 @@ public class InstallDirTest {
             cmd.saveConsoleOutput(true);
         })
         .addBundleVerifier((cmd, result) -> {
-            cmd.validateOutput(JPackageStringBundle.MAIN.cannedFormattedString("error.invalid-install-dir"));
+            cmd.validateErr(JPackageCommand.makeError("error.invalid-install-dir"));
         })
         .run();
     }

--- a/test/jdk/tools/jpackage/share/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/MainClassTest.java
@@ -91,7 +91,7 @@ public final class MainClassTest {
         }
 
         Script expectedErrorMessage(String key, Object... args) {
-            expectedErrorMessage = JPackageStringBundle.MAIN.cannedFormattedString(key, args);
+            expectedErrorMessage = JPackageCommand.makeError(key, args);
             return this;
         }
 
@@ -222,7 +222,7 @@ public final class MainClassTest {
         if (script.expectedErrorMessage != null) {
             // This is the case when main class is not found nor in jar
             // file nor on command line.
-            cmd.validateOutput(script.expectedErrorMessage).execute(1);
+            cmd.validateErr(script.expectedErrorMessage).execute(1);
             return;
         }
 

--- a/test/jdk/tools/jpackage/share/ModulePathTest.java
+++ b/test/jdk/tools/jpackage/share/ModulePathTest.java
@@ -125,14 +125,14 @@ public final class ModulePathTest {
         } else {
             final CannedFormattedString expectedErrorMessage;
             if (modulePathArgs.isEmpty()) {
-                expectedErrorMessage = JPackageStringBundle.MAIN.cannedFormattedString(
+                expectedErrorMessage = JPackageCommand.makeError(
                         "ERR_MissingArgument2", "--runtime-image", "--module-path");
             } else {
-                expectedErrorMessage = JPackageStringBundle.MAIN.cannedFormattedString(
+                expectedErrorMessage = JPackageCommand.makeError(
                         "error.no-module-in-path", appDesc.moduleName());
             }
 
-            cmd.validateOutput(expectedErrorMessage).execute(1);
+            cmd.validateErr(expectedErrorMessage).execute(1);
         }
     }
 

--- a/test/jdk/tools/jpackage/share/OutputErrorTest.java
+++ b/test/jdk/tools/jpackage/share/OutputErrorTest.java
@@ -34,7 +34,6 @@ import jdk.internal.util.OperatingSystem;
 import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.JPackageStringBundle;
 import jdk.jpackage.test.JavaTool;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.TKit;
@@ -62,8 +61,8 @@ public final class OutputErrorTest {
             cmd.setFakeRuntime();
             cmd.setArgumentValue("--dest", TKit.createTempDirectory("output"));
             cmd.removeOldOutputBundle(false);
-            cmd.validateOutput(JPackageCommand.makeError(JPackageStringBundle.MAIN.cannedFormattedString(
-                    "error.output-bundle-cannot-be-overwritten", cmd.outputBundle().toAbsolutePath())));
+            cmd.validateErr(JPackageCommand.makeError(
+                    "error.output-bundle-cannot-be-overwritten", cmd.outputBundle().toAbsolutePath()));
 
             var outputBundle = cmd.outputBundle();
 


### PR DESCRIPTION
Tighten up the jpackage output validation:

 - Replace `JPackageCommand.validateOutput()` with `JPackageCommand.validateOut()` and `JPackageCommand.validateErr()`. This way, the tests can validate where jpackage writes messages: stdout or stderr
 - Use `String#equals()` instead of `String#contains()` when validating strings from jpackage string bundles in jpackage output

Fix bugs revealed by the above changes:

- Fix jdk.jpackage.internal.AppImageSigner: use `Log.fatalError()` to report a fatal signing error instead of `Log.info()`. This change directs signing error messages to stderr, where all warnings and errors belong, rather than stdout.
- Fix test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsValidationFailTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29374/head:pull/29374` \
`$ git checkout pull/29374`

Update a local copy of the PR: \
`$ git checkout pull/29374` \
`$ git pull https://git.openjdk.org/jdk.git pull/29374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29374`

View PR using the GUI difftool: \
`$ git pr show -t 29374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29374.diff">https://git.openjdk.org/jdk/pull/29374.diff</a>

</details>
