### PR TITLE
8379396: "assert(offset + partition_size <= size()) failed: partition failed" when combining NonProfiledCodeHeapSize and large value for CICompilerCount

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -228,9 +228,13 @@ void CodeCache::initialize_heaps() {
 
   assert(heap_available(CodeBlobType::MethodNonProfiled), "MethodNonProfiled heap is always available for segmented code heap");
 
-  size_t compiler_buffer_size = 0;
-  COMPILER1_PRESENT(compiler_buffer_size += (size_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
-  COMPILER2_PRESENT(compiler_buffer_size += (size_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
+  uint64_t compiler_buffer_size_uint64 = 0;
+  COMPILER1_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
+  COMPILER2_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
+  if (compiler_buffer_size_uint64 > (uint64_t)CODE_CACHE_SIZE_LIMIT) {
+    vm_exit_during_initialization("Compiler buffer size exceeds the architectural CodeCache limit");
+  }
+  size_t compiler_buffer_size = (size_t)compiler_buffer_size_uint64;
 
   if (!non_nmethod.set) {
     non_nmethod.size += compiler_buffer_size;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -65,6 +65,7 @@
 #include "sanitizers/leak.hpp"
 #include "services/memoryService.hpp"
 #include "utilities/align.hpp"
+#include "utilities/integerCast.hpp"
 #include "utilities/vmError.hpp"
 #include "utilities/xmlstream.hpp"
 #ifdef COMPILER1
@@ -234,7 +235,7 @@ void CodeCache::initialize_heaps() {
   if (compiler_buffer_size_uint64 > (uint64_t)CODE_CACHE_SIZE_LIMIT) {
     vm_exit_during_initialization("CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit");
   }
-  size_t compiler_buffer_size = checked_cast<size_t>(compiler_buffer_size_uint64);
+  size_t compiler_buffer_size = integer_cast_permit_tautology<size_t>(compiler_buffer_size_uint64);
 
   if (!non_nmethod.set) {
     non_nmethod.size += compiler_buffer_size;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -233,7 +233,8 @@ void CodeCache::initialize_heaps() {
   COMPILER1_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
   COMPILER2_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
   if (compiler_buffer_size_uint64 > (uint64_t)CODE_CACHE_SIZE_LIMIT) {
-    vm_exit_during_initialization("CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit");
+    err_msg msg("CICompilerCount is too large (%d): compiler buffer size exceeds the CodeCache size limit", (int)CICompilerCount);
+    vm_exit_during_initialization(msg);
   }
   size_t compiler_buffer_size = integer_cast_permit_tautology<size_t>(compiler_buffer_size_uint64);
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -233,7 +233,7 @@ void CodeCache::initialize_heaps() {
   COMPILER1_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
   COMPILER2_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
   if (compiler_buffer_size_uint64 > (uint64_t)CODE_CACHE_SIZE_LIMIT) {
-    err_msg msg("CICompilerCount is too large (%d): compiler buffer size exceeds the CodeCache size limit", (int)CICompilerCount);
+    err_msg msg("CICompilerCount is too large (%" PRIdPTR "): compiler buffer size exceeds the CodeCache size limit", CICompilerCount);
     vm_exit_during_initialization(msg);
   }
   size_t compiler_buffer_size = integer_cast_permit_tautology<size_t>(compiler_buffer_size_uint64);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -229,8 +229,8 @@ void CodeCache::initialize_heaps() {
   assert(heap_available(CodeBlobType::MethodNonProfiled), "MethodNonProfiled heap is always available for segmented code heap");
 
   size_t compiler_buffer_size = 0;
-  COMPILER1_PRESENT(compiler_buffer_size += CompilationPolicy::c1_count() * Compiler::code_buffer_size());
-  COMPILER2_PRESENT(compiler_buffer_size += CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
+  COMPILER1_PRESENT(compiler_buffer_size += (size_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
+  COMPILER2_PRESENT(compiler_buffer_size += (size_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
 
   if (!non_nmethod.set) {
     non_nmethod.size += compiler_buffer_size;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -231,10 +231,10 @@ void CodeCache::initialize_heaps() {
   uint64_t compiler_buffer_size_uint64 = 0;
   COMPILER1_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
   COMPILER2_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
-  if (compiler_buffer_size_uint64 > MIN2((uint64_t)CODE_CACHE_SIZE_LIMIT, (uint64_t)SIZE_MAX)) {
+  if (compiler_buffer_size_uint64 > (uint64_t)CODE_CACHE_SIZE_LIMIT) {
     vm_exit_during_initialization("CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit");
   }
-  size_t compiler_buffer_size = (size_t)compiler_buffer_size_uint64;
+  size_t compiler_buffer_size = checked_cast<size_t>(compiler_buffer_size_uint64);
 
   if (!non_nmethod.set) {
     non_nmethod.size += compiler_buffer_size;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -231,8 +231,8 @@ void CodeCache::initialize_heaps() {
   uint64_t compiler_buffer_size_uint64 = 0;
   COMPILER1_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c1_count() * Compiler::code_buffer_size());
   COMPILER2_PRESENT(compiler_buffer_size_uint64 += (uint64_t)CompilationPolicy::c2_count() * C2Compiler::initial_code_buffer_size());
-  if (compiler_buffer_size_uint64 > (uint64_t)CODE_CACHE_SIZE_LIMIT) {
-    vm_exit_during_initialization("Compiler buffer size exceeds the architectural CodeCache limit");
+  if (compiler_buffer_size_uint64 > MIN2((uint64_t)CODE_CACHE_SIZE_LIMIT, (uint64_t)SIZE_MAX)) {
+    vm_exit_during_initialization("CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit");
   }
   size_t compiler_buffer_size = (size_t)compiler_buffer_size_uint64;
 

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -69,8 +69,8 @@ JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
   // On a single-CPU machine we still can run C1 and C2 compiler threads, so allow up to 2x for tiered.
   int reasonable_threads_num = CompilerConfig::is_tiered() ? active_processor_count * 2 : active_processor_count;
   if (value > reasonable_threads_num) {
-    JVMFlag::printError(verbose, "CICompilerCount is too large (%d) for current active processor count %d \n",
-                        (int)CICompilerCount, active_processor_count);
+    JVMFlag::printError(verbose, "CICompilerCount is too large (%" PRIdPTR ") for current active processor count %d \n",
+                        CICompilerCount, active_processor_count);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
 #endif

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -61,9 +61,21 @@ JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
                         "at least %d \n",
                         value, min_number_of_compiler_threads);
     return JVMFlag::VIOLATES_CONSTRAINT;
-  } else {
-    return JVMFlag::SUCCESS;
   }
+
+  // Limit CICompilerCount to a reasonable value in product builds.
+#ifndef ASSERT
+  int active_processor_count = os::active_processor_count();
+  // On a single-CPU machine we still can run C1 and C2 compiler threads, so allow up to 2x for tiered.
+  int reasonable_threads_num = CompilerConfig::is_tiered() ? active_processor_count * 2 : active_processor_count;
+  if (value > reasonable_threads_num) {
+    JVMFlag::printError(verbose, "CICompilerCount is too large for current active processor count %d \n",
+                        active_processor_count);
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+#endif
+
+  return JVMFlag::SUCCESS;
 }
 
 JVMFlag::Error AllocatePrefetchStepSizeConstraintFunc(int value, bool verbose) {

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -69,8 +69,8 @@ JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
   // On a single-CPU machine we still can run C1 and C2 compiler threads, so allow up to 2x for tiered.
   int reasonable_threads_num = CompilerConfig::is_tiered() ? active_processor_count * 2 : active_processor_count;
   if (value > reasonable_threads_num) {
-    JVMFlag::printError(verbose, "CICompilerCount is too large for current active processor count %d \n",
-                        active_processor_count);
+    JVMFlag::printError(verbose, "CICompilerCount is too large (%d) for current active processor count %d \n",
+                        (int)CICompilerCount, active_processor_count);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
 #endif

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -895,11 +895,9 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   /* compiler */                                                            \
                                                                             \
-  /* notice: the max range value here is max_jint, not max_intx  */         \
-  /* because of overflow issue                                   */         \
   product(intx, CICompilerCount, CI_COMPILER_COUNT,                         \
           "Number of compiler threads to run")                              \
-          range(0, max_jint)                                                \
+          range(0, 1024)                                                    \
           constraint(CICompilerCountConstraintFunc, AfterErgo)              \
                                                                             \
   product(bool, UseDynamicNumberOfCompilerThreads, true,                    \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -895,9 +895,11 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   /* compiler */                                                            \
                                                                             \
+  /* notice: the max range value here is max_jint, not max_intx  */         \
+  /* because of overflow issue                                   */         \
   product(intx, CICompilerCount, CI_COMPILER_COUNT,                         \
           "Number of compiler threads to run")                              \
-          range(0, 1024)                                                    \
+          range(0, max_jint)                                                \
           constraint(CICompilerCountConstraintFunc, AfterErgo)              \
                                                                             \
   product(bool, UseDynamicNumberOfCompilerThreads, true,                    \

--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test CheckCheckCICompilerCount
- * @bug 8130858 8132525 8162881
+ * @bug 8130858 8132525 8162881 8379396
  * @summary Check that correct range of values for CICompilerCount are allowed depending on whether tiered is enabled or not
  * @library /test/lib /
  * @requires vm.flagless
@@ -186,7 +186,22 @@ public class CheckCICompilerCount {
         0
     };
 
-    private static void verifyValidOption(String[] arguments, String expected_output, int exit, boolean tiered) throws Exception {
+    private static final String[][] INVALID_ARGUMENTS = {
+        {
+            "-XX:CICompilerCount=100M",
+            "-version"
+        },
+    };
+
+    private static final String[] INVALID_EXPECTED_OUTPUTS = {
+        "Compiler buffer size exceeds the architectural CodeCache limit"
+    };
+
+    private static final int[] INVALID_EXIT = {
+        1,
+    };
+
+    private static void verifyOptionBehavior(String[] arguments, String expected_output, int exit, boolean tiered) throws Exception {
         ProcessBuilder pb;
         OutputAnalyzer out;
 
@@ -215,11 +230,15 @@ public class CheckCICompilerCount {
         }
 
         for (int i = 0; i < NON_TIERED_ARGUMENTS.length; i++) {
-            verifyValidOption(NON_TIERED_ARGUMENTS[i], NON_TIERED_EXPECTED_OUTPUTS[i], NON_TIERED_EXIT[i], false);
+            verifyOptionBehavior(NON_TIERED_ARGUMENTS[i], NON_TIERED_EXPECTED_OUTPUTS[i], NON_TIERED_EXIT[i], false);
         }
 
         for (int i = 0; i < TIERED_ARGUMENTS.length; i++) {
-            verifyValidOption(TIERED_ARGUMENTS[i], TIERED_EXPECTED_OUTPUTS[i], TIERED_EXIT[i], true);
+            verifyOptionBehavior(TIERED_ARGUMENTS[i], TIERED_EXPECTED_OUTPUTS[i], TIERED_EXIT[i], true);
+        }
+
+        for (int i = 0; i < INVALID_ARGUMENTS.length; i++) {
+            verifyOptionBehavior(INVALID_ARGUMENTS[i], INVALID_EXPECTED_OUTPUTS[i], INVALID_EXIT[i], true);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -194,7 +194,7 @@ public class CheckCICompilerCount {
     };
 
     private static final String[] INVALID_EXPECTED_OUTPUTS = {
-        "Compiler buffer size exceeds the architectural CodeCache limit"
+        "compiler buffer size exceeds the CodeCache size limit"
     };
 
     private static final int[] INVALID_EXIT = {

--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -194,7 +194,10 @@ public class CheckCICompilerCount {
     };
 
     private static final String[] INVALID_EXPECTED_OUTPUTS = {
-        "compiler buffer size exceeds the CodeCache size limit"
+        // "CICompilerCount is too large" is a common prefix for two different messages:
+        // - product build: flag constraint fires early: "CICompilerCount is too large for current active processor count N"
+        // - debug build: CodeCache overflow guard fires: "CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit"
+        "CICompilerCount is too large"
     };
 
     private static final int[] INVALID_EXIT = {

--- a/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
+++ b/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
@@ -29,7 +29,6 @@
  *          trigger the old bug.
  * @library /test/lib
  * @requires vm.flagless
- * @requires vm.debug
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
@@ -54,7 +53,7 @@ public class SmallCodeCacheStartup {
             analyzer.shouldHaveExitValue(0);
         } catch (RuntimeException e) {
             // Error occurred during initialization
-            assertTrue(analyzer.getOutput().contains("CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit"),
+            assertTrue(analyzer.getOutput().contains("CICompilerCount is too large"),
                     "Expected VirtualMachineError");
         }
 

--- a/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
+++ b/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
@@ -29,6 +29,7 @@
  *          trigger the old bug.
  * @library /test/lib
  * @requires vm.flagless
+ * @requires vm.debug
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
@@ -52,8 +53,8 @@ public class SmallCodeCacheStartup {
         try {
             analyzer.shouldHaveExitValue(0);
         } catch (RuntimeException e) {
-            // Error occurred during initialization, did we run out of adapter space?
-            assertTrue(analyzer.getOutput().contains("VirtualMachineError: Out of space in CodeCache"),
+            // Error occurred during initialization
+            assertTrue(analyzer.getOutput().contains("CICompilerCount is too large: compiler buffer size exceeds the CodeCache size limit"),
                     "Expected VirtualMachineError");
         }
 


### PR DESCRIPTION
CodeCache::initialize_heaps() computes additional non-nmethod space for compiler buffers from compiler thread counts and per-compiler buffer sizes. With abnormally large CICompilerCount values, the intermediate multiplication may overflow in 32-bit arithmetic before the result is accumulated into size_t.

The fix computes compiler buffer size in uint64_t, checks it against the CodeCache size limit, and converts it to size_t only after that. In addition, in product builds, CICompilerCount is now capped at the active processor count, or at twice that value when tiered compilation is enabled. The regression test was updated accordingly.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379396](https://bugs.openjdk.org/browse/JDK-8379396): "assert(offset + partition_size &lt;= size()) failed: partition failed" when combining NonProfiledCodeHeapSize and large value for CICompilerCount (**Bug** - P5)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30121/head:pull/30121` \
`$ git checkout pull/30121`

Update a local copy of the PR: \
`$ git checkout pull/30121` \
`$ git pull https://git.openjdk.org/jdk.git pull/30121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30121`

View PR using the GUI difftool: \
`$ git pr show -t 30121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30121.diff">https://git.openjdk.org/jdk/pull/30121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30121#issuecomment-4024713117)
</details>
