### PR TITLE
8378100: Unused code in rewriter.hpp

### DIFF
--- a/src/hotspot/share/interpreter/rewriter.hpp
+++ b/src/hotspot/share/interpreter/rewriter.hpp
@@ -78,9 +78,6 @@ class Rewriter: public StackObj {
     _resolved_reference_limit = _resolved_references_map.length();
   }
 
-  int  cp_entry_to_cp_cache(int i) { assert(has_cp_cache(i), "oob"); return _cp_map.at(i); }
-  bool has_cp_cache(int i) { return (uint) i < (uint) _cp_map.length() && _cp_map.at(i) >= 0; }
-
   int add_map_entry(int cp_index, GrowableArray<int>* cp_map, GrowableArray<int>* cp_cache_map) {
     assert(cp_map->at(cp_index) == -1, "not twice on same cp_index");
     int cache_index = cp_cache_map->append(cp_index);


### PR DESCRIPTION
Hi everyone,

[JDK-8301997](https://bugs.openjdk.org/browse/JDK-8301997) moved method resolution information out of the cpCache, and with that, moved a lot of code around.

The functions `cp_entry_to_cp_cache` and `has_cp_cache` in `rewriter.hpp` were only called by that removed code, and are now unused.

This is dead code and should thus be removed.

Testing:
- Oracle tier 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378100](https://bugs.openjdk.org/browse/JDK-8378100): Unused code in rewriter.hpp (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29790/head:pull/29790` \
`$ git checkout pull/29790`

Update a local copy of the PR: \
`$ git checkout pull/29790` \
`$ git pull https://git.openjdk.org/jdk.git pull/29790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29790`

View PR using the GUI difftool: \
`$ git pr show -t 29790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29790.diff">https://git.openjdk.org/jdk/pull/29790.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29790#issuecomment-3921190221)
</details>
