### PR TITLE
8380281: Remove the client emulation mode

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -185,46 +185,6 @@ intx CompilerConfig::scaled_freq_log(intx freq_log, double scale) {
   }
 }
 
-void CompilerConfig::set_client_emulation_mode_flags() {
-  assert(has_c1(), "Must have C1 compiler present");
-  CompilationModeFlag::set_quick_only();
-
-  FLAG_SET_ERGO(ProfileInterpreter, false);
-#if INCLUDE_JVMCI
-  FLAG_SET_ERGO(EnableJVMCI, false);
-  FLAG_SET_ERGO(UseJVMCICompiler, false);
-#endif
-  if (FLAG_IS_DEFAULT(InitialCodeCacheSize)) {
-    FLAG_SET_ERGO(InitialCodeCacheSize, 160*K);
-  }
-  if (FLAG_IS_DEFAULT(ReservedCodeCacheSize)) {
-    FLAG_SET_ERGO(ReservedCodeCacheSize, 32*M);
-  }
-  if (FLAG_IS_DEFAULT(NonProfiledCodeHeapSize)) {
-    FLAG_SET_ERGO(NonProfiledCodeHeapSize, 27*M);
-  }
-  if (FLAG_IS_DEFAULT(ProfiledCodeHeapSize)) {
-    FLAG_SET_ERGO(ProfiledCodeHeapSize, 0);
-  }
-  if (FLAG_IS_DEFAULT(NonNMethodCodeHeapSize)) {
-    FLAG_SET_ERGO(NonNMethodCodeHeapSize, 5*M);
-  }
-  if (FLAG_IS_DEFAULT(CodeCacheExpansionSize)) {
-    FLAG_SET_ERGO(CodeCacheExpansionSize, 32*K);
-  }
-  if (FLAG_IS_DEFAULT(CICompilerCount)) {
-    FLAG_SET_ERGO(CICompilerCount, 1);
-  }
-}
-
-bool CompilerConfig::is_compilation_mode_selected() {
-  return !FLAG_IS_DEFAULT(TieredCompilation) ||
-         !FLAG_IS_DEFAULT(TieredStopAtLevel) ||
-         !FLAG_IS_DEFAULT(CompilationMode)
-         JVMCI_ONLY(|| !FLAG_IS_DEFAULT(EnableJVMCI)
-                    || !FLAG_IS_DEFAULT(UseJVMCICompiler));
-}
-
 static bool check_legacy_flags() {
   JVMFlag* compile_threshold_flag = JVMFlag::flag_from_enum(FLAG_MEMBER_ENUM(CompileThreshold));
   if (JVMFlagAccess::check_constraint(compile_threshold_flag, JVMFlagLimit::get_constraint(compile_threshold_flag)->constraint_func(), false) != JVMFlag::SUCCESS) {
@@ -540,28 +500,10 @@ bool CompilerConfig::check_args_consistency(bool status) {
   return status;
 }
 
-bool CompilerConfig::should_set_client_emulation_mode_flags() {
-#if !COMPILER1_OR_COMPILER2
-  return false;
-#endif
-
-  return has_c1() &&
-         is_compilation_mode_selected() &&
-         !has_c2() &&
-         !is_jvmci_compiler();
-}
-
 void CompilerConfig::ergo_initialize() {
 #if !COMPILER1_OR_COMPILER2
   return;
 #endif
-
-  // This property is also checked when selecting the heap size. Since client
-  // emulation mode influences Java heap memory usage, part of the logic must
-  // occur before choosing the heap size.
-  if (should_set_client_emulation_mode_flags()) {
-    set_client_emulation_mode_flags();
-  }
 
   set_legacy_emulation_flags();
   set_compilation_policy_flags();
@@ -581,9 +523,6 @@ void CompilerConfig::ergo_initialize() {
   }
 
   if (ProfileInterpreter && CompilerConfig::is_c1_simple_only()) {
-    if (!FLAG_IS_DEFAULT(ProfileInterpreter)) {
-        warning("ProfileInterpreter disabled due to client emulation mode");
-    }
     FLAG_SET_CMDLINE(ProfileInterpreter, false);
   }
 

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -151,14 +151,10 @@ public:
 
   inline static CompilerType compiler_type();
 
-  static bool should_set_client_emulation_mode_flags();
-
 private:
-  static bool is_compilation_mode_selected();
   static void set_compilation_policy_flags();
   static void set_jvmci_specific_flags();
   static void set_legacy_emulation_flags();
-  static void set_client_emulation_mode_flags();
 };
 
 #endif // SHARE_COMPILER_COMPILERDEFINITIONS_HPP

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -152,28 +152,14 @@ const char* Abstract_VM_Version::vm_info_string() {
       }
     case Arguments::_mixed:
       if (is_vm_statically_linked()) {
-        if (CompilationModeFlag::quick_only()) {
-          return CDSConfig::is_using_archive() ? "mixed mode, emulated-client, static, sharing" : "mixed mode, emulated-client, static";
-        } else {
-          return CDSConfig::is_using_archive() ? "mixed mode, static, sharing" : "mixed mode, static";
-         }
+        return CDSConfig::is_using_archive() ? "mixed mode, static, sharing" : "mixed mode, static";
       } else {
-        if (CompilationModeFlag::quick_only()) {
-          return CDSConfig::is_using_archive() ? "mixed mode, emulated-client, sharing" : "mixed mode, emulated-client";
-        } else {
-          return CDSConfig::is_using_archive() ? "mixed mode, sharing" : "mixed mode";
-        }
+        return CDSConfig::is_using_archive() ? "mixed mode, sharing" : "mixed mode";
       }
     case Arguments::_comp:
       if (is_vm_statically_linked()) {
-        if (CompilationModeFlag::quick_only()) {
-          return CDSConfig::is_using_archive() ? "compiled mode, emulated-client, static, sharing" : "compiled mode, emulated-client, static";
-        }
         return CDSConfig::is_using_archive() ? "compiled mode, static, sharing" : "compiled mode, static";
       } else {
-        if (CompilationModeFlag::quick_only()) {
-          return CDSConfig::is_using_archive() ? "compiled mode, emulated-client, sharing" : "compiled mode, emulated-client";
-        }
         return CDSConfig::is_using_archive() ? "compiled mode, sharing" : "compiled mode";
       }
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1513,10 +1513,7 @@ void Arguments::set_heap_size() {
                        !FLAG_IS_DEFAULT(MinRAMPercentage) ||
                        !FLAG_IS_DEFAULT(InitialRAMPercentage);
 
-  // Limit the available memory if client emulation mode is enabled.
-  const size_t avail_mem = CompilerConfig::should_set_client_emulation_mode_flags()
-      ? 1ULL*G
-      : os::physical_memory();
+  const size_t avail_mem = os::physical_memory();
 
   // If the maximum heap size has not been set with -Xmx, then set it as
   // fraction of the size of physical memory, respecting the maximum and

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -69,7 +69,6 @@ requires.properties= \
     vm.gc.Z \
     vm.jvmci \
     vm.jvmci.enabled \
-    vm.emulatedClient \
     vm.cpu.features \
     vm.pageSize \
     vm.debug \

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyNoInitDeopt.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyNoInitDeopt.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8072016
  * @summary Infinite deoptimization/recompilation cycles in case of arraycopy with tightly coupled allocation
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -87,8 +87,8 @@ public class TestArrayCopyNoInitDeopt {
     }
 
     static public void main(String[] args) throws Exception {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         // Only execute if C2 is available
         if (TIERED_STOP_AT_LEVEL == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {

--- a/test/hotspot/jtreg/compiler/arraycopy/TestDefaultMethodArrayCloneDeoptC2.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestDefaultMethodArrayCloneDeoptC2.java
@@ -27,7 +27,7 @@
  * @summary C2: Access to [].clone from interfaces fails.
  * @library /test/lib /
  *
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xcomp -Xbatch -Xbootclasspath/a:.  -XX:-TieredCompilation  -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -26,7 +26,7 @@
  * @bug 8319784
  * @summary Check that the JVM is able to dump the heap even when there are ReduceAllocationMerge in the scope.
  * @library /test/lib /
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @run main/othervm compiler.c2.TestReduceAllocationAndHeapDump
  */
 

--- a/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
@@ -112,9 +112,9 @@ public class OverloadCompileQueueTest implements Runnable {
             AVAILABLE_LEVELS = IntStream
                     .rangeClosed(LEVEL_SIMPLE, TIERED_STOP_AT_LEVEL)
                     .toArray();
-        } else if (Platform.isServer() && !Platform.isEmulatedClient()) {
+        } else if (Platform.isServer()) {
             AVAILABLE_LEVELS = new int[] { LEVEL_FULL_OPTIMIZATION };
-        } else if (Platform.isClient() || Platform.isMinimal() || Platform.isEmulatedClient()) {
+        } else if (Platform.isClient() || Platform.isMinimal()) {
             AVAILABLE_LEVELS = new int[] { LEVEL_SIMPLE };
         } else {
             throw new Error("TESTBUG: unknown VM: " + Platform.vmName);

--- a/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java
@@ -76,7 +76,7 @@ public class TestAESIntrinsicsOnSupportedConfig extends AESIntrinsicsBase {
                 prepareArguments(prepareBooleanFlag(AESIntrinsicsBase
                         .USE_AES, true)));
         final String errorMessage = "Case testUseAES failed";
-        if (Platform.isServer() && !Platform.isEmulatedClient() && isTieredLevelGreaterThan(3)) {
+        if (Platform.isServer() && isTieredLevelGreaterThan(3)) {
             verifyOutput(new String[]{AESIntrinsicsBase.CIPHER_INTRINSIC,
                     AESIntrinsicsBase.AES_INTRINSIC}, null, errorMessage,
                     outputAnalyzer);

--- a/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires vm.flagless
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  *
  * @run driver compiler.inlining.InlineBimorphicVirtualCallAfterMorphismChanged
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/IntrinsicAvailableTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/IntrinsicAvailableTest.java
@@ -142,7 +142,7 @@ public class IntrinsicAvailableTest extends CompilerWhiteBoxTest {
 
     public void test() throws Exception {
         Executable intrinsicMethod = testCase.getExecutable();
-        if (Platform.isServer() && !Platform.isEmulatedClient() && (TIERED_STOP_AT_LEVEL == COMP_LEVEL_FULL_OPTIMIZATION)) {
+        if (Platform.isServer() && (TIERED_STOP_AT_LEVEL == COMP_LEVEL_FULL_OPTIMIZATION)) {
             if (TIERED_COMPILATION) {
                 checkIntrinsicForCompilationLevel(intrinsicMethod, COMP_LEVEL_SIMPLE);
             }

--- a/test/hotspot/jtreg/compiler/intrinsics/IntrinsicDisabledTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/IntrinsicDisabledTest.java
@@ -217,8 +217,7 @@ public class IntrinsicDisabledTest {
     }
 
     public static void main(String args[]) {
-        if (Platform.isServer() && !Platform.isEmulatedClient() &&
-                                   (TIERED_STOP_AT_LEVEL == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)) {
+        if (Platform.isServer() && (TIERED_STOP_AT_LEVEL == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)) {
             if (TIERED_COMPILATION) {
                 test(CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE);
             }

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/MontgomeryMultiplyTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/MontgomeryMultiplyTest.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8130150 8131779 8139907
  * @summary Verify that the Montgomery multiply and square intrinsic works and correctly checks their arguments.
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.math:open
  * @library /test/lib /
@@ -313,8 +313,8 @@ public class MontgomeryMultiplyTest {
     }
 
     public static void main(String args[]) {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         if (wb.isIntrinsicAvailable(getExecutable(true), CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) &&
                 wb.isIntrinsicAvailable(getExecutable(false), CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)) {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
@@ -83,7 +83,7 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
 
         System.out.println(testCase.name());
 
-        if (TIERED_COMPILATION && TIERED_STOP_AT_LEVEL != CompilerWhiteBoxTest.COMP_LEVEL_MAX || Platform.isEmulatedClient()) {
+        if (TIERED_COMPILATION && TIERED_STOP_AT_LEVEL != CompilerWhiteBoxTest.COMP_LEVEL_MAX) {
             System.out.println("TieredStopAtLevel value (" + TIERED_STOP_AT_LEVEL + ") is too low, test SKIPPED");
             return;
         }

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires vm.simpleArch == "x64" & vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.simpleArch == "x64" & vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/TZcntTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
@@ -26,7 +26,7 @@
  * @bug 8054492
  * @summary Casting can result in redundant null checks in generated code
  * @requires vm.hasJFR
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -93,8 +93,8 @@ public class CastNullCheckDroppingsTest {
     int[]   asink;
 
     public static void main(String[] args) throws Exception {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         // Make sure background compilation is disabled
         if (WHITE_BOX.getBooleanVMFlag("BackgroundCompilation")) {

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/sanity/IntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/sanity/IntrinsicBase.java
@@ -50,7 +50,7 @@ public abstract class IntrinsicBase extends CompilerWhiteBoxTest {
 
         int expectedIntrinsicCount = 0;
 
-        if (Platform.isServer() && !Platform.isEmulatedClient()) {
+        if (Platform.isServer()) {
             if (TIERED_COMPILATION) {
                 int max_level = TIERED_STOP_AT_LEVEL;
                 expectedIntrinsicCount = (max_level == COMP_LEVEL_MAX) ? 1 : 0;

--- a/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopSafepointBackedge.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCountedLoopSafepointBackedge.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8161147
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Safepoint on backedge breaks UseCountedLoopSafepoints
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+UseCountedLoopSafepoints TestCountedLoopSafepointBackedge
  *

--- a/test/hotspot/jtreg/compiler/loopopts/UseCountedLoopSafepointsTest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/UseCountedLoopSafepointsTest.java
@@ -28,7 +28,7 @@
  * @summary Test that C2 flag UseCountedLoopSafepoints ensures a safepoint is kept in a CountedLoop
  * @library /test/lib /
  * @requires vm.compMode != "Xint" & vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4) & vm.debug == true
- * @requires !vm.emulatedClient & !vm.graal.enabled
+ * @requires !vm.graal.enabled
  * @modules java.base/jdk.internal.misc
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -37,7 +37,6 @@
 
 package compiler.loopopts;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import java.util.List;

--- a/test/hotspot/jtreg/compiler/profiling/TestTypeProfiling.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestTypeProfiling.java
@@ -27,7 +27,7 @@
   * @summary Parameters type profiling is not performed from aarch64 interpreter
   *
   * @requires os.arch != "arm"
-  * @requires vm.flavor == "server" & vm.compMode == "Xmixed" & !vm.emulatedClient & !vm.graal.enabled
+  * @requires vm.flavor == "server" & vm.compMode == "Xmixed" & !vm.graal.enabled
   *
   * @comment the test can't be run w/ TieredStopAtLevel < 4
   * @requires vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4
@@ -94,8 +94,8 @@ public class TestTypeProfiling {
     }
 
     static public void main(String[] args) throws Exception {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         // Only execute if C2 is available
         if (TIERED_STOP_AT_LEVEL != CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {

--- a/test/hotspot/jtreg/compiler/rangechecks/TestExplicitRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestExplicitRangeChecks.java
@@ -447,8 +447,7 @@ public class TestExplicitRangeChecks {
                 success = false;
             }
             // Only perform these additional checks if C2 is available
-            if (Platform.isServer() && !Platform.isEmulatedClient() &&
-                TIERED_STOP_AT_LEVEL == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {
+            if (Platform.isServer() && TIERED_STOP_AT_LEVEL == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {
                 if (deoptimize && WHITE_BOX.isMethodCompiled(m)) {
                     System.out.println(name + " not deoptimized on invalid access");
                     success = false;

--- a/test/hotspot/jtreg/compiler/testlibrary/CompilerUtils.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/CompilerUtils.java
@@ -53,10 +53,10 @@ public class CompilerUtils {
                     "TieredStopAtLevel has value out of int capacity");
             return IntStream.rangeClosed(1, maxLevel).toArray();
         } else {
-            if (Platform.isServer() && !Platform.isEmulatedClient()) {
+            if (Platform.isServer()) {
                 return new int[]{4};
             }
-            if (Platform.isClient() || Platform.isMinimal() || Platform.isEmulatedClient()) {
+            if (Platform.isClient() || Platform.isMinimal()) {
                 return new int[]{1};
             }
         }

--- a/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
@@ -56,7 +56,7 @@ public class IntrinsicPredicates {
                 "TieredStopAtLevel");
         boolean maxLevelIsReachable = (tieredMaxLevel
                 == IntrinsicPredicates.TIERED_MAX_LEVEL);
-        return Platform.isServer() && !Platform.isEmulatedClient() && (!isTiered || maxLevelIsReachable);
+        return Platform.isServer() && (!isTiered || maxLevelIsReachable);
     };
 
     public static final BooleanSupplier MD5_INSTRUCTION_AVAILABLE

--- a/test/hotspot/jtreg/compiler/tiered/NonTieredLevelsTest.java
+++ b/test/hotspot/jtreg/compiler/tiered/NonTieredLevelsTest.java
@@ -47,10 +47,10 @@ public class NonTieredLevelsTest extends CompLevelsTest {
     private static final int AVAILABLE_COMP_LEVEL;
     private static final IntPredicate IS_AVAILABLE_COMPLEVEL;
     static {
-        if (Platform.isServer() && !Platform.isEmulatedClient()) {
+        if (Platform.isServer()) {
             AVAILABLE_COMP_LEVEL = COMP_LEVEL_FULL_OPTIMIZATION;
             IS_AVAILABLE_COMPLEVEL = x -> x == COMP_LEVEL_FULL_OPTIMIZATION;
-        } else if (Platform.isClient() || Platform.isMinimal() || Platform.isEmulatedClient()) {
+        } else if (Platform.isClient() || Platform.isMinimal()) {
             AVAILABLE_COMP_LEVEL = COMP_LEVEL_SIMPLE;
             IS_AVAILABLE_COMPLEVEL = x -> x == COMP_LEVEL_SIMPLE;
         } else {

--- a/test/hotspot/jtreg/compiler/types/correctness/CorrectnessTest.java
+++ b/test/hotspot/jtreg/compiler/types/correctness/CorrectnessTest.java
@@ -25,7 +25,7 @@
  * @test CorrectnessTest
  * @bug 8038418
  * @summary Tests correctness of type usage with type profiling and speculations
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -87,8 +87,8 @@ public class CorrectnessTest {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
     public static void main(String[] args) {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         Asserts.assertGTE(args.length, 1);
         ProfilingType profilingType = ProfilingType.valueOf(args[0]);

--- a/test/hotspot/jtreg/compiler/types/correctness/OffTest.java
+++ b/test/hotspot/jtreg/compiler/types/correctness/OffTest.java
@@ -25,7 +25,7 @@
  * @test CorrectnessTest
  * @key randomness
  * @bug 8038418
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/uncommontrap/TestUnstableIfTrap.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestUnstableIfTrap.java
@@ -210,7 +210,7 @@ public class TestUnstableIfTrap {
         boolean isMethodCompiledAtMaxTier
                 = WB.getMethodCompilationLevel(m) == MAX_TIER;
 
-        return Platform.isServer() && !Platform.isEmulatedClient() && isMethodCompiled
+        return Platform.isServer() && isMethodCompiled
                 && (!isTiered || isMethodCompiledAtMaxTier);
     }
 

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetConstantField.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetConstantField.java
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @library /testlibrary/asm
  *
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  *
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.misc
@@ -97,8 +97,8 @@ public class UnsafeGetConstantField {
     static final Unsafe U = Unsafe.getUnsafe();
 
     public static void main(String[] args) {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         testUnsafeGetAddress();
         testUnsafeGetField();

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
@@ -26,7 +26,7 @@
  * @summary tests on constant folding of unsafe get operations from stable arrays
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  *
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.misc
@@ -343,8 +343,8 @@ public class UnsafeGetStableArrayElement {
     }
 
     public static void main(String[] args) throws Exception {
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
         testUnsafeAccess();
         System.out.println("TEST PASSED");

--- a/test/hotspot/jtreg/compiler/whitebox/DeoptimizeRelocatedNMethod.java
+++ b/test/hotspot/jtreg/compiler/whitebox/DeoptimizeRelocatedNMethod.java
@@ -29,7 +29,6 @@
  * @modules java.base/jdk.internal.misc java.management
  * @requires vm.opt.DeoptimizeALot != true
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
- * @requires !vm.emulatedClient
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch -XX:+SegmentedCodeCache

--- a/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
@@ -30,7 +30,7 @@
  *          java.management
  *
  * @requires vm.opt.DeoptimizeALot != true
- * @requires vm.flavor == "server"
+ * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/IsMethodCompilableTest.java
@@ -30,8 +30,7 @@
  *          java.management
  *
  * @requires vm.opt.DeoptimizeALot != true
- * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
- * @requires !vm.emulatedClient
+ * @requires vm.flavor == "server"
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -84,8 +83,8 @@ public class IsMethodCompilableTest extends CompilerWhiteBoxTest {
     protected void test() throws Exception {
 
         // Only c2 compilations can be disabled through PerMethodRecompilationCutoff
-        if (!Platform.isServer() || Platform.isEmulatedClient()) {
-            throw new Error("TESTBUG: Not server mode");
+        if (!Platform.isServer()) {
+            throw new Error("TESTBUG: Not server VM");
         }
 
         if (skipXcompOSR()) {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithAllocateHeapAt.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.G1
- * @requires vm.flavor == "server" & !vm.emulatedClient & os.family != "aix"
+ * @requires vm.flavor == "server" & os.family != "aix"
  * @summary Stress Java heap allocation with AllocateHeapAt flag using GC basher.
  * @run main/othervm/timeout=500 -Xlog:gc*=info -Xmx256m -server -XX:+UseG1GC -XX:AllocateHeapAt=. gc.stress.gcbasher.TestGCBasherWithAllocateHeapAt 120000
  */

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithG1.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.G1
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the G1 GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseG1GC gc.stress.gcbasher.TestGCBasherWithG1 120000
  */

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Parallel
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the Parallel GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseParallelGC -XX:-UseGCOverheadLimit gc.stress.gcbasher.TestGCBasherWithParallel 120000
  */

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithSerial.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Serial
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the Serial GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseSerialGC gc.stress.gcbasher.TestGCBasherWithSerial 120000
  */

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the Shenandoah GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -51,7 +51,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the Shenandoah GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -74,7 +74,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the Shenandoah GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -92,7 +92,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -105,7 +105,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -126,7 +126,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -152,7 +152,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -172,7 +172,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -185,7 +185,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress the Shenandoah GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -203,7 +203,7 @@ import java.io.IOException;
   * @key stress
   * @library /
   * @requires vm.gc.Shenandoah
-  * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+  * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
   * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
   *
   * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithZ.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithZ.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Z
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @summary Stress ZGC
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx384m -XX:+UseZGC gc.stress.gcbasher.TestGCBasherWithZ 120000
  */
@@ -41,7 +41,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Z
- * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & vm.opt.ClassUnloading != false
  * @summary Stress ZGC with nmethod barrier forced deoptimization enabled.
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx384m -XX:+UseZGC
  *   -XX:+UnlockDiagnosticVMOptions -XX:+DeoptimizeNMethodBarriersALot -XX:-Inline

--- a/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTestCompiler.java
+++ b/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTestCompiler.java
@@ -25,7 +25,7 @@
  * @test ReservedStackTestCompiler
  * @summary Run ReservedStackTest with dedicated compilers C1 and C2.
  *
- * @requires vm.flavor == "server" & !vm.emulatedClient
+ * @requires vm.flavor == "server"
  * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/AbstractMethodError/AbstractMethodErrorTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/AbstractMethodError/AbstractMethodErrorTest.java
@@ -25,7 +25,7 @@
 /**
  * @test
  * @summary Check that the verbose message of the AME is printed correctly.
- * @requires !(os.arch=="arm") & vm.flavor == "server" & !vm.emulatedClient & vm.compMode=="Xmixed" & !vm.graal.enabled & vm.opt.UseJVMCICompiler != true & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel==4)
+ * @requires !(os.arch=="arm") & vm.flavor == "server" & vm.compMode=="Xmixed" & !vm.graal.enabled & vm.opt.UseJVMCICompiler != true & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel==4)
  * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/IncompatibleClassChangeError/IncompatibleClassChangeErrorTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/IncompatibleClassChangeError/IncompatibleClassChangeErrorTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Check that the verbose message of ICCE is printed correctly.
  *          The test forces errors in vtable stubs and interpreter.
- * @requires !(os.arch=="arm") & vm.flavor == "server" & !vm.emulatedClient & vm.compMode=="Xmixed" & (!vm.graal.enabled | vm.opt.TieredCompilation == true) & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel==4)
+ * @requires !(os.arch=="arm") & vm.flavor == "server" & vm.compMode=="Xmixed" & (!vm.graal.enabled | vm.opt.TieredCompilation == true) & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel==4)
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerDirectivesDCMDTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerDirectivesDCMDTest.java
@@ -49,7 +49,7 @@ public class CompilerDirectivesDCMDTest {
 
     public void run(CommandExecutor executor) {
 
-        if (Platform.isServer() && !Platform.isEmulatedClient()) {
+        if (Platform.isServer()) {
             filename = System.getProperty("test.src", ".") + File.separator + "control2.txt";
         } else {
             filename = System.getProperty("test.src", ".") + File.separator + "control1.txt";

--- a/test/hotspot/jtreg/serviceability/jvmti/NMethodRelocation/NMethodRelocationTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/NMethodRelocation/NMethodRelocationTest.java
@@ -28,7 +28,6 @@
  * @requires vm.jvmti &
  *           vm.gc != "Epsilon" &
  *           vm.flavor == "server" &
- *           !vm.emulatedClient &
  *           (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4) &
  *           vm.compMode == "Xmixed"
  * @library /test/lib /test/hotspot/jtreg

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
@@ -86,12 +86,10 @@ public class Utils {
             INITIAL_COMP_LEVEL = 1;
         } else {
             String vmName = System.getProperty("java.vm.name");
-            String vmInfo = System.getProperty("java.vm.info");
-            boolean isEmulatedClient = (vmInfo != null) && vmInfo.contains("emulated-client");
-            if (Utils.endsWithIgnoreCase(vmName, " Server VM") && !isEmulatedClient) {
+            if (Utils.endsWithIgnoreCase(vmName, " Server VM")) {
                 INITIAL_COMP_LEVEL = 4;
             } else if (Utils.endsWithIgnoreCase(vmName, " Client VM")
-                    || Utils.endsWithIgnoreCase(vmName, " Minimal VM") || isEmulatedClient) {
+                    || Utils.endsWithIgnoreCase(vmName, " Minimal VM")) {
                 INITIAL_COMP_LEVEL = 1;
             } else {
                 throw new RuntimeException("Unknown VM: " + vmName);

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerInlining.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerInlining.java
@@ -131,10 +131,10 @@ public class TestCompilerInlining {
         if (WHITE_BOX.getBooleanVMFlag("TieredCompilation")) {
             return IntStream.rangeClosed(LEVEL_SIMPLE, WHITE_BOX.getIntxVMFlag("TieredStopAtLevel").intValue()).toArray();
         }
-        if (Platform.isServer() && !Platform.isEmulatedClient()) {
+        if (Platform.isServer()) {
             return new int[] { LEVEL_FULL_OPTIMIZATION };
         }
-        if (Platform.isClient() || Platform.isEmulatedClient()) {
+        if (Platform.isClient()) {
             return new int[] { LEVEL_SIMPLE };
         }
         throw new Error("TESTBUG: unknown VM");

--- a/test/jdk/jdk/jfr/event/runtime/TestThrowableInstrumentation.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestThrowableInstrumentation.java
@@ -52,7 +52,7 @@ public class TestThrowableInstrumentation {
     public static void main(String[] args) {
         // Compile Throwable::<clinit> with C1 (if available)
         if (!WHITE_BOX.enqueueInitializerForCompilation(java.lang.Throwable.class, COMP_LEVEL_SIMPLE)) {
-          if (!Platform.isServer() || isTieredCompilationEnabled() || Platform.isEmulatedClient()) {
+          if (!Platform.isServer() || isTieredCompilationEnabled()) {
             throw new RuntimeException("Unable to compile Throwable::<clinit> with C1");
           }
         }

--- a/test/jdk/jdk/jfr/jvm/TestJFRIntrinsic.java
+++ b/test/jdk/jdk/jfr/jvm/TestJFRIntrinsic.java
@@ -131,10 +131,10 @@ public class TestJFRIntrinsic {
             int maxLevel = flagValue.intValue();
             return IntStream.rangeClosed(1, maxLevel).toArray();
         } else {
-            if (Platform.isServer() && !Platform.isEmulatedClient()) {
+            if (Platform.isServer()) {
                 return new int[]{4};
             }
-            if (Platform.isClient() || Platform.isMinimal() || Platform.isEmulatedClient()) {
+            if (Platform.isClient() || Platform.isMinimal()) {
                 return new int[]{1};
             }
         }

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -107,7 +107,6 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.debug", this::vmDebug);
         map.put("vm.jvmci", this::vmJvmci);
         map.put("vm.jvmci.enabled", this::vmJvmciEnabled);
-        map.put("vm.emulatedClient", this::vmEmulatedClient);
         // vm.hasSA is "true" if the VM contains the serviceability agent
         // and jhsdb.
         map.put("vm.hasSA", this::vmHasSA);
@@ -297,18 +296,6 @@ public class VMProps implements Callable<Map<String, String>> {
         }
 
         return "" + Compiler.isJVMCIEnabled();
-    }
-
-
-    /**
-     * @return true if VM runs in emulated-client mode and false otherwise.
-     */
-    protected String vmEmulatedClient() {
-        String vmInfo = System.getProperty("java.vm.info");
-        if (vmInfo == null) {
-            return errorWithMessage("Can't get 'java.vm.info' property");
-        }
-        return "" + vmInfo.contains(" emulated-client");
     }
 
     /**

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -50,7 +50,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         OS("isAix", "isLinux", "isOSX", "isWindows"),
         VM_TYPE("isClient", "isServer", "isMinimal", "isZero", "isEmbedded"),
         MODE("isInt", "isMixed", "isComp"),
-        IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
+        IGNORED("isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isStatic", "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
                 "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOnWayland");

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -75,10 +75,6 @@ public class Platform {
         return vmInfo.contains("static");
     }
 
-    public static boolean isEmulatedClient() {
-        return vmInfo.contains(" emulated-client");
-    }
-
     public static boolean isTieredSupported() {
         return (compiler != null) && compiler.contains("Tiered Compilers");
     }


### PR DESCRIPTION
Hello,

This PR removes the code related to the client emulation mode, which was deprecated through the deprecation of its interface, the `NeverActAsServerClassMachine` and `AlwaysActAsServerClassMachine` flags in [JDK-8370843](https://bugs.openjdk.org/browse/JDK-8370843) and obsoleted in [JDK-8379665](https://bugs.openjdk.org/browse/JDK-8379665).

Much of the changes in this commit reverts the commits part of [JDK-8166002](https://bugs.openjdk.org/browse/JDK-8166002). For some reason there are several commits tied to this issue: https://github.com/openjdk/jdk/commit/0ac0d9ac29c0226fce7a965163e96e2a536d3716, https://github.com/openjdk/jdk/commit/197ce5bafabd12ec7ae6d8542188fea17358bacb

A semantic issue around the JTREG test property `vm.emulatedClient` is that it checks if the compilation mode is set to "quick-only", which the client emulation mode code sets it to. However, a user might enable the quick-only mode with `-XX:CompilationMode=quick-only`, without enabling the rest of the client emulation mode features. When removing `vm.emulatedClient`, some tests can now be run with `-XX:CompilationMode=quick-only`. So `vm.emulatedClient` really means "running with only C1 enabled". Looking back at when this code was added in [JDK-8166002](https://bugs.openjdk.org/browse/JDK-8166002) this seems to have been intentional, but nonetheless confusing.

My suggestion is that we remove the client emulation mode by reverting many of the changes from [JDK-8166002](https://bugs.openjdk.org/browse/JDK-8166002), and file follow-up issue(s) to look at adding more robust/correct/precise @requires-lines to the tests.

Testing:
* Oracle's tier1-4
* Local testing making sure that all the changed tests run out of the box

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380281](https://bugs.openjdk.org/browse/JDK-8380281): Remove the client emulation mode (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30297/head:pull/30297` \
`$ git checkout pull/30297`

Update a local copy of the PR: \
`$ git checkout pull/30297` \
`$ git pull https://git.openjdk.org/jdk.git pull/30297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30297`

View PR using the GUI difftool: \
`$ git pr show -t 30297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30297.diff">https://git.openjdk.org/jdk/pull/30297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30297#issuecomment-4082630370)
</details>
