### PR TITLE
8379776: Authenticator Modification Access Check

### DIFF
--- a/src/java.base/share/classes/java/net/Authenticator.java
+++ b/src/java.base/share/classes/java/net/Authenticator.java
@@ -44,6 +44,11 @@ package java.net;
  * requestPasswordAuthentication() methods which in turn will call the
  * getPasswordAuthentication() method of the registered object.
  * <p>
+ * To prevent or authorize modification of default authenticator by any third party libraries,
+ * creat a sub-class of {@link AuthenticatorModifyAccessChecker}
+ * and supply the name of sub-class in "authenticator.modify.access.checker.class" system property.
+ * Modification will be allowed by default.
+ * <p>
  * All methods that request authentication have a default implementation
  * that fails.
  *
@@ -61,6 +66,15 @@ class Authenticator {
 
     // The system-wide authenticator object.  See setDefault().
     private static volatile Authenticator theAuthenticator;
+    private static AuthenticatorModifyAccessChecker modifyAccessChecker;
+
+    static {
+        try {
+            modifyAccessChecker = (AuthenticatorModifyAccessChecker) Class.forName(System.getProperty("authenticator.modify.access.checker.class", AuthenticatorModifyAccessChecker.class.getName())).getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            modifyAccessChecker = new AuthenticatorModifyAccessChecker();
+        }
+    }
 
     private String requestingHost;
     private InetAddress requestingSite;
@@ -112,6 +126,9 @@ class Authenticator {
      *                  any previously set authenticator is removed.
      */
     public static synchronized void setDefault(Authenticator a) {
+        if (!modifyAccessChecker.canModifyAuthenticator(a)) {
+            return;
+        }
         theAuthenticator = a;
     }
 

--- a/src/java.base/share/classes/java/net/AuthenticatorModifyAccessChecker.java
+++ b/src/java.base/share/classes/java/net/AuthenticatorModifyAccessChecker.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.net;
+
+/**
+ * A checker that determines if an Authenticator can be modified.
+ * This class can be extended to override {@link AuthenticatorModifyAccessChecker#canModifyAuthenticator(Authenticator)}
+ * to implement custom access checking logics.
+ */
+public class AuthenticatorModifyAccessChecker {
+    /**
+     * Constructs a new AuthenticatorModifyAccessChecker.
+     */
+    public AuthenticatorModifyAccessChecker() {
+    }
+
+    /**
+     * Checks if the given Authenticator can be modified.
+     *
+     * @param a The Authenticator to check.
+     * @return true if the Authenticator can be modified, false otherwise.
+     */
+    public boolean canModifyAuthenticator(Authenticator a) {
+        return true;
+    }
+}


### PR DESCRIPTION
### Problem
In a large java project with multiple third party dependencies, there is a case where the default **Authenticator** set by the java project owner is overridden by the third party dependency jars.

### Example
While using **Google Big Query JDBC Jar**, If proxy username property is present in the connection url, the **default authenticator is reset** by a code piece in the jar without any checks for existing authenticator.

### Solution
Since, Authenticator is set on JVM level, the modification should provide **access control capability to the java project owner**.

### Changes
In java.net.Authenticator class, an AccessChecker class is initialized on class loading. By default, **java.net.AuthenticatorModifyAccessChecker** is loaded. The Java project owner can extend this class and implement their own custom implementation for **canModifyAuthenticator()** method. Java project owner should supply the custom class name in _"**authenticator.modify.access.checker.class**"_ system property which will be initialized on class loading time.

### Result
This change will give access modification control for the Java Project owner. The project owner can just skip the setDefault() call by return false in canModifyAuthenticator() method or can throw error according to their need.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8379776](https://bugs.openjdk.org/browse/JDK-8379776)

### Issue
 * [JDK-8379776](https://bugs.openjdk.org/browse/JDK-8379776): No control over Default Authenticator Change (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30193/head:pull/30193` \
`$ git checkout pull/30193`

Update a local copy of the PR: \
`$ git checkout pull/30193` \
`$ git pull https://git.openjdk.org/jdk.git pull/30193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30193`

View PR using the GUI difftool: \
`$ git pr show -t 30193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30193.diff">https://git.openjdk.org/jdk/pull/30193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30193#issuecomment-4039286055)
</details>
