### PR TITLE
Show proper error instead of an IllegalArgumentException without a me…

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
@@ -129,7 +129,8 @@ ERR_NoInstallerEntryPoint=Option [{0}] is not valid without --module or --main-j
 ERR_MutuallyExclusiveOptions=Mutually exclusive options [{0}] and [{1}]
 ERR_InvalidOptionWithAppImageSigning=Option [{0}] is not valid when signing application image
 
-ERR_MissingArgument2=Missing argument: {0} or {1}
+ERR_MissingOption2=Option {0} must be used with option {1} or {2}
+ERR_MissingOption3=Option {0} must be used with option {1}, {2}, or {3}
 ERR_InvalidAppName=Invalid Application name: {0}
 ERR_InvalidSLName=Invalid Add Launcher name: {0}
 ERR_InvalidOption=Invalid Option: [{0}]

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsProcessorTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsProcessorTest.java
@@ -265,7 +265,7 @@ public class OptionsProcessorTest {
     public void testMultipleCommandLineStructureAnalyzerErrors() {
         build().createAppImageByDefault().expectValidationErrors(
                 new JPackageException(I18N.format("ERR_MutuallyExclusiveOptions", "-m", "--main-jar")),
-                new JPackageException(I18N.format("ERR_MissingArgument2", "--runtime-image", "--module-path")),
+                new JPackageException(I18N.format("ERR_MissingOption2", "--module", "--runtime-image", "--module-path")),
                 new JPackageException(I18N.format("error.no-input-parameter"))
         ).validationErrorsOrdered(false).create("-m", "com.foo", "--main-jar", "main.jar").validate();
     }

--- a/test/jdk/tools/jpackage/share/ModulePathTest.java
+++ b/test/jdk/tools/jpackage/share/ModulePathTest.java
@@ -126,7 +126,7 @@ public final class ModulePathTest {
             final CannedFormattedString expectedErrorMessage;
             if (modulePathArgs.isEmpty()) {
                 expectedErrorMessage = JPackageStringBundle.MAIN.cannedFormattedString(
-                        "ERR_MissingArgument2", "--runtime-image", "--module-path");
+                        "ERR_MissingOption2", "--module", "--runtime-image", "--module-path");
             } else {
                 expectedErrorMessage = JPackageStringBundle.MAIN.cannedFormattedString(
                         "error.no-module-in-path", appDesc.moduleName());


### PR DESCRIPTION
Show proper error instead of an IllegalArgumentException without a message when the "--mac-sign" option is specified without a sign identity

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29514/head:pull/29514` \
`$ git checkout pull/29514`

Update a local copy of the PR: \
`$ git checkout pull/29514` \
`$ git pull https://git.openjdk.org/jdk.git pull/29514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29514`

View PR using the GUI difftool: \
`$ git pr show -t 29514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29514.diff">https://git.openjdk.org/jdk/pull/29514.diff</a>

</details>
