### PR TITLE
signature_algorithms in TLS up to 1.2 may not enforce a curve

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -542,7 +542,7 @@ enum SignatureScheme {
                     ECParameterSpec params =
                             x509Possession.getECParameterSpec();
                     if (params != null &&
-                            ss.namedGroup == NamedGroup.valueOf(params)) {
+                            (!version.useTLS13PlusSpec()||ss.namedGroup == NamedGroup.valueOf(params))) {
                         Signature signer = ss.getSigner(signingKey);
                         if (signer != null) {
                             return new SimpleImmutableEntry<>(ss, signer);

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -542,7 +542,8 @@ enum SignatureScheme {
                     ECParameterSpec params =
                             x509Possession.getECParameterSpec();
                     if (params != null &&
-                            (!version.useTLS13PlusSpec()||ss.namedGroup == NamedGroup.valueOf(params))) {
+                            (!version.useTLS13PlusSpec() || 
+                            ss.namedGroup == NamedGroup.valueOf(params))) {
                         Signature signer = ss.getSigner(signingKey);
                         if (signer != null) {
                             return new SimpleImmutableEntry<>(ss, signer);


### PR DESCRIPTION
SignatureSchemes in the TLS Client Hello message are decoded as enums like ECDSA_SECP256R1_SHA256 for the bytes 0x0403.

This is correct for TLS1.3:
https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.3
0x0403 = ecdsa_secp256r1_sha256

However such en enum does not exist in TLS1.2:
https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.4.1
There the bytes are separate and mean 0x04 = SHA256, 0x03 = ECDSA.
Note that no curve is specified.

This leads to the problem, that a client that only specifies 0x04 0x03 in TLS1.2 will not get a certificate that has a secp384r1 key, even though that is perfectly valid in TLS1.2.

This change removes the curve check for TLS up to 1.2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30327/head:pull/30327` \
`$ git checkout pull/30327`

Update a local copy of the PR: \
`$ git checkout pull/30327` \
`$ git pull https://git.openjdk.org/jdk.git pull/30327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30327`

View PR using the GUI difftool: \
`$ git pr show -t 30327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30327.diff">https://git.openjdk.org/jdk/pull/30327.diff</a>

</details>
