### PR TITLE
8372952: Respect landscape orientation user selection on macOS and Linux

### DIFF
--- a/src/java.desktop/share/classes/sun/print/CustomMediaSize.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaSize.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.print;
+
+import javax.print.attribute.standard.MediaSize;
+import javax.print.attribute.standard.MediaSizeName;
+import java.io.Serial;
+
+/**
+ * Class allows to use medium with a landscape orientation.
+ * The orientation is specified relative to the media feed direction
+ * as described in the "PostScript Printer Description
+ * File Format Specification".
+ * Width - the width of the page perpendicular to the direction
+ * of media feed.
+ * Height - the height of the page parallel to the direction of
+ * media feed.
+ * It stores orientation of the medium and use this information
+ * to provide the physical width and height of the medium.
+ */
+class CustomMediaSize extends MediaSize {
+
+    /**
+     * Serial
+     */
+    @Serial
+    private static final long serialVersionUID = -1967958664615414771L;
+
+    public static final int PORTRAIT  = 0;
+    public static final int LANDSCAPE  = 1;
+    private final int orientation;
+
+    /**
+     * Ctor
+     * @param x width
+     * @param y height
+     * @param units units
+     * @param orientation orientation
+     */
+    private CustomMediaSize(float x, float y, int units, int orientation) {
+        super(x, y, units);
+        this.orientation = orientation;
+    }
+
+    private CustomMediaSize(int x, int y, int units, int orientation) {
+        super(x, y, units);
+        this.orientation = orientation;
+    }
+
+    private CustomMediaSize(float x, float y, int units, MediaSizeName media, int orientation) {
+        super(x, y, units, media);
+        this.orientation = orientation;
+    }
+
+    private CustomMediaSize(int x, int y, int units, MediaSizeName media, int orientation) {
+        super(x, y, units, media);
+        this.orientation = orientation;
+    }
+
+    /**
+     * Returns this media's width in the given units as a floating-point value.
+     * It takes into account the physical orientation.
+     * @param units unit conversion factor, e.g. {@link #INCH INCH} or
+     *         {@link #MM MM}
+     * @return the physical width of the medium
+     */
+    @Override
+    public float getX(int units) {
+        return orientation == PORTRAIT ?
+                super.getX(units) : super.getY(units);
+    }
+
+    /**
+     * Returns this media's height in the given units as a floating-point value.
+     * It takes into account the physical orientation.
+     * @param units unit conversion factor, e.g. {@link #INCH INCH} or
+     *         {@link #MM MM}
+     * @return the physical hight of the medium
+     */
+    @Override
+    public float getY(int units) {
+        return orientation == PORTRAIT ?
+                super.getY(units) : super.getX(units);
+    }
+
+    @Override
+    protected int getXMicrometers() {
+        return orientation == PORTRAIT ?
+                super.getXMicrometers() : super.getYMicrometers();
+    }
+
+    @Override
+    protected int getYMicrometers() {
+        return orientation == PORTRAIT ?
+                super.getYMicrometers() : super.getXMicrometers();
+    }
+
+    /**
+     * Creates new instance of CustomMediaSize from the given floating-point
+     * values.
+     *
+     * @param x physical width of the media
+     * @param y physical height of the media
+     * @param units unit conversion factor, e.g. {@link #INCH INCH} or
+     *         {@link #MM MM}
+     * @return CustomMediaSize with provided dimension
+     */
+    public static CustomMediaSize create(float x, float y, int units) {
+        CustomMediaSize cms;
+        if (x > y) {
+            cms = new CustomMediaSize(y, x, units, LANDSCAPE);
+        } else {
+            cms = new CustomMediaSize(x, y, units, PORTRAIT);
+        }
+        return cms;
+    }
+
+    /**
+     * Creates new instance of CustomMediaSize from the given integer
+     * values.
+     *
+     * @param x physical width of the media
+     * @param y physical height of the media
+     * @param units unit conversion factor, e.g. {@link #INCH INCH} or
+     *         {@link #MM MM}
+     * @return CustomMediaSize with provided dimension
+     */
+    public static CustomMediaSize create(int x, int y, int units) {
+        CustomMediaSize cms;
+        if (x > y) {
+            cms = new CustomMediaSize(y, x, units, LANDSCAPE);
+        } else {
+            cms = new CustomMediaSize(x, y, units, PORTRAIT);
+        }
+        return cms;
+    }
+
+    /**
+     * Creates new instance of CustomMediaSize from the given floating-point
+     * values.
+     *
+     * @param x physical width of the media
+     * @param y physical height of the media
+     * @param units unit conversion factor, e.g. {@link #INCH INCH} or
+     *         {@link #MM MM}
+     * @param media a media name to associate with this {@code MediaSize}
+     * @return CustomMediaSize
+     */
+    public static CustomMediaSize create(float x, float y, int units, MediaSizeName media) {
+        CustomMediaSize cms;
+        if (x > y) {
+            cms = new CustomMediaSize(y, x, units, media, LANDSCAPE);
+        } else {
+            cms = new CustomMediaSize(x, y, units, media, PORTRAIT);
+        }
+        return cms;
+    }
+
+    /**
+     * Creates new instance of CustomMediaSize from the given integer
+     * values.
+     *
+     * @param x physical width of the media
+     * @param y physical height of the media
+     * @param units unit conversion factor, e.g. {@link #INCH INCH} or
+     *         {@link #MM MM}
+     * @param media a media name to associate with this {@code MediaSize}
+     * @return CustomMediaSize
+     */
+    public static CustomMediaSize create(int x, int y, int units, MediaSizeName media) {
+        CustomMediaSize cms;
+        if (x > y) {
+            cms = new CustomMediaSize(y, x, units, media, LANDSCAPE);
+        } else {
+            cms = new CustomMediaSize(x, y, units, media, PORTRAIT);
+        }
+        return cms;
+    }
+}

--- a/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,8 +211,8 @@ class CustomMediaSizeName extends MediaSizeName {
                     } catch (IllegalArgumentException e) {
                         /* PDF printer in Linux for Ledger paper causes
                         "IllegalArgumentException: X dimension > Y dimension".
-                        We rotate based on IPP spec. */
-                        new MediaSize(length, width, Size2DSyntax.INCH, value);
+                        */
+                        CustomMediaSize.create(width, length, Size2DSyntax.INCH, value);
                     }
                 }
             }

--- a/test/jdk/java/awt/print/PageFormat/MarginsTest.java
+++ b/test/jdk/java/awt/print/PageFormat/MarginsTest.java
@@ -35,7 +35,10 @@ import java.awt.Graphics;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.print.*;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 import java.lang.Override;
 import java.lang.reflect.InvocationTargetException;
 
@@ -47,7 +50,7 @@ import java.lang.reflect.InvocationTargetException;
  * @requires (os.family == "mac")
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @summary verifies printing margins .
+ * @summary Verifies printing margins
  * @run main/manual MarginsTest
  */
 
@@ -59,17 +62,17 @@ public class MarginsTest {
     private static final float bottomMargin = 0.9f;
 
     private static final String INSTRUCTIONS = """
-        This test checks margins correctness.
-        Portrait-oriented and landscape-oriented papers should be supported by the test printer,
-        a PDF printer is acceptable.
+            This test checks margins correctness.
+            Portrait-oriented and landscape-oriented papers should be supported by the test printer,
+            a PDF printer is acceptable.
 
-        1. Read an instruction in the bottom of this window.
-        2. Press "Print page ..." button.
-        3. Check a printed rectangle along the borders and margins' size. The margins should
-        equal the printed values, all rectangle's sides should be visible.
-        4. Repeat steps 1-3 until instructions are visible.
-        5. Press "Pass" button if all printed pages are correct, else press "Fail" button.
-        """;
+            1. Read an instruction in the bottom of this window.
+            2. Press "Print page ..." button.
+            3. Check a printed rectangle along the borders and margins' size. The margins should
+            equal the printed values, all rectangle's sides should be visible.
+            4. Repeat steps 1-3 until instructions are visible.
+            5. Press "Pass" button if all printed pages are correct, else press "Fail" button.
+            """;
 
     private static final String[] WINDOW_INSTRUCTIONS = new String[]{
             """
@@ -106,7 +109,7 @@ public class MarginsTest {
                         JTextArea textArea = new JTextArea();
                         textArea.setText(WINDOW_INSTRUCTIONS[index]);
                         textArea.setMargin(new Insets(5, 5, 5, 5));
-                        JButton button = new JButton("Print page " + (index+1) + " of 4");
+                        JButton button = new JButton("Print page " + (index + 1) + " of 4");
                         button.addActionListener(new ActionListener() {
                             @Override
                             public void actionPerformed(ActionEvent e) {
@@ -123,10 +126,10 @@ public class MarginsTest {
                                         }
                                         final int units = MediaPrintableArea.INCH;
                                         attrs.add(new MediaPrintableArea(mpa.getX(units) + leftMargin,
-                                                        mpa.getY(units) + topMargin,
-                                                        mpa.getWidth(units) - rightMargin,
-                                                        mpa.getHeight(units) - bottomMargin,
-                                                        units));
+                                                mpa.getY(units) + topMargin,
+                                                mpa.getWidth(units) - rightMargin,
+                                                mpa.getHeight(units) - bottomMargin,
+                                                units));
                                         printerJob.print(attrs);
                                     } catch (PrinterException ex) {
                                         throw new RuntimeException(ex);
@@ -137,7 +140,7 @@ public class MarginsTest {
                                     return;
                                 }
                                 index++;
-                                button.setText("Print page " + (index+1) + " of 4");
+                                button.setText("Print page " + (index + 1) + " of 4");
                                 button.setEnabled(true);
                                 textArea.setText(WINDOW_INSTRUCTIONS[index]);
                             }
@@ -171,24 +174,24 @@ public class MarginsTest {
         @Override
         public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
             if (pageIndex == 0) {
-                final int left = (int) pageFormat.getImageableX()+1;
-                final int top = (int) pageFormat.getImageableY()+1;
-                final int width = (int) pageFormat.getImageableWidth()-1;
-                final int height = (int) pageFormat.getImageableHeight()-1;
+                final int left = (int) pageFormat.getImageableX() + 1;
+                final int top = (int) pageFormat.getImageableY() + 1;
+                final int width = (int) pageFormat.getImageableWidth() - 1;
+                final int height = (int) pageFormat.getImageableHeight() - 1;
                 final int right = (int) pageFormat.getWidth() - left - width;
                 final int bottom = (int) pageFormat.getHeight() - top - height;
 
                 final int fontHeight = graphics.getFontMetrics().getHeight();
-                final double pointsPerMM = 72/25.4;
+                final double pointsPerMM = 72 / 25.4;
 
                 graphics.drawRect(left, top, width, height);
-                graphics.drawString(String.format("%.2fmm", left/pointsPerMM), left + 5, top + height / 2);
-                graphics.drawString(String.format("%.2fmm", top/pointsPerMM), left + width / 2, top + fontHeight + 5);
-                String rightStr = String.format("%.2fmm", right/pointsPerMM);
+                graphics.drawString(String.format("%.2fmm", left / pointsPerMM), left + 5, top + height / 2);
+                graphics.drawString(String.format("%.2fmm", top / pointsPerMM), left + width / 2, top + fontHeight + 5);
+                String rightStr = String.format("%.2fmm", right / pointsPerMM);
                 graphics.drawString(rightStr, (left + width) - (graphics.getFontMetrics().stringWidth(rightStr) + 5),
-                        (top + height)/2);
-                String bottomStr = String.format("%.2fmm", bottom/pointsPerMM);
-                graphics.drawString(bottomStr, left + (width/2 - (graphics.getFontMetrics().stringWidth(bottomStr))/2),
+                        (top + height) / 2);
+                String bottomStr = String.format("%.2fmm", bottom / pointsPerMM);
+                graphics.drawString(bottomStr, left + (width / 2 - (graphics.getFontMetrics().stringWidth(bottomStr)) / 2),
                         (top + height) - fontHeight - 5);
 
                 return PAGE_EXISTS;

--- a/test/jdk/java/awt/print/PageFormat/MarginsTest.java
+++ b/test/jdk/java/awt/print/PageFormat/MarginsTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.DialogTypeSelection;
+import javax.print.attribute.standard.MediaPrintableArea;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.*;
+import java.lang.Override;
+import java.lang.reflect.InvocationTargetException;
+
+
+/*
+ * @test
+ * @bug 8372952
+ * @key printer
+ * @requires (os.family == "mac")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary verifies printing margins .
+ * @run main/manual MarginsTest
+ */
+
+public class MarginsTest {
+
+    private static final float leftMargin = 0.15f;
+    private static final float rightMargin = 0.5f;
+    private static final float topMargin = 0.3f;
+    private static final float bottomMargin = 0.9f;
+
+    private static final String INSTRUCTIONS = """
+        This test checks margins correctness.
+        Portrait-oriented and landscape-oriented papers should be supported by the test printer,
+        a PDF printer is acceptable.
+
+        1. Read an instruction in the bottom of this window.
+        2. Press "Print page ..." button.
+        3. Check a printed rectangle along the borders and margins' size. The margins should
+        equal the printed values, all rectangle's sides should be visible.
+        4. Repeat steps 1-3 until instructions are visible.
+        5. Press "Pass" button if all printed pages are correct, else press "Fail" button.
+        """;
+
+    private static final String[] WINDOW_INSTRUCTIONS = new String[]{
+            """
+            Choose portrait-oriented paper (Tabloid, ISO-A4, ...), printing orientation - Portrait.
+            Check the actual size of margins, and the printed rectangle.
+            """
+            , """
+            Choose portrait-oriented paper (Tabloid, ISO-A4, ...), printing orientation - Landscape.
+            Check actual size of the margins, and a printed rectangle.
+            """
+            , """
+            Choose landscape-oriented paper (Ledger, 80x40, ...), printing orientation - Portrait.
+            Check actual size of the margins, and a printed rectangle.
+            """
+            , """
+            Choose landscape-oriented paper (Ledger, 80x40, ...), printing orientation - Landscape.
+            Check actual size of the margins, and a printed rectangle.
+            """
+    };
+
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException, PrinterException {
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .title("Margin test Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .splitUIBottom(new PassFailJFrame.PanelCreator() {
+
+                    int index = 0;
+
+                    @Override
+                    public JComponent createUIPanel() {
+                        JPanel panel = new JPanel();
+                        JTextArea textArea = new JTextArea();
+                        textArea.setText(WINDOW_INSTRUCTIONS[index]);
+                        textArea.setMargin(new Insets(5, 5, 5, 5));
+                        JButton button = new JButton("Print page " + (index+1) + " of 4");
+                        button.addActionListener(new ActionListener() {
+                            @Override
+                            public void actionPerformed(ActionEvent e) {
+                                button.setEnabled(false);
+                                PrinterJob printerJob = PrinterJob.getPrinterJob();
+                                PrintRequestAttributeSet attrs = new HashPrintRequestAttributeSet();
+                                attrs.add(DialogTypeSelection.COMMON);
+                                printerJob.setPrintable(new PrintableRect());
+                                if (printerJob.printDialog(attrs)) {
+                                    try {
+                                        MediaPrintableArea mpa = (MediaPrintableArea) attrs.get(MediaPrintableArea.class);
+                                        if (mpa == null) {
+                                            throw new RuntimeException("No margins found");
+                                        }
+                                        final int units = MediaPrintableArea.INCH;
+                                        attrs.add(new MediaPrintableArea(mpa.getX(units) + leftMargin,
+                                                        mpa.getY(units) + topMargin,
+                                                        mpa.getWidth(units) - rightMargin,
+                                                        mpa.getHeight(units) - bottomMargin,
+                                                        units));
+                                        printerJob.print(attrs);
+                                    } catch (PrinterException ex) {
+                                        throw new RuntimeException(ex);
+                                    }
+                                }
+                                if (index >= 3) {
+                                    panel.setVisible(false);
+                                    return;
+                                }
+                                index++;
+                                button.setText("Print page " + (index+1) + " of 4");
+                                button.setEnabled(true);
+                                textArea.setText(WINDOW_INSTRUCTIONS[index]);
+                            }
+                        });
+                        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+                        panel.add(textArea);
+                        JPanel splitter = new JPanel();
+                        splitter.getInsets().set(2, 0, 2, 0);
+                        panel.add(splitter);
+                        panel.add(button);
+                        splitter = new JPanel();
+                        splitter.getInsets().set(2, 0, 2, 0);
+                        panel.add(splitter);
+                        panel.setSize(180, 80);
+                        return panel;
+                    }
+                })
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .build();
+
+        passFailJFrame.awaitAndCheck();
+    }
+
+    private static class PrintableRect implements Printable {
+
+        public PrintableRect() {
+
+        }
+
+        @Override
+        public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+            if (pageIndex == 0) {
+                final int left = (int) pageFormat.getImageableX()+1;
+                final int top = (int) pageFormat.getImageableY()+1;
+                final int width = (int) pageFormat.getImageableWidth()-1;
+                final int height = (int) pageFormat.getImageableHeight()-1;
+                final int right = (int) pageFormat.getWidth() - left - width;
+                final int bottom = (int) pageFormat.getHeight() - top - height;
+
+                final int fontHeight = graphics.getFontMetrics().getHeight();
+                final double pointsPerMM = 72/25.4;
+
+                graphics.drawRect(left, top, width, height);
+                graphics.drawString(String.format("%.2fmm", left/pointsPerMM), left + 5, top + height / 2);
+                graphics.drawString(String.format("%.2fmm", top/pointsPerMM), left + width / 2, top + fontHeight + 5);
+                String rightStr = String.format("%.2fmm", right/pointsPerMM);
+                graphics.drawString(rightStr, (left + width) - (graphics.getFontMetrics().stringWidth(rightStr) + 5),
+                        (top + height)/2);
+                String bottomStr = String.format("%.2fmm", bottom/pointsPerMM);
+                graphics.drawString(bottomStr, left + (width/2 - (graphics.getFontMetrics().stringWidth(bottomStr))/2),
+                        (top + height) - fontHeight - 5);
+
+                return PAGE_EXISTS;
+            }
+            return NO_SUCH_PAGE;
+        }
+    }
+
+}

--- a/test/jdk/javax/print/MediaPrintableAreaTest.java
+++ b/test/jdk/javax/print/MediaPrintableAreaTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.attribute.HashPrintJobAttributeSet;
+import javax.print.attribute.PrintJobAttributeSet;
+import javax.print.attribute.standard.Media;
+import javax.print.attribute.standard.MediaPrintableArea;
+import javax.print.attribute.standard.MediaSize;
+import javax.print.attribute.standard.MediaSizeName;
+
+/*
+ * @test
+ * @bug 8372952
+ * @key printer
+ * @summary MediaPrintableArea size should be less or equal to media size
+ * @requires (os.family == "linux" | os.family == "mac")
+ */
+
+public class MediaPrintableAreaTest {
+
+    public static void main(String[] args) {
+        PrintService[] printServices = PrintServiceLookup.lookupPrintServices(null, null);
+
+        for (PrintService ps : printServices) {
+            testPrintService(ps);
+        }
+    }
+
+    private static void testPrintService(PrintService printServices) {
+        Media[] medias = (Media[]) printServices.getSupportedAttributeValues(Media.class, null, null);
+        PrintJobAttributeSet attrs = new HashPrintJobAttributeSet();
+
+        for (Media m : medias) {
+            if (!(m instanceof MediaSizeName msn)) {
+                continue;
+            }
+            MediaSize mediaSize = MediaSize.getMediaSizeForName(msn);
+            if (mediaSize == null) {
+                continue;
+            }
+            attrs.add(msn);
+            MediaPrintableArea[] printableAreas = (MediaPrintableArea[]) printServices
+                    .getSupportedAttributeValues(MediaPrintableArea.class, null, attrs);
+            if (printableAreas == null || printableAreas.length == 0) {
+                continue;
+            }
+            final double acceptableDiff = -4.0;
+            final int units = MediaPrintableArea.MM;
+            for (MediaPrintableArea mpa : printableAreas) {
+                double mediaWidth = mediaSize.getX(units);
+                double mediaHeight = mediaSize.getY(units);
+                double printableWidth = mpa.getX(units) + mpa.getWidth(units);
+                double printableHeight = mpa.getY(units) + mpa.getHeight(units);
+                if ((mediaWidth - printableWidth) < acceptableDiff ||
+                        (mediaHeight - printableHeight) < acceptableDiff) {
+                    String msg = String.format("Media %s less than media printable area. %n" +
+                                    "Media size width: %f, height: %f.%nPrintable area: width: %f, height %f",
+                            msn.getName(), mediaWidth, mediaHeight, printableWidth, printableHeight);
+                    throw new RuntimeException(msg);
+                }
+            }
+        }
+    }
+
+}

--- a/test/jdk/javax/print/MediaPrintableAreaTest.java
+++ b/test/jdk/javax/print/MediaPrintableAreaTest.java
@@ -22,7 +22,8 @@
  * questions.
  */
 
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
 import javax.print.attribute.HashPrintJobAttributeSet;
@@ -42,18 +43,41 @@ import javax.print.attribute.standard.MediaSizeName;
 
 public class MediaPrintableAreaTest {
 
+    private static final int LANDSCAPE = 1;
+    private static final int PORTRAIT = 2;
+
     public static void main(String[] args) {
         PrintService[] printServices = PrintServiceLookup.lookupPrintServices(null, null);
-
+        List<String> errorList = new ArrayList<>();
+        int testedOrientation = 0;
         for (PrintService ps : printServices) {
-            testPrintService(ps);
+            testedOrientation |= testPrintService(ps, errorList);
+        }
+
+        if (!errorList.isEmpty()) {
+            String errorString = String.join("\r\n", errorList);
+            System.err.println(errorString);
+            throw new RuntimeException();
+        }
+
+        if (testedOrientation == (PORTRAIT | LANDSCAPE)) {
+            // OK, all orientations were tested
+        } else if (testedOrientation == PORTRAIT) {
+            // landscape-oriented paper not found
+            System.out.println("WARNING!!! Landscape-oriented paper not found.");
+        } else if (testedOrientation == LANDSCAPE) {
+            // portrait-oriented paper not found
+            System.out.println("WARNING!!! Portrait-oriented paper not found.");
+        } else {
+            // no paper found
+            System.out.println("WARNING!!! Paper not found.");
         }
     }
 
-    private static void testPrintService(PrintService printServices) {
+    private static int testPrintService(PrintService printServices, List<String> errorList) {
         Media[] medias = (Media[]) printServices.getSupportedAttributeValues(Media.class, null, null);
         PrintJobAttributeSet attrs = new HashPrintJobAttributeSet();
-
+        int testedOrientation = 0;
         for (Media m : medias) {
             if (!(m instanceof MediaSizeName msn)) {
                 continue;
@@ -75,15 +99,17 @@ public class MediaPrintableAreaTest {
                 double mediaHeight = mediaSize.getY(units);
                 double printableWidth = mpa.getX(units) + mpa.getWidth(units);
                 double printableHeight = mpa.getY(units) + mpa.getHeight(units);
+                testedOrientation |= (mediaHeight >= mediaWidth ? PORTRAIT : LANDSCAPE);
                 if ((mediaWidth - printableWidth) < acceptableDiff ||
                         (mediaHeight - printableHeight) < acceptableDiff) {
-                    String msg = String.format("Media %s less than media printable area. %n" +
+                    String errorMsg = String.format("Print service: %s. Media %s less than media printable area. %n" +
                                     "Media size width: %f, height: %f.%nPrintable area: width: %f, height %f",
-                            msn.getName(), mediaWidth, mediaHeight, printableWidth, printableHeight);
-                    throw new RuntimeException(msg);
+                            printServices.getName(), msn.toString(), mediaWidth, mediaHeight, printableWidth, printableHeight);
+                    errorList.add(errorMsg);
                 }
             }
         }
+        return testedOrientation;
     }
 
 }


### PR DESCRIPTION
These changes fix https://bugs.openjdk.org/browse/JDK-8372952 "Respect landscape orientation user selection on macOS and Linux". 

There are three issues which cause this bug.
#### The first issue
Media printable area does not match the corresponding media size for the landscape-oriented medias. \
An example of the actual prints on a paper 80mmx40mm (Epson T-TA88V) 
[actual_cut_off.pdf](https://github.com/user-attachments/files/25064646/actual_cut_off.pdf)

#### The second issue
_MediaSize_ does not allow landscape-oriented medias (X dimension bigger than Y dimension of the media) so rotated size is used, but the media printable area stays the same - landscape-oriented. 
Current implementation does not allow to use landscape-oriented paper because _MediaSize_
constructor allows portrait paper only (width < height). 

I read comments about _MediaSize_ restrictions (width<height) in https://bugs.openjdk.org/browse/JDK-8041911, which states that this is "by design" and specification. But I did not find media size restrictions in the https://datatracker.ietf.org/doc/html/rfc2911.
The RFC defines "orientation-requested" attribute, that was mentioned in the JDK-8041911 comments, but this attribute indicates the desired orientation for printed print-stream pages and is used for only a subset of the supported document formats ('text/plain' or 'text/html') to format the document. \
As described in the RFC https://datatracker.ietf.org/doc/html/rfc2911#section-15.3
> If the document data has been formatted, then go to step 2. Otherwise, the document data MUST be formatted. The formatting detection algorithm is implementation defined and is not specified by this document.  The formatting of the document data uses the "orientation-requested" attribute to determine how the formatted print data should be placed on a print-stream page

Therefore, if a printer object uses a landscape-oriented paper, a document format is "text/plain" and an "orientation-requested" attribute contains "portrait" value then the printer object should rotate the document 90 degrees. \
If a printer uses a portrait-oriented paper, a document format is "text/plain," and an "orientation-requested" attribute contains value "portrait" then the printer object does no rotation.

Also, https://datatracker.ietf.org/doc/html/rfc3382 defines a "media-size" IPP attribute which identifies the size of the media. The RFC contains an example of this attribute where the X-dimension (the width of the media in inch) larger than the Y-dimension (the height of the media in inch units).

>       "media-col" =
>         {  "media-color" =  'blue';
>            "media-size" =
>            {    "x-dimension" = 6;
>                 "y-dimension" = 4
>              }
>         },


#### The third issue
Implicit selection of the paper on macOS. Desired paper size and orientation is set during printer job setup and there is no explicit paper selection (landscape-oriented or portrait-oriented), so users cannot choose landscape-oriented paper if portrait-oriented paper with the same size exists and unable to set valid margins for landscape-oriented prints. If a label printer charged with landscape-oriented sticks but has a portrait sticks in settings with the same size then printer prints on the landscape-oriented sticks with portrait-oriented settings. \
An examples: \
Incorrect margins.
[incorrect_margins_landscape.pdf](https://github.com/user-attachments/files/25064640/incorrect_margins_landscape.pdf) \
A landscape-oriented (Ledger) is selected by a user but portrait-oriented (Tabloid) paper is used.
[incorrect_orientation.pdf](https://github.com/user-attachments/files/25064638/incorrect_orientation.pdf)

#### Changes
To solve the first and the second issues I added a new class _CustomMediaSize_, a wrapper for the _MediaSize_,
that allows to create a landscape media size (width > height). The getX, getY methods of the new class return the real
size of the media depending on paper orientation. The _CustomMediaSize_ is used in _CustomMediaSizeName_ during new _MediaSize_ creation and catches _IllegalArgumentException_ exception (X dimension > Y dimension) instead of swapping the width and height of the paper. The _CustomMediaSize_ implementation fixes the media printable area mismatch.

To solve the third problem I changed _CPrinterJob_ and _PrinterView_ files and added explicit paper selection. The _PMPaper_ and _PMPageFormat_ classes are used to choose desired paper. First of all, new approach tries to find existing paper with desired size and margins and use it, if the paper doesn't exist - it creates a new one. Also, this approach takes into account page format orientation to set paper margins properly, so this solves the issue with incorrect margins during landscape printing and allows reverse landscape printing.

An example of printings with this fix
[fixed_wo_cut_off.pdf](https://github.com/user-attachments/files/25064627/fixed_wo_cut_off.pdf)

#### Tests
I've run jtreg tests from the _java.awt.print_ and _javax.print_, there is no regression after updates. \
Two new test added to check media printable area and margins.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8372952](https://bugs.openjdk.org/browse/JDK-8372952): Respect landscape orientation user selection on macOS and Linux (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29560/head:pull/29560` \
`$ git checkout pull/29560`

Update a local copy of the PR: \
`$ git checkout pull/29560` \
`$ git pull https://git.openjdk.org/jdk.git pull/29560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29560`

View PR using the GUI difftool: \
`$ git pr show -t 29560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29560.diff">https://git.openjdk.org/jdk/pull/29560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29560#issuecomment-3845848664)
</details>
