### PR TITLE
8376167: RISC-V: Fix redundant zext.w in macroAssembler_riscv.cpp

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5342,10 +5342,17 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   int index = oop_recorder()->find_index(k);
 
   narrowKlass nk = CompressedKlassPointers::encode(k);
+
+  bool needs_zext = ((int32_t)nk & 0x80000000) != 0;
+
   relocate(metadata_Relocation::spec(index), [&] {
     li32(dst, nk);
   });
-  zext(dst, dst, 32);
+
+  if (needs_zext) {
+    zext(dst, dst, 32);
+  }
+
 }
 
 address MacroAssembler::reloc_call(Address entry, Register tmp) {


### PR DESCRIPTION
The RISC-V addiw instruction includes built-in sign extension. When the 32-bit immediate value is 0, no sign extension is needed. The current JIT assembler generates a redundant zext.w instruction.
```
0x0000002aac9e9ce8:   lui     t3,0x95010                  ; {metadata('java/lang/Long')}
0x0000002aac9e9cec:   addiw   t3,t3,-1136
0x0000002aac9e9cf0:   zext.w  t3,t3
0x0000002aac9e9cf4:   beq     t2,t3,0x0000002aac9e9cfc
```
So, in macroAssembler_riscv.cpp source code, we can add the additional judgment to avoid the zext instruction

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8376167](https://bugs.openjdk.org/browse/JDK-8376167): RISC-V: Fix redundant zext.w in macroAssembler_riscv.cpp (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29683/head:pull/29683` \
`$ git checkout pull/29683`

Update a local copy of the PR: \
`$ git checkout pull/29683` \
`$ git pull https://git.openjdk.org/jdk.git pull/29683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29683`

View PR using the GUI difftool: \
`$ git pr show -t 29683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29683.diff">https://git.openjdk.org/jdk/pull/29683.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29683#issuecomment-3888445832)
</details>
