### PR TITLE
8357828: Add a timestamp to jcmd diagnostic commands

### DIFF
--- a/src/jdk.jcmd/share/classes/sun/tools/jcmd/JCmd.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jcmd/JCmd.java
@@ -28,6 +28,8 @@ package sun.tools.jcmd;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Comparator;
 import java.net.URISyntaxException;
@@ -90,6 +92,13 @@ public class JCmd {
         boolean success = true;
         for (String pid : pids) {
             System.out.println(pid + ":");
+
+            if (arg.shouldTimestamp()) {
+                final String timePattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+                final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(timePattern);
+                System.out.println(ZonedDateTime.now().format(formatter));
+            }
+
             if (arg.isListCounters()) {
                 listCounters(pid);
             } else {

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -33,7 +33,7 @@ jcmd - send diagnostic command requests to a running Java Virtual Machine
 
 ## Synopsis
 
-`jcmd` \[*pid* \| *main-class*\] *command*... \| `PerfCounter.print` \| `-f`
+`jcmd` \[*pid* \| *main-class*\] [`-t`] *command*... \| `PerfCounter.print` \| `-f`
 *filename*
 
 `jcmd` \[`-l`\]
@@ -47,6 +47,9 @@ jcmd - send diagnostic command requests to a running Java Virtual Machine
 *main-class*
 :   When used, the `jcmd` utility sends the diagnostic command request to all
     Java processes with the specified name of the main class.
+
+`-t`
+:   When used, the diagnostic commands output starts with a timestamp.
 
 *command*
 :   The `command` must be a valid `jcmd` command for the selected JVM. The list

--- a/test/jdk/sun/tools/jcmd/TestJcmdTimestamp.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdTimestamp.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.Duration;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.dcmd.FileJcmdExecutor;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.dcmd.JcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.JDKToolFinder;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * @test
+ * @summary test whether jcmd generic flag "-t" adds a timestamp to the output
+ * @modules jdk.jcmd
+ * @library /test/lib
+ * @run main/othervm TestJcmdTimestamp
+ */
+public class TestJcmdTimestamp {
+
+    public static void main(String[] args) throws Exception {
+        TestJcmdTimestamp("-t", "VM.version", true /* expectTimestamp */);
+        TestJcmdTimestamp(null, "VM.version", false /* expectTimestamp */);
+    }
+
+    // timestamp should be there and it should be recent
+    public static void assertTimestamp(final String line) throws java.time.format.DateTimeParseException {
+        // ISO 8601. Example "2026-01-21T16:58:49.518+0100"
+        final String timePattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(timePattern);
+        final LocalDateTime parsedDateTime = LocalDateTime.parse(line, formatter);
+
+        final Duration duration = Duration.between(parsedDateTime, LocalDateTime.now());
+        Asserts.assertLessThan(duration.getSeconds(), 5L, "the timestamp is not recent");
+    }
+
+    private static void TestJcmdTimestamp(final String jcmdOptions,
+            final String command,
+            final boolean expectTimestamp) throws Exception {
+
+        final List<String> commandLine = new ArrayList<String>();
+
+        commandLine.add(JDKToolFinder.getJDKTool("jcmd"));
+        if (jcmdOptions != null) {
+            commandLine.add(jcmdOptions);
+        };
+        final long pid = ProcessTools.getProcessId(); // PID of this JVM
+        commandLine.add(String.valueOf(pid));
+        commandLine.add(command);
+
+        OutputAnalyzer output = ProcessTools.executeProcess(new ProcessBuilder(commandLine));
+
+        // Assert
+        output.shouldHaveExitValue(0);
+
+        final String secondLine = output.getOutput().split("\\r?\\n")[1];
+
+        if (expectTimestamp) {
+            assertTimestamp(secondLine);
+        }
+        else {
+            Asserts.assertThrows(java.time.format.DateTimeParseException.class, () -> assertTimestamp(secondLine));
+        }
+    }
+}

--- a/test/jdk/sun/tools/jcmd/usage.out
+++ b/test/jdk/sun/tools/jcmd/usage.out
@@ -1,8 +1,10 @@
-Usage: jcmd <pid | main class> <command ...|PerfCounter.print|-f file>
+Usage: jcmd <pid | main class> [-t] <command ...|PerfCounter.print|-f file>
    or: jcmd -l                                                    
-   or: jcmd -h                                                    
+   or: jcmd <-h | --help>                                         
                                                                   
-  command must be a valid jcmd command for the selected jvm.      
+  -t flag ensures the dignostic command begins with a timestamp   
+                                                                  
+  command must be a valid jcmd command for the selected JVM.      
   Use the command "help" to see which commands are available.   
   If the pid is 0, commands will be sent to all Java processes.   
   The main class argument will be used to match (either partially 
@@ -12,4 +14,4 @@ Usage: jcmd <pid | main class> <command ...|PerfCounter.print|-f file>
   PerfCounter.print display the counters exposed by this process  
   -f  read and execute commands from the file                     
   -l  list JVM processes on the local machine                     
-  -? -h --help print this help message                            
+  -? -h --help  print this help message                           


### PR DESCRIPTION
as an option to earlier variants
* v1 - https://github.com/openjdk/jdk/pull/27368
* v2 - https://github.com/openjdk/jdk/pull/27368

Here the `jcmd` is handled in `JCmd.java`, before we attach to the target JVM.
The benefit here is that the timestamp becomes a thing of `jcmd` tool, so users can timestamp invocations against older JVM as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357828](https://bugs.openjdk.org/browse/JDK-8357828): Add a timestamp to jcmd diagnostic commands (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29388/head:pull/29388` \
`$ git checkout pull/29388`

Update a local copy of the PR: \
`$ git checkout pull/29388` \
`$ git pull https://git.openjdk.org/jdk.git pull/29388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29388`

View PR using the GUI difftool: \
`$ git pr show -t 29388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29388.diff">https://git.openjdk.org/jdk/pull/29388.diff</a>

</details>
