### PR TITLE
8049630: Custom socket factory is not checked for the existence of a getDefault() method

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,11 @@ import java.io.InterruptedIOException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.InputStream;
+import java.lang.reflect.Modifier;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+
+import javax.naming.ConfigurationException;
 import javax.net.ssl.SSLSocket;
 
 import javax.naming.CommunicationException;
@@ -296,7 +299,7 @@ public final class Connection implements Runnable {
         return socket;
     }
 
-    private SocketFactory getSocketFactory(String socketFactoryName) throws Exception {
+    private SocketFactory getSocketFactory(String socketFactoryName) throws ConfigurationException {
         if (socketFactoryName == null) {
             if (debug) {
                 System.err.println("Connection: using default SocketFactory");
@@ -306,14 +309,41 @@ public final class Connection implements Runnable {
             if (debug) {
                 System.err.println("Connection: loading supplied SocketFactory: " + socketFactoryName);
             }
-            @SuppressWarnings("unchecked")
-            Class<? extends SocketFactory> socketFactoryClass =
-                    (Class<? extends SocketFactory>) Class.forName(socketFactoryName,
-                            true, Thread.currentThread().getContextClassLoader());
-            Method getDefault =
-                    socketFactoryClass.getMethod("getDefault");
-            SocketFactory factory = (SocketFactory) getDefault.invoke(null, new Object[]{});
-            return factory;
+            Class<?> klass;
+            try {
+                klass = Class.forName(socketFactoryName, false,
+                        Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new ConfigurationException("failed to load SocketFactory - " + e);
+            }
+            if (!SocketFactory.class.isAssignableFrom(klass)) {
+                throw new ConfigurationException(socketFactoryName + " is not of type "
+                        + SocketFactory.class.getName());
+            }
+            Method method;
+            try {
+                method = klass.getDeclaredMethod("getDefault");
+            } catch (NoSuchMethodException e) {
+                throw new ConfigurationException(socketFactoryName
+                        +  " is missing a public static getDefault() method"
+                        +  " that returns a SocketFactory");
+            }
+            int modifiers = method.getModifiers();
+            if (!Modifier.isStatic(modifiers)
+                    || !Modifier.isPublic(modifiers)
+                    || Modifier.isAbstract(modifiers)) {
+                throw new ConfigurationException(socketFactoryName
+                        +  " is missing a public static getDefault() method"
+                        +  " that returns a SocketFactory");
+            }
+            try {
+                return (SocketFactory) method.invoke(null, new Object[]{});
+            } catch (IllegalAccessException | ClassCastException e) {
+                throw new ConfigurationException(socketFactoryName + ".getDefault() failed - " + e);
+            } catch (InvocationTargetException e) {
+                throw new ConfigurationException(socketFactoryName + ".getDefault() failed - "
+                        + e.getCause());
+            }
         }
     }
 

--- a/src/java.naming/share/classes/module-info.java
+++ b/src/java.naming/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@
  *         <br>The value of this environment property specifies the fully
  *         qualified class name of the socket factory used by the LDAP provider.
  *         This class must implement the {@link javax.net.SocketFactory} abstract class
- *         and provide an implementation of the static "getDefault()" method that
- *         returns an instance of the socket factory. By default the environment
+ *         and provide an implementation of the {@code public static SocketFactory getDefault()}
+ *         method that returns an instance of the socket factory. By default the environment
  *         property is not set.
  *     </li>
  *     <li>{@code com.sun.jndi.ldap.connect.timeout}:

--- a/test/jdk/javax/naming/ldap/LdapSocketFactoryInvalidConfigTest.java
+++ b/test/jdk/javax/naming/ldap/LdapSocketFactoryInvalidConfigTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.math.BigDecimal;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.net.SocketFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/*
+ * @test
+ * @bug 8049619 8049630
+ * @summary Verify that if the configured java.naming.ldap.factory.socket
+ *          class name doesn't match the expectation of a SocketFactory,
+ *          then a NamingException is raised
+ *
+ * @run junit ${test.main.class}
+ */
+class LdapSocketFactoryInvalidConfigTest {
+    private static final String LDAP_CTX_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    private static final String ENV_PROP_SOCKET_FACTORY = "java.naming.ldap.factory.socket";
+
+    /*
+     * Verifies that if the class configured for java.naming.ldap.factory.socket
+     * is not of type SocketFactory, then a NamingException is thrown.
+     */
+    @ParameterizedTest
+    @ValueSource(classes = {BigDecimal.class, NotSocketFactoryButHasGetDefault.class})
+    void testNotSocketFactory(final Class<?> klass) throws Exception {
+        final Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, LDAP_CTX_FACTORY);
+        env.put(ENV_PROP_SOCKET_FACTORY, klass.getName());
+        final NamingException ne = assertThrows(NamingException.class,
+                () -> new InitialContext(env));
+        if (!ne.toString().contains("not of type javax.net.SocketFactory")) {
+            throw ne; // propagate the unexpected exception
+        }
+    }
+
+    /*
+     * Verifies that if the class configured for java.naming.ldap.factory.socket
+     * does not declare a "public static SocketFactory getDefault()" method,
+     * then a NamingException is thrown.
+     */
+    @Test
+    void testNoGetDefault() throws Exception {
+        final Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, LDAP_CTX_FACTORY);
+        env.put(ENV_PROP_SOCKET_FACTORY, NoGetDefaultSocketFactory.class.getName());
+        final NamingException ne = assertThrows(NamingException.class,
+                () -> new InitialContext(env));
+        if (!ne.toString().contains("missing a public static getDefault() method")) {
+            throw ne; // propagate the unexpected exception
+        }
+    }
+
+    public static class NotSocketFactoryButHasGetDefault {
+        public static SocketFactory getDefault() {
+            return new SocketFactory() {
+                @Override
+                public Socket createSocket(String host, int port) {
+                    throw new UnsupportedOperationException("wasn't expected to be invoked");
+                }
+
+                @Override
+                public Socket createSocket(String host, int port,
+                                           InetAddress localHost, int localPort) {
+                    throw new UnsupportedOperationException("wasn't expected to be invoked");
+                }
+
+                @Override
+                public Socket createSocket(InetAddress host, int port) {
+                    throw new UnsupportedOperationException("wasn't expected to be invoked");
+                }
+
+                @Override
+                public Socket createSocket(InetAddress address, int port,
+                                           InetAddress localAddress, int localPort) {
+                    throw new UnsupportedOperationException("wasn't expected to be invoked");
+                }
+            };
+        }
+    }
+
+    public static class NoGetDefaultSocketFactory extends SocketFactory {
+
+        @Override
+        public Socket createSocket(String host, int port) {
+            throw new UnsupportedOperationException("wasn't expected to be invoked");
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) {
+            throw new UnsupportedOperationException("wasn't expected to be invoked");
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) {
+            throw new UnsupportedOperationException("wasn't expected to be invoked");
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+                                   int localPort) {
+            throw new UnsupportedOperationException("wasn't expected to be invoked");
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which addresses the issues noted in https://bugs.openjdk.org/browse/JDK-8049630 and https://bugs.openjdk.org/browse/JDK-8049619?

The `java.naming` module allows for the `java.naming.ldap.factory.socket` environment property to be configured to point to the class name of the implementation of a `javax.net.SocketFactory`. As noted in the specification of that property https://docs.oracle.com/en/java/javase/25/docs/api/java.naming/module-summary.html:

> The value of this environment property specifies the fully qualified class name of the socket factory used by the LDAP provider. This class must implement the SocketFactory abstract class and provide an implementation of the static "getDefault()" method that returns an instance of the socket factory.

The implementation in the JDK default LDAP provider currently doesn't verify that the given class name points to a type which is `javax.net.SocketFactory`, nor does it verify that the correct expected `getDefault()` method exists. The changes in this PR addresses that issue and introduces a jtreg test to reproduce the issue and verify the fix.

Given the nature of this change, I believe a CSR will be needed which I'll file shortly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8377864](https://bugs.openjdk.org/browse/JDK-8377864) to be approved

### Issues
 * [JDK-8049630](https://bugs.openjdk.org/browse/JDK-8049630): Custom socket factory is not checked for the existence of a getDefault() method (**Bug** - P4)
 * [JDK-8049619](https://bugs.openjdk.org/browse/JDK-8049619): Custom socket factory is not type checked against javax.net.SocketFactory (**Bug** - P4)
 * [JDK-8377864](https://bugs.openjdk.org/browse/JDK-8377864): Custom socket factory is not checked for the existence of a getDefault() method (**CSR**)
 * [JDK-8377864](https://bugs.openjdk.org/browse/JDK-8377864): Custom socket factory is not checked for the existence of a getDefault() method (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29706/head:pull/29706` \
`$ git checkout pull/29706`

Update a local copy of the PR: \
`$ git checkout pull/29706` \
`$ git pull https://git.openjdk.org/jdk.git pull/29706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29706`

View PR using the GUI difftool: \
`$ git pr show -t 29706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29706.diff">https://git.openjdk.org/jdk/pull/29706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29706#issuecomment-3894471673)
</details>
