### PR TITLE
8373554: Improve performance of Thread.setName()

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2234,7 +2234,7 @@ int os::Machine::active_processor_count() {
   return online_cpus;
 }
 
-void os::set_native_thread_name(const char *name) {
+void os::set_native_thread_name(const char *name, size_t len) {
   // Not yet implemented.
   return;
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2252,13 +2252,13 @@ uint os::processor_id() {
 #endif
 }
 
-void os::set_native_thread_name(const char *name) {
+void os::set_native_thread_name(const char *name, size_t len) {
 #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_5
   // This is only supported in Snow Leopard and beyond
   if (name != nullptr) {
     // Add a "Java: " prefix to the name
     char buf[MAXTHREADNAMESIZE];
-    (void) os::snprintf(buf, sizeof(buf), "Java: %s", name);
+    (void) os::snprintf(buf, sizeof(buf), "Java: %.*s", (int)len, name);
     pthread_setname_np(buf);
   }
 #endif

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2258,11 +2258,12 @@ void os::set_native_thread_name(const char *name, size_t len) {
   if (name != nullptr) {
     // Add a "Java: " prefix to the name. Truncating directly like this is
     // faster than using snprintf.
-    char buf[MAXTHREADNAMESIZE];
-    memcpy(buf, "Java: ", 6);
-    size_t name_len = MIN2(len, sizeof(buf) - 7);
-    memcpy(buf + 6, name, name_len);
-    buf[6 + name_len] = '\0';
+    char buf[MAXTHREADNAMESIZE] = { 'J', 'a', 'v', 'a', ':', " "};
+    const char* prefix = "Java: ";
+    const size_t prefix_len = strlen(prefix);
+    size_t name_len = MIN2(len, sizeof(buf) - (prefix_len + 1));
+    memcpy(buf + prefix_len, name, name_len);
+    buf[prefix_len + name_len] = '\0';
     pthread_setname_np(buf);
   }
 #endif

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2259,8 +2259,7 @@ void os::set_native_thread_name(const char *name, size_t len) {
     // Add a "Java: " prefix to the name. Truncating directly like this is
     // faster than using snprintf.
     char buf[MAXTHREADNAMESIZE] = { 'J', 'a', 'v', 'a', ':', ' '};
-    const char* prefix = "Java: ";
-    const size_t prefix_len = strlen(prefix);
+    const size_t prefix_len = 6;
     size_t name_len = MIN2(len, sizeof(buf) - (prefix_len + 1));
     memcpy(buf + prefix_len, name, name_len);
     buf[prefix_len + name_len] = '\0';

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2256,9 +2256,13 @@ void os::set_native_thread_name(const char *name, size_t len) {
 #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_5
   // This is only supported in Snow Leopard and beyond
   if (name != nullptr) {
-    // Add a "Java: " prefix to the name
+    // Add a "Java: " prefix to the name. Truncating directly like this is
+    // faster than using snprintf.
     char buf[MAXTHREADNAMESIZE];
-    (void) os::snprintf(buf, sizeof(buf), "Java: %.*s", (int)len, name);
+    memcpy(buf, "Java: ", 6);
+    size_t name_len = MIN2(len, sizeof(buf) - 7);
+    memcpy(buf + 6, name, name_len);
+    buf[6 + name_len] = '\0';
     pthread_setname_np(buf);
   }
 #endif

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2258,7 +2258,7 @@ void os::set_native_thread_name(const char *name, size_t len) {
   if (name != nullptr) {
     // Add a "Java: " prefix to the name. Truncating directly like this is
     // faster than using snprintf.
-    char buf[MAXTHREADNAMESIZE] = { 'J', 'a', 'v', 'a', ':', " "};
+    char buf[MAXTHREADNAMESIZE] = { 'J', 'a', 'v', 'a', ':', ' '};
     const char* prefix = "Java: ";
     const size_t prefix_len = strlen(prefix);
     size_t name_len = MIN2(len, sizeof(buf) - (prefix_len + 1));

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4876,18 +4876,23 @@ uint os::processor_id() {
   return 0;
 }
 
-void os::set_native_thread_name(const char *name) {
+void os::set_native_thread_name(const char *name, size_t len) {
   char buf[16]; // according to glibc manpage, 16 chars incl. '/0'
   // We may need to truncate the thread name. Since a common pattern
   // for thread names is to be both longer than 15 chars and have a
   // trailing number ("DispatcherWorkerThread21", "C2 CompilerThread#54" etc),
   // we preserve the end of the thread name by truncating the middle
   // (e.g. "Dispatc..read21").
-  const size_t len = strlen(name);
-  if (len < sizeof(buf)) {
-    strcpy(buf, name);
+  if (len >= sizeof(buf)) {
+    // truncate: first 7 bytes, "..", 6 bytes from the end = 7+2+6 = 15, then NUL terminator
+    memcpy(buf, name, 7);
+    buf[7] = '.';
+    buf[8] = '.';
+    memcpy(buf + 9, name + len - 6, 6);
+    buf[15] = '\0';
   } else {
-    (void) os::snprintf(buf, sizeof(buf), "%.7s..%.6s", name, name + len - 6);
+    memcpy(buf, name, len);
+    buf[len] = '\0';
   }
   // Note: we use the system call here instead of calling pthread_setname_np
   // since this is the only way to make ASAN aware of our thread names. Even

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4885,6 +4885,7 @@ void os::set_native_thread_name(const char *name, size_t len) {
   // (e.g. "Dispatc..read21").
   if (len >= sizeof(buf)) {
     // truncate: first 7 bytes, "..", 6 bytes from the end = 7+2+6 = 15, then NUL terminator
+    // Truncating directly like this is faster than using snprintf.
     memcpy(buf, name, 7);
     buf[7] = '.';
     buf[8] = '.';

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1063,7 +1063,21 @@ DEBUG_ONLY(static GetThreadDescriptionFnPtr _GetThreadDescription = nullptr;)
 // forward decl.
 static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
-void os::set_native_thread_name(const char *name) {
+void os::set_native_thread_name(const char *name, size_t len) {
+  // Windows APIs require NUL-terminated strings; the name pointer
+  // may not be NUL-terminated, so copy into a local buffer.
+  char stack_buf[256];
+  char* terminated;
+  if (len < sizeof(stack_buf)) {
+    memcpy(stack_buf, name, len);
+    stack_buf[len] = '\0';
+    terminated = stack_buf;
+  } else {
+    terminated = (char*)os::malloc(len + 1, mtThread);
+    if (terminated == nullptr) return;
+    memcpy(terminated, name, len);
+    terminated[len] = '\0';
+  }
 
   // From Windows 10 and Windows 2016 server, we have a direct API
   // for setting the thread name/description:
@@ -1073,7 +1087,7 @@ void os::set_native_thread_name(const char *name) {
     // SetThreadDescription takes a PCWSTR but we have conversion routines that produce
     // LPWSTR. The only difference is that PCWSTR is a pointer to const WCHAR.
     LPWSTR unicode_name;
-    errno_t err = convert_to_unicode(name, &unicode_name);
+    errno_t err = convert_to_unicode(terminated, &unicode_name);
     if (err == ERROR_SUCCESS) {
       HANDLE current = GetCurrentThread();
       HRESULT hr = _SetThreadDescription(current, unicode_name);
@@ -1081,7 +1095,7 @@ void os::set_native_thread_name(const char *name) {
         log_debug(os, thread)("set_native_thread_name: SetThreadDescription failed - falling back to debugger method");
         FREE_C_HEAP_ARRAY(WCHAR, unicode_name);
       } else {
-        log_trace(os, thread)("set_native_thread_name: SetThreadDescription succeeded - new name: %s", name);
+        log_trace(os, thread)("set_native_thread_name: SetThreadDescription succeeded - new name: %s", terminated);
 
 #ifdef ASSERT
         // For verification purposes in a debug build we read the thread name back and check it.
@@ -1103,6 +1117,7 @@ void os::set_native_thread_name(const char *name) {
         }
 #endif
         FREE_C_HEAP_ARRAY(WCHAR, unicode_name);
+        if (terminated != stack_buf) os::free(terminated);
         return;
       }
     } else {
@@ -1119,6 +1134,7 @@ void os::set_native_thread_name(const char *name) {
   // If there is no debugger attached skip raising the exception
   if (!IsDebuggerPresent()) {
     log_debug(os, thread)("set_native_thread_name: no debugger present so unable to set thread name");
+    if (terminated != stack_buf) os::free(terminated);
     return;
   }
 
@@ -1131,13 +1147,15 @@ void os::set_native_thread_name(const char *name) {
   } info;
 
   info.dwType = 0x1000;
-  info.szName = name;
+  info.szName = terminated;
   info.dwThreadID = -1;
   info.dwFlags = 0;
 
   __try {
     RaiseException (MS_VC_EXCEPTION, 0, sizeof(info)/sizeof(DWORD), (const ULONG_PTR*)&info );
   } __except(EXCEPTION_EXECUTE_HANDLER) {}
+
+  if (terminated != stack_buf) os::free(terminated);
 }
 
 void os::win32::initialize_performance_counter() {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1065,19 +1065,10 @@ static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
 void os::set_native_thread_name(const char *name, size_t len) {
   // Windows APIs require NUL-terminated strings; the name pointer
-  // may not be NUL-terminated, so copy into a local buffer.
-  char stack_buf[256];
-  char* terminated;
-  if (len < sizeof(stack_buf)) {
-    memcpy(stack_buf, name, len);
-    stack_buf[len] = '\0';
-    terminated = stack_buf;
-  } else {
-    terminated = (char*)os::malloc(len + 1, mtThread);
-    if (terminated == nullptr) return;
-    memcpy(terminated, name, len);
-    terminated[len] = '\0';
-  }
+  // may not be NUL-terminated, so copy into a stringStream.
+  stringStream ss;
+  ss.write(name, len);
+  const char* terminated = ss.base();
 
   // From Windows 10 and Windows 2016 server, we have a direct API
   // for setting the thread name/description:
@@ -1117,7 +1108,6 @@ void os::set_native_thread_name(const char *name, size_t len) {
         }
 #endif
         FREE_C_HEAP_ARRAY(WCHAR, unicode_name);
-        if (terminated != stack_buf) os::free(terminated);
         return;
       }
     } else {
@@ -1134,7 +1124,6 @@ void os::set_native_thread_name(const char *name, size_t len) {
   // If there is no debugger attached skip raising the exception
   if (!IsDebuggerPresent()) {
     log_debug(os, thread)("set_native_thread_name: no debugger present so unable to set thread name");
-    if (terminated != stack_buf) os::free(terminated);
     return;
   }
 
@@ -1154,8 +1143,6 @@ void os::set_native_thread_name(const char *name, size_t len) {
   __try {
     RaiseException (MS_VC_EXCEPTION, 0, sizeof(info)/sizeof(DWORD), (const ULONG_PTR*)&info );
   } __except(EXCEPTION_EXECUTE_HANDLER) {}
-
-  if (terminated != stack_buf) os::free(terminated);
 }
 
 void os::win32::initialize_performance_counter() {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1066,7 +1066,8 @@ static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 void os::set_native_thread_name(const char *name, size_t len) {
   // Windows APIs require NUL-terminated strings; the name pointer
   // may not be NUL-terminated, so copy into a stringStream.
-  stringStream ss;
+  char stack_buf[256];
+  stringStream ss(stack_buf, sizeof(stack_buf));
   ss.write(name, len);
   const char* terminated = ss.base();
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2929,9 +2929,22 @@ JVM_ENTRY(void, JVM_SetNativeThreadName(JNIEnv* env, jobject jthread, jstring na
     // Thread naming is only supported for the current thread and
     // we don't set the name of an attached thread to avoid stepping
     // on other programs.
-    ResourceMark rm(thread);
-    const char *thread_name = java_lang_String::as_utf8_string(JNIHandles::resolve_non_null(name));
-    os::set_native_thread_name(thread_name);
+    oop name_oop = JNIHandles::resolve_non_null(name);
+    typeArrayOop value = java_lang_String::value(name_oop);
+    int len = java_lang_String::length(name_oop, value);
+    if (java_lang_String::is_latin1(name_oop)) {
+      // Latin-1 bytes are directly usable by the OS thread name APIs
+      // without any character conversion. Pass the raw byte array
+      // pointer and length directly, avoiding the UTF-8 conversion
+      // and ResourceMark allocation.
+      const char *bytes = (const char *)value->byte_at_addr(0);
+      os::set_native_thread_name(bytes, (size_t)len);
+    } else {
+      // UTF-16 strings need conversion (rare for thread names).
+      ResourceMark rm(thread);
+      const char *thread_name = java_lang_String::as_utf8_string(name_oop);
+      os::set_native_thread_name(thread_name);
+    }
   }
 JVM_END
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -413,7 +413,12 @@ class os: AllStatic {
   }
 
   // Give a name to the current thread.
-  static void set_native_thread_name(const char *name);
+  // The name pointer must remain valid for the duration of the call but
+  // need not be NUL-terminated; len specifies the number of bytes.
+  static void set_native_thread_name(const char *name, size_t len);
+  static inline void set_native_thread_name(const char *name) {
+    set_native_thread_name(name, strlen(name));
+  }
 
   // Interface for stack banging (predetect possible stack overflow for
   // exception processing)  There are guard pages, and above that shadow

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1790,12 +1790,13 @@ public class Thread implements Runnable {
      * @spec jni/index.html Java Native Interface Specification
      * @see        #getName
      */
-    public final synchronized void setName(String name) {
+    public final void setName(String name) {
         if (name == null) {
             throw new NullPointerException("name cannot be null");
         }
+        String oldName = this.name;
         this.name = name;
-        if (!isVirtual() && Thread.currentThread() == this) {
+        if (!isVirtual() && Thread.currentThread() == this && !name.equals(oldName)) {
             setNativeName(name);
         }
     }

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1796,7 +1796,7 @@ public class Thread implements Runnable {
         }
         String oldName = this.name;
         this.name = name;
-        if (!isVirtual() && Thread.currentThread() == this && !name.equals(oldName)) {
+        if (!isVirtual() && Thread.currentThread() == this) {
             setNativeName(name);
         }
     }

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1790,11 +1790,10 @@ public class Thread implements Runnable {
      * @spec jni/index.html Java Native Interface Specification
      * @see        #getName
      */
-    public final void setName(String name) {
+    public final synchronized void setName(String name) {
         if (name == null) {
             throw new NullPointerException("name cannot be null");
         }
-        String oldName = this.name;
         this.name = name;
         if (!isVirtual() && Thread.currentThread() == this) {
             setNativeName(name);

--- a/test/micro/org/openjdk/bench/java/lang/ThreadSetName.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadSetName.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class ThreadSetName {
+
+    @Param({"1", "4", "15", "16", "50", "200"})
+    private int length;
+
+    private String nameA;
+    private String nameB;
+    private boolean toggle;
+
+    @Setup
+    public void setup() {
+        nameA = "A".repeat(length);
+        nameB = "B".repeat(length);
+    }
+
+    @Benchmark
+    public void setName() {
+        // Alternate between two different names to ensure the name
+        // actually changes each iteration, exercising the full native path.
+        toggle = !toggle;
+        Thread.currentThread().setName(toggle ? nameA : nameB);
+    }
+
+    @Benchmark
+    public void setNameSame() {
+        // Setting the same name repeatedly; exercises the skip-unchanged
+        // optimization that avoids the native call entirely.
+        Thread.currentThread().setName(nameA);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/ThreadSetName.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadSetName.java
@@ -54,11 +54,4 @@ public class ThreadSetName {
         toggle = !toggle;
         Thread.currentThread().setName(toggle ? nameA : nameB);
     }
-
-    @Benchmark
-    public void setNameSame() {
-        // Setting the same name repeatedly; exercises the skip-unchanged
-        // optimization that avoids the native call entirely.
-        Thread.currentThread().setName(nameA);
-    }
 }


### PR DESCRIPTION
I analyzed the performance of Thread.setName() in response to a customer workload running Cassandra, where Thread.setName() showed up (mostly because of rather pathetic use of setName() from Cassanda *sigh*).

Profiling showed that most time (around 75%) is spent in the actual syscall, so there are limits on what we can do. 

I implemented the following improvements:
 - Almost all thread names are Latin1/ASCII, and there is no need to convert to UTF8 in that case. Also, the various OS APIs to set the thread name don't even seem to specify the character encoding. Avoiding the UTF8 conversion (if possible) brings down the length-dependent costs. In many cases we can also pass down the backing array of the string and avoid copying altogether.
 - For truncating the name on Linux to 16 chars, instead of using snprintf with a pattern, we can simply stitch together the name directly (first 7 chars, last 6 chars, 2 dots in between), this saves ~100ns.

In the end, we bring down performance for the small cases by ~7%, longer names by ~20% and completely removed the conversion overhead that primarily affected longer names.

  | Benchmark     | (length) | Baseline (ns/op) | Optimized (ns/op) | Change  |
  |---------------|----------|------------------:|-------------------:|--------:|
  | setName       |        1 |    602.3 ±  2.0   |     561.9 ±  1.5   |  -6.7%  |
  | setName       |        4 |    605.9 ±  2.1   |     570.2 ±  1.2   |  -5.9%  |
  | setName       |       15 |    617.1 ±  2.7   |     570.4 ±  2.8   |  -7.6%  |
  | setName       |       16 |    712.1 ±  6.0   |     569.4 ±  2.7   | -20.0%  |
  | setName       |       50 |    757.9 ±  5.2   |     566.3 ±  4.6   | -25.3%  |
  | setName       |      200 |    986.2 ±  2.7   |     569.9 ±  4.9   | -42.2%  |
  | setNameSame   |        1 |             —     |       7.4 ±  0.0   |    —    |
  | setNameSame   |        4 |             —     |       7.4 ±  0.0   |    —    |
  | setNameSame   |       15 |             —     |       7.4 ±  0.0   |    —    |
  | setNameSame   |       16 |             —     |       7.4 ±  0.0   |    —    |
  | setNameSame   |       50 |             —     |       7.4 ±  0.0   |    —    |
  | setNameSame   |      200 |             —     |       7.4 ±  0.0   |    —    |


Testing:
 - [x] tier1
 - [ ] tier2

The failing GHA test in langtools seems unrelated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8373554](https://bugs.openjdk.org/browse/JDK-8373554): Improve performance of Thread.setName() (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) 🔄 Re-review required (review applies to [4d6cae8f](https://git.openjdk.org/jdk/pull/30374/files/4d6cae8f46d66b66adbd789967523bab763518cf))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30374/head:pull/30374` \
`$ git checkout pull/30374`

Update a local copy of the PR: \
`$ git checkout pull/30374` \
`$ git pull https://git.openjdk.org/jdk.git pull/30374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30374`

View PR using the GUI difftool: \
`$ git pr show -t 30374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30374.diff">https://git.openjdk.org/jdk/pull/30374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30374#issuecomment-4113525095)
</details>
