### PR TITLE
8378823: AIX build fails after zlib updated by JDK-8378631

### DIFF
--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -267,7 +267,7 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
   LIBZ_LIBS=""
   if test "x$USE_EXTERNAL_LIBZ" = "xfalse"; then
     LIBZ_CFLAGS="$LIBZ_CFLAGS -I$TOPDIR/src/java.base/share/native/libzip/zlib"
-    if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+    if test "x$OPENJDK_TARGET_OS" = xmacosx || test "x$OPENJDK_TARGET_OS" = xaix; then
         LIBZ_CFLAGS="$LIBZ_CFLAGS -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1"
     fi
   else

--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -267,7 +267,7 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
   LIBZ_LIBS=""
   if test "x$USE_EXTERNAL_LIBZ" = "xfalse"; then
     LIBZ_CFLAGS="$LIBZ_CFLAGS -I$TOPDIR/src/java.base/share/native/libzip/zlib"
-    if test "x$OPENJDK_TARGET_OS" = xmacosx || test "x$OPENJDK_TARGET_OS" = xaix; then
+    if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix; then
         LIBZ_CFLAGS="$LIBZ_CFLAGS -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1"
     fi
   else

--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -267,7 +267,7 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
   LIBZ_LIBS=""
   if test "x$USE_EXTERNAL_LIBZ" = "xfalse"; then
     LIBZ_CFLAGS="$LIBZ_CFLAGS -I$TOPDIR/src/java.base/share/native/libzip/zlib"
-    if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix; then
+    if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix -o "x$OPENJDK_TARGET_OS" = xlinux; then
         LIBZ_CFLAGS="$LIBZ_CFLAGS -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1"
     fi
   else


### PR DESCRIPTION
We run into compile errors on AIX :
```

/priv/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.base/share/native/libzip/zlib/zconf.h:470:5: error: 'HAVE_UNISTD_H' is not defined, evaluates to 0 [-Werror,-Wundef]
  470 | #if HAVE_UNISTD_H-0 /* may be set to #if 1 by ./configure */
      | ^
/priv/client-home/workspace/openjdk-jdk-aix_ppc64-opt/jdk/src/java.base/share/native/libzip/zlib/zconf.h:474:5: error: 'HAVE_STDARG_H' is not defined, evaluates to 0 [-Werror,-Wundef]
  474 | #if HAVE_STDARG_H-0 /* may be set to #if 1 by ./configure */
      | ^
2 errors generated.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378823](https://bugs.openjdk.org/browse/JDK-8378823): AIX build fails after zlib updated by JDK-8378631 (**Bug** - P1)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [4c54b252](https://git.openjdk.org/jdk/pull/29953/files/4c54b2529f80f8093b13dad64dff2e1652ef2a10)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29953/head:pull/29953` \
`$ git checkout pull/29953`

Update a local copy of the PR: \
`$ git checkout pull/29953` \
`$ git pull https://git.openjdk.org/jdk.git pull/29953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29953`

View PR using the GUI difftool: \
`$ git pr show -t 29953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29953.diff">https://git.openjdk.org/jdk/pull/29953.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29953#issuecomment-3971754325)
</details>
