### PR TITLE
8380076: Refactor accessFlags() parsing in core reflection

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -74,6 +74,7 @@ import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.module.Resources;
+import jdk.internal.reflect.AccessFlagSet;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.CallerSensitiveAdapter;
 import jdk.internal.reflect.ConstantPool;
@@ -1386,17 +1387,15 @@ public final class Class<T> implements java.io.Serializable,
      * @since 20
      */
     public Set<AccessFlag> accessFlags() {
-        // Location.CLASS allows SUPER and AccessFlag.MODULE which
-        // INNER_CLASS forbids. INNER_CLASS allows PRIVATE, PROTECTED,
-        // and STATIC, which are not allowed on Location.CLASS.
-        // Use getClassFileAccessFlags to expose SUPER status.
-        // Arrays need to use PRIVATE/PROTECTED from its component modifiers.
-        var location = (isMemberClass() || isLocalClass() ||
-                        isAnonymousClass() || isArray()) ?
-            AccessFlag.Location.INNER_CLASS :
-            AccessFlag.Location.CLASS;
-        return getReflectionFactory().parseAccessFlags((location == AccessFlag.Location.CLASS) ?
-                        getClassFileAccessFlags() : getModifiers(), location, this);
+        // INNER_CLASS_FLAGS exclusively defines PRIVATE, PROTECTED, and STATIC.
+        // CLASS_FLAGS exclusively defines SUPER and MODULE.
+        // Nested classes and interfaces need to report PRIVATE/PROTECTED/STATIC.
+        // Arrays need to report PRIVATE/PROTECTED.
+        // Top-level classes need to report SUPER, using getClassFileAccessFlags.
+        // Module descriptors do not have Class objects so nothing reports MODULE.
+        return (isArray() || getEnclosingClass() != null)
+                ? AccessFlagSet.ofValidated(AccessFlagSet.INNER_CLASS_FLAGS, getModifiers())
+                : AccessFlagSet.ofValidated(AccessFlagSet.CLASS_FLAGS, getClassFileAccessFlags());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2029,9 +2029,6 @@ public final class System {
             E[] getEnumConstantsShared(Class<E> klass) {
                 return klass.getEnumConstantsShared();
             }
-            public int classFileVersion(Class<?> clazz) {
-                return clazz.getClassFileVersion();
-            }
             public void blockedOn(Interruptible b) {
                 Thread.currentThread().blockedOn(b);
             }

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package java.lang.reflect;
 
+import jdk.internal.reflect.AccessFlagSet;
+
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
 import java.lang.classfile.MethodModel;
@@ -35,18 +37,10 @@ import java.lang.classfile.attribute.ModuleExportInfo;
 import java.lang.classfile.attribute.ModuleOpenInfo;
 import java.lang.classfile.attribute.ModuleRequireInfo;
 import java.lang.module.ModuleDescriptor;
-import java.util.AbstractSet;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
-import jdk.internal.vm.annotation.Stable;
 
 import static java.lang.classfile.ClassFile.*;
 import static java.lang.reflect.ClassFileFormatVersion.*;
@@ -353,7 +347,7 @@ public enum AccessFlag {
      * the current class file format version.
      */
     public Set<Location> locations() {
-        return locations;
+        return locations(latest());
     }
 
     /**
@@ -381,14 +375,7 @@ public enum AccessFlag {
      * @throws NullPointerException if {@code location} is {@code null}
      */
     public static Set<AccessFlag> maskToAccessFlags(int mask, Location location) {
-        var definition = findDefinition(location);  // null checks location
-        int unmatchedMask = mask & (~location.flagsMask());
-        if (unmatchedMask != 0) {
-            throw new IllegalArgumentException("Unmatched bit position 0x" +
-                    Integer.toHexString(unmatchedMask) +
-                    " for location " + location);
-        }
-        return new AccessFlagSet(definition, mask);
+        return maskToAccessFlags(mask, location, latest());
     }
 
     /**
@@ -404,15 +391,15 @@ public enum AccessFlag {
      * @since 25
      */
     public static Set<AccessFlag> maskToAccessFlags(int mask, Location location, ClassFileFormatVersion cffv) {
-        var definition = findDefinition(location);  // null checks location
-        int unmatchedMask = mask & (~location.flagsMask(cffv));  // null checks cffv
+        var definition = AccessFlagSet.findDefinition(location, cffv);  // null checks location
+        int unmatchedMask = mask & (~location.flagsMask(cffv));
         if (unmatchedMask != 0) {
             throw new IllegalArgumentException("Unmatched bit position 0x" +
                     Integer.toHexString(unmatchedMask) +
                     " for location " + location +
                     " for class file format " + cffv);
         }
-        return new AccessFlagSet(definition, mask);
+        return AccessFlagSet.ofValidated(definition, mask);
     }
 
     /**
@@ -501,9 +488,9 @@ public enum AccessFlag {
                     ACC_STATIC | ACC_FINAL | ACC_INTERFACE | ACC_ABSTRACT |
                     ACC_SYNTHETIC | ACC_ANNOTATION | ACC_ENUM,
                     List.of(Map.entry(RELEASE_4, // no synthetic, annotation, enum
-                            ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED |
-                            ACC_STATIC | ACC_FINAL | ACC_INTERFACE |
-                            ACC_ABSTRACT),
+                                      ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED |
+                                      ACC_STATIC | ACC_FINAL | ACC_INTERFACE |
+                                      ACC_ABSTRACT),
                             Map.entry(RELEASE_0, 0))), // did not exist
 
         /**
@@ -620,7 +607,7 @@ public enum AccessFlag {
         // These 2 utilities reside in Location because Location must be initialized before AccessFlag
         private static <T> List<Map.Entry<ClassFileFormatVersion, T>> ensureHistoryOrdered(
                 List<Map.Entry<ClassFileFormatVersion, T>> history) {
-            ClassFileFormatVersion lastVersion = ClassFileFormatVersion.latest();
+            ClassFileFormatVersion lastVersion = latest();
             for (var e : history) {
                 var historyVersion = e.getKey();
                 if (lastVersion.compareTo(historyVersion) <= 0) {
@@ -654,7 +641,7 @@ public enum AccessFlag {
          * @since 25
          */
         public int flagsMask() {
-            return flagsMask;
+            return flagsMask(latest());
         }
 
         /**
@@ -682,7 +669,7 @@ public enum AccessFlag {
          * @since 25
          */
         public Set<AccessFlag> flags() {
-            return new AccessFlagSet(findDefinition(this), flagsMask());
+            return flags(latest());
         }
 
         /**
@@ -697,136 +684,8 @@ public enum AccessFlag {
          * @since 25
          */
         public Set<AccessFlag> flags(ClassFileFormatVersion cffv) {
-            // implicit null check cffv
-            return new AccessFlagSet(findDefinition(this), flagsMask(cffv));
-        }
-    }
-
-    private static AccessFlag[] createDefinition(AccessFlag... known) {
-        var ret = new AccessFlag[Character.SIZE];
-        for (var flag : known) {
-            var mask = flag.mask;
-            int pos = Integer.numberOfTrailingZeros(mask);
-            assert ret[pos] == null : ret[pos] + " " + flag;
-            ret[pos] = flag;
-        }
-        return ret;
-    }
-
-    // Will take extra args in the future for valhalla switch
-    private static AccessFlag[] findDefinition(Location location) {
-        return switch (location) {
-            case CLASS -> CLASS_FLAGS;
-            case FIELD -> FIELD_FLAGS;
-            case METHOD -> METHOD_FLAGS;
-            case INNER_CLASS -> INNER_CLASS_FLAGS;
-            case METHOD_PARAMETER -> METHOD_PARAMETER_FLAGS;
-            case MODULE -> MODULE_FLAGS;
-            case MODULE_REQUIRES -> MODULE_REQUIRES_FLAGS;
-            case MODULE_EXPORTS -> MODULE_EXPORTS_FLAGS;
-            case MODULE_OPENS -> MODULE_OPENS_FLAGS;
-        };
-    }
-
-    private static final @Stable AccessFlag[] // Can use stable array and lazy init in the future
-            CLASS_FLAGS = createDefinition(PUBLIC, FINAL, SUPER, INTERFACE, ABSTRACT, SYNTHETIC, ANNOTATION, ENUM, MODULE),
-            FIELD_FLAGS = createDefinition(PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, VOLATILE, TRANSIENT, SYNTHETIC, ENUM),
-            METHOD_FLAGS = createDefinition(PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, SYNCHRONIZED, BRIDGE, VARARGS, NATIVE, ABSTRACT, STRICT, SYNTHETIC),
-            INNER_CLASS_FLAGS = createDefinition(PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, INTERFACE, ABSTRACT, SYNTHETIC, ANNOTATION, ENUM),
-            METHOD_PARAMETER_FLAGS = createDefinition(FINAL, SYNTHETIC, MANDATED),
-            MODULE_FLAGS = createDefinition(OPEN, SYNTHETIC, MANDATED),
-            MODULE_REQUIRES_FLAGS = createDefinition(TRANSITIVE, STATIC_PHASE, SYNTHETIC, MANDATED),
-            MODULE_EXPORTS_FLAGS = createDefinition(SYNTHETIC, MANDATED),
-            MODULE_OPENS_FLAGS = createDefinition(SYNTHETIC, MANDATED);
-
-    private static int undefinedMask(AccessFlag[] definition, int mask) {
-        assert definition.length == Character.SIZE;
-        int definedMask = 0;
-        for (int i = 0; i < Character.SIZE; i++) {
-            if (definition[i] != null) {
-                definedMask |= 1 << i;
-            }
-        }
-        return mask & ~definedMask;
-    }
-
-    private static final class AccessFlagSet extends AbstractSet<AccessFlag> {
-        private final @Stable AccessFlag[] definition;
-        private final int mask;
-
-        // all mutating methods throw UnsupportedOperationException
-        @Override public boolean add(AccessFlag e) { throw uoe(); }
-        @Override public boolean addAll(Collection<? extends AccessFlag> c) { throw uoe(); }
-        @Override public void    clear() { throw uoe(); }
-        @Override public boolean remove(Object o) { throw uoe(); }
-        @Override public boolean removeAll(Collection<?> c) { throw uoe(); }
-        @Override public boolean removeIf(Predicate<? super AccessFlag> filter) { throw uoe(); }
-        @Override public boolean retainAll(Collection<?> c) { throw uoe(); }
-        private static UnsupportedOperationException uoe() { return new UnsupportedOperationException(); }
-
-        private AccessFlagSet(AccessFlag[] definition, int mask) {
-            assert undefinedMask(definition, mask) == 0 : mask;
-            this.definition = definition;
-            this.mask = mask;
-        }
-
-        @Override
-        public Iterator<AccessFlag> iterator() {
-            return new AccessFlagIterator(definition, mask);
-        }
-
-        @Override
-        public void forEach(Consumer<? super AccessFlag> action) {
-            Objects.requireNonNull(action); // in case of empty
-            for (int i = 0; i < Character.SIZE; i++) {
-                if ((mask & (1 << i)) != 0) {
-                    action.accept(definition[i]);
-                }
-            }
-        }
-
-        private static final class AccessFlagIterator implements Iterator<AccessFlag> {
-            private final @Stable AccessFlag[] definition;
-            private int remainingMask;
-
-            private AccessFlagIterator(AccessFlag[] definition, int remainingMask) {
-                this.definition = definition;
-                this.remainingMask = remainingMask;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return remainingMask != 0;
-            }
-
-            @Override
-            public AccessFlag next() {
-                int flagBit = Integer.lowestOneBit(remainingMask);
-                if (flagBit == 0) {
-                    throw new NoSuchElementException();
-                }
-                remainingMask &= ~flagBit;
-                return definition[Integer.numberOfTrailingZeros(flagBit)];
-            }
-        }
-
-        @Override
-        public int size() {
-            return Integer.bitCount(mask);
-        }
-
-        @Override
-        public boolean contains(Object o) {
-            if (Objects.requireNonNull(o) instanceof AccessFlag flag) {
-                int bit = flag.mask;
-                return (bit & mask) != 0 && definition[Integer.numberOfTrailingZeros(bit)] == flag;
-            }
-            return false;
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return mask == 0;
+            // flagsMask null checks cffv and always returns valid mask
+            return AccessFlagSet.ofValidated(AccessFlagSet.findDefinition(this, cffv), flagsMask(cffv));
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -34,6 +34,7 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.reflect.AccessFlagSet;
 import jdk.internal.vm.annotation.Stable;
 import sun.reflect.annotation.AnnotationParser;
 import sun.reflect.annotation.AnnotationSupport;
@@ -225,9 +226,7 @@ public abstract sealed class Executable extends AccessibleObject
      */
     @Override
     public Set<AccessFlag> accessFlags() {
-        return reflectionFactory.parseAccessFlags(getModifiers(),
-                                                  AccessFlag.Location.METHOD,
-                                                  getDeclaringClass());
+        return AccessFlagSet.ofValidated(AccessFlagSet.METHOD_FLAGS, getModifiers());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -37,6 +37,7 @@ import jdk.internal.loader.ClassLoaders;
 import jdk.internal.misc.VM;
 import jdk.internal.module.ModuleBootstrap;
 import jdk.internal.module.Modules;
+import jdk.internal.reflect.AccessFlagSet;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.FieldAccessor;
 import jdk.internal.reflect.Reflection;
@@ -246,7 +247,7 @@ class Field extends AccessibleObject implements Member {
      */
     @Override
     public Set<AccessFlag> accessFlags() {
-        return reflectionFactory.parseAccessFlags(getModifiers(), AccessFlag.Location.FIELD, getDeclaringClass());
+        return AccessFlagSet.ofValidated(AccessFlagSet.FIELD_FLAGS, getModifiers());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.Objects;
+
+import jdk.internal.reflect.AccessFlagSet;
 import sun.reflect.annotation.AnnotationSupport;
 
 /**
@@ -172,8 +174,7 @@ public final class Parameter implements AnnotatedElement {
      * @since 20
      */
     public Set<AccessFlag> accessFlags() {
-        return AccessibleObject.reflectionFactory.parseAccessFlags(getModifiers(),
-                AccessFlag.Location.METHOD_PARAMETER, getDeclaringExecutable().getDeclaringClass());
+        return AccessFlagSet.ofValidated(AccessFlagSet.METHOD_PARAMETER_FLAGS, getModifiers());
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -125,12 +125,6 @@ public interface JavaLangAccess {
     <E extends Enum<E>> E[] getEnumConstantsShared(Class<E> klass);
 
     /**
-     * Returns the big-endian packed minor-major version of the class file
-     * of this class.
-     */
-    int classFileVersion(Class<?> clazz);
-
-    /**
      * Set current thread's blocker field.
      */
     void blockedOn(Interruptible b);

--- a/src/java.base/share/classes/jdk/internal/reflect/AccessFlagSet.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/AccessFlagSet.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.reflect;
+
+import java.lang.reflect.AccessFlag;
+import java.lang.reflect.ClassFileFormatVersion;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import jdk.internal.vm.annotation.Stable;
+
+import static java.lang.reflect.AccessFlag.*;
+
+/// An access flag set is an optimized immutable set backed by an integer mask
+/// and a "definition" that interprets each bit in that mask.
+/// This set has a well-defined iteration order from the least significant bit
+/// to the most significant bit, is null-hostile, and throws UOE for any
+/// modification operation, like the other unmodifiable collections.
+///
+/// The "definition" is an array of 16 entries, the maximum number of different
+/// access flags a classfile `u2 access_flags` field can represent.
+/// Given an access flag bit, we can look up the array entry corresponding to
+/// its bit position to find the corresponding AccessFlag.
+///
+/// The definition can vary by location and class file format of the
+/// access_flags field.
+/// If a bit position does not have an access flag defined, its corresponding
+/// array entry is `null`.
+public final class AccessFlagSet extends AbstractSet<AccessFlag> {
+
+    public static final @Stable AccessFlag[]
+            CLASS_FLAGS = createDefinition(PUBLIC, FINAL, SUPER, INTERFACE, ABSTRACT, SYNTHETIC, ANNOTATION, ENUM, MODULE),
+            FIELD_FLAGS = createDefinition(PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, VOLATILE, TRANSIENT, SYNTHETIC, ENUM),
+            METHOD_FLAGS = createDefinition(PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, SYNCHRONIZED, BRIDGE, VARARGS, NATIVE, ABSTRACT, STRICT, SYNTHETIC),
+            INNER_CLASS_FLAGS = createDefinition(PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, INTERFACE, ABSTRACT, SYNTHETIC, ANNOTATION, ENUM),
+            METHOD_PARAMETER_FLAGS = createDefinition(FINAL, SYNTHETIC, MANDATED),
+            MODULE_FLAGS = createDefinition(OPEN, SYNTHETIC, MANDATED),
+            MODULE_REQUIRES_FLAGS = createDefinition(TRANSITIVE, STATIC_PHASE, SYNTHETIC, MANDATED),
+            MODULE_EXPORTS_FLAGS = createDefinition(SYNTHETIC, MANDATED),
+            MODULE_OPENS_FLAGS = createDefinition(SYNTHETIC, MANDATED);
+
+    /// Finds a definition that works for access flags for a classfile location for the latest class file format.
+    /// @see #findDefinition(Location, ClassFileFormatVersion)
+    public static AccessFlag[] findDefinition(Location location) {
+        return findDefinition(location, ClassFileFormatVersion.latest());
+    }
+
+    /// Finds a definition that works for access flags for a classfile location for the given class file format.
+    /// The definition may define extraneous flags not present in the given class file format, so do not derive
+    /// the mask of defined flags from this definition.
+    public static AccessFlag[] findDefinition(Location location, ClassFileFormatVersion cffv) {
+        Objects.requireNonNull(cffv);
+        // implicit null check location
+        return switch (location) {
+            case CLASS -> CLASS_FLAGS;
+            case FIELD -> FIELD_FLAGS;
+            case METHOD -> METHOD_FLAGS;
+            case INNER_CLASS -> INNER_CLASS_FLAGS;
+            case METHOD_PARAMETER -> METHOD_PARAMETER_FLAGS;
+            case MODULE -> MODULE_FLAGS;
+            case MODULE_REQUIRES -> MODULE_REQUIRES_FLAGS;
+            case MODULE_EXPORTS -> MODULE_EXPORTS_FLAGS;
+            case MODULE_OPENS -> MODULE_OPENS_FLAGS;
+        };
+    }
+
+    /// Converts an array of defined access flags to a proper "definition".
+    /// Users no longer have to explicitly assign access flags to their correct bit positions.
+    static AccessFlag[] createDefinition(AccessFlag... known) {
+        var ret = new AccessFlag[Character.SIZE];
+        for (var flag : known) {
+            var mask = flag.mask();
+            int pos = Integer.numberOfTrailingZeros(mask);
+            assert ret[pos] == null : ret[pos] + " duplicates " + flag;
+            ret[pos] = flag;
+        }
+        return ret;
+    }
+
+    /// Creates an access flag set with a mask where every set bit corresponds
+    /// to an access flag in the definition.
+    /// The mask must be validated: if any bit in the mask does not have a
+    /// corresponding access flag, this set will be corrupted.
+    public static Set<AccessFlag> ofValidated(AccessFlag[] definition, int mask) {
+        return new AccessFlagSet(definition, mask);
+    }
+
+    // Minimal mask validation for a definition.
+    // In practice, more bits are usually rejected due to context like class file versions.
+    private static int undefinedMask(AccessFlag[] definition, int mask) {
+        assert definition.length == Character.SIZE;
+        int definedMask = 0;
+        for (int i = 0; i < Character.SIZE; i++) {
+            if (definition[i] != null) {
+                definedMask |= 1 << i;
+            }
+        }
+        return mask & ~definedMask;
+    }
+
+    private final @Stable AccessFlag[] definition;
+    private final int mask;
+
+    // all mutating methods throw UnsupportedOperationException
+    @Override public boolean add(AccessFlag e) { throw uoe(); }
+    @Override public boolean addAll(Collection<? extends AccessFlag> c) { throw uoe(); }
+    @Override public void    clear() { throw uoe(); }
+    @Override public boolean remove(Object o) { throw uoe(); }
+    @Override public boolean removeAll(Collection<?> c) { throw uoe(); }
+    @Override public boolean removeIf(Predicate<? super AccessFlag> filter) { throw uoe(); }
+    @Override public boolean retainAll(Collection<?> c) { throw uoe(); }
+    private static UnsupportedOperationException uoe() { return new UnsupportedOperationException(); }
+
+    private AccessFlagSet(AccessFlag[] definition, int mask) {
+        assert undefinedMask(definition, mask) == 0 : mask;
+        this.definition = definition;
+        this.mask = mask;
+    }
+
+    @Override
+    public Iterator<AccessFlag> iterator() {
+        return new AccessFlagIterator(definition, mask);
+    }
+
+    @Override
+    public void forEach(Consumer<? super AccessFlag> action) {
+        Objects.requireNonNull(action); // in case of empty
+        for (int i = 0; i < Character.SIZE; i++) {
+            if ((mask & (1 << i)) != 0) {
+                action.accept(definition[i]);
+            }
+        }
+    }
+
+    private static final class AccessFlagIterator implements Iterator<AccessFlag> {
+        private final @Stable AccessFlag[] definition;
+        private int remainingMask;
+
+        private AccessFlagIterator(AccessFlag[] definition, int remainingMask) {
+            this.definition = definition;
+            this.remainingMask = remainingMask;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return remainingMask != 0;
+        }
+
+        @Override
+        public AccessFlag next() {
+            int flagBit = Integer.lowestOneBit(remainingMask);
+            if (flagBit == 0) {
+                throw new NoSuchElementException();
+            }
+            remainingMask &= ~flagBit;
+            return definition[Integer.numberOfTrailingZeros(flagBit)];
+        }
+    }
+
+    @Override
+    public int size() {
+        return Integer.bitCount(mask);
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (Objects.requireNonNull(o) instanceof AccessFlag flag) {
+            int bit = flag.mask();
+            return (bit & mask) != 0 && definition[Integer.numberOfTrailingZeros(bit)] == flag;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return mask == 0;
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.VM;
-import jdk.internal.module.ModuleBootstrap;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -32,7 +32,6 @@ import java.io.ObjectStreamClass;
 import java.io.ObjectStreamField;
 import java.io.OptionalDataException;
 import java.io.Serializable;
-import java.lang.classfile.ClassFile;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.*;
@@ -511,31 +510,6 @@ public class ReflectionFactory {
         } catch (ReflectiveOperationException e) {
             return null;
         }
-    }
-
-    public final Set<AccessFlag> parseAccessFlags(int mask, AccessFlag.Location location, Class<?> classFile) {
-        var cffv = classFileFormatVersion(classFile);
-        return cffv == null ?
-                AccessFlag.maskToAccessFlags(mask, location) :
-                AccessFlag.maskToAccessFlags(mask, location, cffv);
-    }
-
-    private final ClassFileFormatVersion classFileFormatVersion(Class<?> cl) {
-        int raw = SharedSecrets.getJavaLangAccess().classFileVersion(cl);
-
-        int major = raw & 0xFFFF;
-        int minor = raw >>> Character.SIZE;
-
-        assert VM.isSupportedClassFileVersion(major, minor) : major + "." + minor;
-
-        if (major >= ClassFile.JAVA_12_VERSION) {
-            if (minor == 0)
-                return ClassFileFormatVersion.fromMajor(raw);
-            return null; // preview or old preview, fallback to default handling
-        } else if (major == ClassFile.JAVA_1_VERSION) {
-            return minor < 3 ? ClassFileFormatVersion.RELEASE_0 : ClassFileFormatVersion.RELEASE_1;
-        }
-        return ClassFileFormatVersion.fromMajor(major);
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Currently, the access flags in core reflection are parsed through a central factory that dispatches through ReflectionFactory, which examines the location plus the class file format version, so that if a Method has STRICT, we call AccessFlag.maskToAccessFlag with the right class file format version so we do not fail on encountering STRICT.

After recent studies in project Valhalla, we noticed that Hotspot has a uniform representation of access flags for all class file versions. This means that if we can avoid passing the ClassFileVersion complexities and just parse based on the uniform representation Hotspot recognizes.

This change requires moving the AccessFlagSet to jdk.internal so it could be accessed by parsers. But we can remove the JavaLangAccess backdoor to fetch the class file versions.

Also see the companion Valhalla PR: https://github.com/openjdk/valhalla/pull/2209

---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8380076](https://bugs.openjdk.org/browse/JDK-8380076): Refactor accessFlags() parsing in core reflection (**Enhancement** - P4)


### Reviewers
 * [Shaojin Wen](https://openjdk.org/census#swen) (@wenshao - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30248/head:pull/30248` \
`$ git checkout pull/30248`

Update a local copy of the PR: \
`$ git checkout pull/30248` \
`$ git pull https://git.openjdk.org/jdk.git pull/30248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30248`

View PR using the GUI difftool: \
`$ git pr show -t 30248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30248.diff">https://git.openjdk.org/jdk/pull/30248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30248#issuecomment-4058713858)
</details>
