### PR TITLE
8376287: Crashes when using -XX:ObjArrayMarkingStride=0

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -261,7 +261,7 @@
   develop(uintx, ObjArrayMarkingStride, 2048,                               \
           "Number of object array elements to push onto the marking stack " \
           "before pushing a continuation entry")                            \
-          range(1, max_uintx)                                               \
+          range(1, INT_MAX/2)                                               \
                                                                             \
   product_pd(bool, NeverActAsServerClassMachine,                            \
           "(Deprecated) Never act like a server-class machine")             \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -261,6 +261,7 @@
   develop(uintx, ObjArrayMarkingStride, 2048,                               \
           "Number of object array elements to push onto the marking stack " \
           "before pushing a continuation entry")                            \
+          range(1, max_uintx)                                               \
                                                                             \
   product_pd(bool, NeverActAsServerClassMachine,                            \
           "(Deprecated) Never act like a server-class machine")             \

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -226,8 +226,6 @@ inline void ShenandoahMark::do_chunked_array(ShenandoahObjToScanQueue* q, T* cl,
   assert(obj->is_objArray(), "expect object array");
   objArrayOop array = objArrayOop(obj);
 
-  assert (ObjArrayMarkingStride > 0, "sanity");
-
   // Split out tasks, as suggested in ShenandoahMarkTask docs. Avoid pushing tasks that
   // are known to start beyond the array.
   while ((1 << pow) > (int)ObjArrayMarkingStride && (chunk*2 < ShenandoahMarkTask::chunk_size())) {


### PR DESCRIPTION
Please review this change, it addresses a trivial issue. Thanks!

**Description:**

This is a trivial issue caused by the invalid value of -XX:ObjArrayMarkingStride=0, which results in a division by zero in the PartialArrayTaskStepper::start() method.
https://github.com/openjdk/jdk/blob/2529e2fe8dfe9685033bb0ae558266b8bc3cf95c/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp#L39-L40

**Fix:**

Restrict the ObjArrayMarkingStride to positive values.

**Test:**

GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376287](https://bugs.openjdk.org/browse/JDK-8376287): Crashes when using -XX:ObjArrayMarkingStride=0 (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [6662176e](https://git.openjdk.org/jdk/pull/29479/files/6662176e0756e961163fd3a675a8ff68bb006777)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29479/head:pull/29479` \
`$ git checkout pull/29479`

Update a local copy of the PR: \
`$ git checkout pull/29479` \
`$ git pull https://git.openjdk.org/jdk.git pull/29479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29479`

View PR using the GUI difftool: \
`$ git pr show -t 29479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29479.diff">https://git.openjdk.org/jdk/pull/29479.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29479#issuecomment-3815331818)
</details>
