### PR TITLE
8376106: TestObjectDescription.java intermittent fails Unable to replace class name

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
@@ -39,7 +39,7 @@ public final class TestClassLoader extends ClassLoader {
     }
 
     static byte[] classByteCode = readTestClassBytes();
-    private  int classIdCounter;
+    private int classIdCounter;
 
     TestClassLoader() {
         super(TestClassLoader.class.getClassLoader());

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
@@ -39,7 +39,7 @@ public final class TestClassLoader extends ClassLoader {
     }
 
     static byte[] classByteCode = readTestClassBytes();
-    private int classIdCounter;
+    private  int classIdCounter;
 
     TestClassLoader() {
         super(TestClassLoader.class.getClassLoader());

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoader.java
@@ -39,7 +39,7 @@ public final class TestClassLoader extends ClassLoader {
     }
 
     static byte[] classByteCode = readTestClassBytes();
-    private static int classIdCounter;
+    private  int classIdCounter;
 
     TestClassLoader() {
         super(TestClassLoader.class.getClassLoader());

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -87,7 +87,7 @@ public class TestObjectDescription {
     }
 
     private static void testThreadName() throws Exception {
-        assertObjectDescription(() -> {
+        asseertObjectDescription(() -> {
             List<MyThread> threads = new ArrayList<>(OldObjects.MIN_SIZE);
             for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 threads.add(new MyThread());
@@ -97,7 +97,7 @@ public class TestObjectDescription {
     }
 
     private static void testThreadGroupName() throws Exception {
-        assertObjectDescription(() -> {
+        asseertObjectDescription(() -> {
             List<MyThreadGroup> groups = new ArrayList<>(OldObjects.MIN_SIZE);
             for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 groups.add(new MyThreadGroup("My Thread Group"));
@@ -107,7 +107,7 @@ public class TestObjectDescription {
     }
 
     private static void testClassName() throws Exception {
-        assertObjectDescription(() -> {
+        asseertObjectDescription(() -> {
             TestClassLoader testClassLoader = new TestClassLoader();
             List<Object> classObjects = new ArrayList<>(OldObjects.MIN_SIZE);
             for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)) {
@@ -123,7 +123,7 @@ public class TestObjectDescription {
     }
 
     private static void testSize() throws Exception {
-        assertObjectDescription(() -> {
+        asseertObjectDescription(() -> {
             List<Object> arrayLists = new ArrayList<>(OldObjects.MIN_SIZE);
             for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 List<Object> arrayList = new ArrayList<>();
@@ -137,7 +137,7 @@ public class TestObjectDescription {
     }
 
     private static void testEllipsis() throws Exception {
-        assertObjectDescription(() -> {
+        asseertObjectDescription(() -> {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < 2 * OBJECT_DESCRIPTION_MAX_SIZE; i++) {
                 sb.append("x");
@@ -151,7 +151,7 @@ public class TestObjectDescription {
         }, "xxx...");
     }
 
-    private static void assertObjectDescription(Callable<List<?>> callable, String text) throws Exception {
+    private static void asseertObjectDescription(Callable<List<?>> callable, String text) throws Exception {
         int iteration = 1;
         while (true) {
             try (Recording recording = new Recording()) {

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -46,12 +46,11 @@ import jdk.test.lib.jfr.Events;
  * @comment Marked as flagless until JDK-8344015 is fixed
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm/timeout=960 -XX:-UseTLAB jdk.jfr.event.oldobject.TestObjectDescription
+ * @run main/othervm/timeout=960 -XX:TLABSize=2k jdk.jfr.event.oldobject.TestObjectDescription
  */
 public class TestObjectDescription {
 
     private static final int OBJECT_DESCRIPTION_MAX_SIZE = 100;
-    private static final int OBJECT_COUNT = 200;
     private static final String CLASS_NAME = TestClassLoader.class.getName() + "$TestClass";
     public static List<?> leaks;
 
@@ -89,8 +88,8 @@ public class TestObjectDescription {
 
     private static void testThreadName() throws Exception {
         assertObjectDescription(() -> {
-            List<MyThread> threads = new ArrayList<>(OBJECT_COUNT);
-            for (int i = 0; i < OBJECT_COUNT; i++) {
+            List<MyThread> threads = new ArrayList<>(OldObjects.MIN_SIZE);
+            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 threads.add(new MyThread());
             }
             return threads;
@@ -99,8 +98,8 @@ public class TestObjectDescription {
 
     private static void testThreadGroupName() throws Exception {
         assertObjectDescription(() -> {
-            List<MyThreadGroup> groups = new ArrayList<>(OBJECT_COUNT);
-            for (int i = 0; i < OBJECT_COUNT; i++) {
+            List<MyThreadGroup> groups = new ArrayList<>(OldObjects.MIN_SIZE);
+            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 groups.add(new MyThreadGroup("My Thread Group"));
             }
             return groups;
@@ -110,9 +109,10 @@ public class TestObjectDescription {
     private static void testClassName() throws Exception {
         assertObjectDescription(() -> {
             TestClassLoader testClassLoader = new TestClassLoader();
-            List<Object> classObjects = new ArrayList<>();
-            for (Class<?> clazz : testClassLoader.loadClasses(20)) {
-                for (int i = 0; i < 10; i++) {
+            List<Object> classObjects = new ArrayList<>(OldObjects.MIN_SIZE);
+            for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)) {
+                // Allocate array to trigger sampling code path for interpreter / c1
+                for (int i = 0; i < 20; i++) {
                     Object classArray = Array.newInstance(clazz, 20);
                     Array.set(classArray, i, clazz.newInstance());
                     classObjects.add(classArray);
@@ -124,8 +124,8 @@ public class TestObjectDescription {
 
     private static void testSize() throws Exception {
         assertObjectDescription(() -> {
-            List<Object> arrayLists = new ArrayList<>(OBJECT_COUNT);
-            for (int i = 0; i < OBJECT_COUNT; i++) {
+            List<Object> arrayLists = new ArrayList<>(OldObjects.MIN_SIZE);
+            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 List<Object> arrayList = new ArrayList<>();
                 arrayList.add(new Object());
                 arrayList.add(new Object());
@@ -144,7 +144,7 @@ public class TestObjectDescription {
             }
             String threadName = sb.toString();
             List<Thread> threads = new ArrayList<>();
-            for (int i = 0; i < OBJECT_COUNT; i++) {
+            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 threads.add(new Thread(threadName));
             }
             return threads;

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -46,11 +46,12 @@ import jdk.test.lib.jfr.Events;
  * @comment Marked as flagless until JDK-8344015 is fixed
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm/timeout=960 -XX:TLABSize=2k jdk.jfr.event.oldobject.TestObjectDescription
+ * @run main/othervm/timeout=960 -XX:-UseTLAB jdk.jfr.event.oldobject.TestObjectDescription
  */
 public class TestObjectDescription {
 
     private static final int OBJECT_DESCRIPTION_MAX_SIZE = 100;
+    private static final int OBJECT_COUNT = 200;
     private static final String CLASS_NAME = TestClassLoader.class.getName() + "$TestClass";
     public static List<?> leaks;
 
@@ -88,8 +89,8 @@ public class TestObjectDescription {
 
     private static void testThreadName() throws Exception {
         assertObjectDescription(() -> {
-            List<MyThread> threads = new ArrayList<>(OldObjects.MIN_SIZE);
-            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
+            List<MyThread> threads = new ArrayList<>(OBJECT_COUNT);
+            for (int i = 0; i < OBJECT_COUNT; i++) {
                 threads.add(new MyThread());
             }
             return threads;
@@ -98,8 +99,8 @@ public class TestObjectDescription {
 
     private static void testThreadGroupName() throws Exception {
         assertObjectDescription(() -> {
-            List<MyThreadGroup> groups = new ArrayList<>(OldObjects.MIN_SIZE);
-            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
+            List<MyThreadGroup> groups = new ArrayList<>(OBJECT_COUNT);
+            for (int i = 0; i < OBJECT_COUNT; i++) {
                 groups.add(new MyThreadGroup("My Thread Group"));
             }
             return groups;
@@ -109,10 +110,9 @@ public class TestObjectDescription {
     private static void testClassName() throws Exception {
         assertObjectDescription(() -> {
             TestClassLoader testClassLoader = new TestClassLoader();
-            List<Object> classObjects = new ArrayList<>(OldObjects.MIN_SIZE);
-            for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)) {
-                // Allocate array to trigger sampling code path for interpreter / c1
-                for (int i = 0; i < 20; i++) {
+            List<Object> classObjects = new ArrayList<>();
+            for (Class<?> clazz : testClassLoader.loadClasses(20)) {
+                for (int i = 0; i < 10; i++) {
                     Object classArray = Array.newInstance(clazz, 20);
                     Array.set(classArray, i, clazz.newInstance());
                     classObjects.add(classArray);
@@ -124,8 +124,8 @@ public class TestObjectDescription {
 
     private static void testSize() throws Exception {
         assertObjectDescription(() -> {
-            List<Object> arrayLists = new ArrayList<>(OldObjects.MIN_SIZE);
-            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
+            List<Object> arrayLists = new ArrayList<>(OBJECT_COUNT);
+            for (int i = 0; i < OBJECT_COUNT; i++) {
                 List<Object> arrayList = new ArrayList<>();
                 arrayList.add(new Object());
                 arrayList.add(new Object());
@@ -144,7 +144,7 @@ public class TestObjectDescription {
             }
             String threadName = sb.toString();
             List<Thread> threads = new ArrayList<>();
-            for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
+            for (int i = 0; i < OBJECT_COUNT; i++) {
                 threads.add(new Thread(threadName));
             }
             return threads;

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -87,7 +87,7 @@ public class TestObjectDescription {
     }
 
     private static void testThreadName() throws Exception {
-        asseertObjectDescription(() -> {
+        assertObjectDescription(() -> {
             List<MyThread> threads = new ArrayList<>(OldObjects.MIN_SIZE);
             for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 threads.add(new MyThread());
@@ -97,7 +97,7 @@ public class TestObjectDescription {
     }
 
     private static void testThreadGroupName() throws Exception {
-        asseertObjectDescription(() -> {
+        assertObjectDescription(() -> {
             List<MyThreadGroup> groups = new ArrayList<>(OldObjects.MIN_SIZE);
             for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 groups.add(new MyThreadGroup("My Thread Group"));
@@ -107,7 +107,7 @@ public class TestObjectDescription {
     }
 
     private static void testClassName() throws Exception {
-        asseertObjectDescription(() -> {
+        assertObjectDescription(() -> {
             TestClassLoader testClassLoader = new TestClassLoader();
             List<Object> classObjects = new ArrayList<>(OldObjects.MIN_SIZE);
             for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)) {
@@ -123,7 +123,7 @@ public class TestObjectDescription {
     }
 
     private static void testSize() throws Exception {
-        asseertObjectDescription(() -> {
+        assertObjectDescription(() -> {
             List<Object> arrayLists = new ArrayList<>(OldObjects.MIN_SIZE);
             for (int i = 0; i < OldObjects.MIN_SIZE; i++) {
                 List<Object> arrayList = new ArrayList<>();
@@ -137,7 +137,7 @@ public class TestObjectDescription {
     }
 
     private static void testEllipsis() throws Exception {
-        asseertObjectDescription(() -> {
+        assertObjectDescription(() -> {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < 2 * OBJECT_DESCRIPTION_MAX_SIZE; i++) {
                 sb.append("x");
@@ -151,7 +151,7 @@ public class TestObjectDescription {
         }, "xxx...");
     }
 
-    private static void asseertObjectDescription(Callable<List<?>> callable, String text) throws Exception {
+    private static void assertObjectDescription(Callable<List<?>> callable, String text) throws Exception {
         int iteration = 1;
         while (true) {
             try (Recording recording = new Recording()) {


### PR DESCRIPTION
This change prevents the counter from overflowing. 

### Problem:
The counter overflows at 2002 iterations because on each iteration the retry loop calls `testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)`. 
`OldObjects.MIN_SIZE` = 99901 , so 99901 / 20 = 4995 classes are loaded each iteration.

The constructed `className` must be exactly the same length as "TestClass0000000". Which means the max number of classes loaded can be 9,999,999. After 2002 iterations we hit the limit (2002 * 4995 = 9,999,990).

### Solution

Making `classIdCounter`  non-`static` forces the counter to reset with each iteration of `TestObjectDescription.asseertObjectDescription`. The maximum value of the counter is now 4995, so it cannot possibly overflow no matter how long it takes to collect the leak samples. 

Testing:
- Re-running the test 60 times never results in overflow.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8376106](https://bugs.openjdk.org/browse/JDK-8376106): TestObjectDescription.java intermittent fails Unable to replace class name (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role) Review applies to [66977dc1](https://git.openjdk.org/jdk/pull/29945/files/66977dc19565b4b860fb7e56d4ede7b255f94a77)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29945/head:pull/29945` \
`$ git checkout pull/29945`

Update a local copy of the PR: \
`$ git checkout pull/29945` \
`$ git pull https://git.openjdk.org/jdk.git pull/29945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29945`

View PR using the GUI difftool: \
`$ git pr show -t 29945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29945.diff">https://git.openjdk.org/jdk/pull/29945.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29945#issuecomment-3969499932)
</details>
