### PR TITLE
8378580: Make ArrayDeque bulk add methods bootstrap-proof

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -324,7 +324,9 @@ public class ArrayDeque<E> extends AbstractCollection<E>
     }
 
     private void copyElements(Collection<? extends E> c) {
-        c.forEach(this::addLast);
+        for (E e : c) {
+            addLast(e);
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -324,9 +324,13 @@ public class ArrayDeque<E> extends AbstractCollection<E>
     }
 
     private void copyElements(Collection<? extends E> c) {
-        for (E e : c) {
-            addLast(e);
-        }
+        // Using anonymous class here avoids introducing lambda in early bootstrap
+        c.forEach(new Consumer<E>() {
+            @Override
+            public void accept(E e) {
+                addLast(e);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Please review this small change to avoid loading lambda machinery in `ArrayDeque.addAll` and `ArrayDeque(Collection)`.

Core collections like these may be useful in early bootstrap where we want to avoid eager loading of lambda machinery.  JDK-8375580 recently showed one example where `URLClassPath` was avoiding these bulk-adding methods exactly to avoid triggering lambdas.

This PR replaces the use of `Collection.forEach` with a plain old for loop.

This was initially discussed here: https://mail.openjdk.org/pipermail/core-libs-dev/2026-February/159362.html

Cleanup, low risk enhancement, `noreg-cleanup`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378580](https://bugs.openjdk.org/browse/JDK-8378580): Make ArrayDeque bulk add methods bootstrap-proof (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29894/head:pull/29894` \
`$ git checkout pull/29894`

Update a local copy of the PR: \
`$ git checkout pull/29894` \
`$ git pull https://git.openjdk.org/jdk.git pull/29894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29894`

View PR using the GUI difftool: \
`$ git pr show -t 29894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29894.diff">https://git.openjdk.org/jdk/pull/29894.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29894#issuecomment-3953084235)
</details>
