### PR TITLE
8377923: Add anchors to the options in the Tools man pages

### DIFF
--- a/src/jdk.jdeps/share/man/javap.md
+++ b/src/jdk.jdeps/share/man/javap.md
@@ -80,56 +80,56 @@ from its value.
 `-verbose` or `-v`
 :   Prints additional information about the selected class.
 
-`-l`
+[`-l`]{#option-l}
 :   Prints line and local variable tables.
 
-`-public`
+[`-public`]{#option-public}
 :   Shows only public classes and members.
 
-`-protected`
+[`-protected`]{#option-protected}
 :   Shows only protected and public classes and members.
 
-`-package`
+[`-package`]{#option-package}
 :   Shows package/protected/public classes and members (default).
 
-`-private` or `-p`
+[`-private`]{#option-private} or `-p`
 :   Shows all classes and members.
 
-`-c`
+[`-c`]{#option-c}
 :   Prints disassembled code, for example, the instructions that comprise the
     Java bytecodes, for each of the methods in the class.
 
-`-s`
+[`-s`]{#option-s}
 :   Prints internal type signatures.
 
-`-sysinfo`
+[`-sysinfo`]{#option-sysinfo}
 :   Shows system information (path, size, date, SHA-256 hash) of the class being
     processed.
 
-`-verify`
+[`-verify`]{#option-verify}
 :   Prints additional class verification info.
 
-`-constants`
+[`-constants`]{#option-constants}
 :   Shows `static final` constants.
 
-`--module` *module* or `-m` *module*
+[`--module`]{#option--module} *module* or `-m` *module*
 :   Specifies the module containing classes to be disassembled.
 
-`--module-path` *path*
+[`--module-path`]{#option--module-path} *path*
 :   Specifies where to find application modules.
 
-`--system` *jdk*
+[`--system`]{#option--system} *jdk*
 :   Specifies where to find system modules.
 
-`--class-path` *path*, `-classpath` *path*, or `-cp` *path*
+[`--class-path`]{#option--class-path} *path*, `-classpath` *path*, or `-cp` *path*
 :   Specifies the path that the `javap` command uses to find user class files.
     It overrides the default or the `CLASSPATH` environment variable when it's
     set.
 
-`-bootclasspath` *path*
+[`-bootclasspath`]{#option-bootclasspath} *path*
 :   Overrides the location of bootstrap class files.
 
-`--multi-release` *version*
+[`--multi-release`]{#option--multi-release} *version*
 :   Specifies the version to select in multi-release JAR files.
 
 `-J`*option*

--- a/src/jdk.jdeps/share/man/jdeprscan.md
+++ b/src/jdk.jdeps/share/man/jdeprscan.md
@@ -111,7 +111,7 @@ The following options are available:
 :   Limits scanning or listing to APIs that are deprecated for removal. Can't
     be used with a release value of 6, 7, or 8.
 
-[`--full-version`]{#option--full-version}
+`--full-version`
 :   Prints out the full version string of the tool.
 
 `--help` or `-h`

--- a/src/jdk.jdeps/share/man/jdeprscan.md
+++ b/src/jdk.jdeps/share/man/jdeprscan.md
@@ -88,7 +88,7 @@ all dependent classes.
 
 The following options are available:
 
-`--class-path` *path*
+[`--class-path`]{#option--class-path} *path*
 :   Provides a search path for resolution of dependent classes.
 
     *path* can be a search path that consists of one or more directories
@@ -107,21 +107,21 @@ The following options are available:
 
         >   `--class-path \some\directory;\another\different\dir`
 
-`--for-removal`
+[`--for-removal`]{#option--for-removal}
 :   Limits scanning or listing to APIs that are deprecated for removal. Can't
     be used with a release value of 6, 7, or 8.
 
-`--full-version`
+[`--full-version`]{#option--full-version}
 :   Prints out the full version string of the tool.
 
 `--help` or `-h`
 :   Prints out a full help message.
 
-`--list` or `-l`
+[`--list`]{#option--list} or `-l`
 :   Prints the set of deprecated APIs. No scanning is done, so no directory,
     jar, or class arguments should be provided.
 
-`--release` `6`\|`7`\|`8`\|`9`
+[`--release`]{#option--release} `6`\|`7`\|`8`\|`9`
 :   Specifies the Java SE release that provides the set of deprecated APIs for
     scanning.
 

--- a/src/jdk.jdeps/share/man/jdeps.md
+++ b/src/jdk.jdeps/share/man/jdeps.md
@@ -63,14 +63,14 @@ dependencies in DOT language (see the `-dotoutput` option).
 `-?` or `-h` or `--help`
 :   Prints the help message.
 
-`-dotoutput` *dir* or `--dot-output` *dir*
+[`-dotoutput`]{#option-dotoutput} *dir* or `--dot-output` *dir*
 :   Specifies the destination directory for DOT file output. If this option is
     specified, then the `jdeps`command generates one `.dot` file for each
     analyzed archive named `archive-file-name.dot` that lists the dependencies,
     and also a summary file named `summary.dot` that lists the dependencies
     among the archive files.
 
-`-s` or `-summary`
+[`-s`]{#option-summary} or `-summary`
 :   Prints a dependency summary only.
 
 `-v` or `-verbose`
@@ -78,20 +78,20 @@ dependencies in DOT language (see the `-dotoutput` option).
 
     >   `-verbose:class -filter:none`
 
-`-verbose:package`
+[`-verbose:-verbose_package`]{#option-verbose_package}
 :   Prints package-level dependencies excluding, by default, dependences within
     the same package.
 
-`-verbose:class`
+[`-verbose:-verbose_class`]{#option-verbose_class}
 :   Prints class-level dependencies excluding, by default, dependencies within
     the same archive.
 
-`-apionly` or `--api-only`
+[`-apionly`]{#option-apionly} or `--api-only`
 :   Restricts the analysis to APIs, for example, dependences from the signature
     of `public` and `protected` members of public classes including field type,
     method parameter types, returned type, and checked exception types.
 
-`-jdkinternals` or `--jdk-internals`
+[`-jdkinternals`]{#option-jdkinternals} or `--jdk-internals`
 :   Finds class-level dependences in the JDK internal APIs. By default, this
     option analyzes all classes specified in the `--classpath` option and input
     files unless you specified the `-include` option. You can't use this option
@@ -99,22 +99,22 @@ dependencies in DOT language (see the `-dotoutput` option).
 
     **Warning**: The JDK internal APIs are inaccessible.
 
-`-cp` *path*, `-classpath` *path*, or `--class-path` *path*
+[`-cp`]{#option-classpath} *path*, `-classpath` *path*, or `--class-path` *path*
 :   Specifies where to find class files.
 
-`--module-path` *module-path*
+[`--module-path`]{#option--module-path} *module-path*
 :   Specifies the module path.
 
-`--upgrade-module-path` *module-path*
+[`--upgrade-module-path`]{#option--upgrade-module-path} *module-path*
 :   Specifies the upgrade module path.
 
-`--system` *java-home*
+[`--system`]{#option--system} *java-home*
 :   Specifies an alternate system module path.
 
-`--add-modules` *module-name*\[`,` *module-name*...\]
+[`--add-modules`]{#option--add-modules} *module-name*\[`,` *module-name*...\]
 :   Adds modules to the root set for analysis.
 
-`--multi-release` *version*
+[`--multi-release`]{#option--multi-release} *version*
 :   Specifies the version when processing multi-release JAR files. *version*
     should be an integer \>=9 or base.
 
@@ -126,106 +126,106 @@ dependencies in DOT language (see the `-dotoutput` option).
 
 ## Module Dependence Analysis Options
 
-`-m` *module-name* or `--module` *module-name*
+[`-m`]{#option--module} *module-name* or `--module` *module-name*
 :   Specifies the root module for analysis.
 
-`--generate-module-info` *dir*
+[`--generate-module-info`]{#option--generate-module-info} *dir*
 :   Generates `module-info.java` under the specified directory. The specified
     JAR files will be analyzed. This option cannot be used with `--dot-output`
     or `--class-path` options. Use the `--generate-open-module` option for open
     modules.
 
-`--generate-open-module` *dir*
+[`--generate-open-module`]{#option--generate-open-module} *dir*
 :   Generates `module-info.java` for the specified JAR files under the
     specified directory as open modules. This option cannot be used with the
     `--dot-output` or `--class-path` options.
 
-`--check` *module-name* \[`,` *module-name*...\]
+[`--check`]{#option--check} *module-name* \[`,` *module-name*...\]
 :   Analyzes the dependence of the specified modules. It prints the module
     descriptor, the resulting module dependences after analysis and the graph
     after transition reduction. It also identifies any unused qualified
     exports.
 
-`--list-deps`
+[`--list-deps`]{#option--list-deps}
 :   Lists the module dependences and also the package names of JDK internal
     APIs (if referenced).  This option transitively analyzes libraries on
     class path and module path if referenced.  Use `--no-recursive` option for
     non-transitive dependency analysis.
 
-`--list-reduced-deps`
+[`--list-reduced-deps`]{#option--list-reduced-deps}
 :   Same as `--list-deps` without listing the implied reads edges from the
     module graph. If module M1 reads M2, and M2 requires transitive on M3, then
     M1 reading M3 is implied and is not shown in the graph.
 
-`--print-module-deps`
+[`--print-module-deps`]{#option--print-module-deps}
 :   Same as `--list-reduced-deps` with printing a comma-separated list of
     module dependences. The output can be used by `jlink --add-modules` to
     create a custom image that contains those modules and their transitive
     dependences.
 
-`--ignore-missing-deps`
+[`--ignore-missing-deps`]{#option--ignore-missing-deps}
 :   Ignore missing dependences.
 
 ## Options to Filter Dependences
 
-`-p` *pkg\_name*, `-package` *pkg\_name*, or `--package` *pkg\_name*
+[`-p`]{#option--package} *pkg\_name*, `-package` *pkg\_name*, or `--package` *pkg\_name*
 :   Finds dependences matching the specified package name. You can specify this
     option multiple times for different packages. The `-p` and `-e` options are
     mutually exclusive.
 
-`-e` *regex*, `-regex` *regex*, or `--regex` *regex*
+[`-e`]{#option--regex} *regex*, `-regex` *regex*, or `--regex` *regex*
 :   Finds dependences matching the specified pattern. The `-p` and `-e` options
     are mutually exclusive.
 
-`--require` *module-name*
+[`--require`]{#option--require} *module-name*
 :   Finds dependences matching the given module name (may be given multiple
     times). The `--package`, `--regex`, and `--require` options are mutually
     exclusive.
 
-`-f` *regex* or `-filter` *regex*
+[`-f`]{#option-filter} *regex* or `-filter` *regex*
 :   Filters dependences matching the given pattern. If give multiple times, the
     last one will be selected.
 
-`-filter:package`
+[`-filter:package`]{#option-filter_package}
 :   Filters dependences within the same package. This is the default.
 
-`-filter:archive`
+[`-filter:archive`]{#option-filter_archive}
 :   Filters dependences within the same archive.
 
-`-filter:module`
+[`-filter:module`]{#option-filter_module}
 :   Filters dependences within the same module.
 
-`-filter:none`
+[`-filter:none`]{#option-filter_none}
 :   No `-filter:package` and `-filter:archive` filtering. Filtering specified
     via the `-filter` option still applies.
 
-`--missing-deps`
+[`--missing-deps`]{#option--missing-deps}
 :   Finds missing dependences.  This option cannot be used with `-p`, `-e` and
     `-s` options.
 
 ## Options to Filter Classes to be Analyzed
 
-`-include` *regex*
+[`-include`]{#option-include} *regex*
 :   Restricts analysis to the classes matching pattern. This option filters the
     list of classes to be analyzed. It can be used together with `-p` and `-e`,
     which apply the pattern to the dependencies.
 
-`-R` or `--recursive`
+[`-R`]{#option--recursive} or `--recursive`
 :   Recursively traverses all run-time dependences. The `-R` option implies
     `-filter:none`. If `-p`, `-e`, or `-f` options are specified, only the
     matching dependences are analyzed.
 
-`--no-recursive`
+[`--no-recursive`]{#option--no-recursive}
 :   Do not recursively traverse dependences.
 
-`-I` or `--inverse`
+[`-I`]{#option--inverse} or `--inverse`
 :   Analyzes the dependences per other given options and then finds all
     artifacts that directly and indirectly depend on the matching nodes. This
     is equivalent to the inverse of the compile-time view analysis and the
     print dependency summary. This option must be used with the `--require`,
     `--package`, or `--regex` options.
 
-`--compile-time`
+[`--compile-time`]{#option--compile-time}
 :   Analyzes the compile-time view of transitive dependencies, such as the
     compile-time view of the `-R` option. Analyzes the dependences per other
     specified options. If a dependency is found from a directory, a JAR file or

--- a/src/jdk.jdeps/share/man/jdeps.md
+++ b/src/jdk.jdeps/share/man/jdeps.md
@@ -73,16 +73,16 @@ dependencies in DOT language (see the `-dotoutput` option).
 [`-s`]{#option-summary} or `-summary`
 :   Prints a dependency summary only.
 
-`-v` or `-verbose`
+[`-v`]{#option-verbose} or `-verbose`
 :   Prints all class-level dependencies. This is equivalent to
 
     >   `-verbose:class -filter:none`
 
-[`-verbose:-verbose_package`]{#option-verbose_package}
+`-verbose:-verbose_package`
 :   Prints package-level dependencies excluding, by default, dependences within
     the same package.
 
-[`-verbose:-verbose_class`]{#option-verbose_class}
+`-verbose:-verbose_class`
 :   Prints class-level dependencies excluding, by default, dependencies within
     the same archive.
 

--- a/src/jdk.jdeps/share/man/jdeps.md
+++ b/src/jdk.jdeps/share/man/jdeps.md
@@ -78,11 +78,11 @@ dependencies in DOT language (see the `-dotoutput` option).
 
     >   `-verbose:class -filter:none`
 
-`-verbose:-verbose_package`
+`-verbose:package`
 :   Prints package-level dependencies excluding, by default, dependences within
     the same package.
 
-`-verbose:-verbose_class`
+`-verbose:class`
 :   Prints class-level dependencies excluding, by default, dependencies within
     the same archive.
 

--- a/src/jdk.jdeps/share/man/jdeps.md
+++ b/src/jdk.jdeps/share/man/jdeps.md
@@ -186,16 +186,16 @@ dependencies in DOT language (see the `-dotoutput` option).
 :   Filters dependences matching the given pattern. If give multiple times, the
     last one will be selected.
 
-[`-filter:package`]{#option-filter_package}
+`-filter:package`
 :   Filters dependences within the same package. This is the default.
 
-[`-filter:archive`]{#option-filter_archive}
+`-filter:archive`
 :   Filters dependences within the same archive.
 
-[`-filter:module`]{#option-filter_module}
+`-filter:module`
 :   Filters dependences within the same module.
 
-[`-filter:none`]{#option-filter_none}
+`-filter:none`
 :   No `-filter:package` and `-filter:archive` filtering. Filtering specified
     via the `-filter` option still applies.
 

--- a/src/jdk.jdeps/share/man/jnativescan.md
+++ b/src/jdk.jdeps/share/man/jnativescan.md
@@ -54,7 +54,7 @@ of module names when the `--print-native-access` flag is specified.
 
 The following options are available:
 
-`--class-path` *path*
+[`--class-path`]{#option--class-path} *path*
 :   Used to specify a list of paths pointing to jar files to be scanned.
 
 All jar files specified through this list will be scanned. If a jar file
@@ -63,7 +63,7 @@ will be scanned as well. Jar files listed in the `Class-Path` manifest
 attribute that can not be found are ignored. All the jar files found are
 treated as if they belonged to the unnamed module.
 
-`--module-path` *path*
+[`--module-path`]{#option--module-path} *path*
 :   Used to specify a list of paths pointing to jar files or directories
 containing jar files, that the tool can use to find modules that need
 to be scanned. The list of jar files that will be scanned depends on the
@@ -86,7 +86,7 @@ to be scanned. The list of jar files that will be scanned depends on the
 
         >   `--class-path C:\some\foo.jar;C:\another\different\bar.jar`
 
-`--add-modules` *module[,module...]*
+[`--add-modules`]{#option--add-modules} *module[,module...]*
 :   Used to specify a comma-separated list of module names that indicate
 the root modules to scan. All the root modules will be scanned,
 as well as any modules that they depend on. This includes dependencies on
@@ -94,7 +94,7 @@ service implementations specified through the `uses` directive in a module's
 `module-info` file. All modules found on the module path that provide an
 implementation of such a service will be scanned as well.
 
-`--release` *version*
+[`--release`]{#option--release} *version*
 :   Used to specify the Java SE release that specifies the set of restricted
 methods to scan for. For multi-release jar files, this option also indicates
 the version of class file that should be loaded from the jar. This option
@@ -103,7 +103,7 @@ eventually intended to be run. If this flag is omitted, the version of
 `jnativescan` is used as release version, which is the same as the version of
 the JDK that the tool belongs to.
 
-`--print-native-access`
+[`--print-native-access`]{#option--print-native-access}
 :   Print a comma-separated list of module names that use native functionalities,
 instead of the default tree structure.
 

--- a/src/jdk.jlink/share/man/jmod.md
+++ b/src/jdk.jlink/share/man/jmod.md
@@ -93,20 +93,20 @@ error.
 
 ## Options for jmod
 
-`--class-path` *path*
+[`--class-path`]{#option--class-path} *path*
 :   Specifies the location of application JAR files or a directory containing
     classes to copy into the resulting JMOD file.
 
-`--cmds` *path*
+[`--cmds`]{#option--cmds} *path*
 :   Specifies the location of native commands to copy into the resulting JMOD
     file.
 
-`--compress` *compress*
+[`--compress`]{#option--compress} *compress*
 :   Specifies the compression to use in creating the JMOD file.
     The accepted values are `zip-[0-9]`, where `zip-0` provides no
     compression, and `zip-9` provides the best compression. Default is `zip-6`.
 
-`--config` *path*
+[`--config`]{#option--config} *path*
 :   Specifies the location of user-editable configuration files to copy into
     the resulting JMOD file.
 
@@ -115,15 +115,15 @@ error.
 format, to use for the timestamp of the entries,
 e.g. "2022-02-12T12:30:00-05:00".
 
-`--dir` *path*
+[`--dir`]{#option--dir} *path*
 :   Specifies the location where `jmod` puts extracted files from the specified
     JMOD archive.
 
-`--dry-run`
+[`--dry-run`]{#option--dry-run}
 :   Performs a dry run of hash mode. It identifies leaf modules and their
     required modules without recording any hash values.
 
-`--exclude` *pattern-list*
+[`--exclude`]{#option--exclude} *pattern-list*
 :   Excludes files matching the supplied comma-separated pattern list, each
     element using one the following forms:
 
@@ -140,14 +140,14 @@ e.g. "2022-02-12T12:30:00-05:00".
     class for the syntax of *regex-pattern*, which represents a regular
     expression.
 
-`--hash-modules` *regex-pattern*
+[`--hash-modules`]{#option--hash-modules} *regex-pattern*
 :   Determines the leaf modules and records the hashes of the dependencies
     directly and indirectly requiring them, based on the module graph of the
     modules matching the given *regex-pattern*. The hashes are recorded in the
     JMOD archive file being created, or a JMOD archive or modular JAR on the
     module path specified by the `jmod hash` command.
 
-`--header-files` *path*
+[`--header-files`]{#option--header-files} *path*
 :   Specifies the location of header files to copy into the resulting JMOD
     file.
 
@@ -157,28 +157,28 @@ e.g. "2022-02-12T12:30:00-05:00".
 `--help-extra`
 :   Prints help for extra options.
 
-`--legal-notices` *path*
+[`--legal-notices`]{#option--legal-notices} *path*
 :   Specifies the location of legal notices to copy into the resulting JMOD
     file.
 
-`--libs` *path*
+[`--libs`]{#option--libs} *path*
 :   Specifies location of native libraries to copy into the resulting JMOD
     file.
 
-`--main-class` *class-name*
+[`--main-class`]{#option--main-class} *class-name*
 :   Specifies main class to record in the module-info.class file.
 
-`--man-pages` *path*
+[`--man-pages`]{#option--man-pages} *path*
 :   Specifies the location of man pages to copy into the resulting JMOD file.
 
-`--module-version` *module-version*
+[`--module-version`]{#option--module-version} *module-version*
 :   Specifies the module version to record in the module-info.class file.
 
-`--module-path` *path* or `-p` *path*
+[`--module-path`]{#option--module-path} *path* or `-p` *path*
 :   Specifies the module path. This option is required if you also specify
     `--hash-modules`.
 
-`--target-platform` *platform*
+[`--target-platform`]{#option--target-platform} *platform*
 :   Specifies the target platform of a JMOD file intended for a specific
     operating system and architecture. The value should follow
     the format `<os>-<arch>`, where `<os>` is the operating system
@@ -213,10 +213,10 @@ e.g. "2022-02-12T12:30:00-05:00".
 In addition to the options described in [Options for jmod], the following are
 extra options that can be used with the command.
 
-`--do-not-resolve-by-default`
+[`--do-not-resolve-by-default`]{#option--do-not-resolve-by-default}
 :   Exclude from the default root set of modules
 
-`--warn-if-resolved`
+[`--warn-if-resolved`]{#option--warn-if-resolved}
 :   Hint for a tool to issue a warning if the module is resolved. One of
     deprecated, deprecated-for-removal, or incubating.
 

--- a/src/jdk.jshell/share/man/jshell.md
+++ b/src/jdk.jshell/share/man/jshell.md
@@ -181,7 +181,7 @@ use, save them to a file.
     For example, `-R-Dfoo=bar` means that execution of the snippet
     `System.getProperty("foo")` will return `"bar"`.
 
-[`-s`]{#option-s}
+`-s`
 :   Sets the feedback mode to `silent`, which is the same as entering
     `--feedback silent`.
 

--- a/src/jdk.jshell/share/man/jshell.md
+++ b/src/jdk.jshell/share/man/jshell.md
@@ -172,7 +172,7 @@ use, save them to a file.
     or to start JShell without any preloaded information if no scripts are
     entered. This option can't be used if the `--startup` option is used.
 
-[`-q`]{#option-q}
+`-q`
 :   Sets the feedback mode to `concise`, which is the same as entering
     `--feedback concise`.
 

--- a/src/jdk.jshell/share/man/jshell.md
+++ b/src/jdk.jshell/share/man/jshell.md
@@ -93,18 +93,18 @@ use, save them to a file.
 
 ## Options for jshell
 
-`--add-exports` *module*/*package*
+[`--add-exports`]{#option--add-exports} *module*/*package*
 :   Specifies a package to be considered as exported from its defining module.
 
-`--add-modules` *module*\[`,`*module*...\]
+[`--add-modules`]{#option--add-modules} *module*\[`,`*module*...\]
 :   Specifies the root modules to resolve in addition to the initial module.
 
-`-C`*flag*
+[`-C`]{#option-C}*flag*
 :   passes *flag* to the Java compiler inside JShell. For example, `-C-Xlint`
     enables all the recommended lint warnings, and `-C--release=<N>` compiles
     for Java SE N, as if --release N was specified.
 
-`--class-path` *path*
+[`--class-path`]{#option--class-path} *path*
 :   Specifies the directories and archives that are searched to locate class
     files. This option overrides the path in the `CLASSPATH` environment
     variable. If the environment variable isn't set and this option isn't used,
@@ -112,15 +112,15 @@ use, save them to a file.
     (:) to separate items in the path. For Windows, use a semicolon (;) to
     separate items.
 
-`--enable-preview`
+[`--enable-preview`]{#option--enable-preview}
 :   Allows code to depend on the preview features of this release.
 
-`--execution` *specification*
+[`--execution`]{#option--execution} *specification*
 :   Specifies an alternate execution engine, where *specification* is an
     ExecutionControl spec. See the documentation of the package jdk.jshell.spi
     for the syntax of the spec.
 
-`--feedback` *mode*
+[`--feedback`]{#option--feedback} *mode*
 :   Sets the initial level of feedback provided in response to what's entered.
     The initial level can be overridden within a session by using the
     `/set feedback` *mode* command. The default is `normal`.
@@ -161,34 +161,34 @@ use, save them to a file.
     code snippets. To specify flags that affect the execution of code snippets,
     use `-R`*flag*. Alternatively, use `-J`*flag* with `--execution local`.
 
-`--module-path` *modulepath*
+[`--module-path`]{#option--module-path} *modulepath*
 :   Specifies where to find application modules. For Linux and macOS, use a
     colon (:) to separate items in the path. For Windows, use a semicolon (;)
     to separate items.
 
-`--no-startup`
+[`--no-startup`]{#option--no-startup}
 :   Prevents startup scripts from running when JShell starts. Use this option
     to run only the scripts entered on the command line when JShell is started,
     or to start JShell without any preloaded information if no scripts are
     entered. This option can't be used if the `--startup` option is used.
 
-`-q`
+[`-q`]{#option-q}
 :   Sets the feedback mode to `concise`, which is the same as entering
     `--feedback concise`.
 
-`-R`*flag*
+[`-R`]{#option-R}*flag*
 :   passes *flag* to the runtime system only when code snippets are executed.
     For example, `-R-Dfoo=bar` means that execution of the snippet
     `System.getProperty("foo")` will return `"bar"`.
 
-`-s`
+[`-s`]{#option-s}
 :   Sets the feedback mode to `silent`, which is the same as entering
     `--feedback silent`.
 
-`--show-version`
+[`--show-version`]{#option--show-version}
 :   Prints version information and enters the tool.
 
-`--startup` *file*
+[`--startup`]{#option--startup} *file*
 :   Overrides the default startup script for this session. The script can
     contain any valid code snippets or commands.
 


### PR DESCRIPTION
adjust each of the command line options to include an html anchor so that one can give a link that goes directly to the section in the man page that covers a specific option

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377923](https://bugs.openjdk.org/browse/JDK-8377923): Add anchors to the options in the Tools man pages (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/29979/head:pull/29979` \
`$ git checkout pull/29979`

Update a local copy of the PR: \
`$ git checkout pull/29979` \
`$ git pull https://git.openjdk.org/jdk.git pull/29979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29979`

View PR using the GUI difftool: \
`$ git pr show -t 29979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/29979.diff">https://git.openjdk.org/jdk/pull/29979.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/29979#issuecomment-3977243263)
</details>
