### PR TITLE
8378144: File associations MimeInfo.xml not generated when building installer from predefined app image

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/Application.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/Application.java
@@ -238,7 +238,7 @@ public non-sealed interface Application extends BundleSpec {
      * @see Launcher#fileAssociations
      */
     default Stream<FileAssociation> fileAssociations() {
-        return launchers().stream().map(Launcher::fileAssociations).flatMap(List::stream);
+        return launchers().stream().map(Launcher::fileAssociations).flatMap(Collection::stream);
     }
 
     /**

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/Launcher.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/Launcher.java
@@ -25,6 +25,7 @@
 package jdk.jpackage.internal.model;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -88,7 +89,7 @@ public interface Launcher {
      *
      * @return the file associations of this launcher
      */
-    List<FileAssociation> fileAssociations();
+    Collection<FileAssociation> fileAssociations();
 
     /**
      * Returns <code>true</code> if this launcher should be installed as a service.
@@ -185,8 +186,14 @@ public interface Launcher {
     /**
      * Default implementation of {@link Launcher} interface.
      */
-    record Stub(String name, Optional<LauncherStartupInfo> startupInfo, List<FileAssociation> fileAssociations,
-            boolean isService, String description, Optional<LauncherIcon> icon, String defaultIconResourceName,
+    record Stub(
+            String name,
+            Optional<LauncherStartupInfo> startupInfo,
+            Collection<FileAssociation> fileAssociations,
+            boolean isService,
+            String description,
+            Optional<LauncherIcon> icon,
+            String defaultIconResourceName,
             Map<String, String> extraAppImageFileData) implements Launcher {
     }
 }

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -172,7 +172,7 @@ final class WixAppImageFragmentBuilder extends WixFragmentBuilder {
                 Launcher::executableNameWithSuffix,
                 WinLauncher::fileAssociations));
 
-        associations.values().stream().flatMap(List::stream).filter(FileAssociation::hasIcon).toList().forEach(fa -> {
+        associations.values().stream().flatMap(Collection::stream).filter(FileAssociation::hasIcon).toList().forEach(fa -> {
             // Need to add fa icon in the image.
             Object key = new Object();
             appImagePathGroup.setPath(key, fa.icon().orElseThrow().toAbsolutePath().normalize());
@@ -968,7 +968,7 @@ final class WixAppImageFragmentBuilder extends WixFragmentBuilder {
 
     private String programMenuFolderName;
 
-    private Map<String, List<FileAssociation>> associations;
+    private Map<String, Collection<FileAssociation>> associations;
 
     private Set<ShortcutsFolder> shortcutFolders;
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
@@ -27,11 +27,15 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public final class FileAssociations {
@@ -228,6 +232,101 @@ public final class FileAssociations {
         DesktopOpenAssociatedFile,
         WinCommandLine,
         WinDesktopOpenShortcut
+    }
+
+    record FileAssociationDescriptor(
+            String launcherName,
+            Optional<String> description,
+            String mimeType,
+            Optional<String> extension) {
+
+        FileAssociationDescriptor {
+            Objects.requireNonNull(launcherName);
+            Objects.requireNonNull(description);
+            Objects.requireNonNull(mimeType);
+            Objects.requireNonNull(extension);
+        }
+
+        FileAssociationDescriptor copyWithDescription(String description) {
+            return new FileAssociationDescriptor(launcherName, Optional.of(description), mimeType, extension);
+        }
+
+        static FileAssociationDescriptor create(String launcherName, PropertyFile props) {
+            return new FileAssociationDescriptor(
+                    launcherName,
+                    props.findProperty("description"),
+                    props.findProperty("mime-type").orElseThrow(),
+                    props.findProperty("extension"));
+        }
+
+        private static <T> Comparator<Optional<T>> optionalComparator(Comparator<T> valueComparator) {
+            return Comparator
+                    .comparing(Optional<T>::isPresent)
+                    .thenComparing(opt -> {
+                        return opt.orElse(null);
+                    }, Comparator.nullsLast(valueComparator));
+        }
+
+        static final Comparator<FileAssociationDescriptor> COMPARATOR = Comparator
+                .comparing(FileAssociationDescriptor::launcherName)
+                .thenComparing(FileAssociationDescriptor::mimeType)
+                .thenComparing(FileAssociationDescriptor::extension, optionalComparator(String::compareTo))
+                .thenComparing(FileAssociationDescriptor::description, optionalComparator(String::compareTo));
+    }
+
+    static void vallidateFileAssociations(JPackageCommand cmd) {
+        var comm = Comm.compare(Set.copyOf(declaredFileAssociations(cmd)), Set.copyOf(definedFileAssociations(cmd)));
+        if (!Stream.of(comm.unique1(), comm.unique2(), comm.common()).allMatch(Collection::isEmpty)) {
+            trace(comm.common(), "Expected file associations (size=%d):");
+            trace(comm.unique1(), "Missing file associations (size=%d):");
+            trace(comm.unique2(), "Unexpected file associations (size=%d):");
+            TKit.trace("DONE");
+            TKit.assertTrue(comm.uniqueEmpty(), "Check file associations are as expected");
+        }
+    }
+
+    private static void trace(Collection<FileAssociationDescriptor> fas, String format) {
+        Objects.requireNonNull(fas);
+        Objects.requireNonNull(format);
+        if (!fas.isEmpty()) {
+            TKit.trace(String.format(format, fas.size()));
+            fas.stream().sorted(FileAssociationDescriptor.COMPARATOR).forEach(fa -> {
+                var tokens = new ArrayList<String>();
+                tokens.add("launcher=[" + fa.launcherName() + "]");
+                tokens.add("mime=[" + fa.mimeType() + "]");
+                fa.extension().ifPresent(extension -> {
+                    tokens.add("ext=[" + extension + "]");
+                });
+                fa.description().ifPresent(description -> {
+                    tokens.add("description=[" + description + "]");
+                });
+                TKit.trace(String.format("  %s", tokens.stream().collect(Collectors.joining(", "))));
+            });
+        }
+    }
+
+    private static Collection<FileAssociationDescriptor> definedFileAssociations(JPackageCommand cmd) {
+        if (cmd.isImagePackageType()) {
+            return List.of();
+        } else if (TKit.isWindows()) {
+            return WindowsHelper.fileAssociations(cmd);
+        } else if (TKit.isLinux()) {
+            return LinuxHelper.fileAssociations(cmd);
+        } else if (TKit.isOSX()) {
+            return MacHelper.fileAssociations(cmd);
+        } else {
+            throw new AssertionError();
+        }
+    }
+
+    private static Collection<FileAssociationDescriptor> declaredFileAssociations(JPackageCommand cmd) {
+        return Stream.of(cmd.getAllArgumentValues("--file-associations")).map(Path::of).map(PropertyFile::new).map(props -> {
+            var fa = FileAssociationDescriptor.create(cmd.mainLauncherName(), props);
+            if (fa.description().isEmpty() && !TKit.isOSX()) {
+                fa = fa.copyWithDescription(String.format("%s association", cmd.name()));
+            }
+            return fa;
+        }).toList();
     }
 
     private final String suffixName;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/FileAssociations.java
@@ -37,11 +37,10 @@ import java.util.TreeMap;
 public final class FileAssociations {
     public FileAssociations(String faSuffixName) {
         suffixName = faSuffixName;
-        setFilename("fa");
         setDescription("jpackage test extension");
     }
 
-    private void createFile() {
+    private Path createPropertiesFile() {
         Map<String, String> entries = new TreeMap<>(Map.of(
             "extension", suffixName,
             "mime-type", getMime()
@@ -56,12 +55,11 @@ public final class FileAssociations {
                 entries.put("icon", icon.toString());
             }
         }
-        TKit.createPropertiesFile(file, entries);
-    }
 
-    public FileAssociations setFilename(String v) {
-        file = TKit.workDir().resolve(v + ".properties");
-        return this;
+        var path = TKit.createTempFile("fa.properties");
+        TKit.createPropertiesFile(path, entries);
+
+        return path;
     }
 
     public FileAssociations setDescription(String v) {
@@ -72,10 +70,6 @@ public final class FileAssociations {
     public FileAssociations setIcon(Path v) {
         icon = v;
         return this;
-    }
-
-    Path getPropertiesFile() {
-        return file;
     }
 
     String getSuffix() {
@@ -93,8 +87,7 @@ public final class FileAssociations {
     public void applyTo(PackageTest test) {
         test.notForTypes(PackageType.MAC_DMG, () -> {
             test.addInitializer(cmd -> {
-                createFile();
-                cmd.addArguments("--file-associations", getPropertiesFile());
+                cmd.addArguments("--file-associations", createPropertiesFile());
             });
             test.addHelloAppFileAssociationsVerifier(this);
         });
@@ -119,14 +112,18 @@ public final class FileAssociations {
         return new TestRunsBuilder();
     }
 
-    static class TestRun {
-        Iterable<String> getFileNames() {
-            return testFileNames;
+    record TestRun(Path fileName, InvocationType invocationType) {
+
+        TestRun {
+            Objects.requireNonNull(fileName);
+            Objects.requireNonNull(invocationType);
+
+            if (fileName.getNameCount() != 1 || fileName.isAbsolute()) {
+                throw new IllegalArgumentException();
+            }
         }
 
-        List<String> openFiles(List<Path> testFiles) throws IOException {
-            // current supported invocation types work only on single files
-            Path testFile = testFiles.get(0);
+        List<String> openFile(Path testFile) throws IOException {
 
             // To test unicode arguments on Windows manually:
             // 1. add the following argument ("Hello" in Bulgarian) to the
@@ -202,54 +199,37 @@ public final class FileAssociations {
                             "Invalid invocationType: [%s]", invocationType));
             }
         }
-
-        private TestRun(Collection<String> testFileNames,
-                InvocationType invocationType) {
-
-            Objects.requireNonNull(invocationType);
-
-            if (testFileNames.size() == 0) {
-                throw new IllegalArgumentException("Empty test file names list");
-            }
-
-            if (invocationType == InvocationType.DesktopOpenAssociatedFile && testFileNames.size() != 1) {
-                throw new IllegalArgumentException("Only one file can be configured for opening with the desktop");
-            }
-
-            this.testFileNames = testFileNames;
-            this.invocationType = invocationType;
-        }
-
-        private final Collection<String> testFileNames;
-        private final InvocationType invocationType;
     }
 
-    public static class TestRunsBuilder {
+    public static final class TestRunsBuilder {
+
+        private TestRunsBuilder() {
+        }
+
         public TestRunsBuilder setCurrentInvocationType(InvocationType v) {
             curInvocationType = v;
             return this;
         }
 
-        public TestRunsBuilder addTestRunForFilenames(String ... filenames) {
-            testRuns.add(new TestRun(List.of(filenames), curInvocationType));
+        public TestRunsBuilder addTestRunForFilenames(String fileName) {
+            testRuns.add(new TestRun(Path.of(fileName), curInvocationType));
             return this;
         }
 
         public void applyTo(FileAssociations fa) {
-            fa.testRuns = testRuns;
+            fa.testRuns = List.copyOf(testRuns);
         }
 
         private InvocationType curInvocationType = InvocationType.DesktopOpenAssociatedFile;
         private List<TestRun> testRuns = new ArrayList<>();
     }
 
-    public static enum InvocationType {
+    public enum InvocationType {
         DesktopOpenAssociatedFile,
         WinCommandLine,
         WinDesktopOpenShortcut
     }
 
-    private Path file;
     private final String suffixName;
     private String description;
     private Path icon;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1389,6 +1389,7 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
                 TKit.assertFileExists(libjliPath);
             }
         }),
+        FILE_ASSOCIATIONS(FileAssociations::vallidateFileAssociations),
         MAC_BUNDLE_STRUCTURE(cmd -> {
             if (TKit.isOSX()) {
                 MacHelper.verifyBundleStructure(cmd);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -27,6 +27,9 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static jdk.jpackage.internal.util.MemoizingSupplier.runOnce;
+import static jdk.jpackage.internal.util.XmlUtils.queryNodes;
+import static jdk.jpackage.internal.util.function.ThrowingFunction.toFunction;
+import static jdk.jpackage.test.TKit.findZeroOrSingleItem;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -50,11 +53,19 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import jdk.internal.util.Architecture;
 import jdk.jpackage.internal.util.PathUtils;
 import jdk.jpackage.internal.util.Result;
+import jdk.jpackage.internal.util.XmlUtils;
+import jdk.jpackage.internal.util.function.ExceptionBox;
+import jdk.jpackage.test.FileAssociations.FileAssociationDescriptor;
 import jdk.jpackage.test.LauncherShortcut.InvokeShortcutSpec;
 import jdk.jpackage.test.PackageTest.PackageHandlers;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 
 public final class LinuxHelper {
@@ -379,6 +390,57 @@ public final class LinuxHelper {
                     LauncherShortcut.LINUX_SHORTCUT,
                     new DesktopFile(systemDesktopFile, false).findQuotedValue("Path").map(Path::of),
                     List.of("gtk-launch", PathUtils.replaceSuffix(systemDesktopFile.getFileName(), "").toString()));
+        }).toList();
+    }
+
+    static Collection<FileAssociationDescriptor> fileAssociations(JPackageCommand cmd) {
+        cmd.verifyIsOfType(PackageType.LINUX);
+
+        final var mimeInfoXml = findZeroOrSingleItem(relativePackageFilesInSubdirectory(
+                cmd, ApplicationLayout::desktopIntegrationDirectory).filter(path -> {
+                    return path.getNameCount() == 1 && path.toString().endsWith("-MimeInfo.xml");
+                }).map(cmd.appLayout().desktopIntegrationDirectory()::resolve));
+
+        var mimeTypes = mimeInfoXml
+                .map(Path::toFile)
+                .map(toFunction(XmlUtils.initDocumentBuilder()::parse))
+                .map(MimeType::parseMimeTypes)
+                .orElseGet(List::of);
+
+        final var desktopFiles = getDesktopFiles(cmd);
+
+        var launcherWithMimeType = desktopFiles.stream().flatMap(path -> {
+            var launcherName = launcherNameFromDesktopFile(cmd, path);
+            return new DesktopFile(path, false).find("MimeType").map(mimeTypesString -> {
+                return Stream.of(mimeTypesString.split(";")).map(mimeType -> {
+                    return Map.entry(launcherName, mimeType);
+                });
+            }).orElseGet(Stream::of);
+        }).toList();
+
+        var mimeTypesInMimeInfoXml = mimeTypes.stream().map(MimeType::value).collect(toMap(x -> x, x -> x, (a, _) -> {
+            throw new IllegalStateException(String.format("Duplicated mime type [%s] in [%s] file", a, mimeInfoXml.orElseThrow()));
+        })).keySet().stream().sorted().toList();
+
+        var mimeTypeToLauncher = launcherWithMimeType.stream().collect(toMap(Map.Entry::getValue, Map.Entry::getKey, (a, _) -> {
+            throw new IllegalStateException(String.format("Mime type [%s] is handled by multiple launchers", a));
+        }));
+
+        TKit.assertStringListEquals(mimeTypesInMimeInfoXml, mimeTypeToLauncher.keySet().stream().sorted().toList(), mimeInfoXml.map(path -> {
+            return String.format("Check mime types in [%s] file match mime types handled by launchers", path);
+        }).orElseGet(() -> {
+            return "Check launchers don't handle mime types";
+        }));
+
+        return mimeTypes.stream().flatMap(mimeType -> {
+            var extensions = mimeType.globToExtensions().stream().map(Optional::of).toList();
+            if (extensions.isEmpty()) {
+                extensions = List.of(Optional.empty());
+            }
+            return extensions.stream().map(extension -> {
+                return new FileAssociationDescriptor(
+                        mimeTypeToLauncher.get(mimeType.value()), mimeType.comment(), mimeType.value(), extension);
+            });
         }).toList();
     }
 
@@ -921,6 +983,55 @@ public final class LinuxHelper {
         }
 
         private final Map<String, String> data;
+    }
+
+
+    private record MimeType(String value, Optional<String> glob, Optional<String> comment) {
+
+        MimeType {
+            Objects.requireNonNull(value);
+            Objects.requireNonNull(glob);
+            Objects.requireNonNull(comment);
+        }
+
+        static Collection<MimeType> parseMimeTypes(Node node) {
+
+            final String query;
+            if (node.getParentNode() == null) {
+                query = "/mime-info/mime-type";
+            } else {
+                query = "mime-type";
+            }
+
+            try {
+                return queryNodes(node, XPathSingleton.INSTANCE, query).map(Element.class::cast).map(toFunction(e -> {
+                    var mimeType = e.getAttribute("type");
+                    var glob = queryNodes(e, XPathSingleton.INSTANCE, "glob[1]/@pattern").findFirst().map(Node::getTextContent);
+                    var comment = queryNodes(e, XPathSingleton.INSTANCE, "comment[1]").findFirst().map(Node::getTextContent);
+
+                    return new MimeType(mimeType, glob, comment);
+                })).toList();
+            } catch (XPathExpressionException ex) {
+                throw ExceptionBox.toUnchecked(ex);
+            }
+        }
+
+        List<String> globToExtensions() {
+            return glob.map(v -> {
+                return Stream.of(v.split(";")).map(str -> {
+                    if (str.startsWith("*.")) {
+                        // Strip the leading '*.' substring
+                        return str.substring(2);
+                    } else {
+                        return str;
+                    }
+                }).toList();
+            }).orElseGet(List::of);
+        }
+
+        private static final class XPathSingleton {
+            private static final XPath INSTANCE = XPathFactory.newInstance().newXPath();
+        }
     }
 
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -53,7 +53,6 @@ import java.util.stream.Stream;
 import jdk.internal.util.Architecture;
 import jdk.jpackage.internal.util.PathUtils;
 import jdk.jpackage.internal.util.Result;
-import jdk.jpackage.internal.util.function.ThrowingConsumer;
 import jdk.jpackage.test.LauncherShortcut.InvokeShortcutSpec;
 import jdk.jpackage.test.PackageTest.PackageHandlers;
 
@@ -647,48 +646,35 @@ public final class LinuxHelper {
                 "Failed to locate system .desktop files folder"));
     }
 
-    private static void withTestFileAssociationsFile(FileAssociations fa,
-            ThrowingConsumer<Path, ? extends Exception> consumer) {
-        boolean iterated[] = new boolean[] { false };
-        PackageTest.withFileAssociationsTestRuns(fa, (testRun, testFiles) -> {
-            if (!iterated[0]) {
-                iterated[0] = true;
-                consumer.accept(testFiles.get(0));
-            }
-        });
-    }
-
     static void addFileAssociationsVerifier(PackageTest test, FileAssociations fa) {
         test.addInstallVerifier(cmd -> {
             if (cmd.isPackageUnpacked("Not running file associations checks")) {
                 return;
             }
 
-            withTestFileAssociationsFile(fa, testFile -> {
+            PackageTest.withFileAssociationsTestRuns(fa, (_, testFile) -> {
                 String mimeType = queryFileMimeType(testFile);
 
                 TKit.assertEquals(fa.getMime(), mimeType, String.format(
                         "Check mime type of [%s] file", testFile));
 
-                String desktopFileName = queryMimeTypeDefaultHandler(mimeType).orElse(null);
+                String desktopFileName = queryMimeTypeDefaultHandler(mimeType).orElseThrow();
 
-                Path systemDesktopFile = getSystemDesktopFilesFolder().resolve(
-                        desktopFileName);
-                Path appDesktopFile = cmd.appLayout().desktopIntegrationDirectory().resolve(
-                        desktopFileName);
+                Path systemDesktopFile = getSystemDesktopFilesFolder().resolve(desktopFileName);
+                Path appDesktopFile = cmd.appLayout().desktopIntegrationDirectory().resolve(desktopFileName);
 
                 TKit.assertFileExists(systemDesktopFile);
                 TKit.assertFileExists(appDesktopFile);
 
-                TKit.assertStringListEquals(Files.readAllLines(appDesktopFile),
-                        Files.readAllLines(systemDesktopFile), String.format(
-                        "Check [%s] file is a copy of [%s] file",
-                        systemDesktopFile, appDesktopFile));
+                TKit.assertStringListEquals(
+                        Files.readAllLines(appDesktopFile),
+                        Files.readAllLines(systemDesktopFile),
+                        String.format("Check [%s] file is a copy of [%s] file", systemDesktopFile, appDesktopFile));
             });
         });
 
         test.addUninstallVerifier(cmd -> {
-            withTestFileAssociationsFile(fa, testFile -> {
+            PackageTest.withFileAssociationsTestRuns(fa, (_, testFile) -> {
                 String mimeType = queryFileMimeType(testFile);
 
                 TKit.assertNotEquals(fa.getMime(), mimeType, String.format(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -23,6 +23,7 @@
 package jdk.jpackage.test;
 
 import static java.util.stream.Collectors.toSet;
+import static jdk.jpackage.internal.util.MemoizingSupplier.runOnce;
 import static jdk.jpackage.internal.util.PListWriter.writeArray;
 import static jdk.jpackage.internal.util.PListWriter.writeBoolean;
 import static jdk.jpackage.internal.util.PListWriter.writeBooleanOptional;
@@ -35,6 +36,7 @@ import static jdk.jpackage.internal.util.XmlUtils.initDocumentBuilder;
 import static jdk.jpackage.internal.util.XmlUtils.toXmlConsumer;
 import static jdk.jpackage.internal.util.function.ThrowingFunction.toFunction;
 import static jdk.jpackage.internal.util.function.ThrowingRunnable.toRunnable;
+import static jdk.jpackage.test.TKit.getSingleItem;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -48,6 +50,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +65,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -76,6 +80,7 @@ import jdk.jpackage.internal.util.RetryExecutor;
 import jdk.jpackage.internal.util.XmlUtils;
 import jdk.jpackage.internal.util.function.ThrowingConsumer;
 import jdk.jpackage.internal.util.function.ThrowingSupplier;
+import jdk.jpackage.test.FileAssociations.FileAssociationDescriptor;
 import jdk.jpackage.test.MacSign.CertificateHash;
 import jdk.jpackage.test.MacSign.CertificateRequest;
 import jdk.jpackage.test.MacSign.CertificateType;
@@ -402,6 +407,90 @@ public final class MacHelper {
         return MacSignVerify.findSpctlSignOrigin(MacSignVerify.SpctlType.EXEC, bundle.root(), true).isPresent();
     }
 
+    static Collection<FileAssociationDescriptor> fileAssociations(JPackageCommand cmd) {
+        cmd.verifyIsOfType(PackageType.MAC_DMG, PackageType.MAC_PKG, PackageType.IMAGE);
+
+        final var infoPlistFile = new MacBundle(cmd.isImagePackageType() ? cmd.outputBundle()
+                : cmd.pathToUnpackedPackageFile(cmd.appInstallationDirectory())).infoPlistFile();
+
+        TKit.trace(String.format("Read file associations data from [%s] file...", infoPlistFile));
+
+        final var plist = MacHelper.readPList(infoPlistFile);
+
+        var bundleIdPrefixGetter = runOnce(() -> {
+            return getPackageId(cmd) + ".";
+        });
+
+        var mainLauncherNameGetter = runOnce(cmd::mainLauncherName);
+
+        var fromUTExportedTypeDeclarations = plist.findArrayValue("UTExportedTypeDeclarations", false).orElseGet(Stream::of)
+                .map(PListReader.class::cast)
+                .map(dict -> {
+                    var description = dict.findValue("UTTypeDescription");
+
+                    dict = dict.findDictValue("UTTypeTagSpecification").orElseThrow();
+
+                    var mimeType = getSingleItem(dict.findStringArrayValue("public.mime-type").orElseThrow().stream());
+                    var extension = getSingleItem(dict.findStringArrayValue("public.filename-extension").orElseThrow().stream());
+
+                    return new FileAssociationDescriptor(mainLauncherNameGetter.get(), description, mimeType, Optional.of(extension));
+                }).toList();
+
+        var fromCFBundleDocumentTypes = plist.findArrayValue("CFBundleDocumentTypes", false).orElseGet(Stream::of)
+                .map(PListReader.class::cast)
+                .flatMap(dict -> {
+                    var description = dict.findValue("CFBundleTypeName");
+                    var extensions = dict.findStringArrayValue("LSItemContentTypes").orElseThrow().stream().map(str -> {
+                        var prefix = bundleIdPrefixGetter.get();
+                        TKit.assertTrue(str.startsWith(prefix), String.format(
+                                "Check [%s] element of 'CFBundleDocumentTypes/LSItemContentTypes' array key starts with [%s] prefix",
+                                str, prefix));
+                        return str.substring(prefix.length());
+                    }).toList();
+                    return extensions.stream().map(extension -> {
+                        return new FileAssociationDescriptor(mainLauncherNameGetter.get(), description, "foo", Optional.of(extension));
+                    });
+                }).toList();
+
+        BiFunction<String, Collection<FileAssociationDescriptor>, Map<String, FileAssociationDescriptor>> toExtensionMap = (dictKey, fas) -> {
+            Objects.requireNonNull(dictKey);
+            return fas.stream().collect(Collectors.toMap(fa -> {
+                return fa.extension().orElseThrow();
+            }, x -> x, (a, _) -> {
+                throw new IllegalStateException(String.format(
+                        "Duplicated FA extension [%s] in '%s' dictionary in [%s] file",
+                        dictKey, a.extension().orElseThrow(), infoPlistFile));
+            }));
+        };
+
+        var fromCFBundleDocumentTypesExtensionMap = toExtensionMap.apply("CFBundleDocumentTypes", fromCFBundleDocumentTypes);
+        var fromUTExportedTypeDeclarationsExtensionMap = toExtensionMap.apply("UTExportedTypeDeclarations", fromUTExportedTypeDeclarations);
+
+        fromUTExportedTypeDeclarations.stream().collect(Collectors.toMap(FileAssociationDescriptor::mimeType, x -> x, (a, _) -> {
+            throw new IllegalStateException(String.format(
+                    "Duplicated FA mime type [%s] in [%s] file", a.extension().orElseThrow(), infoPlistFile));
+        }));
+
+        TKit.assertStringListEquals(
+                fromUTExportedTypeDeclarationsExtensionMap.keySet().stream().sorted().toList(),
+                fromCFBundleDocumentTypesExtensionMap.keySet().stream().sorted().toList(),
+                "Check FA extensions in 'UTExportedTypeDeclarations' and 'CFBundleDocumentTypes' dictionaries match");
+
+        for (var e : fromUTExportedTypeDeclarationsExtensionMap.entrySet()) {
+            var extension = e.getKey();
+            var expectedDescription = e.getValue().description();
+            var actualDescription = fromCFBundleDocumentTypesExtensionMap.get(extension).description();
+            TKit.assertEquals(
+                    expectedDescription,
+                    actualDescription,
+                    String.format(
+                            "Check FA descriptions for [%s] extension in 'UTExportedTypeDeclarations' and 'CFBundleDocumentTypes' dictionaries match",
+                            extension));
+        }
+
+        return fromUTExportedTypeDeclarations;
+    }
+
     private static void createFaPListFragmentFromFaProperties(JPackageCommand cmd, XMLStreamWriter xml)
             throws XMLStreamException, IOException {
 
@@ -534,7 +623,7 @@ public final class MacHelper {
 
         private JPackageCommand.RuntimeImageType type = JPackageCommand.RuntimeImageType.RUNTIME_TYPE_HELLO_APP;
         private Consumer<JPackageCommand> mutator;
-    };
+    }
 
     public static RuntimeBundleBuilder buildRuntimeBundle() {
         return new RuntimeBundleBuilder();

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MsiDatabase.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MsiDatabase.java
@@ -22,6 +22,7 @@
  */
 package jdk.jpackage.test;
 
+import static jdk.jpackage.test.TKit.getSingleItem;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -42,6 +43,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import jdk.jpackage.internal.util.PathUtils;
+import jdk.jpackage.test.FileAssociations.FileAssociationDescriptor;
 
 
 final class MsiDatabase {
@@ -80,6 +84,7 @@ final class MsiDatabase {
         DIRECTORY("Directory"),
         FILE("File"),
         PROPERTY("Property"),
+        REGISTRY("Registry"),
         SHORTCUT("Shortcut"),
         ;
 
@@ -95,6 +100,7 @@ final class MsiDatabase {
 
         static final Set<Table> FIND_PROPERTY_REQUIRED_TABLES = Set.of(PROPERTY);
         static final Set<Table> LIST_SHORTCUTS_REQUIRED_TABLES = Set.of(COMPONENT, DIRECTORY, FILE, SHORTCUT);
+        static final Set<Table> FA_REQUIRED_TABLES = Set.of(COMPONENT, DIRECTORY, FILE, REGISTRY);
     }
 
 
@@ -120,12 +126,7 @@ final class MsiDatabase {
     }
 
     Collection<Shortcut> listShortcuts() {
-        var shortcuts = tables.get(Table.SHORTCUT);
-        if (shortcuts == null) {
-            return List.of();
-        }
-        return IntStream.range(0, shortcuts.rowCount()).mapToObj(i -> {
-            var row = shortcuts.row(i);
+        return rows(Table.SHORTCUT).map(row -> {
             var shortcutPath = directoryPath(row.apply("Directory_")).resolve(fileNameFromFieldValue(row.apply("Name")));
             var workDir = directoryPath(row.apply("WkDir"));
             var shortcutTarget = Path.of(expandFormattedString(row.apply("Target")));
@@ -133,6 +134,50 @@ final class MsiDatabase {
         }).toList();
     }
 
+    Collection<FileAssociationDescriptor> fileAssociations() {
+        return rows(Table.REGISTRY).filter(row -> {
+            return row.apply("Name").equals("Content Type");
+        }).map(row -> {
+            var extension = row.apply("Key");
+
+            var mime = row.apply("Value");
+
+            var id = getSingleItem(rows(Table.REGISTRY).filter(row2 -> {
+                return row2.apply("Name").equals("") && row2.apply("Key").equals(extension);
+            }).map(row2 -> {
+                return row2.apply("Value");
+            }));
+
+            var description = getSingleItem(rows(Table.REGISTRY).filter(row2 -> {
+                return row2.apply("Key").equals(id);
+            }).map(row2 -> {
+                return row2.apply("Value");
+            }).map(v -> {
+                if (v.isEmpty()) {
+                    v = null;
+                }
+                return v;
+            }));
+
+            var launcherName = getSingleItem(rows(Table.REGISTRY).filter(row2 -> {
+                return row2.apply("Key").equals(id + "\\shell\\open\\command");
+            }).map(row2 -> {
+                // "[#file10a74e783935359393275e13817c7281]" "%1" %*
+                var cmdline = row2.apply("Value");
+                // [#file10a74e783935359393275e13817c7281]
+                var formattedExecutable = removeQuotes(cmdline.split("\\s+")[0]);
+                var launcherExecutable = Path.of(expandFormattedString(formattedExecutable)).getFileName();
+                return PathUtils.replaceSuffix(launcherExecutable, "");
+            })).toString();
+
+            return new FileAssociationDescriptor(
+                    launcherName,
+                    Optional.ofNullable(description),
+                    mime,
+                    // .foo -> foo
+                    Optional.of(extension.substring(1)));
+        }).toList();
+    }
     record Shortcut(Path path, Path target, Path workDir) {
 
         Shortcut {
@@ -146,6 +191,13 @@ final class MsiDatabase {
             TKit.assertEquals(expected.target, target, "Check the shortcut target");
             TKit.assertEquals(expected.workDir, workDir, "Check the shortcut work directory");
         }
+    }
+
+
+    private Stream<Function<String, String>> rows(Table tableName) {
+        return Optional.ofNullable(tables.get(tableName)).stream().flatMap(table -> {
+            return IntStream.range(0, table.rowCount()).mapToObj(table::row);
+        });
     }
 
     private Path directoryPath(String directoryId) {
@@ -227,6 +279,14 @@ final class MsiDatabase {
         }
         m.appendTail(sb);
         return sb.toString();
+    }
+
+    private static String removeQuotes(String str) {
+        if (str.charAt(0) == '"' && str.charAt(str.length() - 1) == '"') {
+            return str.substring(1, str.length() - 1);
+        } else {
+            return str;
+        }
     }
 
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -56,7 +56,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import jdk.jpackage.internal.util.function.ThrowingBiConsumer;
 import jdk.jpackage.internal.util.function.ThrowingConsumer;
 import jdk.jpackage.internal.util.function.ThrowingRunnable;
@@ -259,21 +258,19 @@ public final class PackageTest extends RunnablePackageTest {
     }
 
     static void withFileAssociationsTestRuns(FileAssociations fa,
-            ThrowingBiConsumer<FileAssociations.TestRun, List<Path>, ? extends Exception> consumer) {
+            ThrowingBiConsumer<FileAssociations.TestRun, Path, ? extends Exception> consumer) {
         Objects.requireNonNull(consumer);
         for (var testRun : fa.getTestRuns()) {
             TKit.withTempDirectory("fa-test-files", tempDir -> {
-                List<Path> testFiles = StreamSupport.stream(testRun.getFileNames().spliterator(), false).map(fname -> {
-                    return tempDir.resolve(fname + fa.getSuffix()).toAbsolutePath().normalize();
-                }).toList();
+                var testFile = tempDir.resolve(testRun.fileName().toString() + fa.getSuffix()).toAbsolutePath().normalize();
 
-                testFiles.forEach(toConsumer(Files::createFile));
+                Files.createFile(testFile);
 
                 if (TKit.isLinux()) {
-                    testFiles.forEach(LinuxHelper::initFileAssociationsTestFile);
+                    LinuxHelper.initFileAssociationsTestFile(testFile);
                 }
 
-                consumer.accept(testRun, testFiles);
+                consumer.accept(testRun, testFile);
             });
         }
     }
@@ -300,12 +297,11 @@ public final class PackageTest extends RunnablePackageTest {
                 return;
             }
 
-            withFileAssociationsTestRuns(fa, (testRun, testFiles) -> {
-                final Path appOutput = testFiles.get(0).getParent()
-                        .resolve(HelloApp.OUTPUT_FILENAME);
+            withFileAssociationsTestRuns(fa, (testRun, testFile) -> {
+                final Path appOutput = testFile.getParent().resolve(HelloApp.OUTPUT_FILENAME);
                 Files.deleteIfExists(appOutput);
 
-                List<String> expectedArgs = testRun.openFiles(testFiles);
+                List<String> expectedArgs = testRun.openFile(testFile);
                 TKit.waitForFileCreated(appOutput, Duration.ofSeconds(7), Duration.ofSeconds(3));
 
                 HelloApp.verifyOutputFile(appOutput, expectedArgs, Map.of());

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -605,6 +605,16 @@ public final class TKit {
         return JtregSkippedExceptionClass.INSTANCE.isInstance(t);
     }
 
+    public static <T> T getSingleItem(Stream<T> stream) {
+        return findZeroOrSingleItem(stream).orElseThrow();
+    }
+
+    public static <T> Optional<T> findZeroOrSingleItem(Stream<T> stream) {
+        return stream.reduce((_, _) -> {
+            throw new IllegalArgumentException("Multiple items in the stream");
+        });
+    }
+
     public static void waitForFileCreated(Path fileToWaitFor,
             Duration timeout, Duration afterCreatedTimeout) throws IOException {
         waitForFileCreated(fileToWaitFor, timeout);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import jdk.jpackage.internal.util.function.ThrowingRunnable;
+import jdk.jpackage.test.FileAssociations.FileAssociationDescriptor;
 import jdk.jpackage.test.PackageTest.PackageHandlers;
 
 public class WindowsHelper {
@@ -274,6 +275,11 @@ public class WindowsHelper {
     public static String getMsiProperty(JPackageCommand cmd, String propertyName) {
         cmd.verifyIsOfType(PackageType.WIN_MSI);
         return MsiDatabaseCache.INSTANCE.findProperty(cmd.outputBundle(), propertyName).orElseThrow();
+    }
+
+    static Collection<FileAssociationDescriptor> fileAssociations(JPackageCommand cmd) {
+        cmd.verifyIsOfType(PackageType.WIN_MSI);
+        return MsiDatabaseCache.INSTANCE.fileAssociations(cmd.outputBundle());
     }
 
     static Collection<MsiDatabase.Shortcut> getMsiShortcuts(JPackageCommand cmd) {
@@ -570,6 +576,10 @@ public class WindowsHelper {
 
         Collection<MsiDatabase.Shortcut> listShortcuts(Path msiPath) {
             return ensureTables(msiPath, MsiDatabase.Table.LIST_SHORTCUTS_REQUIRED_TABLES).listShortcuts();
+        }
+
+        Collection<FileAssociationDescriptor> fileAssociations(Path msiPath) {
+            return ensureTables(msiPath, MsiDatabase.Table.FA_REQUIRED_TABLES).fileAssociations();
         }
 
         MsiDatabase ensureTables(Path msiPath, Set<MsiDatabase.Table> tableNames) {

--- a/test/jdk/tools/jpackage/share/FileAssociationsTest.java
+++ b/test/jdk/tools/jpackage/share/FileAssociationsTest.java
@@ -102,7 +102,6 @@ public class FileAssociationsTest {
         Files.copy(ICON, icon);
 
         new FileAssociations("jptest2")
-                .setFilename("fa2")
                 .setIcon(icon)
                 .applyTo(packageTest);
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Errors
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`
&nbsp;⚠️ The pull request body must not be empty.

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Issue
 * [JDK-8378144](https://bugs.openjdk.org/browse/JDK-8378144): File associations MimeInfo.xml not generated when building installer from predefined app image (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30290/head:pull/30290` \
`$ git checkout pull/30290`

Update a local copy of the PR: \
`$ git checkout pull/30290` \
`$ git pull https://git.openjdk.org/jdk.git pull/30290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30290`

View PR using the GUI difftool: \
`$ git pr show -t 30290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30290.diff">https://git.openjdk.org/jdk/pull/30290.diff</a>

</details>
