### PR TITLE
fix(javadoc): change search link display from `innerHTML` to `textContent`

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -449,7 +449,7 @@ window.addEventListener("load", () => {
         if (redirect.checked) {
             href += "&r=1";
         }
-        searchLink.innerHTML = href;
+        searchLink.textContent = href;
         copy.onmouseenter();
     }
     function copyLink(e) {


### PR DESCRIPTION
Directly writing user input to a webpage without properly sanitizing the input first, allows for a cross-site scripting vulnerability.

I think using `textContent` here should be enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30147/head:pull/30147` \
`$ git checkout pull/30147`

Update a local copy of the PR: \
`$ git checkout pull/30147` \
`$ git pull https://git.openjdk.org/jdk.git pull/30147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30147`

View PR using the GUI difftool: \
`$ git pr show -t 30147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30147.diff">https://git.openjdk.org/jdk/pull/30147.diff</a>

</details>
