### PR TITLE
8373439: Deadlock between flight recorder & VM shutdown

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,6 +104,9 @@ public final class Recording implements Closeable {
         Map<String, String> sanitized = Utils.sanitizeNullFreeStringMap(settings);
         PlatformRecorder r = FlightRecorder.getFlightRecorder().getInternal();
         synchronized (r) {
+            if (PlatformRecorder.isInShutDown()) {
+                throw new IllegalStateException("A new recording cannot be created after JFR has shut down.");
+            }
             this.internal = r.newRecording(sanitized);
             this.internal.setRecording(this);
             if (internal.getRecording() != this) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public final class PlatformRecorder {
         inShutdown = true;
     }
 
-    static boolean isInShutDown() {
+    public static boolean isInShutDown() {
         return inShutdown;
     }
 
@@ -165,7 +165,6 @@ public final class PlatformRecorder {
         } catch (Exception ex) {
             Logger.log(JFR_SYSTEM, WARN, "Shutdown hook could not cancel timer");
         }
-
         for (PlatformRecording p : getRecordings()) {
             if (p.getState() == RecordingState.RUNNING) {
                 try {
@@ -175,8 +174,12 @@ public final class PlatformRecorder {
                 }
             }
         }
-
         writeReports();
+        // This will prevent further interaction with recordings after JFR has been destroyed.
+        for (PlatformRecording p : getRecordings()) {
+            p.setState(RecordingState.CLOSED);
+        }
+        recordings.clear();
         JDKEvents.remove();
 
         if (JVMSupport.hasJFR()) {

--- a/test/jdk/jdk/jfr/jvm/AfterShutdown.java
+++ b/test/jdk/jdk/jfr/jvm/AfterShutdown.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.jvm;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.RecordingState;
+
+/**
+ * Test application that tries to interact with JFR after shutdown.
+ */
+public class AfterShutdown {
+    public static void main(String... args) {
+        Recording r = new Recording();
+        r.start();
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                awaitRepositoryRemoved();
+                try {
+                    r.dump(Path.of("file.jfr"));
+                    System.out.println("FAIL: Should not be able to dump after shutdown.");
+                    System.exit(1);
+                } catch (IOException ioe) {
+                    if (r.getState() != RecordingState.CLOSED) {
+                        System.out.println("FAIL: Expected recording to be closed.");
+                        System.out.println("Recording state: " + r.getState());
+                        System.exit(1);
+                    }
+                    List<Recording> recordings = FlightRecorder.getFlightRecorder().getRecordings();
+                    if (!recordings.isEmpty()) {
+                        System.out.println("FAIL: Expected no available recordings.");
+                        System.exit(1);
+                    }
+                }
+                try {
+                    new Recording();
+                    System.out.println("FAIL: Expected IllegalStateException if recording is created after repository removal.");
+                    System.exit(1);
+                } catch (IllegalStateException ise) {
+                    // As expected
+                }
+            }
+
+            private void awaitRepositoryRemoved() {
+                String path = System.getProperty("jdk.jfr.repository");
+                Path repository = Path.of(path);
+                while (Files.exists(repository)) {
+                    System.out.println("Repository still exist. Waiting 100 ms ...");
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                System.out.println("Repository removed.");
+            }
+        });
+    }
+}

--- a/test/jdk/jdk/jfr/jvm/AfterShutdown.java
+++ b/test/jdk/jdk/jfr/jvm/AfterShutdown.java
@@ -25,60 +25,119 @@ package jdk.jfr.jvm;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import jdk.jfr.Recording;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.RecordingState;
+import jdk.jfr.consumer.RecordingStream;
 
 /**
  * Test application that tries to interact with JFR after shutdown.
  */
+@SuppressWarnings("resource")
 public class AfterShutdown {
-    public static void main(String... args) {
-        Recording r = new Recording();
-        r.start();
+    public static void main(String... args) throws Exception {
+       Recording r1 = new Recording();
+        r1.start();
+        Recording r2 = new Recording();
+        r2.start();
+        Recording r3 = new Recording();
+        r3.start();
+        Recording r4 = new Recording();
+        r4.start();
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {
                 awaitRepositoryRemoved();
-                try {
-                    r.dump(Path.of("file.jfr"));
-                    System.out.println("FAIL: Should not be able to dump after shutdown.");
-                    System.exit(1);
-                } catch (IOException ioe) {
-                    if (r.getState() != RecordingState.CLOSED) {
-                        System.out.println("FAIL: Expected recording to be closed.");
-                        System.out.println("Recording state: " + r.getState());
-                        System.exit(1);
-                    }
-                    List<Recording> recordings = FlightRecorder.getFlightRecorder().getRecordings();
-                    if (!recordings.isEmpty()) {
-                        System.out.println("FAIL: Expected no available recordings.");
-                        System.exit(1);
-                    }
-                }
-                try {
-                    new Recording();
-                    System.out.println("FAIL: Expected IllegalStateException if recording is created after repository removal.");
-                    System.exit(1);
-                } catch (IllegalStateException ise) {
-                    // As expected
-                }
-            }
-
-            private void awaitRepositoryRemoved() {
-                String path = System.getProperty("jdk.jfr.repository");
-                Path repository = Path.of(path);
-                while (Files.exists(repository)) {
-                    System.out.println("Repository still exist. Waiting 100 ms ...");
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-                System.out.println("Repository removed.");
+                testNew();
+                testDump(r1);
+                testStop(r2);
+                testClose(r3);
+                testCopy(r4);
+                testSnapshot();
             }
         });
+    }
+
+    private static void testNew() {
+        try {
+            new Recording();
+            fail("Expected IllegalStateException if recording is created after repository removal.");
+        } catch (IllegalStateException ise) {
+            // As expected
+        }
+        try {
+            new RecordingStream();
+            fail("Expected IllegalStateException if recording is created after repository removal.");
+        } catch (IllegalStateException ise) {
+            // As expected
+        }
+    }
+
+    private static void testDump(Recording r) {
+        try {
+            r.dump(Path.of("file.jfr"));
+            fail("Should not be able to dump recording after shutdown");
+        } catch (IOException ioe) {
+            assertClosed(r);
+        }
+    }
+
+    private static void testStop(Recording r) {
+        try {
+            r.stop();
+            fail("Should not be able to stop recording after shutdown.");
+        } catch (IllegalStateException ioe) {
+            assertClosed(r);
+        }
+    }
+
+    private static void testClose(Recording r) {
+        try {
+            r.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Should not be close recording after shutdown.");
+        }
+    }
+
+    private static void testCopy(Recording r) {
+        try {
+            Recording copy = r.copy(true);
+            assertClosed(copy);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Recording copy should not throw Exception.");
+        }
+    }
+
+    private static void testSnapshot() {
+        Recording r = FlightRecorder.getFlightRecorder().takeSnapshot();
+        assertClosed(r);
+    }
+
+    private static void awaitRepositoryRemoved() {
+        String path = System.getProperty("jdk.jfr.repository");
+        Path repository = Path.of(path);
+        while (Files.exists(repository)) {
+            System.out.println("Repository still exist. Waiting 100 ms ...");
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        System.out.println("Repository removed.");
+    }
+
+    private static void assertClosed(Recording r) {
+        if (r.getState() != RecordingState.CLOSED) {
+            fail("Recording was in state " + r.getState() + " but expected it to be CLOSED");
+        }
+    }
+
+    private static void fail(String message) {
+        System.out.println("FAIL: " + message);
+        // This will typically hang the application because of shutdown lock.
+        System.exit(1);
     }
 }

--- a/test/jdk/jdk/jfr/jvm/TestAfterShutdown.java
+++ b/test/jdk/jdk/jfr/jvm/TestAfterShutdown.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import java.util.ArrayList;
+import java.util.List;
+import jdk.jfr.jvm.AfterShutdown;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+/**
+ * @test TestAfterShutdown
+ * @requires vm.flagless
+ * @summary Checks that API interactions with JFR after shutdown works as expected
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @build jdk.jfr.jvm.AfterShutdown
+ * @run main/othervm -Xlog:jfr jdk.jfr.jvm.TestAfterShutdown
+ */
+public class TestAfterShutdown {
+    public static void main(String... args) throws Exception {
+        var pb = ProcessTools.createTestJavaProcessBuilder(AfterShutdown.class.getName());
+        var result = ProcessTools.executeProcess(pb);
+        if (result.getExitValue() != 0) {
+            result.reportDiagnosticSummary();
+            throw new Exception("Unexpected behavior when doing API operations after shutdown.");
+        }
+        result.shouldNotContain("FAIL");
+    }
+}


### PR DESCRIPTION
Could I have a review of the PR that prevents a deadlock during VM shutdown? This is a follow-up to a prior [PR](https://github.com/openjdk/jdk/pull/28767).Here are some ideas I explored:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Issue
 * [JDK-8373439](https://bugs.openjdk.org/browse/JDK-8373439): Deadlock between flight recorder &amp; VM shutdown (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29775/head:pull/29775` \
`$ git checkout pull/29775`

Update a local copy of the PR: \
`$ git checkout pull/29775` \
`$ git pull https://git.openjdk.org/jdk.git pull/29775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29775`

View PR using the GUI difftool: \
`$ git pr show -t 29775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29775.diff">https://git.openjdk.org/jdk/pull/29775.diff</a>

</details>
