### PR TITLE
8379744: Add a way to update the key of a red-black tree node

### DIFF
--- a/src/hotspot/share/utilities/rbTree.hpp
+++ b/src/hotspot/share/utilities/rbTree.hpp
@@ -385,7 +385,7 @@ public:
 
   void free_node(RBNode<K, V>* node);
 
-  // Updates the key in the given the node or node cursor.
+  // Updates the key in the given node or node cursor.
   // The user must ensure that no tree properties are broken:
   // There must not exist any node with the new key
   // For all nodes with key < old_key, must also have key < new_key

--- a/src/hotspot/share/utilities/rbTree.hpp
+++ b/src/hotspot/share/utilities/rbTree.hpp
@@ -385,6 +385,14 @@ public:
 
   void free_node(RBNode<K, V>* node);
 
+  // Updates the key in the given the node or node cursor.
+  // The user must ensure that no tree properties are broken:
+  // There must not exist any node with the new key
+  // For all nodes with key < old_key, must also have key < new_key
+  // For all nodes with key > old_key, must also have key > new_key
+  void update_key(const Cursor& node_cursor, const K& new_key);
+  void update_key(RBNode<K, V>* node, const K& new_key);
+
   // Inserts a node with the given key/value into the tree,
   // if the key already exist, the value is updated instead.
   // Returns false if and only if allocation of a new node failed.

--- a/src/hotspot/share/utilities/rbTree.hpp
+++ b/src/hotspot/share/utilities/rbTree.hpp
@@ -386,6 +386,7 @@ public:
   void free_node(RBNode<K, V>* node);
 
   // Updates the key in the given node or node cursor.
+  // This will never trigger a tree rebalancing.
   // The user must ensure that no tree properties are broken:
   // There must not exist any node with the new key
   // For all nodes with key < old_key, must also have key < new_key

--- a/src/hotspot/share/utilities/rbTree.inline.hpp
+++ b/src/hotspot/share/utilities/rbTree.inline.hpp
@@ -1148,6 +1148,31 @@ inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::free_node(RBNode<K, V>* node) {
 }
 
 template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
+inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::update_key(const Cursor& node_cursor, const K& new_key) {
+  precond(node_cursor.valid());
+  precond(node_cursor.found());
+
+  RBNode<K, V>* node = node_cursor.node();
+  update_key(node, new_key);
+}
+
+template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
+inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::update_key(RBNode<K, V>* node, const K& new_key) {
+  precond(node != nullptr);
+  #ifdef ASSERT
+    const RBNode<K, V>* prev = node->prev();
+    const RBNode<K, V>* next = node->next();
+
+    if (prev != nullptr) assert(COMPARATOR::cmp(new_key, prev->key()) == RBTreeOrdering::GT, "updated key not GT previous node's key.");
+    if (next != nullptr) assert(COMPARATOR::cmp(new_key, next->key()) == RBTreeOrdering::LT, "updated key not LT next node's key.");
+  #endif // ASSERT
+
+  node->_key = new_key;
+}
+
+
+
+template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
 inline bool RBTree<K, V, COMPARATOR, ALLOCATOR>::upsert(const K& key, const V& val, const RBNode<K, V>* hint_node) {
   Cursor node_cursor = cursor(key, hint_node);
   RBNode<K, V>* node = node_cursor.node();

--- a/src/hotspot/share/utilities/rbTree.inline.hpp
+++ b/src/hotspot/share/utilities/rbTree.inline.hpp
@@ -1170,8 +1170,6 @@ inline void RBTree<K, V, COMPARATOR, ALLOCATOR>::update_key(RBNode<K, V>* node, 
   node->_key = new_key;
 }
 
-
-
 template <typename K, typename V, typename COMPARATOR, typename ALLOCATOR>
 inline bool RBTree<K, V, COMPARATOR, ALLOCATOR>::upsert(const K& key, const V& val, const RBNode<K, V>* hint_node) {
   Cursor node_cursor = cursor(key, hint_node);

--- a/test/hotspot/gtest/utilities/test_rbtree.cpp
+++ b/test/hotspot/gtest/utilities/test_rbtree.cpp
@@ -851,6 +851,46 @@ public:
     tree.verify_self();
   }
 
+  void test_update_key() {
+    RBTreeInt tree;
+
+    tree.upsert(10, 10);
+    tree.upsert(20, 20);
+    tree.upsert(30, 30);
+
+    RBTreeIntNode* node = tree.find_node(20);
+    EXPECT_NOT_NULL(node);
+
+    tree.update_key(node, 25);
+
+    EXPECT_NULL(tree.find_node(20));
+
+    RBTreeIntNode* updated_node = tree.find_node(25);
+    EXPECT_NOT_NULL(updated_node);
+    EXPECT_EQ(updated_node, node);
+
+    EXPECT_EQ(25, updated_node->key());
+    EXPECT_EQ(20, updated_node->val());
+
+    RBTreeInt::Cursor cursor = tree.cursor(10);
+    EXPECT_TRUE(cursor.found());
+
+    tree.update_key(cursor, 20);
+
+    EXPECT_FALSE(tree.cursor(10).found());
+
+    RBTreeInt::Cursor updated_cursor = tree.cursor(20);
+    EXPECT_TRUE(updated_cursor.found());
+
+    RBTreeIntNode* updated_cursor_node = updated_cursor.node();
+    EXPECT_EQ(updated_cursor_node, cursor.node());
+
+    EXPECT_EQ(20, updated_cursor_node->key());
+    EXPECT_EQ(10, updated_cursor_node->val());
+
+    tree.verify_self();
+  }
+
   void test_intrusive() {
     IntrusiveTreeInt intrusive_tree;
     int num_iterations = 100;
@@ -1167,9 +1207,28 @@ TEST_VM_F(RBTreeTest, CursorReplace) {
   this->test_cursor_replace();
 }
 
+TEST_VM_F(RBTreeTest, UpdateKey) {
+  this->test_update_key();
+}
+
 #ifdef ASSERT
 TEST_VM_F(RBTreeTest, NodesVisitedOnce) {
   this->test_nodes_visited_once();
+}
+
+TEST_VM_ASSERT_MSG(RBTreeTestNonFixture, UpdateKeyAssert,
+                   ".*updated key not LT next node's key.*") {
+  typedef RBTreeCHeap<int, int, IntCmp, mtTest> TreeType;
+
+  TreeType tree;
+  tree.upsert(10, 10);
+  tree.upsert(20, 20);
+  tree.upsert(30, 30);
+
+  RBNode<int, int>* node = tree.find_node(20);
+  ASSERT_NOT_NULL(node);
+
+  tree.update_key(node, 35);
 }
 
 TEST_VM_ASSERT_MSG(RBTreeTestNonFixture, CustomVerifyAssert, ".*failed on key = 7") {


### PR DESCRIPTION
Hi everyone,

For more advanced users of the red-black tree, we should add a way to update the key of an existing node. This can be needed if, for example, a node represents a range that has been expanded. Updating the key avoids having to remove and re-insert the node, both of which can trigger tree balancing. In contrast, updating the key can be done efficiently with only a lookup.

Assuming the tree is not ill-formed, it is sufficient to validate the new key against the node's local neighbours to ensure that we do not violate ordering. We assert for this in debug builds. It is the user's responsibility to ensure that the new key does not break tree invariants. The tree performs no additional operations besides updating the key. 

Testing:
- Oracle tier 1
- 2 new gtests covering both success and failure cases

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379744](https://bugs.openjdk.org/browse/JDK-8379744): Add a way to update the key of a red-black tree node (**Enhancement** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30183/head:pull/30183` \
`$ git checkout pull/30183`

Update a local copy of the PR: \
`$ git checkout pull/30183` \
`$ git pull https://git.openjdk.org/jdk.git pull/30183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30183`

View PR using the GUI difftool: \
`$ git pr show -t 30183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30183.diff">https://git.openjdk.org/jdk/pull/30183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30183#issuecomment-4038042714)
</details>
