### PR TITLE
CodeStackTrackerImpl pops wrong number of operands for IF_ICMPxx and IF_ACMPxx branches

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeStackTrackerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeStackTrackerImpl.java
@@ -152,7 +152,12 @@ public final class CodeStackTrackerImpl implements CodeStackTracker {
                     map.put(i.target(), stack);
                     stack = null;
                 } else {
-                    pop(1);
+                    // IF_ICMP* and IF_ACMP* instructions pop 2 values, others pop 1
+                    switch (i.opcode()) {
+                        case IF_ICMPEQ, IF_ICMPNE, IF_ICMPLT, IF_ICMPGE,
+                             IF_ICMPGT, IF_ICMPLE, IF_ACMPEQ, IF_ACMPNE -> pop(2);
+                        default -> pop(1);
+                    }
                     map.put(i.target(), fork());
                 }
             }

--- a/test/jdk/jdk/classfile/StackTrackerTest.java
+++ b/test/jdk/jdk/classfile/StackTrackerTest.java
@@ -78,6 +78,81 @@ class StackTrackerTest {
     }
 
     @Test
+    void testIfIcmpBranch() {
+        ClassFile.of().build(ClassDesc.of("Foo"), clb ->
+            clb.withMethodBody("m", MethodTypeDesc.of(ConstantDescs.CD_int,
+                    ConstantDescs.CD_int, ConstantDescs.CD_int), 0, cob -> {
+                var stackTracker = CodeStackTracker.of();
+                cob.transforming(stackTracker, stcb -> {
+                    // Push two ints for IF_ICMPEQ
+                    stcb.iload(1);
+                    assertIterableEquals(stackTracker.stack().get(), List.of(INT));
+                    stcb.iload(2);
+                    assertIterableEquals(stackTracker.stack().get(), List.of(INT, INT));
+                    // IF_ICMPEQ should pop both ints
+                    var end = stcb.newLabel();
+                    stcb.if_icmpeq(end);
+                    assertIterableEquals(stackTracker.stack().get(), List.of());
+                    stcb.iconst_0();
+                    stcb.ireturn();
+                    stcb.labelBinding(end);
+                    assertIterableEquals(stackTracker.stack().get(), List.of());
+                    stcb.iconst_1();
+                    stcb.ireturn();
+                });
+            }));
+    }
+
+    @Test
+    void testIfAcmpBranch() {
+        ClassFile.of().build(ClassDesc.of("Foo"), clb ->
+            clb.withMethodBody("m", MethodTypeDesc.of(ConstantDescs.CD_int,
+                    ConstantDescs.CD_Object, ConstantDescs.CD_Object), 0, cob -> {
+                var stackTracker = CodeStackTracker.of();
+                cob.transforming(stackTracker, stcb -> {
+                    // Push two references for IF_ACMPNE
+                    stcb.aload(1);
+                    assertIterableEquals(stackTracker.stack().get(), List.of(REFERENCE));
+                    stcb.aload(2);
+                    assertIterableEquals(stackTracker.stack().get(), List.of(REFERENCE, REFERENCE));
+                    // IF_ACMPNE should pop both references
+                    var end = stcb.newLabel();
+                    stcb.if_acmpne(end);
+                    assertIterableEquals(stackTracker.stack().get(), List.of());
+                    stcb.iconst_0();
+                    stcb.ireturn();
+                    stcb.labelBinding(end);
+                    assertIterableEquals(stackTracker.stack().get(), List.of());
+                    stcb.iconst_1();
+                    stcb.ireturn();
+                });
+            }));
+    }
+
+    @Test
+    void testIfSingleOperandBranch() {
+        ClassFile.of().build(ClassDesc.of("Foo"), clb ->
+            clb.withMethodBody("m", MethodTypeDesc.of(ConstantDescs.CD_int,
+                    ConstantDescs.CD_int), 0, cob -> {
+                var stackTracker = CodeStackTracker.of();
+                cob.transforming(stackTracker, stcb -> {
+                    // Push one int for IFEQ
+                    stcb.iload(1);
+                    assertIterableEquals(stackTracker.stack().get(), List.of(INT));
+                    // IFEQ should pop only one int
+                    var end = stcb.newLabel();
+                    stcb.ifeq(end);
+                    assertIterableEquals(stackTracker.stack().get(), List.of());
+                    stcb.iconst_0();
+                    stcb.ireturn();
+                    stcb.labelBinding(end);
+                    stcb.iconst_1();
+                    stcb.ireturn();
+                });
+            }));
+    }
+
+    @Test
     void testTrackingLost() {
         ClassFile.of().build(ClassDesc.of("Foo"), clb ->
             clb.withMethodBody("m", MethodTypeDesc.of(ConstantDescs.CD_Void), 0, cob -> {


### PR DESCRIPTION
## Summary

`CodeStackTrackerImpl` unconditionally calls `pop(1)` for all non-GOTO branch instructions. However, `IF_ICMP*` and `IF_ACMP*` instructions compare two operand stack values and should pop 2 entries.

### Before

All non-GOTO branch instructions unconditionally call `pop(1)`.

### After

`IF_ICMPEQ`, `IF_ICMPNE`, `IF_ICMPLT`, `IF_ICMPGE`, `IF_ICMPGT`, `IF_ICMPLE`, `IF_ACMPEQ`, `IF_ACMPNE` now correctly call `pop(2)`; other branches (`IFEQ`, `IFNE`, `IFLT`, `IFGE`,
`IFGT`, `IFLE`, `IFNULL`, `IFNONNULL`) remain `pop(1)`.

This aligns `CodeStackTrackerImpl` with the existing behavior in `StackCounter` (line 250-256), which already correctly distinguishes these two groups of branch instructions.

## Test

Added 3 test cases to `StackTrackerTest`:
- `testIfIcmpBranch` — verifies `IF_ICMPEQ` pops 2 values
- `testIfAcmpBranch` — verifies `IF_ACMPNE` pops 2 values
- `testIfSingleOperandBranch` — verifies `IFEQ` still correctly pops only 1 value

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30198/head:pull/30198` \
`$ git checkout pull/30198`

Update a local copy of the PR: \
`$ git checkout pull/30198` \
`$ git pull https://git.openjdk.org/jdk.git pull/30198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30198`

View PR using the GUI difftool: \
`$ git pr show -t 30198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30198.diff">https://git.openjdk.org/jdk/pull/30198.diff</a>

</details>
