### PR TITLE
8373426: Remove ffdhe6144 and ffdhe8192 from default list of TLS named groups

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
@@ -878,9 +878,8 @@ enum NamedGroup {
                 // FFDHE (RFC 7919)
                 FFDHE_2048,
                 FFDHE_3072,
-                FFDHE_4096,
-                FFDHE_6144,
-                FFDHE_8192
+                FFDHE_4096
+                // FFDHE_6144 and FFDHE_8192 were removed in JDK-8373426
         };
 
         // Filter default groups names against default constraints.

--- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
@@ -879,7 +879,6 @@ enum NamedGroup {
                 FFDHE_2048,
                 FFDHE_3072,
                 FFDHE_4096
-                // FFDHE_6144 and FFDHE_8192 were removed in JDK-8373426
         };
 
         // Filter default groups names against default constraints.

--- a/test/jdk/sun/security/ssl/CipherSuite/DefaultNamedGroups.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/DefaultNamedGroups.java
@@ -52,9 +52,7 @@ public class DefaultNamedGroups extends SSLEngineTemplate {
                     "x448",
                     "ffdhe2048",
                     "ffdhe3072",
-                    "ffdhe4096",
-                    "ffdhe6144",
-                    "ffdhe8192")
+                    "ffdhe4096")
             .sorted()
             .toList();
 

--- a/test/jdk/sun/security/ssl/DHKeyExchange/UseStrongDHSizes.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/UseStrongDHSizes.java
@@ -28,7 +28,7 @@
 
 /*
  * @test
- * @bug 8140436
+ * @bug 8140436 8373426
  * @modules jdk.crypto.ec
  * @library /javax/net/ssl/templates
  * @summary Negotiated Finite Field Diffie-Hellman Ephemeral Parameters for TLS

--- a/test/jdk/sun/security/ssl/DHKeyExchange/UseStrongDHSizes.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/UseStrongDHSizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,10 +47,8 @@
  * @run main/othervm -Djdk.tls.namedGroups=ffdhe4096 UseStrongDHSizes 4096
  * @run main/othervm -Djdk.tls.namedGroups=ffdhe6144 UseStrongDHSizes 4096
  * @run main/othervm -Djdk.tls.namedGroups=ffdhe8192 UseStrongDHSizes 4096
- * @run main/othervm UseStrongDHSizes 6144
  * @run main/othervm -Djdk.tls.namedGroups=ffdhe6144 UseStrongDHSizes 6144
  * @run main/othervm -Djdk.tls.namedGroups=ffdhe8192 UseStrongDHSizes 6144
- * @run main/othervm UseStrongDHSizes 8192
  * @run main/othervm -Djdk.tls.namedGroups=ffdhe8192 UseStrongDHSizes 8192
  */
 


### PR DESCRIPTION
Removed FFDHE_6144 and FFHDE_8192 from the default list of TLS named groups, so now to consider them as candidates in TLS handshake user has to enable them explicitly (e.g. `-Djdk.tls.namedGroups=ffdhe6144,ffhde8192`)

Tested on Linux x64/aarch64, MacOS aarch64, Windows x64 using jtreg `test/jdk/sun/security/ssl` and `test/jdk/javax/net/ssl`.

[tests-linux-aarch64.log](https://github.com/user-attachments/files/25080233/tests-linux-aarch64.log)
[tests-linux-x86.log](https://github.com/user-attachments/files/25080235/tests-linux-x86.log)
[tests-macos-aarch64.log](https://github.com/user-attachments/files/25080236/tests-macos-aarch64.log)
[tests-windows-x64.log](https://github.com/user-attachments/files/25080237/tests-windows-x64.log)

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8377197](https://bugs.openjdk.org/browse/JDK-8377197) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8373426](https://bugs.openjdk.org/browse/JDK-8373426): Remove ffdhe6144 and ffdhe8192 from default list of TLS named groups (**Enhancement** - P4)
 * [JDK-8377197](https://bugs.openjdk.org/browse/JDK-8377197): Remove ffdhe6144 and ffdhe8192 from default list of TLS named groups (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29577/head:pull/29577` \
`$ git checkout pull/29577`

Update a local copy of the PR: \
`$ git checkout pull/29577` \
`$ git pull https://git.openjdk.org/jdk.git pull/29577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29577`

View PR using the GUI difftool: \
`$ git pr show -t 29577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29577.diff">https://git.openjdk.org/jdk/pull/29577.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29577#issuecomment-3849378746)
</details>
