### PR TITLE
Fix resource leaks in close() methods missing try-finally

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -696,9 +696,12 @@ public class ObjectOutputStream
      */
     @Override
     public void close() throws IOException {
-        flush();
-        clear();
-        bout.close();
+        try {
+            flush();
+        } finally {
+            clear();
+            bout.close();
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/net/SocksSocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocksSocketImpl.java
@@ -507,10 +507,13 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
 
     @Override
     protected void close() throws IOException {
-        if (cmdsock != null)
-            cmdsock.close();
-        cmdsock = null;
-        delegate.close();
+        try {
+            if (cmdsock != null)
+                cmdsock.close();
+        } finally {
+            cmdsock = null;
+            delegate.close();
+        }
     }
 
     private String getUserName() {

--- a/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
@@ -156,10 +156,12 @@ public class DeflaterInputStream extends FilterInputStream {
                 if (usesDefaultDeflater) {
                     def.end();
                 }
-
-                in.close();
             } finally {
-                in = null;
+                try {
+                    in.close();
+                } finally {
+                    in = null;
+                }
             }
         }
     }

--- a/src/java.base/share/classes/javax/crypto/CipherOutputStream.java
+++ b/src/java.base/share/classes/javax/crypto/CipherOutputStream.java
@@ -264,23 +264,26 @@ public class CipherOutputStream extends FilterOutputStream {
         closed = true;
         ensureCapacity(0);
         try {
-            int ostored;
-            if (obuffer != null && obuffer.length > 0) {
-                ostored = cipher.doFinal(obuffer, 0);
-            } else {
-                obuffer = cipher.doFinal();
-                ostored = (obuffer != null) ? obuffer.length : 0;
+            try {
+                int ostored;
+                if (obuffer != null && obuffer.length > 0) {
+                    ostored = cipher.doFinal(obuffer, 0);
+                } else {
+                    obuffer = cipher.doFinal();
+                    ostored = (obuffer != null) ? obuffer.length : 0;
+                }
+                if (ostored > 0) {
+                    output.write(obuffer, 0, ostored);
+                }
+            } catch (IllegalBlockSizeException | BadPaddingException
+                    | ShortBufferException e) {
             }
-            if (ostored > 0) {
-                output.write(obuffer, 0, ostored);
-            }
-        } catch (IllegalBlockSizeException | BadPaddingException
-                | ShortBufferException e) {
+            obuffer = null;
+            try {
+                flush();
+            } catch (IOException ignored) {}
+        } finally {
+            output.close();
         }
-        obuffer = null;
-        try {
-            flush();
-        } catch (IOException ignored) {}
-        output.close();
     }
 }


### PR DESCRIPTION
## Summary

Several `close()` methods call multiple cleanup operations sequentially without `try-finally` protection. If an earlier operation throws, later operations are skipped and underlying resources are permanently leaked.

### SocksSocketImpl.close()
If `cmdsock.close()` throws IOException, `delegate.close()` is never called, leaking the underlying network socket.

```java
// Before (buggy)
if (cmdsock != null)
    cmdsock.close();     // can throw
cmdsock = null;
delegate.close();        // skipped on exception
```

### ObjectOutputStream.close()
If `flush()` throws IOException, `bout.close()` is never called, leaking the underlying `BlockDataOutputStream` and its wrapped stream.

```java
// Before (buggy)
flush();           // can throw
clear();           // skipped
bout.close();      // skipped
```

### DeflaterInputStream.close()
If `def.end()` throws, `in.close()` is skipped. The `finally` block then sets `in = null`, making the underlying input stream permanently unreachable — subsequent `close()` calls become no-ops.

```java
// Before (buggy)
try {
    if (usesDefaultDeflater) {
        def.end();       // can throw
    }
    in.close();          // skipped on exception
} finally {
    in = null;           // makes leak permanent
}
```

### CipherOutputStream.close()
The `catch` block only catches cipher exceptions (`IllegalBlockSizeException | BadPaddingException | ShortBufferException`), not `IOException`. If `output.write()` throws `IOException`, it propagates out of `close()`, skipping `output.close()`.

## Fix

Wrap cleanup operations in `try-finally` to ensure downstream resources are always closed, following the same pattern as `InflaterOutputStream.close()` (recently fixed in JDK-8369181).

## Test plan

- [x] Verified all four fixes compile correctly
- [ ] Existing tests pass (close/resource leak tests in java/io/, java/net/, java/util/zip/, javax/crypto/)

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30359/head:pull/30359` \
`$ git checkout pull/30359`

Update a local copy of the PR: \
`$ git checkout pull/30359` \
`$ git pull https://git.openjdk.org/jdk.git pull/30359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30359`

View PR using the GUI difftool: \
`$ git pr show -t 30359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30359.diff">https://git.openjdk.org/jdk/pull/30359.diff</a>

</details>
