### PR TITLE
8377932: AOT cache is not rejected when JAR file has changed

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -426,7 +426,8 @@ bool AOTClassLocation::check(const char* runtime_path, bool has_aot_linked_class
     bool size_differs = _filesize != st.st_size;
     bool time_differs = _check_time && (_timestamp != st.st_mtime);
     if (size_differs || time_differs) {
-      aot_log_warning(aot)("This file is not the one used while building the shared archive file: '%s'%s%s",
+      aot_log_warning(aot)("This file is not the one used while building the %s: '%s'%s%s",
+                       CDSConfig::type_of_archive_being_loaded(),
                        runtime_path,
                        time_differs ? ", timestamp has changed" : "",
                        size_differs ? ", size has changed" : "");
@@ -447,6 +448,13 @@ void AOTClassLocationConfig::dumptime_init(JavaThread* current) {
     // shouldn't happen this early in bootstrap.
     java_lang_Throwable::print(current->pending_exception(), tty);
     vm_exit_during_initialization("AOTClassLocationConfig::dumptime_init_helper() failed unexpectedly");
+  }
+
+  if (CDSConfig::is_dumping_final_static_archive()) {
+    // The _max_used_index is usually updated by ClassLoader::record_result(). However,
+    // when dumping the final archive, the classes are loaded from their images in
+    // the AOT config file, so we don't go through ClassLoader::record_result().
+    dumptime_update_max_used_index(runtime()->_max_used_index); // Same value as recorded in the training run.
   }
 }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ChangedJarFile.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ChangedJarFile.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary AOT cache should be rejected if JAR file(s) in the classpath have changed
+ * @bug 8377932
+ * @requires vm.cds.supports.aot.class.linking
+ * @library /test/lib
+ * @build ChangedJarFile
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar MyTestApp OtherClass
+ * @run driver ChangedJarFile AOT
+ */
+
+import jdk.jfr.Event;
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ChangedJarFile {
+    static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+    static final String mainClass = MyTestApp.class.getName();
+
+    public static void main(String[] args) throws Exception {
+        // Train and run with unchanged JAR file (which has OtherClass.class)
+        Tester tester = new Tester();
+        tester.run(args);
+
+        // Run again with changed JAR file (which doesn't have OtherClass.class anymore)
+        ClassFileInstaller.writeJar(appJar, "MyTestApp");
+
+        // First disable AOT cache to verify test login
+        tester.productionRun(new String[] {"-XX:AOTMode=off"},
+                             new String[] {"jarHasChanged"});
+
+        // Now see if the AOT cache will be automatically disabled
+        OutputAnalyzer out =
+            tester.productionRun(new String[] {"-XX:AOTMode=auto", "-Xlog:aot"},
+                                 new String[] {"jarHasChanged"});
+        out.shouldMatch("This file is not the one used while building the " +
+                        "AOT cache: '.*app.jar', timestamp has changed, size has changed");
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return appJar;
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] { mainClass };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) {
+
+        }
+    }
+
+
+}
+
+class MyTestApp {
+    public static void main(String args[]) {
+        boolean jarHasChanged = (args.length != 0);
+
+        System.out.println("JAR has changed = " + (jarHasChanged));
+        Class c = null;
+        try {
+            c = Class.forName("OtherClass");
+            System.out.println("Other class = " + c);
+        } catch (Throwable t) {
+            if (!jarHasChanged) {
+                throw new RuntimeException("OtherClass should have been loaded because JAR has not been changed yet", t);
+            }
+        }
+
+        if (jarHasChanged && c != null) {
+            throw new RuntimeException("OtherClass should not be in JAR file");
+        }
+    }
+}
+
+class OtherClass {}


### PR DESCRIPTION
**Background:**

The value of `AOTClassLocationConfig::_max_used_index` controls how many JAR files are checked on the classpath. For example, if you have the following program but classes are loaded only from `a.jar`:

```
java -cp a.jar:b.jar -XX:AOTCacheOutput=app.aot App
```

Then `_max_used_index` should be `1`. When loading `app.aot` in a production run, we only check if `a.jar` has changed. It doesn't matter if `b.jar` has changed because `app.aot` doesn't contain any classes from `b.jar`.

**About the fix:**

The bug is that  `_max_used_index` was incorrectly set to zero in the AOT cache. As a result, we don't check any JAR files in the classpath.

The fix is to propagate the value that we recorded in the AOR configuration file (in `runtime()->_max_used_index`) into the final AOT cache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377932](https://bugs.openjdk.org/browse/JDK-8377932): AOT cache is not rejected when JAR file has changed (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29728/head:pull/29728` \
`$ git checkout pull/29728`

Update a local copy of the PR: \
`$ git checkout pull/29728` \
`$ git pull https://git.openjdk.org/jdk.git pull/29728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29728`

View PR using the GUI difftool: \
`$ git pr show -t 29728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29728.diff">https://git.openjdk.org/jdk/pull/29728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29728#issuecomment-3903371193)
</details>
