### PR TITLE
8XXXXXX: Typo in Logger.java findResourceBundle method comment

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/Logger.java
+++ b/src/java.logging/share/classes/java/util/logging/Logger.java
@@ -643,7 +643,7 @@ public class Logger {
         }
         return manager.demandLogger(name, resourceBundleName, caller);
         // ends up calling new Logger(name, resourceBundleName, caller)
-        // iff the logger doesn't exist already
+        // if the logger doesn't exist already
     }
 
     /**


### PR DESCRIPTION
I found a typo in the internal comments of the findResourceBundle
method in java.util.logging.Logger.
"iff" is changed to "if" for better readability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29538/head:pull/29538` \
`$ git checkout pull/29538`

Update a local copy of the PR: \
`$ git checkout pull/29538` \
`$ git pull https://git.openjdk.org/jdk.git pull/29538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29538`

View PR using the GUI difftool: \
`$ git pr show -t 29538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29538.diff">https://git.openjdk.org/jdk/pull/29538.diff</a>

</details>
