### PR TITLE
8379535: test/jdk/java/io/File/ListRoots.java fails with RuntimeException: Does not match FileSystem::getRootDirectories

### DIFF
--- a/test/jdk/java/io/File/ListRoots.java
+++ b/test/jdk/java/io/File/ListRoots.java
@@ -62,10 +62,10 @@ public class ListRoots {
             StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
                 .map(Path::toFile);
 
-        if (OperatingSystem.isWindows()) {
-            if (!expectedStream.anyMatch(actualSet::contains)) {
-                System.err.println(actualSet);
-                throw new RuntimeException("Does not intersect FileSystem::getRootDirectories");
+        if (OperatingSystem.isWindows() &&
+                !expectedStream.anyMatch(actualSet::contains)) {
+            System.err.println(actualSet);
+            throw new RuntimeException("Does not intersect FileSystem::getRootDirectories");
         } else { // Unix
             Set<File> expectedSet = expectedStream.collect(Collectors.toSet());
             if (!actualSet.equals(expectedSet)) {

--- a/test/jdk/java/io/File/ListRoots.java
+++ b/test/jdk/java/io/File/ListRoots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
    @bug 4071322
+   @modules java.base/jdk.internal.util
    @summary Basic test for File.listRoots method
  */
 
@@ -34,6 +35,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import jdk.internal.util.OperatingSystem;
 
 public class ListRoots {
 
@@ -53,14 +56,22 @@ public class ListRoots {
         }
 
         // the list of roots should match FileSystem::getRootDirectories
-        Set<File> roots1 = Stream.of(rs).collect(Collectors.toSet());
+        Set<File> actualSet = Stream.of(rs).collect(Collectors.toSet());
         FileSystem fs = FileSystems.getDefault();
-        Set<File> roots2 = StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
-                .map(Path::toFile)
-                .collect(Collectors.toSet());
-        if (!roots1.equals(roots2)) {
-            System.out.println(roots2);
-            throw new RuntimeException("Does not match FileSystem::getRootDirectories");
+        Stream<File> expectedStream =
+            StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
+                .map(Path::toFile);
+
+        if (OperatingSystem.isWindows()) {
+            if (!expectedStream.anyMatch(actualSet::contains)) {
+                System.err.println(actualSet);
+                throw new RuntimeException("Does not intersect FileSystem::getRootDirectories");
+        } else { // Unix
+            Set<File> expectedSet = expectedStream.collect(Collectors.toSet());
+            if (!actualSet.equals(expectedSet)) {
+                System.err.println(actualSet);
+                throw new RuntimeException("Does not equal FileSystem::getRootDirectories");
+            }
         }
     }
 

--- a/test/jdk/java/io/File/ListRoots.java
+++ b/test/jdk/java/io/File/ListRoots.java
@@ -23,11 +23,12 @@
 
 /* @test
    @bug 4071322
-   @modules java.base/jdk.internal.util
    @summary Basic test for File.listRoots method
+   @run junit ListRoots
  */
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -36,14 +37,26 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import jdk.internal.util.OperatingSystem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ListRoots {
 
-    public static void main(String[] args) throws Exception {
+    private static Stream<File> expectedStream;
+    private static Set<File> actualSet;
+
+    @BeforeAll
+    public static void init() throws IOException {
         File[] rs = File.listRoots();
         for (int i = 0; i < rs.length; i++) {
-            System.out.println(i + ": " + rs[i]);
+            System.err.println(i + ": " + rs[i]);
         }
 
         File f = new File(System.getProperty("test.src", "."), "ListRoots.java");
@@ -51,29 +64,32 @@ public class ListRoots {
         boolean found = Stream.of(rs)
                 .map(File::getPath)
                 .anyMatch(p -> cp.startsWith(p));
-        if (!found) {
-            throw new RuntimeException(cp + " does not have a recognized root");
-        }
+        assertTrue(found, cp + " does not have a recognized root");
 
         // the list of roots should match FileSystem::getRootDirectories
-        Set<File> actualSet = Stream.of(rs).collect(Collectors.toSet());
+        actualSet = Stream.of(rs).collect(Collectors.toSet());
         FileSystem fs = FileSystems.getDefault();
-        Stream<File> expectedStream =
+        expectedStream =
             StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
                 .map(Path::toFile);
-
-        if (OperatingSystem.isWindows()) {
-            if (!expectedStream.anyMatch(actualSet::contains)) {
-                System.err.println(actualSet);
-                throw new RuntimeException("Does not intersect FileSystem::getRootDirectories");
-            }
-        } else { // Unix
-            Set<File> expectedSet = expectedStream.collect(Collectors.toSet());
-            if (!actualSet.equals(expectedSet)) {
-                System.err.println(actualSet);
-                throw new RuntimeException("Does not equal FileSystem::getRootDirectories");
-            }
-        }
     }
 
+    @AfterAll
+    public static void cleanup() throws IOException {
+        expectedStream.close();
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void listRootsUnix() throws IOException {
+        Set<File> expectedSet = expectedStream.collect(Collectors.toSet());
+        assertEquals(expectedSet, actualSet,
+                     "Does not equal FileSystem::getRootDirectories");
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void listRootsWindows() throws IOException {
+        assertTrue(expectedStream.anyMatch(actualSet::contains));
+    }
 }

--- a/test/jdk/java/io/File/ListRoots.java
+++ b/test/jdk/java/io/File/ListRoots.java
@@ -62,10 +62,11 @@ public class ListRoots {
             StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
                 .map(Path::toFile);
 
-        if (OperatingSystem.isWindows() &&
-                !expectedStream.anyMatch(actualSet::contains)) {
-            System.err.println(actualSet);
-            throw new RuntimeException("Does not intersect FileSystem::getRootDirectories");
+        if (OperatingSystem.isWindows()) {
+            if (!expectedStream.anyMatch(actualSet::contains)) {
+                System.err.println(actualSet);
+                throw new RuntimeException("Does not intersect FileSystem::getRootDirectories");
+            }
         } else { // Unix
             Set<File> expectedSet = expectedStream.collect(Collectors.toSet());
             if (!actualSet.equals(expectedSet)) {

--- a/test/jdk/java/io/File/ListRoots.java
+++ b/test/jdk/java/io/File/ListRoots.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -49,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ListRoots {
 
-    private static Stream<File> expectedStream;
+    private static Set<File> expectedSet;
     private static Set<File> actualSet;
 
     @BeforeAll
@@ -59,30 +58,28 @@ public class ListRoots {
             System.err.println(i + ": " + rs[i]);
         }
 
-        File f = new File(System.getProperty("test.src", "."), "ListRoots.java");
+        // the list of roots should match FileSystem::getRootDirectories
+        FileSystem fs = FileSystems.getDefault();
+        expectedSet =
+            StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
+                         .map(Path::toFile)
+                         .collect(Collectors.toSet());
+        actualSet = Stream.of(rs).collect(Collectors.toSet());
+    }
+
+    @Test
+    public void checkRoot() throws IOException {
+        File f = new File(System.getProperty("user.dir"));
         String cp = f.getCanonicalPath();
-        boolean found = Stream.of(rs)
+        boolean found = Stream.of(File.listRoots())
                 .map(File::getPath)
                 .anyMatch(p -> cp.startsWith(p));
         assertTrue(found, cp + " does not have a recognized root");
-
-        // the list of roots should match FileSystem::getRootDirectories
-        actualSet = Stream.of(rs).collect(Collectors.toSet());
-        FileSystem fs = FileSystems.getDefault();
-        expectedStream =
-            StreamSupport.stream(fs.getRootDirectories().spliterator(), false)
-                .map(Path::toFile);
-    }
-
-    @AfterAll
-    public static void cleanup() throws IOException {
-        expectedStream.close();
     }
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
     public void listRootsUnix() throws IOException {
-        Set<File> expectedSet = expectedStream.collect(Collectors.toSet());
         assertEquals(expectedSet, actualSet,
                      "Does not equal FileSystem::getRootDirectories");
     }
@@ -90,6 +87,7 @@ public class ListRoots {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     public void listRootsWindows() throws IOException {
-        assertTrue(expectedStream.anyMatch(actualSet::contains));
+        assertTrue(expectedSet.stream().anyMatch(actualSet::contains),
+                   "Does not intersect FileSystem::getRootDirectories");
     }
 }


### PR DESCRIPTION
On Windows, relax the success criterion of `ListRoots` to the values returned by `File.listRoots` intersecting the values returned by `FileSystem.getRootDirectories` instead of being equal.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379535](https://bugs.openjdk.org/browse/JDK-8379535): test/jdk/java/io/File/ListRoots.java fails with RuntimeException: Does not match FileSystem::getRootDirectories (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30301/head:pull/30301` \
`$ git checkout pull/30301`

Update a local copy of the PR: \
`$ git checkout pull/30301` \
`$ git pull https://git.openjdk.org/jdk.git pull/30301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30301`

View PR using the GUI difftool: \
`$ git pr show -t 30301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30301.diff">https://git.openjdk.org/jdk/pull/30301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30301#issuecomment-4084661047)
</details>
