### PR TITLE
8376406: Avoid loading ArrayDeque in jdk.internal.loader.NativeLibraries

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -476,7 +476,7 @@ public final class NativeLibraries {
     private static final class NativeLibraryContext {
 
         // Maps thread object to the native library context stack, maintained by each thread
-        private static Map<Thread, List<NativeLibraryImpl>> nativeLibraryThreadContext =
+        private final static Map<Thread, List<NativeLibraryImpl>> nativeLibraryThreadContext =
                 new ConcurrentHashMap<>();
 
         // returns a context associated with the current thread


### PR DESCRIPTION
Please review this PR which replaces `ArrayDeque` with `ArrayList` for the native library context stack in `jdk.internal.loader.NativeLibraries.NativeLibraryContext`.

With this follow-up to similar changes in #29288 and #29430, a simple JAR-based "hello world" program no longer loads the `ArrayDeque` class during startup.

The change here is mostly a straightforward replacement. The existing processing was a LIFO stack, which it still is after this PR, just backed by ArrayList instead.

Since ArrayList is null-friendly, I added an explicit `Objects.requireNullNull` before pushing to the stack.

Pure refactoring, no tests updated, `noreg-cleanup`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376406](https://bugs.openjdk.org/browse/JDK-8376406): Avoid loading ArrayDeque in jdk.internal.loader.NativeLibraries (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29432/head:pull/29432` \
`$ git checkout pull/29432`

Update a local copy of the PR: \
`$ git checkout pull/29432` \
`$ git pull https://git.openjdk.org/jdk.git pull/29432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29432`

View PR using the GUI difftool: \
`$ git pr show -t 29432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29432.diff">https://git.openjdk.org/jdk/pull/29432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29432#issuecomment-3801675512)
</details>
