### PR TITLE
8378315: C2 VectorAPI: optimize loops with indexInRange mask into unmasked main loop and masked drain loop

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -64,6 +64,190 @@ Node *IdealLoopTree::is_loop_exit(Node *iff) const {
 
 //=============================================================================
 
+// Strip long casts that may be introduced around expressions in loop optimization.
+static Node* strip_long_casts(Node* n) {
+  n = n->uncast();
+  while (n->Opcode() == Op_CastLL) {
+    n = n->in(1)->uncast();
+  }
+  return n;
+}
+
+// Match indexInRange mask length expressions derived from loop limits/ivs.
+// Supported forms:
+//   SubL(ConvI2L(limit), ConvI2L(iv))
+//   ConvI2L(SubI(limit, iv))
+static bool match_index_in_range_mask_len(Node* mask_len, Node* loop_limit, Node* iv) {
+  Node* len = strip_long_casts(mask_len);
+
+  if (len->Opcode() == Op_SubL) {
+    Node* limit_long = strip_long_casts(len->in(1));
+    Node* offset_long = strip_long_casts(len->in(2));
+    return (offset_long->Opcode() == Op_ConvI2L && offset_long->in(1) == iv) &&
+           (limit_long->Opcode() == Op_ConvI2L && limit_long->in(1) == loop_limit);
+  }
+
+  if (len->Opcode() == Op_ConvI2L) {
+    Node* sub = len->in(1)->uncast();
+    if (sub->Opcode() == Op_SubI) {
+      Node* limit = sub->in(1)->uncast();
+      Node* offset = sub->in(2)->uncast();
+      return (offset == iv) && (limit == loop_limit);
+    }
+  }
+
+  return false;
+}
+
+// Return true if all uses of n are inside loop.
+static bool all_uses_in_loop(Node* n, IdealLoopTree* loop, PhaseIdealLoop* phase) {
+  for (DUIterator_Fast jmax, j = n->fast_outs(jmax); j < jmax; j++) {
+    Node* use = n->fast_out(j);
+    if (!loop->is_member(phase->get_loop(use))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Detect loops with masked vector memory accesses using
+//   VectorMaskGen(limit - iv)
+// where limit is the counted-loop limit and iv is the counted-loop phi.
+// Return the maximum lane count among such masks, or 0 if not found.
+static int detect_index_in_range_masked_vector_lanes(IdealLoopTree* loop, CountedLoopNode* cl) {
+  Node* iv = cl->phi();
+  Node* loop_limit = cl->limit();
+  int max_lanes = 0;
+
+  for (uint i = 0; i < loop->_body.size(); i++) {
+    Node* n = loop->_body.at(i);
+    Node* mask = nullptr;
+    if (n->Opcode() == Op_LoadVectorMasked) {
+      mask = n->in(3);
+    } else if (n->Opcode() == Op_StoreVectorMasked) {
+      mask = n->in(4);
+    } else if (n->Opcode() == Op_VectorBlend) {
+      mask = n->in(3);
+    } else {
+      continue;
+    }
+
+    if (mask == nullptr || mask->Opcode() != Op_VectorMaskGen) {
+      continue;
+    }
+
+    if (!match_index_in_range_mask_len(mask->in(1), loop_limit, iv)) {
+      continue;
+    }
+
+    const TypeVect* mask_type = mask->bottom_type()->is_vect();
+    if (mask_type == nullptr) {
+      continue;
+    }
+    max_lanes = MAX2(max_lanes, (int)mask_type->length());
+  }
+
+  return max_lanes;
+}
+
+// Tighten main-loop limit so all main-loop iterations have a full mask:
+//   iv + (vlen - 1) < limit  <=>  iv < limit - (vlen - 1)
+static bool tighten_main_loop_limit_for_vector_masked_ops(PhaseIdealLoop* phase,
+                                                           CountedLoopNode* main_head,
+                                                           int mask_lanes) {
+  if (mask_lanes <= 1) {
+    return false;
+  }
+
+  CountedLoopEndNode* main_end = main_head->loopexit();
+  if (main_end == nullptr || main_end->test_trip() != BoolTest::lt || !main_end->stride_is_con() ||
+      main_end->stride_con() <= 0) {
+    return false;
+  }
+
+  Node* main_limit = main_end->limit();
+  if (phase->igvn().type(main_limit)->isa_int() == nullptr) {
+    return false;
+  }
+
+  Node* main_limit_ctrl = phase->get_ctrl(main_limit);
+  Node* underflow_bound = phase->intcon(min_jint + mask_lanes - 1);
+  Node* cmp = new CmpINode(main_limit, underflow_bound);
+  Node* bol = new BoolNode(cmp, BoolTest::lt);
+  phase->register_new_node(cmp, main_limit_ctrl);
+  phase->register_new_node(bol, main_limit_ctrl);
+
+  Node* sub = new SubINode(main_limit, phase->intcon(mask_lanes - 1));
+  phase->register_new_node(sub, main_limit_ctrl);
+
+  // Clamp to min_jint if the subtraction would underflow.
+  Node* adjusted_main_limit = CMoveNode::make(bol, phase->intcon(min_jint), sub, TypeInt::INT);
+  phase->register_new_node(adjusted_main_limit, main_limit_ctrl);
+
+  main_head->set_nonexact_trip_count();
+
+  Node* main_bol = main_end->in(CountedLoopEndNode::TestValue);
+  if (main_bol->outcnt() > 1) {
+    main_bol = main_bol->clone();
+    phase->register_new_node(main_bol, main_end->in(CountedLoopEndNode::TestControl));
+    phase->igvn().replace_input_of(main_end, CountedLoopEndNode::TestValue, main_bol);
+  }
+
+  Node* main_cmp = main_bol->in(1);
+  if (main_cmp->outcnt() > 1) {
+    main_cmp = main_cmp->clone();
+    phase->register_new_node(main_cmp, main_end->in(CountedLoopEndNode::TestControl));
+    phase->igvn().replace_input_of(main_bol, 1, main_cmp);
+  }
+  phase->igvn().replace_input_of(main_cmp, 2, adjusted_main_limit);
+
+  // Keep zero-trip guard for main loop consistent with the tightened limit.
+  Node* ctrl = main_head->skip_assertion_predicates_with_halt();
+  Node* iffm = ctrl != nullptr ? ctrl->in(0) : nullptr;
+  if (iffm != nullptr) {
+    Node* bol = iffm->in(1);
+    Node* cmp = bol != nullptr ? bol->in(1) : nullptr;
+    Node* opq = cmp != nullptr ? cmp->in(2) : nullptr;
+    OpaqueZeroTripGuardNode* opqz = (opq != nullptr && opq->Opcode() == Op_OpaqueZeroTripGuard)
+        ? (OpaqueZeroTripGuardNode*)opq : nullptr;
+    if (opqz != nullptr) {
+      phase->igvn().replace_input_of(opqz, 1, adjusted_main_limit);
+      phase->set_ctrl(opqz, phase->get_ctrl(adjusted_main_limit));
+    }
+  }
+
+  // Make indexInRange masks in the main loop explicit all-true masks so IGVN can
+  // fold masked operations reliably even when original limits are non-constant.
+  IdealLoopTree* main_ilt = phase->get_loop(main_head);
+  Node* iv = main_head->phi();
+  Node* loop_limit = main_head->limit();
+  for (uint i = 0; i < main_ilt->_body.size(); i++) {
+    Node* n = main_ilt->_body.at(i);
+    if (n->Opcode() != Op_VectorMaskGen) {
+      continue;
+    }
+
+    if (!match_index_in_range_mask_len(n->in(1), loop_limit, iv)) {
+      continue;
+    }
+
+    const TypeVect* mask_type = n->bottom_type()->is_vect();
+    if (mask_type == nullptr) {
+      continue;
+    }
+    // Be conservative: avoid rewriting a shared mask node that is also used
+    // outside the main loop (e.g. by post/drain). Rewriting such a node could
+    // accidentally force non-main users to all-true as well.
+    if (!all_uses_in_loop(n, main_ilt, phase)) {
+      continue;
+    }
+    phase->igvn().replace_input_of(n, 1, phase->longcon((jlong)mask_type->length()));
+  }
+
+  phase->C->set_major_progress();
+  return true;
+}
+
 
 //------------------------------record_for_igvn----------------------------
 // Put loop body on igvn work list
@@ -3570,6 +3754,8 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
   bool should_unroll = policy_unroll(phase);
   bool should_rce    = policy_range_check(phase, false, T_INT);
   bool should_rce_long = policy_range_check(phase, false, T_LONG);
+  int vector_mask_lanes = detect_index_in_range_masked_vector_lanes(this, cl);
+  bool should_vector_mask_split = (vector_mask_lanes > 0);
 
   // If not RCE'ing (iteration splitting), then we do not need a pre-loop.
   // We may still need to peel an initial iteration but we will not
@@ -3582,7 +3768,7 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
   // If we have any of these conditions (RCE, unrolling) met, then
   // we switch to the pre-/main-/post-loop model.  This model also covers
   // peeling.
-  if (should_rce || should_unroll) {
+  if (should_rce || should_unroll || should_vector_mask_split) {
     if (cl->is_normal_loop()) { // Convert to 'pre/main/post' loops
       if (should_rce_long && phase->create_loop_nest(this, old_new)) {
         return true;
@@ -3603,6 +3789,13 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
       }
 
       phase->insert_pre_post_loops(this, old_new, peel_only);
+
+      if (should_vector_mask_split) {
+        CountedLoopNode* main_head = _head->as_CountedLoop();
+        if (main_head->is_main_loop()) {
+          tighten_main_loop_limit_for_vector_masked_ops(phase, main_head, vector_mask_lanes);
+        }
+      }
     }
     // Adjust the pre- and main-loop limits to let the pre and  post loops run
     // with full checks, but the main-loop with no checks.  Remove said checks

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1143,18 +1143,30 @@ Node* LoadVectorMaskedNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (!in(3)->is_top() && in(3)->Opcode() == Op_VectorMaskGen) {
     Node* mask_len = in(3)->in(1);
     const TypeLong* ty = phase->type(mask_len)->isa_long();
-    if (ty && ty->is_con()) {
-      BasicType mask_bt = Matcher::vector_element_basic_type(in(3));
-      int load_sz = type2aelembytes(mask_bt) * ty->get_con();
-      if (load_sz > MaxVectorSize) {
-        // After loop opts, cast nodes are aggressively removed, if the input is then transformed
-        // into a constant that is outside the range of the removed cast, we may encounter it here.
-        // This should be a dead node then.
-        assert(Compile::current()->post_loop_opts_phase(), "Unexpected load size");
-        return phase->C->top();
+    if (ty != nullptr) {
+      bool is_all_true_mask = false;
+      if (ty->is_con()) {
+        BasicType mask_bt = Matcher::vector_element_basic_type(in(3));
+        jlong mask_lanes = ty->get_con();
+        int max_mask_lanes = Matcher::max_vector_size(mask_bt);
+        if (mask_lanes > max_mask_lanes) {
+          // After loop opts, cast nodes are aggressively removed, if the input is then transformed
+          // into a constant that is outside the range of the removed cast, we may encounter it here.
+          // This should be a dead node then.
+          assert(Compile::current()->post_loop_opts_phase(), "Unexpected load size");
+          return phase->C->top();
+        }
+
+        is_all_true_mask = (mask_lanes >= (jlong)vect_type()->length());
+      } else if (ty->lo_as_long() >= vect_type()->length()) {
+        // If loop optimizations can prove that the generated mask always has at least as many
+        // active lanes as this vector operation needs, then this masked load is equivalent to
+        // an unmasked load. This is important for main-loop iterations where the tail predicate
+        // is known to be all-true.
+        is_all_true_mask = true;
       }
 
-      if (load_sz == MaxVectorSize) {
+      if (is_all_true_mask) {
         Node* ctr = in(MemNode::Control);
         Node* mem = in(MemNode::Memory);
         Node* adr = in(MemNode::Address);
@@ -1169,18 +1181,27 @@ Node* StoreVectorMaskedNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (!in(4)->is_top() && in(4)->Opcode() == Op_VectorMaskGen) {
     Node* mask_len = in(4)->in(1);
     const TypeLong* ty = phase->type(mask_len)->isa_long();
-    if (ty && ty->is_con()) {
-      BasicType mask_bt = Matcher::vector_element_basic_type(in(4));
-      int load_sz = type2aelembytes(mask_bt) * ty->get_con();
-      if (load_sz > MaxVectorSize) {
-        // After loop opts, cast nodes are aggressively removed, if the input is then transformed
-        // into a constant that is outside the range of the removed cast, we may encounter it here.
-        // This should be a dead node then.
-        assert(Compile::current()->post_loop_opts_phase(), "Unexpected store size");
-        return phase->C->top();
+    if (ty != nullptr) {
+      bool is_all_true_mask = false;
+      if (ty->is_con()) {
+        BasicType mask_bt = Matcher::vector_element_basic_type(in(4));
+        jlong mask_lanes = ty->get_con();
+        int max_mask_lanes = Matcher::max_vector_size(mask_bt);
+        if (mask_lanes > max_mask_lanes) {
+          // After loop opts, cast nodes are aggressively removed, if the input is then transformed
+          // into a constant that is outside the range of the removed cast, we may encounter it here.
+          // This should be a dead node then.
+          assert(Compile::current()->post_loop_opts_phase(), "Unexpected store size");
+          return phase->C->top();
+        }
+
+        is_all_true_mask = (mask_lanes >= (jlong)vect_type()->length());
+      } else if (ty->lo_as_long() >= vect_type()->length()) {
+        // See LoadVectorMaskedNode::Ideal for rationale.
+        is_all_true_mask = true;
       }
 
-      if (load_sz == MaxVectorSize) {
+      if (is_all_true_mask) {
         Node* ctr = in(MemNode::Control);
         Node* mem = in(MemNode::Memory);
         Node* adr = in(MemNode::Address);
@@ -2382,6 +2403,26 @@ Node* VectorBlendNode::Identity(PhaseGVN* phase) {
   }
   return this;
 }
+
+Node* VectorBlendNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  Node* mask = in(3);
+  if (mask != nullptr && mask->Opcode() == Op_VectorMaskGen) {
+    const TypeLong* ty = phase->type(mask->in(1))->isa_long();
+    if (ty != nullptr) {
+      bool is_all_true_mask = false;
+      if (ty->is_con()) {
+        is_all_true_mask = (ty->get_con() >= (jlong)vect_type()->length());
+      } else if (ty->lo_as_long() >= vect_type()->length()) {
+        is_all_true_mask = true;
+      }
+      if (is_all_true_mask) {
+        return in(2);
+      }
+    }
+  }
+  return nullptr;
+}
+
 static bool is_replicate_uint_constant(const Node* n) {
   return n->Opcode() == Op_Replicate &&
          n->in(1)->is_Con() &&

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1704,8 +1704,8 @@ class VectorTestNode : public CmpNode {
 };
 
 // Blend two vectors based on a vector mask. For each lane, select the value
-// from the first input vector (vec1) if the corresponding mask lane is set,
-// otherwise select from the second input vector (vec2).
+// from the second input vector (vec2) if the corresponding mask lane is set,
+// otherwise select from the first input vector (vec1).
 class VectorBlendNode : public VectorNode {
  public:
   VectorBlendNode(Node* vec1, Node* vec2, Node* mask)
@@ -1713,6 +1713,7 @@ class VectorBlendNode : public VectorNode {
   }
 
   virtual int Opcode() const;
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
   Node* vec1() const { return in(1); }
   Node* vec2() const { return in(2); }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIndexInRangeMainAndDrain.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIndexInRangeMainAndDrain.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+import jdk.incubator.vector.*;
+import jdk.test.lib.Asserts;
+
+/**
+ * @test 8378315
+ * @summary C2 should optimize indexInRange loops into unmasked main loop and masked drain loop
+ * @library /test/lib /
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.TestIndexInRangeMainAndDrain
+ */
+public class TestIndexInRangeMainAndDrain {
+    private static final VectorSpecies<Integer> SPECIES = IntVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Long> LONG_SPECIES = LongVector.SPECIES_PREFERRED;
+    private static final int SIZE = 1027;
+    private static final int STRIDE = Math.max(1, SPECIES.length() * 2);
+
+    private static final int[] SRC = new int[SIZE];
+    private static final int[] DST = new int[SIZE];
+    private static final int[] DST_STRIDE = new int[SIZE];
+    private static final int[] DST_SHARED1 = new int[SIZE];
+    private static final int[] DST_SHARED2 = new int[SIZE];
+    private static final long[] LSRC = new long[SIZE];
+    private static final long[] LDST = new long[SIZE];
+
+    static {
+        for (int i = 0; i < SIZE; i++) {
+            SRC[i] = i * 3 + 17;
+            LSRC[i] = i * 5L + 13L;
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR_I, ">= 1",
+                  IRNode.STORE_VECTOR, ">= 1",
+                  IRNode.LOAD_VECTOR_MASKED, ">= 1",
+                  IRNode.STORE_VECTOR_MASKED, ">= 1"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"})
+    public static void maskedLoopWithIndexInRange() {
+        for (int i = 0; i < SIZE; i += SPECIES.length()) {
+            VectorMask<Integer> m = SPECIES.indexInRange(i, SIZE);
+            IntVector v = IntVector.fromArray(SPECIES, SRC, i, m);
+            v.add(1).intoArray(DST, i, m);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR_I, ">= 1",
+                  IRNode.STORE_VECTOR, ">= 1",
+                  IRNode.LOAD_VECTOR_MASKED, ">= 1",
+                  IRNode.STORE_VECTOR_MASKED, ">= 1"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"})
+    public static void maskedLoopWithIndexInRangeNonUnitStride() {
+        for (int i = 0; i < SIZE; i += STRIDE) {
+            VectorMask<Integer> m = SPECIES.indexInRange(i, SIZE);
+            IntVector v = IntVector.fromArray(SPECIES, SRC, i, m);
+            v.add(2).intoArray(DST_STRIDE, i, m);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR_I, ">= 1",
+                  IRNode.LOAD_VECTOR_L, ">= 1",
+                  IRNode.STORE_VECTOR, ">= 2",
+                  IRNode.LOAD_VECTOR_MASKED, ">= 2",
+                  IRNode.STORE_VECTOR_MASKED, ">= 2"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"})
+    public static void maskedLoopWithMultipleVectorLengths() {
+        for (int i = 0; i < SIZE; i += SPECIES.length()) {
+            VectorMask<Integer> im = SPECIES.indexInRange(i, SIZE);
+            IntVector iv = IntVector.fromArray(SPECIES, SRC, i, im);
+            iv.add(3).intoArray(DST, i, im);
+
+            VectorMask<Long> lm = LONG_SPECIES.indexInRange(i, SIZE);
+            LongVector lv = LongVector.fromArray(LONG_SPECIES, LSRC, i, lm);
+            lv.add(7L).intoArray(LDST, i, lm);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR_I, ">= 1",
+                  IRNode.STORE_VECTOR, ">= 1",
+                  IRNode.LOAD_VECTOR_MASKED, ">= 2",
+                  IRNode.STORE_VECTOR_MASKED, ">= 2"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"})
+    public static void maskedLoopSharedMaskNodeSafety() {
+        for (int i = 0; i < SIZE; i += SPECIES.length()) {
+            VectorMask<Integer> m = SPECIES.indexInRange(i, SIZE);
+
+            IntVector v1 = IntVector.fromArray(SPECIES, SRC, i, m);
+            v1.add(11).intoArray(DST_SHARED1, i, m);
+
+            IntVector v2 = IntVector.fromArray(SPECIES, SRC, i, m);
+            v2.mul(3).intoArray(DST_SHARED2, i, m);
+        }
+    }
+
+    @Check(test = "maskedLoopWithIndexInRange")
+    public static void checkMaskedLoopWithIndexInRange() {
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(DST[i], SRC[i] + 1);
+        }
+    }
+
+    @Check(test = "maskedLoopWithIndexInRangeNonUnitStride")
+    public static void checkMaskedLoopWithIndexInRangeNonUnitStride() {
+        int[] expected = new int[SIZE];
+        for (int i = 0; i < SIZE; i += STRIDE) {
+            int upper = Math.min(i + SPECIES.length(), SIZE);
+            for (int j = i; j < upper; j++) {
+                expected[j] = SRC[j] + 2;
+            }
+        }
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(DST_STRIDE[i], expected[i]);
+        }
+    }
+
+    @Check(test = "maskedLoopWithMultipleVectorLengths")
+    public static void checkMaskedLoopWithMultipleVectorLengths() {
+        int[] expectedInt = new int[SIZE];
+        long[] expectedLong = new long[SIZE];
+
+        for (int i = 0; i < SIZE; i += SPECIES.length()) {
+            int intUpper = Math.min(i + SPECIES.length(), SIZE);
+            for (int j = i; j < intUpper; j++) {
+                expectedInt[j] = SRC[j] + 3;
+            }
+
+            int longUpper = Math.min(i + LONG_SPECIES.length(), SIZE);
+            for (int j = i; j < longUpper; j++) {
+                expectedLong[j] = LSRC[j] + 7L;
+            }
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(DST[i], expectedInt[i]);
+            Asserts.assertEquals(LDST[i], expectedLong[i]);
+        }
+    }
+
+    @Check(test = "maskedLoopSharedMaskNodeSafety")
+    public static void checkMaskedLoopSharedMaskNodeSafety() {
+        int[] expected1 = new int[SIZE];
+        int[] expected2 = new int[SIZE];
+
+        for (int i = 0; i < SIZE; i += SPECIES.length()) {
+            int upper = Math.min(i + SPECIES.length(), SIZE);
+            for (int j = i; j < upper; j++) {
+                expected1[j] = SRC[j] + 11;
+                expected2[j] = SRC[j] * 3;
+            }
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            Asserts.assertEquals(DST_SHARED1[i], expected1[i]);
+            Asserts.assertEquals(DST_SHARED2[i], expected2[i]);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework testFramework = new TestFramework();
+        testFramework.addFlags("--add-modules=jdk.incubator.vector")
+                     .setDefaultWarmup(5000)
+                     .start();
+    }
+}


### PR DESCRIPTION
This optimizes Vector API loops that use `indexInRange` masks by splitting them into a high-performance main loop and a masked "drain" loop for the tail. Tightening the main-loop limit and syncing the zero-trip guard ensures the main loop only runs when full vectors are available. Rather than instrumenting every vector node, replacing the length input of VectorMaskGen with a constant allows existing IGVN to fold these into unmasked operations naturally. The VectorBlendNode comment was corrected to show the mask selects lanes from the second vector per the Vector API specification at https://docs.oracle.com/en/java/javase/25/docs/api/jdk.incubator.vector/jdk/incubator/vector/Vector.html#blend(jdk.incubator.vector.Vector,jdk.incubator.vector.VectorMask)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8378315](https://bugs.openjdk.org/browse/JDK-8378315): C2 VectorAPI: optimize loops with indexInRange mask into unmasked main loop and masked drain loop (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30353/head:pull/30353` \
`$ git checkout pull/30353`

Update a local copy of the PR: \
`$ git checkout pull/30353` \
`$ git pull https://git.openjdk.org/jdk.git pull/30353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30353`

View PR using the GUI difftool: \
`$ git pr show -t 30353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30353.diff">https://git.openjdk.org/jdk/pull/30353.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30353#issuecomment-4102769636)
</details>
