### PR TITLE
Fix CodeStackTrackerImpl switch key not popped and comparison result type

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeStackTrackerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeStackTrackerImpl.java
@@ -190,6 +190,7 @@ public final class CodeStackTrackerImpl implements CodeStackTracker {
             case StoreInstruction i ->
                 pop(1);
             case LookupSwitchInstruction i -> {
+                pop(1); // pop the int switch key
                 map.put(i.defaultTarget(), stack);
                 for (var c : i.cases()) map.put(c.target(), fork());
                 stack = null;
@@ -213,7 +214,12 @@ public final class CodeStackTrackerImpl implements CodeStackTracker {
                     case ARRAYLENGTH, INEG, LNEG, FNEG, DNEG -> pop(1);
                     default -> pop(2);
                 }
-                push(i.typeKind());
+                // Comparison operators always produce int result
+                TypeKind resultType = switch (i.opcode()) {
+                    case LCMP, FCMPL, FCMPG, DCMPL, DCMPG -> TypeKind.INT;
+                    default -> i.typeKind();
+                };
+                push(resultType);
             }
             case ReturnInstruction i ->
                 stack = null;
@@ -289,6 +295,7 @@ public final class CodeStackTrackerImpl implements CodeStackTracker {
                 }
             }
             case TableSwitchInstruction i -> {
+                pop(1); // pop the int switch key
                 map.put(i.defaultTarget(), stack);
                 for (var c : i.cases()) map.put(c.target(), fork());
                 stack = null;


### PR DESCRIPTION
## Summary

Two bugs in `CodeStackTrackerImpl` stack tracking, independent of the IF_ICMPxx fix in PR #30198:

### 1. Switch instructions don't pop the int key

`LookupSwitchInstruction` and `TableSwitchInstruction` save the current stack to branch targets **without first popping the int switch key**. Per JVM Spec §6.5, both `lookupswitch` and `tableswitch` consume an int from the operand stack before branching.

```java
// Before (buggy) — switch key still on stack when saving to targets
case LookupSwitchInstruction i -> {
    map.put(i.defaultTarget(), stack);           // stack has extra int
    for (var c : i.cases()) map.put(c.target(), fork());
    stack = null;
}
```

`StackCounter.java` correctly does `addStackSlot(-1)` before recording jump targets (line 270).

### 2. Comparison operators push operand type instead of INT

`OperatorInstruction` uses `push(i.typeKind())` which returns the **operand** type. For comparison instructions, the result type is always `int` regardless of operand type:

| Instruction | `i.typeKind()` (wrong) | Correct result | Slot error |
|---|---|---|---|
| LCMP | LONG (2 slots) | INT (1 slot) | +1 |
| DCMPL | DOUBLE (2 slots) | INT (1 slot) | +1 |
| DCMPG | DOUBLE (2 slots) | INT (1 slot) | +1 |
| FCMPL | FLOAT (1 slot) | INT (1 slot) | 0 (accidental) |
| FCMPG | FLOAT (1 slot) | INT (1 slot) | 0 (accidental) |

`StackCounter.java` correctly computes `LCMP, DCMPL, DCMPG -> addStackSlot(-3)` (line 157).

## Test plan

- [ ] Existing ClassFile API tests pass
- [ ] `test/jdk/jdk/classfile/StackTrackerTest.java` passes

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30361/head:pull/30361` \
`$ git checkout pull/30361`

Update a local copy of the PR: \
`$ git checkout pull/30361` \
`$ git pull https://git.openjdk.org/jdk.git pull/30361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30361`

View PR using the GUI difftool: \
`$ git pr show -t 30361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30361.diff">https://git.openjdk.org/jdk/pull/30361.diff</a>

</details>
