### PR TITLE
Bugfix/compile gcc6

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2014,7 +2014,7 @@ void MacroAssembler::clinit_barrier(Register klass, Register scratch, Label* L_f
   // Fast path check: class is fully initialized
   lea(scratch, Address(klass, InstanceKlass::init_state_offset()));
   ldarb(scratch, scratch);
-  cmp(scratch, InstanceKlass::fully_initialized);
+  cmp(scratch, (unsigned char)InstanceKlass::fully_initialized);
   br(Assembler::EQ, *L_fast_path);
 
   // Fast path check: current thread is initializer thread

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -90,7 +90,7 @@ public:
     return array_idx;
   }
 
-  inline constexpr idx_t alignment() const {
+  inline idx_t alignment() const {
     return BitsPerWord;
   }
 


### PR DESCRIPTION
This to support GCC6, this is the oldest tool-chain which is actively tested in Buildroot, and also the reason for this fix. See https://github.com/buildroot/buildroot/commit/85d47bbc40bb9b62d2b59b6f5653f6e69c494372.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29856/head:pull/29856` \
`$ git checkout pull/29856`

Update a local copy of the PR: \
`$ git checkout pull/29856` \
`$ git pull https://git.openjdk.org/jdk.git pull/29856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29856`

View PR using the GUI difftool: \
`$ git pr show -t 29856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29856.diff">https://git.openjdk.org/jdk/pull/29856.diff</a>

</details>
