### PR TITLE
8376777: Consistent use of nonstatic instead of non_static in ci files

### DIFF
--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -213,7 +213,7 @@ ciField::ciField(fieldDescriptor *fd) :
          "bootstrap classes must not create & cache unshared fields");
 }
 
-static bool trust_final_non_static_fields(ciInstanceKlass* holder) {
+static bool trust_final_nonstatic_fields(ciInstanceKlass* holder) {
   if (holder == nullptr)
     return false;
   if (holder->trust_final_fields()) {
@@ -259,7 +259,7 @@ void ciField::initialize_from(fieldDescriptor* fd) {
       // An instance field can be constant if it's a final static field or if
       // it's a final non-static field of a trusted class (classes in
       // java.lang.invoke and sun.invoke packages and subpackages).
-      _is_constant = is_stable_field || trust_final_non_static_fields(_holder);
+      _is_constant = is_stable_field || trust_final_nonstatic_fields(_holder);
     }
   } else {
     // For CallSite objects treat the target field as a compile time constant.

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -392,7 +392,7 @@ bool ciInstanceKlass::contains_field_offset(int offset) {
   return get_instanceKlass()->contains_field_offset(offset);
 }
 
-ciField* ciInstanceKlass::get_non_static_field_by_offset(const int field_offset) {
+ciField* ciInstanceKlass::get_nonstatic_field_by_offset(const int field_offset) {
   for (int i = 0, len = nof_nonstatic_fields(); i < len; i++) {
     ciField* field = _nonstatic_fields->at(i);
     int field_off = field->offset_in_bytes();
@@ -406,7 +406,7 @@ ciField* ciInstanceKlass::get_non_static_field_by_offset(const int field_offset)
 // ciInstanceKlass::get_field_by_offset
 ciField* ciInstanceKlass::get_field_by_offset(int field_offset, bool is_static) {
   if (!is_static) {
-    return get_non_static_field_by_offset(field_offset);
+    return get_nonstatic_field_by_offset(field_offset);
   }
   VM_ENTRY_MARK;
   InstanceKlass* k = get_instanceKlass();
@@ -437,7 +437,7 @@ ciField* ciInstanceKlass::get_field_by_name(ciSymbol* name, ciSymbol* signature,
 // except this does not require allocating memory for a new ciField
 BasicType ciInstanceKlass::get_field_type_by_offset(const int field_offset, const bool is_static) {
   if (!is_static) {
-    ciField* field = get_non_static_field_by_offset(field_offset);
+    ciField* field = get_nonstatic_field_by_offset(field_offset);
     return field != nullptr ? field->layout_type() : T_ILLEGAL;
   }
 

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -83,7 +83,7 @@ private:
   bool compute_injected_fields_helper();
   void compute_transitive_interfaces();
 
-  ciField* get_non_static_field_by_offset(int field_offset);
+  ciField* get_nonstatic_field_by_offset(int field_offset);
 
 protected:
   ciInstanceKlass(Klass* k);


### PR DESCRIPTION
Hello,

While working towards having more consistent names for nonstatic fields in Valhalla (see [JDK-8376652](https://bugs.openjdk.org/browse/JDK-8376652)), I noticed that we have a few places in the ci files that uses non_static over nonstatic. I suggest we should be consistent in this case and use nonstatic, which is favored in HotSpot.

Testing:
* GHA
* Oracle's tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376777](https://bugs.openjdk.org/browse/JDK-8376777): Consistent use of nonstatic instead of non_static in ci files (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29500/head:pull/29500` \
`$ git checkout pull/29500`

Update a local copy of the PR: \
`$ git checkout pull/29500` \
`$ git pull https://git.openjdk.org/jdk.git pull/29500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29500`

View PR using the GUI difftool: \
`$ git pr show -t 29500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29500.diff">https://git.openjdk.org/jdk/pull/29500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29500#issuecomment-3822536514)
</details>
