### PR TITLE
8379786: Fix integer overflow in String.encodedLengthUTF8 LATIN1 path

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1504,8 +1504,8 @@ public final class String
         if (positives == val.length) {
             return positives;
         }
-        int dp = positives;
-        for (int i = dp; i < val.length; i++) {
+        long dp = positives;
+        for (int i = positives; i < val.length; i++) {
             byte c = val[i];
             if (c < 0) {
                 dp += 2;
@@ -1513,7 +1513,10 @@ public final class String
                 dp++;
             }
         }
-        return dp;
+        if (dp > (long)Integer.MAX_VALUE) {
+            throw new OutOfMemoryError("Required length exceeds implementation limit");
+        }
+        return (int) dp;
     }
 
     /**

--- a/test/jdk/java/lang/String/EncodedLengthUTF8Overflow.java
+++ b/test/jdk/java/lang/String/EncodedLengthUTF8Overflow.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 9999903
+ * @summary String.encodedLengthUTF8() LATIN1 path should use long accumulator
+ *          to avoid integer overflow, matching the UTF16 path
+ * @requires os.maxMemory > 3g
+ * @run main/othervm -Xmx3g EncodedLengthUTF8Overflow
+ */
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class EncodedLengthUTF8Overflow {
+
+    public static void main(String[] args) throws Exception {
+        testSmallStringCorrectness();
+        testLargeStringOverflow();
+    }
+
+    /**
+     * Verify small LATIN1 strings with non-ASCII bytes encode correctly.
+     */
+    static void testSmallStringCorrectness() {
+        // Each of these LATIN1 chars (0x80-0xFF) encodes to 2 UTF-8 bytes
+        String s = "\u00e9\u00e8\u00ea\u00eb"; // éèêë
+        byte[] utf8 = s.getBytes(StandardCharsets.UTF_8);
+        if (utf8.length != 8) {
+            throw new RuntimeException(
+                "Expected 8 UTF-8 bytes for 4 LATIN1 non-ASCII chars, got "
+                + utf8.length);
+        }
+
+        // Mix of ASCII and non-ASCII
+        String mixed = "abc\u00ff";
+        byte[] mixedUtf8 = mixed.getBytes(StandardCharsets.UTF_8);
+        if (mixedUtf8.length != 5) { // 3 ASCII (1 byte each) + 1 non-ASCII (2 bytes)
+            throw new RuntimeException(
+                "Expected 5 UTF-8 bytes for mixed string, got "
+                + mixedUtf8.length);
+        }
+
+        System.out.println("PASS: small string correctness verified");
+    }
+
+    /**
+     * Test that a very large LATIN1 string with all non-ASCII bytes
+     * throws OutOfMemoryError instead of silently overflowing.
+     */
+    static void testLargeStringOverflow() {
+        // We need > Integer.MAX_VALUE/2 non-ASCII bytes to overflow.
+        // Each non-ASCII LATIN1 byte → 2 UTF-8 bytes, so:
+        //   dp = 2 * length > Integer.MAX_VALUE when length > MAX_VALUE/2
+        int length = Integer.MAX_VALUE / 2 + 1; // 1,073,741,824
+
+        System.out.println("Allocating " + (length / (1024*1024))
+            + " MB byte array...");
+        byte[] bigArray;
+        try {
+            bigArray = new byte[length];
+        } catch (OutOfMemoryError e) {
+            System.out.println("SKIP: not enough memory to allocate test array");
+            return;
+        }
+
+        // Fill with 0xFF (non-ASCII in LATIN1, signed byte = -1)
+        Arrays.fill(bigArray, (byte) 0xFF);
+
+        System.out.println("Creating LATIN1 string...");
+        String bigString;
+        try {
+            bigString = new String(bigArray, StandardCharsets.ISO_8859_1);
+        } catch (OutOfMemoryError e) {
+            System.out.println("SKIP: not enough memory for String creation");
+            return;
+        }
+
+        System.out.println("Encoding to UTF-8 (should throw OutOfMemoryError)...");
+        try {
+            byte[] utf8 = bigString.getBytes(StandardCharsets.UTF_8);
+            // If we get here, either the JVM has >2GB arrays (unlikely)
+            // or the overflow wasn't caught
+            throw new RuntimeException(
+                "Expected OutOfMemoryError but got " + utf8.length + " bytes");
+        } catch (OutOfMemoryError e) {
+            System.out.println("PASS: OutOfMemoryError thrown as expected: "
+                + e.getMessage());
+        } catch (NegativeArraySizeException e) {
+            // This is the bug: int overflow → negative dp → negative array size
+            throw new RuntimeException(
+                "BUG: int overflow in encodedLengthUTF8 caused "
+                + "NegativeArraySizeException", e);
+        }
+    }
+}

--- a/test/jdk/java/lang/String/EncodedLengthUTF8Overflow.java
+++ b/test/jdk/java/lang/String/EncodedLengthUTF8Overflow.java
@@ -30,7 +30,6 @@
  */
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 public class EncodedLengthUTF8Overflow {
 
@@ -86,28 +85,16 @@ public class EncodedLengthUTF8Overflow {
         //   dp = 2 * length > Integer.MAX_VALUE when length > MAX_VALUE/2
         int length = Integer.MAX_VALUE / 2 + 1; // 1,073,741,824
 
-        System.out.println("Allocating " + (length / (1024 * 1024))
-            + " MB byte array...");
-        byte[] bigArray;
-        try {
-            bigArray = new byte[length];
-        } catch (OutOfMemoryError e) {
-            System.out.println("SKIP: not enough memory to allocate test array");
-            return;
-        }
-
-        // Fill with 0xFF (non-ASCII in LATIN1, signed byte = -1)
-        Arrays.fill(bigArray, (byte) 0xFF);
-
-        System.out.println("Creating LATIN1 string...");
+        System.out.println("Creating " + (length / (1024 * 1024))
+            + " char LATIN1 string...");
         String bigString;
         try {
-            bigString = new String(bigArray, StandardCharsets.ISO_8859_1);
+            // Create a LATIN1 string with non-ASCII chars (U+00FF encodes to 2 bytes in UTF-8)
+            bigString = "\u00ff".repeat(length);
         } catch (OutOfMemoryError e) {
             System.out.println("SKIP: not enough memory for String creation");
             return;
         }
-        bigArray = null; // allow GC
 
         // Use encodedLength() which directly calls encodedLengthUTF8().
         // This avoids allocating a 2GB+ output byte array, making the

--- a/test/jdk/java/lang/String/EncodedLengthUTF8Overflow.java
+++ b/test/jdk/java/lang/String/EncodedLengthUTF8Overflow.java
@@ -23,11 +23,10 @@
 
 /**
  * @test
- * @bug 9999903
  * @summary String.encodedLengthUTF8() LATIN1 path should use long accumulator
  *          to avoid integer overflow, matching the UTF16 path
- * @requires os.maxMemory > 3g
- * @run main/othervm -Xmx3g EncodedLengthUTF8Overflow
+ * @requires os.maxMemory > 5g
+ * @run main/othervm -Xmx5g EncodedLengthUTF8Overflow
  */
 
 import java.nio.charset.StandardCharsets;
@@ -36,46 +35,58 @@ import java.util.Arrays;
 public class EncodedLengthUTF8Overflow {
 
     public static void main(String[] args) throws Exception {
-        testSmallStringCorrectness();
+        testSmallStringEncodedLength();
         testLargeStringOverflow();
     }
 
     /**
-     * Verify small LATIN1 strings with non-ASCII bytes encode correctly.
+     * Verify encodedLength(UTF_8) returns correct values for small
+     * LATIN1 strings with non-ASCII bytes.
      */
-    static void testSmallStringCorrectness() {
-        // Each of these LATIN1 chars (0x80-0xFF) encodes to 2 UTF-8 bytes
-        String s = "\u00e9\u00e8\u00ea\u00eb"; // éèêë
-        byte[] utf8 = s.getBytes(StandardCharsets.UTF_8);
-        if (utf8.length != 8) {
+    static void testSmallStringEncodedLength() {
+        // Each LATIN1 char 0x80-0xFF encodes to 2 UTF-8 bytes
+        String latin1 = "\u00e9\u00e8\u00ea\u00eb"; // éèêë
+        int len = latin1.encodedLength(StandardCharsets.UTF_8);
+        if (len != 8) {
             throw new RuntimeException(
-                "Expected 8 UTF-8 bytes for 4 LATIN1 non-ASCII chars, got "
-                + utf8.length);
+                "Expected encodedLength=8 for 4 non-ASCII LATIN1 chars, got " + len);
         }
 
         // Mix of ASCII and non-ASCII
+        // 3 ASCII (1 byte each) + 1 non-ASCII (2 bytes) = 5
         String mixed = "abc\u00ff";
-        byte[] mixedUtf8 = mixed.getBytes(StandardCharsets.UTF_8);
-        if (mixedUtf8.length != 5) { // 3 ASCII (1 byte each) + 1 non-ASCII (2 bytes)
+        int mixedLen = mixed.encodedLength(StandardCharsets.UTF_8);
+        if (mixedLen != 5) {
             throw new RuntimeException(
-                "Expected 5 UTF-8 bytes for mixed string, got "
-                + mixedUtf8.length);
+                "Expected encodedLength=5 for mixed string, got " + mixedLen);
         }
 
-        System.out.println("PASS: small string correctness verified");
+        // Pure ASCII
+        String ascii = "hello";
+        int asciiLen = ascii.encodedLength(StandardCharsets.UTF_8);
+        if (asciiLen != 5) {
+            throw new RuntimeException(
+                "Expected encodedLength=5 for ASCII string, got " + asciiLen);
+        }
+
+        System.out.println("PASS: small string encodedLength correctness verified");
     }
 
     /**
-     * Test that a very large LATIN1 string with all non-ASCII bytes
-     * throws OutOfMemoryError instead of silently overflowing.
+     * Test that encodedLength(UTF_8) throws OutOfMemoryError for a very
+     * large LATIN1 string whose UTF-8 length exceeds Integer.MAX_VALUE,
+     * instead of silently overflowing to a negative value.
+     *
+     * Uses encodedLength() directly which calls encodedLengthUTF8()
+     * internally, avoiding the need to allocate a 2GB+ output buffer.
      */
     static void testLargeStringOverflow() {
         // We need > Integer.MAX_VALUE/2 non-ASCII bytes to overflow.
-        // Each non-ASCII LATIN1 byte → 2 UTF-8 bytes, so:
+        // Each non-ASCII LATIN1 byte encodes to 2 UTF-8 bytes, so:
         //   dp = 2 * length > Integer.MAX_VALUE when length > MAX_VALUE/2
         int length = Integer.MAX_VALUE / 2 + 1; // 1,073,741,824
 
-        System.out.println("Allocating " + (length / (1024*1024))
+        System.out.println("Allocating " + (length / (1024 * 1024))
             + " MB byte array...");
         byte[] bigArray;
         try {
@@ -96,22 +107,26 @@ public class EncodedLengthUTF8Overflow {
             System.out.println("SKIP: not enough memory for String creation");
             return;
         }
+        bigArray = null; // allow GC
 
-        System.out.println("Encoding to UTF-8 (should throw OutOfMemoryError)...");
+        // Use encodedLength() which directly calls encodedLengthUTF8().
+        // This avoids allocating a 2GB+ output byte array, making the
+        // test much more memory-efficient and reliable.
+        System.out.println("Calling encodedLength(UTF_8) "
+            + "(should throw OutOfMemoryError)...");
         try {
-            byte[] utf8 = bigString.getBytes(StandardCharsets.UTF_8);
-            // If we get here, either the JVM has >2GB arrays (unlikely)
-            // or the overflow wasn't caught
+            int encodedLen = bigString.encodedLength(StandardCharsets.UTF_8);
+            // If we get here with a negative or small value, the int overflowed
+            if (encodedLen < length) {
+                throw new RuntimeException(
+                    "BUG: encodedLength returned " + encodedLen
+                    + " (likely int overflow), expected > " + length);
+            }
             throw new RuntimeException(
-                "Expected OutOfMemoryError but got " + utf8.length + " bytes");
+                "Expected OutOfMemoryError but got encodedLength=" + encodedLen);
         } catch (OutOfMemoryError e) {
             System.out.println("PASS: OutOfMemoryError thrown as expected: "
                 + e.getMessage());
-        } catch (NegativeArraySizeException e) {
-            // This is the bug: int overflow → negative dp → negative array size
-            throw new RuntimeException(
-                "BUG: int overflow in encodedLengthUTF8 caused "
-                + "NegativeArraySizeException", e);
         }
     }
 }


### PR DESCRIPTION
The encodedLengthUTF8() method uses an int accumulator (dp) for the LATIN1 code path, while the UTF16 path (encodedLengthUTF8_UTF16) correctly uses a long accumulator with an overflow check. When a LATIN1 string contains more than Integer.MAX_VALUE/2 non-ASCII bytes, the int dp overflows, potentially causing NegativeArraySizeException in downstream buffer allocation.

Fix: change dp from int to long and add the same overflow check used in the UTF16 path.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379786](https://bugs.openjdk.org/browse/JDK-8379786): Fix integer overflow in String.encodedLengthUTF8 LATIN1 path (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30189/head:pull/30189` \
`$ git checkout pull/30189`

Update a local copy of the PR: \
`$ git checkout pull/30189` \
`$ git pull https://git.openjdk.org/jdk.git pull/30189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30189`

View PR using the GUI difftool: \
`$ git pr show -t 30189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30189.diff">https://git.openjdk.org/jdk/pull/30189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30189#issuecomment-4040116561)
</details>
