### PR TITLE
8378700: Migrate lang/annotation tests away from TestNG

### DIFF
--- a/test/jdk/java/lang/annotation/AnnotationVerifier.java
+++ b/test/jdk/java/lang/annotation/AnnotationVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,17 @@
  * Create class file using ASM, slightly modified the ASMifier output
  */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.lang.annotation.Annotation;
 import java.lang.annotation.AnnotationFormatError;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
@@ -46,17 +48,12 @@ import java.util.stream.Stream;
  *        AnnotationWithoutAnnotationAccessModifier HolderX
  * @compile -XDignore.symbol.file ClassFileGenerator.java GoodAnnotation.java
  * @run main ClassFileGenerator
- * @run testng AnnotationVerifier
+ * @run junit AnnotationVerifier
  */
-
 public class AnnotationVerifier {
 
     //=======================================================
     // GoodAnnotation...
-
-    @GoodAnnotation
-    static class HolderA {
-    }
 
     @Test
     public void holderA_goodAnnotation() {
@@ -77,11 +74,6 @@ public class AnnotationVerifier {
         int m(int x) default -1;
     }
     */
-
-    @GoodAnnotation
-    @AnnotationWithParameter
-    static class HolderB {
-    }
 
     @Test
     public void holderB_annotationWithParameter() {
@@ -108,24 +100,22 @@ public class AnnotationVerifier {
     }
     */
 
-    @GoodAnnotation
-    @AnnotationWithVoidReturn
-    static class HolderC {
-    }
-
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderC_annotationWithVoidReturn() {
-        testGetAnnotation(HolderC.class, AnnotationWithVoidReturn.class, false);
+        assertThrows(AnnotationFormatError.class, () ->
+                testGetAnnotation(HolderC.class, AnnotationWithVoidReturn.class, false));
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderC_goodAnnotation() {
-        testGetAnnotation(HolderC.class, GoodAnnotation.class, false);
+        assertThrows(AnnotationFormatError.class, () ->
+                testGetAnnotation(HolderC.class, GoodAnnotation.class, false));
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderC_annotations() {
-        testGetAnnotations(HolderC.class);
+        assertThrows(AnnotationFormatError.class, () ->
+                testGetAnnotations(HolderC.class));
     }
 
     //=======================================================
@@ -138,24 +128,22 @@ public class AnnotationVerifier {
     }
     */
 
-    @GoodAnnotation
-    @AnnotationWithExtraInterface
-    static class HolderD {
-    }
-
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderD_annotationWithExtraInterface() {
-        testGetAnnotation(HolderD.class, AnnotationWithExtraInterface.class, false);
+        assertThrows(AnnotationFormatError.class, () ->
+                testGetAnnotation(HolderD.class, AnnotationWithExtraInterface.class, false));
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderD_goodAnnotation() {
-        testGetAnnotation(HolderD.class, GoodAnnotation.class, false);
+        assertThrows(AnnotationFormatError.class, () ->
+                testGetAnnotation(HolderD.class, GoodAnnotation.class, false));
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderD_annotations() {
-        testGetAnnotations(HolderD.class);
+        assertThrows(AnnotationFormatError.class, () ->
+                testGetAnnotations(HolderD.class));
     }
 
     //=======================================================
@@ -167,15 +155,6 @@ public class AnnotationVerifier {
         int m() throws Exception default 1;
     }
     */
-
-    @GoodAnnotation
-    @AnnotationWithException
-    static class HolderE {
-    }
-
-    @AnnotationWithException
-    static class HolderE2 {
-    }
 
     @Test
     public void holderE_annotationWithException() {
@@ -192,7 +171,7 @@ public class AnnotationVerifier {
         testGetAnnotations(HolderE.class, GoodAnnotation.class, AnnotationWithException.class);
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderE_annotationWithException_equals() {
         AnnotationWithException ann1, ann2;
         try {
@@ -201,10 +180,10 @@ public class AnnotationVerifier {
         } catch (Throwable t) {
             throw new AssertionError("Unexpected exception", t);
         }
-        Assert.assertNotNull(ann1);
-        Assert.assertNotNull(ann2);
+        assertNotNull(ann1);
+        assertNotNull(ann2);
 
-        testEquals(ann1, ann2, true); // this throws AnnotationFormatError
+        assertThrows(AnnotationFormatError.class, () -> ann1.equals(ann2));
     }
 
     //=======================================================
@@ -216,15 +195,6 @@ public class AnnotationVerifier {
         int hashCode() default 1;
     }
     */
-
-    @GoodAnnotation
-    @AnnotationWithHashCode
-    static class HolderF {
-    }
-
-    @AnnotationWithHashCode
-    static class HolderF2 {
-    }
 
     @Test
     public void holderF_annotationWithHashCode() {
@@ -241,7 +211,7 @@ public class AnnotationVerifier {
         testGetAnnotations(HolderF.class, GoodAnnotation.class, AnnotationWithHashCode.class);
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderF_annotationWithHashCode_equals() {
         AnnotationWithHashCode ann1, ann2;
         try {
@@ -250,10 +220,10 @@ public class AnnotationVerifier {
         } catch (Throwable t) {
             throw new AssertionError("Unexpected exception", t);
         }
-        Assert.assertNotNull(ann1);
-        Assert.assertNotNull(ann2);
+        assertNotNull(ann1);
+        assertNotNull(ann2);
 
-        testEquals(ann1, ann2, true); // this throws AnnotationFormatError
+        assertThrows(AnnotationFormatError.class, () -> ann1.equals(ann2));
     }
 
     //=======================================================
@@ -266,15 +236,6 @@ public class AnnotationVerifier {
         default int d() default 2 { return 2; }
     }
     */
-
-    @GoodAnnotation
-    @AnnotationWithDefaultMember
-    static class HolderG {
-    }
-
-    @AnnotationWithDefaultMember
-    static class HolderG2 {
-    }
 
     @Test
     public void holderG_annotationWithDefaultMember() {
@@ -291,7 +252,7 @@ public class AnnotationVerifier {
         testGetAnnotations(HolderG.class, GoodAnnotation.class, AnnotationWithDefaultMember.class);
     }
 
-    @Test(expectedExceptions = AnnotationFormatError.class)
+    @Test
     public void holderG_annotationWithDefaultMember_equals() {
         AnnotationWithDefaultMember ann1, ann2;
         try {
@@ -300,10 +261,10 @@ public class AnnotationVerifier {
         } catch (Throwable t) {
             throw new AssertionError("Unexpected exception", t);
         }
-        Assert.assertNotNull(ann1);
-        Assert.assertNotNull(ann2);
+        assertNotNull(ann1);
+        assertNotNull(ann2);
 
-        testEquals(ann1, ann2, true); // this throws AnnotationFormatError
+        assertThrows(AnnotationFormatError.class, () -> ann1.equals(ann2));
     }
 
     //=======================================================
@@ -400,20 +361,53 @@ public class AnnotationVerifier {
                                result);
         }
     }
-
-    private static void testEquals(Annotation ann1, Annotation ann2, boolean expectedEquals) {
-        Object result = null;
-        try {
-            try {
-                boolean gotEquals = ann1.equals(ann2);
-                Assert.assertEquals(gotEquals, expectedEquals);
-                result = gotEquals;
-            } catch (Throwable t) {
-                result = t;
-                throw t;
-            }
-        } finally {
-            System.out.println("\n" + ann1 + ".equals(" + ann2 + ") = " + result);
-        }
-    }
 }
+
+// Do not declare the holders as nested - JUnit scans their annotations and
+// results in AnnotationFormatError
+@GoodAnnotation
+class HolderA {
+}
+
+@GoodAnnotation
+@AnnotationWithParameter
+class HolderB {
+}
+
+@GoodAnnotation
+@AnnotationWithVoidReturn
+class HolderC {
+}
+
+@GoodAnnotation
+@AnnotationWithExtraInterface
+class HolderD {
+}
+
+@GoodAnnotation
+@AnnotationWithException
+class HolderE {
+}
+
+@AnnotationWithException
+class HolderE2 {
+}
+
+@GoodAnnotation
+@AnnotationWithHashCode
+class HolderF {
+}
+
+@AnnotationWithHashCode
+class HolderF2 {
+}
+
+@GoodAnnotation
+@AnnotationWithDefaultMember
+class HolderG {
+}
+
+@AnnotationWithDefaultMember
+class HolderG2 {
+}
+

--- a/test/jdk/java/lang/annotation/AnnotationWithLambda.java
+++ b/test/jdk/java/lang/annotation/AnnotationWithLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8147585
  * @summary Check Annotation with Lambda, with or without parameter
- * @run testng AnnotationWithLambda
+ * @run junit AnnotationWithLambda
  */
 
 import java.lang.annotation.ElementType;
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.function.Consumer;
 
-import org.testng.annotations.*;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class AnnotationWithLambda {
 

--- a/test/jdk/java/lang/annotation/LoaderLeakTest.java
+++ b/test/jdk/java/lang/annotation/LoaderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,21 +26,21 @@
  * @bug 5040740
  * @summary annotations cause memory leak
  * @library /test/lib
- * @build jdk.test.lib.process.*
- * @run testng/timeout=480 LoaderLeakTest
+ * @build jdk.test.lib.*
+ * @run junit LoaderLeakTest
  */
 
-import jdk.test.lib.Utils;
-import jdk.test.lib.process.ProcessTools;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import java.io.FileInputStream;
 import java.lang.annotation.Retention;
-import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.nio.file.*;
 import java.util.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.ForceGC;
+import org.junit.jupiter.api.Test;
 
 public class LoaderLeakTest {
 
@@ -65,37 +65,23 @@ public class LoaderLeakTest {
 class Main {
 
     public static void main(String[] args) throws Exception {
-        for (int i = 0; i < 100; i++) {
-            doTest(args.length != 0);
-        }
+        doTest(args.length != 0);
     }
 
     static void doTest(boolean readAnn) throws Exception {
         ClassLoader loader = new SimpleClassLoader();
+        var loaderRef = new WeakReference<>(loader);
         var c = new WeakReference<Class<?>>(loader.loadClass("C"));
-        if (c.refersTo(null)) throw new AssertionError("class missing after loadClass");
         // c.get() should never return null here since we hold a strong
         // reference to the class loader that loaded the class referred by c.
-        if (c.get().getClassLoader() != loader) throw new AssertionError("wrong classloader");
-        if (readAnn) System.out.println(c.get().getAnnotations()[0]);
-        if (c.refersTo(null)) throw new AssertionError("class missing before GC");
-        System.gc();
-        System.gc();
-        if (c.refersTo(null)) throw new AssertionError("class missing after GC but before loader is unreachable");
-        System.gc();
-        System.gc();
-        Reference.reachabilityFence(loader);
+        if (c.get().getClassLoader() != loader)
+            throw new AssertionError("wrong classloader");
+        if (readAnn)
+            System.out.println(c.get().getAnnotations()[0]);
         loader = null;
 
-        // Might require multiple calls to System.gc() for weak-references
-        // processing to be complete. If the weak-reference is not cleared as
-        // expected we will hang here until timed out by the test harness.
-        while (true) {
-            System.gc();
-            Thread.sleep(20);
-            if (c.refersTo(null)) {
-                break;
-            }
+        if (!ForceGC.wait(() -> loaderRef.refersTo(null) && c.refersTo(null))) {
+            Asserts.fail("loader and C not unloaded");
         }
     }
 }

--- a/test/jdk/java/lang/annotation/TypeVariableBounds.java
+++ b/test/jdk/java/lang/annotation/TypeVariableBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8038994
  * @summary Test that getAnnotatedBounds().getType() match getBounds()
- * @run testng TypeVariableBounds
+ * @run junit TypeVariableBounds
  */
 
 import java.io.Serializable;
@@ -35,15 +35,20 @@ import java.util.concurrent.Callable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TypeVariableBounds {
-    @Test(dataProvider = "classData")
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Case1.class,
+            Case2.class,
+            Case5.class,
+            Case6.class,
+    })
     public void testClass(Class<?> c) throws Exception {
-        assertNotEquals(c.getTypeParameters().length, 0);
+        assertNotEquals(0, c.getTypeParameters().length);
 
         TypeVariable[] tv = c.getTypeParameters();
 
@@ -52,7 +57,13 @@ public class TypeVariableBounds {
 
     }
 
-    @Test(dataProvider = "methodData")
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Case3.class,
+            Case4.class,
+            Case5.class,
+            Case6.class,
+    })
     public void testMethod(Class<?>c) throws Exception {
         Method m = c.getMethod("aMethod");
         TypeVariable[] tv = m.getTypeParameters();
@@ -66,31 +77,13 @@ public class TypeVariableBounds {
         Type[] t = tv.getBounds();
         AnnotatedType[] at = tv.getAnnotatedBounds();
 
-        assertEquals(t.length, at.length, Arrays.asList(t) + " and " + Arrays.asList(at) + " should be the same length");
+        assertEquals(t.length, at.length, () -> "Bounds count t = %s; at = %s".formatted(Arrays.asList(t), Arrays.asList(at)));
 
-        for (int i = 0; i < t.length; i++)
-            assertSame(at[i].getType(), t[i], "T: " + t[i] + ", AT: " + at[i] + ", AT.getType(): " + at[i].getType() + "\n");
+        for (int i = 0; i < t.length; i++) {
+            int p = i;
+            assertSame(t[i], at[i].getType(), () -> "Underlying type for at[%d]: %s; t = %s; at = %s".formatted(p, at[p], Arrays.asList(t), Arrays.asList(at)));
+        }
     }
-
-    @DataProvider
-    public Object[][] classData() { return CLASS_TESTS; }
-
-    @DataProvider
-    public Object[][] methodData() { return METHOD_TESTS; }
-
-    public static final Object[][] CLASS_TESTS = {
-        { Case1.class, },
-        { Case2.class, },
-        { Case5.class, },
-        { Case6.class, },
-    };
-
-    public static final Object[][] METHOD_TESTS = {
-        { Case3.class, },
-        { Case4.class, },
-        { Case5.class, },
-        { Case6.class, },
-    };
 
     // Class type var
     public static class Case1<C1T1, C1T2 extends AnnotatedElement, C1T3 extends AnnotatedElement & Type & Serializable> {}

--- a/test/jdk/java/lang/annotation/typeAnnotations/BadCPIndex.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/BadCPIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,17 @@
  * @bug 8023878
  * @summary Test that the right kind of exception is thrown from the type
  *          annotation reflection code.
- * @run testng BadCPIndex
+ * @run junit BadCPIndex
  */
 
 import java.lang.annotation.*;
 import java.util.Base64;
 import java.util.function.Function;
 
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BadCPIndex {
     private static final  MyLoader loader = new MyLoader(BadCPIndex.class.getClassLoader());
@@ -57,21 +59,13 @@ public class BadCPIndex {
         { new Case("BadCPIndex$E", encodedBrokenE, Class::getAnnotatedSuperclass) },
     };
 
-    @DataProvider
     public static Object[][] data() { return cases; }
 
-    @Test(dataProvider="data")
-    public static void testOpThrowsAFE(Case testCase) {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOpThrowsAFE(Case testCase) {
         Class<?> c = loader.defineClass(testCase.name, Base64.getDecoder().decode(testCase.encoding));
-        try {
-            System.out.println("Testing: " + c);
-            testCase.trigger.apply(c);
-            throw new RuntimeException("Expecting AnnotationFormatError here");
-        } catch (AnnotationFormatError e) {
-            ; //ok
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        assertThrows(AnnotationFormatError.class, () -> testCase.trigger.apply(c), "Testing " + c);
     }
 
     private static class MyLoader extends ClassLoader {

--- a/test/jdk/java/lang/annotation/typeAnnotations/ConstructorReceiverTest.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/ConstructorReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,14 @@
  * @bug 8023651 8044629
  * @summary Test that the receiver annotations and the return annotations of
  *          constructors behave correctly.
- * @run testng ConstructorReceiverTest
+ * @run junit ConstructorReceiverTest
  */
 
 import java.lang.annotation.*;
 import java.lang.reflect.*;
-import java.util.Arrays;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConstructorReceiverTest {
     public static final Integer EMPTY_ANNOTATED_TYPE =  Integer.valueOf(-1);
@@ -65,10 +63,10 @@ public class ConstructorReceiverTest {
     };
 
 
-    @DataProvider
-    public Object[][] data() { return TESTS; }
+    public static Object[][] data() { return TESTS; }
 
-    @Test(dataProvider = "data")
+    @ParameterizedTest
+    @MethodSource("data")
     public void testAnnotatedReciver(Class<?> toTest, Class<?> ctorParamType,
             Integer returnVal, Integer receiverVal) throws NoSuchMethodException {
         Constructor c;
@@ -87,12 +85,10 @@ public class ConstructorReceiverTest {
 
         // check that getType() matches the receiver (which can be parameterized)
         if (annotatedReceiverType.getType() instanceof ParameterizedType) {
-            assertEquals(((ParameterizedType) annotatedReceiverType.getType()).getRawType(),
-                    ctorParamType,
+            assertEquals(ctorParamType, ((ParameterizedType) annotatedReceiverType.getType()).getRawType(),
                     "getType() doesn't match receiver type: " + ctorParamType);
         } else {
-            assertEquals(annotatedReceiverType.getType(),
-                    ctorParamType,
+            assertEquals(ctorParamType, annotatedReceiverType.getType(),
                     "getType() doesn't match receiver type: " + ctorParamType);
         }
 
@@ -100,19 +96,20 @@ public class ConstructorReceiverTest {
 
         // Some Constructors have no annotations on but in theory can have a receiver
         if (receiverVal.equals(EMPTY_ANNOTATED_TYPE)) {
-            assertEquals(receiverAnnotations.length, 0, "expecting an empty annotated type for: " + c);
+            assertEquals(0, receiverAnnotations.length, "expecting an empty annotated type for: " + c);
             return;
         }
 
         // The rest should have annotations
-        assertEquals(receiverAnnotations.length, 1, "expecting a 1 element array. Looking at 'length': ");
-        assertEquals(((Annot)receiverAnnotations[0]).value(), receiverVal.intValue(), " wrong annotation found. Found " +
+        assertEquals(1, receiverAnnotations.length, "expecting a 1 element array. Looking at 'length': ");
+        assertEquals(receiverVal.intValue(), ((Annot)receiverAnnotations[0]).value(), " wrong annotation found. Found " +
                 receiverAnnotations[0] +
                 " should find @Annot with value=" +
                 receiverVal);
     }
 
-    @Test(dataProvider = "data")
+    @ParameterizedTest
+    @MethodSource("data")
     public void testAnnotatedReturn(Class<?> toTest, Class<?> ctorParamType,
             Integer returnVal, Integer receiverVal) throws NoSuchMethodException {
         Constructor c;
@@ -124,8 +121,8 @@ public class ConstructorReceiverTest {
         AnnotatedType annotatedReturnType = c.getAnnotatedReturnType();
         Annotation[] returnAnnotations = annotatedReturnType.getAnnotations();
 
-        assertEquals(returnAnnotations.length, 1, "expecting a 1 element array. Looking at 'length': ");
-        assertEquals(((Annot)returnAnnotations[0]).value(), returnVal.intValue(), " wrong annotation found. Found " +
+        assertEquals(1, returnAnnotations.length, "expecting a 1 element array. Looking at 'length': ");
+        assertEquals(returnVal.intValue(), ((Annot)returnAnnotations[0]).value(), " wrong annotation found. Found " +
                 returnAnnotations[0] +
                 " should find @Annot with value=" +
                 returnVal);

--- a/test/jdk/java/lang/annotation/typeAnnotations/TestExecutableGetAnnotatedType.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/TestExecutableGetAnnotatedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,8 @@
  * @summary Test that a call to getType() on an AnnotatedType returned from an
  *          Executable.getAnnotated* returns the same type as the corresponding
  *          Executable.getGeneric* call.
- * @run testng TestExecutableGetAnnotatedType
+ * @run junit TestExecutableGetAnnotatedType
  */
-
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import java.lang.annotation.*;
 import java.lang.reflect.*;
@@ -40,57 +37,69 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestExecutableGetAnnotatedType {
-    @Test(dataProvider = "genericExecutableData")
+    @ParameterizedTest
+    @MethodSource("genericExecutableData")
     public void testGenericMethodExceptions(Executable e) throws Exception {
         testExceptions(e);
     }
 
-    @Test(dataProvider = "executableData")
+    @ParameterizedTest
+    @MethodSource("executableData")
     public void testMethodExceptions(Executable e) throws Exception {
         testExceptions(e);
     }
 
-    @Test(dataProvider = "genericExecutableData")
+    @ParameterizedTest
+    @MethodSource("genericExecutableData")
     public void testGenericMethodParameterTypes(Executable e) throws Exception {
         testMethodParameters(e);
     }
 
-    @Test(dataProvider = "executableData")
+    @ParameterizedTest
+    @MethodSource("executableData")
     public void testMethodParameterTypes(Executable e) throws Exception {
         testMethodParameters(e);
     }
 
-    @Test(dataProvider = "genericExecutableData")
+    @ParameterizedTest
+    @MethodSource("genericExecutableData")
     public void testGenericParameterTypes(Executable e) throws Exception {
         testParameters(e.getParameters());
     }
 
-    @Test(dataProvider = "executableData")
+    @ParameterizedTest
+    @MethodSource("executableData")
     public void testParameterTypes(Executable e) throws Exception {
         testParameters(e.getParameters());
     }
 
-    @Test(dataProvider = "genericMethodData")
+    @ParameterizedTest
+    @MethodSource("genericMethodData")
     public void testGenericReceiverType(Executable e) throws Exception {
         testParameterizedReceiverType0(e);
     }
 
-    @Test(dataProvider = "methodData")
+    @ParameterizedTest
+    @MethodSource("methodData")
     public void testReceiverType(Executable e) throws Exception {
         testReceiverType0(e);
     }
 
-    @Test(dataProvider = "genericMethodData")
+    @ParameterizedTest
+    @MethodSource("genericMethodData")
     public void testGenericMethodReturnType(Object o) throws Exception {
         // testng gets confused if the param to this method has type Method
         Method m = (Method)o;
         testReturnType(m);
     }
 
-    @Test(dataProvider = "methodData")
+    @ParameterizedTest
+    @MethodSource("methodData")
     public void testMethodReturnType(Object o) throws Exception {
         // testng gets confused if the param to this method has type Method
         Method m = (Method)o;
@@ -100,7 +109,7 @@ public class TestExecutableGetAnnotatedType {
     private void testExceptions(Executable e) {
         Type[] ts = e.getGenericExceptionTypes();
         AnnotatedType[] ats = e.getAnnotatedExceptionTypes();
-        assertEquals(ts.length, ats.length);
+        assertEquals(ats.length, ts.length);
 
         for (int i = 0; i < ts.length; i++) {
             Type t = ts[i];
@@ -112,7 +121,7 @@ public class TestExecutableGetAnnotatedType {
     private void testMethodParameters(Executable e) {
         Type[] ts = e.getGenericParameterTypes();
         AnnotatedType[] ats = e.getAnnotatedParameterTypes();
-        assertEquals(ts.length, ats.length);
+        assertEquals(ats.length, ts.length);
 
         for (int i = 0; i < ts.length; i++) {
             Type t = ts[i];
@@ -151,20 +160,17 @@ public class TestExecutableGetAnnotatedType {
         assertSame(at.getType(), t, m.toString() + ": T: " + t + ", AT: " + at + ", AT.getType(): " + at.getType() + "\n");
     }
 
-    @DataProvider
-    public Object[][] methodData() throws Exception {
+    public static Object[][] methodData() throws Exception {
         return filterData(Arrays.stream(Methods1.class.getMethods()), Methods1.class)
             .toArray(new Object[0][0]);
     }
 
-    @DataProvider
-    public Object[][] genericMethodData()  throws Exception {
+    public static Object[][] genericMethodData()  throws Exception {
         return filterData(Arrays.stream(GenericMethods1.class.getMethods()), GenericMethods1.class)
             .toArray(new Object[0][0]);
     }
 
-    @DataProvider
-    public Object[][] executableData() throws Exception {
+    public static Object[][] executableData() throws Exception {
     @SuppressWarnings("raw")
         List l = filterData(Arrays.stream(Methods1.class.getMethods()), Methods1.class);
         l.addAll(filterData(Arrays.stream(Methods1.class.getConstructors()), Methods1.class));
@@ -172,8 +178,7 @@ public class TestExecutableGetAnnotatedType {
         return ((List<Object[][]>)l).toArray(new Object[0][0]);
     }
 
-    @DataProvider
-    public Object[][] genericExecutableData() throws Exception {
+    public static Object[][] genericExecutableData() throws Exception {
     @SuppressWarnings("raw")
         List l = filterData(Arrays.stream(GenericMethods1.class.getMethods()), GenericMethods1.class);
         l.addAll(filterData(Arrays.stream(GenericMethods1.class.getConstructors()), GenericMethods1.class));
@@ -181,7 +186,7 @@ public class TestExecutableGetAnnotatedType {
         return ((List<Object[][]>)l).toArray(new Object[0][0]);
     }
 
-    private List<?> filterData(Stream<? extends Executable> l, Class<?> c) {
+    private static List<?> filterData(Stream<? extends Executable> l, Class<?> c) {
         return l.filter(m -> (m.getDeclaringClass() == c)) // remove object methods
             .map(m -> { Object[] o = new Object[1]; o[0] = m; return o; })
             .collect(Collectors.toList());

--- a/test/jdk/java/lang/annotation/typeAnnotations/TestExecutableGetAnnotatedType.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/TestExecutableGetAnnotatedType.java
@@ -165,7 +165,7 @@ public class TestExecutableGetAnnotatedType {
             .toArray(new Object[0][0]);
     }
 
-    public static Object[][] genericMethodData()  throws Exception {
+    public static Object[][] genericMethodData() throws Exception {
         return filterData(Arrays.stream(GenericMethods1.class.getMethods()), GenericMethods1.class)
             .toArray(new Object[0][0]);
     }


### PR DESCRIPTION
Remove the use of TestNG from java/lang/annotation tests.
Interesting that JUnit scans annotations on member classes, so we can't put malformed annotations on classes nested in the test class; we can put them on package-private classes in the same source file instead.
Also refactored LoaderLeakTest to perform GC more reliably within our test framework.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8378700](https://bugs.openjdk.org/browse/JDK-8378700): Migrate lang/annotation tests away from TestNG (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29921/head:pull/29921` \
`$ git checkout pull/29921`

Update a local copy of the PR: \
`$ git checkout pull/29921` \
`$ git pull https://git.openjdk.org/jdk.git pull/29921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29921`

View PR using the GUI difftool: \
`$ git pr show -t 29921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29921.diff">https://git.openjdk.org/jdk/pull/29921.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29921#issuecomment-3960437164)
</details>
