### PR TITLE
8376300: Avoid more leaks in KeystoreImpl.m because of missing CFRelease calls

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -328,10 +328,12 @@ static void addIdentitiesToKeystore(JNIEnv *env, jobject keyStore, jmethodID jm_
             for (i = 0; i < certCount; i++) {
                 CSSM_DATA currCertData;
 
-                if (i == 0)
+                if (i == 0) {
                     currCertRef = certificate;
-                else
+                } else {
                     currCertRef = (SecCertificateRef)CFArrayGetValueAtIndex(certChain, i);
+                    CFRetain(currCertRef);
+                }
 
                 bzero(&currCertData, sizeof(CSSM_DATA));
                 err = SecCertificateGetData(currCertRef, &currCertData);


### PR DESCRIPTION
Seems there is a call to  SecIdentityCopyPrivateKey where we miss calling CFRelease in early returns/failure cases; same for SecIdentityCopyPrivateKey .

See the Apple documentation
https://developer.apple.com/documentation/security/secidentitycopyprivatekey(_:_:)

Also for https://developer.apple.com/documentation/security/secidentitycopycertificate(_:_:)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376300](https://bugs.openjdk.org/browse/JDK-8376300): Avoid more leaks in KeystoreImpl.m because of missing CFRelease calls (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [5d5216be](https://git.openjdk.org/jdk/pull/29821/files/5d5216beaefa5d350e68ad8725245c039ca9b1da)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29821/head:pull/29821` \
`$ git checkout pull/29821`

Update a local copy of the PR: \
`$ git checkout pull/29821` \
`$ git pull https://git.openjdk.org/jdk.git pull/29821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29821`

View PR using the GUI difftool: \
`$ git pr show -t 29821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29821.diff">https://git.openjdk.org/jdk/pull/29821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29821#issuecomment-3928403727)
</details>
