### PR TITLE
8367330: Loosen container detection to include soft limits

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -647,7 +647,7 @@ bool CgroupSubsystem::active_processor_count(int (*cpu_bound_func)(), double& va
     return true;
   }
 
-  int cpu_count = cpu_bound_func();
+  double cpu_count = static_cast<double>(cpu_bound_func());
   double result = -1;
   if (!CgroupUtil::processor_count(contrl->controller(), cpu_count, result)) {
     return false;

--- a/src/hotspot/os/linux/cgroupUtil_linux.cpp
+++ b/src/hotspot/os/linux/cgroupUtil_linux.cpp
@@ -25,7 +25,7 @@
 
 #include "cgroupUtil_linux.hpp"
 
-bool CgroupUtil::processor_count(CgroupCpuController* cpu_ctrl, int upper_bound, double& value) {
+bool CgroupUtil::processor_count(CgroupCpuController* cpu_ctrl, double upper_bound, double& value) {
   assert(upper_bound > 0, "upper bound of cpus must be positive");
   int quota = -1;
   int period = -1;
@@ -68,8 +68,8 @@ physical_memory_size_type CgroupUtil::get_updated_mem_limit(CgroupMemoryControll
 // Get an updated cpu limit. The return value is strictly less than or equal to the
 // passed in 'lowest' value.
 double CgroupUtil::get_updated_cpu_limit(CgroupCpuController* cpu,
-                                     int lowest,
-                                     int upper_bound) {
+                                     double lowest,
+                                     double upper_bound) {
   assert(lowest > 0 && lowest <= upper_bound, "invariant");
   double cpu_limit_val = -1;
   if (CgroupUtil::processor_count(cpu, upper_bound, cpu_limit_val) && cpu_limit_val != upper_bound) {
@@ -145,7 +145,7 @@ void CgroupUtil::adjust_controller(CgroupMemoryController* mem, physical_memory_
   os::free(limit_cg_path);
 }
 
-void CgroupUtil::adjust_controller(CgroupCpuController* cpu, int upper_bound) {
+void CgroupUtil::adjust_controller(CgroupCpuController* cpu, double upper_bound) {
   assert(cpu->cgroup_path() != nullptr, "invariant");
   if (strstr(cpu->cgroup_path(), "../") != nullptr) {
     log_warning(os, container)("Cgroup cpu controller path at '%s' seems to have moved "
@@ -163,9 +163,9 @@ void CgroupUtil::adjust_controller(CgroupCpuController* cpu, int upper_bound) {
   char* cg_path = os::strdup(orig);
   char* last_slash;
   assert(cg_path[0] == '/', "cgroup path must start with '/'");
-  int lowest_limit = upper_bound;
+  double lowest_limit = upper_bound;
   double cpus = get_updated_cpu_limit(cpu, lowest_limit, upper_bound);
-  int orig_limit = lowest_limit != upper_bound ? lowest_limit : upper_bound;
+  double orig_limit = lowest_limit != upper_bound ? lowest_limit : upper_bound;
   char* limit_cg_path = nullptr;
   while ((last_slash = strrchr(cg_path, '/')) != cg_path) {
     *last_slash = '\0'; // strip path
@@ -193,10 +193,10 @@ void CgroupUtil::adjust_controller(CgroupCpuController* cpu, int upper_bound) {
     assert(limit_cg_path != nullptr, "limit path must be set");
     cpu->set_subsystem_path(limit_cg_path);
     log_trace(os, container)("Adjusted controller path for cpu to: %s. "
-                             "Lowest limit was: %d",
+                             "Lowest limit was: %.2f",
                              cpu->subsystem_path(), lowest_limit);
   } else {
-    log_trace(os, container)("Lowest limit was: %d", lowest_limit);
+    log_trace(os, container)("Lowest limit was: %.2f", lowest_limit);
     log_trace(os, container)("No lower limit found for cpu in hierarchy %s, "
                              "adjusting to original path %s",
                               cpu->mount_point(), orig);

--- a/src/hotspot/os/linux/cgroupUtil_linux.hpp
+++ b/src/hotspot/os/linux/cgroupUtil_linux.hpp
@@ -32,18 +32,18 @@
 class CgroupUtil: AllStatic {
 
   public:
-    static bool processor_count(CgroupCpuController* cpu, int upper_bound, double& value);
+    static bool processor_count(CgroupCpuController* cpu, double upper_bound, double& value);
     // Given a memory controller, adjust its path to a point in the hierarchy
     // that represents the closest memory limit.
     static void adjust_controller(CgroupMemoryController* m, physical_memory_size_type upper_bound);
     // Given a cpu controller, adjust its path to a point in the hierarchy
     // that represents the closest cpu limit.
-    static void adjust_controller(CgroupCpuController* c, int upper_bound);
+    static void adjust_controller(CgroupCpuController* c, double upper_bound);
   private:
     static physical_memory_size_type get_updated_mem_limit(CgroupMemoryController* m,
                                                            physical_memory_size_type lowest,
                                                            physical_memory_size_type upper_bound);
-    static double get_updated_cpu_limit(CgroupCpuController* c, int lowest, int upper_bound);
+    static double get_updated_cpu_limit(CgroupCpuController* c, double lowest, double upper_bound);
 };
 
 #endif // CGROUP_UTIL_LINUX_HPP

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -79,9 +79,12 @@ void OSContainer::init() {
    * that limits enforced by other means (e.g. systemd slice) are properly
    * detected.
    */
-  const char *reason;
-  bool any_mem_cpu_limit_present = false;
+  const char* reason;
   bool controllers_read_only = cgroup_subsystem->is_containerized();
+
+  bool any_mem_limit_present = false;
+  bool cpu_limit_present = false;
+
   if (controllers_read_only) {
     // in-container case
     reason = " because all controllers are mounted read-only (container case)";
@@ -89,19 +92,31 @@ void OSContainer::init() {
     // We can be in one of two cases:
     //  1.) On a physical Linux system without any limit
     //  2.) On a physical Linux system with a limit enforced by other means (like systemd slice)
+
     physical_memory_size_type mem_limit_val = value_unlimited;
     (void)memory_limit_in_bytes(mem_limit_val);  // discard error and use default
-    double host_cpus = os::Linux::active_processor_count();
+
+    physical_memory_size_type throttle_limit_val = value_unlimited;
+    (void)memory_throttle_limit_in_bytes(throttle_limit_val);  // discard error and use default
+
+    physical_memory_size_type soft_limit_val = value_unlimited;
+    (void)memory_soft_limit_in_bytes(soft_limit_val);  // discard error and use default
+
+    any_mem_limit_present = mem_limit_val != value_unlimited || throttle_limit_val != value_unlimited ||
+                            (soft_limit_val != value_unlimited && soft_limit_val != 0);
+
+    const double host_cpus = os::Linux::active_processor_count();
     double cpus = host_cpus;
     (void)active_processor_count(cpus);  // discard error and use default
-    any_mem_cpu_limit_present = mem_limit_val != value_unlimited || host_cpus != cpus;
-    if (any_mem_cpu_limit_present) {
+    cpu_limit_present = host_cpus != cpus;
+
+    if (any_mem_limit_present || cpu_limit_present) {
       reason = " because either a cpu or a memory limit is present";
     } else {
       reason = " because no cpu or memory limit is present";
     }
   }
-  _is_containerized = controllers_read_only || any_mem_cpu_limit_present;
+  _is_containerized = controllers_read_only || any_mem_limit_present || cpu_limit_present;
   log_debug(os, container)("OSContainer::init: is_containerized() = %s%s",
                                                             _is_containerized ? "true" : "false",
                                                             reason);

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -94,21 +94,20 @@ void OSContainer::init() {
     //  2.) On a physical Linux system with a limit enforced by other means (like systemd slice)
 
     physical_memory_size_type mem_limit_val = value_unlimited;
-    (void)memory_limit_in_bytes(mem_limit_val);  // discard error and use default
+    any_mem_limit_present = any_mem_limit_present || (memory_limit_in_bytes(mem_limit_val) &&
+                                                      mem_limit_val != value_unlimited);
 
     physical_memory_size_type throttle_limit_val = value_unlimited;
-    (void)memory_throttle_limit_in_bytes(throttle_limit_val);  // discard error and use default
+    any_mem_limit_present = any_mem_limit_present || (memory_throttle_limit_in_bytes(throttle_limit_val) &&
+                                                      throttle_limit_val != value_unlimited);
 
     physical_memory_size_type soft_limit_val = value_unlimited;
-    (void)memory_soft_limit_in_bytes(soft_limit_val);  // discard error and use default
-
-    any_mem_limit_present = mem_limit_val != value_unlimited || throttle_limit_val != value_unlimited ||
-                            (soft_limit_val != value_unlimited && soft_limit_val != 0);
+    any_mem_limit_present = any_mem_limit_present || (memory_soft_limit_in_bytes(soft_limit_val) &&
+                                                     (soft_limit_val != value_unlimited && soft_limit_val != 0));
 
     const double host_cpus = os::Linux::active_processor_count();
     double cpus = host_cpus;
-    (void)active_processor_count(cpus);  // discard error and use default
-    cpu_limit_present = host_cpus != cpus;
+    cpu_limit_present = active_processor_count(cpus) && host_cpus != cpus;
 
     if (any_mem_limit_present || cpu_limit_present) {
       reason = " because either a cpu or a memory limit is present";

--- a/test/hotspot/jtreg/containers/systemd/SystemdContainerDetectionTest.java
+++ b/test/hotspot/jtreg/containers/systemd/SystemdContainerDetectionTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import jdk.internal.platform.Metrics;
+import jdk.test.lib.containers.systemd.SystemdRunOptions;
+import jdk.test.lib.containers.systemd.SystemdTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @summary Container detection test for a JDK inside a systemd slice.
+ * @requires systemd.support
+ * @library /test/lib
+ * @modules java.base/jdk.internal.platform
+ * @build HelloSystemd jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
+ * @run main/othervm SystemdContainerDetectionTest
+ */
+public class SystemdContainerDetectionTest {
+
+    private static final int MB = 1024 * 1024;
+    private static final int EXPECTED_LIMIT_MB = 512;
+
+    public static void main(String[] args) throws Exception {
+        Metrics metrics = Metrics.systemMetrics();
+
+        testWithoutLimits();
+        testCpuLimit();
+        testMemoryLimit();
+        if ("cgroupv2".equals(metrics.getProvider())) {
+            // MemoryHigh/MemoryLow based detection requires cgroup v2
+            testMemoryLow();
+            testMemoryHigh();
+        }
+    }
+
+    private static void testWithoutLimits() throws Exception {
+        OutputAnalyzer out = runWithLimits("infinity", null, null, null);
+        assertContainerized(out, false);
+    }
+
+    private static void testCpuLimit() throws Exception {
+        OutputAnalyzer out = runWithLimits("infinity", null, null, "50%");
+        assertContainerized(out, true);
+        out.shouldContain("OSContainer::active_processor_count:");
+    }
+
+    private static void testMemoryLimit() throws Exception {
+        OutputAnalyzer out = runWithLimits(String.format("%dM", EXPECTED_LIMIT_MB), null, null, null);
+        assertContainerized(out, true);
+        out.shouldContain(String.format("Memory Limit is: %d", EXPECTED_LIMIT_MB * MB));
+    }
+
+    private static void testMemoryLow() throws Exception {
+        OutputAnalyzer out = runWithLimits("infinity", String.format("%dM", EXPECTED_LIMIT_MB), null, null);
+        assertContainerized(out, true);
+        out.shouldContain(String.format("Memory Throttle Limit is: %d", EXPECTED_LIMIT_MB * MB));
+    }
+
+    private static void testMemoryHigh() throws Exception {
+        OutputAnalyzer out = runWithLimits("infinity", null, String.format("%dM", EXPECTED_LIMIT_MB), null);
+        assertContainerized(out, true);
+        out.shouldContain(String.format("Memory Soft Limit is: %d", EXPECTED_LIMIT_MB * MB));
+    }
+
+    private static void assertContainerized(OutputAnalyzer out, boolean expected) {
+        try {
+            out.shouldHaveExitValue(0)
+               .shouldContain("Hello Systemd")
+               .shouldContain(String.format("OSContainer::init: is_containerized() = %b", expected));
+        } catch (RuntimeException e) {
+            // CPU/memory delegation needs to be enabled when run as user on cg v2
+            if (SystemdTestUtils.RUN_AS_USER) {
+                String hint = "When run as user on cg v2 cpu/memory delegation needs to be configured!";
+                throw new SkippedException(hint);
+            }
+            throw e;
+        }
+    }
+
+    private static OutputAnalyzer runWithLimits(String memoryLimit,
+                                                String memoryLow,
+                                                String memoryHigh,
+                                                String cpuLimit) throws Exception {
+        SystemdRunOptions opts = SystemdTestUtils.newOpts("HelloSystemd");
+        opts.memoryLimit(memoryLimit);
+        if (memoryHigh != null) {
+            opts.memoryHigh(memoryHigh);
+        }
+        if (memoryLow != null) {
+            opts.memoryLow(memoryLow);
+        }
+        if (cpuLimit != null) {
+            opts.cpuLimit(cpuLimit);
+        }
+        return SystemdTestUtils.buildAndRunSystemdJava(opts);
+    }
+
+}

--- a/test/hotspot/jtreg/containers/systemd/SystemdContainerDetectionTest.java
+++ b/test/hotspot/jtreg/containers/systemd/SystemdContainerDetectionTest.java
@@ -76,13 +76,13 @@ public class SystemdContainerDetectionTest {
     private static void testMemoryLow() throws Exception {
         OutputAnalyzer out = runWithLimits("infinity", String.format("%dM", EXPECTED_LIMIT_MB), null, null);
         assertContainerized(out, true);
-        out.shouldContain(String.format("Memory Throttle Limit is: %d", EXPECTED_LIMIT_MB * MB));
+        out.shouldContain(String.format("Memory Soft Limit is: %d", EXPECTED_LIMIT_MB * MB));
     }
 
     private static void testMemoryHigh() throws Exception {
         OutputAnalyzer out = runWithLimits("infinity", null, String.format("%dM", EXPECTED_LIMIT_MB), null);
         assertContainerized(out, true);
-        out.shouldContain(String.format("Memory Soft Limit is: %d", EXPECTED_LIMIT_MB * MB));
+        out.shouldContain(String.format("Memory Throttle Limit is: %d", EXPECTED_LIMIT_MB * MB));
     }
 
     private static void assertContainerized(OutputAnalyzer out, boolean expected) {

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdRunOptions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Red Hat, Inc.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +38,8 @@ public class SystemdRunOptions {
     public ArrayList<String> classParams = new ArrayList<>();
     public String memoryLimit; // used in slice for MemoryLimit property
     public String cpuLimit;    // used in slice for CPUQuota property
+    public String memoryLow;   // used in the systemd-run scope for MemoryLow property
+    public String memoryHigh;  // used in the systemd-run scope for MemoryHigh property
     public String sliceName;   // name of the slice (nests CPU in memory)
     public String sliceDMemoryLimit; // used in jdk_internal.slice.d
     public String sliceDCpuLimit;    // used in jdk_internal.slice.d
@@ -115,6 +118,28 @@ public class SystemdRunOptions {
      */
     public SystemdRunOptions cpuLimit(String cpuLimit) {
         this.cpuLimit = cpuLimit;
+        return this;
+    }
+
+    /**
+     * The memory soft protection set on the systemd-run scope that launches the JVM.
+     *
+     * @param memoryLow The memory soft protection to set (e.g. 500M).
+     * @return The run options.
+     */
+    public SystemdRunOptions memoryLow(String memoryLow) {
+        this.memoryLow = memoryLow;
+        return this;
+    }
+
+    /**
+     * The memory throttle limit set on the systemd-run scope that launches the JVM.
+     *
+     * @param memoryHigh The memory throttle limit to set (e.g. 500M).
+     * @return The run options.
+     */
+    public SystemdRunOptions memoryHigh(String memoryHigh) {
+        this.memoryHigh = memoryHigh;
         return this;
     }
 

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Red Hat, Inc.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,6 +292,18 @@ public class SystemdTestUtils {
         return String.format("%s.slice", sliceName);
     }
 
+    private static void addScopeMemoryProperties(List<String> javaCmd, SystemdRunOptions opts) {
+        if (opts.memoryLow != null || opts.memoryHigh != null) {
+            javaCmd.add("--property=MemoryAccounting=true");
+        }
+        if (opts.memoryLow != null) {
+            javaCmd.add("--property=MemoryLow=" + opts.memoryLow);
+        }
+        if (opts.memoryHigh != null) {
+            javaCmd.add("--property=MemoryHigh=" + opts.memoryHigh);
+        }
+    }
+
     /**
      * Build the java command to run inside a systemd slice
      *
@@ -304,6 +317,7 @@ public class SystemdTestUtils {
         List<String> javaCmd = systemdRun();
         javaCmd.add("--slice");
         javaCmd.add(sliceFileName(sliceNameCpu(opts)));
+        addScopeMemoryProperties(javaCmd, opts);
         javaCmd.add("--scope");
         javaCmd.add(Path.of(Utils.TEST_JDK, "bin", "java").toString());
         javaCmd.addAll(opts.javaOpts);


### PR DESCRIPTION
Hi everyone,

Our current container detection looks for two things:
1. Whether the cgroup filesystem is mounted read-only, and if not,
2. Whether a hard memory or CPU limit is configured.

This definition, however, is too narrow for certain setups. Some deployments rely on soft limits for burstable workloads, for example, multiple containers sharing a host with memory or CPU prioritization but without hard caps. Today, we would classify those environments as not containerized.

I therefore suggest we broaden the limits check to also consider softer memory limits (`memory.low` and `memory.high`), so we correctly identify those deployments. For `memory_soft_limit_in_bytes` (`memory.low`), we need to check both `0` and `value_unlimited`, since group v1 and v2 differ slightly in how they represent an unset limit.

Testing:
- Oracle tiers 1-5

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8367330](https://bugs.openjdk.org/browse/JDK-8367330): Loosen container detection to include soft limits (**Enhancement** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30370/head:pull/30370` \
`$ git checkout pull/30370`

Update a local copy of the PR: \
`$ git checkout pull/30370` \
`$ git pull https://git.openjdk.org/jdk.git pull/30370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30370`

View PR using the GUI difftool: \
`$ git pr show -t 30370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30370.diff">https://git.openjdk.org/jdk/pull/30370.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30370#issuecomment-4109896666)
</details>
