### PR TITLE
8176085: Please expose ScrollBarUI#getTrackBounds()   ScrollBarUI#getThumbBounds()

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/ScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/ScrollBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package javax.swing.plaf;
+import java.awt.Rectangle;
 
 /**
  * Pluggable look and feel interface for JScrollBar.
@@ -35,4 +36,20 @@ public abstract class ScrollBarUI extends ComponentUI {
      * Constructor for subclasses to call.
      */
     protected ScrollBarUI() {}
+
+   /**
+    * Returns the current bounds of the track
+    *
+    * @return the current bounds of the scrollbar track
+    * @since 27
+    */
+    protected Rectangle getTrackBounds() { return new Rectangle(0, 0, 0, 0);}
+
+   /**
+    * Return the current size/location of the thumb.
+    *
+    * @return The current size/location of the thumb.
+    * @since 27
+    */
+    protected Rectangle getThumbBounds() { return new Rectangle(0, 0, 0, 0);}
 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1068,7 +1068,7 @@ public class BasicScrollBarUI
      * @return The current size/location of the thumb.
      * @see #setThumbBounds
      */
-    protected Rectangle getThumbBounds() {
+    public Rectangle getThumbBounds() {
         return thumbRect;
     }
 
@@ -1085,7 +1085,7 @@ public class BasicScrollBarUI
      * @return the current bounds of the scrollbar track
      * @see #layoutContainer
      */
-    protected Rectangle getTrackBounds() {
+    public Rectangle getTrackBounds() {
         return trackRect;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1068,7 +1068,7 @@ public class BasicScrollBarUI
      * @return The current size/location of the thumb.
      * @see #setThumbBounds
      */
-    public Rectangle getThumbBounds() {
+    protected Rectangle getThumbBounds() {
         return thumbRect;
     }
 
@@ -1085,7 +1085,7 @@ public class BasicScrollBarUI
      * @return the current bounds of the scrollbar track
      * @see #layoutContainer
      */
-    public Rectangle getTrackBounds() {
+    protected Rectangle getTrackBounds() {
         return trackRect;
     }
 


### PR DESCRIPTION
The protected methods ScrollBarUI#getTrackBounds() ScrollBarUI#getThumbBounds() have
become inaccessible since JRE9 which is required to override the paint method and to paint the knob/thumb so we can consider making them public.

A CSR will be raised if this access expansion is accepted..

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8176085](https://bugs.openjdk.org/browse/JDK-8176085): Please expose ScrollBarUI#getTrackBounds()   ScrollBarUI#getThumbBounds() (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30209/head:pull/30209` \
`$ git checkout pull/30209`

Update a local copy of the PR: \
`$ git checkout pull/30209` \
`$ git pull https://git.openjdk.org/jdk.git pull/30209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30209`

View PR using the GUI difftool: \
`$ git pr show -t 30209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30209.diff">https://git.openjdk.org/jdk/pull/30209.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30209#issuecomment-4044894017)
</details>
