### PR TITLE
8034818: JFormattedTextField does not accept DateTimeFormatter as formatter

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -45,7 +45,6 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
 
 import javax.swing.event.DocumentEvent;

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -881,24 +881,39 @@ public class JFormattedTextField extends JTextField {
                                                displayFormatter,editFormatter);
         }
         if (type instanceof DateTimeFormatter formatter) {
-            AbstractFormatter abstractFormatter = new AbstractFormatter() {
-                @Override
-                public Object stringToValue(String text) throws ParseException {
-                    return formatter.parse(text);
-                }
-
-                @Override
-                public String valueToString(Object value) throws ParseException {
-                    if (value != null) {
-                        DateTimeFormatter format = (DateTimeFormatter) value;
-                        return format.toString();
-                    }
-                    return "";
-                }
-            };
-            return new DefaultFormatterFactory(abstractFormatter);
+            return new DefaultFormatterFactory(new DTFormatter(formatter));
         }
         return new DefaultFormatterFactory(new DefaultFormatter());
+    }
+
+    /**
+     * Returns a DateTimeFormatter configured with specified format
+     */
+    public static class DTFormatter extends DefaultFormatter {
+        DateTimeFormatter formatter;
+
+        /**
+         * Returns a DateTimeFormatter configured with specified format
+         *
+         * @param format Format used to dictate legal values
+         */
+        public DTFormatter(DateTimeFormatter format) {
+            formatter = format;
+        }
+
+        @Override
+        public Object stringToValue(String text) throws ParseException {
+            return formatter.parse(text);
+        }
+
+        @Override
+        public String valueToString(Object value) throws ParseException {
+            if (value != null) {
+                DateTimeFormatter format = (DateTimeFormatter) value;
+                return format.toString();
+            }
+            return "";
+        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -438,8 +438,9 @@ public class JFormattedTextField extends JTextField {
      * <code>AbstractFormatter</code> will be used based on the
      * <code>Class</code> of the value. <code>NumberFormatter</code> will
      * be used for <code>Number</code>s, <code>DateFormatter</code> will
-     * be used for <code>Dates</code>, otherwise <code>DefaultFormatter</code>
-     * will be used.
+     * be used for <code>Dates</code>, <code>DTFormatter</code> will be
+     * used for <code></code>DateTimeFormatter</code>,
+     * </code>otherwise <code>DefaultFormatter</code> will be used.
      * <p>
      * This is a JavaBeans bound property.
      *

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -43,6 +43,9 @@ import java.text.DecimalFormat;
 import java.text.Format;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
 
 import javax.swing.event.DocumentEvent;
@@ -540,6 +543,11 @@ public class JFormattedTextField extends JTextField {
      * @return Last valid value
      */
     public Object getValue() {
+        if (value instanceof DateTimeFormatter formatter) {
+            if (getText() != null && !getText().isEmpty()) {
+                return LocalDate.parse(getText(), formatter);
+            }
+        }
         return value;
     }
 
@@ -873,9 +881,27 @@ public class JFormattedTextField extends JTextField {
             return new DefaultFormatterFactory(displayFormatter,
                                                displayFormatter,editFormatter);
         }
+        if (type instanceof DateTimeFormatter) {
+            DateTimeFormatter formatter = new DateTimeFormatterBuilder().toFormatter();
+            AbstractFormatter abstractFormatter = new AbstractFormatter() {
+                @Override
+                public Object stringToValue(String text) throws ParseException {
+                    return formatter.parse(text);
+                }
+
+                @Override
+                public String valueToString(Object value) throws ParseException {
+                    if (value != null) {
+                        DateTimeFormatter format = (DateTimeFormatter) value;
+                        return format.toString();
+                    }
+                    return "";
+                }
+            };
+            return new DefaultFormatterFactory(abstractFormatter);
+        }
         return new DefaultFormatterFactory(new DefaultFormatter());
     }
-
 
     /**
      * Instances of <code>AbstractFormatterFactory</code> are used by

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -881,8 +881,7 @@ public class JFormattedTextField extends JTextField {
             return new DefaultFormatterFactory(displayFormatter,
                                                displayFormatter,editFormatter);
         }
-        if (type instanceof DateTimeFormatter) {
-            DateTimeFormatter formatter = new DateTimeFormatterBuilder().toFormatter();
+        if (type instanceof DateTimeFormatter formatter) {
             AbstractFormatter abstractFormatter = new AbstractFormatter() {
                 @Override
                 public Object stringToValue(String text) throws ParseException {

--- a/test/jdk/javax/swing/JFormattedTextField/TestFormatter.java
+++ b/test/jdk/javax/swing/JFormattedTextField/TestFormatter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8034818
+ * @summary Tests JFormattedTextField accepts DateTimeFormatter as formatter
+ * @run main TestFormatter
+ */
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import javax.swing.JFormattedTextField;
+
+public class TestFormatter {
+    public static void main(String[] args) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+        JFormattedTextField tf = new JFormattedTextField(formatter);
+        tf.setText(formatter.format(LocalDate.now()));
+        LocalDate date = (LocalDate) tf.getValue();
+        System.out.println(date); 
+    }
+}

--- a/test/jdk/javax/swing/JFormattedTextField/TestFormatter.java
+++ b/test/jdk/javax/swing/JFormattedTextField/TestFormatter.java
@@ -39,6 +39,6 @@ public class TestFormatter {
         JFormattedTextField tf = new JFormattedTextField(formatter);
         tf.setText(formatter.format(LocalDate.now()));
         LocalDate date = (LocalDate) tf.getValue();
-        System.out.println(date); 
+        System.out.println(date);
     }
 }


### PR DESCRIPTION
Support for the new DateTimeFormatter in JFormattedTextField is added

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change requires a CSR request matching fixVersion 28 to be approved (needs to be created)
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8034818](https://bugs.openjdk.org/browse/JDK-8034818): JFormattedTextField does not accept DateTimeFormatter as formatter (**Enhancement** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - **Reviewer**) 🔄 Re-review required (review applies to [b12b6d20](https://git.openjdk.org/jdk/pull/30292/files/b12b6d2093d494944224bb78c0db92968506d2fa))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30292/head:pull/30292` \
`$ git checkout pull/30292`

Update a local copy of the PR: \
`$ git checkout pull/30292` \
`$ git pull https://git.openjdk.org/jdk.git pull/30292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30292`

View PR using the GUI difftool: \
`$ git pr show -t 30292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30292.diff">https://git.openjdk.org/jdk/pull/30292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30292#issuecomment-4080857765)
</details>
