### PR TITLE
8367897: Document the javax.net.debug property in javadoc

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/doc-files/debug-system-property.html
+++ b/src/java.base/share/classes/javax/net/ssl/doc-files/debug-system-property.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<!--
+ Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+ This code is free software; you can redistribute it and/or modify it
+ under the terms of the GNU General Public License version 2 only, as
+ published by the Free Software Foundation.  Oracle designates this
+ particular file as subject to the "Classpath" exception as provided
+ by Oracle in the LICENSE file that accompanied this code.
+
+ This code is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ version 2 for more details (a copy is included in the LICENSE file that
+ accompanied this code).
+
+ You should have received a copy of the GNU General Public License version
+ 2 along with this work; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ or visit www.oracle.com if you need additional information or have any
+ questions.
+-->
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>The javax.net.debug system property</title>
+    <style>
+        #debug {
+         border: 1px solid black;
+         border-collapse: collapse;
+         margin: 0 auto;
+        }
+        #debug caption {
+          font-weight: bold;
+          font-size: smaller;
+        }
+        #debug, #debug th, #debug td {
+         border: 1px solid black;
+         padding: 2px .5em;
+        }
+        #debug tbody th {
+         font-weight: normal;
+         text-align:left;
+        }
+    </style>
+</head>
+<body LANG="en-US" DIR="LTR">
+<h1><B>{@systemProperty javax.net.debug}</B></h1>
+<p> To monitor SSL/TLS activity, you can set the <code>javax.net.debug</code>
+    system property, which determines what trace messages are printed during
+    execution.
+</p>
+
+<p> If the <code>javax.net.debug</code> property is not defined, debug logging
+    is disabled. If it is defined as empty, the debug logger is
+    <code>System.getLogger("javax.net.ssl")</code>, and applications can
+    customize and configure it using external logging mechanisms. If it is
+    defined and non-empty, a private debug logger that writes to
+    <code>System.err</code> is used.
+</p>
+
+<p>The following table lists the <code>javax.net.debug</code> options:</p>
+
+<table id="debug">
+    <caption><b>SSL/TLS Debug Options</b></caption>
+    <thead>
+    <tr>
+        <th scope="col">Option</th>
+        <th scope="col">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <th scope="row"><code>all</code></th>
+        <td>Turn on all debugging</td>
+    </tr>
+    <tr>
+        <th scope="row"><code>ssl</code></th>
+        <td>Turn on SSL debugging. If specified by itself, all non-widening
+            filters are enabled. If specified with additional filter options,
+            general SSL debug messages are produced plus just the selected
+            categories. The following filters can be used with
+            <code>ssl</code>:
+            <ul>
+                <li><code><b>defaultctx</b></code>: Print default SSL
+                    initialization</li>
+                <li><code><b>handshake</b></code>: Print each handshake
+                    message. The following sub-option can be used with
+                    <code>handshake</code>:
+                    <ul>
+                        <li><code><b>verbose</b></code>: Verbose handshake
+                            message printing</li>
+                    </ul>
+                </li>
+                <li><code><b>keymanager</b></code>: Print key manager
+                    tracing</li>
+                <li><code><b>record</b></code>: Enable per-record tracing.
+                    The following sub-options can be used with
+                    <code>record</code>:
+                    <ul>
+                        <li><code><b>packet</b></code>: Print raw SSL/TLS
+                            packets</li>
+                        <li><code><b>plaintext</b></code>: Hex dump of record
+                            plaintext</li>
+                    </ul>
+                </li>
+                <li><code><b>respmgr</b></code>: Print OCSP response
+                    tracing</li>
+                <li><code><b>session</b></code>: Print session activity</li>
+                <li><code><b>sessioncache</b></code>: Print session cache
+                    tracing</li>
+                <li><code><b>sslctx</b></code>: Print SSLContext tracing</li>
+                <li><code><b>trustmanager</b></code>: Print trust manager
+                    tracing</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th scope="row"><code>expand</code></th>
+        <td>Use expanded (less compact) output format</td>
+    </tr>
+    <tr>
+        <th scope="row"><code>help</code></th>
+        <td>Print help message and exit</td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/java.base/share/classes/javax/net/ssl/package-info.java
+++ b/src/java.base/share/classes/javax/net/ssl/package-info.java
@@ -36,6 +36,12 @@
  * </b></a></li>
  * </ul>
  *
+ * <h2>Additional Specification</h2>
+ * <ul>
+ *   <li><a href="doc-files/debug-system-property.html">
+ *     The {@code javax.net.debug} System Property</a></li>
+ * </ul>
+ *
  * @spec security/standard-names.html Java Security Standard Algorithm Names
  * @since 1.4
  */


### PR DESCRIPTION
Adds javadoc documentation for the javax.net.debug system property to the javax.net.ssl    
package, following the same pattern used for java.security.debug in the java.security      
package. A new doc-files/debug-system-property.html page is created documenting all        
supported options, and a link to it is added to the package-info.java.                     
                                                                                           
make docs-javadoc

Results:
Finished building target 'docs-javadoc' in configuration 'linux-x86_64-server-release'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 27 to be approved (needs to be created)

### Issue
 * [JDK-8367897](https://bugs.openjdk.org/browse/JDK-8367897): Document the javax.net.debug property in javadoc (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30097/head:pull/30097` \
`$ git checkout pull/30097`

Update a local copy of the PR: \
`$ git checkout pull/30097` \
`$ git pull https://git.openjdk.org/jdk.git pull/30097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30097`

View PR using the GUI difftool: \
`$ git pr show -t 30097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30097.diff">https://git.openjdk.org/jdk/pull/30097.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30097#issuecomment-4010878613)
</details>
