### PR TITLE
8376650: os::release_memory_special may not be needed anymore

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1956,11 +1956,6 @@ char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_
   return nullptr;
 }
 
-bool os::pd_release_memory_special(char* base, size_t bytes) {
-  fatal("os::release_memory_special should not be called on AIX.");
-  return false;
-}
-
 size_t os::large_page_size() {
   return _large_page_size;
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1885,11 +1885,6 @@ char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_
   return nullptr;
 }
 
-bool os::pd_release_memory_special(char* base, size_t bytes) {
-  fatal("os::release_memory_special should not be called on BSD.");
-  return false;
-}
-
 size_t os::large_page_size() {
   return _large_page_size;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4208,12 +4208,6 @@ char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_
   return addr;
 }
 
-bool os::pd_release_memory_special(char* base, size_t bytes) {
-  assert(UseLargePages, "only for large pages");
-  // Plain munmap is sufficient
-  return pd_release_memory(base, bytes);
-}
-
 size_t os::large_page_size() {
   return _large_page_size;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3517,11 +3517,6 @@ char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_
   return reserve_large_pages(bytes, addr, exec);
 }
 
-bool os::pd_release_memory_special(char* base, size_t bytes) {
-  assert(base != nullptr, "Sanity check");
-  return pd_release_memory(base, bytes);
-}
-
 static void warn_fail_commit_memory(char* addr, size_t bytes, bool exec) {
   int err = os::get_last_error();
   char buf[256];

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,12 +231,7 @@ ReservedSpace MemoryReserver::reserve(size_t size,
 
 void MemoryReserver::release(const ReservedSpace& reserved) {
   assert(reserved.is_reserved(), "Precondition");
-
-  if (reserved.special()) {
-    os::release_memory_special(reserved.base(), reserved.size());
-  } else {
-    os::release_memory(reserved.base(), reserved.size());
-  }
+  os::release_memory(reserved.base(), reserved.size());
 }
 
 static char* map_memory_to_file(char* requested_address,
@@ -372,11 +367,7 @@ ReservedSpace HeapReserver::Instance::reserve_memory(size_t size,
 void HeapReserver::Instance::release(const ReservedSpace& reserved) {
   if (reserved.is_reserved()) {
     if (_fd == -1) {
-      if (reserved.special()) {
-        os::release_memory_special(reserved.base(), reserved.size());
-      } else{
-        os::release_memory(reserved.base(), reserved.size());
-      }
+      os::release_memory(reserved.base(), reserved.size());
     } else {
       os::unmap_memory(reserved.base(), reserved.size());
     }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2442,22 +2442,6 @@ char* os::reserve_memory_special(size_t size, size_t alignment, size_t page_size
   return result;
 }
 
-void os::release_memory_special(char* addr, size_t bytes) {
-  bool res;
-  if (MemTracker::enabled()) {
-    MemTracker::NmtVirtualMemoryLocker nvml;
-    res = pd_release_memory_special(addr, bytes);
-    if (res) {
-      MemTracker::record_virtual_memory_release(addr, bytes);
-    }
-  } else {
-    res = pd_release_memory_special(addr, bytes);
-  }
-  if (!res) {
-    fatal("Failed to release memory special " RANGEFMT, RANGEFMTARGS(addr, bytes));
-  }
-}
-
 // Convenience wrapper around naked_short_sleep to allow for longer sleep
 // times. Only for use by non-JavaThreads.
 void os::naked_sleep(jlong millis) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -245,9 +245,7 @@ class os: AllStatic {
   static size_t pd_pretouch_memory(void* first, void* last, size_t page_size);
 
   static char*  pd_reserve_memory_special(size_t size, size_t alignment, size_t page_size,
-
                                           char* addr, bool executable);
-  static bool   pd_release_memory_special(char* addr, size_t bytes);
 
   static size_t page_size_for_region(size_t region_size, size_t min_pages, bool must_be_aligned);
 
@@ -605,7 +603,6 @@ class os: AllStatic {
   // reserve, commit and pin the entire memory region
   static char*  reserve_memory_special(size_t size, size_t alignment, size_t page_size,
                                        char* addr, bool executable);
-  static void   release_memory_special(char* addr, size_t bytes);
   static void   large_page_init();
   static size_t large_page_size();
   static bool   can_commit_large_page_memory();

--- a/test/hotspot/gtest/memory/test_virtualspace.cpp
+++ b/test/hotspot/gtest/memory/test_virtualspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -354,11 +354,7 @@ class TestReservedSpace : AllStatic {
   }
 
   static void release_memory_for_test(ReservedSpace rs) {
-    if (rs.special()) {
-      os::release_memory_special(rs.base(), rs.size());
-    } else {
-      os::release_memory(rs.base(), rs.size());
-    }
+    os::release_memory(rs.base(), rs.size());
   }
 
   static void test_reserved_space1(size_t size, size_t alignment) {

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ namespace {
     HugeTlbfsMemory(char* const ptr, size_t size) : _ptr(ptr), _size(size) { }
     ~HugeTlbfsMemory() {
       if (_ptr != nullptr) {
-        os::release_memory_special(_ptr, _size);
+        os::release_memory(_ptr, _size);
       }
     }
   };
@@ -227,7 +227,7 @@ class TestReserveMemorySpecial : AllStatic {
     char* addr = os::reserve_memory_special(size, alignment, page_size, nullptr, false);
     if (addr != nullptr) {
       small_page_write(addr, size);
-      os::release_memory_special(addr, size);
+      os::release_memory(addr, size);
     }
   }
 
@@ -285,7 +285,7 @@ class TestReserveMemorySpecial : AllStatic {
         if (p != nullptr) {
           EXPECT_TRUE(is_aligned(p, alignment));
           small_page_write(p, size);
-          os::release_memory_special(p, size);
+          os::release_memory(p, size);
         }
       }
     }
@@ -300,7 +300,7 @@ class TestReserveMemorySpecial : AllStatic {
         if (p != nullptr) {
           EXPECT_EQ(p, req_addr);
           small_page_write(p, size);
-          os::release_memory_special(p, size);
+          os::release_memory(p, size);
         }
       }
     }

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ namespace {
     MemoryReleaser(char* ptr, size_t size) : _ptr(ptr), _size(size) { }
     ~MemoryReleaser() {
       if (_ptr != nullptr) {
-        os::release_memory_special(_ptr, _size);
+        os::release_memory(_ptr, _size);
       }
     }
   };


### PR DESCRIPTION
Hi everyone,

`os::release_memory_special` releases memory backed by explicit (non-THP) large pages on Linux. Its point was to handle the case where explicit large pages were allocated with system V shared memory instead of mmap. Since we removed the use of system V memory with [JDK-8261894](https://bugs.openjdk.org/browse/JDK-8261894), `pd_release_memory_special` was changed to simply forward to `pd_release_memory`. 

With these functions no longer serving a purpose (`os::release_memory_special` effectively just calls `os::release_memory`) I propose we remove them completely and replace uses with calls to `os::release_memory` instead.

Testing:
- Oracle tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376650](https://bugs.openjdk.org/browse/JDK-8376650): os::release_memory_special may not be needed anymore (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29880/head:pull/29880` \
`$ git checkout pull/29880`

Update a local copy of the PR: \
`$ git checkout pull/29880` \
`$ git pull https://git.openjdk.org/jdk.git pull/29880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29880`

View PR using the GUI difftool: \
`$ git pr show -t 29880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29880.diff">https://git.openjdk.org/jdk/pull/29880.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29880#issuecomment-3944913486)
</details>
