### PR TITLE
8329548: Change KeyUpdate messages from TLS 1.3

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -376,11 +376,11 @@ enum SSLCipher {
 
     // Keywords found on the jdk.tls.keyLimits security property.
     static final String[] tag = {"KEYUPDATE"};
+    static final long COUNTDOWNWARN = 20000; // Print debug warning under limit
 
     static  {
         final long max = 4611686018427387904L; // 2^62
         String prop = Security.getProperty("jdk.tls.keyLimits");
-
         if (prop != null) {
             String[] propvalue = prop.split(",");
 
@@ -574,7 +574,6 @@ enum SSLCipher {
         boolean keyLimitEnabled = false;
         long keyLimitCountdown = 0;
         SecretKey baseSecret;
-        static final long COUNTDOWNWARN = 20000; // Print debug warning under limit
 
         SSLReadCipher(Authenticator authenticator,
                 ProtocolVersion protocolVersion) {
@@ -622,10 +621,8 @@ enum SSLCipher {
          * If key usage limit is not be monitored, return false.
          */
         public boolean atKeyLimit() {
-            if (keyLimitCountdown < COUNTDOWNWARN) {
-                if (SSLLogger.isOn()) {
-                    SSLLogger.fine("keyLimitCountdown: " + keyLimitCountdown);
-                }
+            if (keyLimitCountdown < COUNTDOWNWARN && SSLLogger.isOn()) {
+                SSLLogger.fine("keyLimitCountdown: " + keyLimitCountdown);
             }
             if (keyLimitCountdown >= 0) {
                 return false;

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.security.ssl;
 
 import sun.security.ssl.Authenticator.MAC;
+import sun.security.util.Debug;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -371,7 +372,7 @@ enum SSLCipher {
             ProtocolVersion[]>[] writeCipherGenerators;
 
     // Map of Ciphers listed in jdk.tls.keyLimits
-    private static final HashMap<String, Long> cipherLimits = new HashMap<>();
+    static final HashMap<String, Long> cipherLimits = new HashMap<>();
 
     // Keywords found on the jdk.tls.keyLimits security property.
     static final String[] tag = {"KEYUPDATE"};
@@ -573,6 +574,7 @@ enum SSLCipher {
         boolean keyLimitEnabled = false;
         long keyLimitCountdown = 0;
         SecretKey baseSecret;
+        static final long COUNTDOWNWARN = 20000; // Print debug warning under limit
 
         SSLReadCipher(Authenticator authenticator,
                 ProtocolVersion protocolVersion) {
@@ -620,7 +622,18 @@ enum SSLCipher {
          * If key usage limit is not be monitored, return false.
          */
         public boolean atKeyLimit() {
+            if (keyLimitCountdown < COUNTDOWNWARN) {
+                if (SSLLogger.isOn()) {
+                    SSLLogger.fine("keyLimitCountdown: " + keyLimitCountdown);
+                }
+            }
             if (keyLimitCountdown >= 0) {
+                return false;
+            }
+            if (keyLimitEnabled == false) {
+                if (SSLLogger.isOn()) {
+                    SSLLogger.fine("KeyUpdate already send, skipping");
+                }
                 return false;
             }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -618,7 +618,7 @@ enum SSLCipher {
 
         /**
          * Check if processed bytes have reached the key usage limit.
-         * If key usage limit is not be monitored, return false.
+         * If key usage limits are not be monitored, return false.
          */
         public boolean atKeyLimit() {
             if (keyLimitCountdown < COUNTDOWNWARN && SSLLogger.isOn()) {
@@ -629,7 +629,7 @@ enum SSLCipher {
             }
             if (keyLimitEnabled == false) {
                 if (SSLLogger.isOn()) {
-                    SSLLogger.fine("KeyUpdate already send, skipping");
+                    SSLLogger.fine("KeyUpdate already sent, skipping");
                 }
                 return false;
             }

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  * @summary Verify one KeyUpdate message is sent
  *
  * @run main KeyUpdateOnce server TLS_AES_256_GCM_SHA384 200000
+ * @run main KeyUpdateOnce client TLS_AES_256_GCM_SHA384 200000
  */
 
 /*
@@ -45,46 +46,67 @@ import jdk.test.lib.process.ProcessTools;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
+
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
-public class KeyUpdateOnce extends SSLContextTemplate{
-    SSLEngine eng;
-    static ByteBuffer cTos, sToc, outdata;
-    ByteBuffer buf;
-    static boolean ready = false;
-    static int dataLen = 10240;
-    static boolean serverwrite = true;
-    int totalDataLen = 0;
-    static boolean sc = true;
-    int delay = 1;
-    static boolean readdone = false;
-    static long newLimit;
+public class KeyUpdateOnce extends SSLContextTemplate {
 
-    // Turn on debugging
-    static boolean debug = true;
+    private static final int DATALEN = 10240;
+    private static final int BUF_DATALEN = 4 * DATALEN;
+    private static final int MAXLOOPS = 150;
+    private static final int COUNTDOWNLIMIT = 5;
+
+    private static final boolean DEBUG = true;
+
+    private static ByteBuffer cTos;
+    private static ByteBuffer sToc;
+    private static ByteBuffer outData;
+    private final ByteBuffer inData;
+
+    // thread flags
+    private static boolean ready = false;
+    private static boolean sc = true;
+    private static boolean readDone = false;
+    private static boolean serverWrites = true;
+
+    private static long newLimit;
+
+    // Reflection handle captured on read side once handshake completes
+    private static Object readSideInputRecord = null;
+
+    protected SSLEngine engine;
+    private final int delay = 1;
+    private int totalDataLen = 0;
 
     KeyUpdateOnce() {
-        buf = ByteBuffer.allocate(dataLen * 4);
+        this.inData = ByteBuffer.allocate(BUF_DATALEN);
     }
+
     /**
-     * args should have two values:  server|client, cipher suite, <limit size>
-     * Prepending 'p' is for internal use only.
+     * args should have:
+     *   server|client, cipherSuite, <limit size>
+     *
+     * Prepending 'p' is for internal use only (test harness relaunch).
      */
     public static void main(String[] args) throws Exception {
         for (String arg : args) {
             System.out.print(" " + arg);
         }
         System.out.println();
-        if (args[0].compareTo("p") != 0) {
+
+        // Harness mode: relaunch self with 'p' to force add-opens + debugging flags
+        if (!"p".equals(args[0])) {
             // args[]: 0 = client/server, 1 = cipher suite, 2 = newLimit
-            System.setProperty("test.java.opts", System.getProperty("test.java.opts") +
-                " -Dtest.src=" + System.getProperty("test.src") +
-                " -Dtest.jdk=" + System.getProperty("test.jdk") +
-                " -Djavax.net.debug=ssl,handshake -Djavatest.maxOutputSize=99999999" +
-                " --add-opens java.base/sun.security.ssl=ALL-UNNAMED");
+            System.setProperty("test.java.opts",
+                System.getProperty("test.java.opts") +
+                    " -Dtest.src=" + System.getProperty("test.src") +
+                    " -Dtest.jdk=" + System.getProperty("test.jdk") +
+                    " -Djavax.net.debug=ssl,handshake" +
+                    " -Djavatest.maxOutputSize=99999999" +
+                    " --add-opens java.base/sun.security.ssl=ALL-UNNAMED");
 
             System.out.println("test.java.opts: " +
                 System.getProperty("test.java.opts"));
@@ -97,17 +119,23 @@ public class KeyUpdateOnce extends SSLContextTemplate{
             try {
                 output.shouldContain(String.format(
                     "\"cipher suite\"        : \"%s", args[1]));
+                System.err.println("Output logs should show KeyUpdate has" +
+                    " been sent and skipped");
                 // Check client side for KeyUpdate messages (Thread-0)
                 List<String> list = output.stderrShouldContain("Thread-0")
-                    .asLines().stream().filter(s ->
-                        s.contains("KeyUpdate already send, skipping")).toList();
+                    .asLines().stream()
+                    .filter(s -> s.contains("KeyUpdate already send, skipping"))
+                    .toList();
+
                 for (String s : list) {
                     System.err.println(s);
                 }
                 System.err.println("list size = " + list.size());
-                if (list.size() == 0) {
-                    throw new AssertionError("No skipped messages seen");
+                if (list.isEmpty()) {
+                    throw new AssertionError("No KeyUpdate skipping " +
+                        "messages seen");
                 }
+
                 output.shouldContain("trigger key update");
                 output.shouldContain("KeyUpdate: write key updated");
                 output.shouldContain("KeyUpdate: read key updated");
@@ -122,35 +150,34 @@ public class KeyUpdateOnce extends SSLContextTemplate{
             return;
         }
 
-        // args[]:  0 = p, 1 = client/server, 2 = cipher suite, 3 = newLimit
-        if (args[1].compareTo("client") == 0) {
-            serverwrite = false;
-        }
-
+        // Worker mode:
+        // args[]: 0 = p, 1 = client/server, 2 = cipher suite, 3 = newLimit
+        serverWrites = !"client".equals(args[1]);
         newLimit = Long.parseLong(args[3]);
 
-        cTos = ByteBuffer.allocateDirect(dataLen*4);
-        sToc = ByteBuffer.allocateDirect(dataLen*4);
-        outdata = ByteBuffer.allocateDirect(dataLen);
+        cTos = ByteBuffer.allocateDirect(BUF_DATALEN);
+        sToc = ByteBuffer.allocateDirect(BUF_DATALEN);
+        outData = ByteBuffer.allocateDirect(DATALEN);
 
-        byte[] data  = new byte[dataLen];
-        Arrays.fill(data, (byte)0x0A);
-        outdata.put(data);
-        outdata.flip();
+        byte[] data = new byte[DATALEN];
+        Arrays.fill(data, (byte) 0x0A);
+        outData.put(data).flip();
+
         cTos.clear();
         sToc.clear();
 
-        Thread ts = new Thread(serverwrite ? new Client() :
+        Thread peer = new Thread(serverWrites ? new Client() :
             new Server(args[2]));
-        ts.start();
-        (serverwrite ? new Server(args[2]) : new Client()).run();
-        ts.interrupt();
-        ts.join();
+        peer.start();
+
+        (serverWrites ? new Server(args[2]) : new Client()).run();
+
+        peer.interrupt();
+        peer.join();
     }
 
-    private static void doTask(SSLEngineResult result,
-        SSLEngine engine) throws Exception {
-
+    private static void doTask(SSLEngineResult result, SSLEngine engine)
+        throws Exception {
         if (result.getHandshakeStatus() ==
             SSLEngineResult.HandshakeStatus.NEED_TASK) {
             Runnable runnable;
@@ -161,63 +188,64 @@ public class KeyUpdateOnce extends SSLContextTemplate{
             SSLEngineResult.HandshakeStatus hsStatus =
                 engine.getHandshakeStatus();
             if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_TASK) {
-                throw new Exception(
-                    "handshake shouldn't need additional tasks");
+                throw new Exception("handshake shouldn't need additional tasks");
             }
             print("\tnew HandshakeStatus: " + hsStatus);
         }
     }
 
-    static void print(String s) {
-        if (debug) {
+    private static void print(String s) {
+        if (DEBUG) {
             System.err.println(s);
         }
     }
 
-    static void log(String s, SSLEngineResult r) {
-        if (!debug) {
-            return;
+    private static void log(String s, SSLEngineResult r) {
+        if (DEBUG) {
+            System.err.println(s + ": " +
+                r.getStatus() + "/" + r.getHandshakeStatus() + " " +
+                r.bytesConsumed() + "/" + r.bytesProduced());
         }
-        System.err.println(s + ": " +
-            r.getStatus() + "/" + r.getHandshakeStatus()+ " " +
-            r.bytesConsumed() + "/" + r.bytesProduced() + " ");
-
     }
 
-    void write() throws Exception {
+    private static void dumpBuffers(String aName, ByteBuffer a) {
+        if (DEBUG) {
+            System.err.println(aName + " pos=" + a.position() +
+                " rem=" + a.remaining() +
+                " lim=" + a.limit() + " cap=" + a.capacity());
+        }
+    }
+
+    void writeLoop() throws Exception {
         int i = 0;
         SSLEngineResult r;
-        int countdown = 5;
+        int countdown = COUNTDOWNLIMIT;
 
         while (!ready) {
             Thread.sleep(delay);
         }
-        print("Write-side. ");
 
-        while (i++ < 150) {
+        print("Write-side begins");
+
+        while (i++ < MAXLOOPS) {
             while (sc) {
-                if (readdone) {
+                if (readDone) {
                     return;
                 }
                 Thread.sleep(delay);
             }
 
-            outdata.rewind();
-            print("write wrap");
+            outData.rewind();
 
             while (true) {
-                r = eng.wrap(outdata, getWriteBuf());
+                r = engine.wrap(outData, getWriteBuf());
                 log("write wrap", r);
-                if (debug && r.getStatus() != SSLEngineResult.Status.OK) {
-                    print("outdata pos: " + outdata.position() +
-                        " rem: " + outdata.remaining() +
-                        " lim: " + outdata.limit() +
-                        " cap: " + outdata.capacity());
-                    print("writebuf pos: " + getWriteBuf().position() +
-                        " rem: " + getWriteBuf().remaining() +
-                        " lim: " + getWriteBuf().limit() +
-                        " cap: " + getWriteBuf().capacity());
+
+                if (DEBUG && r.getStatus() != SSLEngineResult.Status.OK) {
+                    dumpBuffers("outData", outData);
+                    dumpBuffers("writeBuf", getWriteBuf());
                 }
+
                 if (r.getStatus() == SSLEngineResult.Status.OK &&
                     r.getHandshakeStatus() ==
                         SSLEngineResult.HandshakeStatus.NEED_WRAP) {
@@ -225,11 +253,14 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                 }
                 break;
             }
-            doTask(r, eng);
+
+            doTask(r, engine);
+
             getWriteBuf().flip();
             sc = true;
+
             while (sc) {
-                if (readdone) {
+                if (readDone) {
                     return;
                 }
                 Thread.sleep(delay);
@@ -243,40 +274,36 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                 countdown--;
             }
             System.err.println("Write side readLimit = " + rlimit);
-            if (countdown == 5 || countdown <= 0) {
-                buf.clear();
-                r = eng.unwrap(getReadBuf(), buf);
+
+            if (countdown == COUNTDOWNLIMIT || countdown <= 0) {
+                inData.clear();
+                r = engine.unwrap(getReadBuf(), inData);
                 log("write unwrap", r);
-                if (debug && r.getStatus() != SSLEngineResult.Status.OK) {
-                    print("buf pos: " + buf.position() +
-                        " rem: " + buf.remaining() +
-                        " lim: " + buf.limit() +
-                        " cap: " + buf.capacity());
-                    print("readbuf pos: " + getReadBuf().position() +
-                        " rem: " + getReadBuf().remaining() +
-                        " lim: " + getReadBuf().limit() +
-                        " cap:"  + getReadBuf().capacity());
+
+                if (DEBUG && r.getStatus() != SSLEngineResult.Status.OK) {
+                    dumpBuffers("inData", inData);
+                    dumpBuffers("readBuf", getReadBuf());
                 }
+            } else {
+                print("write side unwrap skipped");
             }
-            doTask(r, eng);
+
+            doTask(r, engine);
             getReadBuf().compact();
-            print("compacted readbuf pos: " + getReadBuf().position() +
-                " rem: " + getReadBuf().remaining() +
-                " lim: " + getReadBuf().limit() +
-                " cap: " + getReadBuf().capacity());
+            dumpBuffers("compacted getReadBuf()", getReadBuf());
             sc = true;
         }
     }
 
-    void read() throws Exception {
+    void readLoop() throws Exception {
         byte b = 0x0B;
-        ByteBuffer buf2 = ByteBuffer.allocateDirect(dataLen);
-        SSLEngineResult r = null;
-        boolean exit, again = true;
-        int countdown = 5;
-        boolean firstOccurance = false;
+        ByteBuffer buf = ByteBuffer.allocateDirect(DATALEN);
 
-        while (eng == null) {
+        SSLEngineResult r = null;
+        boolean again = true;
+        boolean firstNotHandshake = false;
+
+        while (engine == null) {
             Thread.sleep(delay);
         }
 
@@ -284,41 +311,39 @@ public class KeyUpdateOnce extends SSLContextTemplate{
             System.out.println("connected");
             print("entering read loop");
             ready = true;
-            while (true) {
 
+            while (true) {
                 while (!sc) {
                     Thread.sleep(delay);
                 }
 
-                print("read wrap");
-
-                exit = false;
+                boolean exit = false;
                 while (!exit) {
-                    buf2.put(b);
-                    buf2.flip();
-                    r = eng.wrap(buf2, getWriteBuf());
+                    buf.put(b);
+                    buf.flip();
+
+                    r = engine.wrap(buf, getWriteBuf());
                     log("read wrap", r);
-                    if (debug) {
-                        print("buf2 pos: " + buf2.position() +
-                            " rem: " + buf2.remaining() +
-                            " cap: " + buf2.capacity());
-                        print("writebuf pos: " + getWriteBuf().position() +
-                            " rem: " + getWriteBuf().remaining() +
-                            " cap: " + getWriteBuf().capacity());
+
+                    if (DEBUG) {
+                        dumpBuffers("buf", buf);
+                        dumpBuffers( "writeBuf", getWriteBuf());
                     }
+
                     if (again && r.getStatus() == SSLEngineResult.Status.OK &&
                         r.getHandshakeStatus() ==
                             SSLEngineResult.HandshakeStatus.NEED_WRAP) {
-                        buf2.compact();
+                        buf.compact();
                         again = false;
                         continue;
                     }
                     exit = true;
                 }
-                doTask(r, eng);
-                buf2.clear();
-                getWriteBuf().flip();
 
+                doTask(r, engine);
+
+                buf.clear();
+                getWriteBuf().flip();
                 sc = false;
 
                 while (!sc) {
@@ -326,69 +351,62 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                 }
 
                 while (true) {
-                    buf.clear();
-                    r = eng.unwrap(getReadBuf(), buf);
+                    inData.clear();
+                    r = engine.unwrap(getReadBuf(), inData);
                     log("read unwrap", r);
-                    if (debug &&
-                        r.getStatus() != SSLEngineResult.Status.OK) {
-                        print("buf pos " + buf.position() +
-                            " rem: " + buf.remaining() +
-                            " lim: " + buf.limit() +
-                            " cap: " + buf.capacity());
-                        print("readbuf pos: " + getReadBuf().position() +
-                            " rem: " + getReadBuf().remaining() +
-                            " lim: " + getReadBuf().limit() +
-                            " cap: " + getReadBuf().capacity());
-                        doTask(r, eng);
+
+                    if (DEBUG && r.getStatus() != SSLEngineResult.Status.OK) {
+                        dumpBuffers("inData", inData);
+                        dumpBuffers("readBuf", getReadBuf());
+
+                        doTask(r, engine);
                     }
 
                     if (again && r.getStatus() == SSLEngineResult.Status.OK &&
                         r.getHandshakeStatus() ==
                             SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
-                        buf.clear();
+                        inData.clear();
                         print("again");
                         again = false;
                         continue;
-
                     }
                     break;
                 }
-                buf.clear();
+
+                inData.clear();
                 getReadBuf().compact();
 
                 totalDataLen += r.bytesProduced();
                 sc = false;
-                System.err.println("rstatus = " + r.getHandshakeStatus());
-                if (!firstOccurance &&
-                    r.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
-                    if (countdown == 0) {
-                        try {
-                            readSideInputRecord = getInputRecord(eng);
-                            setReadLimit(readSideInputRecord, newLimit);
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        }
-                        System.err.println("Resetting readside");
-                        firstOccurance = true;
 
+                if (!firstNotHandshake &&
+                    r.getHandshakeStatus() ==
+                        SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+
+                    try {
+                        readSideInputRecord = getInputRecord(engine);
+                        setReadLimit(readSideInputRecord, newLimit);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
                     }
-                    countdown--;
+                    System.err.println("Resetting readside");
+                    firstNotHandshake = true;
                 }
             }
         } catch (Exception e) {
             sc = false;
-            readdone = true;
+            readDone = true;
+
             System.out.println(e.getMessage());
             e.printStackTrace();
             System.out.println("Total data read = " + totalDataLen);
         }
     }
 
-    static Object readSideInputRecord  = null;
+    // Overridden in Server/Client
     ByteBuffer getReadBuf() {
         return null;
     }
-
     ByteBuffer getWriteBuf() {
         return null;
     }
@@ -403,25 +421,28 @@ public class KeyUpdateOnce extends SSLContextTemplate{
     }
 
     static Object getInputRecord(SSLEngine eng) throws Exception {
-        Class<?> Cls = Class.forName("sun.security.ssl.SSLEngineImpl");
-        var conContext = getPrivate(eng, Cls, "conContext");
+        Class<?> engineImplCls = Class.forName("sun.security.ssl.SSLEngineImpl");
+        Object conContext = getPrivate(eng, engineImplCls, "conContext");
+
         Class<?> transportCtxCls = Class.forName("sun.security.ssl.TransportContext");
         return getPrivate(conContext, transportCtxCls, "inputRecord");
     }
 
     static void setReadLimit(Object inputRecord, long newCountdown) throws Exception {
         Class<?> inputRecordCls = Class.forName("sun.security.ssl.InputRecord");
-        var readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
-        var sslReadCipher = readCipher.getClass().getSuperclass();
-        Field f = getField(sslReadCipher,"keyLimitCountdown");
+        Object readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
+        Class<?> sslReadCipher = readCipher.getClass().getSuperclass();
+
+        Field f = getField(sslReadCipher, "keyLimitCountdown");
         f.setLong(readCipher, newCountdown);
     }
 
     static long getReadLimit(Object inputRecord) throws Exception {
         Class<?> inputRecordCls = Class.forName("sun.security.ssl.InputRecord");
-        var readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
-        var sslReadCipher = readCipher.getClass().getSuperclass();
-        Field f = getField(sslReadCipher,"keyLimitCountdown");
+        Object readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
+        Class<?> sslReadCipher = readCipher.getClass().getSuperclass();
+
+        Field f = getField(sslReadCipher, "keyLimitCountdown");
         return f.getLong(readCipher);
     }
 
@@ -438,24 +459,25 @@ public class KeyUpdateOnce extends SSLContextTemplate{
     static class Server extends KeyUpdateOnce implements Runnable {
         Server(String cipherSuite) throws Exception {
             super();
-            eng = initContext().createSSLEngine();
-            eng.setUseClientMode(false);
-            eng.setNeedClientAuth(true);
+            engine = initContext().createSSLEngine();
+            engine.setUseClientMode(false);
+            engine.setNeedClientAuth(true);
+
             if (cipherSuite != null && !cipherSuite.isEmpty()) {
-                eng.setEnabledCipherSuites(new String[] { cipherSuite });
+                engine.setEnabledCipherSuites(new String[] { cipherSuite });
             }
         }
 
+        @Override
         public void run() {
             try {
-                if (serverwrite) {
-                    write();
+                if (serverWrites) {
+                    writeLoop();
                 } else {
-                    read();
+                    readLoop();
                 }
-
             } catch (Exception e) {
-                    System.out.println("server: " + e.getMessage());
+                System.out.println("server: " + e.getMessage());
                 e.printStackTrace();
             }
             System.out.println("Server closed");
@@ -463,28 +485,29 @@ public class KeyUpdateOnce extends SSLContextTemplate{
 
         @Override
         ByteBuffer getWriteBuf() {
-                return sToc;
-            }
+            return sToc;
+        }
+
         @Override
         ByteBuffer getReadBuf() {
-                return cTos;
-            }
+            return cTos;
+        }
     }
-
 
     static class Client extends KeyUpdateOnce implements Runnable {
         Client() throws Exception {
             super();
-            eng = initContext().createSSLEngine();
-            eng.setUseClientMode(true);
+            engine = initContext().createSSLEngine();
+            engine.setUseClientMode(true);
         }
 
+        @Override
         public void run() {
             try {
-                if (!serverwrite) {
-                    write();
+                if (!serverWrites) {
+                    writeLoop();
                 } else {
-                    read();
+                    readLoop();
                 }
             } catch (Exception e) {
                 System.out.println("client: " + e.getMessage());
@@ -492,14 +515,15 @@ public class KeyUpdateOnce extends SSLContextTemplate{
             }
             System.out.println("Client closed");
         }
+
         @Override
         ByteBuffer getWriteBuf() {
-                return cTos;
-            }
+            return cTos;
+        }
+
         @Override
         ByteBuffer getReadBuf() {
-                return sToc;
-            }
+            return sToc;
+        }
     }
-
 }

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
@@ -1,0 +1,630 @@
+/*
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8164879 8300285
+ * @library ../../
+ *          /test/lib
+ *          /javax/net/ssl/templates
+ * @summary Verify AEAD TLS cipher suite limits set in the jdk.tls.keyLimits
+ * property
+ * start a new handshake sequence to renegotiate the symmetric key with an
+ * SSLSocket connection.  This test verifies the handshake method was called
+ * via debugging info.  It does not verify the renegotiation was successful
+ * as that is very hard.
+ *
+ * @run main KeyUpdateOnce 0 server TLS_AES_256_GCM_SHA384
+ *
+ */
+
+/*
+ * This test runs in another process so we can monitor the debug
+ * results.  The OutputAnalyzer must see correct debug output to return a
+ * success.
+ */
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLSocket;
+import java.io.File;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+public class KeyUpdateOnce extends SSLContextTemplate{
+        SSLEngine eng;
+        static ByteBuffer cTos;
+        static ByteBuffer sToc;
+        static ByteBuffer outdata;
+        ByteBuffer buf;
+        static boolean ready = false;
+        static int dataLen = 10240;
+        static boolean serverwrite = true;
+        int totalDataLen = 0;
+        static boolean sc = true;
+        int delay = 1;
+        static boolean readdone = false;
+
+        static int READSIDELIMIT = 200000;
+        static int WRITESIDELIMIT = 370000;
+
+        // Turn on debugging
+        static boolean debug = true;
+
+        KeyUpdateOnce() {
+            buf = ByteBuffer.allocate(dataLen * 4);
+        }
+        /**
+         * args should have two values:  server|client, cipher suite, <limit size>
+         * Prepending 'p' is for internal use only.
+         */
+        public static void main(String args[]) throws Exception {
+
+        for (int i = 0; i < args.length; i++) {
+            System.out.print(" " + args[i]);
+        }
+        System.out.println();
+        if (args[0].compareTo("p") != 0) {
+            boolean expectedFail = (Integer.parseInt(args[0]) == 1);
+            if (expectedFail) {
+                System.out.println("Test expected to not find updated msg");
+            }
+
+            // Write security property file to overwrite default
+            //File f = new File("keyusage."+ System.nanoTime());
+            //PrintWriter p = new PrintWriter(f);
+            //p.write("jdk.tls.keyLimits= AES/GCM/NoPadding keyupdate " + WRITESIDELIMIT);
+            //p.close();
+
+            System.setProperty("test.java.opts", System.getProperty("test.java.opts") +
+                " -Dtest.src=" + System.getProperty("test.src") +
+                " -Dtest.jdk=" + System.getProperty("test.jdk") +
+                " -Djavax.net.debug=ssl,handshake -Djavatest.maxOutputSize=99999999" +
+                " --add-opens java.base/sun.security.ssl=ALL-UNNAMED"
+                //" -Djava.security.properties=" + f.getName());
+                              );
+
+            System.out.println("test.java.opts: " +
+                System.getProperty("test.java.opts"));
+
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Utils.addTestJavaOpts("KeyUpdateOnce", "p", args[1],
+                    args[2]));
+
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            try {
+                output.shouldContain(String.format(
+                    "\"cipher suite\"        : \"%s", args[2]));
+                if (expectedFail) {
+                    output.shouldNotContain("KeyUpdate: write key updated");
+                    output.shouldNotContain("KeyUpdate: read key updated");
+                } else {
+                    //javax.net.ssl|DEBUG|81|Thread-0|2025-12-05 09:22:14.279 PST|KeyUpdate.java:280|Produced KeyUpdate post-handshake message
+                    List<String> list = output.stderrShouldContain("Thread-0")
+                        .asLines().stream().filter(s ->
+                            s.contains("Produced KeyUpdate post-handshake message")).toList();
+                    for (String s : list) {
+                        System.err.println(s);
+                    }
+                    System.err.println("list size = " + list.size());
+                    output.shouldContain("trigger key update");
+                    output.shouldContain("KeyUpdate: write key updated");
+                    output.shouldContain("KeyUpdate: read key updated");
+                }
+            } catch (Exception e) {
+                throw e;
+            } finally {
+                System.out.println("-- BEGIN Stdout:");
+                System.out.println(output.getStdout());
+                System.out.println("-- END Stdout");
+                System.out.println("-- BEGIN Stderr:");
+                System.out.println(output.getStderr());
+                System.out.println("-- END Stderr");
+            }
+            return;
+        }
+
+        if (args[0].compareTo("p") != 0) {
+            throw new Exception ("Tried to run outside of a spawned process");
+        }
+
+        if (args[1].compareTo("client") == 0) {
+            serverwrite = false;
+        }
+
+        cTos = ByteBuffer.allocateDirect(dataLen*4);
+        sToc = ByteBuffer.allocateDirect(dataLen*4);
+        outdata = ByteBuffer.allocateDirect(dataLen);
+
+        byte[] data  = new byte[dataLen];
+        Arrays.fill(data, (byte)0x0A);
+        outdata.put(data);
+        outdata.flip();
+        cTos.clear();
+        sToc.clear();
+
+        Thread ts = new Thread(serverwrite ? new Client() :
+            new Server(args[2]));
+        ts.start();
+        (serverwrite ? new Server(args[2]) : new Client()).run();
+        ts.interrupt();
+        ts.join();
+    }
+
+    private static void doTask(SSLEngineResult result,
+        SSLEngine engine) throws Exception {
+
+        if (result.getHandshakeStatus() ==
+            SSLEngineResult.HandshakeStatus.NEED_TASK) {
+            Runnable runnable;
+            while ((runnable = engine.getDelegatedTask()) != null) {
+                print("\trunning delegated task...");
+                runnable.run();
+            }
+            SSLEngineResult.HandshakeStatus hsStatus =
+                engine.getHandshakeStatus();
+            if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                throw new Exception(
+                    "handshake shouldn't need additional tasks");
+            }
+            print("\tnew HandshakeStatus: " + hsStatus);
+        }
+    }
+
+    static void print(String s) {
+        if (debug) {
+            System.err.println(s);
+        }
+    }
+
+    static void log(String s, SSLEngineResult r) {
+        if (!debug) {
+            return;
+        }
+        System.err.println(s + ": " +
+            r.getStatus() + "/" + r.getHandshakeStatus()+ " " +
+            r.bytesConsumed() + "/" + r.bytesProduced() + " ");
+
+    }
+
+    void write() throws Exception {
+        int i = 0;
+        SSLEngineResult r;
+        boolean again = true;
+        int countdown = 5;
+
+        while (!ready) {
+            Thread.sleep(delay);
+        }
+        print("Write-side. ");
+
+        while (i++ < 150) {
+            while (sc) {
+                if (readdone) {
+                    return;
+                }
+                Thread.sleep(delay);
+            }
+
+            outdata.rewind();
+            print("write wrap");
+
+            while (true) {
+                r = eng.wrap(outdata, getWriteBuf());
+                log("write wrap", r);
+                if (debug && r.getStatus() != SSLEngineResult.Status.OK) {
+                    print("outdata pos: " + outdata.position() +
+                        " rem: " + outdata.remaining() +
+                        " lim: " + outdata.limit() +
+                        " cap: " + outdata.capacity());
+                    print("writebuf pos: " + getWriteBuf().position() +
+                        " rem: " + getWriteBuf().remaining() +
+                        " lim: " + getWriteBuf().limit() +
+                        " cap: " + getWriteBuf().capacity());
+                }
+                if (again && r.getStatus() == SSLEngineResult.Status.OK &&
+                    r.getHandshakeStatus() ==
+                        SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                    //print("again");
+                    //again = false;
+                    continue;
+                }
+                break;
+            }
+            doTask(r, eng);
+            getWriteBuf().flip();
+            sc = true;
+            while (sc) {
+                if (readdone) {
+                    return;
+                }
+                Thread.sleep(delay);
+            }
+
+            // XXX  Maybe check put the reflecion value of read-side keyLimitCountdown, then when it goes negative,
+            // skip the unwrap operation?  Have to remove the half-open on the readside.
+            long rlimit = Long.MAX_VALUE;
+            if (readSideInputRecord != null) {
+                rlimit = getReadLimit(readSideInputRecord);
+            }
+            if (rlimit <= 0) {
+                countdown--;
+            }
+            System.err.println("Write side readLimit = " + rlimit);
+            while (countdown == 5 || countdown <= 0) {
+                buf.clear();
+                r = eng.unwrap(getReadBuf(), buf);
+                log("write unwrap", r);
+                if (debug && r.getStatus() != SSLEngineResult.Status.OK) {
+                    print("buf pos: " + buf.position() +
+                        " rem: " + buf.remaining() +
+                        " lim: " + buf.limit() +
+                        " cap: " + buf.capacity());
+                    print("readbuf pos: " + getReadBuf().position() +
+                        " rem: " + getReadBuf().remaining() +
+                        " lim: " + getReadBuf().limit() +
+                        " cap:"  + getReadBuf().capacity());
+                }
+                break;
+            }
+            doTask(r, eng);
+            getReadBuf().compact();
+            print("compacted readbuf pos: " + getReadBuf().position() +
+                " rem: " + getReadBuf().remaining() +
+                " lim: " + getReadBuf().limit() +
+                " cap: " + getReadBuf().capacity());
+            sc = true;
+        }
+    }
+
+    void read() throws Exception {
+        byte b = 0x0B;
+        ByteBuffer buf2 = ByteBuffer.allocateDirect(dataLen);
+        SSLEngineResult r = null;
+        boolean exit, again = true;
+        int countdown = 5;
+        boolean firstOccurance = false;
+
+        while (eng == null) {
+            Thread.sleep(delay);
+        }
+
+        try {
+            System.out.println("connected");
+            print("entering read loop");
+            ready = true;
+            while (true) {
+
+                while (!sc) {
+                    Thread.sleep(delay);
+                }
+
+                print("read wrap");
+
+                exit = false;
+                while (!exit) {
+                    buf2.put(b);
+                    buf2.flip();
+                    r = eng.wrap(buf2, getWriteBuf());
+                    log("read wrap", r);
+                    if (debug) {
+                        // && r.getStatus() != SSLEngineResult.Status.OK) {
+                        print("buf2 pos: " + buf2.position() +
+                            " rem: " + buf2.remaining() +
+                            " cap: " + buf2.capacity());
+                        print("writebuf pos: " + getWriteBuf().position() +
+                            " rem: " + getWriteBuf().remaining() +
+                            " cap: " + getWriteBuf().capacity());
+                    }
+                    if (again && r.getStatus() == SSLEngineResult.Status.OK &&
+                        r.getHandshakeStatus() ==
+                            SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+                        buf2.compact();
+                        again = false;
+                        continue;
+                    }
+                    exit = true;
+                }
+                doTask(r, eng);
+                buf2.clear();
+                getWriteBuf().flip();
+
+                sc = false;
+
+                while (!sc) {
+                    Thread.sleep(delay);
+                }
+
+                while (true) {
+                    buf.clear();
+                    r = eng.unwrap(getReadBuf(), buf);
+                    log("read unwrap", r);
+                    if (debug &&
+                        r.getStatus() != SSLEngineResult.Status.OK) {
+                        print("buf pos " + buf.position() +
+                            " rem: " + buf.remaining() +
+                            " lim: " + buf.limit() +
+                            " cap: " + buf.capacity());
+                        print("readbuf pos: " + getReadBuf().position() +
+                            " rem: " + getReadBuf().remaining() +
+                            " lim: " + getReadBuf().limit() +
+                            " cap: " + getReadBuf().capacity());
+                        doTask(r, eng);
+                    }
+
+                    if (again && r.getStatus() == SSLEngineResult.Status.OK &&
+                        r.getHandshakeStatus() ==
+                            SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+                        buf.clear();
+                        print("again");
+                        again = false;
+                        continue;
+
+                    }
+                    break;
+                }
+                buf.clear();
+                getReadBuf().compact();
+
+                totalDataLen += r.bytesProduced();
+                sc = false;
+                if (r != null) {
+                    System.err.println("rstatus = " + r.getHandshakeStatus());
+                    if (r != null && !firstOccurance &&
+                        r.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+                        if (countdown == 0) {
+                            try {
+                                //forceKeyLimitViaReflection(eng, 200000);
+                                readSideInputRecord = getInputRecord(eng);
+                                setReadLimit(readSideInputRecord, 200000);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                            System.err.println("Resetting readside");
+                            firstOccurance = true;
+                            //eng.closeOutbound();
+                            /*
+                            while (true) {
+                                Thread.sleep(delay);
+                                System.err.println("read side off");
+                                sc = false;
+                            }
+
+                            */
+                        }
+                        countdown--;
+                    }
+                } else {
+                    System.err.println("rstatus = null");
+                }
+            }
+        } catch (Exception e) {
+            sc = false;
+            readdone = true;
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            System.out.println("Total data read = " + totalDataLen);
+        }
+    }
+
+    static Object readSideInputRecord  = null;
+    ByteBuffer getReadBuf() {
+        return null;
+    }
+
+    ByteBuffer getWriteBuf() {
+        return null;
+    }
+
+
+    SSLContext initContext() throws Exception {
+        return createServerSSLContext();
+    }
+
+    @Override
+    protected SSLContextTemplate.ContextParameters getServerContextParameters() {
+        return new SSLContextTemplate.ContextParameters("TLSv1.3", "PKIX", "NewSunX509");
+    }
+
+    static Object getInputRecord(SSLEngine eng) throws Exception {
+        Class<?> Cls = Class.forName("sun.security.ssl.SSLEngineImpl");
+        var conContext = getPrivate(eng, Cls, "conContext");
+        Class<?> transportCtxCls = Class.forName("sun.security.ssl.TransportContext");
+        return getPrivate(conContext, transportCtxCls, "inputRecord");
+    }
+
+    static void setReadLimit(Object inputRecord, long newCountdown) throws Exception {
+        Class<?> inputRecordCls = Class.forName("sun.security.ssl.InputRecord");
+        var readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
+        var sslReadCipher = readCipher.getClass().getSuperclass();
+        Field f = getField(sslReadCipher,"keyLimitCountdown");
+        f.setLong(readCipher, newCountdown);
+    }
+
+    static long getReadLimit(Object inputRecord) throws Exception {
+        Class<?> inputRecordCls = Class.forName("sun.security.ssl.InputRecord");
+        var readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
+        var sslReadCipher = readCipher.getClass().getSuperclass();
+        Field f = getField(sslReadCipher,"keyLimitCountdown");
+        return f.getLong(readCipher);
+    }
+
+    static void forceKeyLimitViaReflection(SSLEngine sslSocket, long newCountdown) throws Exception {
+        // Requires: --add-opens java.base/sun.security.ssl=ALL-UNNAMED
+            Class<?> Cls = Class.forName("sun.security.ssl.SSLEngineImpl");
+        if (!Cls.isInstance(sslSocket)) {
+            throw new IllegalStateException("Not a sun.security.ssl.SSLSocketImpl at runtime.");
+        }
+
+        // SSLSocketImpl -> conContext (TransportContext)
+        var conContext = getPrivate(sslSocket, Cls, "conContext");
+
+        // TransportContext -> inputRecord, outputRecord
+        Class<?> transportCtxCls = Class.forName("sun.security.ssl.TransportContext");
+        var inputRecord = getPrivate(conContext, transportCtxCls, "inputRecord");
+        var outputRecord = getPrivate(conContext, transportCtxCls, "outputRecord");
+
+        Class<?> inputRecordCls = Class.forName("sun.security.ssl.InputRecord");
+        System.err.println("inputRecord " + (inputRecord == null ? "null" : inputRecord));
+        System.err.println("outputRecord " + (outputRecord == null ? "null" : outputRecord));
+        // InputRecord/OutputRecord -> readCipher/writeCipher (names differ across updates; try both)
+        //Class<?> readCipherCls = Class.forName("sun.security.ssl.SSLCipher.SSLReadCipher");
+        Object readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
+        System.err.println(readCipher.getClass());
+        System.err.println(readCipher.getClass().getSuperclass());
+        var sslReadCipher = readCipher.getClass().getSuperclass();
+        //var readCipher = getField(inputRecord.getClass(), "readCipher");
+        //var readCipher = tryGetAny(inputRecord, new String[]{"readCipher", "readCipherBox", "readCipherState"});
+        var writeCipher = tryGetAny(outputRecord, new String[]{"writeCipher", "writeCipherBox", "writeCipherState"});
+        // SSLCipher$SSLReadCipher / SSLCipher$SSLWriteCipher -> keyLimitEnabled=true; keyLimitCountdown=<value>
+        if (readCipher != null) {
+//            setBoolean(readCipher, "keyLimitEnabled", true);
+            Field f = getField(sslReadCipher,"keyLimitCountdown");
+            f.setLong(readCipher, newCountdown);
+            //setLong(readCipher, "keyLimitCountdown", newCountdown);
+            System.err.println("readCipher.keyLimit set to " + newCountdown);
+        } else {
+            System.err.println("readCipher is null");
+        }
+        if (writeCipher != null) {
+            setBoolean(writeCipher, "keyLimitEnabled", true);
+            setLong(writeCipher, "keyLimitCountdown", newCountdown);
+        } else {
+            System.err.println("writeCipher is null");
+        }
+    }
+
+    private static Field getField(Class<?> type, String name) throws Exception {
+        Field f = type.getDeclaredField(name);
+        f.setAccessible(true); // requires --add-opens for sun.security.ssl
+        return f;
+    }
+
+    private static Object getPrivate(Object target, Class<?> owner, String name) throws Exception {
+        return getField(owner, name).get(target);
+    }
+
+    private static void setBoolean(Object target, String name, boolean v) throws Exception {
+        Field f = getField(target.getClass(), name);
+        if (f.getType() != boolean.class) throw new NoSuchFieldException(name);
+        f.setBoolean(target, v);
+    }
+
+    private static void setLong(Object target, String name, long v) throws Exception {
+        Field f = getField(target.getClass(), name);
+        if (f.getType() != long.class) throw new NoSuchFieldException(name);
+        f.setLong(target, v);
+    }
+
+    private static Object tryGetAny(Object holder, String[] names) throws Exception {
+        if (holder == null) return null;
+        Class<?> c = holder.getClass();
+        for (String n : names) {
+            System.err.println("name: " + n);
+            try {
+                Field f = getField(c, n);
+                return f.get(holder);
+            } catch (NoSuchFieldException e) {
+                System.err.println("exception: " + e.getMessage());
+            }
+        }
+        return null;
+    }
+
+
+    static class Server extends KeyUpdateOnce implements Runnable {
+        Server(String cipherSuite) throws Exception {
+            super();
+            eng = initContext().createSSLEngine();
+            eng.setUseClientMode(false);
+            eng.setNeedClientAuth(true);
+            if (cipherSuite != null && cipherSuite.length() > 0) {
+                eng.setEnabledCipherSuites(new String[] { cipherSuite });
+            }
+        }
+
+        public void run() {
+            try {
+                if (serverwrite) {
+                    write();
+                } else {
+                    read();
+                }
+
+            } catch (Exception e) {
+                    System.out.println("server: " + e.getMessage());
+                e.printStackTrace();
+            }
+            System.out.println("Server closed");
+        }
+
+        @Override
+        ByteBuffer getWriteBuf() {
+                return sToc;
+            }
+        @Override
+        ByteBuffer getReadBuf() {
+                return cTos;
+            }
+    }
+
+
+    static class Client extends KeyUpdateOnce implements Runnable {
+        Client() throws Exception {
+            super();
+            eng = initContext().createSSLEngine();
+            eng.setUseClientMode(true);
+        }
+
+        public void run() {
+            try {
+                if (!serverwrite) {
+                    write();
+                } else {
+                    read();
+                }
+            } catch (Exception e) {
+                System.out.println("client: " + e.getMessage());
+                e.printStackTrace();
+            }
+            System.out.println("Client closed");
+        }
+        @Override
+        ByteBuffer getWriteBuf() {
+                return cTos;
+            }
+        @Override
+        ByteBuffer getReadBuf() {
+                return sToc;
+            }
+    }
+
+}

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
@@ -100,11 +100,14 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                 // Check client side for KeyUpdate messages (Thread-0)
                 List<String> list = output.stderrShouldContain("Thread-0")
                     .asLines().stream().filter(s ->
-                        s.contains("Produced KeyUpdate post-handshake message")).toList();
+                        s.contains("KeyUpdate already send, skipping")).toList();
                 for (String s : list) {
                     System.err.println(s);
                 }
                 System.err.println("list size = " + list.size());
+                if (list.size() == 0) {
+                    throw new AssertionError("No skipped messages seen");
+                }
                 output.shouldContain("trigger key update");
                 output.shouldContain("KeyUpdate: write key updated");
                 output.shouldContain("KeyUpdate: read key updated");

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
@@ -23,19 +23,13 @@
 
 /*
  * @test
- * @bug 8164879 8300285
+ * @bug 8329548
  * @library ../../
  *          /test/lib
  *          /javax/net/ssl/templates
- * @summary Verify AEAD TLS cipher suite limits set in the jdk.tls.keyLimits
- * property
- * start a new handshake sequence to renegotiate the symmetric key with an
- * SSLSocket connection.  This test verifies the handshake method was called
- * via debugging info.  It does not verify the renegotiation was successful
- * as that is very hard.
+ * @summary Verify one KeyUpdate message is sent
  *
- * @run main KeyUpdateOnce 0 server TLS_AES_256_GCM_SHA384
- *
+ * @run main KeyUpdateOnce server TLS_AES_256_GCM_SHA384 200000
  */
 
 /*
@@ -51,96 +45,69 @@ import jdk.test.lib.process.ProcessTools;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
-import javax.net.ssl.SSLSocket;
-import java.io.File;
-import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
 public class KeyUpdateOnce extends SSLContextTemplate{
-        SSLEngine eng;
-        static ByteBuffer cTos;
-        static ByteBuffer sToc;
-        static ByteBuffer outdata;
-        ByteBuffer buf;
-        static boolean ready = false;
-        static int dataLen = 10240;
-        static boolean serverwrite = true;
-        int totalDataLen = 0;
-        static boolean sc = true;
-        int delay = 1;
-        static boolean readdone = false;
+    SSLEngine eng;
+    static ByteBuffer cTos, sToc, outdata;
+    ByteBuffer buf;
+    static boolean ready = false;
+    static int dataLen = 10240;
+    static boolean serverwrite = true;
+    int totalDataLen = 0;
+    static boolean sc = true;
+    int delay = 1;
+    static boolean readdone = false;
+    static long newLimit;
 
-        static int READSIDELIMIT = 200000;
-        static int WRITESIDELIMIT = 370000;
+    // Turn on debugging
+    static boolean debug = true;
 
-        // Turn on debugging
-        static boolean debug = true;
-
-        KeyUpdateOnce() {
-            buf = ByteBuffer.allocate(dataLen * 4);
-        }
-        /**
-         * args should have two values:  server|client, cipher suite, <limit size>
-         * Prepending 'p' is for internal use only.
-         */
-        public static void main(String args[]) throws Exception {
-
-        for (int i = 0; i < args.length; i++) {
-            System.out.print(" " + args[i]);
+    KeyUpdateOnce() {
+        buf = ByteBuffer.allocate(dataLen * 4);
+    }
+    /**
+     * args should have two values:  server|client, cipher suite, <limit size>
+     * Prepending 'p' is for internal use only.
+     */
+    public static void main(String[] args) throws Exception {
+        for (String arg : args) {
+            System.out.print(" " + arg);
         }
         System.out.println();
         if (args[0].compareTo("p") != 0) {
-            boolean expectedFail = (Integer.parseInt(args[0]) == 1);
-            if (expectedFail) {
-                System.out.println("Test expected to not find updated msg");
-            }
-
-            // Write security property file to overwrite default
-            //File f = new File("keyusage."+ System.nanoTime());
-            //PrintWriter p = new PrintWriter(f);
-            //p.write("jdk.tls.keyLimits= AES/GCM/NoPadding keyupdate " + WRITESIDELIMIT);
-            //p.close();
-
+            // args[]: 0 = client/server, 1 = cipher suite, 2 = newLimit
             System.setProperty("test.java.opts", System.getProperty("test.java.opts") +
                 " -Dtest.src=" + System.getProperty("test.src") +
                 " -Dtest.jdk=" + System.getProperty("test.jdk") +
                 " -Djavax.net.debug=ssl,handshake -Djavatest.maxOutputSize=99999999" +
-                " --add-opens java.base/sun.security.ssl=ALL-UNNAMED"
-                //" -Djava.security.properties=" + f.getName());
-                              );
+                " --add-opens java.base/sun.security.ssl=ALL-UNNAMED");
 
             System.out.println("test.java.opts: " +
                 System.getProperty("test.java.opts"));
 
             ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                Utils.addTestJavaOpts("KeyUpdateOnce", "p", args[1],
-                    args[2]));
+                Utils.addTestJavaOpts("KeyUpdateOnce", "p", args[0],
+                    args[1], args[2]));
 
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
             try {
                 output.shouldContain(String.format(
-                    "\"cipher suite\"        : \"%s", args[2]));
-                if (expectedFail) {
-                    output.shouldNotContain("KeyUpdate: write key updated");
-                    output.shouldNotContain("KeyUpdate: read key updated");
-                } else {
-                    //javax.net.ssl|DEBUG|81|Thread-0|2025-12-05 09:22:14.279 PST|KeyUpdate.java:280|Produced KeyUpdate post-handshake message
-                    List<String> list = output.stderrShouldContain("Thread-0")
-                        .asLines().stream().filter(s ->
-                            s.contains("Produced KeyUpdate post-handshake message")).toList();
-                    for (String s : list) {
-                        System.err.println(s);
-                    }
-                    System.err.println("list size = " + list.size());
-                    output.shouldContain("trigger key update");
-                    output.shouldContain("KeyUpdate: write key updated");
-                    output.shouldContain("KeyUpdate: read key updated");
+                    "\"cipher suite\"        : \"%s", args[1]));
+                // Check client side for KeyUpdate messages (Thread-0)
+                List<String> list = output.stderrShouldContain("Thread-0")
+                    .asLines().stream().filter(s ->
+                        s.contains("Produced KeyUpdate post-handshake message")).toList();
+                for (String s : list) {
+                    System.err.println(s);
                 }
-            } catch (Exception e) {
-                throw e;
+                System.err.println("list size = " + list.size());
+                output.shouldContain("trigger key update");
+                output.shouldContain("KeyUpdate: write key updated");
+                output.shouldContain("KeyUpdate: read key updated");
             } finally {
                 System.out.println("-- BEGIN Stdout:");
                 System.out.println(output.getStdout());
@@ -152,13 +119,12 @@ public class KeyUpdateOnce extends SSLContextTemplate{
             return;
         }
 
-        if (args[0].compareTo("p") != 0) {
-            throw new Exception ("Tried to run outside of a spawned process");
-        }
-
+        // args[]:  0 = p, 1 = client/server, 2 = cipher suite, 3 = newLimit
         if (args[1].compareTo("client") == 0) {
             serverwrite = false;
         }
+
+        newLimit = Long.parseLong(args[3]);
 
         cTos = ByteBuffer.allocateDirect(dataLen*4);
         sToc = ByteBuffer.allocateDirect(dataLen*4);
@@ -218,7 +184,6 @@ public class KeyUpdateOnce extends SSLContextTemplate{
     void write() throws Exception {
         int i = 0;
         SSLEngineResult r;
-        boolean again = true;
         int countdown = 5;
 
         while (!ready) {
@@ -250,11 +215,9 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                         " lim: " + getWriteBuf().limit() +
                         " cap: " + getWriteBuf().capacity());
                 }
-                if (again && r.getStatus() == SSLEngineResult.Status.OK &&
+                if (r.getStatus() == SSLEngineResult.Status.OK &&
                     r.getHandshakeStatus() ==
                         SSLEngineResult.HandshakeStatus.NEED_WRAP) {
-                    //print("again");
-                    //again = false;
                     continue;
                 }
                 break;
@@ -269,8 +232,6 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                 Thread.sleep(delay);
             }
 
-            // XXX  Maybe check put the reflecion value of read-side keyLimitCountdown, then when it goes negative,
-            // skip the unwrap operation?  Have to remove the half-open on the readside.
             long rlimit = Long.MAX_VALUE;
             if (readSideInputRecord != null) {
                 rlimit = getReadLimit(readSideInputRecord);
@@ -279,7 +240,7 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                 countdown--;
             }
             System.err.println("Write side readLimit = " + rlimit);
-            while (countdown == 5 || countdown <= 0) {
+            if (countdown == 5 || countdown <= 0) {
                 buf.clear();
                 r = eng.unwrap(getReadBuf(), buf);
                 log("write unwrap", r);
@@ -293,7 +254,6 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                         " lim: " + getReadBuf().limit() +
                         " cap:"  + getReadBuf().capacity());
                 }
-                break;
             }
             doTask(r, eng);
             getReadBuf().compact();
@@ -336,7 +296,6 @@ public class KeyUpdateOnce extends SSLContextTemplate{
                     r = eng.wrap(buf2, getWriteBuf());
                     log("read wrap", r);
                     if (debug) {
-                        // && r.getStatus() != SSLEngineResult.Status.OK) {
                         print("buf2 pos: " + buf2.position() +
                             " rem: " + buf2.remaining() +
                             " cap: " + buf2.capacity());
@@ -396,34 +355,21 @@ public class KeyUpdateOnce extends SSLContextTemplate{
 
                 totalDataLen += r.bytesProduced();
                 sc = false;
-                if (r != null) {
-                    System.err.println("rstatus = " + r.getHandshakeStatus());
-                    if (r != null && !firstOccurance &&
-                        r.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
-                        if (countdown == 0) {
-                            try {
-                                //forceKeyLimitViaReflection(eng, 200000);
-                                readSideInputRecord = getInputRecord(eng);
-                                setReadLimit(readSideInputRecord, 200000);
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            }
-                            System.err.println("Resetting readside");
-                            firstOccurance = true;
-                            //eng.closeOutbound();
-                            /*
-                            while (true) {
-                                Thread.sleep(delay);
-                                System.err.println("read side off");
-                                sc = false;
-                            }
-
-                            */
+                System.err.println("rstatus = " + r.getHandshakeStatus());
+                if (!firstOccurance &&
+                    r.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+                    if (countdown == 0) {
+                        try {
+                            readSideInputRecord = getInputRecord(eng);
+                            setReadLimit(readSideInputRecord, newLimit);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
                         }
-                        countdown--;
+                        System.err.println("Resetting readside");
+                        firstOccurance = true;
+
                     }
-                } else {
-                    System.err.println("rstatus = null");
+                    countdown--;
                 }
             }
         } catch (Exception e) {
@@ -443,7 +389,6 @@ public class KeyUpdateOnce extends SSLContextTemplate{
     ByteBuffer getWriteBuf() {
         return null;
     }
-
 
     SSLContext initContext() throws Exception {
         return createServerSSLContext();
@@ -477,51 +422,6 @@ public class KeyUpdateOnce extends SSLContextTemplate{
         return f.getLong(readCipher);
     }
 
-    static void forceKeyLimitViaReflection(SSLEngine sslSocket, long newCountdown) throws Exception {
-        // Requires: --add-opens java.base/sun.security.ssl=ALL-UNNAMED
-            Class<?> Cls = Class.forName("sun.security.ssl.SSLEngineImpl");
-        if (!Cls.isInstance(sslSocket)) {
-            throw new IllegalStateException("Not a sun.security.ssl.SSLSocketImpl at runtime.");
-        }
-
-        // SSLSocketImpl -> conContext (TransportContext)
-        var conContext = getPrivate(sslSocket, Cls, "conContext");
-
-        // TransportContext -> inputRecord, outputRecord
-        Class<?> transportCtxCls = Class.forName("sun.security.ssl.TransportContext");
-        var inputRecord = getPrivate(conContext, transportCtxCls, "inputRecord");
-        var outputRecord = getPrivate(conContext, transportCtxCls, "outputRecord");
-
-        Class<?> inputRecordCls = Class.forName("sun.security.ssl.InputRecord");
-        System.err.println("inputRecord " + (inputRecord == null ? "null" : inputRecord));
-        System.err.println("outputRecord " + (outputRecord == null ? "null" : outputRecord));
-        // InputRecord/OutputRecord -> readCipher/writeCipher (names differ across updates; try both)
-        //Class<?> readCipherCls = Class.forName("sun.security.ssl.SSLCipher.SSLReadCipher");
-        Object readCipher = getPrivate(inputRecord, inputRecordCls, "readCipher");
-        System.err.println(readCipher.getClass());
-        System.err.println(readCipher.getClass().getSuperclass());
-        var sslReadCipher = readCipher.getClass().getSuperclass();
-        //var readCipher = getField(inputRecord.getClass(), "readCipher");
-        //var readCipher = tryGetAny(inputRecord, new String[]{"readCipher", "readCipherBox", "readCipherState"});
-        var writeCipher = tryGetAny(outputRecord, new String[]{"writeCipher", "writeCipherBox", "writeCipherState"});
-        // SSLCipher$SSLReadCipher / SSLCipher$SSLWriteCipher -> keyLimitEnabled=true; keyLimitCountdown=<value>
-        if (readCipher != null) {
-//            setBoolean(readCipher, "keyLimitEnabled", true);
-            Field f = getField(sslReadCipher,"keyLimitCountdown");
-            f.setLong(readCipher, newCountdown);
-            //setLong(readCipher, "keyLimitCountdown", newCountdown);
-            System.err.println("readCipher.keyLimit set to " + newCountdown);
-        } else {
-            System.err.println("readCipher is null");
-        }
-        if (writeCipher != null) {
-            setBoolean(writeCipher, "keyLimitEnabled", true);
-            setLong(writeCipher, "keyLimitCountdown", newCountdown);
-        } else {
-            System.err.println("writeCipher is null");
-        }
-    }
-
     private static Field getField(Class<?> type, String name) throws Exception {
         Field f = type.getDeclaredField(name);
         f.setAccessible(true); // requires --add-opens for sun.security.ssl
@@ -532,41 +432,13 @@ public class KeyUpdateOnce extends SSLContextTemplate{
         return getField(owner, name).get(target);
     }
 
-    private static void setBoolean(Object target, String name, boolean v) throws Exception {
-        Field f = getField(target.getClass(), name);
-        if (f.getType() != boolean.class) throw new NoSuchFieldException(name);
-        f.setBoolean(target, v);
-    }
-
-    private static void setLong(Object target, String name, long v) throws Exception {
-        Field f = getField(target.getClass(), name);
-        if (f.getType() != long.class) throw new NoSuchFieldException(name);
-        f.setLong(target, v);
-    }
-
-    private static Object tryGetAny(Object holder, String[] names) throws Exception {
-        if (holder == null) return null;
-        Class<?> c = holder.getClass();
-        for (String n : names) {
-            System.err.println("name: " + n);
-            try {
-                Field f = getField(c, n);
-                return f.get(holder);
-            } catch (NoSuchFieldException e) {
-                System.err.println("exception: " + e.getMessage());
-            }
-        }
-        return null;
-    }
-
-
     static class Server extends KeyUpdateOnce implements Runnable {
         Server(String cipherSuite) throws Exception {
             super();
             eng = initContext().createSSLEngine();
             eng.setUseClientMode(false);
             eng.setNeedClientAuth(true);
-            if (cipherSuite != null && cipherSuite.length() > 0) {
+            if (cipherSuite != null && !cipherSuite.isEmpty()) {
                 eng.setEnabledCipherSuites(new String[] { cipherSuite });
             }
         }

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
@@ -136,7 +136,7 @@ public class KeyUpdateOnce extends SSLContextTemplate {
                     .filter(s -> s.contains("Produced KeyUpdate"))
                     .toList();
                 List<String> skippingList = output.asLines().stream()
-                    .filter(s -> s.contains("KeyUpdate already send, skipping"))
+                    .filter(s -> s.contains("KeyUpdate already sent, skipping"))
                     .toList();
                 producedList.forEach(System.err::println);
                 skippingList.forEach(System.err::println);

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/KeyUpdateOnce.java
@@ -27,7 +27,7 @@
  * @library ../../
  *          /test/lib
  *          /javax/net/ssl/templates
- * @summary Verify one KeyUpdate message is sent
+ * @summary Verify KeyUpdate messages skipped after first one sent.
  *
  * @run main KeyUpdateOnce server TLS_AES_256_GCM_SHA384 200000
  * @run main KeyUpdateOnce client TLS_AES_256_GCM_SHA384 200000
@@ -51,6 +51,17 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+
+/**
+ * This server/client TLS test will force side A to stop reading as it
+ * continuously writes out.  These write ops will trigger the side B to
+ * request a KeyUpdate.  With side A not reading, side B must skip
+ * sending more KeyUpdate messages.  Only one KeyUpdate message will be
+ * sent by side B.
+ *
+ * This test depends on debug messages string match.  Changing the KeyUpdate-
+ * related messages may cause a failure.
+ */
 
 public class KeyUpdateOnce extends SSLContextTemplate {
 
@@ -121,24 +132,30 @@ public class KeyUpdateOnce extends SSLContextTemplate {
                     "\"cipher suite\"        : \"%s", args[1]));
                 System.err.println("Output logs should show KeyUpdate has" +
                     " been sent and skipped");
-                // Check client side for KeyUpdate messages (Thread-0)
-                List<String> list = output.stderrShouldContain("Thread-0")
-                    .asLines().stream()
+                List<String> producedList = output.asLines().stream()
+                    .filter(s -> s.contains("Produced KeyUpdate"))
+                    .toList();
+                List<String> skippingList = output.asLines().stream()
                     .filter(s -> s.contains("KeyUpdate already send, skipping"))
                     .toList();
+                producedList.forEach(System.err::println);
+                skippingList.forEach(System.err::println);
+                System.err.println("\"Produced KeyUpdate\" count = " + producedList.size());
+                System.err.println("\"KeyUpdate already send, skipping\" count = " + skippingList.size());
 
-                for (String s : list) {
-                    System.err.println(s);
+                /*
+                 * Sometimes debug messages may not be consistent.  The below
+                 * checks verify that at least 1 of each message were received.
+                 */
+                // Ideally there should be 2 "Produced KeyUpdate"
+                if (producedList.isEmpty()) {
+                    throw new AssertionError("No \"Produced KeyUpdate\"");
                 }
-                System.err.println("list size = " + list.size());
-                if (list.isEmpty()) {
-                    throw new AssertionError("No KeyUpdate skipping " +
-                        "messages seen");
+                // Ideally there should be 5 "KeyUpdate already send, skipping"
+                if (skippingList.isEmpty()) {
+                    throw new AssertionError("No \"KeyUpdate already send, skipping\"");
                 }
 
-                output.shouldContain("trigger key update");
-                output.shouldContain("KeyUpdate: write key updated");
-                output.shouldContain("KeyUpdate: read key updated");
             } finally {
                 System.out.println("-- BEGIN Stdout:");
                 System.out.println(output.getStdout());


### PR DESCRIPTION
Hi,

Please review this change that prevents multiple KeyUpdate messages from being sent when the KeyLimit defined in the java.security file has been reached.

https://bugs.openjdk.org/browse/JDK-8329548

thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8329548](https://bugs.openjdk.org/browse/JDK-8329548): Change KeyUpdate messages from TLS 1.3 (**Bug** - P3)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30288/head:pull/30288` \
`$ git checkout pull/30288`

Update a local copy of the PR: \
`$ git checkout pull/30288` \
`$ git pull https://git.openjdk.org/jdk.git pull/30288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30288`

View PR using the GUI difftool: \
`$ git pr show -t 30288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30288.diff">https://git.openjdk.org/jdk/pull/30288.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30288#issuecomment-4606370060)
</details>
