### PR TITLE
8378250: C2 VectorAPI : wrong result with MUL reduction at various AVX levels

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2135,8 +2135,8 @@ void C2_MacroAssembler::mulreduce16B(int opcode, Register dst, Register src1, XM
   } else {
     pmovsxbw(vtmp2, src2);
     reduce8S(opcode, dst, src1, vtmp2, vtmp1, vtmp2);
-    pshufd(vtmp2, src2, 0x1);
-    pmovsxbw(vtmp2, src2);
+    pshufd(vtmp2, src2, 0xe);
+    pmovsxbw(vtmp2, vtmp2);
     reduce8S(opcode, dst, dst, vtmp2, vtmp1, vtmp2);
   }
 }
@@ -2145,7 +2145,7 @@ void C2_MacroAssembler::mulreduce32B(int opcode, Register dst, Register src1, XM
   if (UseAVX > 2 && VM_Version::supports_avx512bw()) {
     int vector_len = Assembler::AVX_512bit;
     vpmovsxbw(vtmp1, src2, vector_len);
-    reduce32S(opcode, dst, src1, vtmp1, vtmp1, vtmp2);
+    reduce32S(opcode, dst, src1, vtmp1, vtmp2, vtmp1);
   } else {
     assert(UseAVX >= 2,"Should not reach here.");
     mulreduce16B(opcode, dst, src1, src2, vtmp1, vtmp2);
@@ -2211,6 +2211,7 @@ void C2_MacroAssembler::reduce16S(int opcode, Register dst, Register src1, XMMRe
 }
 
 void C2_MacroAssembler::reduce32S(int opcode, Register dst, Register src1, XMMRegister src2, XMMRegister vtmp1, XMMRegister vtmp2) {
+  assert_different_registers(src2, vtmp1);
   int vector_len = Assembler::AVX_256bit;
   vextracti64x4_high(vtmp1, src2);
   reduce_operation_256(T_SHORT, opcode, vtmp1, vtmp1, src2);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2192,6 +2192,7 @@ void C2_MacroAssembler::reduce8S(int opcode, Register dst, Register src1, XMMReg
     }
     phaddw(vtmp1, src2);
   } else {
+    assert_different_registers(src2, vtmp1);
     pshufd(vtmp1, src2, 0xE);
     reduce_operation_128(T_SHORT, opcode, vtmp1, src2);
   }
@@ -2204,6 +2205,7 @@ void C2_MacroAssembler::reduce16S(int opcode, Register dst, Register src1, XMMRe
     vphaddw(vtmp2, src2, src2, vector_len);
     vpermq(vtmp2, vtmp2, 0xD8, vector_len);
   } else {
+    assert_different_registers(src2, vtmp2);
     vextracti128_high(vtmp2, src2);
     reduce_operation_128(T_SHORT, opcode, vtmp2, src2);
   }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMultiplyReductionByte.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMultiplyReductionByte.java
@@ -31,6 +31,7 @@ import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorOperators;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -41,16 +42,17 @@ import jdk.test.lib.Asserts;
  *          when most lanes are 1 and a single lane differs.
  * @library /test/lib /
  * @modules jdk.incubator.vector
- * @run driver compiler.vectorapi.TestMultiplyReductionByte
+ * @run driver ${test.main.class}
  */
 public class TestMultiplyReductionByte {
 
     static byte[] input = new byte[64];
 
-    static int pos;
+    static int pos = Utils.getRandomInstance().nextInt(input.length);
 
     static {
         Arrays.fill(input, (byte) 1);
+        input[pos] = -3;
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMultiplyReductionByte.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMultiplyReductionByte.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Arrays;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorOperators;
+
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @bug 8378250
+ * @summary Verify correctness of byte vector MUL reduction across all species.
+ *          A register aliasing bug in mulreduce32B caused the upper half of
+ *          sign-extended data to overwrite the source, producing wrong results
+ *          when most lanes are 1 and a single lane differs.
+ * @library /test/lib /
+ * @modules jdk.incubator.vector
+ * @run driver compiler.vectorapi.TestMultiplyReductionByte
+ */
+public class TestMultiplyReductionByte {
+
+    static byte[] input = new byte[64];
+
+    static int pos;
+
+    static {
+        Arrays.fill(input, (byte) 1);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"},
+        applyIf = {"MaxVectorSize", ">=8"})
+    static byte testMulReduce64() {
+        return ByteVector.fromArray(ByteVector.SPECIES_64, input, 0)
+                         .reduceLanes(VectorOperators.MUL);
+    }
+
+    @Run(test = "testMulReduce64")
+    static void runMulReduce64() {
+        input[pos] = 1;
+        pos = (pos + 1) % ByteVector.SPECIES_64.length();
+        input[pos] = -3;
+        byte result = testMulReduce64();
+        Asserts.assertEquals((byte) -3, result, "MUL reduction (64-bit), pos=" + pos);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"},
+        applyIf = {"MaxVectorSize", ">=16"})
+    static byte testMulReduce128() {
+        return ByteVector.fromArray(ByteVector.SPECIES_128, input, 0)
+                         .reduceLanes(VectorOperators.MUL);
+    }
+
+    @Run(test = "testMulReduce128")
+    static void runMulReduce128() {
+        input[pos] = 1;
+        pos = (pos + 1) % ByteVector.SPECIES_128.length();
+        input[pos] = -3;
+        byte result = testMulReduce128();
+        Asserts.assertEquals((byte) -3, result, "MUL reduction (128-bit), pos=" + pos);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"},
+        applyIf = {"MaxVectorSize", ">=32"})
+    static byte testMulReduce256() {
+        return ByteVector.fromArray(ByteVector.SPECIES_256, input, 0)
+                         .reduceLanes(VectorOperators.MUL);
+    }
+
+    @Run(test = "testMulReduce256")
+    static void runMulReduce256() {
+        input[pos] = 1;
+        pos = (pos + 1) % ByteVector.SPECIES_256.length();
+        input[pos] = -3;
+        byte result = testMulReduce256();
+        Asserts.assertEquals((byte) -3, result, "MUL reduction (256-bit), pos=" + pos);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
+        applyIfCPUFeatureOr = {"avx512f", "true", "asimd", "true"},
+        applyIf = {"MaxVectorSize", ">=64"})
+    static byte testMulReduce512() {
+        return ByteVector.fromArray(ByteVector.SPECIES_512, input, 0)
+                         .reduceLanes(VectorOperators.MUL);
+    }
+
+    @Run(test = "testMulReduce512")
+    static void runMulReduce512() {
+        input[pos] = 1;
+        pos = (pos + 1) % ByteVector.SPECIES_512.length();
+        input[pos] = -3;
+        byte result = testMulReduce512();
+        Asserts.assertEquals((byte) -3, result, "MUL reduction (512-bit), pos=" + pos);
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+}

--- a/test/jdk/jdk/incubator/vector/ByteVector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/ByteVector128Tests.java
@@ -1114,6 +1114,10 @@ public class ByteVector128Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((byte)(i + 1) == 0) ? 1 : (byte)(i + 1)));
             }),
+            withToString("byte[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (byte)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("byte[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ByteVector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/ByteVector256Tests.java
@@ -1114,6 +1114,10 @@ public class ByteVector256Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((byte)(i + 1) == 0) ? 1 : (byte)(i + 1)));
             }),
+            withToString("byte[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (byte)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("byte[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ByteVector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/ByteVector512Tests.java
@@ -1114,6 +1114,10 @@ public class ByteVector512Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((byte)(i + 1) == 0) ? 1 : (byte)(i + 1)));
             }),
+            withToString("byte[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (byte)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("byte[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ByteVector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/ByteVector64Tests.java
@@ -1114,6 +1114,10 @@ public class ByteVector64Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((byte)(i + 1) == 0) ? 1 : (byte)(i + 1)));
             }),
+            withToString("byte[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (byte)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("byte[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ByteVectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteVectorMaxTests.java
@@ -1120,6 +1120,10 @@ public class ByteVectorMaxTests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((byte)(i + 1) == 0) ? 1 : (byte)(i + 1)));
             }),
+            withToString("byte[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (byte)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("byte[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/DoubleVector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleVector128Tests.java
@@ -1239,6 +1239,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((double)(i + 1) == 0) ? 1 : (double)(i + 1)));
             }),
+            withToString("double[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (double)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("double[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (double)0.01 + ((double)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/DoubleVector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleVector256Tests.java
@@ -1239,6 +1239,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((double)(i + 1) == 0) ? 1 : (double)(i + 1)));
             }),
+            withToString("double[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (double)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("double[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (double)0.01 + ((double)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/DoubleVector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleVector512Tests.java
@@ -1239,6 +1239,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((double)(i + 1) == 0) ? 1 : (double)(i + 1)));
             }),
+            withToString("double[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (double)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("double[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (double)0.01 + ((double)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/DoubleVector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleVector64Tests.java
@@ -1239,6 +1239,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((double)(i + 1) == 0) ? 1 : (double)(i + 1)));
             }),
+            withToString("double[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (double)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("double[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (double)0.01 + ((double)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/DoubleVectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleVectorMaxTests.java
@@ -1245,6 +1245,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((double)(i + 1) == 0) ? 1 : (double)(i + 1)));
             }),
+            withToString("double[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (double)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("double[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (double)0.01 + ((double)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/FloatVector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/FloatVector128Tests.java
@@ -1256,6 +1256,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((float)(i + 1) == 0) ? 1 : (float)(i + 1)));
             }),
+            withToString("float[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (float)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("float[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (float)0.01 + ((float)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/FloatVector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/FloatVector256Tests.java
@@ -1256,6 +1256,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((float)(i + 1) == 0) ? 1 : (float)(i + 1)));
             }),
+            withToString("float[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (float)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("float[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (float)0.01 + ((float)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/FloatVector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/FloatVector512Tests.java
@@ -1256,6 +1256,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((float)(i + 1) == 0) ? 1 : (float)(i + 1)));
             }),
+            withToString("float[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (float)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("float[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (float)0.01 + ((float)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/FloatVector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/FloatVector64Tests.java
@@ -1256,6 +1256,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((float)(i + 1) == 0) ? 1 : (float)(i + 1)));
             }),
+            withToString("float[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (float)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("float[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (float)0.01 + ((float)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/FloatVectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatVectorMaxTests.java
@@ -1262,6 +1262,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> (((float)(i + 1) == 0) ? 1 : (float)(i + 1)));
             }),
+            withToString("float[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (float)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("float[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> (float)0.01 + ((float)i / (i + 1)));

--- a/test/jdk/jdk/incubator/vector/IntVector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/IntVector128Tests.java
@@ -1104,6 +1104,10 @@ public class IntVector128Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((int)(i + 1) == 0) ? 1 : (int)(i + 1)));
             }),
+            withToString("int[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (int)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("int[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/IntVector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/IntVector256Tests.java
@@ -1104,6 +1104,10 @@ public class IntVector256Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((int)(i + 1) == 0) ? 1 : (int)(i + 1)));
             }),
+            withToString("int[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (int)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("int[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/IntVector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/IntVector512Tests.java
@@ -1104,6 +1104,10 @@ public class IntVector512Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((int)(i + 1) == 0) ? 1 : (int)(i + 1)));
             }),
+            withToString("int[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (int)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("int[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/IntVector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/IntVector64Tests.java
@@ -1104,6 +1104,10 @@ public class IntVector64Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((int)(i + 1) == 0) ? 1 : (int)(i + 1)));
             }),
+            withToString("int[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (int)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("int[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/IntVectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/IntVectorMaxTests.java
@@ -1110,6 +1110,10 @@ public class IntVectorMaxTests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((int)(i + 1) == 0) ? 1 : (int)(i + 1)));
             }),
+            withToString("int[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (int)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("int[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/LongVector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/LongVector128Tests.java
@@ -1088,6 +1088,10 @@ public class LongVector128Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((long)(i + 1) == 0) ? 1 : (long)(i + 1)));
             }),
+            withToString("long[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (long)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("long[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/LongVector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/LongVector256Tests.java
@@ -1088,6 +1088,10 @@ public class LongVector256Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((long)(i + 1) == 0) ? 1 : (long)(i + 1)));
             }),
+            withToString("long[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (long)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("long[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/LongVector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/LongVector512Tests.java
@@ -1088,6 +1088,10 @@ public class LongVector512Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((long)(i + 1) == 0) ? 1 : (long)(i + 1)));
             }),
+            withToString("long[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (long)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("long[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/LongVector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/LongVector64Tests.java
@@ -1088,6 +1088,10 @@ public class LongVector64Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((long)(i + 1) == 0) ? 1 : (long)(i + 1)));
             }),
+            withToString("long[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (long)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("long[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/LongVectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/LongVectorMaxTests.java
@@ -1094,6 +1094,10 @@ public class LongVectorMaxTests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((long)(i + 1) == 0) ? 1 : (long)(i + 1)));
             }),
+            withToString("long[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (long)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("long[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ShortVector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/ShortVector128Tests.java
@@ -1104,6 +1104,10 @@ public class ShortVector128Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((short)(i + 1) == 0) ? 1 : (short)(i + 1)));
             }),
+            withToString("short[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (short)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("short[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ShortVector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/ShortVector256Tests.java
@@ -1104,6 +1104,10 @@ public class ShortVector256Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((short)(i + 1) == 0) ? 1 : (short)(i + 1)));
             }),
+            withToString("short[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (short)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("short[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ShortVector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/ShortVector512Tests.java
@@ -1104,6 +1104,10 @@ public class ShortVector512Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((short)(i + 1) == 0) ? 1 : (short)(i + 1)));
             }),
+            withToString("short[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (short)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("short[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ShortVector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/ShortVector64Tests.java
@@ -1104,6 +1104,10 @@ public class ShortVector64Tests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((short)(i + 1) == 0) ? 1 : (short)(i + 1)));
             }),
+            withToString("short[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (short)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("short[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/ShortVectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortVectorMaxTests.java
@@ -1110,6 +1110,10 @@ public class ShortVectorMaxTests extends AbstractVectorTest {
                 return fill(s * BUFFER_REPS,
                             i -> (((short)(i + 1) == 0) ? 1 : (short)(i + 1)));
             }),
+            withToString("short[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> (short)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
             withToString("short[cornerCaseValue(i)]", (int s) -> {
                 return fill(s * BUFFER_REPS,
                             i -> cornerCaseValue(i));

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -1375,6 +1375,10 @@ relativeError));
                 return fill(s * BUFFER_REPS,
                             i -> ((($type$)(i + 1) == 0) ? 1 : ($type$)(i + 1)));
             }),
+            withToString("$type$[smallOddValue(i)]", (int s) -> {
+                return fill(s * BUFFER_REPS,
+                            i -> ($type$)(i % 7 == 0 ? -3 : (i % 3 == 0 ? -1 : 1)));
+            }),
 #if[FP]
             withToString("$type$[0.01 + (i / (i + 1))]", (int s) -> {
                 return fill(s * BUFFER_REPS,


### PR DESCRIPTION
This bug fix patch fixes two incorrectness issues seen during byte vector multiply reductions at various AVX levels.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378250](https://bugs.openjdk.org/browse/JDK-8378250): C2 VectorAPI : wrong result with MUL reduction at various AVX levels (**Bug** - P3)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30363/head:pull/30363` \
`$ git checkout pull/30363`

Update a local copy of the PR: \
`$ git checkout pull/30363` \
`$ git pull https://git.openjdk.org/jdk.git pull/30363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30363`

View PR using the GUI difftool: \
`$ git pr show -t 30363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30363.diff">https://git.openjdk.org/jdk/pull/30363.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30363#issuecomment-4108190419)
</details>
