### PR TITLE
8379457: Test EATests.java#id0 ERROR: monitor list errors: error_cnt=1

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1416,7 +1416,11 @@ void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
   }
 
   const markWord mark = obj->mark();
-  if (!mark.has_monitor()) {
+  // Note: When using ObjectMonitorTable we may observe the intermediate state
+  // where the monitor is globally visible but no thread has yet transitioned
+  // the markWord. To avoid reporting a false positive during this transition we
+  // skip the !mark.has_monitor() test if we are using the ObjectMonitorTable.
+  if (!UseObjectMonitorTable && !mark.has_monitor()) {
     out->print_cr("ERROR: monitor=" INTPTR_FORMAT ": in-use monitor's "
                   "object does not think it has a monitor: obj="
                   INTPTR_FORMAT ", mark=" INTPTR_FORMAT, p2i(n),

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1416,10 +1416,10 @@ void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
   }
 
   const markWord mark = obj->mark();
-  // Note: When using ObjectMonitorTable we may observe the intermediate state
-  // where the monitor is globally visible but no thread has yet transitioned
-  // the markWord. To avoid reporting a false positive during this transition we
-  // skip the !mark.has_monitor() test if we are using the ObjectMonitorTable.
+  // Note: When using ObjectMonitorTable we may observe an intermediate state,
+  // where the monitor is globally visible, but no thread has yet transitioned
+  // the markWord. To avoid reporting a false positive during this transition, we
+  // skip the `!mark.has_monitor()` test if we are using the ObjectMonitorTable.
   if (!UseObjectMonitorTable && !mark.has_monitor()) {
     out->print_cr("ERROR: monitor=" INTPTR_FORMAT ": in-use monitor's "
                   "object does not think it has a monitor: obj="


### PR DESCRIPTION
**Test com/sun/jdi/EATests.java#id0 crashed: guarantee(error_cnt == 0) failed: ERROR: found monitor list errors: error_cnt=1** 

When using ObjectMonitorTable we may observe the intermediate state where the monitor is globally visible but no thread has yet transitioned the markWord. To avoid reporting a false positive during this transition we skip the `!mark.has_monitor()` test if we are using the ObjectMonitorTable.

Tested tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379457](https://bugs.openjdk.org/browse/JDK-8379457): Test EATests.java#id0 ERROR: monitor list errors: error_cnt=1 (**Bug** - P4)


### Reviewers
 * [Anton Artemov](https://openjdk.org/census#aartemov) (@toxaart - Committer)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30213/head:pull/30213` \
`$ git checkout pull/30213`

Update a local copy of the PR: \
`$ git checkout pull/30213` \
`$ git pull https://git.openjdk.org/jdk.git pull/30213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30213`

View PR using the GUI difftool: \
`$ git pr show -t 30213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30213.diff">https://git.openjdk.org/jdk/pull/30213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30213#issuecomment-4046419260)
</details>
