### PR TITLE
8379804: Refactor jdk/com/sun tests to use JUnit

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java
@@ -31,8 +31,10 @@
  */
 import java.security.Key;
 import java.security.AlgorithmParameters;
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import java.util.Arrays;
 import java.math.BigInteger;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 5008156 8248268
- * @run testng NISTWrapKAT
+ * @run junit NISTWrapKAT
  * @summary Verify that the AES-Key-Wrap and AES-Key-Wrap-Pad ciphers
  * work as expected using NIST test vectors.
  * @author Valerie Peng
@@ -35,9 +35,8 @@ import javax.crypto.*;
 import javax.crypto.spec.*;
 import java.util.Arrays;
 import java.math.BigInteger;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import org.testng.Assert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class NISTWrapKAT {
 
@@ -101,8 +100,7 @@ public class NISTWrapKAT {
         }
     }
 
-    @DataProvider
-    public Object[][] testData() {
+    static Object[][] testData() {
         return new Object[][] {
             { "AESWrap", KEK, 16, DATA, 16, KW_AES128_128 },
             { "AESWrap", KEK, 24, DATA, 16, KW_AES192_128 },
@@ -249,7 +247,8 @@ public class NISTWrapKAT {
         };
     }
 
-    @Test(dataProvider = "testData")
+    @ParameterizedTest
+    @MethodSource("testData")
     public void testKeyWrap(String algo, String key, int keyLen,
             String data, int dataLen, String expected) throws Exception {
         System.out.println("Testing " +  algo + " Cipher with wrapping " +
@@ -311,7 +310,8 @@ public class NISTWrapKAT {
         }
     }
 
-    @Test(dataProvider = "testData")
+    @ParameterizedTest
+    @MethodSource("testData")
     public void testEnc(String algo, String key, int keyLen, String data, int dataLen, String expected)
             throws Exception {
         System.out.println("Testing " +  algo + " Cipher with enc " +

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
@@ -28,8 +28,9 @@
  * @library /test/lib
  * @run junit/othervm PBEKeyDestroyTest
  */
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import java.nio.charset.StandardCharsets;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
@@ -31,7 +31,9 @@
 import javax.crypto.*;
 import javax.crypto.spec.*;
 import java.nio.charset.StandardCharsets;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
@@ -51,20 +53,20 @@ public class PBEKeyDestroyTest {
         // should be equal
         assertFalse(key1.isDestroyed());
         assertFalse(key2.isDestroyed());
-        assertTrue(key1.equals(key2));
-        assertTrue(key2.equals(key1));
+        assertEquals(key1, key2);
+        assertEquals(key2, key1);
 
         // destroy key1
         key1.destroy();
         assertTrue(key1.isDestroyed());
-        assertFalse(key1.equals(key2));
-        assertFalse(key2.equals(key1));
+        assertNotEquals(key1, key2);
+        assertNotEquals(key2, key1);
 
         // also destroy key2
         key2.destroy();
         assertTrue(key2.isDestroyed());
-        assertFalse(key1.equals(key2));
-        assertFalse(key2.equals(key1));
+        assertNotEquals(key1, key2);
+        assertNotEquals(key2, key1);
 
         // call destroy again to make sure no unexpected exceptions
         key2.destroy();

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,14 @@
  * @bug 8312306
  * @summary Check the destroy()/isDestroyed() of the PBEKey impl from SunJCE
  * @library /test/lib
- * @run testng/othervm PBEKeyDestroyTest
+ * @run junit/othervm PBEKeyDestroyTest
  */
 import javax.crypto.*;
 import javax.crypto.spec.*;
 import java.nio.charset.StandardCharsets;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class PBEKeyDestroyTest {
 
@@ -48,22 +49,22 @@ public class PBEKeyDestroyTest {
         SecretKey key2 = skf.generateSecret(keySpec);
 
         // should be equal
-        Assert.assertFalse(key1.isDestroyed());
-        Assert.assertFalse(key2.isDestroyed());
-        Assert.assertTrue(key1.equals(key2));
-        Assert.assertTrue(key2.equals(key1));
+        assertFalse(key1.isDestroyed());
+        assertFalse(key2.isDestroyed());
+        assertTrue(key1.equals(key2));
+        assertTrue(key2.equals(key1));
 
         // destroy key1
         key1.destroy();
-        Assert.assertTrue(key1.isDestroyed());
-        Assert.assertFalse(key1.equals(key2));
-        Assert.assertFalse(key2.equals(key1));
+        assertTrue(key1.isDestroyed());
+        assertFalse(key1.equals(key2));
+        assertFalse(key2.equals(key1));
 
         // also destroy key2
         key2.destroy();
-        Assert.assertTrue(key2.isDestroyed());
-        Assert.assertFalse(key1.equals(key2));
-        Assert.assertFalse(key2.equals(key1));
+        assertTrue(key2.isDestroyed());
+        assertFalse(key1.equals(key2));
+        assertFalse(key2.equals(key1));
 
         // call destroy again to make sure no unexpected exceptions
         key2.destroy();

--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -27,10 +27,10 @@
  * @summary Multi-threaded client timeout tests for ldap pool
  * @library /test/lib
  *          lib/
- * @run testng/othervm/timeout=480 LdapPoolTimeoutTest
+ * @run junit/othervm/timeout=480 LdapPoolTimeoutTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.naming.Context;
 import javax.naming.NamingException;

--- a/test/jdk/com/sun/jndi/ldap/LdapTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,17 @@
  * @test
  * @library /test/lib
  *          lib/
- * @run testng/othervm LdapTimeoutTest
+ * @run junit/othervm LdapTimeoutTest
  * @bug 7094377 8000487 6176036 7056489 8151678
  * @summary Timeout tests for ldap
  */
 
-import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -60,8 +63,6 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static jdk.test.lib.Utils.adjustTimeout;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
 
 public class LdapTimeoutTest {
 
@@ -90,7 +91,7 @@ public class LdapTimeoutTest {
         assert (2 * CONNECT_MILLIS + READ_MILLIS + TOLERANCE < INFINITY_MILLIS);
     }
 
-    @BeforeTest
+    @BeforeEach
     public void beforeTest() {
         startAuxiliaryDiagnosticOutput();
     }
@@ -98,11 +99,6 @@ public class LdapTimeoutTest {
     /*
      * These are timeout tests and they are run in parallel to reduce the total
      * amount of run time.
-     *
-     * Currently it doesn't seem possible to instruct JTREG to run TestNG test
-     * methods in parallel. That said, this JTREG test is still
-     * a "TestNG-flavored" test for the sake of having org.testng.Assert
-     * capability.
      */
     @Test
     public void test() throws Exception {
@@ -190,11 +186,11 @@ public class LdapTimeoutTest {
             env.put(Context.PROVIDER_URL, urlTo(server));
             server.start();
             server.starting().join();
-            Assert.ThrowingRunnable completion =
+            Executable completion =
                     () -> assertCompletion(CONNECT_MILLIS,
                                            2 * CONNECT_MILLIS + TOLERANCE,
                                            () -> new InitialDirContext(env));
-            NamingException e = expectThrows(NamingException.class, completion);
+            NamingException e = assertThrows(NamingException.class, completion);
             String msg = e.getMessage();
             assertTrue(msg != null && msg.contains("timeout")
                                && msg.contains(String.valueOf(CONNECT_MILLIS)),
@@ -214,11 +210,11 @@ public class LdapTimeoutTest {
             InitialDirContext ctx = new InitialDirContext(env);
             SearchControls scl = new SearchControls();
             scl.setSearchScope(SearchControls.SUBTREE_SCOPE);
-            Assert.ThrowingRunnable completion =
+            Executable completion =
                     () -> assertCompletion(READ_MILLIS,
                                            READ_MILLIS + TOLERANCE,
                                            () -> ctx.search("ou=People,o=JNDITutorial", "(objectClass=*)", scl));
-            NamingException e = expectThrows(NamingException.class, completion);
+            NamingException e = assertThrows(NamingException.class, completion);
             String msg = e.getMessage();
             assertTrue(msg != null && msg.contains("timeout")
                                && msg.contains(String.valueOf(READ_MILLIS)),
@@ -235,11 +231,11 @@ public class LdapTimeoutTest {
             env.put(Context.PROVIDER_URL, urlTo(server));
             server.start();
             server.starting().join();
-            Assert.ThrowingRunnable completion =
+            Executable completion =
                     () -> assertCompletion(CONNECT_MILLIS,
                                            2 * CONNECT_MILLIS + TOLERANCE,
                                            () -> new InitialDirContext(env));
-            NamingException e = expectThrows(NamingException.class, completion);
+            NamingException e = assertThrows(NamingException.class, completion);
             String msg = e.getMessage();
             assertTrue(msg != null && msg.contains("timeout")
                                && msg.contains(String.valueOf(CONNECT_MILLIS)),
@@ -261,11 +257,11 @@ public class LdapTimeoutTest {
             env.put(Context.PROVIDER_URL, urlTo(server));
             server.start();
             server.starting().join();
-            Assert.ThrowingRunnable completion =
+            Executable completion =
                     () -> assertCompletion(CONNECT_MILLIS,
                                            2 * CONNECT_MILLIS + TOLERANCE,
                                            () -> new InitialDirContext(env));
-            NamingException e = expectThrows(NamingException.class, completion);
+            NamingException e = assertThrows(NamingException.class, completion);
             String msg = e.getMessage();
             assertTrue(msg != null && msg.contains("timeout")
                                && msg.contains(String.valueOf(CONNECT_MILLIS)),

--- a/test/jdk/com/sun/jndi/ldap/NamingExceptionMessageTest.java
+++ b/test/jdk/com/sun/jndi/ldap/NamingExceptionMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Test that CommunicationException is thrown when connection is timed out or closed/cancelled,
  *  and it's text matches the failure reason.
  * @library /test/lib lib
- * @run testng NamingExceptionMessageTest
+ * @run junit NamingExceptionMessageTest
  */
 
 import javax.naming.CommunicationException;
@@ -45,8 +45,11 @@ import java.util.Hashtable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.testng.annotations.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import jdk.test.lib.net.URIBuilder;
 
 public class NamingExceptionMessageTest {
@@ -58,9 +61,9 @@ public class NamingExceptionMessageTest {
             ldapServer.awaitStartup();
             var env = ldapServer.getInitialLdapCtxEnvironment(TIMEOUT_VALUE);
             var communicationException =
-                    Assert.expectThrows(CommunicationException.class, () -> new InitialDirContext(env));
+                    assertThrows(CommunicationException.class, () -> new InitialDirContext(env));
             System.out.println("Got CommunicationException:" + communicationException);
-            Assert.assertEquals(communicationException.getMessage(), EXPECTED_TIMEOUT_MESSAGE);
+            assertEquals(EXPECTED_TIMEOUT_MESSAGE, communicationException.getMessage());
         }
     }
 
@@ -70,7 +73,7 @@ public class NamingExceptionMessageTest {
             ldapServer.start();
             ldapServer.awaitStartup();
             var env = ldapServer.getInitialLdapCtxEnvironment(0);
-            var namingException = Assert.expectThrows(NamingException.class, () -> new InitialDirContext(env));
+            var namingException = assertThrows(NamingException.class, () -> new InitialDirContext(env));
             if (namingException instanceof ServiceUnavailableException) {
                 // If naming exception is ServiceUnavailableException it could mean
                 // that the connection was closed on test server-side before LDAP client starts
@@ -78,11 +81,11 @@ public class NamingExceptionMessageTest {
                 System.out.println("Got ServiceUnavailableException: Test PASSED");
             } else {
                 // If exception is not ServiceUnavailableException, CommunicationException is expected
-                Assert.assertTrue(namingException instanceof CommunicationException);
+                assertInstanceOf(CommunicationException.class, namingException);
                 var communicationException = (CommunicationException) namingException;
                 System.out.println("Got CommunicationException:" + communicationException);
                 // Check exception message
-                Assert.assertEquals(communicationException.getMessage(), EXPECTED_CLOSURE_MESSAGE);
+                assertEquals(EXPECTED_CLOSURE_MESSAGE, communicationException.getMessage());
             }
         }
     }


### PR DESCRIPTION
Please review this change to use JUnit Jupiter API in `jdk/com/sun` tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379804](https://bugs.openjdk.org/browse/JDK-8379804): Refactor jdk/com/sun tests to use JUnit (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30203/head:pull/30203` \
`$ git checkout pull/30203`

Update a local copy of the PR: \
`$ git checkout pull/30203` \
`$ git pull https://git.openjdk.org/jdk.git pull/30203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30203`

View PR using the GUI difftool: \
`$ git pr show -t 30203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30203.diff">https://git.openjdk.org/jdk/pull/30203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30203#issuecomment-4040449809)
</details>
