### PR TITLE
8378869: Enable Intel APX optimizations in x86-64 stubs on supported platforms

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1409,7 +1409,7 @@ address StubGenerator::generate_md5_implCompress(StubId stub_id) {
   StubCodeMark mark(this, stub_id);
   address start = __ pc();
 
-  const Register buf_param = r15;
+  const Register buf_param = UseAPX ? r16 : r15;
   const Address state_param(rsp, 0 * wordSize);
   const Address ofs_param  (rsp, 1 * wordSize    );
   const Address limit_param(rsp, 1 * wordSize + 4);
@@ -1418,8 +1418,10 @@ address StubGenerator::generate_md5_implCompress(StubId stub_id) {
   __ push_ppx(rbx);
   __ push_ppx(rdi);
   __ push_ppx(rsi);
-  __ push_ppx(r15);
-  __ subptr(rsp, 2 * wordSize);
+  if (!UseAPX) {
+    __ push_ppx(r15);
+  }
+    __ subptr(rsp, 2 * wordSize);
 
   __ movptr(buf_param, c_rarg0);
   __ movptr(state_param, c_rarg1);
@@ -1430,7 +1432,9 @@ address StubGenerator::generate_md5_implCompress(StubId stub_id) {
   __ fast_md5(buf_param, state_param, ofs_param, limit_param, multi_block);
 
   __ addptr(rsp, 2 * wordSize);
-  __ pop_ppx(r15);
+   if (!UseAPX) {
+    __ pop_ppx(r15);
+  }
   __ pop_ppx(rsi);
   __ pop_ppx(rdi);
   __ pop_ppx(rbx);
@@ -1774,10 +1778,12 @@ address StubGenerator::generate_base64_encodeBlock()
   __ enter();
 
   // Save callee-saved registers before using them
-  __ push_ppx(r12);
-  __ push_ppx(r13);
-  __ push_ppx(r14);
-  __ push_ppx(r15);
+   __ push_ppx(r12);
+  if (!UseAPX) {
+    __ push_ppx(r13);
+    __ push_ppx(r14);
+    __ push_ppx(r15);
+  }
 
   // arguments
   const Register source = c_rarg0;       // Source Array
@@ -1797,8 +1803,9 @@ address StubGenerator::generate_base64_encodeBlock()
   __ movl(isURL, isURL_mem);
 #endif
 
-  const Register length = r14;
-  const Register encode_table = r13;
+  const Register length = UseAPX ? r16 : r14;
+  const Register tmp_r13 = UseAPX ? r17 : r13;
+  const Register tmp_r15 = UseAPX ? r18 : r15;
   Label L_process3, L_exit, L_processdata, L_vbmiLoop, L_not512, L_32byteLoop;
 
   // calculate length from offsets
@@ -1810,6 +1817,7 @@ address StubGenerator::generate_base64_encodeBlock()
   // output bytes. We read 64 input bytes and ignore the last 16, so be
   // sure not to read past the end of the input buffer.
   if (VM_Version::supports_avx512_vbmi()) {
+    const Register encode_table = tmp_r13;
     __ cmpl(length, 64); // Do not overrun input buffer.
     __ jcc(Assembler::below, L_not512);
 
@@ -1819,7 +1827,7 @@ address StubGenerator::generate_base64_encodeBlock()
     __ shrl(isURL, 6); // restore isURL
 
     __ mov64(rax, 0x3036242a1016040aull); // Shifts
-    __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()), Assembler::AVX_512bit, r15);
+    __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()), Assembler::AVX_512bit, tmp_r15);
     __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
     __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
 
@@ -2011,9 +2019,9 @@ address StubGenerator::generate_base64_encodeBlock()
 
     // Load the proper lookup table
     __ lea(r11, ExternalAddress(StubRoutines::x86::base64_avx2_lut_addr()));
-    __ movl(r15, isURL);
-    __ shll(r15, 5);
-    __ vmovdqu(xmm2, Address(r11, r15));
+    __ movl(tmp_r15, isURL);
+    __ shll(tmp_r15, 5);
+    __ vmovdqu(xmm2, Address(r11, tmp_r15));
 
     // Shuffle the offsets based on the range calculation done
     // above. This allows us to add the correct offset to the
@@ -2072,16 +2080,16 @@ address StubGenerator::generate_base64_encodeBlock()
 
   // Load the encoding table based on isURL
   __ lea(r11, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
-  __ movl(r15, isURL);
-  __ shll(r15, 6);
-  __ addptr(r11, r15);
+  __ movl(tmp_r15, isURL);
+  __ shll(tmp_r15, 6);
+  __ addptr(r11, tmp_r15);
 
   __ BIND(L_processdata);
 
   // Load 3 bytes
-  __ load_unsigned_byte(r15, Address(source, start_offset));
+  __ load_unsigned_byte(tmp_r15, Address(source, start_offset));
   __ load_unsigned_byte(r10, Address(source, start_offset, Address::times_1, 1));
-  __ load_unsigned_byte(r13, Address(source, start_offset, Address::times_1, 2));
+  __ load_unsigned_byte(tmp_r13, Address(source, start_offset, Address::times_1, 2));
 
   // Build a 32-bit word with bytes 1, 2, 0, 1
   __ movl(rax, r10);
@@ -2090,27 +2098,27 @@ address StubGenerator::generate_base64_encodeBlock()
 
   __ subl(length, 3);
 
-  __ shll(r15, 8);
-  __ shll(r13, 16);
-  __ orl(rax, r15);
+  __ shll(tmp_r15, 8);
+  __ shll(tmp_r13, 16);
+  __ orl(rax, tmp_r15);
 
   __ addl(start_offset, 3);
 
-  __ orl(rax, r13);
+  __ orl(rax, tmp_r13);
   // At this point, rax contains | byte1 | byte2 | byte0 | byte1
   // r13 has byte2 << 16 - need low-order 6 bits to translate.
   // This translated byte is the fourth output byte.
-  __ shrl(r13, 16);
-  __ andl(r13, 0x3f);
+  __ shrl(tmp_r13, 16);
+  __ andl(tmp_r13, 0x3f);
 
   // The high-order 6 bits of r15 (byte0) is translated.
   // The translated byte is the first output byte.
-  __ shrl(r15, 10);
+  __ shrl(tmp_r15, 10);
 
-  __ load_unsigned_byte(r13, Address(r11, r13));
-  __ load_unsigned_byte(r15, Address(r11, r15));
+  __ load_unsigned_byte(tmp_r13, Address(r11, tmp_r13));
+  __ load_unsigned_byte(tmp_r15, Address(r11, tmp_r15));
 
-  __ movb(Address(dest, dp, Address::times_1, 3), r13);
+  __ movb(Address(dest, dp, Address::times_1, 3), tmp_r13);
 
   // Extract high-order 4 bits of byte1 and low-order 2 bits of byte0.
   // This translated byte is the second output byte.
@@ -2118,7 +2126,7 @@ address StubGenerator::generate_base64_encodeBlock()
   __ movl(r10, rax);
   __ andl(rax, 0x3f);
 
-  __ movb(Address(dest, dp, Address::times_1, 0), r15);
+  __ movb(Address(dest, dp, Address::times_1, 0), tmp_r15);
 
   __ load_unsigned_byte(rax, Address(r11, rax));
 
@@ -2137,9 +2145,11 @@ address StubGenerator::generate_base64_encodeBlock()
   __ jcc(Assembler::aboveEqual, L_processdata);
 
   __ BIND(L_exit);
-  __ pop_ppx(r15);
-  __ pop_ppx(r14);
-  __ pop_ppx(r13);
+  if (!UseAPX) {
+    __ pop_ppx(r15);
+    __ pop_ppx(r14);
+    __ pop_ppx(r13);
+  }
   __ pop_ppx(r12);
   __ leave();
   __ ret(0);
@@ -2475,9 +2485,11 @@ address StubGenerator::generate_base64_decodeBlock() {
 
   // Save callee-saved registers before using them
   __ push_ppx(r12);
-  __ push_ppx(r13);
-  __ push_ppx(r14);
-  __ push_ppx(r15);
+  if (!UseAPX) {
+    __ push_ppx(r13);
+    __ push_ppx(r14);
+    __ push_ppx(r15);
+  }
   __ push_ppx(rbx);
 
   // arguments
@@ -2529,9 +2541,9 @@ address StubGenerator::generate_base64_decodeBlock() {
 
   const XMMRegister pack24bits = xmm4;
 
-  const Register length = r14;
-  const Register output_size = r13;
-  const Register output_mask = r15;
+  const Register length = UseAPX ? r16 : r14;
+  const Register tmp_r13 = UseAPX ? r17 : r13;
+  const Register tmp_r15 = UseAPX ? r18 : r15;
   const KRegister input_mask = k1;
 
   const XMMRegister input_initial_valid_b64 = xmm0;
@@ -2551,6 +2563,8 @@ address StubGenerator::generate_base64_decodeBlock() {
   // If AVX512 VBMI not supported, just compile non-AVX code
   if(VM_Version::supports_avx512_vbmi() &&
      VM_Version::supports_avx512bw()) {
+    const Register output_size = tmp_r13;
+    const Register output_mask = tmp_r15;
     __ cmpl(length, 31);     // 32-bytes is break-even for AVX-512
     __ jcc(Assembler::lessEqual, L_lastChunk);
 
@@ -2561,25 +2575,25 @@ address StubGenerator::generate_base64_decodeBlock() {
     __ cmpl(isURL, 0);
     __ jcc(Assembler::notZero, L_loadURL);
 
-    __ evmovdquq(lookup_lo, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_lo_addr()), Assembler::AVX_512bit, r13);
-    __ evmovdquq(lookup_hi, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_hi_addr()), Assembler::AVX_512bit, r13);
+    __ evmovdquq(lookup_lo, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_lo_addr()), Assembler::AVX_512bit, tmp_r13);
+    __ evmovdquq(lookup_hi, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_hi_addr()), Assembler::AVX_512bit, tmp_r13);
 
     __ BIND(L_continue);
 
-    __ movl(r15, 0x01400140);
-    __ evpbroadcastd(pack16_op, r15, Assembler::AVX_512bit);
+    __ movl(tmp_r15, 0x01400140);
+    __ evpbroadcastd(pack16_op, tmp_r15, Assembler::AVX_512bit);
 
-    __ movl(r15, 0x00011000);
-    __ evpbroadcastd(pack32_op, r15, Assembler::AVX_512bit);
+    __ movl(tmp_r15, 0x00011000);
+    __ evpbroadcastd(pack32_op, tmp_r15, Assembler::AVX_512bit);
 
     __ cmpl(length, 0xff);
     __ jcc(Assembler::lessEqual, L_process64);
 
     // load masks required for decoding data
     __ BIND(L_processdata);
-    __ evmovdquq(join01, ExternalAddress(StubRoutines::x86::base64_vbmi_join_0_1_addr()), Assembler::AVX_512bit,r13);
-    __ evmovdquq(join12, ExternalAddress(StubRoutines::x86::base64_vbmi_join_1_2_addr()), Assembler::AVX_512bit, r13);
-    __ evmovdquq(join23, ExternalAddress(StubRoutines::x86::base64_vbmi_join_2_3_addr()), Assembler::AVX_512bit, r13);
+    __ evmovdquq(join01, ExternalAddress(StubRoutines::x86::base64_vbmi_join_0_1_addr()), Assembler::AVX_512bit,tmp_r13);
+    __ evmovdquq(join12, ExternalAddress(StubRoutines::x86::base64_vbmi_join_1_2_addr()), Assembler::AVX_512bit, tmp_r13);
+    __ evmovdquq(join23, ExternalAddress(StubRoutines::x86::base64_vbmi_join_2_3_addr()), Assembler::AVX_512bit, tmp_r13);
 
     __ align32();
     __ BIND(L_process256);
@@ -2658,7 +2672,7 @@ address StubGenerator::generate_base64_decodeBlock() {
 
     __ BIND(L_process64);
 
-    __ evmovdquq(pack24bits, ExternalAddress(StubRoutines::x86::base64_vbmi_pack_vec_addr()), Assembler::AVX_512bit, r13);
+    __ evmovdquq(pack24bits, ExternalAddress(StubRoutines::x86::base64_vbmi_pack_vec_addr()), Assembler::AVX_512bit, tmp_r13);
 
     __ cmpl(length, 63);
     __ jcc(Assembler::lessEqual, L_finalBit);
@@ -2736,8 +2750,8 @@ address StubGenerator::generate_base64_decodeBlock() {
     __ evpbroadcastd(invalid_b64, rax, Assembler::AVX_512bit);
 
     // input_mask is in k1
-    // output_size is in r13
-    // output_mask is in r15
+    // output_size is in r13 (or r17 with APX)
+    // output_mask is in r15 (or r18 with APX)
     // zmm0 - free
     // zmm1 - 0x00011000
     // zmm2 - 0x01400140
@@ -2781,16 +2795,18 @@ address StubGenerator::generate_base64_decodeBlock() {
     __ subptr(dest, rax);      // Number of bytes converted
     __ movptr(rax, dest);
     __ pop_ppx(rbx);
-    __ pop_ppx(r15);
-    __ pop_ppx(r14);
-    __ pop_ppx(r13);
+    if (!UseAPX) {
+      __ pop_ppx(r15);
+      __ pop_ppx(r14);
+      __ pop_ppx(r13);
+    }
     __ pop_ppx(r12);
     __ leave();
     __ ret(0);
 
     __ BIND(L_loadURL);
-    __ evmovdquq(lookup_lo, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_lo_url_addr()), Assembler::AVX_512bit, r13);
-    __ evmovdquq(lookup_hi, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_hi_url_addr()), Assembler::AVX_512bit, r13);
+    __ evmovdquq(lookup_lo, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_lo_url_addr()), Assembler::AVX_512bit, tmp_r13);
+    __ evmovdquq(lookup_hi, ExternalAddress(StubRoutines::x86::base64_vbmi_lookup_hi_url_addr()), Assembler::AVX_512bit, tmp_r13);
     __ jmp(L_continue);
 
     __ BIND(L_padding);
@@ -2824,20 +2840,20 @@ address StubGenerator::generate_base64_decodeBlock() {
     // Encoding and Decoding using AVX2 Instructions".  URL modifications added.
 
     // Set up constants
-    __ lea(r13, ExternalAddress(StubRoutines::x86::base64_AVX2_decode_tables_addr()));
-    __ vpbroadcastd(xmm4, Address(r13, isURL, Address::times_1), Assembler::AVX_256bit);  // 2F or 5F
-    __ vpbroadcastd(xmm10, Address(r13, isURL, Address::times_1, 0x08), Assembler::AVX_256bit);  // -1 or -4
-    __ vmovdqu(xmm12, Address(r13, 0x10));  // permute
-    __ vmovdqu(xmm13, Address(r13, 0x30)); // shuffle
-    __ vpbroadcastd(xmm7, Address(r13, 0x50), Assembler::AVX_256bit);  // merge
-    __ vpbroadcastd(xmm6, Address(r13, 0x54), Assembler::AVX_256bit);  // merge mult
+    __ lea(tmp_r13, ExternalAddress(StubRoutines::x86::base64_AVX2_decode_tables_addr()));
+    __ vpbroadcastd(xmm4, Address(tmp_r13, isURL, Address::times_1), Assembler::AVX_256bit);  // 2F or 5F
+    __ vpbroadcastd(xmm10, Address(tmp_r13, isURL, Address::times_1, 0x08), Assembler::AVX_256bit);  // -1 or -4
+    __ vmovdqu(xmm12, Address(tmp_r13, 0x10));  // permute
+    __ vmovdqu(xmm13, Address(tmp_r13, 0x30)); // shuffle
+    __ vpbroadcastd(xmm7, Address(tmp_r13, 0x50), Assembler::AVX_256bit);  // merge
+    __ vpbroadcastd(xmm6, Address(tmp_r13, 0x54), Assembler::AVX_256bit);  // merge mult
 
-    __ lea(r13, ExternalAddress(StubRoutines::x86::base64_AVX2_decode_LUT_tables_addr()));
+    __ lea(tmp_r13, ExternalAddress(StubRoutines::x86::base64_AVX2_decode_LUT_tables_addr()));
     __ shll(isURL, 4);
-    __ vmovdqu(xmm11, Address(r13, isURL, Address::times_1, 0x00));  // lut_lo
-    __ vmovdqu(xmm8, Address(r13, isURL, Address::times_1, 0x20)); // lut_roll
+    __ vmovdqu(xmm11, Address(tmp_r13, isURL, Address::times_1, 0x00));  // lut_lo
+    __ vmovdqu(xmm8, Address(tmp_r13, isURL, Address::times_1, 0x20)); // lut_roll
     __ shrl(isURL, 6);  // restore isURL
-    __ vmovdqu(xmm9, Address(r13, 0x80));  // lut_hi
+    __ vmovdqu(xmm9, Address(tmp_r13, 0x80));  // lut_hi
     __ jmp(L_enterLoop);
 
     __ align32();
@@ -2916,8 +2932,8 @@ address StubGenerator::generate_base64_decodeBlock() {
 
   const Register decode_table = r11;
   const Register out_byte_count = rbx;
-  const Register byte1 = r13;
-  const Register byte2 = r15;
+  const Register byte1 = tmp_r13;    // r13 or r17 with APX
+  const Register byte2 = tmp_r15;    // r15 or r18 with APX
   const Register byte3 = WIN64_ONLY(r8) NOT_WIN64(rdx);
   const Register byte4 = WIN64_ONLY(r10) NOT_WIN64(r9);
 
@@ -2975,9 +2991,11 @@ address StubGenerator::generate_base64_decodeBlock() {
   __ subptr(dest, rax);                      // Number of bytes converted
   __ movptr(rax, dest);
   __ pop_ppx(rbx);
-  __ pop_ppx(r15);
-  __ pop_ppx(r14);
-  __ pop_ppx(r13);
+  if (!UseAPX) {
+    __ pop_ppx(r15);
+    __ pop_ppx(r14);
+    __ pop_ppx(r13);
+  }
   __ pop_ppx(r12);
   __ leave();
   __ ret(0);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
@@ -82,9 +82,9 @@ address StubGenerator::generate_updateBytesAdler32() {
   const Register data = r9;
   const Register size = r10;
   const Register s = r11;
-  const Register a_d = r12; //r12d
+  const Register a_d = UseAPX ? r16 : r12; //r12d
   const Register b_d = r8; //r8d
-  const Register end = r13;
+  const Register end = UseAPX ? r17 : r13;
 
   assert_different_registers(c_rarg0, c_rarg1, c_rarg2, data, size);
   assert_different_registers(init_d, data, size, s, a_d, b_d, end, rax);
@@ -115,8 +115,10 @@ address StubGenerator::generate_updateBytesAdler32() {
 
   __ enter(); // required for proper stackwalking of RuntimeStub frame
 
-  __ movq(xtmp3, r12);
-  __ movq(xtmp4, r13);
+  if (!UseAPX) {
+    __ movq(xtmp3, r12);
+    __ movq(xtmp4, r13);
+  }
   __ movq(xtmp5, r14);
 
   __ vmovdqu(yshuf0, ExternalAddress((address)ADLER32_SHUF0_TABLE), r14 /*rscratch*/);
@@ -327,8 +329,10 @@ address StubGenerator::generate_updateBytesAdler32() {
   __ bind(END);
 
   __ movq(r14, xtmp5);
-  __ movq(r13, xtmp4);
-  __ movq(r12, xtmp3);
+  if (!UseAPX) {
+    __ movq(r13, xtmp4);
+    __ movq(r12, xtmp3);
+  }
 
   __ vzeroupper();
   __ leave();

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
@@ -263,7 +263,7 @@ address StubGenerator::generate_galoisCounterMode_AESCrypt() {
   const Register state = c_rarg5;
   const Address subkeyH_mem(rbp, 2 * wordSize);
   const Register subkeyHtbl = r10;
-  const Register avx512_subkeyHtbl = r12;
+  const Register avx512_subkeyHtbl = UseAPX ? r16 : r12;
   const Address counter_mem(rbp, 3 * wordSize);
   const Register counter = r11;
 #else
@@ -279,16 +279,23 @@ address StubGenerator::generate_galoisCounterMode_AESCrypt() {
 #endif
   __ enter();
  // Save state before entering routine
+#ifdef _WIN64
   __ push_ppx(r12);//holds pointer to avx512_subkeyHtbl
   __ push_ppx(r14);//holds CTR_CHECK value to check for overflow
   __ push_ppx(r15);//holds number of rounds
   __ push_ppx(rbx);//scratch register
-#ifdef _WIN64
   // on win64, fill len_reg from stack position
   __ push_ppx(rsi);
   __ push_ppx(rdi);
   __ movptr(key, key_mem);
   __ movptr(state, state_mem);
+#else
+  if (!UseAPX) {
+    __ push_ppx(r12);//holds pointer to avx512_subkeyHtbl
+    __ push_ppx(r14);//holds CTR_CHECK value to check for overflow
+  }
+  __ push_ppx(r15);//holds number of rounds
+  __ push_ppx(rbx);//scratch register
 #endif
   __ movptr(subkeyHtbl, subkeyH_mem);
   __ movptr(counter, counter_mem);
@@ -306,13 +313,19 @@ address StubGenerator::generate_galoisCounterMode_AESCrypt() {
   __ lea(rsp, Address(rbp, -6 * wordSize));
   __ pop_ppx(rdi);
   __ pop_ppx(rsi);
-#else
-  __ lea(rsp, Address(rbp, -4 * wordSize));
-#endif
   __ pop_ppx(rbx);
   __ pop_ppx(r15);
   __ pop_ppx(r14);
   __ pop_ppx(r12);
+#else
+  __ lea(rsp, Address(rbp, -(2 + (UseAPX ? 0 : 2)) * wordSize));
+  __ pop_ppx(rbx);
+  __ pop_ppx(r15);
+  if (!UseAPX) {
+    __ pop_ppx(r14);
+    __ pop_ppx(r12);
+  }
+#endif
 
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);
@@ -1816,11 +1829,24 @@ void StubGenerator::ev_add128(XMMRegister xmmdst, XMMRegister xmmsrc1, XMMRegist
 // AES-ECB Encrypt Operation
 void StubGenerator::aesecb_encrypt(Register src_addr, Register dest_addr, Register key, Register len) {
   const Register pos = rax;
+#ifdef _WIN64
   const Register rounds = r12;
+  const Register tmp1 = r13;
+#else
+  const Register rounds = UseAPX ? r16 : r12;
+  const Register tmp1 = UseAPX ? r17 : r13;
+#endif
 
   Label NO_PARTS, LOOP, Loop_start, LOOP2, AES192, END_LOOP, AES256, REMAINDER, LAST2, END, KEY_192, KEY_256, EXIT;
+#ifdef _WIN64
   __ push_ppx(r13);
   __ push_ppx(r12);
+#else
+  if (!UseAPX) {
+    __ push_ppx(r13);
+    __ push_ppx(r12);
+  }
+#endif
 
   // For EVEX with VL and BW, provide a standard mask, VL = 128 will guide the merge
   // context for the registers used, where all instructions below are using 128-bit mode
@@ -1884,11 +1910,11 @@ void StubGenerator::aesecb_encrypt(Register src_addr, Register dest_addr, Regist
   __ movq(rbx, len);
   __ shrq(len, 5);
   __ jcc(Assembler::equal, REMAINDER);
-  __ movl(r13, len);
+  __ movl(tmp1, len);
   // Compute number of blocks that will be processed 512 bytes at a time
   // Subtract this from the total number of blocks which will then be processed by REMAINDER loop
-  __ shlq(r13, 5);
-  __ subq(rbx, r13);
+  __ shlq(tmp1, 5);
+  __ subq(rbx, tmp1);
   //Begin processing 512 bytes
   __ bind(LOOP);
   // Move 64 bytes of PT data into a zmm register, as a result 512 bytes of PT loaded in zmm0-7
@@ -2019,8 +2045,15 @@ void StubGenerator::aesecb_encrypt(Register src_addr, Register dest_addr, Regist
   __ bind(EXIT);
   __ pop_ppx(rbx);
   __ pop_ppx(rax); // return length
+#ifdef _WIN64
   __ pop_ppx(r12);
   __ pop_ppx(r13);
+#else
+  if (!UseAPX) {
+    __ pop_ppx(r12);
+    __ pop_ppx(r13);
+  }
+#endif
 }
 
 // AES-ECB Decrypt Operation
@@ -2028,9 +2061,19 @@ void StubGenerator::aesecb_decrypt(Register src_addr, Register dest_addr, Regist
 
   Label NO_PARTS, LOOP, Loop_start, LOOP2, AES192, END_LOOP, AES256, REMAINDER, LAST2, END, KEY_192, KEY_256, EXIT;
   const Register pos = rax;
+#ifdef _WIN64
   const Register rounds = r12;
+  const Register tmp1 = r13;
   __ push_ppx(r13);
   __ push_ppx(r12);
+#else
+  const Register rounds = UseAPX ? r16 : r12;
+  const Register tmp1 = UseAPX ? r17 : r13;
+  if (!UseAPX) {
+    __ push_ppx(r13);
+    __ push_ppx(r12);
+  }
+#endif
 
   // For EVEX with VL and BW, provide a standard mask, VL = 128 will guide the merge
   // context for the registers used, where all instructions below are using 128-bit mode
@@ -2094,11 +2137,11 @@ void StubGenerator::aesecb_decrypt(Register src_addr, Register dest_addr, Regist
   __ movq(rbx, len);
   __ shrq(len, 5);
   __ jcc(Assembler::equal, REMAINDER);
-  __ movl(r13, len);
+  __ movl(tmp1, len);
   // Compute number of blocks that will be processed as 512 bytes at a time
   // Subtract this from the total number of blocks, which will then be processed by REMAINDER loop.
-  __ shlq(r13, 5);
-  __ subq(rbx, r13);
+  __ shlq(tmp1, 5);
+  __ subq(rbx, tmp1);
 
   __ bind(LOOP);
   // Move 64 bytes of CT data into a zmm register, as a result 512 bytes of CT loaded in zmm0-7
@@ -2230,8 +2273,15 @@ void StubGenerator::aesecb_decrypt(Register src_addr, Register dest_addr, Regist
   __ bind(EXIT);
   __ pop_ppx(rbx);
   __ pop_ppx(rax); // return length
+#ifdef _WIN64
   __ pop_ppx(r12);
   __ pop_ppx(r13);
+#else
+  if (!UseAPX) {
+    __ pop_ppx(r12);
+    __ pop_ppx(r13);
+  }
+#endif
 }
 
 
@@ -3402,7 +3452,11 @@ void StubGenerator::aesgcm_avx512(Register in, Register len, Register ct, Regist
   const KRegister MASKREG = k1;
   const Register pos = rax;
   const Register rounds = r15;
+#ifdef _WIN64
   const Register CTR_CHECK = r14;
+#else
+  const Register CTR_CHECK = UseAPX ? r17 : r14;
+#endif
 
   const int stack_offset = 64;
   const int ghashin_offset = 64;

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -2461,9 +2461,9 @@ address StubGenerator::generate_checkcast_copy(StubId stub_id, address *entry) {
 
   // Registers used as temps (r13, r14 are save-on-entry)
   const Register end_from    = from;  // source array end address
-  const Register end_to      = r13;   // destination array end address
+  const Register end_to      = UseAPX ? r16 : r13;   // destination array end address
   const Register count       = rdx;   // -(count_remaining)
-  const Register r14_length  = r14;   // saved copy of length
+  const Register r14_length  = UseAPX ? r17 : r14;   // saved copy of length
   // End pointers are inclusive, and if length is not zero they point
   // to the last unit copied:  end_to[0] := end_from[0]
 
@@ -2514,10 +2514,12 @@ address StubGenerator::generate_checkcast_copy(StubId stub_id, address *entry) {
     saved_r10_offset,
     saved_rbp_offset
   };
+ if (!UseAPX) {
   __ subptr(rsp, saved_rbp_offset * wordSize);
   __ movptr(Address(rsp, saved_r13_offset * wordSize), r13);
   __ movptr(Address(rsp, saved_r14_offset * wordSize), r14);
   __ movptr(Address(rsp, saved_r10_offset * wordSize), r10);
+ }
 
 #ifdef ASSERT
     Label L2;
@@ -2630,9 +2632,11 @@ address StubGenerator::generate_checkcast_copy(StubId stub_id, address *entry) {
 
   // Common exit point (success or failure).
   __ BIND(L_done);
-  __ movptr(r13, Address(rsp, saved_r13_offset * wordSize));
-  __ movptr(r14, Address(rsp, saved_r14_offset * wordSize));
-  __ movptr(r10, Address(rsp, saved_r10_offset * wordSize));
+  if (!UseAPX) {
+    __ movptr(r13, Address(rsp, saved_r13_offset * wordSize));
+    __ movptr(r14, Address(rsp, saved_r14_offset * wordSize));
+    __ movptr(r10, Address(rsp, saved_r10_offset * wordSize));
+  }
   restore_arg_regs_using_thread();
   INC_COUNTER_NP(SharedRuntime::_checkcast_array_copy_ctr, rscratch1); // Update counter after rscratch1 is free
   __ leave(); // required for proper stackwalking of RuntimeStub frame

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly1305.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly1305.cpp
@@ -554,9 +554,9 @@ void StubGenerator::poly1305_process_blocks_avx512(
     const Register r0, const Register r1, const Register c1)
 {
   Label L_process256Loop, L_process256LoopDone;
-  const Register t0 = r13;
-  const Register t1 = r14;
-  const Register t2 = r15;
+  const Register t0 = UseAPX ? r17 : r13;
+  const Register t1 = UseAPX ? r18 : r14;
+  const Register t2 = UseAPX ? r19 : r15;
   const Register mulql = rax;
   const Register mulqh = rdx;
 
@@ -921,10 +921,12 @@ address StubGenerator::generate_poly1305_processBlocks() {
   __ push_ppx(rsi);
   __ push_ppx(rdi);
   #endif
-  __ push_ppx(r12);
-  __ push_ppx(r13);
-  __ push_ppx(r14);
-  __ push_ppx(r15);
+  if (!UseAPX) {
+    __ push_ppx(r12);
+    __ push_ppx(r13);
+    __ push_ppx(r14);
+    __ push_ppx(r15);
+  }
 
   // Register Map
   const Register input        = rdi; // msg
@@ -936,11 +938,11 @@ address StubGenerator::generate_poly1305_processBlocks() {
   const Register a1 = r9;   // [in/out] accumulator bits 127..64
   const Register a2 = r10;  // [in/out] accumulator bits 195..128
   const Register r0 = r11;  // R constant bits 63..0
-  const Register r1 = r12;  // R constant bits 127..64
+  const Register r1 = UseAPX ? r16 : r12;  // R constant bits 127..64
   const Register c1 = r8;   // 5*R (upper limb only)
-  const Register t0 = r13;
-  const Register t1 = r14;
-  const Register t2 = r15;
+  const Register t0 = UseAPX ? r17 : r13;
+  const Register t1 = UseAPX ? r18 : r14;
+  const Register t2 = UseAPX ? r19 : r15;
   const Register mulql = rax;
   const Register mulqh = rdx;
 
@@ -1016,10 +1018,12 @@ address StubGenerator::generate_poly1305_processBlocks() {
   // Write output
   poly1305_limbs_out(a0, a1, a2, accumulator, t0, t1);
 
-  __ pop_ppx(r15);
-  __ pop_ppx(r14);
-  __ pop_ppx(r13);
-  __ pop_ppx(r12);
+  if (!UseAPX) {
+    __ pop_ppx(r15);
+    __ pop_ppx(r14);
+    __ pop_ppx(r13);
+    __ pop_ppx(r12);
+  }
   #ifdef _WIN64
   __ pop_ppx(rdi);
   __ pop_ppx(rsi);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_sha3.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_sha3.cpp
@@ -117,22 +117,24 @@ static address generate_sha3_implCompress(StubId stub_id,
   const Register limit        = c_rarg4;
 #else
   const Address limit_mem(rbp, 6 * wordSize);
-  const Register limit = r12;
+  const Register limit = UseAPX ? r18 : r12;
 #endif
 
   const Register permsAndRots = r10;
   const Register round_consts = r11;
-  const Register constant2use = r13;
-  const Register roundsLeft = r14;
+  const Register constant2use = UseAPX ? r16 : r13;
+  const Register roundsLeft = UseAPX ? r17 : r14;
 
   Label sha3_loop;
   Label rounds24_loop, block104, block136, block144, block168;
 
   __ enter();
 
-  __ push_ppx(r12);
-  __ push_ppx(r13);
-  __ push_ppx(r14);
+  if (!UseAPX) {
+    __ push_ppx(r12);
+    __ push_ppx(r13);
+    __ push_ppx(r14);
+  }
 
 #ifdef _WIN64
   // on win64, fill limit from stack position
@@ -309,9 +311,11 @@ static address generate_sha3_implCompress(StubId stub_id,
     __ evmovdquq(Address(state, i * 40), k5, xmm(i), true, Assembler::AVX_512bit);
   }
 
-  __ pop_ppx(r14);
-  __ pop_ppx(r13);
-  __ pop_ppx(r12);
+  if (!UseAPX) {
+    __ pop_ppx(r14);
+    __ pop_ppx(r13);
+    __ pop_ppx(r12);
+  }
 
   __ leave(); // required for proper stackwalking of RuntimeStub frame
   __ ret(0);


### PR DESCRIPTION
Currently, the various x86-64 stubs do not take advantage of Intel APX instructions if supported by the underlying platform. The goal of this PR is to add the missing APX support for the stubs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Issue
 * [JDK-8378869](https://bugs.openjdk.org/browse/JDK-8378869): Enable Intel APX optimizations in x86-64 stubs on supported platforms (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29964/head:pull/29964` \
`$ git checkout pull/29964`

Update a local copy of the PR: \
`$ git checkout pull/29964` \
`$ git pull https://git.openjdk.org/jdk.git pull/29964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29964`

View PR using the GUI difftool: \
`$ git pr show -t 29964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29964.diff">https://git.openjdk.org/jdk/pull/29964.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29964#issuecomment-3989888161)
</details>
