### PR TITLE
Assorted cleanups in ZipCoder

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,10 +112,6 @@ class ZipCoder {
         } catch (CharacterCodingException x) {
             throw new IllegalArgumentException(x);
         }
-    }
-
-    static String toStringUTF8(byte[] ba, int len) {
-        return UTF8.toString(ba, 0, len);
     }
 
     boolean isUTF8() {

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -174,13 +174,6 @@ class ZipCoder {
         return dec;
     }
 
-    /**
-     * {@return the {@link Charset} used by this {@code ZipCoder}}
-     */
-    final Charset charset() {
-        return this.cs;
-    }
-
     private CharsetEncoder encoder() {
         if (enc == null) {
             enc = cs.newEncoder()

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -82,6 +82,16 @@ class ZipCoder {
          */
         NO_MATCH = 2;
 
+    // Hash function equivalent of checkedHash for String inputs
+    static int hash(String name) {
+        int hsh = name.hashCode();
+        int len = name.length();
+        if (len > 0 && name.charAt(len - 1) != '/') {
+            hsh = hsh * 31 + '/';
+        }
+        return hsh;
+    }
+
     String toString(byte[] ba, int off, int length) {
         try {
             return decoder().decode(ByteBuffer.wrap(ba, off, length)).toString();
@@ -141,16 +151,6 @@ class ZipCoder {
             h = 31 * h + '/';
         }
         return h;
-    }
-
-    // Hash function equivalent of checkedHash for String inputs
-    static int hash(String name) {
-        int hsh = name.hashCode();
-        int len = name.length();
-        if (len > 0 && name.charAt(len - 1) != '/') {
-            hsh = hsh * 31 + '/';
-        }
-        return hsh;
     }
 
     private final Charset cs;

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -92,6 +92,10 @@ class ZipCoder {
         return hsh;
     }
 
+    String toString(byte[] ba) {
+        return toString(ba, 0, ba.length);
+    }
+
     String toString(byte[] ba, int off, int length) {
         try {
             return decoder().decode(ByteBuffer.wrap(ba, off, length)).toString();
@@ -99,11 +103,7 @@ class ZipCoder {
             throw new IllegalArgumentException(x);
         }
     }
-
-    String toString(byte[] ba) {
-        return toString(ba, 0, ba.length);
-    }
-
+    
     byte[] getBytes(String s) {
         try {
             ByteBuffer bb = encoder().encode(CharBuffer.wrap(s));

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -90,10 +90,6 @@ class ZipCoder {
         }
     }
 
-    String toString(byte[] ba, int length) {
-        return toString(ba, 0, length);
-    }
-
     String toString(byte[] ba) {
         return toString(ba, 0, ba.length);
     }

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -45,13 +45,19 @@ import sun.nio.cs.UTF_8;
  * for other charsets require external synchronization.
  */
 class ZipCoder {
-
+    // Used for efficient UTF-8 string operations
     private static final jdk.internal.access.JavaLangAccess JLA =
         jdk.internal.access.SharedSecrets.getJavaLangAccess();
 
     // Encoding/decoding is stateless, so make it singleton.
     static final UTF8ZipCoder UTF8 = new UTF8ZipCoder(UTF_8.INSTANCE);
 
+    /**
+     * Return a ZipCoder supporting operations using the provided charset
+     *
+     * @param charset the charset to use by the ZipCoder
+     * @return a ZipCoder using the provided charset
+     */
     public static ZipCoder get(Charset charset) {
         if (charset == UTF_8.INSTANCE) {
             return UTF8;
@@ -107,10 +113,26 @@ class ZipCoder {
         return hsh;
     }
 
+    /**
+     * Constructs a new String by decoding the given byte
+     * array using the charset of this ZipCoder
+     *
+     * @param bytes the byte array to decode
+     * @return the decoded String
+     */
     String toString(byte[] bytes) {
         return toString(bytes, 0, bytes.length);
     }
 
+    /**
+     * Constructs a new String by decoding the given byte
+     * array subrange using the charset of this ZipCoder
+     *
+     * @param bytes byte array holding the encoded string
+     * @param off index of the first byte to decode
+     * @param len the number of bytes to decode
+     * @return the decoded String
+     */
     String toString(byte[] bytes, int off, int length) {
         try {
             return decoder().decode(ByteBuffer.wrap(bytes, off, length)).toString();
@@ -119,6 +141,13 @@ class ZipCoder {
         }
     }
 
+    /**
+     * Encodes the given string into a sequence of bytes
+     * using the charset of this ZipCoder
+     *
+     * @param s the string to encode
+     * @return the resultant byte array
+     */
     byte[] getBytes(String s) {
         try {
             ByteBuffer bb = encoder().encode(CharBuffer.wrap(s));
@@ -135,6 +164,11 @@ class ZipCoder {
         }
     }
 
+    /**
+     * Returns {@code true} if this ZipCoder uses UTF-8 for its operations
+     *
+     * @return true if this ZipCoder uses UTF-8
+     */
     boolean isUTF8() {
         return false;
     }
@@ -150,6 +184,10 @@ class ZipCoder {
      * On an error, this function will throw CharacterCodingException while the
      * UTF8ZipCoder override will throw IllegalArgumentException, so we declare
      * throws Exception to keep things simple.
+     *
+     * @param bytes byte array holding the encoded name
+     * @param off index of the first byte of the encoded name
+     * @param len length of encoded name in bytes
      */
     int checkedHash(byte[] bytes, int off, int len) throws Exception {
         if (len == 0) {

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -103,7 +103,7 @@ class ZipCoder {
             throw new IllegalArgumentException(x);
         }
     }
-    
+
     byte[] getBytes(String s) {
         try {
             ByteBuffer bb = encoder().encode(CharBuffer.wrap(s));
@@ -154,14 +154,14 @@ class ZipCoder {
     }
 
     private final Charset cs;
-    protected CharsetDecoder dec;
+    private CharsetDecoder dec;
     private CharsetEncoder enc;
 
     private ZipCoder(Charset cs) {
         this.cs = cs;
     }
 
-    protected CharsetDecoder decoder() {
+    private CharsetDecoder decoder() {
         if (dec == null) {
             dec = cs.newDecoder()
               .onMalformedInput(CodingErrorAction.REPORT)

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -82,7 +82,22 @@ class ZipCoder {
          */
         NO_MATCH = 2;
 
-    // Hash function equivalent of checkedHash for String inputs
+    /**
+     * Returns a hash code for use in ZipFile entry name lookups.
+     *
+     * If the name ends with a trailing '/', we generate the hash code
+     * as-if calling String.hashCode().
+     *
+     * If the name has no trailing '/', we generate the hash code
+     * as-if first appending '/' to the name, then calling String.hashCode()
+     * on the result.
+     *
+     * This "slash-normalization" ensures that "directory" and "directory/" produce
+     * identical hash codes and allows us to simplify and speed up lookups.
+     *
+     * @param name the ZIP entry name to generate a hash code for
+     * @return the slash-normalized hash code of the name
+     */
     static int hash(String name) {
         int hsh = name.hashCode();
         int len = name.length();
@@ -124,15 +139,18 @@ class ZipCoder {
         return false;
     }
 
-    // Hash code functions for ZipFile entry names. We generate the hash as-if
-    // we first decoded the byte sequence to a String, then appended '/' if no
-    // trailing slash was found, then called String.hashCode(). This
-    // normalization ensures we can simplify and speed up lookups.
-    //
-    // Does encoding error checking and hashing in a single pass for efficiency.
-    // On an error, this function will throw CharacterCodingException while the
-    // UTF8ZipCoder override will throw IllegalArgumentException, so we declare
-    // throws Exception to keep things simple.
+    /**
+     * Returns a hash code for an encoded ZIP entry name, equivalent to
+     * that produced by {@link #hash(String)}
+     *
+     * We generate the hash code as-if we first decoded the byte sequence to
+     * a String, then generated the hash code using {@link #hash(String)}.
+     *
+     * Does encoding error checking and hashing in a single pass for efficiency.
+     * On an error, this function will throw CharacterCodingException while the
+     * UTF8ZipCoder override will throw IllegalArgumentException, so we declare
+     * throws Exception to keep things simple.
+     */
     int checkedHash(byte[] a, int off, int len) throws Exception {
         if (len == 0) {
             return 0;

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -518,7 +518,7 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
         ZipCoder zc = ((flag & USE_UTF8) != 0) ? ZipCoder.UTF8 : this.zc;
         String entryName;
         try {
-            entryName = zc.toString(b, len);
+            entryName = zc.toString(b, 0, len);
         } catch (Exception ex) {
             throw (ZipException) new ZipException(
                     "invalid LOC header (bad entry name)").initCause(ex);

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -515,11 +515,10 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
         }
         readFully(b, 0, len);
         // Force to use UTF-8 if the USE_UTF8 bit is ON
+        ZipCoder zc = ((flag & USE_UTF8) != 0) ? ZipCoder.UTF8 : this.zc;
         String entryName;
         try {
-            entryName = ((flag & USE_UTF8) != 0) ?
-                    ZipCoder.toStringUTF8(b, len)
-                    : zc.toString(b, len);
+            entryName = zc.toString(b, len);
         } catch (Exception ex) {
             throw (ZipException) new ZipException(
                     "invalid LOC header (bad entry name)").initCause(ex);


### PR DESCRIPTION
Please review this PR which suggests some assorted cleanups in `java.util.zip.ZipCoder`. 

The goal of this PR is mainly to pave the way for promoting UTF8 as the base class in  [JDK-8376842](https://bugs.openjdk.org/browse/JDK-8376842).  A secondary goal is to make the class easier to understand for maintainers. While being a utility class, its functions are vital to the understanding of many `ZipFile` optimizations.

The PR removes some methods of questionable value, relocates others inside the source file, adjusts some access flags and parameter names and adds consistently formatted Javadocs.  Additionally, we move the definition of the hash code function used for ZIP entry names to the static String version of  the function.

Can be reviewed as a hole, but here is a breakdown of commits:

* 41923b0 removes `ZipCoder.toStringUTF8()`. This polymorphic shortcut does not carry its weight.
* b207b9b removes `ZipCoder::toString(byte[], int)`. This convenience overload does not carry its weight.
* a05b03f removes `ZipCoder.charset()`. With the promotion of UTF-8, the base class will no longer accept a Charset, so exposing one may become strange.
* 4a828f4 and e1c5a1b moves the static `hash` method and a convenience `toString` method higher up in the source file
* af66448 makes `ZipCoder.dec` and `ZipCoder.decoder()` private
* 0a7ff0c specifies ZipCoder.checkedHash in terms of ZipCoder.hash(String). It seems simpler to explain the  "slash normalization" technique in this String version and refering to that from `checkedHash`
* 79ae23b consistently uses `bytes` as the parameter name for byte arrays
* e040dd2 adds Javadoc comments where missing

Strict refacting, no tests updated. `noreg-cleanup`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29512/head:pull/29512` \
`$ git checkout pull/29512`

Update a local copy of the PR: \
`$ git checkout pull/29512` \
`$ git pull https://git.openjdk.org/jdk.git pull/29512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29512`

View PR using the GUI difftool: \
`$ git pr show -t 29512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29512.diff">https://git.openjdk.org/jdk/pull/29512.diff</a>

</details>
