### PR TITLE
8376104: C2 crashes in PhiNode::Ideal(PhaseGVN*, bool) accessing NULL pointer

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2675,6 +2675,10 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     for( uint i=1; i<req(); ++i ) {// For all paths in
       Node *ii = in(i);
       Node *new_in = MemNode::optimize_memory_chain(ii, at, nullptr, phase);
+      // MemNode::optimize_memory_chain above may kill us!
+      if (outcnt() == 0) {
+        return top;
+      }
       if (ii != new_in ) {
         set_req_X(i, new_in, phase);
         progress = this;


### PR DESCRIPTION
### Issue Summary

The call to `MemNode::optimize_memory_chain` within `PhiNode::Ideal` can kill the Phi node itself. We do not currently handle such a situation and instead simply return `this`, which is now a dead node. Returning dead nodes from `Ideal` is prohibited, eventually causing a nullptr dereference in a subsequent call to `PhiNode::Ideal`.

### Changeset

- Check if the current Phi node is dead  after `MemNode::optimize_memory_chain` in `PhiNode::Ideal`, and, if so, return top. There is precedent for doing it in this way in `PhiNode::Ideal` already.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/21880656905)
- `tier1` to `tier4` (and additional Oracle-internal testing) on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376104](https://bugs.openjdk.org/browse/JDK-8376104): C2 crashes in PhiNode::Ideal(PhaseGVN*, bool) accessing NULL pointer (**Bug** - P3)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Contributors
 * Roman Marchenko `<rmarchenko@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29846/head:pull/29846` \
`$ git checkout pull/29846`

Update a local copy of the PR: \
`$ git checkout pull/29846` \
`$ git pull https://git.openjdk.org/jdk.git pull/29846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29846`

View PR using the GUI difftool: \
`$ git pr show -t 29846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29846.diff">https://git.openjdk.org/jdk/pull/29846.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29846#issuecomment-3934780990)
</details>
