### PR TITLE
8273563 - Improve performance of implicit exceptions with -XX:-OmitStackTraceInFastThrow

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -67,6 +67,7 @@
 #include "oops/symbolHandle.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"
@@ -362,6 +363,40 @@ void ciEnv::cache_dtrace_flags() {
   // Need lock?
   _dtrace_method_probes = DTraceMethodProbes;
   _dtrace_alloc_probes  = DTraceAllocProbes;
+}
+
+// ------------------------------------------------------------------
+// helper for -XX:+OptimizeImplicitExceptions
+ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason) {
+  Symbol* ex_symbol = nullptr;
+  switch (reason) {
+  case Deoptimization::Reason_null_check:
+    ex_symbol = vmSymbols::java_lang_NullPointerException();
+    break;
+  case Deoptimization::Reason_div0_check:
+    ex_symbol = vmSymbols::java_lang_ArithmeticException();
+    break;
+  case Deoptimization::Reason_range_check:
+    ex_symbol = vmSymbols::java_lang_ArrayIndexOutOfBoundsException();
+    break;
+  case Deoptimization::Reason_class_check:
+    ex_symbol = vmSymbols::java_lang_ClassCastException();
+    break;
+  case Deoptimization::Reason_array_check:
+    ex_symbol = vmSymbols::java_lang_ArrayStoreException();
+    break;
+  default:
+    break;
+  }
+  ciInstanceKlass* ex_ciInstKlass = nullptr;
+  if (ex_symbol != nullptr) {
+    VM_ENTRY_MARK;
+    InstanceKlass* ex_instKlass = SystemDictionary::find_instance_klass(thread, ex_symbol, Handle());
+    if (ex_instKlass != nullptr) {
+      ex_ciInstKlass = get_instance_klass(ex_instKlass);
+    }
+  }
+  return ex_ciInstKlass;
 }
 
 ciInstanceKlass* ciEnv::get_box_klass_for_primitive_type(BasicType type) {

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -35,6 +35,7 @@
 #include "compiler/compiler_globals.hpp"
 #include "compiler/compilerThread.hpp"
 #include "oops/methodData.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/javaThread.hpp"
 
 class CompileTask;
@@ -387,6 +388,8 @@ public:
   }
   VM_CLASSES_DO(VM_CLASS_FUNC)
 #undef VM_CLASS_FUNC
+
+  ciInstanceKlass* exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason);
 
   ciInstance* NullPointerException_instance() {
     assert(_NullPointerException_instance != nullptr, "initialization problem");

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1045,7 +1045,8 @@ uint CallJavaNode::size_of() const { return sizeof(*this); }
 bool CallJavaNode::cmp( const Node &n ) const {
   CallJavaNode &call = (CallJavaNode&)n;
   return CallNode::cmp(call) && _method == call._method &&
-         _override_symbolic_info == call._override_symbolic_info;
+         _override_symbolic_info == call._override_symbolic_info &&
+         _implicit_exception_init == call._implicit_exception_init;
 }
 
 void CallJavaNode::copy_call_debug_info(PhaseIterGVN* phase, SafePointNode* sfpt) {
@@ -1089,8 +1090,8 @@ void CallJavaNode::copy_call_debug_info(PhaseIterGVN* phase, SafePointNode* sfpt
 
 #ifdef ASSERT
 bool CallJavaNode::validate_symbolic_info() const {
-  if (method() == nullptr) {
-    return true; // call into runtime or uncommon trap
+  if (method() == nullptr || _implicit_exception_init) {
+    return true; // call into runtime or uncommon trap or implicit exception <init>
   }
   ciMethod* symbolic_info = jvms()->method()->get_method_at_bci(jvms()->bci());
   ciMethod* callee = method();
@@ -1105,6 +1106,7 @@ bool CallJavaNode::validate_symbolic_info() const {
 #ifndef PRODUCT
 void CallJavaNode::dump_spec(outputStream* st) const {
   if( _method ) _method->print_short_name(st);
+  if (_implicit_exception_init) st->print(" (implicit_exception_init)");
   CallNode::dump_spec(st);
 }
 

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -781,6 +781,7 @@ protected:
   ciMethod* _method;               // Method being direct called
   bool    _optimized_virtual;
   bool    _override_symbolic_info; // Override symbolic call site info from bytecode
+  bool    _implicit_exception_init; // Call is <init> for an implicitly created exception
   bool    _arg_escape;             // ArgEscape in parameter list
 public:
   CallJavaNode(const TypeFunc* tf , address addr, ciMethod* method)
@@ -788,20 +789,23 @@ public:
       _method(method),
       _optimized_virtual(false),
       _override_symbolic_info(false),
+      _implicit_exception_init(false),
       _arg_escape(false)
   {
     init_class_id(Class_CallJava);
   }
 
   virtual int   Opcode() const;
-  ciMethod* method() const                 { return _method; }
-  void  set_method(ciMethod *m)            { _method = m; }
-  void  set_optimized_virtual(bool f)      { _optimized_virtual = f; }
-  bool  is_optimized_virtual() const       { return _optimized_virtual; }
-  void  set_override_symbolic_info(bool f) { _override_symbolic_info = f; }
-  bool  override_symbolic_info() const     { return _override_symbolic_info; }
-  void  set_arg_escape(bool f)             { _arg_escape = f; }
-  bool  arg_escape() const                 { return _arg_escape; }
+  ciMethod* method() const                  { return _method; }
+  void  set_method(ciMethod *m)             { _method = m; }
+  void  set_optimized_virtual(bool f)       { _optimized_virtual = f; }
+  bool  is_optimized_virtual() const        { return _optimized_virtual; }
+  void  set_override_symbolic_info(bool f)  { _override_symbolic_info = f; }
+  bool  override_symbolic_info() const      { return _override_symbolic_info; }
+  void  set_implicit_exception_init(bool f) { _implicit_exception_init = f; }
+  bool  implicit_exception_init() const     { return _implicit_exception_init; }
+  void  set_arg_escape(bool f)              { _arg_escape = f; }
+  bool  arg_escape() const                  { return _arg_escape; }
   void copy_call_debug_info(PhaseIterGVN* phase, SafePointNode *sfpt);
   void register_for_late_inline();
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -580,7 +580,48 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason,
 
       add_exception_state(make_exception_state(ex_node));
       return;
-    } else if (builtin_throw_too_many_traps(reason, ex_obj)) {
+    } else if (OptimizeImplicitExceptions) {
+      ciInstanceKlass* ex_ciInstKlass = env()->exception_instanceKlass_for_reason(reason);
+      ciMethod* init = (ex_ciInstKlass != nullptr)
+          ? ex_ciInstKlass->find_method(ciSymbol::make("<init>"), ciSymbol::make("()V"))
+          : nullptr;
+      if (init != nullptr) {
+        if (env()->jvmti_can_post_on_exceptions()) {
+          // check if we must post exception events, take uncommon trap if so
+          uncommon_trap_if_should_post_on_exceptions(reason, true /*must_throw*/);
+          // here if should_post_on_exceptions is false
+          // continue on with the normal codegen
+        }
+
+        const TypeKlassPtr* ex_type = TypeKlassPtr::make(ex_ciInstKlass);
+        kill_dead_locals();
+        Node* ex_node = new_instance(makecon(ex_type), nullptr, nullptr, true);
+        set_argument(0, ex_node);
+
+        // The following code is modeled after DirectCallGenerator::generate().
+        // We can't use that code directly because it assumes at various places
+        // that we're at an invoke bytecode which is in general not the case
+        // for implicit exceptions.
+
+        GraphKit kit(sync_jvms());
+        address target = SharedRuntime::get_resolve_opt_virtual_call_stub();
+
+        CallStaticJavaNode* call = new CallStaticJavaNode(kit.C, TypeFunc::make(init), target, init);
+        call->set_optimized_virtual(true);
+        call->set_implicit_exception_init(true);
+        kit.set_arguments_for_java_call(call);
+        kit.set_edges_for_java_call(call, false, false);
+        Node* ret = kit.set_results_for_java_call(call, false);
+        kit.push_node(init->return_type()->basic_type(), ret);
+        JVMState* new_jvms = kit.transfer_exceptions_into_jvms();
+
+        add_exception_states_from(new_jvms);
+        set_jvms(new_jvms);
+        add_exception_state(make_exception_state(ex_node));
+        return;
+      }
+    }
+    if (builtin_throw_too_many_traps(reason, ex_obj)) {
       // We cannot afford to take too many traps here. Suffer in the interpreter instead.
       assert(allow_too_many_traps, "not allowed");
       if (C->log() != nullptr) {
@@ -594,11 +635,6 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason,
       return;
     }
   }
-
-  // %%% Maybe add entry to OptoRuntime which directly throws the exc.?
-  // It won't be much cheaper than bailing to the interp., since we'll
-  // have to pass up all the debug-info, and the runtime will have to
-  // create the stack trace.
 
   // Usual case:  Bail to interpreter.
   // Reserve the right to recompile if we haven't seen anything yet.

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -778,7 +778,8 @@ uint MachCallJavaNode::size_of() const { return sizeof(*this); }
 bool MachCallJavaNode::cmp( const Node &n ) const {
   MachCallJavaNode &call = (MachCallJavaNode&)n;
   return MachCallNode::cmp(call) && _method->equals(call._method) &&
-         _override_symbolic_info == call._override_symbolic_info;
+         _override_symbolic_info == call._override_symbolic_info &&
+         _implicit_exception_init == call._implicit_exception_init;
 }
 #ifndef PRODUCT
 void MachCallJavaNode::dump_spec(outputStream *st) const {
@@ -786,6 +787,7 @@ void MachCallJavaNode::dump_spec(outputStream *st) const {
     _method->print_short_name(st);
     st->print(" ");
   }
+  if (_implicit_exception_init) st->print("(implicit_exception_init) ");
   MachCallNode::dump_spec(st);
 }
 #endif

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -960,16 +960,17 @@ protected:
 public:
   ciMethod* _method;                 // Method being direct called
   bool      _override_symbolic_info; // Override symbolic call site info from bytecode
+  bool      _implicit_exception_init; // Call is <init> for an implicitly created exception
   bool      _optimized_virtual;      // Tells if node is a static call or an optimized virtual
   bool      _arg_escape;             // ArgEscape in parameter list
-  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false) {
+  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false), _implicit_exception_init(false) {
     init_class_id(Class_MachCallJava);
   }
 
   virtual const RegMask &in_RegMask(uint) const;
 
   int resolved_method_index(C2_MacroAssembler *masm) const {
-    if (_override_symbolic_info) {
+    if (_override_symbolic_info || _implicit_exception_init) {
       // Attach corresponding Method* to the call site, so VM can use it during resolution
       // instead of querying symbolic info from bytecode.
       assert(_method != nullptr, "method should be set");

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1217,6 +1217,7 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
       mcall_java->_method = method;
       mcall_java->_optimized_virtual = call_java->is_optimized_virtual();
       mcall_java->_override_symbolic_info = call_java->override_symbolic_info();
+      mcall_java->_implicit_exception_init = call_java->implicit_exception_init();
       mcall_java->_arg_escape = call_java->arg_escape();
       if( mcall_java->is_MachCallStaticJava() )
         mcall_java->as_MachCallStaticJava()->_name =

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -681,6 +681,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, OmitStackTraceInFastThrow, true,                            \
           "Omit backtraces for some 'hot' exceptions in optimized code")    \
                                                                             \
+  product(bool, OptimizeImplicitExceptions, true, DIAGNOSTIC,               \
+          "Allocate implicit exceptions in compiled code instead of "       \
+          "deoptimizing when OmitStackTraceInFastThrow is disabled")        \
+                                                                            \
   product(bool, ShowCodeDetailsInExceptionMessages, true, MANAGEABLE,       \
           "Show exception messages from RuntimeExceptions that contain "    \
           "snippets of the failing code. Disable this to improve privacy.") \

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1227,12 +1227,23 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     return receiver;
   }
 
-  Bytecode_invoke bytecode(caller, bci);
-  int bytecode_index = bytecode.index();
-  bc = bytecode.invoke_code();
+  Bytecode_invoke bytecode = Bytecode_invoke_check(caller, bci);
+  int bytecode_index = -1;
+  if (bytecode.is_valid()) {
+    // This is the normal case for invoke* bytecodes
+    bytecode_index = bytecode.index();
+    bc = bytecode.invoke_code();
+  } else {
+    // This is for implicit exceptions with -XX:+OptimizeImplicitExceptions
+    // where we create an artificial call to *Exception::<init>().
+    // Notice that we don't catch the case here where we've created an
+    // implicit exception (e.g. NPE) for a regular invoke* bytecode.
+    // This special case is handled further down.
+    bc = Bytecodes::_invokespecial;
+  }
 
   methodHandle attached_method(current, extract_attached_method(vfst));
-  if (attached_method.not_null()) {
+  if (attached_method.not_null() && bytecode.is_valid()) {
     Method* callee = bytecode.static_target(CHECK_NH);
     vmIntrinsics::ID id = callee->intrinsic_id();
     // When VM replaces MH.invokeBasic/linkTo* call with a direct/virtual call,
@@ -1263,6 +1274,15 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
           break;
       }
     }
+  }
+  if (attached_method.not_null() &&
+      attached_method->name() == vmSymbols::object_initializer_name() &&
+      attached_method->method_holder()->is_subclass_of(vmClasses::Throwable_klass())) {
+    // If we've created an implicit exception (e.g. NPE) for an invoke* bytecode
+    // due to -XX:+OptimizeImplicitExceptions we have to adjust the bytecode to
+    // invokespecial here because we're actually invoking the exception's
+    // constructor.
+    bc = Bytecodes::_invokespecial;
   }
 
   assert(bc != Bytecodes::_illegal, "not initialized");

--- a/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
@@ -23,8 +23,9 @@
 
  /*
  * @test
- * @bug 8275908
- * @summary Record null_check traps for calls and array_check traps in the interpreter
+ * @bug 8275908 8273563
+ * @summary Record null_check traps for calls and array_check traps in the interpreter,
+ *          OptimizeImplicitExceptions: allocate implicit exceptions in compiled code
  *
  * @requires vm.compiler2.enabled & vm.compMode != "Xcomp"
  * @requires vm.opt.DeoptimizeALot != true
@@ -70,7 +71,8 @@ public class OptimizeImplicitExceptions {
     // They will be set up in 'setFlags(TestMode testMode)' before a new test run starts.
     public enum TestMode {
         OMIT_STACKTRACES_IN_FASTTHROW,
-        STACKTRACES_IN_FASTTHROW
+        STACKTRACES_IN_FASTTHROW,
+        STACKTRACES_IN_FASTTHROW_OPTIMIZED
     }
 
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
@@ -124,13 +126,19 @@ public class OptimizeImplicitExceptions {
     private static void setFlags(TestMode testMode) {
         if (testMode == TestMode.OMIT_STACKTRACES_IN_FASTTHROW) {
             WB.setBooleanVMFlag("OmitStackTraceInFastThrow", true);
-        } else {
+            WB.setBooleanVMFlag("OptimizeImplicitExceptions", false);
+        } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW) {
             WB.setBooleanVMFlag("OmitStackTraceInFastThrow", false);
+            WB.setBooleanVMFlag("OptimizeImplicitExceptions", false);
+        } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW_OPTIMIZED) {
+            WB.setBooleanVMFlag("OmitStackTraceInFastThrow", false);
+            WB.setBooleanVMFlag("OptimizeImplicitExceptions", true);
         }
 
         System.out.println("==========================================================");
         System.out.println("testMode=" + testMode +
-                           " OmitStackTraceInFastThrow=" + WB.getBooleanVMFlag("OmitStackTraceInFastThrow"));
+                           " OmitStackTraceInFastThrow=" + WB.getBooleanVMFlag("OmitStackTraceInFastThrow") +
+                           " OptimizeImplicitExceptions=" + WB.getBooleanVMFlag("OptimizeImplicitExceptions"));
         System.out.println("==========================================================");
     }
 
@@ -175,10 +183,22 @@ public class OptimizeImplicitExceptions {
             // '-XX:+OmitStackTraceInFastThrow' never has message because it is using a global singleton exception.
             Asserts.assertNull(ex.getMessage(), "Optimized exceptions have no message.");
         } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW) {
-            // We always deoptimize for '-XX:-OmitStackTraceInFastThrow
+            // We always deoptimize for '-XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions'
             Asserts.assertEQ(oldDeoptCount + invocations, deoptCount, "Wrong number of deoptimizations.");
             Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()) + invocations, deoptCountReason, "Wrong number of deoptimizations.");
             Asserts.assertNotNull(ex.getMessage(), "Exceptions thrown in the interpreter should have a message.");
+        } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW_OPTIMIZED) {
+            // No deoptimizations for '-XX:-OmitStackTraceInFastThrow -XX:+OptimizeImplicitExceptions'
+            // The optimization allocates exceptions inline in compiled code, avoiding deoptimization.
+            Asserts.assertEQ(oldDeoptCount, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()), deoptCountReason, "Wrong number of deoptimizations.");
+            // NullPointerExceptions have a message due to JEP 358 (Helpful NullPointerExceptions).
+            if (impExcp == ImplicitException.NULL_POINTER_EXCEPTION || impExcp == ImplicitException.INVOKE_NULL_POINTER_EXCEPTION) {
+                Asserts.assertNotNull(ex.getMessage(), "NullPointerExceptions should have a message (JEP 358).");
+            } else {
+                // Non-NPE implicit exceptions allocated inline have no message (no-arg constructor).
+                Asserts.assertNull(ex.getMessage(), "Optimized non-NPE exceptions have no message.");
+            }
         } else {
             Asserts.fail("Unknown test mode.");
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/flag/FlagVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/flag/FlagVM.java
@@ -128,6 +128,7 @@ public class FlagVM {
         cmds.addAll(compilerDirectivesFlagBuilder.build());
         // Always trap for exception throwing to not confuse IR verification
         cmds.add("-XX:-OmitStackTraceInFastThrow");
+        cmds.add("-XX:-OptimizeImplicitExceptions");
         cmds.add("-DShouldDoIRVerification=true");
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -222,7 +222,7 @@ public class TestIRMatching {
                  BadFailOnConstraint.create(Traps.class, "unstableIf", 2, "CallStaticJava", "uncommon_trap", "unstable_if"),
                  GoodRuleConstraint.create(Traps.class, "unstableIf", 3),
                  BadFailOnConstraint.create(Traps.class, "classCheck", 1, "CallStaticJava", "uncommon_trap"),
-                 BadFailOnConstraint.create(Traps.class, "classCheck", 2, "CallStaticJava", "uncommon_trap", "class_check"),
+                 BadFailOnConstraint.create(Traps.class, "classCheck", 2, "CallStaticJava", "uncommon_trap", "unhandled"),
                  BadFailOnConstraint.create(Traps.class, "classCheck", 3, "CallStaticJava", "uncommon_trap", "null_check"),
                  GoodRuleConstraint.create(Traps.class, "classCheck", 4),
                  BadFailOnConstraint.create(Traps.class, "rangeCheck", 1, "CallStaticJava", "uncommon_trap"),
@@ -1214,7 +1214,7 @@ class Traps {
 
     @Test
     @IR(failOn = IRNode.TRAP) // fails
-    @IR(failOn = IRNode.CLASS_CHECK_TRAP) // fails
+    @IR(failOn = IRNode.UNHANDLED_TRAP) // fails
     @IR(failOn = IRNode.NULL_CHECK_TRAP) // fails
     @IR(failOn = {IRNode.PREDICATE_TRAP,
                   IRNode.UNSTABLE_IF_TRAP,
@@ -1222,7 +1222,7 @@ class Traps {
                   IRNode.RANGE_CHECK_TRAP,
                   IRNode.INTRINSIC_TRAP,
                   IRNode.INTRINSIC_OR_TYPE_CHECKED_INLINING_TRAP,
-                  IRNode.UNHANDLED_TRAP})
+                  IRNode.CLASS_CHECK_TRAP})
     public void classCheck() {
         try {
             myClassSub = (MyClassSub) myClass;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -30,11 +30,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -XX:-OmitStackTraceInFastThrow jit.t.t105.t105
- * @run main/othervm -XX:CompileCommand=MemLimit,*.*,0 -XX:-OmitStackTraceInFastThrow -Xbatch -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0 -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 jit.t.t105.t105
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions jit.t.t105.t105
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:CompileCommand=MemLimit,*.*,0 -XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions -Xbatch -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0 -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 jit.t.t105.t105
  *
- * This test must be run with OmitStackTraceInFastThrow disabled to avoid preallocated
- * exceptions. They don't have the detailed message that this test relies on.
+ * This test must be run with OmitStackTraceInFastThrow and OptimizeImplicitExceptions
+ * disabled to avoid preallocated or inline-allocated exceptions. They don't have the
+ * detailed message that this test relies on.
  */
 
 package jit.t.t105;

--- a/test/micro/org/openjdk/bench/vm/lang/ImplicitExceptions.java
+++ b/test/micro/org/openjdk/bench/vm/lang/ImplicitExceptions.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.lang;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark simulating Tomcat's HttpParser::isAlpha() pattern which uses
+ * array access with exception-based control flow for non-ASCII characters.
+ * This measures the performance impact of implicit exceptions with and
+ * without the OptimizeImplicitExceptions optimization.
+ *
+ * Run with:
+ *   -XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions (baseline)
+ *   -XX:-OmitStackTraceInFastThrow -XX:+OptimizeImplicitExceptions (optimized)
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+public class ImplicitExceptions {
+    static final int ASCII_SIZE = 128;
+    static final boolean[] ASCII_ALPHA = new boolean[ASCII_SIZE];
+    static final int TEST_STRING_LENGTH_LOG = 7;
+    static final int TEST_STRING_LENGTH_MASK = (1 << TEST_STRING_LENGTH_LOG) - 1;
+    static final char[] testString = new char[1 << TEST_STRING_LENGTH_LOG];
+    int iterator = 0;
+
+    @Param({"0.0", "0.33", "0.66", "1.00"})
+    public double exceptionProbability;
+
+    @Setup
+    public void init() {
+        for (int i = 0; i < ASCII_SIZE; i++) {
+            if ((i >= 'a' && i <= 'z') || (i >= 'A' && i <= 'Z')) {
+                ASCII_ALPHA[i] = true;
+            }
+        }
+        Random rnd = new Random();
+        rnd.setSeed(Long.getLong("random.seed", 42L));
+        for (int i = 0; i < testString.length; i++) {
+            if (rnd.nextDouble() < exceptionProbability) {
+                testString[i] = 0xbad; // Something bigger than ASCII_SIZE
+            } else {
+                testString[i] = (char) rnd.nextInt(ASCII_SIZE);
+            }
+        }
+    }
+
+    public boolean isAlphaWithExceptions(int c) {
+        try {
+            return ASCII_ALPHA[c];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    public boolean bench() {
+        return isAlphaWithExceptions(testString[iterator++ & TEST_STRING_LENGTH_MASK]);
+    }
+}


### PR DESCRIPTION
I hit this issue in my application this week, so I'm reviving @simonis's patch from https://github.com/openjdk/jdk/pull/5488.

With `-XX:-OmitStackTraceInFastThrow`, implicit exceptions always cause a deopt which is very expensive. This change avoids the deopt by injecting code to construct the exception in compiled code. This is controlled by a new diagnostic flag `OptimizeImplicitExceptions` (default true).

My patch is mostly the same as the original PR, with a few tweaks:

* various small updates to account for changes since that patch was made
* updated cmp implementations to account for the new field
* updated dump_spec to add "(implicit_exception_init)" where appropriate
* added constructor null check in graphkit.cpp as suggested by @vnkozlov
* added uncommon trap for optimized implicit exception case with JVMTI agent
* tightened check in sharedRuntime.cpp to only look for *exception* initializers
* removed outdated comment in graphKit.cpp
* added `-XX:-OptimizeImplicitExceptions` to `FlagVM.java`
  * a few tests were failing, and these tests already chose to add `-XX:-OmitStackTraceInFastThrow` to avoid these kinds of failures so it seems consistent to disable this new optimization too

That patch had 3 outstanding comments:

1. ["What happened if deoptimization happen during this allocation (which is safepoint)? Which bytecode will be executed in Interpeter after deopt?"](https://github.com/openjdk/jdk/pull/5488/changes#r760672973) - TODO
2. [Missing nullptr check](https://github.com/openjdk/jdk/pull/5488/changes#r760678082) - I've added this
3. ["Should we optimize it by inlining it here so that EA can eliminate above Allocation if it does not escape?"](https://github.com/openjdk/jdk/pull/5488/changes#r760682566) - the main goal here is to avoid the repeated deoptimization, which is achieved. I would like to leave further optimization for a separate PR, if possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8273563](https://bugs.openjdk.org/browse/JDK-8273563): Improve performance of implicit exceptions with -XX:-OmitStackTraceInFastThrow (**Enhancement** - P4)


### Contributors
 * Volker Simonis `<simonis@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29675/head:pull/29675` \
`$ git checkout pull/29675`

Update a local copy of the PR: \
`$ git checkout pull/29675` \
`$ git pull https://git.openjdk.org/jdk.git pull/29675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29675`

View PR using the GUI difftool: \
`$ git pr show -t 29675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29675.diff">https://git.openjdk.org/jdk/pull/29675.diff</a>

</details>
