### PR TITLE
8379496: C2: Unnecessary MemBarCPUOrder for fence intrinsics

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2886,9 +2886,6 @@ bool LibraryCallKit::inline_unsafe_load_store(const BasicType type, const LoadSt
 }
 
 bool LibraryCallKit::inline_unsafe_fence(vmIntrinsics::ID id) {
-  // Regardless of form, don't allow previous ld/st to move down,
-  // then issue acquire, release, or volatile mem_bar.
-  insert_mem_bar(Op_MemBarCPUOrder);
   switch(id) {
     case vmIntrinsics::_loadFence:
       insert_mem_bar(Op_LoadFence);


### PR DESCRIPTION
Hi,

`LibraryCallKit::inline_unsafe_fence` emits a `MemBarCPUOrder` for all `fence` intrinsics. This means that from the compiler perspective, all of them become full fences. This seems unnecessary.

Please take a look and share your thoughts, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8379496](https://bugs.openjdk.org/browse/JDK-8379496): C2: Unnecessary MemBarCPUOrder for fence intrinsics (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30155/head:pull/30155` \
`$ git checkout pull/30155`

Update a local copy of the PR: \
`$ git checkout pull/30155` \
`$ git pull https://git.openjdk.org/jdk.git pull/30155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30155`

View PR using the GUI difftool: \
`$ git pr show -t 30155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30155.diff">https://git.openjdk.org/jdk/pull/30155.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30155#issuecomment-4029245010)
</details>
