### PR TITLE
8379628: Refactor langtools/shellsupport/doc tests to use JUnit

### DIFF
--- a/test/langtools/jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,19 +30,19 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jshell/jdk.internal.shellsupport.doc
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
- * @run testng/timeout=900/othervm -Xmx1024m FullJavadocHelperTest
+ * @run junit/timeout=900/othervm -Xmx1024m FullJavadocHelperTest
  */
 
 import java.io.IOException;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class FullJavadocHelperTest {
 
     /*
      * Long-running test to retrieve doc comments for enclosed elements of all JDK classes.
      */
+    @Test
     public void testAllDocs() throws IOException {
         new JavadocHelperTest().retrieveDocComments(Boolean.TRUE::booleanValue);
     }

--- a/test/langtools/jdk/internal/shellsupport/doc/JavadocFormatterTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/JavadocFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,21 +27,21 @@
  * @summary Test JavadocFormatter
  * @library /tools/lib
  * @modules jdk.jshell/jdk.internal.shellsupport.doc
- * @run testng JavadocFormatterTest
+ * @run junit JavadocFormatterTest
  */
 
 import java.util.Objects;
 
 import jdk.internal.shellsupport.doc.JavadocFormatter;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JavadocFormatterTest {
 
     private static final String CODE_RESET = "\033[0m";
     private static final String CODE_HIGHLIGHT = "\033[1m";
     private static final String CODE_UNDERLINE = "\033[4m";
 
+    @Test
     public void testReflow() {
         String actual;
         String expected;
@@ -401,6 +401,7 @@ public class JavadocFormatterTest {
         }
     }
 
+    @Test
     public void testSpaceAtEndOfLine() {
         String header = "Class<?> Class<T>.forName(Module module, String name)";
         String javadoc = """

--- a/test/langtools/jdk/internal/shellsupport/doc/JavadocHelperTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/JavadocHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jshell/jdk.internal.shellsupport.doc
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
- * @run testng JavadocHelperTest
+ * @run junit JavadocHelperTest
  * @key randomness
  */
 
@@ -69,13 +69,13 @@ import javax.tools.ToolProvider;
 
 import com.sun.source.util.JavacTask;
 import jdk.internal.shellsupport.doc.JavadocHelper;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Test
 public class JavadocHelperTest {
 
+    @Test
     public void testJavadoc() throws Exception {
         doTestJavadoc("",
                       t -> t.getElements().getTypeElement("test.Super"),
@@ -93,6 +93,7 @@ public class JavadocHelperTest {
                       " @return value\n");
     }
 
+    @Test
     public void testInheritNoJavadoc() throws Exception {
         doTestJavadoc("",
                       getSubTest,
@@ -107,6 +108,7 @@ public class JavadocHelperTest {
                       " @return value\n");
     }
 
+    @Test
     public void testInheritFull() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     * Prefix {@inheritDoc} suffix.\n" +
@@ -131,6 +133,7 @@ public class JavadocHelperTest {
                       " @return prefix value suffix\n");
     }
 
+    @Test
     public void testInheritMissingParam() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     * Prefix {@inheritDoc} suffix.\n" +
@@ -154,6 +157,7 @@ public class JavadocHelperTest {
                       " @return prefix value suffix\n");
     }
 
+    @Test
     public void testInheritMissingFirstParam() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     * Prefix {@inheritDoc} suffix.\n" +
@@ -177,6 +181,7 @@ public class JavadocHelperTest {
                       " @return prefix value suffix\n");
     }
 
+    @Test
     public void testInheritMissingThrows() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     * Prefix {@inheritDoc} suffix.\n" +
@@ -200,6 +205,7 @@ public class JavadocHelperTest {
                       " @return prefix value suffix\n");
     }
 
+    @Test
     public void testInheritMissingReturn() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     * Prefix {@inheritDoc} suffix.\n" +
@@ -223,6 +229,7 @@ public class JavadocHelperTest {
                       "@return value\n");
     }
 
+    @Test
     public void testInheritAllButOne() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     * @throws IllegalArgumentException {@inheritDoc}\n" +
@@ -238,6 +245,7 @@ public class JavadocHelperTest {
                       "@return value\n");
     }
 
+    @Test
     public void testInheritEmpty() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     */\n",
@@ -260,6 +268,7 @@ public class JavadocHelperTest {
                       "@return \n");
     }
 
+    @Test
     public void testEmptyValue() throws Exception {
         doTestJavadoc("    /**\n" +
                       "     */\n",
@@ -282,6 +291,7 @@ public class JavadocHelperTest {
                       "@return \n");
     }
 
+    @Test
     public void testShortComment() throws Exception {
         doTestJavadoc("    /**Test.*/\n",
                       getSubTest,
@@ -295,6 +305,7 @@ public class JavadocHelperTest {
                       "@return value\n");
     }
 
+    @Test
     public void testMarkdown() throws Exception {
         doTestJavadoc("""
                       /// Prefix {@inheritDoc} suffix.
@@ -328,6 +339,7 @@ public class JavadocHelperTest {
                       @return prefix value suffix""");
     }
 
+    @Test
     public void testMarkdown2() throws Exception {
         doTestJavadoc("""
                       /// {@inheritDoc}
@@ -352,6 +364,7 @@ public class JavadocHelperTest {
                       @since snc""");
     }
 
+    @Test
     public void testMarkdown3() throws Exception {
         doTestJavadoc("""
                       /// {@inheritDoc}
@@ -373,6 +386,7 @@ public class JavadocHelperTest {
                       """);
     }
 
+    @Test
     public void testMarkdown4() throws Exception {
         doTestJavadoc("""
                       /// {@inheritDoc}
@@ -397,6 +411,7 @@ public class JavadocHelperTest {
                       @since snc""");
     }
 
+    @Test
     public void testMarkdown5() throws Exception {
         doTestJavadoc("""
                       ///[define classes][java.lang.invoke.MethodHandles.Lookup#defineClass(byte\\[\\])]
@@ -417,6 +432,7 @@ public class JavadocHelperTest {
                        @since snc""");
     }
 
+    @Test
     public void testMarkdown6() throws Exception {
         doTestJavadoc("""
                       ///Text1 [define classes][java.lang.invoke.MethodHandles.Lookup#defineClass(byte\\[\\])]
@@ -503,7 +519,7 @@ public class JavadocHelperTest {
             try (JavadocHelper helper = JavadocHelper.create(task, Arrays.asList(srcZip))) {
                 String javadoc = helper.getResolvedDocComment(el);
 
-                assertEquals(javadoc, expectedJavadoc);
+                assertEquals(expectedJavadoc, javadoc);
             }
         }
     }
@@ -547,6 +563,7 @@ public class JavadocHelperTest {
      * Set the system property `seed` to a random seed to reproduce
      * a specific run of this test.
      */
+    @Test
     public void testRandomDocs() throws IOException {
         Random random = new Random(getSeed());
         // Run test on 2% of classes, which corresponds to ~ 140 classes


### PR DESCRIPTION
Please review this change to make tests in `test/langtools/jdk/internal/shellsupport/doc/` use JUnit.

The refactoring mostly converts `@Test` annotations from the class declaration to the method level, replaces `@run testng/...` tags with `@run junit/...`, and also flips the arguments of a single `assertEqual()` to have the expected value in first position.

A local run of `$ make test TEST=test/langtools/jdk/internal/shellsupport/doc/` now shows:
```
Running test 'jtreg:test/langtools/jdk/internal/shellsupport/doc'
Passed: jdk/internal/shellsupport/doc/JavadocFormatterTest.java
Passed: jdk/internal/shellsupport/doc/JavadocHelperTest.java
Passed: jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
Test results: passed: 3
Framework-based tests: 21 = 0 TestNG + 21 JUnit
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379628](https://bugs.openjdk.org/browse/JDK-8379628): Refactor langtools/shellsupport/doc tests to use JUnit (**Sub-task** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @david-beaumont (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30166/head:pull/30166` \
`$ git checkout pull/30166`

Update a local copy of the PR: \
`$ git checkout pull/30166` \
`$ git pull https://git.openjdk.org/jdk.git pull/30166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30166`

View PR using the GUI difftool: \
`$ git pr show -t 30166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30166.diff">https://git.openjdk.org/jdk/pull/30166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30166#issuecomment-4031451897)
</details>
