### PR TITLE
8377745: VoiceOver Identifies Hyperlink as Text

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,15 @@ final class CAccessibility implements PropertyChangeListener {
                 focusChanged();
             }
         }
+    }
+
+    private static final AccessibleRole axLink = new AccessibleRole("AXLink")
+                                                 {};
+    private static AccessibleRole convertRole(final AccessibleRole axRole) {
+        if (AccessibleRole.HYPERLINK == axRole) {
+            return axLink;
+        }
+        return axRole;
     }
 
     private native void focusChanged();
@@ -265,7 +274,7 @@ final class CAccessibility implements PropertyChangeListener {
         final AccessibleContext ac = a.getAccessibleContext();
         if (ac == null) return null;
 
-        final AccessibleRole role = ac.getAccessibleRole();
+        final AccessibleRole role = convertRole(ac.getAccessibleRole());
         return AWTAccessor.getAccessibleBundleAccessor().getKey(role);
     }
 
@@ -620,7 +629,7 @@ final class CAccessibility implements PropertyChangeListener {
                 final AccessibleContext ac = a.getAccessibleContext();
                 if (ac == null) return null;
 
-                final AccessibleRole ar = ac.getAccessibleRole();
+                final AccessibleRole ar = convertRole(ac.getAccessibleRole());
                 if (ar == null) return null;
 
                 return ar.toDisplayString();
@@ -719,7 +728,8 @@ final class CAccessibility implements PropertyChangeListener {
                     String activeDescendantName =
                             activeDescendantAC.getAccessibleName();
                     AccessibleRole activeDescendantRole =
-                            activeDescendantAC.getAccessibleRole();
+                            convertRole(
+                                    activeDescendantAC.getAccessibleRole());
                     // Move active descendant to front of list.
                     // List contains pairs of each selected item's
                     // Accessible and AccessibleRole.
@@ -938,7 +948,7 @@ final class CAccessibility implements PropertyChangeListener {
 
     private static AccessibleRole getAccessibleRole(Accessible a) {
         AccessibleContext ac = a.getAccessibleContext();
-        AccessibleRole role = ac.getAccessibleRole();
+        AccessibleRole role = convertRole(ac.getAccessibleRole());
         Object component = CAccessible.getSwingAccessible(a);
         if (role == null) return null;
         String roleString = role.toString();

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,15 +120,6 @@ final class CAccessibility implements PropertyChangeListener {
                 focusChanged();
             }
         }
-    }
-
-    private static final AccessibleRole axLink = new AccessibleRole("AXLink")
-                                                 {};
-    private static AccessibleRole convertRole(final AccessibleRole axRole) {
-        if (AccessibleRole.HYPERLINK == axRole) {
-            return axLink;
-        }
-        return axRole;
     }
 
     private native void focusChanged();
@@ -274,7 +265,7 @@ final class CAccessibility implements PropertyChangeListener {
         final AccessibleContext ac = a.getAccessibleContext();
         if (ac == null) return null;
 
-        final AccessibleRole role = convertRole(ac.getAccessibleRole());
+        final AccessibleRole role = ac.getAccessibleRole();
         return AWTAccessor.getAccessibleBundleAccessor().getKey(role);
     }
 
@@ -629,7 +620,7 @@ final class CAccessibility implements PropertyChangeListener {
                 final AccessibleContext ac = a.getAccessibleContext();
                 if (ac == null) return null;
 
-                final AccessibleRole ar = convertRole(ac.getAccessibleRole());
+                final AccessibleRole ar = ac.getAccessibleRole();
                 if (ar == null) return null;
 
                 return ar.toDisplayString();
@@ -728,8 +719,7 @@ final class CAccessibility implements PropertyChangeListener {
                     String activeDescendantName =
                             activeDescendantAC.getAccessibleName();
                     AccessibleRole activeDescendantRole =
-                            convertRole(
-                                    activeDescendantAC.getAccessibleRole());
+                            activeDescendantAC.getAccessibleRole();
                     // Move active descendant to front of list.
                     // List contains pairs of each selected item's
                     // Accessible and AccessibleRole.
@@ -948,7 +938,7 @@ final class CAccessibility implements PropertyChangeListener {
 
     private static AccessibleRole getAccessibleRole(Accessible a) {
         AccessibleContext ac = a.getAccessibleContext();
-        AccessibleRole role = convertRole(ac.getAccessibleRole());
+        AccessibleRole role = ac.getAccessibleRole();
         Object component = CAccessible.getSwingAccessible(a);
         if (role == null) return null;
         String roleString = role.toString();

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
     [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];
-    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"hyperlink"];
+    [rolesMap setObject:@"LinkAccessibility" forKey:@"hyperlink"];
     [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/LinkAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/LinkAccessibility.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef LINK_ACCESSIBILITY
+#define LINK_ACCESSIBILITY
+
+#import "CommonTextAccessibility.h"
+
+#import <AppKit/NSAccessibility.h>
+
+
+@interface LinkAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityAttributedStringForRange:(NSRange)range;
+- (NSString * _Nullable)accessibilityValue;
+- (NSRange)accessibilityVisibleCharacterRange;
+@end
+#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/LinkAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/LinkAccessibility.m
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "LinkAccessibility.h"
+
+@implementation LinkAccessibility
+
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityLinkRole;
+}
+
+- (NSString * _Nullable)accessibilityAttributedStringForRange:(NSRange)range
+{
+    return [self accessibilityStringForRangeAttribute:range];
+}
+
+- (NSString * _Nullable)accessibilityValue
+{
+    return [self accessibilityValueAttribute];
+}
+
+- (NSRange)accessibilityVisibleCharacterRange
+{
+    return [self accessibilityVisibleCharacterRangeAttribute];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
+}
+
+@end

--- a/test/jdk/javax/accessibility/8377745/VoiceOverHyperlinkRole.java
+++ b/test/jdk/javax/accessibility/8377745/VoiceOverHyperlinkRole.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.border.EmptyBorder;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8377745
+ * @summary manual test for VoiceOver reading links correctly
+ * @requires os.family == "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual VoiceOverHyperlinkRole
+ */
+
+public class VoiceOverHyperlinkRole {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = "INSTRUCTIONS (Mac-only):\n" +
+                "1. Open VoiceOver\n" +
+                "2. Move the VoiceOver cursor over the link.\n" +
+                "3. Observe how VoiceOver identifies the link.\n\n" +
+                "Expected behavior: VoiceOver should identify it as a " +
+                "\"link\". It should not say \"text element\", \"text\" " +
+                "or \"hyperlink\".\n\n" +
+                "If you select the link using \"Accessibility " +
+                "Inspector\": it should identify its role as AXLink.";
+
+        PassFailJFrame.builder()
+                .title("VoiceOverHyperlinkRole Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(VoiceOverHyperlinkRole::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+        JPanel p = new JPanel();
+        p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
+
+        p.add(createText("This button uses `AccessibleRole.HYPERLINK:`"));
+        p.add(createLink(AccessibleRole.HYPERLINK));
+
+        // for debugging / experimentation:
+        boolean tryOtherRoles = false;
+        if (tryOtherRoles) {
+            p.add(createText(
+                    "This button uses `new AccessibleRole(\"Link\") {}`:"));
+            p.add(createLink(new AccessibleRole("Link") {}));
+            p.add(createText(
+                    "This button uses `new AccessibleRole(\"link\") {}`:"));
+            p.add(createLink(new AccessibleRole("link") {}));
+            p.add(createText(
+                    "This button uses `new AccessibleRole(\"AXLink\") {}`:"));
+            p.add(createLink(new AccessibleRole("AXLink") {}));
+        }
+
+        JFrame frame = new JFrame();
+        frame.getContentPane().add(p);
+        frame.pack();
+        return frame;
+    }
+
+    private static JTextArea createText(String text) {
+        JTextArea textArea = new JTextArea(text);
+        textArea.setOpaque(false);
+        textArea.setEditable(false);
+        textArea.setBorder(new EmptyBorder(20, 10, 3, 10));
+        return textArea;
+    }
+
+    private static JButton createLink(AccessibleRole role) {
+        String text = "<html><u>https://bugs.openjdk.org/</u></html>";
+        JButton button = new JButton(text) {
+            public AccessibleContext getAccessibleContext() {
+                if (accessibleContext == null) {
+                    accessibleContext = new AccessibleJButton() {
+                        @Override
+                        public AccessibleRole getAccessibleRole() {
+                            return role;
+                        }
+                    };
+                }
+                return accessibleContext;
+            }
+        };
+        button.setContentAreaFilled(false);
+        button.setBorderPainted(false);
+        return button;
+    }
+}


### PR DESCRIPTION
~~If we use `new AccessibleRole("AXLink") {}`, then VoiceOver reads this more like other native apps.~~

~~There isn't a similar precedent in CAccessibility for creating custom AccessibleRoles, so I won't mind if this PR is declined. (But I don't know off the top of my head where else to inject code to get the desired result...)~~

This introduces a new LinkAccessibility.m file to help VoiceOver and Accessibility Inspector correctly identify AccessibleRole.HYPERLINK as "link"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377745](https://bugs.openjdk.org/browse/JDK-8377745): VoiceOver Identifies Hyperlink as Text (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29686/head:pull/29686` \
`$ git checkout pull/29686`

Update a local copy of the PR: \
`$ git checkout pull/29686` \
`$ git pull https://git.openjdk.org/jdk.git pull/29686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29686`

View PR using the GUI difftool: \
`$ git pr show -t 29686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29686.diff">https://git.openjdk.org/jdk/pull/29686.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29686#issuecomment-3889504900)
</details>
