### PR TITLE
8379816: C2: Possible integer overflow in BCEscapeAnalyzer::iterate_blocks

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1083,11 +1083,11 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   int numLocals = _method->max_locals();
   StateInfo state;
 
-  int datacount = (numblocks + 1) * (stkSize + numLocals);
-  int datasize = datacount * sizeof(ArgumentMap);
+  size_t datacount = (size_t)(numblocks + 1) * (stkSize + numLocals);
+  size_t datasize = (size_t)datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);
-  for (int i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
+  for (size_t i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
   ArgumentMap *dp = statedata;
   state._vars = dp;
   dp += numLocals;
@@ -1095,7 +1095,7 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   dp += stkSize;
   state._initialized = false;
   state._max_stack = stkSize;
-  for (int i = 0; i < numblocks; i++) {
+  for (size_t i = 0; i < numblocks; i++) {
     blockstates[i]._vars = dp;
     dp += numLocals;
     blockstates[i]._stack = dp;

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1083,11 +1083,11 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   int numLocals = _method->max_locals();
   StateInfo state;
 
-  size_t datacount = (size_t)(numblocks + 1) * (stkSize + numLocals);
+  int64_t datacount = (int64_t)(numblocks + 1) * (stkSize + numLocals);
   size_t datasize = (size_t)datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);
-  for (size_t i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
+  for (int64_t i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
   ArgumentMap *dp = statedata;
   state._vars = dp;
   dp += numLocals;
@@ -1095,7 +1095,7 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   dp += stkSize;
   state._initialized = false;
   state._max_stack = stkSize;
-  for (size_t i = 0; i < numblocks; i++) {
+  for (int i = 0; i < numblocks; i++) {
     blockstates[i]._vars = dp;
     dp += numLocals;
     blockstates[i]._stack = dp;

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1083,16 +1083,17 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   uint numLocals = checked_cast<uint>(_method->max_locals());
   StateInfo state;
 
-  uint64_t datacount = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
+  uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
   // bail out conservatively on overflow
-  if (datacount > SIZE_MAX / sizeof(ArgumentMap)) {
+  if (datacount64 > SIZE_MAX / sizeof(ArgumentMap)) {
     _conservative = true;
     return;
   }
-  size_t datasize = (size_t)datacount * sizeof(ArgumentMap);
+  size_t datacount = (size_t)datacount64;
+  size_t datasize = datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);
-  for (size_t i = 0; i < (size_t)datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
+  for (size_t i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
   ArgumentMap *dp = statedata;
   state._vars = dp;
   dp += numLocals;

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1084,10 +1084,15 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   StateInfo state;
 
   int64_t datacount = (int64_t)(numblocks + 1) * (stkSize + numLocals);
+  // bail out conservatively on overflow
+  if ((uint64_t)datacount > SIZE_MAX / sizeof(ArgumentMap)) {
+    _conservative = true;
+    return;
+  }
   size_t datasize = (size_t)datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);
-  for (int64_t i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
+  for (size_t i = 0; i < (size_t)datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
   ArgumentMap *dp = statedata;
   state._vars = dp;
   dp += numLocals;

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1078,14 +1078,14 @@ void BCEscapeAnalyzer::merge_block_states(StateInfo *blockstates, ciBlock *dest,
 }
 
 void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
-  int numblocks = _methodBlocks->num_blocks();
-  int stkSize   = _method->max_stack();
-  int numLocals = _method->max_locals();
+  uint numblocks = checked_cast<uint>(_methodBlocks->num_blocks());
+  uint stkSize   = checked_cast<uint>(_method->max_stack());
+  uint numLocals = checked_cast<uint>(_method->max_locals());
   StateInfo state;
 
-  int64_t datacount = (int64_t)(numblocks + 1) * (stkSize + numLocals);
+  uint64_t datacount = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
   // bail out conservatively on overflow
-  if ((uint64_t)datacount > SIZE_MAX / sizeof(ArgumentMap)) {
+  if (datacount > SIZE_MAX / sizeof(ArgumentMap)) {
     _conservative = true;
     return;
   }
@@ -1100,7 +1100,7 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   dp += stkSize;
   state._initialized = false;
   state._max_stack = stkSize;
-  for (int i = 0; i < numblocks; i++) {
+  for (uint i = 0; i < numblocks; i++) {
     blockstates[i]._vars = dp;
     dp += numLocals;
     blockstates[i]._stack = dp;
@@ -1175,7 +1175,7 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
       DEBUG_ONLY(int handler_count = 0;)
       int blk_start = blk->start_bci();
       int blk_end = blk->limit_bci();
-      for (int i = 0; i < numblocks; i++) {
+      for (uint i = 0; i < numblocks; i++) {
         ciBlock *b = _methodBlocks->block(i);
         if (b->is_handler()) {
           int ex_start = b->ex_start_bci();

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1077,18 +1077,22 @@ void BCEscapeAnalyzer::merge_block_states(StateInfo *blockstates, ciBlock *dest,
   }
 }
 
+bool BCEscapeAnalyzer::datacount_overflow(uint numblocks, uint stkSize, uint numLocals) {
+  uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
+  return datacount64 > SIZE_MAX / sizeof(ArgumentMap);
+}
+
 void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   uint numblocks = _methodBlocks->num_blocks();
   uint stkSize   = _method->max_stack();
   uint numLocals = _method->max_locals();
   StateInfo state;
 
-  uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
-  // bail out conservatively on overflow
-  if (datacount64 > SIZE_MAX / sizeof(ArgumentMap)) {
+  if (datacount_overflow(numblocks, stkSize, numLocals)) {
     _conservative = true;
     return;
   }
+  uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
   size_t datacount = (size_t)datacount64;
   size_t datasize = datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1077,9 +1077,15 @@ void BCEscapeAnalyzer::merge_block_states(StateInfo *blockstates, ciBlock *dest,
   }
 }
 
-bool BCEscapeAnalyzer::datacount_overflow(uint numblocks, uint stkSize, uint numLocals) {
+bool BCEscapeAnalyzer::datacount_overflow(uint numblocks, uint stkSize, uint numLocals, size_t* datacount) {
   uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
-  return datacount64 > SIZE_MAX / sizeof(ArgumentMap);
+  if (datacount64 > SIZE_MAX / sizeof(ArgumentMap)) {
+    return true;
+  }
+  if (datacount != nullptr) {
+    *datacount = (size_t)datacount64;
+  }
+  return false;
 }
 
 void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
@@ -1088,12 +1094,11 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   uint numLocals = _method->max_locals();
   StateInfo state;
 
-  if (datacount_overflow(numblocks, stkSize, numLocals)) {
+  size_t datacount;
+  if (datacount_overflow(numblocks, stkSize, numLocals, &datacount)) {
     _conservative = true;
     return;
   }
-  uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
-  size_t datacount = (size_t)datacount64;
   size_t datasize = datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1077,14 +1077,12 @@ void BCEscapeAnalyzer::merge_block_states(StateInfo *blockstates, ciBlock *dest,
   }
 }
 
-bool BCEscapeAnalyzer::datacount_overflow(uint numblocks, uint stkSize, uint numLocals, size_t* datacount) {
+bool BCEscapeAnalyzer::datasize_overflow(uint numblocks, uint stkSize, uint numLocals, size_t& datasize) {
   uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
   if (datacount64 > SIZE_MAX / sizeof(ArgumentMap)) {
     return true;
   }
-  if (datacount != nullptr) {
-    *datacount = (size_t)datacount64;
-  }
+  datasize = (size_t)datacount64 * sizeof(ArgumentMap);
   return false;
 }
 
@@ -1094,12 +1092,12 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   uint numLocals = _method->max_locals();
   StateInfo state;
 
-  size_t datacount;
-  if (datacount_overflow(numblocks, stkSize, numLocals, &datacount)) {
+  size_t datasize;
+  if (datasize_overflow(numblocks, stkSize, numLocals, datasize)) {
     _conservative = true;
     return;
   }
-  size_t datasize = datacount * sizeof(ArgumentMap);
+  size_t datacount = datasize / sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);
   for (size_t i = 0; i < datacount; i++) {

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1078,9 +1078,9 @@ void BCEscapeAnalyzer::merge_block_states(StateInfo *blockstates, ciBlock *dest,
 }
 
 void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
-  uint numblocks = checked_cast<uint>(_methodBlocks->num_blocks());
-  uint stkSize   = checked_cast<uint>(_method->max_stack());
-  uint numLocals = checked_cast<uint>(_method->max_locals());
+  uint numblocks = _methodBlocks->num_blocks();
+  uint stkSize   = _method->max_stack();
+  uint numLocals = _method->max_locals();
   StateInfo state;
 
   uint64_t datacount64 = (uint64_t)(numblocks + 1) * (stkSize + numLocals);
@@ -1093,7 +1093,9 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
   size_t datasize = datacount * sizeof(ArgumentMap);
   StateInfo *blockstates = (StateInfo *) arena->Amalloc(numblocks * sizeof(StateInfo));
   ArgumentMap *statedata  = (ArgumentMap *) arena->Amalloc(datasize);
-  for (size_t i = 0; i < datacount; i++) ::new ((void*)&statedata[i]) ArgumentMap();
+  for (size_t i = 0; i < datacount; i++) {
+    ::new ((void*)&statedata[i]) ArgumentMap();
+  }
   ArgumentMap *dp = statedata;
   state._vars = dp;
   dp += numLocals;

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1150,7 +1150,7 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
     if (blk->is_handler() || blk->is_ret_target()) {
       // for an exception handler or a target of a ret instruction, we assume the worst case,
       // that any variable could contain any argument
-      for (int i = 0; i < numLocals; i++) {
+      for (uint i = 0; i < numLocals; i++) {
         state._vars[i] = allVars;
       }
       if (blk->is_handler()) {
@@ -1163,7 +1163,7 @@ void BCEscapeAnalyzer::iterate_blocks(Arena *arena) {
         state._stack[i] = allVars;
       }
     } else {
-      for (int i = 0; i < numLocals; i++) {
+      for (uint i = 0; i < numLocals; i++) {
         state._vars[i] = blkState->_vars[i];
       }
       for (int i = 0; i < blkState->_stack_height; i++) {

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -34,6 +34,7 @@
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/integerCast.hpp"
 
 #ifndef PRODUCT
   #define TRACE_BCEA(level, code)                                            \
@@ -1082,7 +1083,7 @@ bool BCEscapeAnalyzer::datasize_overflow(uint numblocks, uint stkSize, uint numL
   if (datacount64 > SIZE_MAX / sizeof(ArgumentMap)) {
     return true;
   }
-  datasize = (size_t)datacount64 * sizeof(ArgumentMap);
+  datasize = integer_cast_permit_tautology<size_t>(datacount64 * sizeof(ArgumentMap));
   return false;
 }
 

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -152,6 +152,11 @@ class BCEscapeAnalyzer : public ArenaObj {
   // Copy dependencies from this analysis into "deps"
   void copy_dependencies(Dependencies *deps);
 
+  // Returns true if the datacount computation for iterate_blocks would
+  // overflow, i.e. the allocation size exceeds what can be represented.
+  // Extracted as a public static method for testability (JDK-8216486).
+  static bool datacount_overflow(uint numblocks, uint stkSize, uint numLocals);
+
 #ifndef PRODUCT
   // dump escape information
   void dump();

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -155,7 +155,7 @@ class BCEscapeAnalyzer : public ArenaObj {
   // Returns true if the datacount computation for iterate_blocks would
   // overflow, i.e. the allocation size exceeds what can be represented.
   // Extracted as a public static method for testability (JDK-8216486).
-  static bool datacount_overflow(uint numblocks, uint stkSize, uint numLocals);
+  static bool datacount_overflow(uint numblocks, uint stkSize, uint numLocals, size_t* datacount = nullptr);
 
 #ifndef PRODUCT
   // dump escape information

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -152,10 +152,11 @@ class BCEscapeAnalyzer : public ArenaObj {
   // Copy dependencies from this analysis into "deps"
   void copy_dependencies(Dependencies *deps);
 
-  // Returns true if the datacount computation for iterate_blocks would
+  // Returns true if the datasize computation for iterate_blocks would
   // overflow, i.e. the allocation size exceeds what can be represented.
+  // On success, sets datasize to the computed allocation size in bytes.
   // Extracted as a public static method for testability (JDK-8216486).
-  static bool datacount_overflow(uint numblocks, uint stkSize, uint numLocals, size_t* datacount = nullptr);
+  static bool datasize_overflow(uint numblocks, uint stkSize, uint numLocals, size_t& datasize);
 
 #ifndef PRODUCT
   // dump escape information

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -76,8 +76,8 @@ class ciMethod : public ciMetadata {
 
   // Code attributes.
   int _code_size;
-  int _max_stack;
-  int _max_locals;
+  u2 _max_stack;
+  u2 _max_locals;
   vmIntrinsicID _intrinsic_id;
   int _handler_count;
   int _interpreter_invocation_count;
@@ -182,8 +182,8 @@ class ciMethod : public ciMetadata {
   // Method code and related information.
   address code()                                 { if (_code == nullptr) load_code(); return _code; }
   int code_size() const                          { check_is_loaded(); return _code_size; }
-  int max_stack() const                          { check_is_loaded(); return _max_stack; }
-  int max_locals() const                         { check_is_loaded(); return _max_locals; }
+  u2 max_stack() const                           { check_is_loaded(); return _max_stack; }
+  u2 max_locals() const                          { check_is_loaded(); return _max_locals; }
   vmIntrinsicID intrinsic_id() const             { check_is_loaded(); return _intrinsic_id; }
   bool has_exception_handlers() const            { check_is_loaded(); return _handler_count > 0; }
   int exception_table_length() const             { check_is_loaded(); return _handler_count; }

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -182,8 +182,8 @@ class ciMethod : public ciMetadata {
   // Method code and related information.
   address code()                                 { if (_code == nullptr) load_code(); return _code; }
   int code_size() const                          { check_is_loaded(); return _code_size; }
-  uint max_stack() const                          { check_is_loaded(); return _max_stack; }
-  u2 max_locals() const                          { check_is_loaded(); return _max_locals; }
+  int max_stack() const                           { check_is_loaded(); return _max_stack; }
+  int max_locals() const                         { check_is_loaded(); return _max_locals; }
   vmIntrinsicID intrinsic_id() const             { check_is_loaded(); return _intrinsic_id; }
   bool has_exception_handlers() const            { check_is_loaded(); return _handler_count > 0; }
   int exception_table_length() const             { check_is_loaded(); return _handler_count; }

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -182,7 +182,7 @@ class ciMethod : public ciMetadata {
   // Method code and related information.
   address code()                                 { if (_code == nullptr) load_code(); return _code; }
   int code_size() const                          { check_is_loaded(); return _code_size; }
-  int max_stack() const                           { check_is_loaded(); return _max_stack; }
+  int max_stack() const                          { check_is_loaded(); return _max_stack; }
   int max_locals() const                         { check_is_loaded(); return _max_locals; }
   vmIntrinsicID intrinsic_id() const             { check_is_loaded(); return _intrinsic_id; }
   bool has_exception_handlers() const            { check_is_loaded(); return _handler_count > 0; }

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -76,7 +76,7 @@ class ciMethod : public ciMetadata {
 
   // Code attributes.
   int _code_size;
-  u2 _max_stack;
+  uint _max_stack;
   u2 _max_locals;
   vmIntrinsicID _intrinsic_id;
   int _handler_count;
@@ -182,7 +182,7 @@ class ciMethod : public ciMetadata {
   // Method code and related information.
   address code()                                 { if (_code == nullptr) load_code(); return _code; }
   int code_size() const                          { check_is_loaded(); return _code_size; }
-  u2 max_stack() const                           { check_is_loaded(); return _max_stack; }
+  uint max_stack() const                          { check_is_loaded(); return _max_stack; }
   u2 max_locals() const                          { check_is_loaded(); return _max_locals; }
   vmIntrinsicID intrinsic_id() const             { check_is_loaded(); return _intrinsic_id; }
   bool has_exception_handlers() const            { check_is_loaded(); return _handler_count > 0; }

--- a/src/hotspot/share/ci/ciMethodBlocks.hpp
+++ b/src/hotspot/share/ci/ciMethodBlocks.hpp
@@ -38,7 +38,7 @@ private:
   Arena *_arena;
   GrowableArray<ciBlock *>  *_blocks;
   ciBlock  **_bci_to_block;
-  int _num_blocks;
+  u2 _num_blocks;
   int _code_size;
 
   void do_analysis();
@@ -50,7 +50,7 @@ public:
   ciBlock *make_block_at(int bci);
   ciBlock *split_block_at(int bci);
   bool is_block_start(int bci);
-  int num_blocks()  { return _num_blocks;}
+  u2 num_blocks()   { return _num_blocks;}
   void clear_processed();
 
   ciBlock *make_dummy_block(); // a block not associated with a bci

--- a/src/hotspot/share/ci/ciMethodBlocks.hpp
+++ b/src/hotspot/share/ci/ciMethodBlocks.hpp
@@ -50,7 +50,7 @@ public:
   ciBlock *make_block_at(int bci);
   ciBlock *split_block_at(int bci);
   bool is_block_start(int bci);
-  u2 num_blocks()   { return _num_blocks;}
+  int num_blocks()  { return _num_blocks;}
   void clear_processed();
 
   ciBlock *make_dummy_block(); // a block not associated with a bci

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java
@@ -38,20 +38,26 @@
 
 package compiler.escapeAnalysis;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.Label;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.nio.charset.StandardCharsets;
 
 public class TestBCEscapeAnalyzerOverflow {
 
     // Number of goto instructions in the generated method.
-    // Creates NUM_GOTOS + 1 basic blocks. With max_stack=0xFFFF and
-    // max_locals=0xFFFF the product (numblocks+1)*(max_stack+max_locals)
+    // Creates NUM_GOTOS + 1 basic blocks.  With max_stack = 0xFFFF and
+    // max_locals = 0xFFFF the product (numblocks+1)*(max_stack+max_locals)
     // is 16386 * 131070 = 2,147,713,020 which exceeds Integer.MAX_VALUE.
     static final int NUM_GOTOS = 16384;
+    static final int TARGET_MAX_STACK = 0xFFFF;
+    static final int TARGET_MAX_LOCALS = 0xFFFF;
+
+    static final ClassDesc CD_HELPER =
+        ClassDesc.of("compiler.escapeAnalysis.BCEscapeOverflowHelper");
 
     public static void main(String[] args) throws Throwable {
         byte[] classBytes = buildClass();
@@ -68,103 +74,87 @@ public class TestBCEscapeAnalyzerOverflow {
         mh.invoke();
     }
 
-    // Builds a minimal class (version 50, no StackMapTable needed) with:
-    //   public static void bigMethod(Object o)  -- pathological method
-    //   public static void caller()              -- calls bigMethod
-    static byte[] buildClass() throws IOException {
-        int bigCodeLength = 2 + NUM_GOTOS * 3 + 1;
+    /**
+     * Builds a minimal class (version 50, no StackMapTable needed) with:
+     *   public static void bigMethod(Object o)  -- pathological method
+     *   public static void caller()              -- calls bigMethod
+     *
+     * The ClassFile API generates the bytecode; max_stack and max_locals
+     * of bigMethod are then patched to the target overflow-triggering values.
+     */
+    static byte[] buildClass() {
+        var mtd_Obj_void = MethodTypeDesc.of(ConstantDescs.CD_void,
+                                             ConstantDescs.CD_Object);
+        var mtd_void = MethodTypeDesc.of(ConstantDescs.CD_void);
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
+        byte[] bytes = ClassFile.of(ClassFile.StackMapsOption.DROP_STACK_MAPS)
+            .build(CD_HELPER, cb -> {
+                cb.withVersion(50, 0);
+                cb.withFlags(ClassFile.ACC_PUBLIC | ClassFile.ACC_SUPER);
 
-        // ---- header ----
-        dos.writeInt(0xCAFEBABE);
-        dos.writeShort(0);       // minor version
-        dos.writeShort(50);      // major version (Java 6)
+                // bigMethod(Object o): aload_0, pop, <goto chain>, return
+                cb.withMethod("bigMethod", mtd_Obj_void,
+                    ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC,
+                    mb -> mb.withCode(code -> {
+                        code.aload(0);
+                        code.pop();
+                        for (int i = 0; i < NUM_GOTOS; i++) {
+                            Label next = code.newLabel();
+                            code.goto_(next);
+                            code.labelBinding(next);
+                        }
+                        code.return_();
+                    }));
 
-        // ---- constant pool (14 entries, count = 15) ----
-        dos.writeShort(15);
-        writeUtf8(dos, "compiler/escapeAnalysis/BCEscapeOverflowHelper"); // #1
-        writeUtf8(dos, "java/lang/Object");            // #2
-        writeUtf8(dos, "bigMethod");                   // #3
-        writeUtf8(dos, "(Ljava/lang/Object;)V");       // #4
-        writeUtf8(dos, "Code");                        // #5
-        writeUtf8(dos, "caller");                      // #6
-        writeUtf8(dos, "()V");                         // #7
-        writeUtf8(dos, "<init>");                      // #8
-        dos.writeByte(7);  dos.writeShort(1);          // #9  Class -> #1
-        dos.writeByte(7);  dos.writeShort(2);          // #10 Class -> #2
-        dos.writeByte(12); dos.writeShort(8);          // #11 NameAndType <init>:()V
-                           dos.writeShort(7);
-        dos.writeByte(10); dos.writeShort(10);         // #12 MethodRef Object.<init>
-                           dos.writeShort(11);
-        dos.writeByte(12); dos.writeShort(3);          // #13 NameAndType bigMethod:(L..;)V
-                           dos.writeShort(4);
-        dos.writeByte(10); dos.writeShort(9);          // #14 MethodRef this.bigMethod
-                           dos.writeShort(13);
+                // caller(): new Object → dup → invokespecial <init> →
+                //           invokestatic bigMethod → return
+                cb.withMethod("caller", mtd_void,
+                    ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC,
+                    mb -> mb.withCode(code -> {
+                        code.new_(ConstantDescs.CD_Object);
+                        code.dup();
+                        code.invokespecial(ConstantDescs.CD_Object,
+                            "<init>", mtd_void);
+                        code.invokestatic(CD_HELPER,
+                            "bigMethod", mtd_Obj_void);
+                        code.return_();
+                    }));
+            });
 
-        // ---- class header ----
-        dos.writeShort(0x0021);  // ACC_PUBLIC | ACC_SUPER
-        dos.writeShort(9);       // this_class
-        dos.writeShort(10);      // super_class
-        dos.writeShort(0);       // interfaces_count
-        dos.writeShort(0);       // fields_count
-
-        // ---- methods (2) ----
-        dos.writeShort(2);
-
-        // -- Method 1: public static void bigMethod(Object o) --
-        dos.writeShort(0x0009);              // ACC_PUBLIC | ACC_STATIC
-        dos.writeShort(3);                   // name -> "bigMethod"
-        dos.writeShort(4);                   // descriptor
-        dos.writeShort(1);                   // attributes_count
-        dos.writeShort(5);                   // Code attribute name
-        dos.writeInt(12 + bigCodeLength);    // attribute_length
-        dos.writeShort(0xFFFF);              // max_stack  = 65535
-        dos.writeShort(0xFFFF);              // max_locals = 65535
-        dos.writeInt(bigCodeLength);         // code_length
-        // bytecode: aload_0, pop, goto chain, return
-        dos.writeByte(0x2A);                 // aload_0
-        dos.writeByte(0x57);                 // pop
-        for (int i = 0; i < NUM_GOTOS; i++) {
-            dos.writeByte(0xA7);             // goto
-            dos.writeShort(3);               // offset +3 (next instruction)
-        }
-        dos.writeByte(0xB1);                 // return
-        dos.writeShort(0);                   // exception_table_length
-        dos.writeShort(0);                   // code attributes_count
-
-        // -- Method 2: public static void caller() --
-        //    new Object, dup, invokespecial <init>, invokestatic bigMethod, return
-        int callerCodeLength = 11;
-        dos.writeShort(0x0009);              // ACC_PUBLIC | ACC_STATIC
-        dos.writeShort(6);                   // name -> "caller"
-        dos.writeShort(7);                   // descriptor -> "()V"
-        dos.writeShort(1);                   // attributes_count
-        dos.writeShort(5);                   // Code attribute name
-        dos.writeInt(12 + callerCodeLength); // attribute_length
-        dos.writeShort(2);                   // max_stack
-        dos.writeShort(1);                   // max_locals
-        dos.writeInt(callerCodeLength);      // code_length
-        dos.writeByte(0xBB); dos.writeShort(10);   // new #10 (Object)
-        dos.writeByte(0x59);                       // dup
-        dos.writeByte(0xB7); dos.writeShort(12);   // invokespecial #12
-        dos.writeByte(0xB8); dos.writeShort(14);   // invokestatic #14
-        dos.writeByte(0xB1);                       // return
-        dos.writeShort(0);                   // exception_table_length
-        dos.writeShort(0);                   // code attributes_count
-
-        // ---- class attributes ----
-        dos.writeShort(0);
-
-        dos.flush();
-        return baos.toByteArray();
+        patchBigMethodMaxes(bytes);
+        return bytes;
     }
 
-    static void writeUtf8(DataOutputStream dos, String s) throws IOException {
-        dos.writeByte(1);
-        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
-        dos.writeShort(bytes.length);
-        dos.write(bytes);
+    /**
+     * Locates bigMethod's Code attribute and patches max_stack/max_locals
+     * to TARGET_MAX_STACK/TARGET_MAX_LOCALS.  The ClassFile API computes
+     * small values (max_stack=1, max_locals=1); we inflate them to create
+     * the pathological overflow case.
+     *
+     * The Code attribute layout is:
+     *   attribute_name_index(u2), attribute_length(u4),
+     *   max_stack(u2), max_locals(u2), code_length(u4), code[...]...
+     *
+     * We search for bigMethod's unique code_length and patch the two u2
+     * fields immediately before it.
+     */
+    static void patchBigMethodMaxes(byte[] b) {
+        int expectedCodeLen = NUM_GOTOS * 3 + 3;
+        for (int i = 4; i <= b.length - 4; i++) {
+            int codeLen = ((b[i] & 0xFF) << 24) | ((b[i + 1] & 0xFF) << 16)
+                        | ((b[i + 2] & 0xFF) << 8) | (b[i + 3] & 0xFF);
+            if (codeLen == expectedCodeLen) {
+                int ms = ((b[i - 4] & 0xFF) << 8) | (b[i - 3] & 0xFF);
+                int ml = ((b[i - 2] & 0xFF) << 8) | (b[i - 1] & 0xFF);
+                if (ms <= 2 && ml <= 2) {
+                    b[i - 4] = (byte)(TARGET_MAX_STACK >>> 8);
+                    b[i - 3] = (byte)(TARGET_MAX_STACK);
+                    b[i - 2] = (byte)(TARGET_MAX_LOCALS >>> 8);
+                    b[i - 1] = (byte)(TARGET_MAX_LOCALS);
+                    return;
+                }
+            }
+        }
+        throw new RuntimeException("Could not find bigMethod Code attribute");
     }
 }

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8216486
+ * @summary Verify BCEscapeAnalyzer handles methods where
+ *          (numblocks+1)*(max_stack+max_locals) overflows a 32-bit int.
+ *          On a UBSAN build the signed overflow would be caught as UB;
+ *          on a normal build the test verifies no crash from the bogus
+ *          allocation size that resulted from the overflow.
+ *
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      compiler.escapeAnalysis.TestBCEscapeAnalyzerOverflow
+ */
+
+package compiler.escapeAnalysis;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.charset.StandardCharsets;
+
+public class TestBCEscapeAnalyzerOverflow {
+
+    // Number of goto instructions in the generated method.
+    // Creates NUM_GOTOS + 1 basic blocks. With max_stack=0xFFFF and
+    // max_locals=0xFFFF the product (numblocks+1)*(max_stack+max_locals)
+    // is 16386 * 131070 = 2,147,713,020 which exceeds Integer.MAX_VALUE.
+    static final int NUM_GOTOS = 16384;
+
+    public static void main(String[] args) throws Throwable {
+        byte[] classBytes = buildClass();
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Class<?> cls = lookup.defineClass(classBytes);
+
+        // caller() allocates an Object and passes it to bigMethod() via
+        // invokestatic.  Under -Xcomp -XX:-TieredCompilation, C2 compiles
+        // caller() and invokes BCEscapeAnalyzer on bigMethod to determine
+        // whether the argument escapes.  Without the fix the 32-bit
+        // overflow in iterate_blocks leads to undefined behavior.
+        var mh = lookup.findStatic(cls, "caller",
+                     MethodType.methodType(void.class));
+        mh.invoke();
+    }
+
+    // Builds a minimal class (version 50, no StackMapTable needed) with:
+    //   public static void bigMethod(Object o)  -- pathological method
+    //   public static void caller()              -- calls bigMethod
+    static byte[] buildClass() throws IOException {
+        int bigCodeLength = 2 + NUM_GOTOS * 3 + 1;
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+
+        // ---- header ----
+        dos.writeInt(0xCAFEBABE);
+        dos.writeShort(0);       // minor version
+        dos.writeShort(50);      // major version (Java 6)
+
+        // ---- constant pool (14 entries, count = 15) ----
+        dos.writeShort(15);
+        writeUtf8(dos, "compiler/escapeAnalysis/BCEscapeOverflowHelper"); // #1
+        writeUtf8(dos, "java/lang/Object");            // #2
+        writeUtf8(dos, "bigMethod");                   // #3
+        writeUtf8(dos, "(Ljava/lang/Object;)V");       // #4
+        writeUtf8(dos, "Code");                        // #5
+        writeUtf8(dos, "caller");                      // #6
+        writeUtf8(dos, "()V");                         // #7
+        writeUtf8(dos, "<init>");                      // #8
+        dos.writeByte(7);  dos.writeShort(1);          // #9  Class -> #1
+        dos.writeByte(7);  dos.writeShort(2);          // #10 Class -> #2
+        dos.writeByte(12); dos.writeShort(8);          // #11 NameAndType <init>:()V
+                           dos.writeShort(7);
+        dos.writeByte(10); dos.writeShort(10);         // #12 MethodRef Object.<init>
+                           dos.writeShort(11);
+        dos.writeByte(12); dos.writeShort(3);          // #13 NameAndType bigMethod:(L..;)V
+                           dos.writeShort(4);
+        dos.writeByte(10); dos.writeShort(9);          // #14 MethodRef this.bigMethod
+                           dos.writeShort(13);
+
+        // ---- class header ----
+        dos.writeShort(0x0021);  // ACC_PUBLIC | ACC_SUPER
+        dos.writeShort(9);       // this_class
+        dos.writeShort(10);      // super_class
+        dos.writeShort(0);       // interfaces_count
+        dos.writeShort(0);       // fields_count
+
+        // ---- methods (2) ----
+        dos.writeShort(2);
+
+        // -- Method 1: public static void bigMethod(Object o) --
+        dos.writeShort(0x0009);              // ACC_PUBLIC | ACC_STATIC
+        dos.writeShort(3);                   // name -> "bigMethod"
+        dos.writeShort(4);                   // descriptor
+        dos.writeShort(1);                   // attributes_count
+        dos.writeShort(5);                   // Code attribute name
+        dos.writeInt(12 + bigCodeLength);    // attribute_length
+        dos.writeShort(0xFFFF);              // max_stack  = 65535
+        dos.writeShort(0xFFFF);              // max_locals = 65535
+        dos.writeInt(bigCodeLength);         // code_length
+        // bytecode: aload_0, pop, goto chain, return
+        dos.writeByte(0x2A);                 // aload_0
+        dos.writeByte(0x57);                 // pop
+        for (int i = 0; i < NUM_GOTOS; i++) {
+            dos.writeByte(0xA7);             // goto
+            dos.writeShort(3);               // offset +3 (next instruction)
+        }
+        dos.writeByte(0xB1);                 // return
+        dos.writeShort(0);                   // exception_table_length
+        dos.writeShort(0);                   // code attributes_count
+
+        // -- Method 2: public static void caller() --
+        //    new Object, dup, invokespecial <init>, invokestatic bigMethod, return
+        int callerCodeLength = 11;
+        dos.writeShort(0x0009);              // ACC_PUBLIC | ACC_STATIC
+        dos.writeShort(6);                   // name -> "caller"
+        dos.writeShort(7);                   // descriptor -> "()V"
+        dos.writeShort(1);                   // attributes_count
+        dos.writeShort(5);                   // Code attribute name
+        dos.writeInt(12 + callerCodeLength); // attribute_length
+        dos.writeShort(2);                   // max_stack
+        dos.writeShort(1);                   // max_locals
+        dos.writeInt(callerCodeLength);      // code_length
+        dos.writeByte(0xBB); dos.writeShort(10);   // new #10 (Object)
+        dos.writeByte(0x59);                       // dup
+        dos.writeByte(0xB7); dos.writeShort(12);   // invokespecial #12
+        dos.writeByte(0xB8); dos.writeShort(14);   // invokestatic #14
+        dos.writeByte(0xB1);                       // return
+        dos.writeShort(0);                   // exception_table_length
+        dos.writeShort(0);                   // code attributes_count
+
+        // ---- class attributes ----
+        dos.writeShort(0);
+
+        dos.flush();
+        return baos.toByteArray();
+    }
+
+    static void writeUtf8(DataOutputStream dos, String s) throws IOException {
+        dos.writeByte(1);
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        dos.writeShort(bytes.length);
+        dos.write(bytes);
+    }
+}


### PR DESCRIPTION
Use size_t for datacount and datasize to prevent integer overflow when numblocks, stkSize and numLocals are large. The product (numblocks + 1) * (stkSize + numLocals) can exceed INT_MAX with max classfile values (65535 each).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379816](https://bugs.openjdk.org/browse/JDK-8379816): C2: Possible integer overflow in BCEscapeAnalyzer::iterate_blocks (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29812/head:pull/29812` \
`$ git checkout pull/29812`

Update a local copy of the PR: \
`$ git checkout pull/29812` \
`$ git pull https://git.openjdk.org/jdk.git pull/29812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29812`

View PR using the GUI difftool: \
`$ git pr show -t 29812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29812.diff">https://git.openjdk.org/jdk/pull/29812.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29812#issuecomment-3989923195)
</details>
