### PR TITLE
8373359: C2: BoolNode::Value_cmpu_and_mask() should look through cast nodes

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1848,7 +1848,7 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 const Type* BoolNode::Value_cmpu_and_mask(PhaseValues* phase) const {
   Node* cmp = in(1);
   if (cmp != nullptr && cmp->Opcode() == Op_CmpU) {
-    Node* cmp1 = cmp->in(1);
+    Node* cmp1 = cmp->in(1)->uncast();
     Node* cmp2 = cmp->in(2);
 
     if (cmp1->Opcode() == Op_AndI) {

--- a/test/hotspot/jtreg/compiler/c2/TestCastIIAtUnsignedCmp.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastIIAtUnsignedCmp.java
@@ -1,6 +1,30 @@
 /*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
  * @test
- * @summary Example test to use the new test framework.
+ * @bug 8373359
+ * @summary C2: BoolNode::Value_cmpu_and_mask() should look through cast nodes
  * @library /test/lib /
  * @run driver TestCastIIAtUnsignedCmp
  */

--- a/test/hotspot/jtreg/compiler/c2/TestCastIIAtUnsignedCmp.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastIIAtUnsignedCmp.java
@@ -1,0 +1,49 @@
+/*
+ * @test
+ * @summary Example test to use the new test framework.
+ * @library /test/lib /
+ * @run driver TestCastIIAtUnsignedCmp
+ */
+
+import compiler.lib.ir_framework.*;
+
+public class TestCastIIAtUnsignedCmp {
+    float fFld;
+    boolean flag;
+    int m;
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @Warmup(1)
+    @IR(failOn = IRNode.STORE_F)
+    int[] test() {
+        int positiveInt = flag ? 0 : Integer.MAX_VALUE; // [0, max_int]
+        int size = m & positiveInt;
+        int[] arr = new int[size]; // CastII(size) // [0, max_int - 2]
+
+        // size                       <=u positiveInt  (canonicalized condition)
+        // CastII(size & positiveInt) <=u positiveInt
+        //
+        // Before JDK-8354282:
+        //
+        // After Loop Opts -> widen CastII in CastII::Value() -> same type as AndI input
+        // -> ConstraintCastNode::Identity() removes CastII because not UnconditionalDependency
+        // -> can now apply BoolNode::Value_cmpu_and_mask() case (1a):
+        //     size & positiveInt <=u positiveInt
+        // -> always true -> always take else path, and we remove the StoreF and fold the condition.
+        //
+        // After JDK-8354282:
+        //
+        // After Loop Opts -> widen CastII in CastII::Ideal() + set to non-narrowing dependency
+        // -> same type as AndI input -> ConstraintCastNode::Identity() does NOT remove CastII
+        // because non-narrowing dependency -> fail to apply Value_cmpu_and_mask (cannot look
+        // through CastII) and thus cannot fold the condition
+        if (Integer.compareUnsigned(size, positiveInt) > 0) {
+            fFld = 34;
+        }
+        return arr;
+    }
+}


### PR DESCRIPTION
This add an extra `uncast()` call for the code pattern of the bug's
test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8373359](https://bugs.openjdk.org/browse/JDK-8373359): C2: BoolNode::Value_cmpu_and_mask() should look through cast nodes (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30265/head:pull/30265` \
`$ git checkout pull/30265`

Update a local copy of the PR: \
`$ git checkout pull/30265` \
`$ git pull https://git.openjdk.org/jdk.git pull/30265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30265`

View PR using the GUI difftool: \
`$ git pr show -t 30265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30265.diff">https://git.openjdk.org/jdk/pull/30265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30265#issuecomment-4067874203)
</details>
