### PR TITLE
C2 optimization for String.format()

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1096,6 +1096,10 @@ bool CallJavaNode::validate_symbolic_info() const {
   ciMethod* callee = method();
   if (symbolic_info->is_method_handle_intrinsic() && !callee->is_method_handle_intrinsic()) {
     assert(override_symbolic_info(), "should be set");
+  }
+  // Allow deliberate format/formatted -> format_1 redirection.
+  if (override_symbolic_info()) {
+    return true;
   }
   assert(ciMethod::is_consistent_info(symbolic_info, callee), "inconsistent info");
   return true;

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1097,11 +1097,12 @@ bool CallJavaNode::validate_symbolic_info() const {
   if (symbolic_info->is_method_handle_intrinsic() && !callee->is_method_handle_intrinsic()) {
     assert(override_symbolic_info(), "should be set");
   }
-  // Allow deliberate format/formatted -> format_1 redirection.
-  if (override_symbolic_info()) {
-    return true;
+  // override_symbolic_info is set when callee was intentionally replaced:
+  // - method handle intrinsic resolution (existing)
+  // - String.format/formatted -> optimized helper (try_optimize_string_format)
+  if (!override_symbolic_info()) {
+    assert(ciMethod::is_consistent_info(symbolic_info, callee), "inconsistent info");
   }
-  assert(ciMethod::is_consistent_info(symbolic_info, callee), "inconsistent info");
   return true;
 }
 #endif

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -542,14 +542,14 @@ static jchar fmt_char_at(ciTypeArray* val_arr, jbyte coder, int idx) {
 // Sets *is_int to true for Integer.valueOf, false for Long.valueOf.
 static Node* detect_boxing_call(Node* node, bool* is_int) {
   if (node == nullptr) return nullptr;
-  
+
   // Unwrap common node types
   // - EncodeP/DecodeN for compressed oops
   // - CheckCastPP/CastPP for type casts
   // - Phi for merged paths (like cache hit/miss)
   while (node != nullptr) {
     int opc = node->Opcode();
-    if (opc == Op_EncodeP || opc == Op_DecodeN || 
+    if (opc == Op_EncodeP || opc == Op_DecodeN ||
         opc == Op_CheckCastPP || opc == Op_CastPP) {
       node = node->in(1);
       continue;
@@ -561,21 +561,21 @@ static Node* detect_boxing_call(Node* node, bool* is_int) {
     }
     break;
   }
-  
+
   // If this is a Proj node, get the input (the call)
   if (node != nullptr && node->is_Proj()) {
     node = node->in(0);
   }
-  
+
   // Check for CallJavaNode (which has method())
   if (node == nullptr || !node->is_Call()) return nullptr;
-  
+
   CallJavaNode* call = node->isa_CallJava();
   if (call == nullptr) return nullptr;
-  
+
   ciMethod* m = call->method();
   if (m == nullptr || !m->is_boxing_method()) return nullptr;
-  
+
   // Check which boxing method it is
   vmIntrinsics::ID id = m->intrinsic_id();
   if (id == vmIntrinsics::_Integer_valueOf) {
@@ -862,7 +862,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
                                : "([Ljava/lang/Object;J)Ljava/lang/String;";
       }
     }
-  } else if (spec_count == 1 && (spec_flags[0] != 0 || spec_widths[0] != 0 || 
+  } else if (spec_count == 1 && (spec_flags[0] != 0 || spec_widths[0] != 0 ||
              spec_convs[0] == 'x' || spec_convs[0] == 'X')) {
     // Single specifier with width/flags OR %x/%X: format_1 or formatted_1
     // Meta: byte0=specIndex, byte1=conv, byte2=width, byte3=flag

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +26,8 @@
 #include "ci/ciCallSite.hpp"
 #include "ci/ciMethodHandle.hpp"
 #include "ci/ciSymbols.hpp"
+#include "classfile/javaClasses.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileLog.hpp"
@@ -38,6 +41,7 @@
 #include "opto/castnode.hpp"
 #include "opto/cfgnode.hpp"
 #include "opto/mulnode.hpp"
+#include "opto/narrowptrnode.hpp"
 #include "opto/parse.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/runtime.hpp"
@@ -524,6 +528,520 @@ static bool check_call_consistency(JVMState* jvms, CallGenerator* cg) {
 }
 #endif // ASSERT
 
+// --- String.format/formatted fast-path helpers ---
+
+// Helper: read a character from the format string at position idx.
+static jchar fmt_char_at(ciTypeArray* val_arr, jbyte coder, int idx) {
+  return (coder == java_lang_String::CODER_LATIN1)
+         ? (jchar)(val_arr->byte_at(idx) & 0xFF)
+         : (jchar) val_arr->char_at(idx);
+}
+
+// Check if a node is a boxing call (Integer.valueOf, Long.valueOf, etc.)
+// Returns the primitive argument node if it's a boxing call, null otherwise.
+// Sets *is_int to true for Integer.valueOf, false for Long.valueOf.
+static Node* detect_boxing_call(Node* node, bool* is_int) {
+  if (node == nullptr) return nullptr;
+  
+  // Unwrap common node types
+  // - EncodeP/DecodeN for compressed oops
+  // - CheckCastPP/CastPP for type casts
+  // - Phi for merged paths (like cache hit/miss)
+  while (node != nullptr) {
+    int opc = node->Opcode();
+    if (opc == Op_EncodeP || opc == Op_DecodeN || 
+        opc == Op_CheckCastPP || opc == Op_CastPP) {
+      node = node->in(1);
+      continue;
+    }
+    // For Phi, check if all inputs are from the same boxing call type
+    // For simplicity, skip Phi for now (would need more complex analysis)
+    if (node->is_Phi()) {
+      return nullptr;  // Give up on Phi for now
+    }
+    break;
+  }
+  
+  // If this is a Proj node, get the input (the call)
+  if (node != nullptr && node->is_Proj()) {
+    node = node->in(0);
+  }
+  
+  // Check for CallJavaNode (which has method())
+  if (node == nullptr || !node->is_Call()) return nullptr;
+  
+  CallJavaNode* call = node->isa_CallJava();
+  if (call == nullptr) return nullptr;
+  
+  ciMethod* m = call->method();
+  if (m == nullptr || !m->is_boxing_method()) return nullptr;
+  
+  // Check which boxing method it is
+  vmIntrinsics::ID id = m->intrinsic_id();
+  if (id == vmIntrinsics::_Integer_valueOf) {
+    *is_int = true;
+    // The primitive int is the first argument of the call (after receiver which is null for static)
+    return call->in(TypeFunc::Parms);
+  }
+  if (id == vmIntrinsics::_Long_valueOf) {
+    *is_int = false;
+    // The primitive long is the first argument of the call
+    return call->in(TypeFunc::Parms);
+  }
+  return nullptr;
+}
+
+// Scan a constant format string for simple specifiers.
+// Supported format: %[flag][width]conv where:
+//   flag  = optional single flag character: ' ' or '0'
+//   width = optional single digit 1-9
+//   conv  = one of: s, d, x, X
+//
+// spec_indexes[] receives the character position of each '%'.
+// spec_convs[]   receives the conversion character.
+// spec_widths[]  receives the width digit (0 if none).
+// spec_flags[]   receives the flag character (0 if none).
+static int scan_format_string(ciInstance* fmt_inst, int* spec_indexes, char* spec_convs,
+                              int* spec_widths, char* spec_flags, int max_specs) {
+  ciObject* val_obj = fmt_inst->field_value_by_offset(java_lang_String::value_offset()).as_object();
+  if (val_obj == nullptr) return 0;
+  ciTypeArray* val_arr = val_obj->as_type_array();
+  if (val_arr == nullptr) return 0;
+
+  jbyte coder = fmt_inst->field_value_by_offset(java_lang_String::coder_offset()).as_byte();
+  int flen = val_arr->length() >> coder;
+  int count = 0;
+
+  for (int i = 0; i < flen; i++) {
+    if (fmt_char_at(val_arr, coder, i) != '%') continue;
+    if (i + 1 >= flen) return 0;              // trailing %
+    int pos = i + 1;
+    jchar nc = fmt_char_at(val_arr, coder, pos);
+
+    // Check for optional single-char flag (only ' ' and '0' supported)
+    char flag = 0;
+    if (nc == ' ' || nc == '0') {
+      flag = (char)nc;
+      pos++;
+      if (pos >= flen) return 0;
+      nc = fmt_char_at(val_arr, coder, pos);
+    }
+
+    // Check for optional width digit (1-9)
+    int width = 0;
+    if (nc >= '1' && nc <= '9') {
+      width = nc - '0';
+      pos++;
+      if (pos >= flen) return 0;
+      nc = fmt_char_at(val_arr, coder, pos);
+    }
+
+    if (nc == 's' || nc == 'd' || nc == 'x' || nc == 'X') {
+      if (count >= max_specs) return 0;
+      // Flags (' ' and '0') only allowed for numeric conversions, not %s
+      if (flag != 0 && nc == 's') return 0;
+      // specifier position must fit in one byte (specIndexes packs 8 positions into a long)
+      if (i > 0xFF) return 0;
+      spec_indexes[count] = i;
+      spec_convs[count]   = (char)nc;
+      spec_widths[count]  = width;
+      spec_flags[count]   = flag;
+      count++;
+      i = pos;                                 // skip past specifier char
+    } else if (nc == '%' && flag == 0 && width == 0) {
+      // Escaped %%. Skip optimization entirely - the Java helper methods
+      // (formatSplice, formatSplice2) don't handle %% -> % conversion correctly.
+      // This is a conservative approach; format_multi could handle it but
+      // we keep the logic simple by rejecting any %% in the format string.
+      return 0;
+    } else {
+      return 0;                                // unsupported specifier
+    }
+  }
+  return count;
+}
+
+// Map a single specifier character to the format method suffix character.
+// Returns the character if supported, '\0' otherwise.
+static char format_spec_suffix(char spec) {
+  switch (spec) {
+    case 's': case 'd': case 'x': case 'X': return spec;
+    default: return '\0';
+  }
+}
+
+// Try to optimize String.format(constFmt, args) / constFmt.formatted(args)
+// into a call to an optimized format helper.
+// Extra compile-time constant args are pushed onto the operand stack only
+// when there is enough existing capacity (sp + extra <= stk_size).
+// This avoids grow_stack which shifts monoff and breaks exception handler merges.
+void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispatch,
+                                       bool is_virtual_or_interface, bool is_virtual,
+                                       bool& did_redirect, int& extra_args) {
+  if (callee->holder() != C->env()->String_klass()) return;
+
+  const char* mname = callee->name()->as_utf8();
+  bool is_static  = !call_does_dispatch && !is_virtual_or_interface && strcmp(mname, "format") == 0
+                    && callee->arg_size_no_receiver() == 2;  // exclude format(Locale, String, Object...)
+  bool is_virtual_fmt = is_virtual && strcmp(mname, "formatted") == 0;
+  if (!is_static && !is_virtual_fmt) return;
+
+  // Stack: [sp-2]=format, [sp-1]=Object[] array
+  Node* format_node = stack(sp() - 2);
+  Node* args_node   = stack(sp() - 1);
+
+  // Check format is a constant String
+  const TypeOopPtr* fmt_type = _gvn.type(format_node)->isa_oopptr();
+  if (fmt_type == nullptr || !fmt_type->klass_is_exact() || fmt_type->const_oop() == nullptr) return;
+  ciInstance* fmt_inst = fmt_type->const_oop()->as_instance();
+  if (fmt_inst == nullptr) return;
+
+  // Scan format string for specifier positions, characters, widths, and flags (up to 8)
+  int  spec_indexes[8];
+  char spec_convs[8];
+  int  spec_widths[8];
+  char spec_flags[8];
+  int spec_count = scan_format_string(fmt_inst, spec_indexes, spec_convs, spec_widths, spec_flags, 8);
+  if (spec_count == 0) return;
+
+  // Check args is a freshly allocated Object[spec_count]
+  Node* arr = args_node;
+  while (arr != nullptr && arr->is_CheckCastPP()) arr = arr->in(1);
+  if (arr == nullptr || !arr->is_Proj()) return;
+  AllocateArrayNode* alloc = arr->in(0)->isa_AllocateArray();
+  if (alloc == nullptr) return;
+  Node* len_nd = alloc->in(AllocateNode::ALength);
+  const TypeInt* len_t = _gvn.type(len_nd)->isa_int();
+  if (len_t == nullptr || !len_t->is_con() || len_t->get_con() != spec_count) return;
+
+  // For 1-2 specifiers, extract arguments from the array stores to avoid Object[] allocation.
+  // For 3+ specifiers, keep Object[] and use format_multi.
+  Node* arg_nodes[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  bool use_individual_args = (spec_count >= 1 && spec_count <= 2);
+
+  if (use_individual_args) {
+    // Find the values stored into the allocated array.
+    // Look for StoreN nodes (aastore) that store into this array.
+    Node* alloc_res = alloc->proj_out_or_null(TypeFunc::Parms);
+    if (alloc_res == nullptr) {
+      alloc_res = arr;  // fallback to the CheckCastPP result
+    }
+
+    int stores_found = 0;
+
+    // The array may be wrapped in CheckCastPP nodes. Search through all CheckCastPP
+    // wrappers to find the actual stores.
+    Node* search_start = arr;
+    while (search_start != nullptr) {
+      for (DUIterator_Fast imax, i = search_start->fast_outs(imax); i < imax; i++) {
+        Node* use = search_start->fast_out(i);
+        if (use->is_AddP()) {
+          // This is an address calculation using our array
+          for (DUIterator_Fast jmax, j = use->fast_outs(jmax); j < jmax; j++) {
+            Node* use2 = use->fast_out(j);
+            if (use2->is_Store()) {
+              StoreNode* store = use2->as_Store();
+              // Get the index from the address
+              Node* adr = store->in(MemNode::Address);
+              if (adr->is_AddP()) {
+                Node* offset_node = adr->in(AddPNode::Offset);
+                if (offset_node->is_Con()) {
+                  // For Object[], the offset is base + header + idx * element_size
+                  // Use arrayOopDesc::base_offset_in_bytes(T_OBJECT) for header offset
+                  // and heapOopSize for element size (4 with compressed oops, 8 without)
+                  jlong offset = offset_node->bottom_type()->is_long()->get_con();
+                  int base_offset = arrayOopDesc::base_offset_in_bytes(T_OBJECT);
+                  int elem_size = UseCompressedOops ? 4 : 8;
+                  int idx = (int)((offset - base_offset) / elem_size);
+                  if (idx >= 0 && idx < spec_count) {
+                    arg_nodes[idx] = store->in(MemNode::ValueIn);
+                    stores_found++;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // If no stores found, try searching through CheckCastPP nodes
+      if (stores_found == 0) {
+        Node* next_cast = nullptr;
+        for (DUIterator_Fast imax, i = search_start->fast_outs(imax); i < imax; i++) {
+          Node* use = search_start->fast_out(i);
+          int opc = use->Opcode();
+          if (opc == Op_CheckCastPP || opc == Op_CastPP) {
+            next_cast = use;
+            break;
+          }
+        }
+        if (next_cast != nullptr && next_cast != search_start) {
+          search_start = next_cast;
+          continue;
+        }
+      }
+      break;
+    }
+
+    // Verify we found all arguments
+    for (int i = 0; i < spec_count; i++) {
+      if (arg_nodes[i] == nullptr) {
+        use_individual_args = false;
+        break;
+      }
+    }
+  }
+
+  // Validate all specifiers are supported conversion characters
+  for (int i = 0; i < spec_count; i++) {
+    if (format_spec_suffix(spec_convs[i]) == '\0') return;
+  }
+
+  // Compute how many extra stack slots the target method needs beyond the
+  // original 2 (format, args).  We must NOT call grow_stack (which shifts
+  // monoff/scloff/endoff and breaks exception handler merges).  Instead,
+  // only proceed when the existing operand stack has enough spare capacity.
+  // All paths need +2 extra slots:
+  // - Object[] signature: format + Object[] + long = 4 slots (was 2) → +2
+  // - 1 arg with long: format + arg + long = 4 slots → +2
+  // - 2 args with int: format + arg1 + arg2 + int = 4 slots → +2
+  int needed_extra = 2;
+  if (spec_count > 8) return;  // not supported
+
+  uint stk_capacity = jvms()->stk_size();  // max operand stack depth
+  if ((uint)(sp() + needed_extra) > stk_capacity) return;  // not enough room, skip
+
+  // Determine target method name and signature
+  // Static: format_s/d/x/X(format, args, meta) - signature (String, Object[], long)String
+  // Virtual: formatted_s/d/x/X(args, meta) - signature (Object[], long)String (this=format)
+  const char* target_name = nullptr;
+  const char* target_sig = nullptr;
+  char method_name_buf[16];
+
+  // For primitive overloads (format_d with int/long)
+  bool use_primitive_d = false;
+  bool primitive_is_int = false;
+  Node* primitive_arg = nullptr;
+
+  if (spec_count == 1 && spec_flags[0] == 0 && spec_widths[0] == 0 &&
+      (spec_convs[0] == 's' || spec_convs[0] == 'd')) {
+    // Single specifier without width or flags: format_s/d or formatted_s/d
+    if (is_static) {
+      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
+      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
+      method_name_buf[6] = '_'; method_name_buf[7] = spec_convs[0]; method_name_buf[8] = '\0';
+    } else {
+      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
+      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
+      method_name_buf[6] = 't'; method_name_buf[7] = 'e'; method_name_buf[8] = 'd';
+      method_name_buf[9] = '_'; method_name_buf[10] = spec_convs[0]; method_name_buf[11] = '\0';
+    }
+    target_name = method_name_buf;
+
+    // For %d, check if we can use primitive overload to avoid boxing
+    if (use_individual_args && spec_convs[0] == 'd') {
+      primitive_arg = detect_boxing_call(arg_nodes[0], &primitive_is_int);
+      if (primitive_arg != nullptr) {
+        use_primitive_d = true;
+        // format_d(String, int, int) or format_d(String, long, int)
+        // For virtual methods (formatted_d), signature doesn't include receiver
+        target_sig = is_static ? (primitive_is_int ? "(Ljava/lang/String;II)Ljava/lang/String;"
+                                                    : "(Ljava/lang/String;JI)Ljava/lang/String;")
+                               : (primitive_is_int ? "(II)Ljava/lang/String;"
+                                                    : "(JI)Ljava/lang/String;");
+      }
+    }
+
+    if (!use_primitive_d) {
+      if (use_individual_args) {
+        // Single arg uses int for meta to reduce stack pressure
+        target_sig = is_static ? "(Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/String;"
+                               : "(Ljava/lang/Object;I)Ljava/lang/String;";
+      } else {
+        target_sig = is_static ? "(Ljava/lang/String;[Ljava/lang/Object;J)Ljava/lang/String;"
+                               : "([Ljava/lang/Object;J)Ljava/lang/String;";
+      }
+    }
+  } else if (spec_count == 1 && (spec_flags[0] != 0 || spec_widths[0] != 0 || 
+             spec_convs[0] == 'x' || spec_convs[0] == 'X')) {
+    // Single specifier with width/flags OR %x/%X: format_1 or formatted_1
+    // Meta: byte0=specIndex, byte1=conv, byte2=width, byte3=flag
+    target_name = is_static ? "format_1" : "formatted_1";
+    if (use_individual_args) {
+      // Single arg with width/flags uses int for meta (4 bytes packed)
+      target_sig = is_static ? "(Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/String;"
+                             : "(Ljava/lang/Object;I)Ljava/lang/String;";
+    } else {
+      target_sig = is_static ? "(Ljava/lang/String;[Ljava/lang/Object;J)Ljava/lang/String;"
+                             : "([Ljava/lang/Object;J)Ljava/lang/String;";
+    }
+  } else if (spec_count == 2 &&
+             spec_flags[0] == 0 && spec_flags[1] == 0 &&
+             (spec_convs[0] == 's' || spec_convs[0] == 'd') &&
+             (spec_convs[1] == 's' || spec_convs[1] == 'd')) {
+    // Two specifiers with s/d only: format_ss/sd/ds/dd or formatted_ss/sd/ds/dd
+    if (is_static) {
+      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
+      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
+      method_name_buf[6] = '_'; method_name_buf[7] = spec_convs[0];
+      method_name_buf[8] = spec_convs[1]; method_name_buf[9] = '\0';
+    } else {
+      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
+      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
+      method_name_buf[6] = 't'; method_name_buf[7] = 'e'; method_name_buf[8] = 'd';
+      method_name_buf[9] = '_'; method_name_buf[10] = spec_convs[0];
+      method_name_buf[11] = spec_convs[1]; method_name_buf[12] = '\0';
+    }
+    target_name = method_name_buf;
+    if (use_individual_args) {
+      // Two args use int instead of long to reduce stack pressure
+      target_sig = is_static ? "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;I)Ljava/lang/String;"
+                             : "(Ljava/lang/Object;Ljava/lang/Object;I)Ljava/lang/String;";
+    } else {
+      target_sig = is_static ? "(Ljava/lang/String;[Ljava/lang/Object;J)Ljava/lang/String;"
+                             : "([Ljava/lang/Object;J)Ljava/lang/String;";
+    }
+  } else if (spec_count == 2 &&
+             spec_flags[0] == 0 && spec_flags[1] == 0 &&
+             spec_widths[0] == 0 && spec_widths[1] == 0 &&
+             (spec_convs[0] == 'x' || spec_convs[0] == 'X' ||
+              spec_convs[1] == 'x' || spec_convs[1] == 'X')) {
+    // Two specifiers with at least one x/X (no width/flags): format_2 or formatted_2
+    target_name = is_static ? "format_2" : "formatted_2";
+    if (use_individual_args) {
+      target_sig = is_static ? "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;I)Ljava/lang/String;"
+                             : "(Ljava/lang/Object;Ljava/lang/Object;I)Ljava/lang/String;";
+    } else {
+      target_sig = is_static ? "(Ljava/lang/String;[Ljava/lang/Object;J)Ljava/lang/String;"
+                             : "([Ljava/lang/Object;J)Ljava/lang/String;";
+    }
+  } else {
+    // format_multi or formatted_multi for 3-8 specifiers (or 2 with flags/x/X)
+    target_name = is_static ? "format_multi" : "formatted_multi";
+    target_sig = is_static ? "(Ljava/lang/String;[Ljava/lang/Object;J)Ljava/lang/String;"
+                           : "([Ljava/lang/Object;J)Ljava/lang/String;";
+  }
+
+  // Pack specifier metadata into a long
+  // Use & 0xFF to avoid sign extension when value >= 128
+  // Naming: packedSpecIndexes matches Java-side parameter name for consistency
+  jlong packedSpecIndexes = 0;
+  if (spec_count == 1 && spec_flags[0] == 0 && spec_widths[0] == 0 &&
+      (spec_convs[0] == 's' || spec_convs[0] == 'd')) {
+    // Single specifier without width/flags (s/d only): just specIndex
+    packedSpecIndexes = (jlong)(spec_indexes[0] & 0xFF);
+  } else if (spec_count == 1 && (spec_flags[0] != 0 || spec_widths[0] != 0 ||
+             spec_convs[0] == 'x' || spec_convs[0] == 'X')) {
+    // Single specifier with width/flags OR %x/%X: byte0=specIndex, byte1=conv, byte2=width, byte3=flag
+    packedSpecIndexes = ((jlong)(spec_indexes[0] & 0xFF)) |
+                         (((jlong)(spec_convs[0] & 0xFF)) << 8) |
+                         (((jlong)(spec_widths[0] & 0xFF)) << 16) |
+                         (((jlong)(spec_flags[0] & 0xFF)) << 24);
+  } else if (spec_count == 2 &&
+             spec_flags[0] == 0 && spec_flags[1] == 0 &&
+             (spec_convs[0] == 's' || spec_convs[0] == 'd') &&
+             (spec_convs[1] == 's' || spec_convs[1] == 'd')) {
+    // Two s/d specifiers: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+    packedSpecIndexes = ((jlong)(spec_indexes[0] & 0xFF)) |
+                         (((jlong)(spec_widths[0] & 0xFF)) << 8) |
+                         (((jlong)(spec_indexes[1] & 0xFF)) << 16) |
+                         (((jlong)(spec_widths[1] & 0xFF)) << 24);
+  } else if (spec_count == 2 &&
+             spec_flags[0] == 0 && spec_flags[1] == 0 &&
+             spec_widths[0] == 0 && spec_widths[1] == 0 &&
+             (spec_convs[0] == 'x' || spec_convs[0] == 'X' ||
+              spec_convs[1] == 'x' || spec_convs[1] == 'X')) {
+    // Two specifiers with x/X (no width/flags): byte0=ci1, byte1=conv1, byte2=ci2, byte3=conv2
+    packedSpecIndexes = ((jlong)(spec_indexes[0] & 0xFF)) |
+                         (((jlong)(spec_convs[0] & 0xFF)) << 8) |
+                         (((jlong)(spec_indexes[1] & 0xFF)) << 16) |
+                         (((jlong)(spec_convs[1] & 0xFF)) << 24);
+  } else {
+    // format_multi/formatted_multi: pack only specifier positions.
+    // Flags and widths are re-parsed at runtime in format_multi() since the
+    // format string is a compile-time constant and the long has limited space.
+    // This design trades some runtime work for simpler packing and allows
+    // extending flag support without changing the packed format.
+    for (int i = 0; i < spec_count; i++) {
+      packedSpecIndexes |= ((jlong)(spec_indexes[i] & 0xFF)) << (i * 8);
+    }
+  }
+
+  ciSymbol* nm  = ciSymbol::make(target_name);
+  ciSymbol* sig = ciSymbol::make(target_sig);
+  ciMethod* target = C->env()->String_klass()->find_method(nm, sig);
+  if (target == nullptr) return;
+
+  // Stack: [sp-2]=format, [sp-1]=Object[] args
+  if (use_primitive_d) {
+    // Primitive overload: push primitive arg directly, avoiding boxing
+    pop();  // pop Object[] (will be eliminated along with boxing)
+    if (primitive_is_int) {
+      // format_d(String, int, int) - int takes 1 slot
+      push(primitive_arg);
+      push(_gvn.intcon((jint)packedSpecIndexes));
+      extra_args = 1;  // 1 int + 1 int meta - 1 Object[] = 1
+    } else {
+      // format_d(String, long, int) - long takes 2 slots
+      push(primitive_arg);
+      push(C->top());  // second half of long
+      push(_gvn.intcon((jint)packedSpecIndexes));
+      extra_args = 2;  // 2 long + 1 int meta - 1 Object[] = 2
+    }
+  } else if (use_individual_args) {
+    // Pop Object[] - it will be eliminated by escape analysis since we use individual args
+    pop();  // pop Object[]
+    // Push individual args in order (arg0 first, then arg1, etc.)
+    // The calling convention expects arg1 at a lower address than arg2.
+    for (int i = 0; i < spec_count; i++) {
+      Node* arg = arg_nodes[i];
+      // If the arg is a compressed oop (ConN, EncodeN, etc.), decode it to a regular oop
+      if (arg != nullptr && arg->bottom_type()->isa_narrowoop() != nullptr) {
+        const Type* decoded_type = arg->bottom_type()->make_ptr();
+        arg = _gvn.transform(new DecodeNNode(arg, decoded_type));
+      }
+      push(arg);
+    }
+    // For 2 specifiers, use int (1 slot) instead of long (2 slots) to reduce stack pressure
+    if (spec_count == 2) {
+      jint packedMeta;
+      // format_ss/sd/ds/dd: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+      // format_2: byte0=ci1, byte1=conv1, byte2=ci2, byte3=conv2
+      if (strcmp(target_name, "format_2") == 0 || strcmp(target_name, "formatted_2") == 0) {
+        packedMeta = (jint)(((spec_indexes[0] & 0xFF)) |
+                            (((spec_convs[0] & 0xFF)) << 8) |
+                            (((spec_indexes[1] & 0xFF)) << 16) |
+                            (((spec_convs[1] & 0xFF)) << 24));
+      } else {
+        packedMeta = (jint)(((spec_indexes[0] & 0xFF)) |
+                            (((spec_widths[0] & 0xFF)) << 8) |
+                            (((spec_indexes[1] & 0xFF)) << 16) |
+                            (((spec_widths[1] & 0xFF)) << 24));
+      }
+      push(_gvn.intcon(packedMeta));
+      extra_args = spec_count;  // spec_count args + 1 int - 1 Object[] = spec_count
+    } else {
+      // Single arg uses int for meta (1 slot) to reduce stack pressure
+      jint packedMeta = (jint)packedSpecIndexes;
+      push(_gvn.intcon(packedMeta));
+      extra_args = spec_count;  // spec_count args + 1 int - 1 Object[] = spec_count
+    }
+  } else {
+    // Keep Object[] and push long
+    push(_gvn.longcon(packedSpecIndexes));
+    push(C->top());  // second half of long
+    extra_args = 2;
+  }
+  callee = target;
+
+  call_does_dispatch = false;  // Devirtualize: target is a specific private method
+  did_redirect = true;
+  NOT_PRODUCT(if (PrintOptimizeStringConcat) {
+    tty->print_cr("StringFormat: optimized '%s' -> %s in %s",
+                  mname, callee->name()->as_utf8(), method()->name()->as_utf8());
+  });
+}
+
 //------------------------------do_call----------------------------------------
 // Handle your basic call.  Inline if we can & want to, else just setup call.
 void Parse::do_call() {
@@ -647,15 +1165,35 @@ void Parse::do_call() {
   // unless it knows how to optimize the receiver dispatch.
   bool try_inline = (C->do_inlining() || InlineAccessors);
 
+  // --- String.format/formatted fast-path optimization (must be before dec_sp) ---
+  bool did_format_redirect = false;
+  int  format_extra_args = 0;
+  try_optimize_string_format(callee, call_does_dispatch, is_virtual_or_interface, is_virtual,
+                             did_format_redirect, format_extra_args);
+  // Disable inlining for the redirected call: the callee's signature differs
+  // from the original bytecode's expectation, so inlining would produce
+  // scope values that confuse the deoptimizer (bad oop during frame reconstruction).
+  if (did_format_redirect) {
+    try_inline = false;
+  }
+
   // ---------------------
-  dec_sp(nargs);              // Temporarily pop args for JVM state of call
+  dec_sp(nargs + format_extra_args);  // Temporarily pop args for JVM state of call
+
   JVMState* jvms = sync_jvms();
 
   // ---------------------
   // Decide call tactic.
   // This call checks with CHA, the interpreter profile, intrinsics table, etc.
   // It decides whether inlining is desirable or not.
-  CallGenerator* cg = C->call_generator(callee, vtable_index, call_does_dispatch, jvms, try_inline, prof_factor(), speculative_receiver_type);
+  // For String.format/formatted redirect, bypass call_generator to avoid guarded call
+  // wrapper which would prevent setting override_symbolic_info on the actual call node.
+  CallGenerator* cg;
+  if (did_format_redirect) {
+    cg = CallGenerator::for_direct_call(callee);
+  } else {
+    cg = C->call_generator(callee, vtable_index, call_does_dispatch, jvms, try_inline, prof_factor(), speculative_receiver_type);
+  }
 
   // NOTE:  Don't use orig_callee and callee after this point!  Use cg->method() instead.
   orig_callee = callee = nullptr;
@@ -688,6 +1226,16 @@ void Parse::do_call() {
   }
 
   JVMState* new_jvms = cg->generate(jvms);
+  // When we redirected format/formatted -> optimized helper, mark the call node to
+  // bypass the symbolic-info consistency check (bci still refers to original method).
+  if (did_format_redirect && cg->call_node() != nullptr) {
+    CallNode* cn = cg->call_node();
+    if (cn->is_CallStaticJava()) {
+      cn->as_CallStaticJava()->set_override_symbolic_info(true);
+    } else if (cn->is_CallDynamicJava()) {
+      cn->as_CallDynamicJava()->set_override_symbolic_info(true);
+    }
+  }
   if (new_jvms == nullptr) {
     // When inlining attempt fails (e.g., too many arguments),
     // it may contaminate the current compile state, making it
@@ -723,7 +1271,8 @@ void Parse::do_call() {
     set_jvms(new_jvms);
   }
 
-  assert(check_call_consistency(jvms, cg), "inconsistent info");
+  // Skip consistency check when we deliberately redirected format/formatted -> format_1.
+  assert(did_format_redirect || check_call_consistency(jvms, cg), "inconsistent info");
 
   if (!stopped()) {
     // This was some sort of virtual call, which did a null check for us.

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -826,16 +826,8 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
   if (spec_count == 1 && spec_flags[0] == 0 && spec_widths[0] == 0 &&
       (spec_convs[0] == 's' || spec_convs[0] == 'd')) {
     // Single specifier without width or flags: format_s/d or formatted_s/d
-    if (is_static) {
-      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
-      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
-      method_name_buf[6] = '_'; method_name_buf[7] = spec_convs[0]; method_name_buf[8] = '\0';
-    } else {
-      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
-      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
-      method_name_buf[6] = 't'; method_name_buf[7] = 'e'; method_name_buf[8] = 'd';
-      method_name_buf[9] = '_'; method_name_buf[10] = spec_convs[0]; method_name_buf[11] = '\0';
-    }
+    os::snprintf_checked(method_name_buf, sizeof(method_name_buf),
+                         "%s_%c", is_static ? "format" : "formatted", spec_convs[0]);
     target_name = method_name_buf;
 
     // For %d, check if we can use primitive overload to avoid boxing
@@ -880,18 +872,9 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
              (spec_convs[0] == 's' || spec_convs[0] == 'd') &&
              (spec_convs[1] == 's' || spec_convs[1] == 'd')) {
     // Two specifiers with s/d only: format_ss/sd/ds/dd or formatted_ss/sd/ds/dd
-    if (is_static) {
-      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
-      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
-      method_name_buf[6] = '_'; method_name_buf[7] = spec_convs[0];
-      method_name_buf[8] = spec_convs[1]; method_name_buf[9] = '\0';
-    } else {
-      method_name_buf[0] = 'f'; method_name_buf[1] = 'o'; method_name_buf[2] = 'r';
-      method_name_buf[3] = 'm'; method_name_buf[4] = 'a'; method_name_buf[5] = 't';
-      method_name_buf[6] = 't'; method_name_buf[7] = 'e'; method_name_buf[8] = 'd';
-      method_name_buf[9] = '_'; method_name_buf[10] = spec_convs[0];
-      method_name_buf[11] = spec_convs[1]; method_name_buf[12] = '\0';
-    }
+    os::snprintf_checked(method_name_buf, sizeof(method_name_buf),
+                         "%s_%c%c", is_static ? "format" : "formatted",
+                         spec_convs[0], spec_convs[1]);
     target_name = method_name_buf;
     if (use_individual_args) {
       // Two args use int instead of long to reduce stack pressure

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -530,6 +530,20 @@ static bool check_call_consistency(JVMState* jvms, CallGenerator* cg) {
 
 // --- String.format/formatted fast-path helpers ---
 
+// Maximum number of format specifiers supported by the fast-path optimization.
+// Specifier metadata is packed into a jlong (8 bytes), one byte per position.
+static const int MAX_FORMAT_SPECS = 8;
+
+// Kinds of optimized format helper methods selected at compile time.
+// Used to dispatch metadata packing and argument handling without strcmp.
+enum FormatTargetKind {
+  FMT_TARGET_SIMPLE,    // format_s/d, formatted_s/d (single %s/%d, no width/flags)
+  FMT_TARGET_1,         // format_1, formatted_1     (single specifier with width/flags or %x/%X)
+  FMT_TARGET_SS_DD,     // format_ss/sd/ds/dd        (two %s/%d specifiers)
+  FMT_TARGET_2,         // format_2, formatted_2     (two specifiers with %x/%X, no width/flags)
+  FMT_TARGET_MULTI      // format_multi              (3-8 specifiers or complex 2-specifier patterns)
+};
+
 // Helper: read a character from the format string at position idx.
 static jchar fmt_char_at(ciTypeArray* val_arr, jbyte coder, int idx) {
   return (coder == java_lang_String::CODER_LATIN1)
@@ -696,12 +710,12 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
   ciInstance* fmt_inst = fmt_type->const_oop()->as_instance();
   if (fmt_inst == nullptr) return;
 
-  // Scan format string for specifier positions, characters, widths, and flags (up to 8)
-  int  spec_indexes[8];
-  char spec_convs[8];
-  int  spec_widths[8];
-  char spec_flags[8];
-  int spec_count = scan_format_string(fmt_inst, spec_indexes, spec_convs, spec_widths, spec_flags, 8);
+  // Scan format string for specifier positions, characters, widths, and flags
+  int  spec_indexes[MAX_FORMAT_SPECS];
+  char spec_convs[MAX_FORMAT_SPECS];
+  int  spec_widths[MAX_FORMAT_SPECS];
+  char spec_flags[MAX_FORMAT_SPECS];
+  int spec_count = scan_format_string(fmt_inst, spec_indexes, spec_convs, spec_widths, spec_flags, MAX_FORMAT_SPECS);
   if (spec_count == 0) return;
 
   // Check args is a freshly allocated Object[spec_count]
@@ -716,7 +730,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
 
   // For 1-2 specifiers, extract arguments from the array stores to avoid Object[] allocation.
   // For 3+ specifiers, keep Object[] and use format_multi.
-  Node* arg_nodes[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  Node* arg_nodes[MAX_FORMAT_SPECS] = {};
   bool use_individual_args = (spec_count >= 1 && spec_count <= 2);
 
   if (use_individual_args) {
@@ -747,13 +761,11 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
                 Node* offset_node = adr->in(AddPNode::Offset);
                 if (offset_node->is_Con()) {
                   // For Object[], the offset is base + header + idx * element_size
-                  // Use arrayOopDesc::base_offset_in_bytes(T_OBJECT) for header offset
-                  // and heapOopSize for element size (4 with compressed oops, 8 without)
                   jlong offset = offset_node->bottom_type()->is_long()->get_con();
                   int base_offset = arrayOopDesc::base_offset_in_bytes(T_OBJECT);
-                  int elem_size = UseCompressedOops ? 4 : 8;
-                  int idx = (int)((offset - base_offset) / elem_size);
-                  if (idx >= 0 && idx < spec_count) {
+                  jlong idx_l = (offset - base_offset) / heapOopSize;
+                  if (idx_l >= 0 && idx_l < spec_count) {
+                    int idx = (int)idx_l;
                     arg_nodes[idx] = store->in(MemNode::ValueIn);
                     stores_found++;
                   }
@@ -806,17 +818,18 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
   // - 1 arg with long: format + arg + long = 4 slots → +2
   // - 2 args with int: format + arg1 + arg2 + int = 4 slots → +2
   int needed_extra = 2;
-  if (spec_count > 8) return;  // not supported
+  if (spec_count > MAX_FORMAT_SPECS) return;  // not supported
 
   uint stk_capacity = jvms()->stk_size();  // max operand stack depth
   if ((uint)(sp() + needed_extra) > stk_capacity) return;  // not enough room, skip
 
-  // Determine target method name and signature
+  // Determine target method name, signature, and target kind.
   // Static: format_s/d/x/X(format, args, meta) - signature (String, Object[], long)String
   // Virtual: formatted_s/d/x/X(args, meta) - signature (Object[], long)String (this=format)
   const char* target_name = nullptr;
   const char* target_sig = nullptr;
   char method_name_buf[16];
+  FormatTargetKind target_kind = FMT_TARGET_MULTI;  // default
 
   // For primitive overloads (format_d with int/long)
   bool use_primitive_d = false;
@@ -826,6 +839,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
   if (spec_count == 1 && spec_flags[0] == 0 && spec_widths[0] == 0 &&
       (spec_convs[0] == 's' || spec_convs[0] == 'd')) {
     // Single specifier without width or flags: format_s/d or formatted_s/d
+    target_kind = FMT_TARGET_SIMPLE;
     os::snprintf_checked(method_name_buf, sizeof(method_name_buf),
                          "%s_%c", is_static ? "format" : "formatted", spec_convs[0]);
     target_name = method_name_buf;
@@ -858,6 +872,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
              spec_convs[0] == 'x' || spec_convs[0] == 'X')) {
     // Single specifier with width/flags OR %x/%X: format_1 or formatted_1
     // Meta: byte0=specIndex, byte1=conv, byte2=width, byte3=flag
+    target_kind = FMT_TARGET_1;
     target_name = is_static ? "format_1" : "formatted_1";
     if (use_individual_args) {
       // Single arg with width/flags uses int for meta (4 bytes packed)
@@ -872,6 +887,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
              (spec_convs[0] == 's' || spec_convs[0] == 'd') &&
              (spec_convs[1] == 's' || spec_convs[1] == 'd')) {
     // Two specifiers with s/d only: format_ss/sd/ds/dd or formatted_ss/sd/ds/dd
+    target_kind = FMT_TARGET_SS_DD;
     os::snprintf_checked(method_name_buf, sizeof(method_name_buf),
                          "%s_%c%c", is_static ? "format" : "formatted",
                          spec_convs[0], spec_convs[1]);
@@ -890,6 +906,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
              (spec_convs[0] == 'x' || spec_convs[0] == 'X' ||
               spec_convs[1] == 'x' || spec_convs[1] == 'X')) {
     // Two specifiers with at least one x/X (no width/flags): format_2 or formatted_2
+    target_kind = FMT_TARGET_2;
     target_name = is_static ? "format_2" : "formatted_2";
     if (use_individual_args) {
       target_sig = is_static ? "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;I)Ljava/lang/String;"
@@ -953,7 +970,13 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
   ciSymbol* nm  = ciSymbol::make(target_name);
   ciSymbol* sig = ciSymbol::make(target_sig);
   ciMethod* target = C->env()->String_klass()->find_method(nm, sig);
-  if (target == nullptr) return;
+  if (target == nullptr) {
+    NOT_PRODUCT(if (PrintOptimizeStringConcat) {
+      tty->print_cr("StringFormat: helper method %s%s not found in %s",
+                     target_name, target_sig, method()->name()->as_utf8());
+    });
+    return;
+  }
 
   // Stack: [sp-2]=format, [sp-1]=Object[] args
   if (use_primitive_d) {
@@ -962,12 +985,14 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
     if (primitive_is_int) {
       // format_d(String, int, int) - int takes 1 slot
       push(primitive_arg);
+      assert((packedSpecIndexes & ~(jlong)0xFFFFFFFF) == 0, "metadata must fit in 32 bits");
       push(_gvn.intcon((jint)packedSpecIndexes));
       extra_args = 1;  // 1 int + 1 int meta - 1 Object[] = 1
     } else {
       // format_d(String, long, int) - long takes 2 slots
       push(primitive_arg);
       push(C->top());  // second half of long
+      assert((packedSpecIndexes & ~(jlong)0xFFFFFFFF) == 0, "metadata must fit in 32 bits");
       push(_gvn.intcon((jint)packedSpecIndexes));
       extra_args = 2;  // 2 long + 1 int meta - 1 Object[] = 2
     }
@@ -990,7 +1015,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
       jint packedMeta;
       // format_ss/sd/ds/dd: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
       // format_2: byte0=ci1, byte1=conv1, byte2=ci2, byte3=conv2
-      if (strcmp(target_name, "format_2") == 0 || strcmp(target_name, "formatted_2") == 0) {
+      if (target_kind == FMT_TARGET_2) {
         packedMeta = (jint)(((spec_indexes[0] & 0xFF)) |
                             (((spec_convs[0] & 0xFF)) << 8) |
                             (((spec_indexes[1] & 0xFF)) << 16) |
@@ -1005,6 +1030,7 @@ void Parse::try_optimize_string_format(ciMethod*& callee, bool& call_does_dispat
       extra_args = spec_count;  // spec_count args + 1 int - 1 Object[] = spec_count
     } else {
       // Single arg uses int for meta (1 slot) to reduce stack pressure
+      assert((packedSpecIndexes & ~(jlong)0xFFFFFFFF) == 0, "metadata must fit in 32 bits");
       jint packedMeta = (jint)packedSpecIndexes;
       push(_gvn.intcon(packedMeta));
       extra_args = spec_count;  // spec_count args + 1 int - 1 Object[] = spec_count

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -518,6 +518,11 @@ class Parse : public GraphKit {
 
   // Helper function to setup Ideal Call nodes
   void do_call();
+
+  // Try to optimize String.format/formatted with constant format string
+  void try_optimize_string_format(ciMethod*& callee, bool& call_does_dispatch,
+                                  bool is_virtual_or_interface, bool is_virtual,
+                                  bool& did_redirect, int& extra_args);
 
   // Helper function to uncommon-trap or bailout for non-compilable call-sites
   bool can_not_compile_call_site(ciMethod *dest_method, ciInstanceKlass *klass);

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -5027,11 +5027,30 @@ public final class String
     @ForceInline
     private static String format_s(String format, Object arg, int specIndex) {
         int ci = specIndex & 0xFF;
+
         // For Formattable, call formatTo with width=0
         if (arg instanceof java.util.Formattable) {
-            return format_splice1(format, format_toStringArg(arg, 0), ci);
+            String argStr = format_toStringArg(arg, 0);
+            // Optimization for "%s" at the end: use substring+concat for better C1 performance
+            // C1 has intrinsics for substring/concat, while format_splice1 is just a Java method.
+            // For C2, the performance difference is minimal due to inlining and escape analysis.
+            if (ci == format.length() - 2) {
+                return format.substring(0, ci).concat(argStr);
+            }
+            return format_splice1(format, argStr, ci);
         }
-        return format_splice1(format, String.valueOf(arg), ci);
+
+        String argStr = String.valueOf(arg);
+
+        // Optimization for "%s" at the end: use substring+concat for better C1 performance
+        // Pattern: "prefix %s" → format.substring(0, ci).concat(argStr)
+        // This allows C1 to use intrinsics for substring and concat, improving performance
+        // in tiered compilation before methods are recompiled by C2.
+        if (ci == format.length() - 2) {
+            return format.substring(0, ci).concat(argStr);
+        }
+
+        return format_splice1(format, argStr, ci);
     }
 
     // --- Argument conversion helpers ---

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import jdk.internal.util.ArraysSupport;
+import jdk.internal.util.DecimalDigits;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -4810,6 +4811,782 @@ public final class String
     public String formatted(Object... args) {
         return new Formatter().format(this, args).toString();
     }
+
+    // ========== BEGIN: C2 String.format/formatted optimization ==========
+    //
+    // This section contains fast-path implementation for String.format() and String.formatted()
+    // when the format string is a compile-time constant with simple specifiers.
+    //
+    // Supported conversions: %s, %d, %x, %X with optional single-digit width (1-9) and flags (' ' or '0').
+    //
+    // Optimization paths:
+    // - Single %s/%d (no width/flags): format_s/d(formatted, arg, int specIndex)
+    // - Single with width/flags or %x/%X: format_1(formatted, arg, int meta)
+    // - Two s/d specifiers: format_ss/sd/ds/dd(formatted, arg1, arg2, int meta)
+    // - Two with x/X: format_2(formatted, arg1, arg2, int meta)
+    // - 3-8 specifiers: format_multi(formatted, Object[] args, long meta)
+    //
+    // C2 redirects format/formatted calls to these methods via doCall.cpp::try_optimize_string_format().
+    //
+    // Key optimizations:
+    // - Individual Object parameters for 1-2 specifiers enables escape analysis to eliminate Object[] allocation
+    // - Primitive overloads for %d (int/long) avoid boxing allocation
+    // - Direct string building without Formatter overhead
+    //
+    // Limitations (fallback to Formatter):
+    // - %% not supported
+    // - Specifier position must be < 256
+    // - Only single-digit width, no precision
+    // - Only flags ' ' and '0' for numeric types
+    //
+    // --------------------------------------------------------------------------
+
+    // --- Virtual helper methods for formatted() optimization ---
+    // These are called by C2 when redirecting a virtual formatted() call.
+
+    /** Virtual fast-path for single {@code %s} specifier. */
+    @ForceInline
+    private String formatted_s(Object arg, int specIndex) {
+        return format_s(this, arg, specIndex);
+    }
+
+    /** Virtual fast-path for single {@code %d} specifier. */
+    @ForceInline
+    private String formatted_d(Object arg, int specIndex) {
+        return format_d(this, arg, specIndex);
+    }
+
+    /** Virtual fast-path for single {@code %d} specifier with int - avoids boxing allocation. */
+    @ForceInline
+    private String formatted_d(int arg, int specIndex) {
+        return format_d(this, arg, specIndex);
+    }
+
+    /** Virtual fast-path for single {@code %d} specifier with long - avoids boxing allocation. */
+    @ForceInline
+    private String formatted_d(long arg, int specIndex) {
+        return format_d(this, arg, specIndex);
+    }
+
+    /** Virtual fast-path for two {@code %s} specifiers. */
+    @ForceInline
+    private String formatted_ss(Object arg1, Object arg2, int specIndexes) {
+        return format_ss(this, arg1, arg2, specIndexes);
+    }
+
+    /** Virtual fast-path for {@code %s} followed by {@code %d}. */
+    @ForceInline
+    private String formatted_sd(Object arg1, Object arg2, int specIndexes) {
+        return format_sd(this, arg1, arg2, specIndexes);
+    }
+
+    /** Virtual fast-path for {@code %d} followed by {@code %s}. */
+    @ForceInline
+    private String formatted_ds(Object arg1, Object arg2, int specIndexes) {
+        return format_ds(this, arg1, arg2, specIndexes);
+    }
+
+    /** Virtual fast-path for two {@code %d} specifiers. */
+    @ForceInline
+    private String formatted_dd(Object arg1, Object arg2, int specIndexes) {
+        return format_dd(this, arg1, arg2, specIndexes);
+    }
+
+    /** Virtual fast-path for 3-8 specifiers. */
+    @ForceInline
+    private String formatted_multi(Object[] args, long specIndexes) {
+        return format_multi(this, args, specIndexes);
+    }
+
+    // --- Core formatting helpers ---
+
+    /**
+     * Core single-specifier formatting: splice argStr into format at specIndex.
+     * Simple version without width/flag support - just replaces %s/%d/%x/%X with argStr.
+     * Called by format_d/s/x/X when no width or flag is present.
+     */
+    @ForceInline
+    private static String format_splice1(String format, String argStr, int specIndex) {
+        byte coder = (byte) (argStr.coder() | format.coder());
+        int newLen = format.length() - 2 + argStr.length();
+        byte[] bytes = new byte[newLen << coder];
+        format.getBytes(bytes, 0, 0, coder, specIndex);
+        argStr.getBytes(bytes, 0, specIndex, coder, argStr.length());
+        format.getBytes(bytes, specIndex + 2, specIndex + argStr.length(), coder, format.length() - specIndex - 2);
+        return new String(bytes, coder);
+    }
+
+    /**
+     * Localize digits and minus sign in a byte array.
+     * Converts ASCII digits '0'-'9' to locale-specific digits and '-' to locale-specific minus sign.
+     */
+    private static void format_localizeDigitsInPlace(byte[] bytes, int start, int end, byte coder,
+                                               char zeroDigit, char minusSign) {
+        for (int i = start; i < end; i++) {
+            char c = coder == LATIN1 ? (char) (bytes[i] & 0xFF) : StringUTF16.charAt(bytes, i);
+            if (c == '-') {
+                c = minusSign;
+            } else if (c >= '0' && c <= '9') {
+                c = (char) (c - '0' + zeroDigit);
+            }
+            if (coder == LATIN1) {
+                bytes[i] = (byte) c;
+            } else {
+                StringUTF16.putChar(bytes, i, c);
+            }
+        }
+    }
+
+    /**
+     * Primitive overload for int - avoids boxing and intermediate String.
+     * Handles localization of digits and minus sign.
+     */
+    @ForceInline
+    private static String format_splice1(String format, int arg, int specIndex) {
+        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+        char zeroDigit = dfs.getZeroDigit();
+        char minusSign = dfs.getMinusSign();
+
+        int argLen = DecimalDigits.stringSize(arg);
+        // Coder must account for both zeroDigit and minusSign (for negative numbers)
+        byte coder = (byte) (StringLatin1.coderFromChar(zeroDigit)
+                           | StringLatin1.coderFromChar(minusSign)
+                           | format.coder());
+        int newLen = format.length() - 2 + argLen;
+        byte[] bytes = new byte[newLen << coder];
+        format.getBytes(bytes, 0, 0, coder, specIndex);
+        int fillEnd = specIndex + argLen;
+        if (coder == LATIN1) {
+            DecimalDigits.uncheckedGetCharsLatin1(arg, fillEnd, bytes);
+        } else {
+            DecimalDigits.uncheckedGetCharsUTF16(arg, fillEnd, bytes);
+        }
+        format.getBytes(bytes, specIndex + 2, fillEnd, coder, format.length() - specIndex - 2);
+
+        // Localize digits and minus sign if needed
+        if (zeroDigit != '0' || minusSign != '-') {
+            format_localizeDigitsInPlace(bytes, specIndex, fillEnd, coder, zeroDigit, minusSign);
+        }
+
+        return new String(bytes, coder);
+    }
+
+    /** Primitive overload for long - avoids boxing and intermediate String. */
+    @ForceInline
+    private static String format_splice1(String format, long arg, int specIndex) {
+        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+        char zeroDigit = dfs.getZeroDigit();
+        char minusSign = dfs.getMinusSign();
+
+        int argLen = DecimalDigits.stringSize(arg);
+        // Coder must account for both zeroDigit and minusSign (for negative numbers)
+        byte coder = (byte) (StringLatin1.coderFromChar(zeroDigit)
+                           | StringLatin1.coderFromChar(minusSign)
+                           | format.coder());
+        int newLen = format.length() - 2 + argLen;
+        byte[] bytes = new byte[newLen << coder];
+        format.getBytes(bytes, 0, 0, coder, specIndex);
+        int fillEnd = specIndex + argLen;
+        if (coder == LATIN1) {
+            DecimalDigits.uncheckedGetCharsLatin1(arg, fillEnd, bytes);
+        } else {
+            DecimalDigits.uncheckedGetCharsUTF16(arg, fillEnd, bytes);
+        }
+        format.getBytes(bytes, specIndex + 2, fillEnd, coder, format.length() - specIndex - 2);
+
+        // Localize digits and minus sign if needed
+        if (zeroDigit != '0' || minusSign != '-') {
+            format_localizeDigitsInPlace(bytes, specIndex, fillEnd, coder, zeroDigit, minusSign);
+        }
+
+        return new String(bytes, coder);
+    }
+
+    /**
+     * Write padding spaces directly into dst byte array.
+     * Caller must ensure padding > 0.
+     */
+    private static void format_writePadding(byte[] dst, int dstPos, int padding, byte coder) {
+        if (coder == LATIN1) {
+            Arrays.fill(dst, dstPos, dstPos + padding, (byte) ' ');
+        } else {
+            for (int i = 0; i < padding; i++) {
+                StringUTF16.putChar(dst, dstPos + i, ' ');
+            }
+        }
+    }
+
+    // --- Static format methods (called by C2 for String.format) ---
+
+    /**
+     * Fast-path formatter for format strings containing exactly one {@code %s}
+     * specifier without width or flags.
+     * Called from C2-compiled code when the specifier is plain %s.
+     * @param specIndex the position of '%' in the format string
+     */
+    @ForceInline
+    private static String format_s(String format, Object arg, int specIndex) {
+        int ci = specIndex & 0xFF;
+        // For Formattable, call formatTo with width=0
+        if (arg instanceof java.util.Formattable) {
+            return format_splice1(format, format_toStringArg(arg, 0), ci);
+        }
+        return format_splice1(format, String.valueOf(arg), ci);
+    }
+
+    // --- Argument conversion helpers ---
+
+    /**
+     * Convert an Object argument to String for %s conversion.
+     * If the argument implements {@link java.util.Formattable}, uses its formatTo method
+     * with the specified width (flags=0, precision=-1) to match Formatter behavior.
+     * The returned string is already width-padded by formatTo, so no additional
+     * padding should be applied.
+     * Otherwise, returns String.valueOf(arg) which needs width padding.
+     */
+    private static String format_toStringArg(Object arg, int width) {
+        if (arg instanceof java.util.Formattable formattable) {
+            var sb = new StringBuilder();
+            // formatTo handles width internally, no additional padding needed
+            formattable.formatTo(new Formatter(sb), 0, width, -1);
+            return sb.toString();
+        }
+        return String.valueOf(arg);
+    }
+
+    /**
+     * Convert an {@code Object} argument to its decimal string representation,
+     * respecting the default format locale's zero digit.
+     * Supports {@code Integer}, {@code Long}, {@code Short}, and {@code Byte}.
+     * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
+     */
+    private static String format_toDecimalString(Object arg) {
+        return format_toDecimalString(arg, DecimalFormat.FORMATTER_ACCESS
+                .getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT)));
+    }
+
+    /**
+     * Convert an {@code Object} argument to its decimal string representation
+     * with externally provided DecimalFormatSymbols for locale-aware formatting.
+     * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
+     */
+    private static String format_toDecimalString(Object arg, java.text.DecimalFormatSymbols dfs) {
+        String s;
+        if (arg instanceof Integer v) {
+            s = Integer.toString(v);
+        } else if (arg instanceof Long v) {
+            s = Long.toString(v);
+        } else if (arg instanceof Short v) {
+            s = Integer.toString(v);
+        } else if (arg instanceof Byte v) {
+            s = Integer.toString(v);
+        } else {
+            throw new java.util.IllegalFormatConversionException('d', arg != null ? arg.getClass() : Object.class);
+        }
+        return format_localizeDigits(s, dfs);
+    }
+
+    /**
+     * Holder for locale-aware decimal formatting via SharedSecrets.
+     * The static final field ensures the access is resolved once on first use.
+     */
+    private static final class DecimalFormat {
+        static final jdk.internal.access.JavaUtilFormatterAccess FORMATTER_ACCESS =
+                jdk.internal.access.SharedSecrets.getJavaUtilFormatterAccess();
+    }
+
+    /**
+     * Replace ASCII digits '0'-'9' and minus sign '-' with locale-specific
+     * characters using the provided DecimalFormatSymbols.
+     * Note: decimal separator '.' handling is included for future %f support,
+     * though current callers (Integer/Long.toString) never produce '.'.
+     */
+    private static String format_localizeDigits(String s, java.text.DecimalFormatSymbols dfs) {
+        char zero = dfs.getZeroDigit();
+        char decSep = dfs.getDecimalSeparator();
+        if (zero == '0' && decSep == '.') {
+            return s;
+        }
+        char minus = dfs.getMinusSign();
+        char[] chars = new char[s.length()];
+        int i = 0;
+        if (s.length() != 0 && s.charAt(0) == '-') {
+            chars[i++] = minus;
+        }
+        for (; i < chars.length; i++) {
+            char c = s.charAt(i);
+            if (c >= '0' && c <= '9') {
+                chars[i] = (char) (c - '0' + zero);
+            } else if (c == '.') {
+                chars[i] = decSep;
+            } else {
+                chars[i] = c;
+            }
+        }
+        return new String(chars);
+    }
+
+    /**
+     * Convert an {@code Object} argument to its lowercase hexadecimal string
+     * representation. Supports {@code Integer}, {@code Long}, {@code Short},
+     * and {@code Byte}.
+     * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
+     */
+    private static String format_toHexString(Object arg) {
+        if (arg instanceof Integer v) {
+            return Integer.toHexString(v);
+        } else if (arg instanceof Long v) {
+            return Long.toHexString(v);
+        } else if (arg instanceof Short v) {
+            return Integer.toHexString(v & 0xFFFF);
+        } else if (arg instanceof Byte v) {
+            return Integer.toHexString(v & 0xFF);
+        }
+        throw new java.util.IllegalFormatConversionException('x', arg != null ? arg.getClass() : Object.class);
+    }
+
+    /**
+     * Convert an {@code Object} argument to its uppercase hexadecimal string
+     * representation. Supports {@code Integer}, {@code Long}, {@code Short},
+     * and {@code Byte}.
+     * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
+     */
+    private static String format_toUpperHexString(Object arg) {
+        if (arg instanceof Integer v) {
+            return Integer.toHexString(v).toUpperCase(java.util.Locale.ROOT);
+        } else if (arg instanceof Long v) {
+            return Long.toHexString(v).toUpperCase(java.util.Locale.ROOT);
+        } else if (arg instanceof Short v) {
+            return Integer.toHexString(v & 0xFFFF).toUpperCase(java.util.Locale.ROOT);
+        } else if (arg instanceof Byte v) {
+            return Integer.toHexString(v & 0xFF).toUpperCase(java.util.Locale.ROOT);
+        }
+        throw new java.util.IllegalFormatConversionException('X', arg != null ? arg.getClass() : Object.class);
+    }
+
+    // --- Format methods continued ---
+
+    /**
+     * Fast-path formatter for {@code %d} without width or flags.
+     * @param specIndex the position of '%' in the format string
+     */
+    @ForceInline
+    private static String format_d(String format, Object arg, int specIndex) {
+        int ci = specIndex & 0xFF;
+        return format_splice1(format, format_toDecimalString(arg), ci);
+    }
+
+    /** Primitive overload for int arg - avoids boxing allocation. */
+    @ForceInline
+    private static String format_d(String format, int arg, int specIndex) {
+        return format_splice1(format, arg, specIndex & 0xFF);
+    }
+
+    /** Primitive overload for long arg - avoids boxing allocation. */
+    @ForceInline
+    private static String format_d(String format, long arg, int specIndex) {
+        return format_splice1(format, arg, specIndex & 0xFF);
+    }
+
+    /**
+     * Fast-path formatter for single specifier with width and/or flags.
+     * Handles %s/%d/%x/%X with optional width (1-9) and flags (' ' or '0').
+     * @param meta packed: byte0=specIndex, byte1=conv, byte2=width, byte3=flag
+     */
+    @ForceInline
+    private static String format_1(String format, Object arg, int meta) {
+        int ci = meta & 0xFF;
+        int conv = (meta >>> 8) & 0xFF;
+        int width = (meta >>> 16) & 0xFF;
+        int flag = (meta >>> 24) & 0xFF;
+
+        // For %s with Formattable, let formatTo handle width
+        if (conv == 's' && arg instanceof java.util.Formattable) {
+            return format_splice1(format, format_toStringArg(arg, width), ci);
+        }
+
+        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+        String argStr;
+        switch (conv) {
+            case 'd' -> argStr = format_toDecimalString(arg, dfs);
+            case 'x' -> argStr = format_toHexString(arg);
+            case 'X' -> argStr = format_toUpperHexString(arg);
+            default  -> argStr = String.valueOf(arg); // 's'
+        }
+
+        // No width/flag - use simple splice
+        if (width == 0 && flag == 0) {
+            return format_splice1(format, argStr, ci);
+        }
+
+        char minusSign = dfs.getMinusSign();
+
+        // Handle flags and padding
+        int argLen = argStr.length();
+        boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == minusSign;
+        boolean hasLeadingSpace = (flag == ' ' && !isNegative);
+        boolean isZeroPad = (flag == '0');
+
+        // Calculate specifier length: % + [flag] + [width] + conv
+        int convLen = 2 + (flag != 0 ? 1 : 0) + (width > 0 ? 1 : 0);
+
+        // Leading space occupies one position in width
+        int effectiveWidth = width;
+        if (hasLeadingSpace && effectiveWidth > 0) {
+            effectiveWidth--;
+        }
+
+        int padding = Math.max(effectiveWidth - argLen, 0);
+        byte coder = (byte) (argStr.coder() | format.coder());
+        int newLen = format.length() - convLen + (hasLeadingSpace ? 1 : 0) + padding + argLen;
+        byte[] bytes = new byte[newLen << coder];
+        format.getBytes(bytes, 0, 0, coder, ci);
+        int dstPos = ci;
+
+        // Handle LEADING_SPACE flag
+        if (hasLeadingSpace) {
+            if (coder == LATIN1) {
+                bytes[dstPos++] = (byte) ' ';
+            } else {
+                StringUTF16.putChar(bytes, dstPos++, ' ');
+            }
+        }
+
+        // Handle padding
+        if (padding > 0) {
+            char zero = dfs.getZeroDigit();
+            if (isZeroPad && isNegative) {
+                // Zero pad with negative: sign first, then zeros, then digits
+                if (coder == LATIN1) {
+                    bytes[dstPos++] = (byte) minusSign;
+                } else {
+                    StringUTF16.putChar(bytes, dstPos++, minusSign);
+                }
+                for (int i = 0; i < padding; i++) {
+                    if (coder == LATIN1) {
+                        bytes[dstPos++] = (byte) zero;
+                    } else {
+                        StringUTF16.putChar(bytes, dstPos++, zero);
+                    }
+                }
+                argStr.getBytes(bytes, 1, dstPos, coder, argLen - 1);
+                dstPos += argLen - 1;
+            } else {
+                // Space pad or zero pad without negative sign
+                byte padChar = (isZeroPad && !isNegative) ? (byte) zero : (byte) ' ';
+                if (coder == LATIN1) {
+                    Arrays.fill(bytes, dstPos, dstPos + padding, padChar);
+                } else {
+                    char padChar16 = (isZeroPad && !isNegative) ? zero : ' ';
+                    for (int i = 0; i < padding; i++) {
+                        StringUTF16.putChar(bytes, dstPos + i, padChar16);
+                    }
+                }
+                dstPos += padding;
+                argStr.getBytes(bytes, 0, dstPos, coder, argLen);
+                dstPos += argLen;
+            }
+        } else {
+            argStr.getBytes(bytes, 0, dstPos, coder, argLen);
+            dstPos += argLen;
+        }
+
+        format.getBytes(bytes, ci + convLen, dstPos, coder, format.length() - ci - convLen);
+        return new String(bytes, coder);
+    }
+
+    /** Virtual fast-path for single specifier with width/flags. */
+    @ForceInline
+    private String formatted_1(Object arg, int meta) {
+        return format_1(this, arg, meta);
+    }
+
+    /**
+     * Core two-specifier formatting: splice argStr1 and argStr2 into format,
+     * with optional left-padding for each.
+     * @param meta packed: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+     *
+     * Note: This method assumes specifiers have no flags (only optional width).
+     * Specifiers with flags (' ', '0') are handled by format_multi instead.
+     * The convLen calculation (2 or 3) is correct only for %[width]s or %[width]d.
+     */
+    @ForceInline
+    private static String format_splice2(String format, String argStr1, String argStr2, int meta) {
+        int ci1 = meta & 0xFF;
+        int w1  = (meta >> 8) & 0xFF;
+        int ci2 = (meta >> 16) & 0xFF;
+        int w2  = (meta >> 24) & 0xFF;
+        int convLen1 = (w1 > 0) ? 3 : 2;
+        int convLen2 = (w2 > 0) ? 3 : 2;
+        int pad1 = Math.max(w1 - argStr1.length(), 0);
+        int pad2 = Math.max(w2 - argStr2.length(), 0);
+        byte coder = (byte) (argStr1.coder() | argStr2.coder() | format.coder());
+        int newLen = format.length() - convLen1 - convLen2 + pad1 + argStr1.length() + pad2 + argStr2.length();
+        byte[] bytes = new byte[newLen << coder];
+        // segment 1: format[0 .. ci1)
+        format.getBytes(bytes, 0, 0, coder, ci1);
+        int dstPos = ci1;
+        // segment 2: pad1 + arg1
+        if (pad1 > 0) {
+            format_writePadding(bytes, dstPos, pad1, coder);
+            dstPos += pad1;
+        }
+        argStr1.getBytes(bytes, 0, dstPos, coder, argStr1.length());
+        dstPos += argStr1.length();
+        // segment 3: format[ci1+convLen1 .. ci2)
+        int midLen = ci2 - ci1 - convLen1;
+        format.getBytes(bytes, ci1 + convLen1, dstPos, coder, midLen);
+        dstPos += midLen;
+        // segment 4: pad2 + arg2
+        if (pad2 > 0) {
+            format_writePadding(bytes, dstPos, pad2, coder);
+            dstPos += pad2;
+        }
+        argStr2.getBytes(bytes, 0, dstPos, coder, argStr2.length());
+        dstPos += argStr2.length();
+        // segment 5: format[ci2+convLen2 .. end)
+        format.getBytes(bytes, ci2 + convLen2, dstPos, coder, format.length() - ci2 - convLen2);
+        return new String(bytes, coder);
+    }
+
+    /** Fast-path for two {@code %s} specifiers.
+     * @param specIndexes packed: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+     */
+    @ForceInline
+    private static String format_ss(String format, Object arg1, Object arg2, int specIndexes) {
+        int ci1 = specIndexes & 0xFF, w1 = (specIndexes >> 8) & 0xFF;
+        int ci2 = (specIndexes >> 16) & 0xFF, w2 = (specIndexes >> 24) & 0xFF;
+        // For Formattable, formatTo handles width; adjust meta to skip extra padding
+        String s1 = (arg1 instanceof java.util.Formattable) ? format_toStringArg(arg1, w1) : String.valueOf(arg1);
+        String s2 = (arg2 instanceof java.util.Formattable) ? format_toStringArg(arg2, w2) : String.valueOf(arg2);
+        int adjW1 = (arg1 instanceof java.util.Formattable) ? 0 : w1;
+        int adjW2 = (arg2 instanceof java.util.Formattable) ? 0 : w2;
+        int adjMeta = ci1 | (adjW1 << 8) | (ci2 << 16) | (adjW2 << 24);
+        return format_splice2(format, s1, s2, adjMeta);
+    }
+
+    /** Fast-path for {@code %s} followed by {@code %d}.
+     * @param specIndexes packed: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+     */
+    @ForceInline
+    private static String format_sd(String format, Object arg1, Object arg2, int specIndexes) {
+        int ci1 = specIndexes & 0xFF, w1 = (specIndexes >> 8) & 0xFF;
+        int ci2 = (specIndexes >> 16) & 0xFF, w2 = (specIndexes >> 24) & 0xFF;
+        // For Formattable, formatTo handles width; adjust meta to skip extra padding
+        String s1 = (arg1 instanceof java.util.Formattable) ? format_toStringArg(arg1, w1) : String.valueOf(arg1);
+        int adjW1 = (arg1 instanceof java.util.Formattable) ? 0 : w1;
+        int adjMeta = ci1 | (adjW1 << 8) | (ci2 << 16) | (w2 << 24);
+        return format_splice2(format, s1, format_toDecimalString(arg2), adjMeta);
+    }
+
+    /** Fast-path for {@code %d} followed by {@code %s}.
+     * @param specIndexes packed: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+     */
+    @ForceInline
+    private static String format_ds(String format, Object arg1, Object arg2, int specIndexes) {
+        int ci1 = specIndexes & 0xFF, w1 = (specIndexes >> 8) & 0xFF;
+        int ci2 = (specIndexes >> 16) & 0xFF, w2 = (specIndexes >> 24) & 0xFF;
+        // For Formattable, formatTo handles width; adjust meta to skip extra padding
+        String s2 = (arg2 instanceof java.util.Formattable) ? format_toStringArg(arg2, w2) : String.valueOf(arg2);
+        int adjW2 = (arg2 instanceof java.util.Formattable) ? 0 : w2;
+        int adjMeta = ci1 | (w1 << 8) | (ci2 << 16) | (adjW2 << 24);
+        return format_splice2(format, format_toDecimalString(arg1), s2, adjMeta);
+    }
+
+    /** Fast-path for two {@code %d} specifiers.
+     * @param specIndexes packed: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+     */
+    @ForceInline
+    private static String format_dd(String format, Object arg1, Object arg2, int specIndexes) {
+        return format_splice2(format, format_toDecimalString(arg1), format_toDecimalString(arg2), specIndexes);
+    }
+
+    /**
+     * Fast-path for two specifiers where at least one is %x or %X (no width/flags).
+     * @param meta packed: byte0=ci1, byte1=conv1, byte2=ci2, byte3=conv2
+     */
+    @ForceInline
+    private static String format_2(String format, Object arg1, Object arg2, int meta) {
+        int ci1 = meta & 0xFF;
+        int conv1 = (meta >> 8) & 0xFF;
+        int ci2 = (meta >> 16) & 0xFF;
+        int conv2 = (meta >> 24) & 0xFF;
+
+        String s1 = format_argFor2(arg1, conv1);
+        String s2 = format_argFor2(arg2, conv2);
+
+        // Both specifiers have no width/flags, so convLen is always 2
+        int convLen = 2;
+        byte coder = (byte) (s1.coder() | s2.coder() | format.coder());
+        int newLen = format.length() - 2 * convLen + s1.length() + s2.length();
+        byte[] bytes = new byte[newLen << coder];
+        // segment 1: format[0 .. ci1)
+        format.getBytes(bytes, 0, 0, coder, ci1);
+        int dstPos = ci1;
+        // segment 2: arg1
+        s1.getBytes(bytes, 0, dstPos, coder, s1.length());
+        dstPos += s1.length();
+        // segment 3: format[ci1+convLen .. ci2)
+        int midLen = ci2 - ci1 - convLen;
+        format.getBytes(bytes, ci1 + convLen, dstPos, coder, midLen);
+        dstPos += midLen;
+        // segment 4: arg2
+        s2.getBytes(bytes, 0, dstPos, coder, s2.length());
+        dstPos += s2.length();
+        // segment 5: format[ci2+convLen .. end)
+        format.getBytes(bytes, ci2 + convLen, dstPos, coder, format.length() - ci2 - convLen);
+        return new String(bytes, coder);
+    }
+
+    /** Format a single argument for format_2 based on conversion character. */
+    private static String format_argFor2(Object arg, int conv) {
+        return switch (conv) {
+            case 'd' -> format_toDecimalString(arg);
+            case 'x' -> format_toHexString(arg);
+            case 'X' -> format_toUpperHexString(arg);
+            default  -> String.valueOf(arg); // 's'
+        };
+    }
+
+    /** Virtual fast-path for two specifiers with %x/%X. */
+    @ForceInline
+    private String formatted_2(Object arg1, Object arg2, int meta) {
+        return format_2(this, arg1, arg2, meta);
+    }
+
+    /**
+     * Format an argument according to the specifier character and append to StringBuilder,
+     * handling padding and width flags, using the provided DecimalFormatSymbols
+     * for locale-aware formatting.
+     *
+     * @param sb    StringBuilder to append the formatted result to
+     * @param arg   the argument to format
+     * @param conv  the conversion character ('s', 'd', 'x', 'X')
+     * @param flag  the flag character (0 if none, ' ' for leading space, '0' for zero pad)
+     * @param width the minimum width (0 if none)
+     * @param dfs   DecimalFormatSymbols for locale-aware formatting (only used for 'd')
+     */
+    private static void format_arg(StringBuilder sb, Object arg, int conv, char flag, int width,
+                                   java.text.DecimalFormatSymbols dfs) {
+        // For %s with Formattable, let formatTo handle width directly
+        if (conv == 's' && arg instanceof java.util.Formattable) {
+            sb.append(format_toStringArg(arg, width));
+            return;
+        }
+
+        String argStr = switch (conv) {
+            case 'd' -> format_toDecimalString(arg, dfs);
+            case 'x' -> format_toHexString(arg);
+            case 'X' -> format_toUpperHexString(arg);
+            default  -> String.valueOf(arg); // 's' (non-Formattable) and fallback
+        };
+
+        int argLen = argStr.length();
+        int padding = width - argLen;
+
+        // Only 'd' needs locale-aware negative handling
+        if (conv == 'd') {
+            char minusSign = dfs.getMinusSign();
+            boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == minusSign;
+            boolean hasLeadingSpace = (flag == ' ' && !isNegative);
+
+            // Leading space occupies one position in the width, adjust padding
+            if (hasLeadingSpace && padding > 0) {
+                padding--;
+            }
+
+            // Handle LEADING_SPACE flag: insert space before positive values
+            if (hasLeadingSpace) {
+                sb.append(' ');
+            }
+
+            if (padding > 0 && flag == '0') {
+                if (isNegative) {
+                    // ZERO_PAD with negative: sign first, then zeros, then digits
+                    sb.append(minusSign)
+                      .repeat('0', padding)
+                      .append(argStr, 1, argLen);
+                } else {
+                    sb.repeat('0', padding)
+                      .append(argStr);
+                }
+            } else {
+                if (padding > 0) {
+                    sb.repeat(' ', padding);
+                }
+                sb.append(argStr);
+            }
+        } else {
+            // 's', 'x', 'X' - simple padding only
+            if (padding > 0) {
+                sb.repeat(flag == '0' ? '0' : ' ', padding);
+            }
+            sb.append(argStr);
+        }
+    }
+
+    /**
+     * Fast-path formatter for format strings with 1-8 specifiers (%s/%d/%x/%X
+     * with optional single-char flag and single-digit width).
+     * Called from C2-compiled code when the format string is a compile-time constant.
+     *
+     * @param specIndexes packed specifier positions: byte0=ci1, byte1=ci2, ..., byte7=ci8
+     */
+    private static String format_multi(String format, Object[] args, long specIndexes) {
+        // C2 ensures args.length equals the specifier count packed in specIndexes.
+        // We use args.length here as a proxy for spec count since the array length
+        // is guaranteed to match by the C2 optimization guard.
+        // Note: Java assert is not used here because String is bootstrapped before
+        // AssertionError is linked.
+        int count = args.length;
+        StringBuilder sb = new StringBuilder(format.length() + count * 8);
+        int fmtPos = 0;
+        // Get DecimalFormatSymbols once for the entire loop
+        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+
+        for (int i = 0; i < count; i++) {
+            int ci = (int) ((specIndexes >>> (i * 8)) & 0xFF);
+            // Parse specifier at format[ci] to get conv, width, flag
+            int pos = ci + 1;
+            char nc = format.charAt(pos);
+
+            // Check for optional flag (only ' ' and '0' are supported)
+            char flag = 0;
+            if (nc == ' ' || nc == '0') {
+                flag = nc;
+                pos++;
+                nc = format.charAt(pos);
+            }
+
+            // Check for optional width digit
+            int width = 0;
+            if (nc >= '1' && nc <= '9') {
+                width = nc - '0';
+                pos++;
+                nc = format.charAt(pos);
+            }
+
+            char conv = nc;
+            int convLen = pos - ci + 1;
+
+            // Append literal segment before this specifier
+            if (ci > fmtPos) {
+                sb.append(format, fmtPos, ci);
+            }
+
+            // Format argument with padding and flags
+            format_arg(sb, args[i], conv, flag, width, dfs);
+
+            fmtPos = ci + convLen;
+        }
+        // Append trailing literal segment
+        if (fmtPos < format.length()) {
+            sb.append(format, fmtPos, format.length());
+        }
+        return sb.toString();
+    }
+
+    // ========== END: C2 String.format/formatted optimization ==========
 
     /**
      * Returns the string representation of the {@code Object} argument.

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4917,18 +4917,18 @@ public final class String
     }
 
     /**
-     * Localize digits and minus sign in a byte array.
-     * Converts ASCII digits '0'-'9' to locale-specific digits and '-' to locale-specific minus sign.
+     * Localize digits in a byte array.
+     * Converts ASCII digits '0'-'9' to locale-specific digits.
+     * Note: Minus sign '-' is NOT localized (per Formatter.leadingSign behavior).
      */
     private static void format_localizeDigitsInPlace(byte[] bytes, int start, int end, byte coder,
-                                               char zeroDigit, char minusSign) {
+                                               char zeroDigit) {
         for (int i = start; i < end; i++) {
             char c = coder == LATIN1 ? (char) (bytes[i] & 0xFF) : StringUTF16.charAt(bytes, i);
-            if (c == '-') {
-                c = minusSign;
-            } else if (c >= '0' && c <= '9') {
+            if (c >= '0' && c <= '9') {
                 c = (char) (c - '0' + zeroDigit);
             }
+            // Note: minus sign '-' is NOT localized (per Formatter.leadingSign behavior)
             if (coder == LATIN1) {
                 bytes[i] = (byte) c;
             } else {
@@ -4939,18 +4939,17 @@ public final class String
 
     /**
      * Primitive overload for int - avoids boxing and intermediate String.
-     * Handles localization of digits and minus sign.
+     * Handles localization of digits.
      */
     @ForceInline
     private static String format_splice1(String format, int arg, int specIndex) {
         var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
         char zeroDigit = dfs.getZeroDigit();
-        char minusSign = dfs.getMinusSign();
 
         int argLen = DecimalDigits.stringSize(arg);
-        // Coder must account for both zeroDigit and minusSign (for negative numbers)
+        // Coder must account for zeroDigit (for digits localization)
+        // Note: minus sign is NOT localized, so coder only depends on zeroDigit
         byte coder = (byte) (StringLatin1.coderFromChar(zeroDigit)
-                           | StringLatin1.coderFromChar(minusSign)
                            | format.coder());
         int newLen = format.length() - 2 + argLen;
         byte[] bytes = new byte[newLen << coder];
@@ -4963,9 +4962,9 @@ public final class String
         }
         format.getBytes(bytes, specIndex + 2, fillEnd, coder, format.length() - specIndex - 2);
 
-        // Localize digits and minus sign if needed
-        if (zeroDigit != '0' || minusSign != '-') {
-            format_localizeDigitsInPlace(bytes, specIndex, fillEnd, coder, zeroDigit, minusSign);
+        // Localize digits if needed
+        if (zeroDigit != '0') {
+            format_localizeDigitsInPlace(bytes, specIndex, fillEnd, coder, zeroDigit);
         }
 
         return new String(bytes, coder);
@@ -4976,12 +4975,11 @@ public final class String
     private static String format_splice1(String format, long arg, int specIndex) {
         var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
         char zeroDigit = dfs.getZeroDigit();
-        char minusSign = dfs.getMinusSign();
 
         int argLen = DecimalDigits.stringSize(arg);
-        // Coder must account for both zeroDigit and minusSign (for negative numbers)
+        // Coder must account for zeroDigit (for digits localization)
+        // Note: minus sign is NOT localized, so coder only depends on zeroDigit
         byte coder = (byte) (StringLatin1.coderFromChar(zeroDigit)
-                           | StringLatin1.coderFromChar(minusSign)
                            | format.coder());
         int newLen = format.length() - 2 + argLen;
         byte[] bytes = new byte[newLen << coder];
@@ -4994,9 +4992,9 @@ public final class String
         }
         format.getBytes(bytes, specIndex + 2, fillEnd, coder, format.length() - specIndex - 2);
 
-        // Localize digits and minus sign if needed
-        if (zeroDigit != '0' || minusSign != '-') {
-            format_localizeDigitsInPlace(bytes, specIndex, fillEnd, coder, zeroDigit, minusSign);
+        // Localize digits if needed
+        if (zeroDigit != '0') {
+            format_localizeDigitsInPlace(bytes, specIndex, fillEnd, coder, zeroDigit);
         }
 
         return new String(bytes, coder);
@@ -5087,9 +5085,14 @@ public final class String
     /**
      * Convert an {@code Object} argument to its decimal string representation
      * with externally provided DecimalFormatSymbols for locale-aware formatting.
+     * Returns "null" if arg is null (consistent with Formatter behavior).
+     * Supports Integer, Long, Short, Byte, and BigInteger (consistent with Formatter).
      * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
      */
     private static String format_toDecimalString(Object arg, java.text.DecimalFormatSymbols dfs) {
+        if (arg == null) {
+            return "null";
+        }
         String s;
         if (arg instanceof Integer v) {
             s = Integer.toString(v);
@@ -5099,8 +5102,10 @@ public final class String
             s = Integer.toString(v);
         } else if (arg instanceof Byte v) {
             s = Integer.toString(v);
+        } else if (arg instanceof java.math.BigInteger v) {
+            s = v.toString();
         } else {
-            throw new java.util.IllegalFormatConversionException('d', arg != null ? arg.getClass() : Object.class);
+            throw new java.util.IllegalFormatConversionException('d', arg.getClass());
         }
         return format_localizeDigits(s, dfs);
     }
@@ -5115,8 +5120,8 @@ public final class String
     }
 
     /**
-     * Replace ASCII digits '0'-'9' and minus sign '-' with locale-specific
-     * characters using the provided DecimalFormatSymbols.
+     * Replace ASCII digits '0'-'9' with locale-specific characters.
+     * Note: Minus sign '-' is NOT localized (per Formatter spec).
      * Note: decimal separator '.' handling is included for future %f support,
      * though current callers (Integer/Long.toString) never produce '.'.
      */
@@ -5126,21 +5131,15 @@ public final class String
         if (zero == '0' && decSep == '.') {
             return s;
         }
-        char minus = dfs.getMinusSign();
-        char[] chars = new char[s.length()];
-        int i = 0;
-        if (s.length() != 0 && s.charAt(0) == '-') {
-            chars[i++] = minus;
-        }
-        for (; i < chars.length; i++) {
-            char c = s.charAt(i);
+        char[] chars = s.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
             if (c >= '0' && c <= '9') {
                 chars[i] = (char) (c - '0' + zero);
             } else if (c == '.') {
                 chars[i] = decSep;
-            } else {
-                chars[i] = c;
             }
+            // Note: minus sign '-' is NOT localized (per Formatter.leadingSign behavior)
         }
         return new String(chars);
     }
@@ -5148,10 +5147,14 @@ public final class String
     /**
      * Convert an {@code Object} argument to its lowercase hexadecimal string
      * representation. Supports {@code Integer}, {@code Long}, {@code Short},
-     * and {@code Byte}.
+     * {@code Byte}, and {@code BigInteger} (consistent with Formatter).
+     * Returns "null" if arg is null (consistent with Formatter behavior).
      * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
      */
     private static String format_toHexString(Object arg) {
+        if (arg == null) {
+            return "null";
+        }
         if (arg instanceof Integer v) {
             return Integer.toHexString(v);
         } else if (arg instanceof Long v) {
@@ -5160,17 +5163,23 @@ public final class String
             return Integer.toHexString(v & 0xFFFF);
         } else if (arg instanceof Byte v) {
             return Integer.toHexString(v & 0xFF);
+        } else if (arg instanceof java.math.BigInteger v) {
+            return v.toString(16);
         }
-        throw new java.util.IllegalFormatConversionException('x', arg != null ? arg.getClass() : Object.class);
+        throw new java.util.IllegalFormatConversionException('x', arg.getClass());
     }
 
     /**
      * Convert an {@code Object} argument to its uppercase hexadecimal string
      * representation. Supports {@code Integer}, {@code Long}, {@code Short},
-     * and {@code Byte}.
+     * {@code Byte}, and {@code BigInteger} (consistent with Formatter).
+     * Returns "NULL" if arg is null (consistent with Formatter behavior for %X).
      * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
      */
     private static String format_toUpperHexString(Object arg) {
+        if (arg == null) {
+            return "NULL";
+        }
         if (arg instanceof Integer v) {
             return Integer.toHexString(v).toUpperCase(java.util.Locale.ROOT);
         } else if (arg instanceof Long v) {
@@ -5179,8 +5188,10 @@ public final class String
             return Integer.toHexString(v & 0xFFFF).toUpperCase(java.util.Locale.ROOT);
         } else if (arg instanceof Byte v) {
             return Integer.toHexString(v & 0xFF).toUpperCase(java.util.Locale.ROOT);
+        } else if (arg instanceof java.math.BigInteger v) {
+            return v.toString(16).toUpperCase(java.util.Locale.ROOT);
         }
-        throw new java.util.IllegalFormatConversionException('X', arg != null ? arg.getClass() : Object.class);
+        throw new java.util.IllegalFormatConversionException('X', arg.getClass());
     }
 
     // --- Format methods continued ---
@@ -5224,27 +5235,45 @@ public final class String
             return format_splice1(format, format_toStringArg(arg, width), ci);
         }
 
-        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
-        String argStr;
-        switch (conv) {
-            case 'd' -> argStr = format_toDecimalString(arg, dfs);
-            case 'x' -> argStr = format_toHexString(arg);
-            case 'X' -> argStr = format_toUpperHexString(arg);
-            default  -> argStr = String.valueOf(arg); // 's'
-        }
-
-        // No width/flag - use simple splice
-        if (width == 0 && flag == 0) {
+        // Fast path for %x/%X without width/flag - no DFS lookup needed
+        if ((conv == 'x' || conv == 'X') && width == 0 && flag == 0) {
+            String argStr = (conv == 'x') ? format_toHexString(arg) : format_toUpperHexString(arg);
             return format_splice1(format, argStr, ci);
         }
 
-        char minusSign = dfs.getMinusSign();
+        // Only %d needs DFS for locale-aware formatting
+        // For %x/%X and %s, use ASCII '-' and '0' (per Formatter spec)
+        // Note: %s without width/flag is handled by format_s, not format_1
+        // Note: Minus sign is NOT localized (per Formatter.leadingSign behavior)
+        final String argStr;
+        final char zeroDigit;
+
+        if (conv == 'd') {
+            var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+            argStr = format_toDecimalString(arg, dfs);
+            zeroDigit = dfs.getZeroDigit();
+        } else if (conv == 'x') {
+            argStr = format_toHexString(arg);
+            zeroDigit = '0';
+        } else if (conv == 'X') {
+            argStr = format_toUpperHexString(arg);
+            zeroDigit = '0';
+        } else {
+            argStr = String.valueOf(arg); // 's'
+            zeroDigit = '0';
+        }
 
         // Handle flags and padding
+        // Note: Minus sign is always ASCII '-' (per Formatter.leadingSign behavior)
+        // Note: LEADING_SPACE (' ') only applies to numeric values, not null
+        final char minusSign = '-';
         int argLen = argStr.length();
+        boolean isNull = argStr.equals("null") || argStr.equals("NULL");
         boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == minusSign;
-        boolean hasLeadingSpace = (flag == ' ' && !isNegative);
-        boolean isZeroPad = (flag == '0');
+        // LEADING_SPACE and ZERO_PAD flags only apply to numeric values, not null
+        boolean hasLeadingSpace = (flag == ' ' && !isNegative && !isNull);
+        // ZERO_PAD for null uses space padding instead (per Formatter behavior)
+        boolean isZeroPad = (flag == '0' && !isNull);
 
         // Calculate specifier length: % + [flag] + [width] + conv
         int convLen = 2 + (flag != 0 ? 1 : 0) + (width > 0 ? 1 : 0);
@@ -5273,7 +5302,6 @@ public final class String
 
         // Handle padding
         if (padding > 0) {
-            char zero = dfs.getZeroDigit();
             if (isZeroPad && isNegative) {
                 // Zero pad with negative: sign first, then zeros, then digits
                 if (coder == LATIN1) {
@@ -5283,20 +5311,20 @@ public final class String
                 }
                 for (int i = 0; i < padding; i++) {
                     if (coder == LATIN1) {
-                        bytes[dstPos++] = (byte) zero;
+                        bytes[dstPos++] = (byte) zeroDigit;
                     } else {
-                        StringUTF16.putChar(bytes, dstPos++, zero);
+                        StringUTF16.putChar(bytes, dstPos++, zeroDigit);
                     }
                 }
                 argStr.getBytes(bytes, 1, dstPos, coder, argLen - 1);
                 dstPos += argLen - 1;
             } else {
                 // Space pad or zero pad without negative sign
-                byte padChar = (isZeroPad && !isNegative) ? (byte) zero : (byte) ' ';
+                byte padChar = (isZeroPad && !isNegative) ? (byte) zeroDigit : (byte) ' ';
                 if (coder == LATIN1) {
                     Arrays.fill(bytes, dstPos, dstPos + padding, padChar);
                 } else {
-                    char padChar16 = (isZeroPad && !isNegative) ? zero : ' ';
+                    char padChar16 = (isZeroPad && !isNegative) ? zeroDigit : ' ';
                     for (int i = 0; i < padding; i++) {
                         StringUTF16.putChar(bytes, dstPos + i, padChar16);
                     }
@@ -5503,11 +5531,14 @@ public final class String
         int argLen = argStr.length();
         int padding = width - argLen;
 
-        // Only 'd' needs locale-aware negative handling
+        // Only 'd' needs locale-aware zero padding
+        // Note: Minus sign is NOT localized (per Formatter.leadingSign behavior)
+        // Note: LEADING_SPACE (' ') only applies to numeric values, not null
         if (conv == 'd') {
-            char minusSign = dfs.getMinusSign();
-            boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == minusSign;
-            boolean hasLeadingSpace = (flag == ' ' && !isNegative);
+            char zeroDigit = dfs.getZeroDigit();
+            boolean isNull = argStr.equals("null");
+            boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == '-';
+            boolean hasLeadingSpace = (flag == ' ' && !isNegative && !isNull);
 
             // Leading space occupies one position in the width, adjust padding
             if (hasLeadingSpace && padding > 0) {
@@ -5519,10 +5550,32 @@ public final class String
                 sb.append(' ');
             }
 
-            if (padding > 0 && flag == '0') {
+            // ZERO_PAD for null uses space padding instead (per Formatter behavior)
+            if (padding > 0 && flag == '0' && !isNull) {
                 if (isNegative) {
                     // ZERO_PAD with negative: sign first, then zeros, then digits
-                    sb.append(minusSign)
+                    sb.append('-')
+                      .repeat(zeroDigit, padding)
+                      .append(argStr, 1, argLen);
+                } else {
+                    sb.repeat(zeroDigit, padding)
+                      .append(argStr);
+                }
+            } else {
+                if (padding > 0) {
+                    sb.repeat(' ', padding);
+                }
+                sb.append(argStr);
+            }
+        } else {
+            // 's', 'x', 'X' - padding (ASCII '0' for %x/%X, per Formatter spec)
+            boolean isNull = argStr.equals("null") || argStr.equals("NULL");
+            boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == '-';
+            // ZERO_PAD for null uses space padding instead (per Formatter behavior)
+            if (padding > 0 && flag == '0' && !isNull) {
+                if (isNegative) {
+                    // ZERO_PAD with negative: sign first, then zeros, then digits
+                    sb.append('-')
                       .repeat('0', padding)
                       .append(argStr, 1, argLen);
                 } else {
@@ -5535,12 +5588,6 @@ public final class String
                 }
                 sb.append(argStr);
             }
-        } else {
-            // 's', 'x', 'X' - simple padding only
-            if (padding > 0) {
-                sb.repeat(flag == '0' ? '0' : ' ', padding);
-            }
-            sb.append(argStr);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4907,12 +4907,22 @@ public final class String
      */
     @ForceInline
     private static String format_splice1(String format, String argStr, int specIndex) {
+        return format_splice1(format, argStr, specIndex, 2);
+    }
+
+    /**
+     * Core single-specifier formatting with explicit specifier length.
+     * Replaces the specifier (convLen characters starting at specIndex) with argStr.
+     * @param convLen length of the specifier in the format string (e.g. 2 for %s, 3 for %5s)
+     */
+    @ForceInline
+    private static String format_splice1(String format, String argStr, int specIndex, int convLen) {
         byte coder = (byte) (argStr.coder() | format.coder());
-        int newLen = format.length() - 2 + argStr.length();
+        int newLen = format.length() - convLen + argStr.length();
         byte[] bytes = new byte[newLen << coder];
         format.getBytes(bytes, 0, 0, coder, specIndex);
         argStr.getBytes(bytes, 0, specIndex, coder, argStr.length());
-        format.getBytes(bytes, specIndex + 2, specIndex + argStr.length(), coder, format.length() - specIndex - 2);
+        format.getBytes(bytes, specIndex + convLen, specIndex + argStr.length(), coder, format.length() - specIndex - convLen);
         return new String(bytes, coder);
     }
 
@@ -4943,7 +4953,7 @@ public final class String
      */
     @ForceInline
     private static String format_splice1(String format, int arg, int specIndex) {
-        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+        var dfs = FormatterAccessHolder.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
         char zeroDigit = dfs.getZeroDigit();
 
         int argLen = DecimalDigits.stringSize(arg);
@@ -4973,7 +4983,7 @@ public final class String
     /** Primitive overload for long - avoids boxing and intermediate String. */
     @ForceInline
     private static String format_splice1(String format, long arg, int specIndex) {
-        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+        var dfs = FormatterAccessHolder.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
         char zeroDigit = dfs.getZeroDigit();
 
         int argLen = DecimalDigits.stringSize(arg);
@@ -5078,7 +5088,7 @@ public final class String
      * @throws java.util.IllegalFormatConversionException if arg is not a supported numeric type
      */
     private static String format_toDecimalString(Object arg) {
-        return format_toDecimalString(arg, DecimalFormat.FORMATTER_ACCESS
+        return format_toDecimalString(arg, FormatterAccessHolder.FORMATTER_ACCESS
                 .getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT)));
     }
 
@@ -5114,7 +5124,7 @@ public final class String
      * Holder for locale-aware decimal formatting via SharedSecrets.
      * The static final field ensures the access is resolved once on first use.
      */
-    private static final class DecimalFormat {
+    private static final class FormatterAccessHolder {
         static final jdk.internal.access.JavaUtilFormatterAccess FORMATTER_ACCESS =
                 jdk.internal.access.SharedSecrets.getJavaUtilFormatterAccess();
     }
@@ -5230,9 +5240,12 @@ public final class String
         int width = (meta >>> 16) & 0xFF;
         int flag = (meta >>> 24) & 0xFF;
 
+        // Calculate specifier length: % + [flag] + [width] + conv
+        int convLen = 2 + (flag != 0 ? 1 : 0) + (width > 0 ? 1 : 0);
+
         // For %s with Formattable, let formatTo handle width
         if (conv == 's' && arg instanceof java.util.Formattable) {
-            return format_splice1(format, format_toStringArg(arg, width), ci);
+            return format_splice1(format, format_toStringArg(arg, width), ci, convLen);
         }
 
         // Fast path for %x/%X without width/flag - no DFS lookup needed
@@ -5249,7 +5262,7 @@ public final class String
         final char zeroDigit;
 
         if (conv == 'd') {
-            var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+            var dfs = FormatterAccessHolder.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
             argStr = format_toDecimalString(arg, dfs);
             zeroDigit = dfs.getZeroDigit();
         } else if (conv == 'x') {
@@ -5268,15 +5281,12 @@ public final class String
         // Note: LEADING_SPACE (' ') only applies to numeric values, not null
         final char minusSign = '-';
         int argLen = argStr.length();
-        boolean isNull = argStr.equals("null") || argStr.equals("NULL");
+        boolean isNull = (arg == null);
         boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == minusSign;
         // LEADING_SPACE and ZERO_PAD flags only apply to numeric values, not null
         boolean hasLeadingSpace = (flag == ' ' && !isNegative && !isNull);
         // ZERO_PAD for null uses space padding instead (per Formatter behavior)
         boolean isZeroPad = (flag == '0' && !isNull);
-
-        // Calculate specifier length: % + [flag] + [width] + conv
-        int convLen = 2 + (flag != 0 ? 1 : 0) + (width > 0 ? 1 : 0);
 
         // Leading space occupies one position in width
         int effectiveWidth = width;
@@ -5351,20 +5361,22 @@ public final class String
     /**
      * Core two-specifier formatting: splice argStr1 and argStr2 into format,
      * with optional left-padding for each.
-     * @param meta packed: byte0=ci1, byte1=w1, byte2=ci2, byte3=w2
+     * @param meta packed: byte0=ci1, byte1=padW1, byte2=ci2, byte3=padW2
+     *        padW1/padW2 are the effective padding widths (may be 0 for Formattable
+     *        args where formatTo already handles width internally).
+     * @param convLen1 length of the first specifier in the format string (e.g. 2 for %s, 3 for %5s)
+     * @param convLen2 length of the second specifier in the format string
      *
      * Note: This method assumes specifiers have no flags (only optional width).
      * Specifiers with flags (' ', '0') are handled by format_multi instead.
-     * The convLen calculation (2 or 3) is correct only for %[width]s or %[width]d.
      */
     @ForceInline
-    private static String format_splice2(String format, String argStr1, String argStr2, int meta) {
+    private static String format_splice2(String format, String argStr1, String argStr2, int meta,
+                                         int convLen1, int convLen2) {
         int ci1 = meta & 0xFF;
         int w1  = (meta >> 8) & 0xFF;
         int ci2 = (meta >> 16) & 0xFF;
         int w2  = (meta >> 24) & 0xFF;
-        int convLen1 = (w1 > 0) ? 3 : 2;
-        int convLen2 = (w2 > 0) ? 3 : 2;
         int pad1 = Math.max(w1 - argStr1.length(), 0);
         int pad2 = Math.max(w2 - argStr2.length(), 0);
         byte coder = (byte) (argStr1.coder() | argStr2.coder() | format.coder());
@@ -5403,13 +5415,16 @@ public final class String
     private static String format_ss(String format, Object arg1, Object arg2, int specIndexes) {
         int ci1 = specIndexes & 0xFF, w1 = (specIndexes >> 8) & 0xFF;
         int ci2 = (specIndexes >> 16) & 0xFF, w2 = (specIndexes >> 24) & 0xFF;
+        // Compute convLen from original width BEFORE Formattable adjustment
+        int convLen1 = (w1 > 0) ? 3 : 2;
+        int convLen2 = (w2 > 0) ? 3 : 2;
         // For Formattable, formatTo handles width; adjust meta to skip extra padding
         String s1 = (arg1 instanceof java.util.Formattable) ? format_toStringArg(arg1, w1) : String.valueOf(arg1);
         String s2 = (arg2 instanceof java.util.Formattable) ? format_toStringArg(arg2, w2) : String.valueOf(arg2);
         int adjW1 = (arg1 instanceof java.util.Formattable) ? 0 : w1;
         int adjW2 = (arg2 instanceof java.util.Formattable) ? 0 : w2;
         int adjMeta = ci1 | (adjW1 << 8) | (ci2 << 16) | (adjW2 << 24);
-        return format_splice2(format, s1, s2, adjMeta);
+        return format_splice2(format, s1, s2, adjMeta, convLen1, convLen2);
     }
 
     /** Fast-path for {@code %s} followed by {@code %d}.
@@ -5419,11 +5434,14 @@ public final class String
     private static String format_sd(String format, Object arg1, Object arg2, int specIndexes) {
         int ci1 = specIndexes & 0xFF, w1 = (specIndexes >> 8) & 0xFF;
         int ci2 = (specIndexes >> 16) & 0xFF, w2 = (specIndexes >> 24) & 0xFF;
+        // Compute convLen from original width BEFORE Formattable adjustment
+        int convLen1 = (w1 > 0) ? 3 : 2;
+        int convLen2 = (w2 > 0) ? 3 : 2;
         // For Formattable, formatTo handles width; adjust meta to skip extra padding
         String s1 = (arg1 instanceof java.util.Formattable) ? format_toStringArg(arg1, w1) : String.valueOf(arg1);
         int adjW1 = (arg1 instanceof java.util.Formattable) ? 0 : w1;
         int adjMeta = ci1 | (adjW1 << 8) | (ci2 << 16) | (w2 << 24);
-        return format_splice2(format, s1, format_toDecimalString(arg2), adjMeta);
+        return format_splice2(format, s1, format_toDecimalString(arg2), adjMeta, convLen1, convLen2);
     }
 
     /** Fast-path for {@code %d} followed by {@code %s}.
@@ -5433,11 +5451,14 @@ public final class String
     private static String format_ds(String format, Object arg1, Object arg2, int specIndexes) {
         int ci1 = specIndexes & 0xFF, w1 = (specIndexes >> 8) & 0xFF;
         int ci2 = (specIndexes >> 16) & 0xFF, w2 = (specIndexes >> 24) & 0xFF;
+        // Compute convLen from original width BEFORE Formattable adjustment
+        int convLen1 = (w1 > 0) ? 3 : 2;
+        int convLen2 = (w2 > 0) ? 3 : 2;
         // For Formattable, formatTo handles width; adjust meta to skip extra padding
         String s2 = (arg2 instanceof java.util.Formattable) ? format_toStringArg(arg2, w2) : String.valueOf(arg2);
         int adjW2 = (arg2 instanceof java.util.Formattable) ? 0 : w2;
         int adjMeta = ci1 | (w1 << 8) | (ci2 << 16) | (adjW2 << 24);
-        return format_splice2(format, format_toDecimalString(arg1), s2, adjMeta);
+        return format_splice2(format, format_toDecimalString(arg1), s2, adjMeta, convLen1, convLen2);
     }
 
     /** Fast-path for two {@code %d} specifiers.
@@ -5445,7 +5466,10 @@ public final class String
      */
     @ForceInline
     private static String format_dd(String format, Object arg1, Object arg2, int specIndexes) {
-        return format_splice2(format, format_toDecimalString(arg1), format_toDecimalString(arg2), specIndexes);
+        int w1 = (specIndexes >> 8) & 0xFF;
+        int w2 = (specIndexes >> 24) & 0xFF;
+        return format_splice2(format, format_toDecimalString(arg1), format_toDecimalString(arg2), specIndexes,
+                              (w1 > 0) ? 3 : 2, (w2 > 0) ? 3 : 2);
     }
 
     /**
@@ -5531,13 +5555,13 @@ public final class String
 
         int argLen = argStr.length();
         int padding = width - argLen;
+        boolean isNull = (arg == null);
 
         // Only 'd' needs locale-aware zero padding
         // Note: Minus sign is NOT localized (per Formatter.leadingSign behavior)
         // Note: LEADING_SPACE (' ') only applies to numeric values, not null
         if (conv == 'd') {
             char zeroDigit = dfs.getZeroDigit();
-            boolean isNull = argStr.equals("null");
             boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == '-';
             boolean hasLeadingSpace = (flag == ' ' && !isNegative && !isNull);
 
@@ -5570,7 +5594,6 @@ public final class String
             }
         } else {
             // 's', 'x', 'X' - padding (ASCII '0' for %x/%X, per Formatter spec)
-            boolean isNull = argStr.equals("null") || argStr.equals("NULL");
             boolean isNegative = !argStr.isEmpty() && argStr.charAt(0) == '-';
             // ZERO_PAD for null uses space padding instead (per Formatter behavior)
             if (padding > 0 && flag == '0' && !isNull) {
@@ -5608,8 +5631,9 @@ public final class String
         int count = args.length;
         StringBuilder sb = new StringBuilder(format.length() + count * 8);
         int fmtPos = 0;
-        // Get DecimalFormatSymbols once for the entire loop
-        var dfs = DecimalFormat.FORMATTER_ACCESS.getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+        // Lazily acquire DecimalFormatSymbols only when a %d specifier is encountered.
+        // This avoids the locale/DFS lookup overhead when all specifiers are %s/%x/%X.
+        java.text.DecimalFormatSymbols dfs = null;
 
         for (int i = 0; i < count; i++) {
             int ci = (int) ((specIndexes >>> (i * 8)) & 0xFF);
@@ -5636,12 +5660,18 @@ public final class String
             char conv = nc;
             int convLen = pos - ci + 1;
 
+            // Lazily acquire DFS on first %d specifier
+            if (conv == 'd' && dfs == null) {
+                dfs = FormatterAccessHolder.FORMATTER_ACCESS
+                        .getDecimalFormatSymbols(Locale.getDefault(Locale.Category.FORMAT));
+            }
+
             // Append literal segment before this specifier
             if (ci > fmtPos) {
                 sb.append(format, fmtPos, ci);
             }
 
-            // Format argument with padding and flags
+            // Format argument with padding and flags (dfs may be null for non-%d specifiers)
             format_arg(sb, args[i], conv, flag, width, dfs);
 
             fmtPos = ci + convLen;

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -5491,7 +5491,8 @@ public final class String
             case 'd' -> format_toDecimalString(arg);
             case 'x' -> format_toHexString(arg);
             case 'X' -> format_toUpperHexString(arg);
-            default  -> String.valueOf(arg); // 's'
+            default  -> (arg instanceof java.util.Formattable) // 's'
+                         ? format_toStringArg(arg, 0) : String.valueOf(arg);
         };
     }
 

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
 
+import jdk.internal.access.JavaUtilFormatterAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.math.DoubleConsts;
 import jdk.internal.math.FormattedFPDecimal;
 import sun.util.locale.provider.LocaleProviderAdapter;
@@ -5030,6 +5032,21 @@ public final class Formatter implements Closeable, Flushable {
                 case TIME_12_HOUR, TIME_24_HOUR, DATE_TIME, DATE, ISO_STANDARD_DATE -> true;
                 default -> false;
             };
+        }
+    }
+
+    /**
+     * Registers SharedSecrets accessor for Formatter internals.
+     */
+    static final class FormatterAccess {
+        static {
+            SharedSecrets.setJavaUtilFormatterAccess(new JavaUtilFormatterAccess() {
+                @Override
+                public DecimalFormatSymbols getDecimalFormatSymbols(Locale locale) {
+                    return locale == null ? null : Formatter.getDecimalFormatSymbols(locale);
+                }
+
+            });
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/access/JavaUtilFormatterAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaUtilFormatterAccess.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.access;
+
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+public interface JavaUtilFormatterAccess {
+
+    /**
+     * Returns the cached DecimalFormatSymbols for the given locale,
+     * using Formatter's internal cache to avoid repeated lookups.
+     * Returns null if locale is null.
+     */
+    DecimalFormatSymbols getDecimalFormatSymbols(Locale locale);
+}

--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,9 +103,25 @@ public class SharedSecrets {
     @Stable private static JavaSecurityPropertiesAccess javaSecurityPropertiesAccess;
     @Stable private static JavaSecuritySignatureAccess javaSecuritySignatureAccess;
     @Stable private static JavaSecuritySpecAccess javaSecuritySpecAccess;
+    @Stable private static JavaUtilFormatterAccess javaUtilFormatterAccess;
     @Stable private static JavaxCryptoSealedObjectAccess javaxCryptoSealedObjectAccess;
     @Stable private static JavaxCryptoSpecAccess javaxCryptoSpecAccess;
     @Stable private static JavaxSecurityAccess javaxSecurityAccess;
+
+    public static void setJavaUtilFormatterAccess(JavaUtilFormatterAccess jufa) {
+        javaUtilFormatterAccess = jufa;
+    }
+
+    public static JavaUtilFormatterAccess getJavaUtilFormatterAccess() {
+        var access = javaUtilFormatterAccess;
+        if (access == null) {
+            try {
+                Class.forName("java.util.Formatter$FormatterAccess", true, null);
+                access = javaUtilFormatterAccess;
+            } catch (ClassNotFoundException e) {}
+        }
+        return access;
+    }
 
     public static void setJavaUtilCollectionAccess(JavaUtilCollectionAccess juca) {
         javaUtilCollectionAccess = juca;

--- a/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8999999
+ * @summary Test C2 optimization of String.format/formatted with simple specifiers
+ * @run main/othervm -Xcomp -XX:-TieredCompilation TestStringFormatOptimization
+ * @run main/othervm -XX:+TieredCompilation TestStringFormatOptimization
+ */
+public class TestStringFormatOptimization {
+
+    // ========== String.format() - single specifier ==========
+
+    static String testFormat_s(String s) { return String.format("%s", s); }
+    static String testFormat_sPrefix(String s) { return String.format("value : %s", s); }
+    static String testFormat_sNull() { return String.format("%s", (Object) null); }
+    static String testFormat_sFormattable(FormattableString fs) { return String.format("[%s]", fs); }
+    static String testFormat_sFormattableWidth(FormattableString fs) { return String.format("[%14s]", fs); }
+    static String testFormat_dInt(int v) { return String.format("count=%d", v); }
+    static String testFormat_dShort(short v) { return String.format("short=%d", v); }
+    static String testFormat_dByte(byte v) { return String.format("byte=%d", v); }
+    static String testFormat_dNeg(int v) { return String.format("%d items", v); }
+    static String testFormat_dLong(long v) { return String.format("long=%d", v); }
+    static String testFormat_sObject(Object obj) { return String.format("obj=%s", obj); }
+    static String testFormat_x(int v) { return String.format("0x%x", v); }
+    static String testFormat_xShort(short v) { return String.format("short=0x%x", v); }
+    static String testFormat_xByte(byte v) { return String.format("byte=0x%x", v); }
+    static String testFormat_X(int v) { return String.format("0x%X", v); }
+
+    // ========== Exception tests (wrong arg types) ==========
+
+    static void testFormat_dWrongType() { String.format("%d", "string"); }
+    static void testFormat_xWrongType() { String.format("%x", "string"); }
+    static void testFormat_XWrongType() { String.format("%X", "string"); }
+
+    // ========== formatted() - single specifier (optimized) ==========
+
+    static String testFormatted_s(String s) { return "formatted %s".formatted(s); }
+    static String testFormatted_dInt(int v) { return "count=%d".formatted(v); }
+    static String testFormatted_dLong(long v) { return "value=%d".formatted(v); }
+    static String testFormatted_xInt(int v) { return "hex=%x".formatted(v); }
+    static String testFormatted_xLong(long v) { return "hex=%x".formatted(v); }
+    static String testFormatted_XInt(int v) { return "HEX=%X".formatted(v); }
+    static String testFormatted_XLong(long v) { return "HEX=%X".formatted(v); }
+
+    // ========== String.format() - two specifiers ==========
+
+    static String testFormat_ss(String a, String b) { return String.format("%s %s", a, b); }
+    static String testFormat_ssPrefix(String a, String b) { return String.format("x=%s, y=%s", a, b); }
+    static String testFormat_ssNull() { return String.format("%s %s", (Object) null, "b"); }
+    static String testFormat_sd(String s, int v) { return String.format("name=%s age=%d", s, v); }
+    static String testFormat_ds(int v, String s) { return String.format("id=%d name=%s", v, s); }
+    static String testFormat_dd(int a, int b) { return String.format("%d+%d", a, b); }
+    // %x/%X uses format_multi
+    static String testFormat_xx(int a, int b) { return String.format("%x %x", a, b); }
+    static String testFormat_XX(int a, int b) { return String.format("%X %X", a, b); }
+
+    // ========== formatted() - two specifiers (optimized for s/d only) ==========
+
+    static String testFormatted_ss(String a, String b) { return "%s and %s".formatted(a, b); }
+    static String testFormatted_sd(String s, int v) { return "%s=%d".formatted(s, v); }
+    static String testFormatted_ds(int v, String s) { return "%d:%s".formatted(v, s); }
+    static String testFormatted_dd(int a, int b) { return "%d+%d".formatted(a, b); }
+
+    // ========== formatted() - two specifiers (x/X - fallback to Formatter) ==========
+
+    static String testFormatted_xx(int a, int b) { return "%x %x".formatted(a, b); }
+    static String testFormatted_XX(int a, int b) { return "%X %X".formatted(a, b); }
+
+    // ========== String.format() - width tests ==========
+
+    static String testFormat_sWidth(String s) { return String.format("[%5s]", s); }
+    static String testFormat_sWidthNopad(String s) { return String.format("[%3s]", s); }
+    static String testFormat_dWidth(int v) { return String.format("[%5d]", v); }
+    static String testFormat_dWidthNeg(int v) { return String.format("[%8d]", v); }
+    static String testFormat_xWidth(int v) { return String.format("[%4x]", v); }
+    static String testFormat_XWidth(int v) { return String.format("[%4X]", v); }
+    static String testFormat_ssWidth(String a, String b) { return String.format("[%5s|%3s]", a, b); }
+
+    // ========== formatted() - width tests (optimized) ==========
+
+    static String testFormatted_sWidth(String s) { return "[%8s]".formatted(s); }
+    static String testFormatted_dWidth(int v) { return "[%5d]".formatted(v); }
+    static String testFormatted_xWidth(int v) { return "[%4x]".formatted(v); }
+    static String testFormatted_ssWidth(String a, String b) { return "[%5s|%3s]".formatted(a, b); }
+
+    // ========== String.format() - flag tests (' ' and '0') ==========
+
+    // LEADING_SPACE flag ' ' for %d (uses format_multi)
+    static String testFormat_dLeadingSpace(int v) { return String.format("[% d]", v); }
+    static String testFormat_dLeadingSpaceNeg(int v) { return String.format("[% d]", v); }
+    // ZERO_PAD flag '0' for %d (uses format_multi)
+    static String testFormat_dZeroPad(int v) { return String.format("[%05d]", v); }
+    static String testFormat_dZeroPadNeg(int v) { return String.format("[%05d]", v); }
+    // Combined flag and width for %x/%X (uses format_multi)
+    static String testFormat_xZeroPad(int v) { return String.format("[%04x]", v); }
+    static String testFormat_XZeroPad(int v) { return String.format("[%04X]", v); }
+
+    // ========== formatted() - flag tests (fallback to Formatter) ==========
+
+    static String testFormatted_dLeadingSpace(int v) { return "[% d]".formatted(v); }
+    static String testFormatted_dZeroPad(int v) { return "[%05d]".formatted(v); }
+
+    // ========== String.format() - 3+ specifiers (format_multi) ==========
+
+    static String testFormat3s(String a, String b, String c) { return String.format("%s %s %s", a, b, c); }
+    static String testFormat3d(int a, int b, int c) { return String.format("%d+%d=%d", a, b, c); }
+    static String testFormatMixed(String s, int d, int x) { return String.format("name=%s id=%d hex=%x", s, d, x); }
+    static String testFormat4s(String a, String b, String c, String d) { return String.format("[%s|%s|%s|%s]", a, b, c, d); }
+    static String testFormatMultiWidth(String a, int b, String c) { return String.format("[%5s|%3d|%s]", a, b, c); }
+
+    // ========== formatted() - 3+ specifiers (fallback to Formatter) ==========
+
+    static String testFormatted3s(String a, String b, String c) { return "%s %s %s".formatted(a, b, c); }
+    static String testFormatted3d(int a, int b, int c) { return "%d+%d=%d".formatted(a, b, c); }
+    static String testFormattedMixed(String s, int d, int x) { return "name=%s id=%d hex=%x".formatted(s, d, x); }
+
+    // ========== Non-optimized patterns ==========
+
+    static String testFormatWithTag(int a, int b, int c) { return String.format("%+d %,d %-5d", a, b, c); }
+
+    // ========== Specifier position boundary tests (specIndex < 256 required) ==========
+
+    // specIndex = 128 (boundary, should work - tests no sign extension bug)
+    static String testFormat_specIndex128(String s) { return String.format("x".repeat(128) + "%s", s); }
+    // specIndex = 200 (should work)
+    static String testFormat_specIndex200(String s) { return String.format("x".repeat(200) + "%s", s); }
+    // specIndex = 255 (max valid, should work)
+    static String testFormat_specIndex255(String s) { return String.format("x".repeat(255) + "%s", s); }
+    // specIndex = 256 (should fallback to Formatter)
+    static String testFormat_specIndex256(String s) { return String.format("x".repeat(256) + "%s", s); }
+
+    // ========== Escaped %% patterns (fallback to Formatter) ==========
+
+    // %% before specifier
+    static String testFormat_percentBeforeS(String s) { return String.format("%%%s", s); }
+    static String testFormat_percentBeforeD(int v) { return String.format("100%% %d", v); }
+    // %% after specifier
+    static String testFormat_percentAfterS(String s) { return String.format("%s%%", s); }
+    static String testFormat_percentAfterD(int v) { return String.format("%d%% complete", v); }
+    // %% in middle of two specifiers
+    static String testFormat_percentMiddle(String s, String t) { return String.format("%s%% %s", s, t); }
+    // %% at start with specifier
+    static String testFormat_percentStart(String s) { return String.format("progress:%%%s", s); }
+    // %% at end after specifier
+    static String testFormat_percentEnd(int v) { return String.format("value=%d%%", v); }
+    // %% only (no specifiers)
+    static String testFormat_percentOnly() { return String.format("100%%"); }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            // ===== String.format() - single specifier =====
+            check("hello", testFormat_s("hello"));
+            check("value : world", testFormat_sPrefix("world"));
+            check("null", testFormat_sNull());
+            // Formattable objects use formatTo() for %s
+            check("[FORMATTABLE]", testFormat_sFormattable(new FormattableString("formattable")));
+            check("[   FORMATTABLE]", testFormat_sFormattableWidth(new FormattableString("formattable")));
+            check("count=42", testFormat_dInt(42));
+            check("short=100", testFormat_dShort((short) 100));
+            check("byte=127", testFormat_dByte((byte) 127));
+            check("-5 items", testFormat_dNeg(-5));
+            check("long=123456789012345", testFormat_dLong(123456789012345L));
+            check("obj=CustomObject", testFormat_sObject(new CustomObject()));
+            check("0xff", testFormat_x(255));
+            check("short=0xffff", testFormat_xShort((short) -1));
+            check("byte=0xff", testFormat_xByte((byte) -1));
+            check("0xFF", testFormat_X(255));
+
+            // ===== formatted() - single specifier (optimized) =====
+            check("formatted test", testFormatted_s("test"));
+            check("count=42", testFormatted_dInt(42));
+            check("value=123456789012345", testFormatted_dLong(123456789012345L));
+            check("hex=ff", testFormatted_xInt(255));
+            check("hex=1fffffffffffff", testFormatted_xLong(0x1FFFFFFFFFFFFFL));
+            check("HEX=FF", testFormatted_XInt(255));
+            check("HEX=ABCDEF", testFormatted_XLong(0xABCDEFL));
+
+            // ===== String.format() - two specifiers =====
+            check("a b", testFormat_ss("a", "b"));
+            check("x=1, y=2", testFormat_ssPrefix("1", "2"));
+            check("null b", testFormat_ssNull());
+            check("name=Alice age=30", testFormat_sd("Alice", 30));
+            check("id=42 name=Bob", testFormat_ds(42, "Bob"));
+            check("1+2", testFormat_dd(1, 2));
+            check("ff 10", testFormat_xx(255, 16));
+            check("FF 10", testFormat_XX(255, 16));
+
+            // ===== formatted() - two specifiers (optimized for s/d) =====
+            check("foo and bar", testFormatted_ss("foo", "bar"));
+            check("count=42", testFormatted_sd("count", 42));
+            check("42:Bob", testFormatted_ds(42, "Bob"));
+            check("1+2", testFormatted_dd(1, 2));
+
+            // ===== formatted() - two specifiers (x/X - fallback) =====
+            check("ff 10", testFormatted_xx(255, 16));
+            check("FF 10", testFormatted_XX(255, 16));
+
+            // ===== String.format() - width tests =====
+            check("[   hi]", testFormat_sWidth("hi"));
+            check("[hello]", testFormat_sWidthNopad("hello"));
+            check("[   42]", testFormat_dWidth(42));
+            check("[      -5]", testFormat_dWidthNeg(-5));
+            check("[  ff]", testFormat_xWidth(255));
+            check("[  FF]", testFormat_XWidth(255));
+            check("[   ab|  c]", testFormat_ssWidth("ab", "c"));
+
+            // ===== formatted() - width tests (optimized) =====
+            check("[   hello]", testFormatted_sWidth("hello"));
+            check("[   42]", testFormatted_dWidth(42));
+            check("[  ff]", testFormatted_xWidth(255));
+            check("[   ab|  c]", testFormatted_ssWidth("ab", "c"));
+
+            // ===== String.format() - flag tests =====
+            // LEADING_SPACE: positive gets leading space, negative gets minus
+            check("[ 42]", testFormat_dLeadingSpace(42));
+            check("[-5]", testFormat_dLeadingSpaceNeg(-5));
+            // ZERO_PAD: pad with zeros
+            check("[00042]", testFormat_dZeroPad(42));
+            check("[-0005]", testFormat_dZeroPadNeg(-5));
+            check("[00ff]", testFormat_xZeroPad(255));
+            check("[00FF]", testFormat_XZeroPad(255));
+
+            // ===== formatted() - flag tests (fallback) =====
+            check("[ 42]", testFormatted_dLeadingSpace(42));
+            check("[00042]", testFormatted_dZeroPad(42));
+
+            // ===== String.format() - 3+ specifiers =====
+            check("a b c", testFormat3s("a", "b", "c"));
+            check("1+2=3", testFormat3d(1, 2, 3));
+            check("name=Alice id=42 hex=ff", testFormatMixed("Alice", 42, 255));
+            check("[a|b|c|d]", testFormat4s("a", "b", "c", "d"));
+            check("[   hi|  7|end]", testFormatMultiWidth("hi", 7, "end"));
+
+            // ===== formatted() - 3+ specifiers (fallback) =====
+            check("a b c", testFormatted3s("a", "b", "c"));
+            check("1+2=3", testFormatted3d(1, 2, 3));
+            check("name=Alice id=42 hex=ff", testFormattedMixed("Alice", 42, 255));
+
+            // ===== Non-optimized patterns =====
+            check("+42 1,000 7    ", testFormatWithTag(42, 1000, 7));
+
+            // ===== Specifier position boundary tests =====
+            // specIndex = 128 (tests no sign extension bug)
+            check("x".repeat(128) + "test", testFormat_specIndex128("test"));
+            // specIndex = 200
+            check("x".repeat(200) + "y", testFormat_specIndex200("y"));
+            // specIndex = 255 (max valid)
+            check("x".repeat(255) + "z", testFormat_specIndex255("z"));
+            // specIndex = 256 (fallback to Formatter)
+            check("x".repeat(256) + "w", testFormat_specIndex256("w"));
+
+            // ===== Escaped %% patterns (fallback to Formatter) =====
+            check("%done", testFormat_percentBeforeS("done"));
+            check("100% 42", testFormat_percentBeforeD(42));
+            check("test%", testFormat_percentAfterS("test"));
+            check("75% complete", testFormat_percentAfterD(75));
+            check("a% b", testFormat_percentMiddle("a", "b"));
+            check("progress:%complete", testFormat_percentStart("complete"));
+            check("value=100%", testFormat_percentEnd(100));
+            check("100%", testFormat_percentOnly());
+        }
+
+        // Non-optimized fallback patterns
+        check("%s", String.format("%%s"));
+
+        // ===== Exception tests (wrong arg types should throw) =====
+        testException("d", () -> testFormat_dWrongType());
+        testException("x", () -> testFormat_xWrongType());
+        testException("X", () -> testFormat_XWrongType());
+
+        // ===== Locale-specific tests =====
+        testLocaleSpecific();
+
+        System.out.println("ALL TESTS PASSED");
+    }
+
+    static void testLocaleSpecific() {
+        // Save original locale
+        java.util.Locale original = java.util.Locale.getDefault(java.util.Locale.Category.FORMAT);
+
+        try {
+            // Test with Arabic locale (uses different digits and minus sign)
+            java.util.Locale arabic = java.util.Locale.forLanguageTag("ar-EG");
+            java.util.Locale.setDefault(java.util.Locale.Category.FORMAT, arabic);
+
+            // Re-run tests that should be localized
+            for (int i = 0; i < 5_000; i++) {
+                // Test ZERO_PAD with negative - should use locale-specific minus sign
+                String result = testFormat_dZeroPadNeg(-5);
+                // Arabic uses locale-specific digits (٠١٢٣٤٥٦٧٨٩) and minus sign
+                // Verify the result has correct structure: [sign + 3 zeros + 5]
+                // Length should be 7: [ + sign + 3 padding zeros + digit 5 + ]
+                if (result.length() != 7) {
+                    throw new AssertionError("ZERO_PAD negative length wrong: " + result.length() + " - " + result);
+                }
+
+                // Test LEADING_SPACE with positive
+                result = testFormat_dLeadingSpace(42);
+                // Should have space prefix and locale-specific digits
+                if (result.length() != 5) {
+                    throw new AssertionError("LEADING_SPACE length wrong: " + result.length() + " - " + result);
+                }
+            }
+        } finally {
+            // Restore original locale
+            java.util.Locale.setDefault(java.util.Locale.Category.FORMAT, original);
+        }
+    }
+
+    static void check(String expected, String actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError("expected [" + expected + "] but got [" + actual + "]");
+        }
+    }
+
+    static void testException(String conv, Runnable r) {
+        try {
+            r.run();
+            throw new AssertionError("expected IllegalFormatConversionException for %" + conv);
+        } catch (java.util.IllegalFormatConversionException e) {
+            // Expected
+        }
+    }
+
+    /** Custom object for testing %s with non-String arguments. */
+    static class CustomObject {
+        @Override
+        public String toString() {
+            return "CustomObject";
+        }
+    }
+
+    /** Formattable object for testing %s with Formattable interface. */
+    static class FormattableString implements java.util.Formattable {
+        private final String value;
+
+        FormattableString(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public void formatTo(java.util.Formatter formatter, int flags, int width, int precision) {
+            StringBuilder sb = new StringBuilder();
+            String str = value.toUpperCase(java.util.Locale.ROOT);
+            if (precision >= 0 && str.length() > precision) {
+                str = str.substring(0, precision);
+            }
+            int padding = width - str.length();
+            if (padding > 0) {
+                // Right-justify by default (no LEFT_JUSTIFY flag)
+                sb.repeat(' ', padding);
+            }
+            sb.append(str);
+            formatter.format(sb.toString());
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
@@ -94,9 +94,11 @@ public class TestStringFormatOptimization {
     static String testFormat_sd(String s, int v) { return String.format("name=%s age=%d", s, v); }
     static String testFormat_ds(int v, String s) { return String.format("id=%d name=%s", v, s); }
     static String testFormat_dd(int a, int b) { return String.format("%d+%d", a, b); }
-    // %x/%X uses format_multi
+    // %x/%X uses format_2
     static String testFormat_xx(int a, int b) { return String.format("%x %x", a, b); }
     static String testFormat_XX(int a, int b) { return String.format("%X %X", a, b); }
+    // Formattable with %x - tests format_2 path handles Formattable correctly
+    static String testFormat_sxFormattable(FormattableString fs, int v) { return String.format("%s=%x", fs, v); }
 
     // ========== formatted() - two specifiers (optimized for s/d only) ==========
 
@@ -258,6 +260,8 @@ public class TestStringFormatOptimization {
             check("1+2", testFormat_dd(1, 2));
             check("ff 10", testFormat_xx(255, 16));
             check("FF 10", testFormat_XX(255, 16));
+            // Formattable with format_2 path (%s=%x)
+            check("FORMATTABLE=ff", testFormat_sxFormattable(new FormattableString("formattable"), 255));
 
             // ===== formatted() - two specifiers (optimized for s/d) =====
             check("foo and bar", testFormatted_ss("foo", "bar"));

--- a/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
@@ -174,6 +174,20 @@ public class TestStringFormatOptimization {
     static String testFormat4s(String a, String b, String c, String d) { return String.format("[%s|%s|%s|%s]", a, b, c, d); }
     static String testFormatMultiWidth(String a, int b, String c) { return String.format("[%5s|%3d|%s]", a, b, c); }
 
+    // ========== String.format() - 5-8 specifiers (format_multi boundary) ==========
+
+    static String testFormat5(String a, String b, int c, String d, int e) { return String.format("%s-%s-%d-%s-%d", a, b, c, d, e); }
+    static String testFormat6(String a, String b, String c, String d, String e, String f) { return String.format("%s|%s|%s|%s|%s|%s", a, b, c, d, e, f); }
+    static String testFormat7(int a, int b, int c, int d, int e, int f, int g) { return String.format("%d%d%d%d%d%d%d", a, b, c, d, e, f, g); }
+    static String testFormat8(int a, int b, int c, int d, int e, int f, int g, int h) { return String.format("%d%d%d%d%d%d%d%d", a, b, c, d, e, f, g, h); }
+    // 9 specifiers: exceeds MAX_FORMAT_SPECS, falls back to Formatter
+    static String testFormat9(int a, int b, int c, int d, int e, int f, int g, int h, int i) { return String.format("%d%d%d%d%d%d%d%d%d", a, b, c, d, e, f, g, h, i); }
+
+    // ========== Width >= 10 (falls back to Formatter since only single-digit width 1-9 is parsed) ==========
+
+    static String testFormat_sWidth10(String s) { return String.format("[%10s]", s); }
+    static String testFormat_dWidth15(int v) { return String.format("[%15d]", v); }
+
     // ========== formatted() - 3+ specifiers (fallback to Formatter) ==========
 
     static String testFormatted3s(String a, String b, String c) { return "%s %s %s".formatted(a, b, c); }
@@ -334,6 +348,18 @@ public class TestStringFormatOptimization {
             check("name=Alice id=42 hex=ff", testFormatMixed("Alice", 42, 255));
             check("[a|b|c|d]", testFormat4s("a", "b", "c", "d"));
             check("[   hi|  7|end]", testFormatMultiWidth("hi", 7, "end"));
+
+            // ===== String.format() - 5-8 specifiers (format_multi boundary) =====
+            check("a-b-3-d-5", testFormat5("a", "b", 3, "d", 5));
+            check("a|b|c|d|e|f", testFormat6("a", "b", "c", "d", "e", "f"));
+            check("1234567", testFormat7(1, 2, 3, 4, 5, 6, 7));
+            check("12345678", testFormat8(1, 2, 3, 4, 5, 6, 7, 8));
+            // 9 specifiers: exceeds MAX_FORMAT_SPECS, falls back to Formatter
+            check("123456789", testFormat9(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+            // ===== Width >= 10 (falls back to Formatter) =====
+            check("[       abc]", testFormat_sWidth10("abc"));
+            check("[             42]", testFormat_dWidth15(42));
 
             // ===== formatted() - 3+ specifiers (fallback) =====
             check("a b c", testFormatted3s("a", "b", "c"));

--- a/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
@@ -43,6 +43,9 @@ public class TestStringFormatOptimization {
     static String testFormat_dNullZeroPad() { return String.format("[%05d]", (Object) null); }
     static String testFormat_sFormattable(FormattableString fs) { return String.format("[%s]", fs); }
     static String testFormat_sFormattableWidth(FormattableString fs) { return String.format("[%14s]", fs); }
+    // Single-digit width + Formattable: exercises format_1 path (width 1-9 only)
+    static String testFormat_sFormattableWidth5(FormattableString fs) { return String.format("[%5s]", fs); }
+    static String testFormat_sFormattableWidth9(FormattableString fs) { return String.format("[%9s]", fs); }
     static String testFormat_dInt(int v) { return String.format("count=%d", v); }
     static String testFormat_dShort(short v) { return String.format("short=%d", v); }
     static String testFormat_dByte(byte v) { return String.format("byte=%d", v); }
@@ -75,6 +78,14 @@ public class TestStringFormatOptimization {
     static void testFormat_dWrongType() { String.format("%d", "string"); }
     static void testFormat_xWrongType() { String.format("%x", "string"); }
     static void testFormat_XWrongType() { String.format("%X", "string"); }
+    // Float/Double should also throw for %d (consistent with Formatter)
+    static void testFormat_dFloat() { String.format("%d", 1.5f); }
+    static void testFormat_dDouble() { String.format("%d", 1.5); }
+
+    // ========== Edge case tests ==========
+
+    static String testFormat_sEmpty(String s) { return String.format("%s", s); }
+    static String testFormatted_sFormattableWidth(FormattableString fs) { return "[%5s]".formatted(fs); }
 
     // ========== formatted() - single specifier (optimized) ==========
 
@@ -99,6 +110,10 @@ public class TestStringFormatOptimization {
     static String testFormat_XX(int a, int b) { return String.format("%X %X", a, b); }
     // Formattable with %x - tests format_2 path handles Formattable correctly
     static String testFormat_sxFormattable(FormattableString fs, int v) { return String.format("%s=%x", fs, v); }
+    // Two-specifier Formattable + width: exercises format_ss/sd/ds paths with convLen fix
+    static String testFormat_ssFormattableWidth(FormattableString fs, String s) { return String.format("[%5s|%3s]", fs, s); }
+    static String testFormat_sdFormattableWidth(FormattableString fs, int v) { return String.format("[%5s|%3d]", fs, v); }
+    static String testFormat_dsFormattableWidth(int v, FormattableString fs) { return String.format("[%3d|%5s]", v, fs); }
 
     // ========== formatted() - two specifiers (optimized for s/d only) ==========
 
@@ -214,6 +229,9 @@ public class TestStringFormatOptimization {
             // Formattable objects use formatTo() for %s
             check("[FORMATTABLE]", testFormat_sFormattable(new FormattableString("formattable")));
             check("[   FORMATTABLE]", testFormat_sFormattableWidth(new FormattableString("formattable")));
+            // Formattable with single-digit width (format_1 path) - verifies convLen fix
+            check("[   HI]", testFormat_sFormattableWidth5(new FormattableString("hi")));
+            check("[    HELLO]", testFormat_sFormattableWidth9(new FormattableString("hello")));
             check("count=42", testFormat_dInt(42));
             check("short=100", testFormat_dShort((short) 100));
             check("byte=127", testFormat_dByte((byte) 127));
@@ -262,6 +280,10 @@ public class TestStringFormatOptimization {
             check("FF 10", testFormat_XX(255, 16));
             // Formattable with format_2 path (%s=%x)
             check("FORMATTABLE=ff", testFormat_sxFormattable(new FormattableString("formattable"), 255));
+            // Two-specifier Formattable + width (format_ss/sd/ds paths) - verifies convLen fix
+            check("[   HI|  x]", testFormat_ssFormattableWidth(new FormattableString("hi"), "x"));
+            check("[   HI|  1]", testFormat_sdFormattableWidth(new FormattableString("hi"), 1));
+            check("[  1|   HI]", testFormat_dsFormattableWidth(1, new FormattableString("hi")));
 
             // ===== formatted() - two specifiers (optimized for s/d) =====
             check("foo and bar", testFormatted_ss("foo", "bar"));
@@ -340,6 +362,12 @@ public class TestStringFormatOptimization {
             check("progress:%complete", testFormat_percentStart("complete"));
             check("value=100%", testFormat_percentEnd(100));
             check("100%", testFormat_percentOnly());
+
+            // ===== Edge case tests =====
+            // Empty string argument
+            check("", testFormat_sEmpty(""));
+            // formatted() with Formattable + width
+            check("[   HI]", testFormatted_sFormattableWidth(new FormattableString("hi")));
         }
 
         // Non-optimized fallback patterns
@@ -349,6 +377,9 @@ public class TestStringFormatOptimization {
         testException("d", () -> testFormat_dWrongType());
         testException("x", () -> testFormat_xWrongType());
         testException("X", () -> testFormat_XWrongType());
+        // Float/Double should throw for %d (consistent with Formatter)
+        testException("d", () -> testFormat_dFloat());
+        testException("d", () -> testFormat_dDouble());
 
         // ===== Locale-specific tests =====
         testLocaleSpecific();

--- a/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java
@@ -35,6 +35,12 @@ public class TestStringFormatOptimization {
     static String testFormat_s(String s) { return String.format("%s", s); }
     static String testFormat_sPrefix(String s) { return String.format("value : %s", s); }
     static String testFormat_sNull() { return String.format("%s", (Object) null); }
+    static String testFormat_dNull() { return String.format("%d", (Object) null); }
+    static String testFormat_xNull() { return String.format("%x", (Object) null); }
+    static String testFormat_XNull() { return String.format("%X", (Object) null); }
+    // null with LEADING_SPACE flag - Formatter does NOT apply flag to null
+    static String testFormat_dNullLeadingSpace() { return String.format("[% d]", (Object) null); }
+    static String testFormat_dNullZeroPad() { return String.format("[%05d]", (Object) null); }
     static String testFormat_sFormattable(FormattableString fs) { return String.format("[%s]", fs); }
     static String testFormat_sFormattableWidth(FormattableString fs) { return String.format("[%14s]", fs); }
     static String testFormat_dInt(int v) { return String.format("count=%d", v); }
@@ -47,6 +53,22 @@ public class TestStringFormatOptimization {
     static String testFormat_xShort(short v) { return String.format("short=0x%x", v); }
     static String testFormat_xByte(byte v) { return String.format("byte=0x%x", v); }
     static String testFormat_X(int v) { return String.format("0x%X", v); }
+
+    // ========== BigInteger tests (supported by Formatter) ==========
+
+    static String testFormat_dBigInteger(java.math.BigInteger v) { return String.format("big=%d", v); }
+    static String testFormat_dBigIntegerNull() { return String.format("%d", (java.math.BigInteger) null); }
+    static String testFormat_xBigInteger(java.math.BigInteger v) { return String.format("0x%x", v); }
+    static String testFormat_xBigIntegerNull() { return String.format("%x", (java.math.BigInteger) null); }
+    static String testFormat_XBigInteger(java.math.BigInteger v) { return String.format("0x%X", v); }
+    static String testFormat_XBigIntegerNull() { return String.format("%X", (java.math.BigInteger) null); }
+    // BigInteger negative hex tests (different from int/long which use 2's complement)
+    static String testFormat_xBigIntegerNeg(java.math.BigInteger v) { return String.format("hex=%x", v); }
+    static String testFormat_XBigIntegerNeg(java.math.BigInteger v) { return String.format("HEX=%X", v); }
+    static String testFormat_xBigIntegerNegWidth(java.math.BigInteger v) { return String.format("[%08x]", v); }
+    // Multi-specifier tests for format_arg path (3+ specifiers)
+    static String testFormat_xNullZeroPadMulti() { return String.format("[%08x][%s][%s]", (Object) null, "a", "b"); }
+    static String testFormat_xBigIntegerNegZeroPadMulti(java.math.BigInteger v) { return String.format("[%08x][%s][%s]", v, "a", "b"); }
 
     // ========== Exception tests (wrong arg types) ==========
 
@@ -97,6 +119,10 @@ public class TestStringFormatOptimization {
     static String testFormat_xWidth(int v) { return String.format("[%4x]", v); }
     static String testFormat_XWidth(int v) { return String.format("[%4X]", v); }
     static String testFormat_ssWidth(String a, String b) { return String.format("[%5s|%3s]", a, b); }
+    // Null with width tests
+    static String testFormat_dWidthNull() { return String.format("[%5d]", (Object) null); }
+    static String testFormat_xWidthNull() { return String.format("[%5x]", (Object) null); }
+    static String testFormat_XWidthNull() { return String.format("[%5X]", (Object) null); }
 
     // ========== formatted() - width tests (optimized) ==========
 
@@ -126,6 +152,7 @@ public class TestStringFormatOptimization {
 
     static String testFormat3s(String a, String b, String c) { return String.format("%s %s %s", a, b, c); }
     static String testFormat3d(int a, int b, int c) { return String.format("%d+%d=%d", a, b, c); }
+    static String testFormat_d3(int a, int b, int c) { return String.format("[%05d][%05d][%05d]", a, b, c); }
     static String testFormatMixed(String s, int d, int x) { return String.format("name=%s id=%d hex=%x", s, d, x); }
     static String testFormat4s(String a, String b, String c, String d) { return String.format("[%s|%s|%s|%s]", a, b, c, d); }
     static String testFormatMultiWidth(String a, int b, String c) { return String.format("[%5s|%3d|%s]", a, b, c); }
@@ -174,6 +201,14 @@ public class TestStringFormatOptimization {
             check("hello", testFormat_s("hello"));
             check("value : world", testFormat_sPrefix("world"));
             check("null", testFormat_sNull());
+            // Null arguments for numeric conversions (consistent with Formatter behavior)
+            check("null", testFormat_dNull());
+            check("null", testFormat_xNull());
+            check("NULL", testFormat_XNull());
+            // null with LEADING_SPACE flag (no width) - flag is ignored for null
+            check("[null]", testFormat_dNullLeadingSpace());
+            // null with ZERO_PAD and width - ZERO_PAD ignored but width applied with space padding
+            check("[ null]", testFormat_dNullZeroPad());
             // Formattable objects use formatTo() for %s
             check("[FORMATTABLE]", testFormat_sFormattable(new FormattableString("formattable")));
             check("[   FORMATTABLE]", testFormat_sFormattableWidth(new FormattableString("formattable")));
@@ -187,6 +222,23 @@ public class TestStringFormatOptimization {
             check("short=0xffff", testFormat_xShort((short) -1));
             check("byte=0xff", testFormat_xByte((byte) -1));
             check("0xFF", testFormat_X(255));
+
+            // ===== BigInteger tests (consistent with Formatter) =====
+            java.math.BigInteger bigInt = new java.math.BigInteger("123456789012345678901234567890");
+            check("big=123456789012345678901234567890", testFormat_dBigInteger(bigInt));
+            check("null", testFormat_dBigIntegerNull());
+            check("0x18ee90ff6c373e0ee4e3f0ad2", testFormat_xBigInteger(bigInt));
+            check("null", testFormat_xBigIntegerNull());
+            check("0x18EE90FF6C373E0EE4E3F0AD2", testFormat_XBigInteger(bigInt));
+            check("NULL", testFormat_XBigIntegerNull());
+            // BigInteger negative hex (uses sign + magnitude, not 2's complement like int/long)
+            java.math.BigInteger bigNeg = java.math.BigInteger.valueOf(-255);
+            check("hex=-ff", testFormat_xBigIntegerNeg(bigNeg));
+            check("HEX=-FF", testFormat_XBigIntegerNeg(bigNeg));
+            check("[-00000ff]", testFormat_xBigIntegerNegWidth(bigNeg));
+            // Multi-specifier path (format_arg) - null and negative BigInteger with ZERO_PAD
+            check("[    null][a][b]", testFormat_xNullZeroPadMulti());
+            check("[-00000ff][a][b]", testFormat_xBigIntegerNegZeroPadMulti(bigNeg));
 
             // ===== formatted() - single specifier (optimized) =====
             check("formatted test", testFormatted_s("test"));
@@ -225,6 +277,10 @@ public class TestStringFormatOptimization {
             check("[  ff]", testFormat_xWidth(255));
             check("[  FF]", testFormat_XWidth(255));
             check("[   ab|  c]", testFormat_ssWidth("ab", "c"));
+            // Null with width
+            check("[ null]", testFormat_dWidthNull());
+            check("[ null]", testFormat_xWidthNull());
+            check("[ NULL]", testFormat_XWidthNull());
 
             // ===== formatted() - width tests (optimized) =====
             check("[   hello]", testFormatted_sWidth("hello"));
@@ -304,23 +360,88 @@ public class TestStringFormatOptimization {
             // Test with Arabic locale (uses different digits and minus sign)
             java.util.Locale arabic = java.util.Locale.forLanguageTag("ar-EG");
             java.util.Locale.setDefault(java.util.Locale.Category.FORMAT, arabic);
+            java.text.DecimalFormatSymbols arDfs = java.text.DecimalFormatSymbols.getInstance(arabic);
+            char arZero = arDfs.getZeroDigit();
+            char arOne = (char) (arZero + 1);
+            char arTwo = (char) (arZero + 2);
+            char arFour = (char) (arZero + 4);
+            char arFive = (char) (arZero + 5);
 
-            // Re-run tests that should be localized
+            // Re-run tests that should be localized with exact content validation
             for (int i = 0; i < 5_000; i++) {
-                // Test ZERO_PAD with negative - should use locale-specific minus sign
+                // Test ZERO_PAD with negative - should use locale-specific digits
                 String result = testFormat_dZeroPadNeg(-5);
-                // Arabic uses locale-specific digits (٠١٢٣٤٥٦٧٨٩) and minus sign
-                // Verify the result has correct structure: [sign + 3 zeros + 5]
-                // Length should be 7: [ + sign + 3 padding zeros + digit 5 + ]
-                if (result.length() != 7) {
-                    throw new AssertionError("ZERO_PAD negative length wrong: " + result.length() + " - " + result);
+                // Expected: [-٠٠٠٥] with Arabic digits, width 5 includes sign
+                String expected = "[-" + arZero + arZero + arZero + arFive + "]";
+                if (!result.equals(expected)) {
+                    throw new AssertionError("Arabic ZERO_PAD negative: expected [" + expected + "] but got [" + result + "]");
                 }
 
                 // Test LEADING_SPACE with positive
                 result = testFormat_dLeadingSpace(42);
-                // Should have space prefix and locale-specific digits
-                if (result.length() != 5) {
-                    throw new AssertionError("LEADING_SPACE length wrong: " + result.length() + " - " + result);
+                // Expected: [ ٤٢] with Arabic digits
+                expected = "[ " + arFour + arTwo + "]";
+                if (!result.equals(expected)) {
+                    throw new AssertionError("Arabic LEADING_SPACE: expected [" + expected + "] but got [" + result + "]");
+                }
+
+                // Test %x/%X zero-padding should use ASCII '0', not localized digits
+                result = testFormat_xZeroPad(255);
+                expected = "[00ff]";  // ASCII zeros, not Arabic
+                if (!result.equals(expected)) {
+                    throw new AssertionError("Arabic %x ZERO_PAD should use ASCII '0': expected [" + expected + "] but got [" + result + "]");
+                }
+
+                result = testFormat_XZeroPad(255);
+                expected = "[00FF]";  // ASCII zeros, not Arabic
+                if (!result.equals(expected)) {
+                    throw new AssertionError("Arabic %X ZERO_PAD should use ASCII '0': expected [" + expected + "] but got [" + result + "]");
+                }
+            }
+
+            // Test with gsw locale (has zero='0', decSep='.', but minus='−' U+2212)
+            // This tests the early-exit condition in format_localizeDigits
+            // Note: Formatter does NOT localize the minus sign for %d, it uses ASCII '-'
+            java.util.Locale gsw = java.util.Locale.forLanguageTag("gsw");
+            java.util.Locale.setDefault(java.util.Locale.Category.FORMAT, gsw);
+            java.text.DecimalFormatSymbols gswDfs = java.text.DecimalFormatSymbols.getInstance(gsw);
+
+            for (int i = 0; i < 5_000; i++) {
+                // Test ZERO_PAD with negative - uses ASCII minus sign (per Formatter spec)
+                String result = testFormat_dZeroPadNeg(-5);
+                // Expected: [-0005] with ASCII minus, not U+2212
+                // Formatter.leadingSign() uses hardcoded '-', not localized
+                char firstChar = result.charAt(1);
+                if (firstChar != '-') {
+                    throw new AssertionError("gsw ZERO_PAD negative: expected ASCII '-' at pos 1, got U+" + String.format("%04X", (int)firstChar));
+                }
+                // Verify the rest is "0005"
+                String rest = result.substring(2, 6);
+                if (!rest.equals("0005")) {
+                    throw new AssertionError("gsw ZERO_PAD negative: expected [0005] after minus, got [" + rest + "]");
+                }
+
+                // Test positive number with zero padding - should work normally
+                result = testFormat_dZeroPad(42);
+                // Content should be "00042" regardless of internal encoding
+                if (!result.contains("00042")) {
+                    throw new AssertionError("gsw ZERO_PAD positive: expected to contain [00042], got [" + result + "]");
+                }
+            }
+
+            // Test with Arabic locale again for format_arg (multi-specifier path)
+            java.util.Locale.setDefault(java.util.Locale.Category.FORMAT, arabic);
+
+            for (int i = 0; i < 5_000; i++) {
+                // Test 3 specifiers (format_multi -> format_arg path)
+                String result = testFormat_d3(-1, 42, -123);
+                // Expected: [-٠٠٠١][٠٠٠٤٢][-٠١٢٣] with Arabic zero digit
+                char arThree = (char) (arZero + 3);
+                String expected = "[-" + arZero + arZero + arZero + arOne + "][" +
+                                  arZero + arZero + arZero + arFour + arTwo + "][" +
+                                  "-" + arZero + arOne + arTwo + arThree + "]";
+                if (!result.equals(expected)) {
+                    throw new AssertionError("Arabic format_arg: expected [" + expected + "] but got [" + result + "]");
                 }
             }
         } finally {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 more details (a copy has been included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit the Oracle website www.oracle.com if you need additional information.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8999999
+ * @summary IR test for C2 optimization of String.format/formatted with simple specifiers
+ *          - Verify AllocateArray elimination (escape analysis)
+ *          - Verify call redirection to optimized methods (format_s, format_d, format_ss, etc.)
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestStringFormatOptimization
+ */
+public class TestStringFormatOptimization {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    // ========== Single specifier %s - redirect to format_s ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_s", "= 1" })
+    static String testSingle_s(String s) {
+        return String.format("%s", s);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_s", "= 1" })
+    static String testSingle_sPrefix(String s) {
+        return String.format("value: %s", s);
+    }
+
+    // ========== Single specifier %d - redirect to format_d ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_d", "= 1" })
+    static String testSingle_d(int v) {
+        return String.format("count=%d", v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_d", "= 1" })
+    static String testSingle_dLong(long v) {
+        return String.format("value=%d", v);
+    }
+
+    // ========== formatted() single specifier - redirect to formatted_s/d ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_s", "= 1" })
+    static String testFormatted_s(String s) {
+        return "value: %s".formatted(s);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_d", "= 1" })
+    static String testFormatted_d(int v) {
+        return "count=%d".formatted(v);
+    }
+
+    // ========== Two specifiers %s %s - redirect to format_ss ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_ss", "= 1" })
+    static String testTwo_ss(String a, String b) {
+        return String.format("%s %s", a, b);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_ss", "= 1" })
+    static String testTwo_ssPrefix(String a, String b) {
+        return String.format("x=%s, y=%s", a, b);
+    }
+
+    // ========== Two specifiers %s %d - redirect to format_sd ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_sd", "= 1" })
+    static String testTwo_sd(String s, int v) {
+        return String.format("name=%s age=%d", s, v);
+    }
+
+    // ========== Two specifiers %d %s - redirect to format_ds ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_ds", "= 1" })
+    static String testTwo_ds(int v, String s) {
+        return String.format("id=%d name=%s", v, s);
+    }
+
+    // ========== Two specifiers %d %d - redirect to format_dd ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_dd", "= 1" })
+    static String testTwo_dd(int a, int b) {
+        return String.format("%d+%d", a, b);
+    }
+
+    // ========== Two specifiers with %x/%X - redirect to format_2 ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_2", "= 1" })
+    static String testTwo_xx(int a, int b) {
+        return String.format("%x+%x", a, b);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_2", "= 1" })
+    static String testTwo_XX(int a, int b) {
+        return String.format("%X+%X", a, b);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_2", "= 1" })
+    static String testTwo_sx(String s, int v) {
+        return String.format("%s=%x", s, v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_2", "= 1" })
+    static String testTwo_xd(int a, int b) {
+        return String.format("hex=%x dec=%d", a, b);
+    }
+
+    // ========== formatted() two specifiers - redirect to formatted_ss/sd/ds/dd ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_ss", "= 1" })
+    static String testFormatted_ss(String a, String b) {
+        return "%s and %s".formatted(a, b);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_sd", "= 1" })
+    static String testFormatted_sd(String s, int v) {
+        return "%s=%d".formatted(s, v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_ds", "= 1" })
+    static String testFormatted_ds(int v, String s) {
+        return "%d:%s".formatted(v, s);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_dd", "= 1" })
+    static String testFormatted_dd(int a, int b) {
+        return "%d+%d".formatted(a, b);
+    }
+
+    // ========== formatted() two specifiers with %x/%X - redirect to formatted_2 ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_2", "= 1" })
+    static String testFormatted_xx(int a, int b) {
+        return "%x+%x".formatted(a, b);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_2", "= 1" })
+    static String testFormatted_sx(String s, int v) {
+        return "%s=%x".formatted(s, v);
+    }
+
+    // ========== Single specifier with width/flags - redirect to format_1 ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_width_s(String s) {
+        return String.format("[%5s]", s);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_width_d(int v) {
+        return String.format("[%5d]", v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_flag0_d(int v) {
+        return String.format("[%05d]", v);
+    }
+
+    // ========== Single specifier %x/%X - redirect to format_1 ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_x(int v) {
+        return String.format("0x%x", v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_X(int v) {
+        return String.format("0x%X", v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_width_x(int v) {
+        return String.format("[%5x]", v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_width_X(int v) {
+        return String.format("[%5X]", v);
+    }
+
+    // ========== formatted() single specifier with width/flags - redirect to formatted_1 ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_1", "= 1" })
+    static String testFormatted_width_s(String s) {
+        return "[%5s]".formatted(s);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_1", "= 1" })
+    static String testFormatted_width_d(int v) {
+        return "[%5d]".formatted(v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_1", "= 1" })
+    static String testFormatted_flag0_d(int v) {
+        return "[%05d]".formatted(v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_1", "= 1" })
+    static String testFormatted_x(int v) {
+        return "0x%x".formatted(v);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "formatted_1", "= 1" })
+    static String testFormatted_X(int v) {
+        return "0x%X".formatted(v);
+    }
+
+    // ========== Null argument tests ==========
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_s", "= 1" })
+    static String testSingle_null() {
+        return String.format("%s", (Object) null);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_ss", "= 1" })
+    static String testTwo_nullFirst() {
+        return String.format("%s %s", (Object) null, "b");
+    }
+
+    // ========== Three+ specifiers - uses format_multi ==========
+
+    @Test
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
+    static String testThree_sss(String a, String b, String c) {
+        return String.format("%s %s %s", a, b, c);
+    }
+
+    @Test
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
+    static String testThree_ddd(int a, int b, int c) {
+        return String.format("%d+%d=%d", a, b, c);
+    }
+
+    @Test
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
+    static String testFour_ssss(String a, String b, String c, String d) {
+        return String.format("[%s|%s|%s|%s]", a, b, c, d);
+    }
+
+    // ========== Run methods to verify correctness ==========
+
+    @Run(test = {"testSingle_s", "testSingle_sPrefix",
+                 "testSingle_d", "testSingle_dLong",
+                 "testSingle_null"})
+    void runSingleTests() {
+        assertEquals("hello", testSingle_s("hello"));
+        assertEquals("value: hello", testSingle_sPrefix("hello"));
+        assertEquals("count=42", testSingle_d(42));
+        assertEquals("value=123456789012345", testSingle_dLong(123456789012345L));
+        assertEquals("null", testSingle_null());
+    }
+
+    @Run(test = {"testFormatted_s", "testFormatted_d"})
+    void runFormattedSingleTests() {
+        assertEquals("value: test", testFormatted_s("test"));
+        assertEquals("count=42", testFormatted_d(42));
+    }
+
+    @Run(test = {"testTwo_ss", "testTwo_ssPrefix",
+                 "testTwo_sd", "testTwo_ds", "testTwo_dd",
+                 "testTwo_xx", "testTwo_XX", "testTwo_sx", "testTwo_xd",
+                 "testTwo_nullFirst"})
+    void runTwoTests() {
+        assertEquals("a b", testTwo_ss("a", "b"));
+        assertEquals("x=a, y=b", testTwo_ssPrefix("a", "b"));
+        assertEquals("name=Alice age=30", testTwo_sd("Alice", 30));
+        assertEquals("id=42 name=Bob", testTwo_ds(42, "Bob"));
+        assertEquals("1+2", testTwo_dd(1, 2));
+        assertEquals("ff+10", testTwo_xx(255, 16));
+        assertEquals("FF+10", testTwo_XX(255, 16));
+        assertEquals("addr=ff", testTwo_sx("addr", 255));
+        assertEquals("hex=ff dec=16", testTwo_xd(255, 16));
+        assertEquals("null b", testTwo_nullFirst());
+    }
+
+    @Run(test = {"testFormatted_ss", "testFormatted_sd", "testFormatted_ds", "testFormatted_dd",
+                 "testFormatted_xx", "testFormatted_sx"})
+    void runFormattedTwoTests() {
+        assertEquals("foo and bar", testFormatted_ss("foo", "bar"));
+        assertEquals("count=42", testFormatted_sd("count", 42));
+        assertEquals("42:Bob", testFormatted_ds(42, "Bob"));
+        assertEquals("1+2", testFormatted_dd(1, 2));
+        assertEquals("ff+10", testFormatted_xx(255, 16));
+        assertEquals("addr=ff", testFormatted_sx("addr", 255));
+    }
+
+    @Run(test = {"testSingle_width_s", "testSingle_width_d", "testSingle_flag0_d",
+                 "testSingle_x", "testSingle_X", "testSingle_width_x", "testSingle_width_X"})
+    void runFormat1Tests() {
+        assertEquals("[  abc]", testSingle_width_s("abc"));
+        assertEquals("[   42]", testSingle_width_d(42));
+        assertEquals("[00042]", testSingle_flag0_d(42));
+        assertEquals("0xff", testSingle_x(255));
+        assertEquals("0xFF", testSingle_X(255));
+        assertEquals("[   ff]", testSingle_width_x(255));
+        assertEquals("[   FF]", testSingle_width_X(255));
+    }
+
+    @Run(test = {"testFormatted_width_s", "testFormatted_width_d", "testFormatted_flag0_d",
+                 "testFormatted_x", "testFormatted_X"})
+    void runFormatted1Tests() {
+        assertEquals("[  abc]", testFormatted_width_s("abc"));
+        assertEquals("[   42]", testFormatted_width_d(42));
+        assertEquals("[00042]", testFormatted_flag0_d(42));
+        assertEquals("0xff", testFormatted_x(255));
+        assertEquals("0xFF", testFormatted_X(255));
+    }
+
+    @Run(test = {"testThree_sss", "testThree_ddd", "testFour_ssss"})
+    void runMultiTests() {
+        assertEquals("a b c", testThree_sss("a", "b", "c"));
+        assertEquals("1+2=3", testThree_ddd(1, 2, 3));
+        assertEquals("[a|b|c|d]", testFour_ssss("a", "b", "c", "d"));
+    }
+
+    static void assertEquals(String expected, String actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError("Expected [" + expected + "] but got [" + actual + "]");
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
@@ -307,6 +307,27 @@ public class TestStringFormatOptimization {
 
     @Test
     @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_d", "= 1" })
+    static String testSingle_null_d() {
+        return String.format("%d", (Object) null);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_null_x() {
+        return String.format("%x", (Object) null);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_1", "= 1" })
+    static String testSingle_null_X() {
+        return String.format("%X", (Object) null);
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC_ARRAY })
     @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_ss", "= 1" })
     static String testTwo_nullFirst() {
         return String.format("%s %s", (Object) null, "b");
@@ -336,13 +357,18 @@ public class TestStringFormatOptimization {
 
     @Run(test = {"testSingle_s", "testSingle_sPrefix",
                  "testSingle_d", "testSingle_dLong",
-                 "testSingle_null"})
+                 "testSingle_null", "testSingle_null_d",
+                 "testSingle_null_x", "testSingle_null_X"})
     void runSingleTests() {
         assertEquals("hello", testSingle_s("hello"));
         assertEquals("value: hello", testSingle_sPrefix("hello"));
         assertEquals("count=42", testSingle_d(42));
         assertEquals("value=123456789012345", testSingle_dLong(123456789012345L));
         assertEquals("null", testSingle_null());
+        // Null arguments for numeric conversions
+        assertEquals("null", testSingle_null_d());
+        assertEquals("null", testSingle_null_x());
+        assertEquals("NULL", testSingle_null_X());
     }
 
     @Run(test = {"testFormatted_s", "testFormatted_d"})

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
@@ -335,6 +335,8 @@ public class TestStringFormatOptimization {
     }
 
     // ========== Three+ specifiers - uses format_multi ==========
+    // Note: format_multi keeps the Object[] (no individual arg extraction for 3+ specifiers),
+    // so AllocateArray elimination is NOT expected here.
 
     @Test
     @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
@@ -352,6 +354,96 @@ public class TestStringFormatOptimization {
     @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
     static String testFour_ssss(String a, String b, String c, String d) {
         return String.format("[%s|%s|%s|%s]", a, b, c, d);
+    }
+
+    @Test
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
+    static String testFive_ssdsd(String a, String b, int c, String d, int e) {
+        return String.format("%s-%s-%d-%s-%d", a, b, c, d, e);
+    }
+
+    @Test
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
+    static String testSix_ssssss(String a, String b, String c, String d, String e, String f) {
+        return String.format("%s|%s|%s|%s|%s|%s", a, b, c, d, e, f);
+    }
+
+    @Test
+    @IR(counts = { IRNode.STATIC_CALL_OF_METHOD, "format_multi", "= 1" })
+    static String testEight_dddddddd(int a, int b, int c, int d, int e, int f, int g, int h) {
+        return String.format("%d%d%d%d%d%d%d%d", a, b, c, d, e, f, g, h);
+    }
+
+    // ========== Negative tests: verify optimization does NOT happen for unsupported patterns ==========
+
+    // Unsupported flag: %+d (positive sign flag)
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_d",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_plusFlag(int v) {
+        return String.format("%+d", v);
+    }
+
+    // Unsupported flag: %-5d (left-justify)
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_d",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_leftJustify(int v) {
+        return String.format("%-5d", v);
+    }
+
+    // Unsupported flag: %,d (grouping separator)
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_d",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_grouping(int v) {
+        return String.format("%,d", v);
+    }
+
+    // Escaped %% causes fallback
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_s",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_escapedPercent(String s) {
+        return String.format("%%%s", s);
+    }
+
+    // Multi-digit width (%10s) - only single-digit 1-9 is parsed
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_s",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_width10(String s) {
+        return String.format("%10s", s);
+    }
+
+    // 9 specifiers exceeds MAX_FORMAT_SPECS (8)
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_nineSpecs(int a, int b, int c, int d, int e, int f, int g, int h, int i) {
+        return String.format("%d%d%d%d%d%d%d%d%d", a, b, c, d, e, f, g, h, i);
+    }
+
+    // Unsupported conversion: %.2f
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_d",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_floatFormat(double v) {
+        return String.format("%.2f", v);
+    }
+
+    // Locale overload: String.format(Locale, String, Object...) is not optimized
+    @Test
+    @IR(failOn = { IRNode.STATIC_CALL_OF_METHOD, "format_s",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_1",
+                   IRNode.STATIC_CALL_OF_METHOD, "format_multi" })
+    static String testNoOpt_localeOverload(String s) {
+        return String.format(java.util.Locale.US, "%s", s);
     }
 
     // ========== Run methods to verify correctness ==========
@@ -428,11 +520,29 @@ public class TestStringFormatOptimization {
         assertEquals("0xFF", testFormatted_X(255));
     }
 
-    @Run(test = {"testThree_sss", "testThree_ddd", "testFour_ssss"})
+    @Run(test = {"testThree_sss", "testThree_ddd", "testFour_ssss",
+                 "testFive_ssdsd", "testSix_ssssss", "testEight_dddddddd"})
     void runMultiTests() {
         assertEquals("a b c", testThree_sss("a", "b", "c"));
         assertEquals("1+2=3", testThree_ddd(1, 2, 3));
         assertEquals("[a|b|c|d]", testFour_ssss("a", "b", "c", "d"));
+        assertEquals("a-b-3-d-5", testFive_ssdsd("a", "b", 3, "d", 5));
+        assertEquals("a|b|c|d|e|f", testSix_ssssss("a", "b", "c", "d", "e", "f"));
+        assertEquals("12345678", testEight_dddddddd(1, 2, 3, 4, 5, 6, 7, 8));
+    }
+
+    @Run(test = {"testNoOpt_plusFlag", "testNoOpt_leftJustify", "testNoOpt_grouping",
+                 "testNoOpt_escapedPercent", "testNoOpt_width10", "testNoOpt_nineSpecs",
+                 "testNoOpt_floatFormat", "testNoOpt_localeOverload"})
+    void runNegativeTests() {
+        assertEquals("+42", testNoOpt_plusFlag(42));
+        assertEquals("42   ", testNoOpt_leftJustify(42));
+        assertEquals(String.format("%,d", 1000), testNoOpt_grouping(1000));
+        assertEquals("%hello", testNoOpt_escapedPercent("hello"));
+        assertEquals("       abc", testNoOpt_width10("abc"));
+        assertEquals("123456789", testNoOpt_nineSpecs(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(String.format("%.2f", 3.14), testNoOpt_floatFormat(3.14));
+        assertEquals("test", testNoOpt_localeOverload("test"));
     }
 
     static void assertEquals(String expected, String actual) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java
@@ -9,15 +9,16 @@
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 more details (a copy has been included in the LICENSE file that
+ * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
- * You should have received a copy of the GNU General Public License
- * version 2 along with this work; if not, write to the Free Software Foundation,
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit the Oracle website www.oracle.com if you need additional information.
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package compiler.c2.irTests;

--- a/test/micro/org/openjdk/bench/java/lang/StringFormat.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringFormat.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +58,22 @@ public class StringFormat {
 
     @Benchmark
     public String stringFormat() {
-        return "%s".formatted(s);
+        return "value : %s".formatted(s);
+    }
+
+    @Benchmark
+    public String stringFormat2() {
+        return "value : %s %s".formatted(s, s);
+    }
+
+    @Benchmark
+    public String stringFormat4() {
+        return "value : %s %s %s %s".formatted(s, s, s, s);
+    }
+
+    @Benchmark
+    public String stringFormat8() {
+        return "value : %s %s %s %s %s %s %s %s".formatted(s, s, s, s, s, s, s, s);
     }
 
     @Benchmark


### PR DESCRIPTION
## Summary

Optimize `String.format()` and `String.formatted()` calls by bypassing `java.util.Formatter` overhead when the format string is a compile-time constant with simple specifiers (`%s`, `%d`, `%x`, `%X`).

Benchmarks show **2.6x - 4.3x speedup** for simple patterns:

| Pattern | Before (ns/op) | After (ns/op) | Speedup |
|---------|----------------|---------------|---------|
| 1 `%s`  | 65.63 | 17.49 | 3.75x |
| 2 `%s`  | 98.20 | 22.90 | 4.29x |
| `%s %d` | 101.01 | 38.48 | 2.62x |

## Approach

When C2 compiles a `String.format()` or `formatted()` call with a constant format string:

1. Parse the format string at compile time to extract specifier positions and types
2. Redirect the call to optimized fast-path helper methods in `String.java`
3. For 1-2 specifiers, pass arguments individually (enables escape analysis to eliminate `Object[]` allocation)
4. For 3-8 specifiers, use a compact `int[]` metadata array instead of parsing at runtime

## Fallback

The optimization falls back to `Formatter` for unsupported patterns:
- Non-constant format strings
- Complex specifiers (width > 9, precision, flags other than `' '` or `'0'`)
- Specifier position >= 256
- `%%` escaped percent

## Files

- `src/hotspot/share/opto/doCall.cpp` - C2 optimization logic (~550 lines)
- `src/java.base/share/classes/java/lang/String.java` - Fast-path methods (~770 lines)
- `src/java.base/share/classes/jdk/internal/access/JavaUtilFormatterAccess.java` - New access interface
- `test/hotspot/jtreg/compiler/c2/` - Functional and IR tests

## Test

- [x] `make test TEST="micro:java.lang.StringFormat"` - JMH benchmarks
- [x] `test/hotspot/jtreg/compiler/c2/TestStringFormatOptimization.java` - Functional tests
- [x] `test/hotspot/jtreg/compiler/c2/irTests/TestStringFormatOptimization.java` - IR verification

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29915/head:pull/29915` \
`$ git checkout pull/29915`

Update a local copy of the PR: \
`$ git checkout pull/29915` \
`$ git pull https://git.openjdk.org/jdk.git pull/29915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29915`

View PR using the GUI difftool: \
`$ git pr show -t 29915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29915.diff">https://git.openjdk.org/jdk/pull/29915.diff</a>

</details>
