### PR TITLE
Add null check for 'name' parameter in Perf_CreateLong

### DIFF
--- a/src/hotspot/share/prims/perf.cpp
+++ b/src/hotspot/share/prims/perf.cpp
@@ -108,6 +108,11 @@ PERF_ENTRY(jobject, Perf_CreateLong(JNIEnv *env, jobject perf, jstring name,
 
   PerfWrapper("Perf_CreateLong");
 
+  // check for valid name
+  if (name == nullptr) {
+    THROW_NULL(vmSymbols::java_lang_NullPointerException());
+  }
+
   char* name_utf = nullptr;
 
   if (units <= 0 || units > PerfData::U_Last) {


### PR DESCRIPTION
Add null check for 'name' parameter in `Perf_CreateLong` by analogy and consistency with `Perf_CreateByteArray`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30430/head:pull/30430` \
`$ git checkout pull/30430`

Update a local copy of the PR: \
`$ git checkout pull/30430` \
`$ git pull https://git.openjdk.org/jdk.git pull/30430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30430`

View PR using the GUI difftool: \
`$ git pr show -t 30430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30430.diff">https://git.openjdk.org/jdk/pull/30430.diff</a>

</details>
