### PR TITLE
8371260: Improve scaling of downcalls using MemorySegments allocated with shared arenas, take 2

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
@@ -39,7 +39,8 @@ import java.lang.invoke.VarHandle;
  */
 final class ConfinedSession extends MemorySessionImpl {
 
-    private int asyncReleaseCount = 0;
+    private int acquireCount;
+    private int asyncReleaseCount;
 
     static final VarHandle ASYNC_RELEASE_COUNT= MhUtil.findVarHandle(MethodHandles.lookup(), "asyncReleaseCount", int.class);
 

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -68,7 +68,6 @@ public abstract sealed class MemorySessionImpl
     static final int NONCLOSEABLE = 1;
 
     static final VarHandle STATE = MhUtil.findVarHandle(MethodHandles.lookup(), "state", int.class);
-    static final VarHandle ACQUIRE_COUNT = MhUtil.findVarHandle(MethodHandles.lookup(), "acquireCount", int.class);
 
     static final int MAX_FORKS = Integer.MAX_VALUE;
 
@@ -82,8 +81,6 @@ public abstract sealed class MemorySessionImpl
 
     @Stable
     int state;
-
-    int acquireCount;
 
     public ArenaImpl asArena() {
         return new ArenaImpl(this);

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -31,21 +31,43 @@ import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * A shared session, which can be shared across multiple threads. Closing a shared session has to ensure that
  * (i) only one thread can successfully close a session (e.g. in a close vs. close race) and that
  * (ii) no other thread is accessing the memory associated with this session while the segment is being
- * closed. To ensure the former condition, a CAS is performed on the liveness bit. Ensuring the latter
- * is trickier, and require a complex synchronization protocol (see {@link jdk.internal.misc.ScopedMemoryAccess}).
+ * closed.
+ * To ensure the former condition, a CAS is performed on the closingPhase from 0 to 1 to exclusively spin-lock
+ * access to the decision logic which decides whether there are live threads that have the session acquired or not, and
+ * either unlocks closingPhase back to 0 or promotes it to 2.
+ * The decision logic uses two instances of {@link LongAdder}, {@code acquireCount} and {@code releaseCount} which act as atomic
+ * counters. If the only mutating method used on {@code LongAdder} is {@link LongAdder#increment()}, then it is indistinguishable
+ * from {@link java.util.concurrent.atomic.AtomicLong} except it has practically zero contention when incrementing the value,
+ * but some overhead when reading the value depending on previously executed concurrency when incrementing.
+ * Ensuring the latter is trickier, and requires a complex synchronization protocol (see {@link jdk.internal.misc.ScopedMemoryAccess}).
  * Since it is the responsibility of the closing thread to make sure that no concurrent access is possible,
- * checking the liveness bit upon access can be performed in plain mode, as in the confined case.
+ * clever ordering of accesses to all of {@code acquireCount}, {@code releaseCount} and {@code closingPhase} makes this possible
+ * in the following way:
+ * <ul>
+ *     <li>acquire-ing thread 1st increments {@code acquireCount} then checks the {@code closingPhase}.
+ *     If closingPhase is open (0), acquire0 returns immediately (this is the fast-path). If closingPhase is undecided
+ *     (1 - maybe closing) then it spin-waits for decision. If it reverts to open (0), acquire0 returns, else it promotes to
+ *     closed (2) in which case it throws exception</li>
+ *     <li>close-ing thread 1st CAS-es {@code closingPhase} from 0 to 1 and when successful, then reads {@code releaseCount}
+ *     and then reads {@code acquireCount}. This order ensures that the difference between acquireCount and releaseCount is never
+ *     less than the number of threads that are active somewhere between the acquire0 and release0 calls. It may temporarily be more,
+ *     but that only means {@code justClose} will throw "already acquired" exception due to race with releasing thread.
+ * </ul>
  */
 sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
+    private static final VarHandle CLOSING_PHASE = MhUtil.findVarHandle(MethodHandles.lookup(), "closingPhase", int.class);
 
-    private static final int CLOSED_ACQUIRE_COUNT = -1;
+    private final LongAdder acquireCount = new LongAdder();
+    private final LongAdder releaseCount = new LongAdder();
+    private volatile int closingPhase; // 0=open, 1=maybe closing, 2=closed
 
     SharedSession() {
         super(null, new SharedResourceList());
@@ -54,39 +76,38 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
     @Override
     @ForceInline
     public void acquire0() {
-        int value;
-        do {
-            value = (int) ACQUIRE_COUNT.getVolatile(this);
-            if (value < 0) {
-                //segment is not open!
+        acquireCount.increment();
+        int cp;
+        while ((cp = closingPhase) != 0) {
+            if (cp == 2) {
+                releaseCount.increment();
                 throw sharedSessionAlreadyClosed();
-            } else if (value == MAX_FORKS) {
-                //overflow
-                throw tooManyAcquires();
             }
-        } while (!ACQUIRE_COUNT.compareAndSet(this, value, value + 1));
+            Thread.onSpinWait();
+        }
     }
 
     @Override
     @ForceInline
     public void release0() {
-        int value;
-        do {
-            value = (int) ACQUIRE_COUNT.getVolatile(this);
-            if (value <= 0) {
-                //cannot get here - we can't close segment twice
-                throw sharedSessionAlreadyClosed();
-            }
-        } while (!ACQUIRE_COUNT.compareAndSet(this, value, value - 1));
+        releaseCount.increment();
     }
 
     void justClose() {
-        int acquireCount = (int) ACQUIRE_COUNT.compareAndExchange(this, 0, CLOSED_ACQUIRE_COUNT);
-        if (acquireCount < 0) {
-            throw sharedSessionAlreadyClosed();
-        } else if (acquireCount > 0) {
-            throw alreadyAcquired(acquireCount);
+        int cp;
+        while ((cp = (int) CLOSING_PHASE.compareAndExchange(0, 1)) != 0) {
+            if (cp == 2) {
+                throw sharedSessionAlreadyClosed();
+            }
+            Thread.onSpinWait();
         }
+        // reading order is important: 1st RELEASE_COUNT, 2nd ACQUIRE_COUNT
+        long value = -releaseCount.longValue() + acquireCount.longValue();
+        if (value > 0) {
+            closingPhase = 0;
+            throw alreadyAcquired((int) value);
+        }
+        closingPhase = 2;
 
         STATE.setVolatile(this, CLOSED);
         SCOPED_MEMORY_ACCESS.closeScope(this, ALREADY_CLOSED);

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -98,16 +98,15 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
 
     void justClose() {
         int cp;
-        while ((cp = (int) CLOSING_PHASE.compareAndExchange(0, 1)) != 0) {
+        while ((cp = (int) CLOSING_PHASE.compareAndExchange(this, 0, 1)) != 0) {
             if (cp == 2) {
                 throw sharedSessionAlreadyClosed();
             }
             Thread.onSpinWait();
         }
-        // above write to closingPhase may have been reordered after below reads of releaseCount's and acquireCount's Cells if
-        // it was not for this fullFence that prevents this from happening
-        VarHandle.fullFence();
-        // reading order is important: 1st RELEASE_COUNT, 2nd ACQUIRE_COUNT
+        // Above compareAndExchange to closingPhase has the semantics of volatile read and write in one atomic instruction so
+        // it may not be reordered with the below reads of releaseCount's and acquireCount's Cells.
+        // Reading order is important: 1st releaseCount, 2nd acquireCount. This way we never underestimate the number of active acquires.
         long value = -releaseCount.longValue() + acquireCount.longValue();
         if (value > 0) {
             closingPhase = 0;

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -77,10 +77,13 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
     @ForceInline
     public void acquire0() {
         acquireCount.increment();
+        // above write to acquireCount's Cell may have been reordered after below read of closingPhase if
+        // it was not for this fullFence that prevents this from happening
+        VarHandle.fullFence();
         int cp;
         while ((cp = closingPhase) != 0) {
             if (cp == 2) {
-                releaseCount.increment();
+                releaseCount.increment(); // not required, but useful for debugging
                 throw sharedSessionAlreadyClosed();
             }
             Thread.onSpinWait();
@@ -101,6 +104,9 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
             }
             Thread.onSpinWait();
         }
+        // above write to closingPhase may have been reordered after below reads of releaseCount's and acquireCount's Cells if
+        // it was not for this fullFence that prevents this from happening
+        VarHandle.fullFence();
         // reading order is important: 1st RELEASE_COUNT, 2nd ACQUIRE_COUNT
         long value = -releaseCount.longValue() + acquireCount.longValue();
         if (value > 0) {


### PR DESCRIPTION
Hi,

When administering my mailing lists, my attention was drawn to this pull request: https://github.com/openjdk/jdk/pull/28575, which tries to tackle this scaling problem. Although it was dismissed, I remembered that I was dealing with a similar problem in the past, so I looked closely...

Here's an alternative take at the problem. It reuses a maintained public component of JDK, the LongAdder, so in this respect, it does not add complexity and maintainance burden. It also does not change the internal API of the MemorySessionImpl. The size of the patch is also smaller.

For experimenting and benchmarking, I created a separate impmenetation of just the acquire/release/close logic with existing "simple" and this new "striped" implementations here:

https://github.com/plevart/acquire-release-close

Running it on my 8 core (16 threads) Linux PC, it gives promising results without regression for single-threaded use:

```
** Simple, measure run #1...
concurrency: 1, nanos: 39909697 (x 1.0)
concurrency: 2, nanos: 164735444 (x 4.127704702944751)
concurrency: 4, nanos: 394283724 (x 9.87939657873123)
concurrency: 8, nanos: 672278915 (x 16.84500172978011)
concurrency: 16, nanos: 2169282886 (x 54.3547821473062)
** Simple, measure run #2...
concurrency: 1, nanos: 40318379 (x 1.0)
concurrency: 2, nanos: 163438657 (x 4.053701092496799)
concurrency: 4, nanos: 399382210 (x 9.905710991009832)
concurrency: 8, nanos: 694862623 (x 17.23438888750959)
concurrency: 16, nanos: 2182386494 (x 54.12882531810121)
** Simple, measure run #3...
concurrency: 1, nanos: 39871197 (x 1.0)
concurrency: 2, nanos: 168843686 (x 4.234728292707139)
concurrency: 4, nanos: 375489497 (x 9.417562683156966)
concurrency: 8, nanos: 675885694 (x 16.951728186138983)
concurrency: 16, nanos: 2083500812 (x 52.255787856080666)
** end.

** Striped, measure run #1...
concurrency: 1, nanos: 36698350 (x 1.0)
concurrency: 2, nanos: 47349695 (x 1.290240433152989)
concurrency: 4, nanos: 58622304 (x 1.5974098018030782)
concurrency: 8, nanos: 60548173 (x 1.6498881557345222)
concurrency: 16, nanos: 70607406 (x 1.9239940215295783)
** Striped, measure run #2...
concurrency: 1, nanos: 37217044 (x 1.0)
concurrency: 2, nanos: 38610020 (x 1.0374284427317764)
concurrency: 4, nanos: 39166893 (x 1.0523912914738742)
concurrency: 8, nanos: 51778829 (x 1.3912665659314587)
concurrency: 16, nanos: 70277394 (x 1.8883120862581133)
** Striped, measure run #3...
concurrency: 1, nanos: 37589735 (x 1.0)
concurrency: 2, nanos: 38748261 (x 1.0308202758013592)
concurrency: 4, nanos: 38656911 (x 1.0283900910714054)
concurrency: 8, nanos: 40530711 (x 1.0782388064188269)
concurrency: 16, nanos: 52545852 (x 1.3978776918751887)
** end.

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8371260](https://bugs.openjdk.org/browse/JDK-8371260)

### Issue
 * [JDK-8371260](https://bugs.openjdk.org/browse/JDK-8371260): Improve scaling of downcalls using MemorySegments allocated with shared arenas. (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29866/head:pull/29866` \
`$ git checkout pull/29866`

Update a local copy of the PR: \
`$ git checkout pull/29866` \
`$ git pull https://git.openjdk.org/jdk.git pull/29866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29866`

View PR using the GUI difftool: \
`$ git pr show -t 29866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29866.diff">https://git.openjdk.org/jdk/pull/29866.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29866#issuecomment-3941061069)
</details>
