### PR TITLE
8380794: AttributedString performance

### DIFF
--- a/src/java.base/share/classes/java/text/AttributedString.java
+++ b/src/java.base/share/classes/java/text/AttributedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ import java.text.AttributedCharacterIterator.Attribute;
  * @see Annotation
  * @since 1.2
  */
-
 public class AttributedString {
     // field holding the text
     String text;
@@ -56,10 +55,9 @@ public class AttributedString {
     // Arrays are always of equal lengths (the current capacity).
     // Since there are no vectors of int, we have to use arrays.
     private static final int INITIAL_CAPACITY = 10;
-    int runCount;                   // actual number of runs, <= current capacity
-    int[] runStarts;                // start index for each run
-    Vector<Attribute>[] runAttributes;   // vector of attribute keys for each run
-    Vector<Object>[] runAttributeValues; // parallel vector of attribute values for each run
+    int runCount;    // actual number of runs, <= current capacity
+    int[] runStarts; // start index for each run
+    Map<Attribute,Object>[] runAttributes; // attributes for each run
 
     /**
      * Constructs an AttributedString instance with the given
@@ -152,16 +150,8 @@ public class AttributedString {
 
         int attributeCount = attributes.size();
         if (attributeCount > 0) {
-            createRunAttributeDataVectors();
-            Vector<Attribute> newRunAttributes = new Vector<>(attributeCount);
-            Vector<Object> newRunAttributeValues = new Vector<>(attributeCount);
-            runAttributes[0] = newRunAttributes;
-            runAttributeValues[0] = newRunAttributeValues;
-
-            for (Map.Entry<? extends Attribute, ?> entry : attributes.entrySet()) {
-                newRunAttributes.addElement(entry.getKey());
-                newRunAttributeValues.addElement(entry.getValue());
-            }
+            createRunAttributeDataArrays();
+            runAttributes[0] = new HashMap<>(attributes);
         }
     }
 
@@ -250,12 +240,13 @@ public class AttributedString {
 
         // Select attribute keys to be taken care of
         HashSet<Attribute> keys = new HashSet<>();
+        Set<Attribute> textKeys = text.getAllAttributeKeys();
         if (attributes == null) {
-            keys.addAll(text.getAllAttributeKeys());
+            keys.addAll(textKeys);
         } else {
             for (int i = 0; i < attributes.length; i++)
                 keys.add(attributes[i]);
-            keys.retainAll(text.getAllAttributeKeys());
+            keys.retainAll(textKeys);
         }
         if (keys.isEmpty())
             return;
@@ -378,7 +369,7 @@ public class AttributedString {
 
         // make sure we have run attribute data vectors
         if (runCount == 0) {
-            createRunAttributeDataVectors();
+            createRunAttributeDataArrays();
         }
 
         // break up runs if necessary
@@ -395,7 +386,7 @@ public class AttributedString {
 
         // make sure we have run attribute data vectors
         if (runCount == 0) {
-            createRunAttributeDataVectors();
+            createRunAttributeDataArrays();
         }
 
         // break up runs if necessary
@@ -405,19 +396,14 @@ public class AttributedString {
         addAttributeRunData(attribute, value, beginRunIndex, endRunIndex);
     }
 
-    private final void createRunAttributeDataVectors() {
+    private final void createRunAttributeDataArrays() {
         // use temporary variables so things remain consistent in case of an exception
         int[] newRunStarts = new int[INITIAL_CAPACITY];
-
         @SuppressWarnings("unchecked")
-        Vector<Attribute>[] newRunAttributes = (Vector<Attribute>[]) new Vector<?>[INITIAL_CAPACITY];
-
-        @SuppressWarnings("unchecked")
-        Vector<Object>[] newRunAttributeValues = (Vector<Object>[]) new Vector<?>[INITIAL_CAPACITY];
+        Map<Attribute, Object>[] newRunAttributes = (Map<Attribute, Object>[]) new Map<?, ?>[INITIAL_CAPACITY];
 
         runStarts = newRunStarts;
         runAttributes = newRunAttributes;
-        runAttributeValues = newRunAttributeValues;
         runCount = 1; // assume initial run starting at index 0
     }
 
@@ -463,29 +449,21 @@ public class AttributedString {
             // use temporary variables so things remain consistent in case of an exception
             int[] newRunStarts =
                 Arrays.copyOf(runStarts, newCapacity);
-            Vector<Attribute>[] newRunAttributes =
+            Map<Attribute, Object>[] newRunAttributes =
                 Arrays.copyOf(runAttributes, newCapacity);
-            Vector<Object>[] newRunAttributeValues =
-                Arrays.copyOf(runAttributeValues, newCapacity);
 
             runStarts = newRunStarts;
             runAttributes = newRunAttributes;
-            runAttributeValues = newRunAttributeValues;
         }
 
         // make copies of the attribute information of the old run that the new one used to be part of
         // use temporary variables so things remain consistent in case of an exception
-        Vector<Attribute> newRunAttributes = null;
-        Vector<Object> newRunAttributeValues = null;
+        Map<Attribute, Object> newRunAttributes = null;
 
         if (copyAttrs) {
-            Vector<Attribute> oldRunAttributes = runAttributes[runIndex - 1];
-            Vector<Object> oldRunAttributeValues = runAttributeValues[runIndex - 1];
+            Map<Attribute, Object> oldRunAttributes = runAttributes[runIndex - 1];
             if (oldRunAttributes != null) {
-                newRunAttributes = new Vector<>(oldRunAttributes);
-            }
-            if (oldRunAttributeValues != null) {
-                newRunAttributeValues =  new Vector<>(oldRunAttributeValues);
+                newRunAttributes = new HashMap<>(oldRunAttributes);
             }
         }
 
@@ -494,11 +472,9 @@ public class AttributedString {
         for (int i = runCount - 1; i > runIndex; i--) {
             runStarts[i] = runStarts[i - 1];
             runAttributes[i] = runAttributes[i - 1];
-            runAttributeValues[i] = runAttributeValues[i - 1];
         }
         runStarts[runIndex] = offset;
         runAttributes[runIndex] = newRunAttributes;
-        runAttributeValues[runIndex] = newRunAttributeValues;
 
         return runIndex;
     }
@@ -508,32 +484,13 @@ public class AttributedString {
             int beginRunIndex, int endRunIndex) {
 
         for (int i = beginRunIndex; i < endRunIndex; i++) {
-            int keyValueIndex = -1; // index of key and value in our vectors; assume we don't have an entry yet
-            if (runAttributes[i] == null) {
-                Vector<Attribute> newRunAttributes = new Vector<>();
-                Vector<Object> newRunAttributeValues = new Vector<>();
+            Map<Attribute, Object> attributes = runAttributes[i];
+            if (attributes == null) {
+                Map<Attribute, Object> newRunAttributes = new HashMap<>();
                 runAttributes[i] = newRunAttributes;
-                runAttributeValues[i] = newRunAttributeValues;
-            } else {
-                // check whether we have an entry already
-                keyValueIndex = runAttributes[i].indexOf(attribute);
+                attributes = newRunAttributes;
             }
-
-            if (keyValueIndex == -1) {
-                // create new entry
-                int oldSize = runAttributes[i].size();
-                runAttributes[i].addElement(attribute);
-                try {
-                    runAttributeValues[i].addElement(value);
-                }
-                catch (Exception e) {
-                    runAttributes[i].setSize(oldSize);
-                    runAttributeValues[i].setSize(oldSize);
-                }
-            } else {
-                // update existing entry
-                runAttributeValues[i].set(keyValueIndex, value);
-            }
+            attributes.put(attribute, value);
         }
     }
 
@@ -596,18 +553,11 @@ public class AttributedString {
     }
 
     private synchronized Object getAttribute(Attribute attribute, int runIndex) {
-        Vector<Attribute> currentRunAttributes = runAttributes[runIndex];
-        Vector<Object> currentRunAttributeValues = runAttributeValues[runIndex];
+        Map<Attribute, Object> currentRunAttributes = runAttributes[runIndex];
         if (currentRunAttributes == null) {
             return null;
         }
-        int attributeIndex = currentRunAttributes.indexOf(attribute);
-        if (attributeIndex != -1) {
-            return currentRunAttributeValues.elementAt(attributeIndex);
-        }
-        else {
-            return null;
-        }
+        return currentRunAttributes.get(attribute);
     }
 
     // gets an attribute value, but returns an annotation only if it's range does not extend outside the range beginIndex..endIndex
@@ -680,22 +630,11 @@ public class AttributedString {
      */
     private void setAttributes(Map<Attribute, Object> attrs, int offset) {
         if (runCount == 0) {
-            createRunAttributeDataVectors();
+            createRunAttributeDataArrays();
         }
-
         int index = ensureRunBreak(offset, false);
-        int size;
-
-        if (attrs != null && (size = attrs.size()) > 0) {
-            Vector<Attribute> runAttrs = new Vector<>(size);
-            Vector<Object> runValues = new Vector<>(size);
-
-            for (Map.Entry<Attribute, Object> entry : attrs.entrySet()) {
-                runAttrs.add(entry.getKey());
-                runValues.add(entry.getValue());
-            }
-            runAttributes[index] = runAttrs;
-            runAttributeValues[index] = runValues;
+        if (attrs != null && !attrs.isEmpty()) {
+            runAttributes[index] = new HashMap<>(attrs);
         }
     }
 
@@ -945,18 +884,13 @@ public class AttributedString {
                 // ??? should try to create this only once, then update if necessary,
                 // and give callers read-only view
                 Set<Attribute> keys = new HashSet<>();
-                int i = 0;
-                while (i < runCount) {
+                for (int i = 0; i < runCount; i++) {
                     if (runStarts[i] < endIndex && (i == runCount - 1 || runStarts[i + 1] > beginIndex)) {
-                        Vector<Attribute> currentRunAttributes = runAttributes[i];
+                        Map<Attribute, Object> currentRunAttributes = runAttributes[i];
                         if (currentRunAttributes != null) {
-                            int j = currentRunAttributes.size();
-                            while (j-- > 0) {
-                                keys.add(currentRunAttributes.get(j));
-                            }
+                            keys.addAll(currentRunAttributes.keySet());
                         }
                     }
-                    i++;
                 }
                 return keys;
             }
@@ -1040,10 +974,10 @@ public class AttributedString {
         public Set<Map.Entry<Attribute, Object>> entrySet() {
             HashSet<Map.Entry<Attribute, Object>> set = new HashSet<>();
             synchronized (AttributedString.this) {
-                int size = runAttributes[runIndex].size();
-                for (int i = 0; i < size; i++) {
-                    Attribute key = runAttributes[runIndex].get(i);
-                    Object value = runAttributeValues[runIndex].get(i);
+                Map<Attribute, Object> attributes = runAttributes[runIndex];
+                for (Map.Entry<Attribute, Object> entry : attributes.entrySet()) {
+                    Attribute key = entry.getKey();
+                    Object value = entry.getValue();
                     if (value instanceof Annotation) {
                         value = AttributedString.this.getAttributeCheckRange(key,
                                                              runIndex, beginIndex, endIndex);
@@ -1051,9 +985,7 @@ public class AttributedString {
                             continue;
                         }
                     }
-
-                    Map.Entry<Attribute, Object> entry = new AttributeEntry(key, value);
-                    set.add(entry);
+                    set.add(new AttributeEntry(key, value));
                 }
             }
             return set;

--- a/src/java.base/share/classes/java/text/AttributedString.java
+++ b/src/java.base/share/classes/java/text/AttributedString.java
@@ -53,7 +53,7 @@ public class AttributedString {
     // Fields holding run attribute information.
     // Run attributes are organized by run.
     // Arrays are always of equal lengths (the current capacity).
-    // Since there are no vectors of int, we have to use arrays.
+    // Since there are not yet Lists of unboxed int, we use arrays.
     private static final int INITIAL_CAPACITY = 10;
     int runCount;    // actual number of runs, <= current capacity
     int[] runStarts; // start index for each run
@@ -367,7 +367,7 @@ public class AttributedString {
             throw new IllegalArgumentException("Can't add attribute to 0-length text");
         }
 
-        // make sure we have run attribute data vectors
+        // make sure we have run attribute data arrays
         if (runCount == 0) {
             createRunAttributeDataArrays();
         }
@@ -384,7 +384,7 @@ public class AttributedString {
     private synchronized void addAttributeImpl(Attribute attribute, Object value,
             int beginIndex, int endIndex) {
 
-        // make sure we have run attribute data vectors
+        // make sure we have run attribute data arrays
         if (runCount == 0) {
             createRunAttributeDataArrays();
         }

--- a/test/micro/org/openjdk/bench/java/text/AttributedStringBench.java
+++ b/test/micro/org/openjdk/bench/java/text/AttributedStringBench.java
@@ -26,7 +26,6 @@ import java.awt.Color;
 import java.awt.font.TextAttribute;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -69,47 +68,53 @@ public class AttributedStringBench {
     }
 
     @Benchmark
-    public void iterationWithNoAttributes(Blackhole blackhole) {
-        AttributedCharacterIterator it = string1.getIterator();
+    public void iterateMissingWithNoAttributes(Blackhole blackhole) {
+        iterate(string1, TextAttribute.BIDI_EMBEDDING, blackhole);
+    }
+
+    @Benchmark
+    public void iterateMissingWithOneAttribute(Blackhole blackhole) {
+        iterate(string2, TextAttribute.BIDI_EMBEDDING, blackhole);
+    }
+
+    @Benchmark
+    public void iterateMissingWithThreeAttributes(Blackhole blackhole) {
+        iterate(string3, TextAttribute.BIDI_EMBEDDING, blackhole);
+    }
+
+    @Benchmark
+    public void iteratePresentWithOneAttribute(Blackhole blackhole) {
+        iterate(string2, TextAttribute.SIZE, blackhole);
+    }
+
+    @Benchmark
+    public void iteratePresentWithThreeAttributes(Blackhole blackhole) {
+        iterate(string3, TextAttribute.SIZE, blackhole);
+    }
+
+    private static void iterate(AttributedString as, TextAttribute att, Blackhole blackhole) {
+        AttributedCharacterIterator it = as.getIterator();
         for (char c = it.first(); c != AttributedCharacterIterator.DONE; c = it.next()) {
-            Object level = it.getAttribute(TextAttribute.BIDI_EMBEDDING);
-            blackhole.consume(level);
+            Object val = it.getAttribute(att);
+            blackhole.consume(val);
         }
     }
 
     @Benchmark
-    public void iterationWithOneAttribute(Blackhole blackhole) {
-        AttributedCharacterIterator it = string2.getIterator();
-        for (char c = it.first(); c != AttributedCharacterIterator.DONE; c = it.next()) {
-            Object level = it.getAttribute(TextAttribute.BIDI_EMBEDDING);
-            blackhole.consume(level);
-        }
-    }
-
-    @Benchmark
-    public void iterationWithFourAttributes(Blackhole blackhole) {
-        AttributedCharacterIterator it = string3.getIterator();
-        for (char c = it.first(); c != AttributedCharacterIterator.DONE; c = it.next()) {
-            Object level = it.getAttribute(TextAttribute.BIDI_EMBEDDING);
-            blackhole.consume(level);
-        }
-    }
-
-    @Benchmark
-    public void creationWithNoAttributes(Blackhole blackhole) {
+    public void createWithNoAttributes(Blackhole blackhole) {
         AttributedString string = new AttributedString("this is an attributed string test");
         blackhole.consume(string);
     }
 
     @Benchmark
-    public void creationWithOneAttribute(Blackhole blackhole) {
+    public void createWithOneAttribute(Blackhole blackhole) {
         AttributedString string = new AttributedString("this is an attributed string test");
         string.addAttribute(TextAttribute.SIZE, 20);
         blackhole.consume(string);
     }
 
     @Benchmark
-    public void creationWithFourAttributes(Blackhole blackhole) {
+    public void createWithThreeAttributes(Blackhole blackhole) {
         AttributedString string = new AttributedString("this is an attributed string test");
         string.addAttribute(TextAttribute.SIZE, 20);
         string.addAttribute(TextAttribute.FOREGROUND, Color.BLACK);

--- a/test/micro/org/openjdk/bench/java/text/AttributedStringBench.java
+++ b/test/micro/org/openjdk/bench/java/text/AttributedStringBench.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.text;
+
+import java.awt.Color;
+import java.awt.font.TextAttribute;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Thread)
+public class AttributedStringBench {
+
+    private AttributedString string1;
+    private AttributedString string2;
+    private AttributedString string3;
+
+    @Setup
+    public void setup() {
+
+        string1 = new AttributedString("this is an attributed string test");
+
+        string2 = new AttributedString("this is an attributed string test");
+        string2.addAttribute(TextAttribute.SIZE, 20);
+
+        string3 = new AttributedString("this is an attributed string test");
+        string3.addAttribute(TextAttribute.SIZE, 20);
+        string3.addAttribute(TextAttribute.FOREGROUND, Color.BLACK);
+        string3.addAttribute(TextAttribute.WEIGHT, TextAttribute.WEIGHT_REGULAR);
+        string3.addAttribute(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD, 11, 21);
+    }
+
+    @Benchmark
+    public void iterationWithNoAttributes(Blackhole blackhole) {
+        AttributedCharacterIterator it = string1.getIterator();
+        for (char c = it.first(); c != AttributedCharacterIterator.DONE; c = it.next()) {
+            Object level = it.getAttribute(TextAttribute.BIDI_EMBEDDING);
+            blackhole.consume(level);
+        }
+    }
+
+    @Benchmark
+    public void iterationWithOneAttribute(Blackhole blackhole) {
+        AttributedCharacterIterator it = string2.getIterator();
+        for (char c = it.first(); c != AttributedCharacterIterator.DONE; c = it.next()) {
+            Object level = it.getAttribute(TextAttribute.BIDI_EMBEDDING);
+            blackhole.consume(level);
+        }
+    }
+
+    @Benchmark
+    public void iterationWithFourAttributes(Blackhole blackhole) {
+        AttributedCharacterIterator it = string3.getIterator();
+        for (char c = it.first(); c != AttributedCharacterIterator.DONE; c = it.next()) {
+            Object level = it.getAttribute(TextAttribute.BIDI_EMBEDDING);
+            blackhole.consume(level);
+        }
+    }
+
+    @Benchmark
+    public void creationWithNoAttributes(Blackhole blackhole) {
+        AttributedString string = new AttributedString("this is an attributed string test");
+        blackhole.consume(string);
+    }
+
+    @Benchmark
+    public void creationWithOneAttribute(Blackhole blackhole) {
+        AttributedString string = new AttributedString("this is an attributed string test");
+        string.addAttribute(TextAttribute.SIZE, 20);
+        blackhole.consume(string);
+    }
+
+    @Benchmark
+    public void creationWithFourAttributes(Blackhole blackhole) {
+        AttributedString string = new AttributedString("this is an attributed string test");
+        string.addAttribute(TextAttribute.SIZE, 20);
+        string.addAttribute(TextAttribute.FOREGROUND, Color.BLACK);
+        string.addAttribute(TextAttribute.WEIGHT, TextAttribute.WEIGHT_REGULAR);
+        string.addAttribute(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD, 11, 21);
+        blackhole.consume(string);
+    }
+}


### PR DESCRIPTION
While profiling some code which uses `LineBreakMeasurer`, I noticed that a non-trivial amount of time was being spent in `AttributedString`, because iterating through an `AttributedString` and getting a specific attribute for each character ends up calling `Vector.indexOf` inside of `AttributedString.getAttribute`. This boils down to the data structure choice of storing run attribute data in two arrays of `Vector`s, rather than in a single array of `Map`s. Based on testing, it looks like a single array of `Map`s would be simpler, faster, and require slightly less memory in some cases.

A JMH benchmark is included in this PR. With the updated code I'm seeing a 35% to 40% reduction in runtime for the iteration benchmark tests with one or more attributes. I checked memory usage by enabling GC profiling and looking at the three creation benchmark tests; it seems like there is no difference when the string has no attributes, a 20% reduction in memory use when the string has a single attribute, and a very small 1% reduction in memory use when we set four attributes. Full JMH results below (I focused on the `us/op` and `B/op` results specifically).

Tests run:
- make test TEST="jtreg:test/jdk/java/text"
- make test TEST="jtreg:test/jdk/java/awt/font"
- make test TEST="jtreg:test/jdk/java/awt/Graphics2D/DrawString"
- make test TEST="micro:java.text.AttributedStringBench" MICRO="OPTIONS=-prof gc"

I've assumed that the existing tests provide adequate regression test coverage, but there may be other Oracle-internal tests that should also be run to verify correctness.

JMH results **before** PR:

```
Benchmark                                                             Mode  Cnt      Score     Error   Units
AttributedStringBench.creationWithFourAttributes                      avgt   15      0.182 ±   0.004   us/op
AttributedStringBench.creationWithFourAttributes:gc.alloc.rate        avgt   15   3989.259 ±  85.345  MB/sec
AttributedStringBench.creationWithFourAttributes:gc.alloc.rate.norm   avgt   15    760.001 ±   0.001    B/op
AttributedStringBench.creationWithFourAttributes:gc.count             avgt   15    151.000            counts
AttributedStringBench.creationWithFourAttributes:gc.time              avgt   15    116.000                ms
AttributedStringBench.creationWithNoAttributes                        avgt   15      0.003 ±   0.001   us/op
AttributedStringBench.creationWithNoAttributes:gc.alloc.rate          avgt   15  10506.090 ± 336.923  MB/sec
AttributedStringBench.creationWithNoAttributes:gc.alloc.rate.norm     avgt   15     32.000 ±   0.001    B/op
AttributedStringBench.creationWithNoAttributes:gc.count               avgt   15    201.000            counts
AttributedStringBench.creationWithNoAttributes:gc.time                avgt   15    192.000                ms
AttributedStringBench.creationWithOneAttribute                        avgt   15      0.045 ±   0.001   us/op
AttributedStringBench.creationWithOneAttribute:gc.alloc.rate          avgt   15   7951.526 ±  85.521  MB/sec
AttributedStringBench.creationWithOneAttribute:gc.alloc.rate.norm     avgt   15    376.000 ±   0.001    B/op
AttributedStringBench.creationWithOneAttribute:gc.count               avgt   15    152.000            counts
AttributedStringBench.creationWithOneAttribute:gc.time                avgt   15    137.000                ms
AttributedStringBench.iterationWithFourAttributes                     avgt   15      0.363 ±   0.003   us/op
AttributedStringBench.iterationWithFourAttributes:gc.alloc.rate       avgt   15    126.041 ±   1.198  MB/sec
AttributedStringBench.iterationWithFourAttributes:gc.alloc.rate.norm  avgt   15     48.003 ±   0.001    B/op
AttributedStringBench.iterationWithFourAttributes:gc.count            avgt   15     60.000            counts
AttributedStringBench.iterationWithFourAttributes:gc.time             avgt   15     45.000                ms
AttributedStringBench.iterationWithNoAttributes                       avgt   15      0.064 ±   0.001   us/op
AttributedStringBench.iterationWithNoAttributes:gc.alloc.rate         avgt   15    715.475 ±  12.965  MB/sec
AttributedStringBench.iterationWithNoAttributes:gc.alloc.rate.norm    avgt   15     48.000 ±   0.001    B/op
AttributedStringBench.iterationWithNoAttributes:gc.count              avgt   15    113.000            counts
AttributedStringBench.iterationWithNoAttributes:gc.time               avgt   15     73.000                ms
AttributedStringBench.iterationWithOneAttribute                       avgt   15      0.329 ±   0.002   us/op
AttributedStringBench.iterationWithOneAttribute:gc.alloc.rate         avgt   15    139.258 ±   0.957  MB/sec
AttributedStringBench.iterationWithOneAttribute:gc.alloc.rate.norm    avgt   15     48.002 ±   0.001    B/op
AttributedStringBench.iterationWithOneAttribute:gc.count              avgt   15     66.000            counts
AttributedStringBench.iterationWithOneAttribute:gc.time               avgt   15     54.000                ms
```

JMH results **after** PR:

```
Benchmark                                                             Mode  Cnt      Score     Error   Units
AttributedStringBench.creationWithFourAttributes                      avgt   15      0.148 ±   0.002   us/op
AttributedStringBench.creationWithFourAttributes:gc.alloc.rate        avgt   15   4851.679 ±  57.903  MB/sec
AttributedStringBench.creationWithFourAttributes:gc.alloc.rate.norm   avgt   15    752.001 ±   0.001    B/op
AttributedStringBench.creationWithFourAttributes:gc.count             avgt   15    104.000            counts
AttributedStringBench.creationWithFourAttributes:gc.time              avgt   15     92.000                ms
AttributedStringBench.creationWithNoAttributes                        avgt   15      0.003 ±   0.001   us/op
AttributedStringBench.creationWithNoAttributes:gc.alloc.rate          avgt   15  10805.692 ± 530.472  MB/sec
AttributedStringBench.creationWithNoAttributes:gc.alloc.rate.norm     avgt   15     32.000 ±   0.001    B/op
AttributedStringBench.creationWithNoAttributes:gc.count               avgt   15    208.000            counts
AttributedStringBench.creationWithNoAttributes:gc.time                avgt   15    186.000                ms
AttributedStringBench.creationWithOneAttribute                        avgt   15      0.032 ±   0.001   us/op
AttributedStringBench.creationWithOneAttribute:gc.alloc.rate          avgt   15   8936.917 ± 136.734  MB/sec
AttributedStringBench.creationWithOneAttribute:gc.alloc.rate.norm     avgt   15    304.000 ±   0.001    B/op
AttributedStringBench.creationWithOneAttribute:gc.count               avgt   15    172.000            counts
AttributedStringBench.creationWithOneAttribute:gc.time                avgt   15    162.000                ms
AttributedStringBench.iterationWithFourAttributes                     avgt   15      0.239 ±   0.037   us/op
AttributedStringBench.iterationWithFourAttributes:gc.alloc.rate       avgt   15    194.596 ±  27.090  MB/sec
AttributedStringBench.iterationWithFourAttributes:gc.alloc.rate.norm  avgt   15     48.002 ±   0.001    B/op
AttributedStringBench.iterationWithFourAttributes:gc.count            avgt   15     91.000            counts
AttributedStringBench.iterationWithFourAttributes:gc.time             avgt   15     57.000                ms
AttributedStringBench.iterationWithNoAttributes                       avgt   15      0.063 ±   0.001   us/op
AttributedStringBench.iterationWithNoAttributes:gc.alloc.rate         avgt   15    724.316 ±  10.086  MB/sec
AttributedStringBench.iterationWithNoAttributes:gc.alloc.rate.norm    avgt   15     48.000 ±   0.001    B/op
AttributedStringBench.iterationWithNoAttributes:gc.count              avgt   15    114.000            counts
AttributedStringBench.iterationWithNoAttributes:gc.time               avgt   15     75.000                ms
AttributedStringBench.iterationWithOneAttribute                       avgt   15      0.204 ±   0.003   us/op
AttributedStringBench.iterationWithOneAttribute:gc.alloc.rate         avgt   15    224.211 ±   2.974  MB/sec
AttributedStringBench.iterationWithOneAttribute:gc.alloc.rate.norm    avgt   15     48.001 ±   0.001    B/op
AttributedStringBench.iterationWithOneAttribute:gc.count              avgt   15    105.000            counts
AttributedStringBench.iterationWithOneAttribute:gc.time               avgt   15     72.000                ms
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380794](https://bugs.openjdk.org/browse/JDK-8380794): AttributedString performance (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) Review applies to [07e65f70](https://git.openjdk.org/jdk/pull/30402/files/07e65f70c32ca39b38096847816cdf798886f43d)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30402/head:pull/30402` \
`$ git checkout pull/30402`

Update a local copy of the PR: \
`$ git checkout pull/30402` \
`$ git pull https://git.openjdk.org/jdk.git pull/30402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30402`

View PR using the GUI difftool: \
`$ git pr show -t 30402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30402.diff">https://git.openjdk.org/jdk/pull/30402.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30402#issuecomment-4118787995)
</details>
