### PR TITLE
8378442: RBTreeCHeap does not deallocate removed nodes when using remove_at_cursor

### DIFF
--- a/src/hotspot/share/utilities/rbTree.hpp
+++ b/src/hotspot/share/utilities/rbTree.hpp
@@ -374,10 +374,10 @@ public:
   typedef typename BaseType::Cursor Cursor;
   using BaseType::cursor;
   using BaseType::insert_at_cursor;
-  using BaseType::remove_at_cursor;
   using BaseType::next;
   using BaseType::prev;
 
+  void remove_at_cursor(const Cursor& node_cursor);
   void replace_at_cursor(RBNode<K, V>* new_node, const Cursor& node_cursor);
 
   RBNode<K, V>* allocate_node(const K& key);

--- a/src/hotspot/share/utilities/rbTree.inline.hpp
+++ b/src/hotspot/share/utilities/rbTree.inline.hpp
@@ -1104,6 +1104,15 @@ bool RBTree<K, V, COMPARATOR, ALLOCATOR>::copy_into(RBTree& other) const {
 }
 
 template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
+inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::remove_at_cursor(const Cursor& node_cursor) {
+  precond(node_cursor.valid());
+  precond(node_cursor.found());
+  RBNode<K, V>* old_node = node_cursor.node();
+  BaseType::remove_at_cursor(node_cursor);
+  free_node(old_node);
+}
+
+template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
 inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::replace_at_cursor(RBNode<K, V>* new_node, const Cursor& node_cursor) {
   precond(new_node != nullptr);
   precond(node_cursor.valid());
@@ -1170,7 +1179,7 @@ inline V* RBTree<K, V, COMPARATOR, ALLOCATOR>::find(const K& key) const {
 template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
 inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::remove(RBNode<K, V>* node) {
   Cursor node_cursor = cursor(node);
-  remove_at_cursor(node_cursor);
+  BaseType::remove_at_cursor(node_cursor);
   free_node(node);
 }
 
@@ -1181,7 +1190,7 @@ inline bool RBTree<K, V, COMPARATOR, ALLOCATOR>::remove(const K& key) {
     return false;
   }
   RBNode<K, V>* node = node_cursor.node();
-  remove_at_cursor(node_cursor);
+  BaseType::remove_at_cursor(node_cursor);
   free_node((RBNode<K, V>*)node);
   return true;
 }


### PR DESCRIPTION
Hi everyone,

`RBTree::remove_at_cursor` currently uses the abstract (intrusive) `remove_at_cursor`, which does not deallocate the removed node. The other `RBTree::remove` variants call `remove_at_cursor` and then deallocated the removed node. As a result, calling `remove_at_cursor` directly can leak memory. This only affects `RBTreeCHeap`, as the `free` operations in other tree variants are NOOPs.

This PR updates `RBTree::remove_at_cursor` to also deallocate the removed node, and calls from other `remove` functions are redirected to the abstract `remove_at_cursor`. There are currently no external uses of `RBTree::remove_at_cursor`, so this has not been impacting anything. All existing call sites use the other `remove` functions that behave correctly.

Testing:
- Oracle tiers 1-3
- New gtest checking that all functions that are supposed to deallocate nodes do so as expected

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378442](https://bugs.openjdk.org/browse/JDK-8378442): RBTreeCHeap does not deallocate removed nodes when using remove_at_cursor (**Bug** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29883/head:pull/29883` \
`$ git checkout pull/29883`

Update a local copy of the PR: \
`$ git checkout pull/29883` \
`$ git pull https://git.openjdk.org/jdk.git pull/29883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29883`

View PR using the GUI difftool: \
`$ git pr show -t 29883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29883.diff">https://git.openjdk.org/jdk/pull/29883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29883#issuecomment-3945990241)
</details>
