### PR TITLE
8379083: Executable source program should ignore module declaration

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,8 @@ public record ProgramDescriptor(
     }
 
     public boolean isModular() {
-        return Files.exists(sourceRootPath.resolve("module-info.java"));
+        return !fileObject.isFirstLineIgnored() // programs with "shebang" lines are never modular
+               && Files.exists(sourceRootPath.resolve("module-info.java"));
     }
 
     public Set<String> computePackageNames() {

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8192920 8204588 8246774 8248843 8268869 8235876 8328339 8335896 8344706
- *      8362237 8376534
+ *      8362237 8376534 8379083
  * @summary Test source launcher
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -158,6 +158,10 @@ public class SourceLauncherTest extends TestRunner {
             "    }\n" +
             "}");
         Files.copy(base.resolve("HelloWorld.java"), base.resolve("HelloWorld"));
+        testSuccess(base.resolve("HelloWorld"), "Hello World! [1, 2, 3]\n");
+
+        // Re-run with a "stray" module descriptor being ignored
+        Files.writeString(base.resolve("module-info.java"), "module stray {}");
         testSuccess(base.resolve("HelloWorld"), "Hello World! [1, 2, 3]\n");
     }
 


### PR DESCRIPTION
Please review this change to ignore module declarations in source form, when an executable Java source program is using the "shebang" feature.

Prior to this commit, an existing `module-info.java` file in the computed root directory always made the source launcher run in modular mode. Now, and according to JEP 458, the launcher does not enter modular mode when a source program is using the "shebang" feature for execution.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8384084](https://bugs.openjdk.org/browse/JDK-8384084) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8379083](https://bugs.openjdk.org/browse/JDK-8379083): Executable source program should ignore module declaration (**Bug** - P4)
 * [JDK-8384084](https://bugs.openjdk.org/browse/JDK-8384084): Executable source program should ignore module declaration (**CSR**)


### Reviewers
 * [Jonathan László Lampérth](https://openjdk.org/census#jlamperth) (@jonath4ndev - Author)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30019/head:pull/30019` \
`$ git checkout pull/30019`

Update a local copy of the PR: \
`$ git checkout pull/30019` \
`$ git pull https://git.openjdk.org/jdk.git pull/30019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30019`

View PR using the GUI difftool: \
`$ git pr show -t 30019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30019.diff">https://git.openjdk.org/jdk/pull/30019.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30019#issuecomment-3990524794)
</details>
