### PR TITLE
RISC-V: remove redundant vset and change unnecessary mu/tu to ma/ta

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -268,7 +268,12 @@
                              VectorRegister vtmp1, VectorRegister vtmp2, BasicType bt,
                              uint vector_length, VectorMask vm = Assembler::unmasked);
 
-  void vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul = Assembler::m1, Register tmp = t0);
+  void vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul = Assembler::m1, 
+                      Assembler::VMA vma = Assembler::ma, Assembler::VTA vta = Assembler::ta, Register tmp = t0);
+
+  void vsetvli_helper(BasicType bt, uint vector_length, Assembler::VMA vma) {
+    vsetvli_helper(bt, vector_length, Assembler::m1, vma);
+  }
 
   void compare_integral_v(VectorRegister dst, VectorRegister src1, VectorRegister src2, int cond,
                           BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -49,6 +49,27 @@
                                   const int STUB_THRESHOLD, Label *STUB, Label *DONE);
 
  public:
+
+  struct VSetVliState {
+    Assembler::SEW _sew;
+    uint _vlen;
+    Assembler::LMUL _vlmul;
+    Assembler::VMA _vma;
+    Assembler::VTA _vta;
+    bool _valid;
+  };
+
+  static thread_local VSetVliState _current_state;
+
+  void invalidate_vsetvli_state() {
+    _current_state._valid = false;
+  }
+
+  void bind(Label& L) {
+    invalidate_vsetvli_state();
+    MacroAssembler::bind(L);
+  }
+
   // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.
   void fast_lock(Register object, Register box,
                  Register tmp1, Register tmp2, Register tmp3, Register tmp4);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -35,7 +35,7 @@ source %{
                         VectorRegister reg, BasicType bt, Register base,
                         uint vector_length, Assembler::VectorMask vm = Assembler::unmasked) {
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, vector_length);
+    __ vsetvli_helper(bt, vector_length, vm == Assembler::v0_t? Assembler::mu : Assembler::ma);
 
     if (is_store) {
       __ vsex_v(reg, base, sew, vm);
@@ -227,7 +227,7 @@ instruct vloadmask_masked(vRegMask dst, vReg src, vRegMask_V0 v0) %{
   match(Set dst (VectorLoadMask src v0));
   format %{ "vloadmask_masked $dst, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this), Assembler::mu);
     __ vmsne_vx(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), zr, Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -239,7 +239,7 @@ instruct vstoremask(vReg dst, vRegMask_V0 v0, immI size) %{
   match(Set dst (VectorStoreMask v0 size));
   format %{ "vstoremask $dst, V0 # elem size is $size byte[s]" %}
   ins_encode %{
-    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     __ vmerge_vim(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), 1);
   %}
@@ -357,7 +357,7 @@ instruct vabs_masked(vReg dst_src, vRegMask_V0 v0, vReg tmp) %{
   format %{ "vabs_masked $dst_src, $dst_src, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($dst_src$$reg), 0,
                 Assembler::v0_t);
     __ vmax_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($tmp$$reg),
@@ -372,7 +372,7 @@ instruct vabs_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   format %{ "vabs_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfabs_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -434,7 +434,7 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vadd_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vadd_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -448,7 +448,7 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vadd_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfadd_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -523,7 +523,7 @@ instruct vadd_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   format %{ "vadd_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -535,7 +535,7 @@ instruct vaddL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate con)) v0));
   format %{ "vaddL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -552,7 +552,7 @@ instruct vadd_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   format %{ "vadd_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -564,7 +564,7 @@ instruct vaddL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate src2)) v0));
   format %{ "vaddL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -625,7 +625,7 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vsub_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -638,7 +638,7 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vsub_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -683,7 +683,7 @@ instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   format %{ "vsub_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -695,7 +695,7 @@ instruct vsubL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
   format %{ "vsubL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -746,7 +746,7 @@ instruct vsadd_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vsadd_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                 as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -762,7 +762,7 @@ instruct vsaddu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vsaddu_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -810,7 +810,7 @@ instruct vssub_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vssub_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                 as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -826,7 +826,7 @@ instruct vssubu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vssubu_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -855,7 +855,7 @@ instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vand_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vand_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -935,7 +935,7 @@ instruct vand_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   format %{ "vand_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vand_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -948,7 +948,7 @@ instruct vandL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
   format %{ "vandL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vand_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -966,7 +966,7 @@ instruct vand_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   format %{ "vand_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vand_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -979,7 +979,7 @@ instruct vandL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
   format %{ "vandL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vand_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -1009,7 +1009,7 @@ instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vor_vv(as_VectorRegister($dst_src1$$reg),
               as_VectorRegister($dst_src1$$reg),
               as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -1089,7 +1089,7 @@ instruct vor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   format %{ "vor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vor_vi(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               $con$$constant, Assembler::v0_t);
@@ -1102,7 +1102,7 @@ instruct vorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
   format %{ "vorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vor_vi(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               $con$$constant, Assembler::v0_t);
@@ -1120,7 +1120,7 @@ instruct vor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   format %{ "vor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vor_vx(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               as_Register($src$$reg), Assembler::v0_t);
@@ -1133,7 +1133,7 @@ instruct vorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
   format %{ "vorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vor_vx(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               as_Register($src$$reg), Assembler::v0_t);
@@ -1163,7 +1163,7 @@ instruct vxor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vxor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -1243,7 +1243,7 @@ instruct vxor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   format %{ "vxor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -1256,7 +1256,7 @@ instruct vxorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
   format %{ "vxorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -1274,7 +1274,7 @@ instruct vxor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
   format %{ "vxor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -1287,7 +1287,7 @@ instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
   format %{ "vxorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -1356,7 +1356,7 @@ instruct vand_notB_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
   format %{ "vand_notB_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1370,7 +1370,7 @@ instruct vand_notS_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
   format %{ "vand_notS_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1384,7 +1384,7 @@ instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
   format %{ "vand_notI_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1398,7 +1398,7 @@ instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) 
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
   format %{ "vand_notL_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1464,7 +1464,7 @@ instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
   format %{ "vand_notB_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1478,7 +1478,7 @@ instruct vand_notS_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
   format %{ "vand_notS_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1492,7 +1492,7 @@ instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
   format %{ "vand_notI_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1506,7 +1506,7 @@ instruct vand_notL_vx_masked(vReg dst_src1, iRegL src2, immL_M1 m1, vRegMask_V0 
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorL src2 m1))) v0));
   format %{ "vand_notL_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1558,7 +1558,7 @@ instruct vnot_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
   format %{ "vnot_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                -1, Assembler::v0_t);
@@ -1571,7 +1571,7 @@ instruct vnotL_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
   match(Set dst_src (XorV (Binary dst_src (Replicate m1)) v0));
   format %{ "vnotL_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                -1, Assembler::v0_t);
@@ -1617,7 +1617,7 @@ instruct vdiv_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vdiv_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfdiv_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -1664,7 +1664,7 @@ instruct vmax_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vmax_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmax_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1678,7 +1678,7 @@ instruct vmin_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vmin_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmin_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1721,7 +1721,7 @@ instruct vmaxu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmaxu_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1734,7 +1734,7 @@ instruct vminu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vminu_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1879,7 +1879,7 @@ instruct vfmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfmadd_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                  as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -1926,7 +1926,7 @@ instruct vfnmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfnmsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                   as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -1973,7 +1973,7 @@ instruct vfnmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfnmadd_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                   as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2018,7 +2018,7 @@ instruct vfmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfmsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                  as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2053,7 +2053,7 @@ instruct vmla_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   format %{ "vmla_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                 as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2088,7 +2088,7 @@ instruct vmls_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   format %{ "vmls_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                  as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2148,7 +2148,7 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vmul_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -2161,7 +2161,7 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vmul_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -2206,7 +2206,7 @@ instruct vmul_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   format %{ "vmul_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -2218,7 +2218,7 @@ instruct vmulL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVL (Binary dst_src (Replicate src2)) v0));
   format %{ "vmulL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -2248,7 +2248,7 @@ instruct vneg_masked(vReg dst_src, vRegMask_V0 v0) %{
   format %{ "vneg_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vneg_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
               Assembler::v0_t);
   %}
@@ -2277,7 +2277,7 @@ instruct vfneg_masked(vReg dst_src, vRegMask_V0 v0) %{
   format %{ "vfneg_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfneg_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                Assembler::v0_t);
   %}
@@ -2621,7 +2621,7 @@ instruct reduce_addF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, vR
   effect(TEMP tmp);
   format %{ "reduce_addF_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2), Assembler::mu);
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -2635,7 +2635,7 @@ instruct reduce_addD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, vR
   effect(TEMP tmp);
   format %{ "reduce_addD_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
+    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2), Assembler::mu);
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -3076,7 +3076,7 @@ instruct vasrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vasrB $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerByte - 1, clear the low BitsPerByte - 1 bits
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vsra_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3094,7 +3094,7 @@ instruct vasrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vasrS $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerShort - 1, clear the low BitsPerShort - 1 bits
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vsra_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3134,7 +3134,7 @@ instruct vasrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
   effect(TEMP_DEF dst_src, TEMP v0);
   format %{ "vasrB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     // if shift > BitsPerByte - 1, clear the low BitsPerByte - 1 bits
     __ vmerge_vim(as_VectorRegister($shift$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
@@ -3151,7 +3151,7 @@ instruct vasrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
   effect(TEMP_DEF dst_src, TEMP v0);
   format %{ "vasrS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     // if shift > BitsPerShort - 1, clear the low BitsPerShort - 1 bits
     __ vmerge_vim(as_VectorRegister($shift$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
@@ -3168,7 +3168,7 @@ instruct vasrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst_src);
   format %{ "vasrI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vsra_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3180,7 +3180,7 @@ instruct vasrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst_src);
   format %{ "vasrL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsra_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3192,7 +3192,7 @@ instruct vlslB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vlslB $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3210,7 +3210,7 @@ instruct vlslS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vlslS $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3250,7 +3250,7 @@ instruct vlslB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
   effect(TEMP_DEF dst_src, TEMP v0);
   format %{ "vlslB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3270,7 +3270,7 @@ instruct vlslS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
   effect(TEMP_DEF dst_src, TEMP v0);
   format %{ "vlslS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3290,7 +3290,7 @@ instruct vlslI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst_src);
   format %{ "vlslI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vsll_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3302,7 +3302,7 @@ instruct vlslL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst_src);
   format %{ "vlslL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsll_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3314,7 +3314,7 @@ instruct vlsrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vlsrB $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3332,7 +3332,7 @@ instruct vlsrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vlsrS $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3372,7 +3372,7 @@ instruct vlsrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
   effect(TEMP_DEF dst_src, TEMP v0);
   format %{ "vlsrB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3392,7 +3392,7 @@ instruct vlsrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
   effect(TEMP_DEF dst_src, TEMP v0);
   format %{ "vlsrS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3412,7 +3412,7 @@ instruct vlsrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst_src);
   format %{ "vlsrI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vsrl_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3424,7 +3424,7 @@ instruct vlsrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst_src);
   format %{ "vlsrL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsrl_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3507,7 +3507,7 @@ instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
       return;
     }
     if (con >= BitsPerByte) con = BitsPerByte - 1;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3523,7 +3523,7 @@ instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
       return;
     }
     if (con >= BitsPerShort) con = BitsPerShort - 1;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3538,7 +3538,7 @@ instruct vasrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3554,7 +3554,7 @@ instruct vasrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3644,7 +3644,7 @@ instruct vlsrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     if (con >= BitsPerByte) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3664,7 +3664,7 @@ instruct vlsrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     if (con >= BitsPerShort) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3684,7 +3684,7 @@ instruct vlsrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vsrl_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3700,7 +3700,7 @@ instruct vlsrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsrl_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3767,7 +3767,7 @@ instruct vlslB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   format %{ "vlslB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this), Assembler::mu);
     if (con >= BitsPerByte) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3784,7 +3784,7 @@ instruct vlslS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   format %{ "vlslS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this), Assembler::mu);
     if (con >= BitsPerShort) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3801,7 +3801,7 @@ instruct vlslI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   format %{ "vlslI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mu);
     __ vsll_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3814,7 +3814,7 @@ instruct vlslL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   format %{ "vlslL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vsll_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3886,7 +3886,7 @@ instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   format %{ "vrotate_right_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vror_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3899,7 +3899,7 @@ instruct vrotate_right_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0)
   format %{ "vrotate_right_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vror_vx(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_Register($shift$$reg), Assembler::v0_t);
   %}
@@ -3916,7 +3916,7 @@ instruct vrotate_right_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vror_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                con, Assembler::v0_t);
   %}
@@ -3974,7 +3974,7 @@ instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   format %{ "vrotate_left_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vrol_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3987,7 +3987,7 @@ instruct vrotate_left_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) 
   format %{ "vrotate_left_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vrol_vx(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_Register($shift$$reg), Assembler::v0_t);
   %}
@@ -4004,7 +4004,7 @@ instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     con = bits - con;
     __ vror_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                con, Assembler::v0_t);
@@ -4046,7 +4046,7 @@ instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   format %{ "vsqrt_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vfsqrt_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                 Assembler::v0_t);
   %}
@@ -4562,7 +4562,7 @@ instruct vblend(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   format %{ "vblend $dst, $src1, $src2, v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vmerge_vvm(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                   as_VectorRegister($src2$$reg));
   %}
@@ -4779,7 +4779,7 @@ instruct vcvtFtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vcvtFtoX_narrow $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mu);
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ integer_narrow_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),
@@ -4794,7 +4794,7 @@ instruct vcvtFtoI(vReg dst, vReg src, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vcvtFtoI $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mu);
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4808,7 +4808,7 @@ instruct vcvtFtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2, Assembler::mu);
     __ vmfeq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
     __ vfwcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
   %}
@@ -4839,7 +4839,7 @@ instruct vcvtDtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vmfeq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2);
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2, Assembler::mu);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     __ vfncvt_rtz_x_f_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4857,7 +4857,7 @@ instruct vcvtDtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   effect(TEMP_DEF dst, TEMP v0);
   format %{ "vcvtDtoL $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this), Assembler::mu);
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4946,7 +4946,7 @@ instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRe
   format %{ "select_from_two_vectors $dst, $src1, $src2, $index" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                    as_VectorRegister($index$$reg));
     bool use_imm = __ is_simm5(Matcher::vector_length(this) - 1);
@@ -4987,7 +4987,7 @@ instruct rearrange_masked(vReg dst, vReg src, vReg shuffle, vRegMask_V0 v0) %{
   format %{ "rearrange_masked $dst, $src, $shuffle, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -5072,7 +5072,7 @@ instruct vcompress(vReg dst, vReg src, vRegMask_V0 v0) %{
   format %{ "vcompress $dst, $src, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
     __ vcompress_vm(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -5087,7 +5087,7 @@ instruct vexpand(vReg dst, vReg src, vRegMask_V0 v0, vReg tmp) %{
   format %{ "vexpand $dst, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ viota_m(as_VectorRegister($tmp$$reg), as_VectorRegister($v0$$reg));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
@@ -5150,7 +5150,7 @@ instruct vreverse_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
+    __ vsetvli_helper(bt, vlen, Assembler::mu);
     __ vbrev_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5176,7 +5176,7 @@ instruct vreverse_bytes_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
+    __ vsetvli_helper(bt, vlen, Assembler::mu);
     __ vrev8_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5235,7 +5235,7 @@ instruct vpopcount_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
+    __ vsetvli_helper(bt, vlen, Assembler::mu);
     __ vcpop_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5262,7 +5262,7 @@ instruct vcountLeadingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
+    __ vsetvli_helper(bt, vlen, Assembler::mu);
     __ vclz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5288,7 +5288,7 @@ instruct vcountTrailingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
+    __ vsetvli_helper(bt, vlen, Assembler::mu);
     __ vctz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5349,7 +5349,7 @@ instruct gather_loadS_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
@@ -5367,7 +5367,7 @@ instruct gather_loadD_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
@@ -5421,7 +5421,7 @@ instruct scatter_storeS_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
+    __ vsetvli_helper(bt, Matcher::vector_length(this, $src), Assembler::mu);
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vsuxei32_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -5437,7 +5437,7 @@ instruct scatter_storeD_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
+    __ vsetvli_helper(bt, Matcher::vector_length(this, $src), Assembler::mu);
     __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
     __ vsuxei64_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
@@ -5477,7 +5477,7 @@ instruct insert_index_lt32(vReg dst, vReg src, iRegIorL2I val, immI idx, vRegMas
   format %{ "insert_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5496,7 +5496,7 @@ instruct insert_index(vReg dst, vReg src, iRegIorL2I val, iRegIorL2I idx, vReg t
   format %{ "insert_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5515,7 +5515,7 @@ instruct insertL_index_lt32(vReg dst, vReg src, iRegL val, immI idx, vRegMask_V0
   format %{ "insertL_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5532,7 +5532,7 @@ instruct insertL_index(vReg dst, vReg src, iRegL val, iRegIorL2I idx, vReg tmp, 
   format %{ "insertL_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5550,7 +5550,7 @@ instruct insertF_index_lt32(vReg dst, vReg src, fRegF val, immI idx, vRegMask_V0
   effect(TEMP v0);
   format %{ "insertF_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5566,7 +5566,7 @@ instruct insertF_index(vReg dst, vReg src, fRegF val, iRegIorL2I idx, vReg tmp, 
   effect(TEMP tmp, TEMP v0);
   format %{ "insertF_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5584,7 +5584,7 @@ instruct insertD_index_lt32(vReg dst, vReg src, fRegD val, immI idx, vRegMask_V0
   effect(TEMP v0);
   format %{ "insertD_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5600,7 +5600,7 @@ instruct insertD_index(vReg dst, vReg src, fRegD val, iRegIorL2I idx, vReg tmp, 
   effect(TEMP tmp, TEMP v0);
   format %{ "insertD_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
+    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this), Assembler::mu);
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ The pull request body must not be empty.

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29499/head:pull/29499` \
`$ git checkout pull/29499`

Update a local copy of the PR: \
`$ git checkout pull/29499` \
`$ git pull https://git.openjdk.org/jdk.git pull/29499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29499`

View PR using the GUI difftool: \
`$ git pr show -t 29499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29499.diff">https://git.openjdk.org/jdk/pull/29499.diff</a>

</details>
