### PR TITLE
Title: Fix Mac.doFinal(byte[], int) to throw correct exceptions for bad args

### DIFF
--- a/src/java.base/share/classes/javax/crypto/Mac.java
+++ b/src/java.base/share/classes/javax/crypto/Mac.java
@@ -621,7 +621,7 @@ public class Mac implements Cloneable {
             throw new IllegalStateException("MAC not initialized");
         }
         int macLen = getMacLength();
-        if (output == null || output.length-outOffset < macLen) {
+        if (output == null || outOffset < 0 || output.length-outOffset < macLen) {
             throw new ShortBufferException
                 ("Cannot store MAC in output buffer");
         }

--- a/src/java.base/share/classes/javax/crypto/Mac.java
+++ b/src/java.base/share/classes/javax/crypto/Mac.java
@@ -620,8 +620,11 @@ public class Mac implements Cloneable {
         if (!initialized) {
             throw new IllegalStateException("MAC not initialized");
         }
+        if (output == null || outOffset < 0) {
+            throw new IllegalArgumentException("Bad arguments");
+        }
         int macLen = getMacLength();
-        if (output == null || outOffset < 0 || output.length-outOffset < macLen) {
+        if (output.length - outOffset < macLen) {
             throw new ShortBufferException
                 ("Cannot store MAC in output buffer");
         }

--- a/test/jdk/javax/crypto/Mac/MacDoFinalNegativeOffset.java
+++ b/test/jdk/javax/crypto/Mac/MacDoFinalNegativeOffset.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 9999901
+ * @summary Mac.doFinal(byte[], int) should reject negative outOffset
+ * @run main MacDoFinalNegativeOffset
+ */
+
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+
+public class MacDoFinalNegativeOffset {
+
+    public static void main(String[] args) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        byte[] keyBytes = new byte[32];
+        SecretKeySpec key = new SecretKeySpec(keyBytes, "HmacSHA256");
+
+        // Test offset = -1: should throw ShortBufferException
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
+        int macLen = mac.getMacLength();
+        byte[] output = new byte[macLen + 64];
+
+        try {
+            mac.doFinal(output, -1);
+            throw new RuntimeException("Expected ShortBufferException for offset=-1");
+        } catch (ShortBufferException e) {
+            System.out.println("PASS: offset=-1 threw ShortBufferException");
+        }
+
+        // Test offset = Integer.MIN_VALUE
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
+        try {
+            mac.doFinal(output, Integer.MIN_VALUE);
+            throw new RuntimeException("Expected ShortBufferException for MIN_VALUE");
+        } catch (ShortBufferException e) {
+            System.out.println("PASS: offset=MIN_VALUE threw ShortBufferException");
+        }
+
+        // Test valid offset still works
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
+        mac.doFinal(output, 0);
+        System.out.println("PASS: offset=0 succeeded normally");
+    }
+}

--- a/test/jdk/javax/crypto/Mac/MacDoFinalNegativeOffset.java
+++ b/test/jdk/javax/crypto/Mac/MacDoFinalNegativeOffset.java
@@ -24,7 +24,9 @@
 /**
  * @test
  * @bug 9999901
- * @summary Mac.doFinal(byte[], int) should reject negative outOffset
+ * @summary Mac.doFinal(byte[], int) should reject null output and negative
+ *          outOffset with IllegalArgumentException, consistent with
+ *          Cipher.doFinal() and Mac.update()
  * @run main MacDoFinalNegativeOffset
  */
 
@@ -39,33 +41,59 @@ public class MacDoFinalNegativeOffset {
         byte[] keyBytes = new byte[32];
         SecretKeySpec key = new SecretKeySpec(keyBytes, "HmacSHA256");
 
-        // Test offset = -1: should throw ShortBufferException
-        mac.init(key);
-        mac.update(new byte[]{1, 2, 3});
         int macLen = mac.getMacLength();
         byte[] output = new byte[macLen + 64];
 
+        // Test 1: offset = -1 should throw IllegalArgumentException
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
         try {
             mac.doFinal(output, -1);
-            throw new RuntimeException("Expected ShortBufferException for offset=-1");
-        } catch (ShortBufferException e) {
-            System.out.println("PASS: offset=-1 threw ShortBufferException");
+            throw new RuntimeException("Expected IllegalArgumentException for offset=-1");
+        } catch (IllegalArgumentException e) {
+            System.out.println("PASS: offset=-1 threw IllegalArgumentException");
         }
 
-        // Test offset = Integer.MIN_VALUE
+        // Test 2: offset = Integer.MIN_VALUE should throw IllegalArgumentException
         mac.init(key);
         mac.update(new byte[]{1, 2, 3});
         try {
             mac.doFinal(output, Integer.MIN_VALUE);
-            throw new RuntimeException("Expected ShortBufferException for MIN_VALUE");
-        } catch (ShortBufferException e) {
-            System.out.println("PASS: offset=MIN_VALUE threw ShortBufferException");
+            throw new RuntimeException("Expected IllegalArgumentException for MIN_VALUE");
+        } catch (IllegalArgumentException e) {
+            System.out.println("PASS: offset=MIN_VALUE threw IllegalArgumentException");
         }
 
-        // Test valid offset still works
+        // Test 3: null output should throw IllegalArgumentException
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
+        try {
+            mac.doFinal(null, 0);
+            throw new RuntimeException("Expected IllegalArgumentException for null output");
+        } catch (IllegalArgumentException e) {
+            System.out.println("PASS: null output threw IllegalArgumentException");
+        }
+
+        // Test 4: buffer too small should throw ShortBufferException
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
+        try {
+            mac.doFinal(new byte[macLen - 1], 0);
+            throw new RuntimeException("Expected ShortBufferException for small buffer");
+        } catch (ShortBufferException e) {
+            System.out.println("PASS: small buffer threw ShortBufferException");
+        }
+
+        // Test 5: valid offset = 0 works
         mac.init(key);
         mac.update(new byte[]{1, 2, 3});
         mac.doFinal(output, 0);
         System.out.println("PASS: offset=0 succeeded normally");
+
+        // Test 6: valid offset at end of buffer works
+        mac.init(key);
+        mac.update(new byte[]{1, 2, 3});
+        mac.doFinal(output, 64);
+        System.out.println("PASS: offset=64 succeeded normally");
     }
 }


### PR DESCRIPTION
Mac.doFinal(byte[], int) does not validate that outOffset is non-negative or that output is non-null. When outOffset is negative, the bounds check passes due to integer arithmetic, causing System.arraycopy to throw ArrayIndexOutOfBoundsException instead of a proper exception. Fix: separate IllegalArgumentException (null/negative) from ShortBufferException (buffer too small), consistent with Cipher.doFinal(), Signature.sign(), and Mac.update().

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30187/head:pull/30187` \
`$ git checkout pull/30187`

Update a local copy of the PR: \
`$ git checkout pull/30187` \
`$ git pull https://git.openjdk.org/jdk.git pull/30187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30187`

View PR using the GUI difftool: \
`$ git pr show -t 30187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30187.diff">https://git.openjdk.org/jdk/pull/30187.diff</a>

</details>
