### PR TITLE
8067449: Add getSystemMnemonicKeyMask() method to SwingUtilities class

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -903,7 +903,8 @@ public class SwingUtilities implements SwingConstants
     }
 
     /**
-     * Returns the system mnemonic key mask
+     * Returns the system mnemonic key mask to be used
+     * for shortcut keymask and/or accelerator keymask
      *
      * @return the system mnemonic key mask
      */

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -903,6 +903,15 @@ public class SwingUtilities implements SwingConstants
     }
 
     /**
+     * Returns the system mnemonic key mask
+     *
+     * @return the system mnemonic key mask
+     */
+    public static int getSystemMnemonicKeyMask() {
+        return SwingUtilities2.getSystemMnemonicKeyMask();
+    }
+
+    /**
      * Compute the width of the string using a font with the specified
      * "metrics" (sizes).
      *

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -907,6 +907,7 @@ public class SwingUtilities implements SwingConstants
      * for shortcut keymask and/or accelerator keymask
      *
      * @return the system mnemonic key mask
+     * @since 27
      */
     public static int getSystemMnemonicKeyMask() {
         return SwingUtilities2.getSystemMnemonicKeyMask();

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -904,9 +904,18 @@ public class SwingUtilities implements SwingConstants
 
     /**
      * Returns the system mnemonic key mask to be used
-     * for shortcut keymask and/or accelerator keymask
+     * for shortcut keymask and/or accelerator keymask.
+     * The returned key modifiers/mask is used by Swing
+     * to set up a focus accelerator key stroke.
+     * For example, if it returns ALT_MASK it can be mapped
+     * to its virtual keycode VK_ALT and use it as
+     * accelerator keystroke, for e.x.
+     * ALT+F to open a file menu if the menu mnemonic is set to VK_F
+     * and/or
+     * ALT+S to save file if menuitem accelerator is set to VK_S keycode
+     * and this keymask.
      *
-     * @return the system mnemonic key mask
+     * @return the Swing's mnemonic key mask
      * @since 27
      */
     public static int getSystemMnemonicKeyMask() {

--- a/test/jdk/javax/swing/SwingUtilities/TestAcceleratorMask.java
+++ b/test/jdk/javax/swing/SwingUtilities/TestAcceleratorMask.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8067449
  * @key headful
+ * @requires (os.family != "mac")
  * @summary Test SwingUtilities.getSystemMnemonicKeyMask()
  * @run main TestAcceleratorMask
  */
@@ -89,20 +90,8 @@ public class TestAcceleratorMask {
     }
 
     private static int getModKeyCode(int mod) {
-        if ((mod & (InputEvent.SHIFT_DOWN_MASK | InputEvent.SHIFT_MASK)) != 0) {
-            return KeyEvent.VK_SHIFT;
-        }
-
-        if ((mod & (InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK)) != 0) {
-            return KeyEvent.VK_CONTROL;
-        }
-
         if ((mod & (InputEvent.ALT_DOWN_MASK | InputEvent.ALT_MASK)) != 0) {
             return KeyEvent.VK_ALT;
-        }
-
-        if ((mod & (InputEvent.META_DOWN_MASK | InputEvent.META_MASK)) != 0) {
-            return KeyEvent.VK_META;
         }
 
         return 0;

--- a/test/jdk/javax/swing/SwingUtilities/TestAcceleratorMask.java
+++ b/test/jdk/javax/swing/SwingUtilities/TestAcceleratorMask.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8067449
+ * @key headful
+ * @summary Test SwingUtilities.getSystemMnemonicKeyMask()
+ * @run main TestAcceleratorMask
+ */
+
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JMenuBar;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+public class TestAcceleratorMask {
+
+    static JFrame frame;
+    static Robot robot;
+    static boolean passed;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        int keyMask = SwingUtilities.getSystemMnemonicKeyMask();
+        int keyCode = KeyEvent.VK_S;
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("SetAccelerator Example");
+                JMenuBar menuBar = new JMenuBar();
+                JMenu menu = new JMenu("File");
+                JMenuItem saveItem = new JMenuItem("Save");
+
+                saveItem.setAccelerator(KeyStroke.getKeyStroke(
+                                        keyCode, keyMask));
+
+                saveItem.addActionListener(e -> passed = true);
+
+                menu.add(saveItem);
+                menuBar.add(menu);
+                frame.setJMenuBar(menuBar);
+                frame.setSize(300, 200);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(getModKeyCode(keyMask));
+            robot.keyPress(keyCode);
+            robot.keyRelease(keyCode);
+            robot.keyRelease(getModKeyCode(keyMask));
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (!passed) {
+                throw new RuntimeException("Accelerator mask not working");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static int getModKeyCode(int mod) {
+        if ((mod & (InputEvent.SHIFT_DOWN_MASK | InputEvent.SHIFT_MASK)) != 0) {
+            return KeyEvent.VK_SHIFT;
+        }
+
+        if ((mod & (InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK)) != 0) {
+            return KeyEvent.VK_CONTROL;
+        }
+
+        if ((mod & (InputEvent.ALT_DOWN_MASK | InputEvent.ALT_MASK)) != 0) {
+            return KeyEvent.VK_ALT;
+        }
+
+        if ((mod & (InputEvent.META_DOWN_MASK | InputEvent.META_MASK)) != 0) {
+            return KeyEvent.VK_META;
+        }
+
+        return 0;
+    }
+}

--- a/test/jdk/javax/swing/SwingUtilities/TestMnemonicMask.java
+++ b/test/jdk/javax/swing/SwingUtilities/TestMnemonicMask.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8067449
+ * @key headful
+ * @summary Test SwingUtilities.getSystemMnemonicKeyMask()
+ * @run main TestMnemonicMask
+ */
+
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+
+public class TestMnemonicMask {
+    private static JFrame f;
+    private static String[] data = {"one", "two", "three", "four"};
+    private static final JList<String> list = new JList<String>(data);
+    private static boolean menuSelected;
+    private static volatile boolean failed;
+    private static CountDownLatch listGainedFocusLatch = new CountDownLatch(1);
+
+    public static void main(String[] args) throws Exception {
+        try {
+            createUI();
+            runTest();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame("TestMnemonicMask");
+            JMenu menu = new JMenu("File");
+            menu.setMnemonic('F');
+            JMenuItem menuItem = new JMenuItem("item");
+            menu.add(menuItem);
+            JMenuBar menuBar = new JMenuBar();
+            menuBar.add(menu);
+            f.setJMenuBar(menuBar);
+
+            menu.addMenuListener(new MenuListener() {
+                public void menuCanceled(MenuEvent e) {}
+                public void menuDeselected(MenuEvent e) {}
+                public void menuSelected(MenuEvent e) {
+                    menuSelected = true;
+                }
+            });
+
+            list.addFocusListener(new FocusAdapter() {
+                @Override
+                public void focusGained(FocusEvent e) {
+                    listGainedFocusLatch.countDown();
+                }
+            });
+            f.add(list);
+            f.pack();
+            f.setLocationRelativeTo(null);
+            f.setAlwaysOnTop(true);
+            f.setVisible(true);
+        });
+    }
+
+    private static void runTest() throws Exception {
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(1000);
+        if (!listGainedFocusLatch.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Waited too long, but can't gain" +
+                " focus for list");
+        }
+        int keyMask = SwingUtilities.getSystemMnemonicKeyMask();
+        robot.keyPress(KeyEvent.VK_O);
+        robot.keyRelease(KeyEvent.VK_O);
+        robot.waitForIdle();
+        robot.delay(500);
+        robot.keyPress(getModKeyCode(keyMask));
+        robot.keyPress(KeyEvent.VK_F);
+        robot.keyRelease(KeyEvent.VK_F);
+        robot.keyRelease(getModKeyCode(keyMask));
+        robot.waitForIdle();
+        robot.delay(500);
+
+        if (!menuSelected) {
+            throw new RuntimeException("Mnemonics mask not working");
+        }
+    }
+
+    private static int getModKeyCode(int mod) {
+        if ((mod & (InputEvent.SHIFT_DOWN_MASK | InputEvent.SHIFT_MASK)) != 0) {
+            return KeyEvent.VK_SHIFT;
+        }
+
+        if ((mod & (InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK)) != 0) {
+            return KeyEvent.VK_CONTROL;
+        }
+
+        if ((mod & (InputEvent.ALT_DOWN_MASK | InputEvent.ALT_MASK)) != 0) {
+            return KeyEvent.VK_ALT;
+        }
+
+        if ((mod & (InputEvent.META_DOWN_MASK | InputEvent.META_MASK)) != 0) {
+            return KeyEvent.VK_META;
+        }
+
+        return 0;
+    }
+}

--- a/test/jdk/javax/swing/SwingUtilities/TestMnemonicMask.java
+++ b/test/jdk/javax/swing/SwingUtilities/TestMnemonicMask.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8067449
  * @key headful
+ * @requires (os.family != "mac")
  * @summary Test SwingUtilities.getSystemMnemonicKeyMask()
  * @run main TestMnemonicMask
  */
@@ -125,20 +126,8 @@ public class TestMnemonicMask {
     }
 
     private static int getModKeyCode(int mod) {
-        if ((mod & (InputEvent.SHIFT_DOWN_MASK | InputEvent.SHIFT_MASK)) != 0) {
-            return KeyEvent.VK_SHIFT;
-        }
-
-        if ((mod & (InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK)) != 0) {
-            return KeyEvent.VK_CONTROL;
-        }
-
         if ((mod & (InputEvent.ALT_DOWN_MASK | InputEvent.ALT_MASK)) != 0) {
             return KeyEvent.VK_ALT;
-        }
-
-        if ((mod & (InputEvent.META_DOWN_MASK | InputEvent.META_MASK)) != 0) {
-            return KeyEvent.VK_META;
         }
 
         return 0;


### PR DESCRIPTION
A proposal to add getSystemMnemonicKeyMask to SwingUtilities so as to make it publicly accessible from inner SwingUtilities2 class to allow custom L&F to set the own shortcut keys

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change requires CSR request [JDK-8380970](https://bugs.openjdk.org/browse/JDK-8380970) to be approved
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8067449](https://bugs.openjdk.org/browse/JDK-8067449): Add getSystemMnemonicKeyMask() method to SwingUtilities class (**Enhancement** - P4)
 * [JDK-8380970](https://bugs.openjdk.org/browse/JDK-8380970): Add getSystemMnemonicKeyMask() method to SwingUtilities class (**CSR**)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) 🔄 Re-review required (review applies to [4848062b](https://git.openjdk.org/jdk/pull/30366/files/4848062b936e4000a30637ef5b8aeb7e9b520031))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30366/head:pull/30366` \
`$ git checkout pull/30366`

Update a local copy of the PR: \
`$ git checkout pull/30366` \
`$ git pull https://git.openjdk.org/jdk.git pull/30366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30366`

View PR using the GUI difftool: \
`$ git pr show -t 30366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30366.diff">https://git.openjdk.org/jdk/pull/30366.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30366#issuecomment-4109198398)
</details>
