### PR TITLE
8376483: Avoid loading java.nio.charset.StandardCharsets in java.util.zip.ZipCoder

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import jdk.internal.util.ArraysSupport;
@@ -256,7 +255,7 @@ class ZipCoder {
             try {
                 // Copy subrange for exclusive use by the string being created
                 byte[] bytes = Arrays.copyOfRange(ba, off, off + length);
-                return JLA.uncheckedNewStringOrThrow(bytes, StandardCharsets.UTF_8);
+                return JLA.uncheckedNewStringOrThrow(bytes, UTF_8.INSTANCE);
             } catch (CharacterCodingException cce) {
                 throw new IllegalArgumentException(cce);
             }


### PR DESCRIPTION
Please review this PR which removes a dependency on `java.nio.charset.StandardCharsets` introduced in [JDK-8365703](https://bugs.openjdk.org/browse/JDK-8365703).

We can use `UTF_8.INSTANCE` here as elsewhere in this class to prevent startup regression loading otherwise unused classes and charsets.

Verified that running `java -cp hello.jar Hello` observes the following diff in loaded classes when run with this PR:

```
< java.nio.charset.StandardCharsets
< sun.nio.cs.US_ASCII
< sun.nio.cs.ISO_8859_1
< sun.nio.cs.UTF_16BE
< sun.nio.cs.UTF_16LE
< sun.nio.cs.UTF_16
< sun.nio.cs.UTF_32BE
< sun.nio.cs.UTF_32LE
< sun.nio.cs.UTF_32
```

This is a strict refactoring, no tests updated, `noreg-trivial`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376483](https://bugs.openjdk.org/browse/JDK-8376483): Avoid loading java.nio.charset.StandardCharsets in java.util.zip.ZipCoder (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29443/head:pull/29443` \
`$ git checkout pull/29443`

Update a local copy of the PR: \
`$ git checkout pull/29443` \
`$ git pull https://git.openjdk.org/jdk.git pull/29443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29443`

View PR using the GUI difftool: \
`$ git pr show -t 29443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29443.diff">https://git.openjdk.org/jdk/pull/29443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29443#issuecomment-3804504406)
</details>
