### PR TITLE
8377102: cacerts jlink plugin

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CACertsPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CACertsPlugin.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.tools.jlink.internal.plugins;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.HashMap;
+import java.util.Map;
+
+import jdk.tools.jlink.internal.ResourcePoolEntryFactory;
+import jdk.tools.jlink.plugin.PluginException;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
+
+/**
+ * Creates the cacerts keystore in the output image with the certificates of
+ * the specified aliases only.
+ */
+public class CACertsPlugin extends AbstractPlugin {
+
+    private static final String RES = "/java.base/lib/security/cacerts";
+
+    // cacerts keystore aliases
+    private String[] aliases;
+
+    public CACertsPlugin() {
+        super("cacerts");
+    }
+
+    @Override
+    public Category getType() {
+        return Category.TRANSFORMER;
+    }
+
+    @Override
+    public boolean hasArguments() {
+        return true;
+    }
+
+    @Override
+    public void configure(Map<String, String> config) {
+        String option = config.get(getName());
+        if (option == null) {
+            throw new AssertionError();
+        }
+        // If alias has a comma in it, this won't work, but no cacerts
+        // aliases have commas.
+        aliases = option.split(",");
+    }
+
+    @Override
+    public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
+        in.transformAndCopy(res -> {
+            if (res.type() == ResourcePoolEntry.Type.NATIVE_LIB &&
+                    res.path().equals(RES)) {
+                byte[] cacerts = transformCACerts(res.content());
+                return ResourcePoolEntryFactory.create(res, cacerts);
+            }
+            return res;
+        }, out);
+        return out.build();
+    }
+
+    /**
+     * Creates a keystore containing only the certificates of the specified
+     * aliases.
+     */
+    private byte[] transformCACerts(InputStream content) {
+        try {
+            var ks = KeyStore.getInstance("PKCS12");
+            ks.load(content, null);
+            Map<String, Certificate> certs = new HashMap<>(aliases.length);
+            for (var alias : aliases) {
+                var cert = ks.getCertificate(alias);
+                if (cert == null) {
+                    throw new PluginException(
+                        "alias " + alias + " does not exist");
+                }
+                certs.put(alias, cert);
+            }
+            ks.load(null, null);
+            for (var entry : certs.entrySet()) {
+                ks.setCertificateEntry(entry.getKey(), entry.getValue());
+            }
+            var baos = new ByteArrayOutputStream();
+            ks.store(baos, null);
+            return baos.toByteArray();
+        } catch (Exception ex) {
+            throw new PluginException(ex);
+        }
+    }
+}

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CACertsPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CACertsPlugin.java
@@ -53,11 +53,6 @@ public class CACertsPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Category getType() {
-        return Category.TRANSFORMER;
-    }
-
-    @Override
     public boolean hasArguments() {
         return true;
     }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CACertsPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CACertsPlugin.java
@@ -105,6 +105,8 @@ public class CACertsPlugin extends AbstractPlugin {
             var baos = new ByteArrayOutputStream();
             ks.store(baos, null);
             return baos.toByteArray();
+        } catch (PluginException pe) {
+            throw pe;
         } catch (Exception ex) {
             throw new PluginException(ex);
         }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,19 @@ release-info.usage=\
 \                            add: is to add properties to the 'release' file.\n\
 \                            Any number of <key>=<value> pairs can be passed.\n\
 \                            del: is to delete the list of keys in release file.
+
+cacerts.argument=<alias>[,<alias>]*
+
+cacerts.description=\
+Create the cacerts keystore in the output image with the certificates of the\n\
+specified aliases only. <alias> is the name of an alias in the cacerts keystore.
+
+cacerts.usage=\
+\  --cacerts <alias>[,<alias>]*\n\
+\                            Create the cacerts keystore in the output image\n\
+\                            with the certificates of the specified aliases\n\
+\                            only. <alias> is the name of an alias in the\n\
+\                            cacerts keystore.
 
 class-for-name.argument=
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -56,15 +56,16 @@ release-info.usage=\
 cacerts.argument=<alias>[,<alias>]*
 
 cacerts.description=\
-Create the cacerts keystore in the output image with the certificates of the\n\
-specified aliases only. <alias> is the name of an alias in the cacerts keystore.
+Create the cacerts keystore in the output image with only the certificates\n\
+of the specified aliases. <alias> is the name of an alias in the cacerts\n\
+keystore in the java.base module.
 
 cacerts.usage=\
 \  --cacerts <alias>[,<alias>]*\n\
 \                            Create the cacerts keystore in the output image\n\
-\                            with the certificates of the specified aliases\n\
-\                            only. <alias> is the name of an alias in the\n\
-\                            cacerts keystore.
+\                            with only the certificates of the specified\n\
+\                            aliases. <alias> is the name of an alias in the\n\
+\                            cacerts keystore in the java.base module.
 
 class-for-name.argument=
 

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,5 +81,6 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.VendorVMBugURLPlugin,
         jdk.tools.jlink.internal.plugins.VendorVersionPlugin,
         jdk.tools.jlink.internal.plugins.CDSPlugin,
-        jdk.tools.jlink.internal.plugins.SaveJlinkArgfilesPlugin;
+        jdk.tools.jlink.internal.plugins.SaveJlinkArgfilesPlugin,
+        jdk.tools.jlink.internal.plugins.CACertsPlugin;
 }

--- a/src/jdk.jlink/share/man/jlink.md
+++ b/src/jdk.jlink/share/man/jlink.md
@@ -235,6 +235,16 @@ Options
 Description
 :   Generate CDS archive if the runtime image supports the CDS feature.
 
+### Plugin `cacerts`
+
+Options
+:   `--cacerts=`*alias*\[`,`*alias*\]\*
+
+Description
+:   Create the `cacerts` keystore in the output image with the certificates of
+    the specified aliases only. *alias* is the name of an alias in the
+    `cacerts` keystore.
+
 ## jlink Examples
 
 The following command creates a runtime image in the directory `greetingsapp`.

--- a/src/jdk.jlink/share/man/jlink.md
+++ b/src/jdk.jlink/share/man/jlink.md
@@ -241,9 +241,9 @@ Options
 :   `--cacerts=`*alias*\[`,`*alias*\]\*
 
 Description
-:   Create the `cacerts` keystore in the output image with the certificates of
-    the specified aliases only. *alias* is the name of an alias in the
-    `cacerts` keystore.
+:   Create the `cacerts` keystore in the output image with only the
+    certificates of the specified aliases. *alias* is the name of an alias
+    in the `cacerts` keystore in the java.base module.
 
 ## jlink Examples
 

--- a/test/jdk/tools/jlink/plugins/CACertsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CACertsPluginTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.Enumeration;
+
+import jtreg.SkippedException;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.security.SecurityUtils;
+import tests.Helper;
+
+/* @test
+ * @bug 8377102
+ * @summary Test the --cacerts plugin
+ * @library ../../lib /test/lib
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jlink/jdk.tools.jimage
+ * @build tests.*
+ * @run main CACertsPluginTest
+ */
+
+public class CACertsPluginTest {
+
+    private static Helper helper;
+
+    private static String CACERTS_PATH = "lib/security/cacerts";
+
+    public static void main(String[] args) throws Throwable {
+
+        helper = Helper.newHelper();
+        if (helper == null) {
+            throw new SkippedException("Test not run");
+        }
+
+        KeyStore jdkCacerts = SecurityUtils.getCacertsKeyStore();
+        Enumeration<String> aliases = jdkCacerts.aliases();
+        String alias1 = aliases.nextElement();
+        String alias2 = aliases.nextElement();
+
+        // test one alias
+        test("testOne", jdkCacerts, alias1);
+
+        // test two aliases
+        test("testTwo", jdkCacerts, alias1, alias2);
+
+        // test illegal/bad options
+        testBadOptions();
+    }
+
+    private static void test(String module, KeyStore jdkCacerts,
+            String... aliases) throws Exception {
+
+        helper.generateDefaultJModule(module);
+
+        String option = toOption(aliases);
+        Path image = helper.generateDefaultImage(
+                new String[] { "--cacerts", option }, module).assertSuccess();
+        helper.checkImage(image, module, null, null,
+                new String[] { CACERTS_PATH });
+
+        KeyStore imageCacerts = KeyStore.getInstance(
+                image.resolve(CACERTS_PATH).toFile(), (char[]) null);
+
+        Asserts.assertEquals(imageCacerts.size(), aliases.length);
+        for (String alias : aliases) {
+            Asserts.assertTrue(imageCacerts.isCertificateEntry(alias));
+            Asserts.assertEquals(
+                    jdkCacerts.getCertificate(alias),
+                    imageCacerts.getCertificate(alias));
+        }
+    }
+
+    private static void testBadOptions() throws Exception {
+
+        String module = "testBad";
+        helper.generateDefaultJModule(module);
+        helper.generateDefaultImage(new String[]
+                { "--cacerts", "bogus-alias" }, module)
+                .assertFailure("alias bogus-alias does not exist");
+    }
+
+    private static String toOption(String... aliases) {
+        int max = aliases.length - 1;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; ; i++) {
+            sb.append(aliases[i]);
+            if (i == max) {
+                return sb.toString();
+            }
+            sb.append(",");
+        }
+    }
+}

--- a/test/jdk/tools/jlink/plugins/CACertsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CACertsPluginTest.java
@@ -29,6 +29,7 @@ import java.util.Enumeration;
 import jtreg.SkippedException;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.security.SecurityUtils;
+import jdk.tools.jlink.internal.LinkableRuntimeImage;
 import tests.Helper;
 
 /* @test
@@ -37,19 +38,22 @@ import tests.Helper;
  * @library ../../lib /test/lib
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jimage
+ *          jdk.jlink/jdk.tools.jlink.internal
  * @build tests.*
- * @run main CACertsPluginTest
+ * @run main/othervm CACertsPluginTest
  */
 
 public class CACertsPluginTest {
 
     private static Helper helper;
 
-    private static String CACERTS_PATH = "lib/security/cacerts";
+    private static final String CACERTS_PATH = "lib/security/cacerts";
+    private static final boolean LINKABLE_RUNTIME =
+            LinkableRuntimeImage.isLinkableRuntime();
 
     public static void main(String[] args) throws Throwable {
 
-        helper = Helper.newHelper();
+        helper = Helper.newHelper(LINKABLE_RUNTIME);
         if (helper == null) {
             throw new SkippedException("Test not run");
         }


### PR DESCRIPTION
This is a new `jlink` plugin which allows the user to specify the CA certificates it wants to include in the `cacerts` keystore in a custom runtime image. This can be very useful for creating runtimes that only contain the CA certificates that are necessary.

The command-line syntax takes one or more `cacert` keystore aliases as an option, separated by a comma.

For example: 

`jlink --cacerts "letsencryptisrgx1 [jdk]"`

or

`jlink --cacerts "letsencryptisrgx1 [jdk],digicertglobalrootca [jdk]"`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8379135](https://bugs.openjdk.org/browse/JDK-8379135) to be approved

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8377102: cacerts jlink plugin`

### Issues
 * [JDK-8377102](https://bugs.openjdk.org/browse/JDK-8377102): cacerts jlink plugin (**Enhancement** - P4)
 * [JDK-8379135](https://bugs.openjdk.org/browse/JDK-8379135): cacerts jlink plugin (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29700/head:pull/29700` \
`$ git checkout pull/29700`

Update a local copy of the PR: \
`$ git checkout pull/29700` \
`$ git pull https://git.openjdk.org/jdk.git pull/29700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29700`

View PR using the GUI difftool: \
`$ git pr show -t 29700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29700.diff">https://git.openjdk.org/jdk/pull/29700.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29700#issuecomment-3892638831)
</details>
