### PR TITLE
8380573: Improve -Xlog:gc+ref=trace output in debug mode

### DIFF
--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -173,15 +173,31 @@ template <typename T>
 void InstanceRefKlass::trace_reference_gc(const char *s, oop obj) {
   struct Stream : public LogStream {
     Stream() : LogStream(LogTarget(Trace, gc, ref)()) {}
-    void print_contents_cr(oop* addr)       { print_cr(PTR_FORMAT,   *(uintptr_t*)addr); }
-    void print_contents_cr(narrowOop* addr) { print_cr(UINT32_FORMAT_X_0, *(uint32_t*)addr); }
+    void print_name_cr(oop obj) {
+      if (obj == nullptr) {
+        print_cr("");
+      } else {
+        print_cr(" a %s", obj->klass()->internal_name());
+      }
+    }
+    void print_contents_cr(oop* addr) {
+      print(PTR_FORMAT,   *(uintptr_t*)addr);
+      oop obj = CompressedOops::decode(*addr);
+      print_name_cr(obj);
+    }
+    void print_contents_cr(narrowOop* addr) {
+      print(UINT32_FORMAT_X_0, *(uint32_t*)addr);
+      oop obj = CompressedOops::decode(*addr);
+      print_name_cr(obj);
+    }
   } stream;
 
   if (stream.is_enabled()) {
     T* referent_addr   = (T*) java_lang_ref_Reference::referent_addr_raw(obj);
     T* discovered_addr = (T*) java_lang_ref_Reference::discovered_addr_raw(obj);
 
-    stream.print_cr("InstanceRefKlass %s for obj " PTR_FORMAT, s, p2i(obj));
+    ResourceMark rm;
+    stream.print_cr("InstanceRefKlass %s for obj " PTR_FORMAT " a %s", s, p2i(obj), obj->klass()->internal_name());
     stream.print("     referent_addr/* " PTR_FORMAT " / ", p2i(referent_addr));
     stream.print_contents_cr(referent_addr);
     stream.print("     discovered_addr/* " PTR_FORMAT " / ", p2i(discovered_addr));

--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -29,6 +29,7 @@
 
 #include "classfile/javaClasses.inline.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "gc/shared/locationPrinter.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -177,17 +178,30 @@ void InstanceRefKlass::trace_reference_gc(const char *s, oop obj) {
     Stream() : LogStream(LogTarget(Trace, gc, ref)()) {}
     void print_name(oop obj) {
       if (obj != nullptr) {
-        print(" a %s", obj->klass()->internal_name());
+        Klass* k = obj->klass_without_asserts();
+        if (!(Metaspace::contains(k) && Symbol::is_valid(k->name()))) {
+          // Maybe the mark contains a forwarding pointer
+          if (obj->is_forwarded()) {
+            obj = obj->forwardee();
+            k = obj->klass_without_asserts();
+            if (!(Metaspace::contains(k) && Symbol::is_valid(k->name()))) {
+              return; // Give up
+            }
+          } else {
+            return; // Give up
+          }
+        }
+        print(" a %s", k->internal_name());
       }
     }
     void print_contents_cr(oop* addr) {
       print(PTR_FORMAT, *(uintptr_t*)addr);
       if (!UseZGC) {
         // ZGC can't read raw oops without load barriers.
-        oop obj = CompressedOops::decode(*addr);
+        oop obj = *addr;
         print_name(obj);
       }
-      print_cr("");
+      cr();
     }
     void print_contents_cr(narrowOop* addr) {
       print(UINT32_FORMAT_X_0, *(uint32_t*)addr);
@@ -196,7 +210,7 @@ void InstanceRefKlass::trace_reference_gc(const char *s, oop obj) {
         oop obj = CompressedOops::decode(*addr);
         print_name(obj);
       }
-      print_cr("");
+      cr();
     }
   } stream;
 

--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -28,6 +28,7 @@
 #include "oops/instanceRefKlass.hpp"
 
 #include "classfile/javaClasses.inline.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -174,22 +175,28 @@ template <typename T>
 void InstanceRefKlass::trace_reference_gc(const char *s, oop obj) {
   struct Stream : public LogStream {
     Stream() : LogStream(LogTarget(Trace, gc, ref)()) {}
-    void print_name_cr(oop obj) {
-      if (obj == nullptr) {
-        print_cr("");
-      } else {
-        print_cr(" a %s", obj->klass()->internal_name());
+    void print_name(oop obj) {
+      if (obj != nullptr) {
+        print(" a %s", obj->klass()->internal_name());
       }
     }
     void print_contents_cr(oop* addr) {
-      print(PTR_FORMAT,   *(uintptr_t*)addr);
-      oop obj = CompressedOops::decode(*addr);
-      print_name_cr(obj);
+      print(PTR_FORMAT, *(uintptr_t*)addr);
+      if (!UseZGC) {
+        // ZGC can't read raw oops without load barriers.
+        oop obj = CompressedOops::decode(*addr);
+        print_name(obj);
+      }
+      print_cr("");
     }
     void print_contents_cr(narrowOop* addr) {
       print(UINT32_FORMAT_X_0, *(uint32_t*)addr);
-      oop obj = CompressedOops::decode(*addr);
-      print_name_cr(obj);
+      if (!UseZGC) {
+        // ZGC can't read raw oops without load barriers.
+        oop obj = CompressedOops::decode(*addr);
+        print_name(obj);
+      }
+      print_cr("");
     }
   } stream;
 

--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -31,6 +31,7 @@
 #include "gc/shared/referenceProcessor.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
+#include "memory/resourceArea.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/instanceKlass.inline.hpp"
 #include "oops/oop.inline.hpp"


### PR DESCRIPTION
`-Xlog:gc+ref=trace` can be quite useful if debugging the reference handling by the GC. Currently, its output looks as follows:
```
[0,347s][trace][gc,ref] GC(0) InstanceRefKlass do_discovery for obj 0x00007fffbe193b80
[0,347s][trace][gc,ref] GC(0) referent_addr/* 0x00007fffbe193b90 / 0x00007fffbe193ab0
[0,347s][trace][gc,ref] GC(0) discovered_addr/* 0x00007fffbe193ba8 / 0x0000000000000000
[0,347s][trace][gc,ref] GC(0) Encountered Reference: 0x00007fffbe193b80 (Weak, YOUNG)
[0,347s][trace][gc,ref] GC(0) Discovered Reference: 0x00007fffbe193b80 (Weak)
```

It would be useful, if the log would also contain the class names of the corresponding references and referent objects e.g. like:
```
[0,289s][trace][gc,ref] GC(0) InstanceRefKlass do_discovery for obj 0x00007fffbe38aeb8 a java.util.WeakHashMap$Entry
[0,289s][trace][gc,ref] GC(0) referent_addr/* 0x00007fffbe38aec8 / 0x00007fffbe38ade8 a MyReferenceHandlingTest
[0,289s][trace][gc,ref] GC(0) discovered_addr/* 0x00007fffbe38aee0 / 0x0000000000000000
[0,289s][trace][gc,ref] GC(0) Encountered Reference: 0x00007fffbe38aeb8 (Weak, YOUNG)
[0,289s][trace][gc,ref] GC(0) Discovered Reference: 0x00007fffbe38aeb8 (Weak)
```

This PR implements exactly that. Notice that the detailed log is only available in debug builds, so the proposed changes won't introduce any overhead in production builds.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380573](https://bugs.openjdk.org/browse/JDK-8380573): Improve -Xlog:gc+ref=trace output in debug mode (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) 🔄 Re-review required (review applies to [baa0b59d](https://git.openjdk.org/jdk/pull/30354/files/baa0b59d4f7c95fcfeef949f2b0a44c38166e227))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30354/head:pull/30354` \
`$ git checkout pull/30354`

Update a local copy of the PR: \
`$ git checkout pull/30354` \
`$ git pull https://git.openjdk.org/jdk.git pull/30354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30354`

View PR using the GUI difftool: \
`$ git pr show -t 30354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30354.diff">https://git.openjdk.org/jdk/pull/30354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30354#issuecomment-4104453611)
</details>
