### PR TITLE
8178361: JFileChooser does not allow to open folders by a double tap on a touch screen

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -2471,8 +2471,17 @@ MsgRouting AwtComponent::WmMouseMove(UINT flags, int x, int y)
      * Only report mouse move and drag events if a move or drag
      * actually happened -- Windows sends a WM_MOUSEMOVE in case the
      * app wants to modify the cursor.
+     * Skip sending a mouse move event during a double-tap if the movement is within the defined delta threshold
      */
-    if (lastComp != this || x != lastX || y != lastY) {
+
+    BOOL causedByTouchEvent = FALSE;
+    if (m_touchDownOccurred &&
+        (abs(m_touchDownPoint.x - x) <= TOUCH_MOUSE_COORDS_DELTA) &&
+        (abs(m_touchDownPoint.y - y) <= TOUCH_MOUSE_COORDS_DELTA)) {
+        causedByTouchEvent = TRUE;
+    }
+
+    if ((lastComp != this || x != lastX || y != lastY) && !causedByTouchEvent) {
         lastComp = this;
         lastX = x;
         lastY = y;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -2471,7 +2471,8 @@ MsgRouting AwtComponent::WmMouseMove(UINT flags, int x, int y)
      * Only report mouse move and drag events if a move or drag
      * actually happened -- Windows sends a WM_MOUSEMOVE in case the
      * app wants to modify the cursor.
-     * Skip sending a mouse move event during a double-tap if the movement is within the defined delta threshold
+     * Skip sending a mouse move event during a double-tap
+     * if the movement is within the defined delta threshold.
      */
 
     BOOL causedByTouchEvent = FALSE;


### PR DESCRIPTION
Hi Reviewers,

Problem: Double tap  generates WM_LBUTTONDOWN, WM_MOUSEMOVE, and WM_LBUTTONUP messages in response to actions on a primary touch point. [Which is document here](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-touchinput). 

Solution: Skip drag/mouse move in case of touch within delta.

Please review and let me know your suggestions.

Regards,
Renjith.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (4 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 3 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8178361](https://bugs.openjdk.org/browse/JDK-8178361): JFileChooser does not allow to open folders by a double tap on a touch screen (**Bug** - P3)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) 🔄 Re-review required (review applies to [b073a8c7](https://git.openjdk.org/jdk/pull/30450/files/b073a8c7c37f47f508b146193d90503394cb8f73))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30450/head:pull/30450` \
`$ git checkout pull/30450`

Update a local copy of the PR: \
`$ git checkout pull/30450` \
`$ git pull https://git.openjdk.org/jdk.git pull/30450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30450`

View PR using the GUI difftool: \
`$ git pr show -t 30450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30450.diff">https://git.openjdk.org/jdk/pull/30450.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30450#issuecomment-4134334498)
</details>
