### PR TITLE
 8378102: Validly imported symbols of unresolved types do not have their FQN reflected in the Element/TypeMirror instances passed to annotation processors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2355,9 +2355,13 @@ public class Resolve {
         for (Symbol s : scope.getSymbolsByName(name)) {
             Symbol sym = loadClass(env, s.flatName(), recoveryLoadClass);
             if (bestSoFar.kind == TYP && sym.kind == TYP &&
-                bestSoFar != sym)
+                bestSoFar != sym) {
                 return new AmbiguityError(bestSoFar, sym);
-            else
+            } else if (env.toplevel.namedImportScope == scope &&
+                    (sym == typeNotFound || (sym.kind == ERR && s.kind == ERR))) {
+                //TODO: consider: should we allow the search to continue, instead of providing an "existing" answer?
+                bestSoFar = bestOf(bestSoFar, new UnresolvableGobalSymbolError(s));
+            } else
                 bestSoFar = bestOf(bestSoFar, sym);
         }
         return bestSoFar;
@@ -4152,6 +4156,31 @@ public class Resolve {
                 Name name,
                 List<Type> argtypes,
                 List<Type> typeargtypes);
+    }
+
+    class UnresolvableGobalSymbolError extends InvalidSymbolError {
+
+        UnresolvableGobalSymbolError(Symbol sym) {
+            super(HIDDEN, sym, "unresolvable class error");
+            this.name = sym.name;
+        }
+
+        @Override
+        JCDiagnostic getDiagnostic(JCDiagnostic.DiagnosticType dkind,
+                DiagnosticPosition pos,
+                Symbol location,
+                Type site,
+                Name name,
+                List<Type> argtypes,
+                List<Type> typeargtypes) {
+            //the error should have already been reported, ignore:
+            return null;
+        }
+
+        @Override
+        public Symbol access(Name name, TypeSymbol location) {
+            return sym;
+        }
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2359,7 +2359,6 @@ public class Resolve {
                 return new AmbiguityError(bestSoFar, sym);
             } else if (env.toplevel.namedImportScope == scope &&
                     (sym == typeNotFound || (sym.kind == ERR && s.kind == ERR))) {
-                //TODO: consider: should we allow the search to continue, instead of providing an "existing" answer?
                 bestSoFar = bestOf(bestSoFar, new UnresolvableGobalSymbolError(s));
             } else
                 bestSoFar = bestOf(bestSoFar, sym);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -568,8 +568,7 @@ public class TypeEnter implements Completer {
          *                  scope to add to.
          */
         private void importNamed(DiagnosticPosition pos, final Symbol tsym, Env<AttrContext> env, JCImport imp) {
-            if (tsym.kind == TYP)
-                imp.importScope = env.toplevel.namedImportScope.importType(tsym.owner.members(), tsym.owner.members(), tsym);
+            imp.importScope = env.toplevel.namedImportScope.importType(tsym.owner.members(), tsym.owner.members(), tsym);
         }
 
     }

--- a/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
+++ b/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
+++ b/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
@@ -76,9 +76,6 @@ public class IgnoreSourceErrors  extends TestRunner {
         if (!out.contains("package invalid.example does not exist")) {
             throw new Exception("expected string not found \'package invalid.example does not exist\'");
         }
-        if (!out.contains("cannot find symbol")) {
-            throw new Exception("expected string not found \'cannot find symbol\'");
-        }
     }
 
     @Test
@@ -92,9 +89,6 @@ public class IgnoreSourceErrors  extends TestRunner {
         }
         if (!out.contains("package invalid.example does not exist")) {
             throw new Exception("expected string not found \'package invalid.example does not exist\'");
-        }
-        if (!out.contains("cannot find symbol")) {
-            throw new Exception("expected string not found \'cannot find symbol\'");
         }
     }
 

--- a/test/langtools/tools/javac/PackageClassAmbiguity/util.out
+++ b/test/langtools/tools/javac/PackageClassAmbiguity/util.out
@@ -1,3 +1,2 @@
 util.java:13:17: compiler.err.cant.resolve.location: kindname.class, Set, , , (compiler.misc.location: kindname.class, java.util, null)
-util.java:16:5: compiler.err.cant.resolve.location: kindname.class, Set, , , (compiler.misc.location: kindname.class, java.util, null)
-2 errors
+1 error

--- a/test/langtools/tools/javac/importscope/BadClassFileDuringImport.java
+++ b/test/langtools/tools/javac/importscope/BadClassFileDuringImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/importscope/BadClassFileDuringImport.java
+++ b/test/langtools/tools/javac/importscope/BadClassFileDuringImport.java
@@ -81,23 +81,19 @@ public class BadClassFileDuringImport {
         doTest("import p.A;",
                "A a;",
                "Test.java:2:9: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
-               "Test.java:2:33: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import m.A;",
                "A a;",
                "Test.java:2:9: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.package, m, null)",
-               "Test.java:2:33: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import p.A;",
                "void test() { A a; }",
                "Test.java:2:9: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
-               "Test.java:2:47: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import m.A;",
                "void test() { A a; }",
                "Test.java:2:9: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.package, m, null)",
-               "Test.java:2:47: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import p.*;",
                "",
                (String[]) null);
@@ -132,23 +128,19 @@ public class BadClassFileDuringImport {
         doTest("import p.B.I;",
                "I i;",
                "Test.java:2:11: compiler.err.cant.access: p.B.I, (compiler.misc.bad.class.file.header: B$I.class, (compiler.misc.illegal.start.of.class.file))",
-               "Test.java:2:35: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import m.B.I;",
                "I i;",
                "Test.java:2:11: compiler.err.cant.access: m.B.I, (compiler.misc.class.file.not.found: m.B$I)",
-               "Test.java:2:35: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import p.B.I;",
                "void test() { I i; }",
                "Test.java:2:11: compiler.err.cant.access: p.B.I, (compiler.misc.bad.class.file.header: B$I.class, (compiler.misc.illegal.start.of.class.file))",
-               "Test.java:2:49: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import m.B.I;",
                "void test() { I i; }",
                "Test.java:2:11: compiler.err.cant.access: m.B.I, (compiler.misc.class.file.not.found: m.B$I)",
-               "Test.java:2:49: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import p.B.*;",
                "",
                (String[]) null);
@@ -199,8 +191,7 @@ public class BadClassFileDuringImport {
         doTest("import static m.B.I;",
                "void test() { I i; }",
                "Test.java:2:1: compiler.err.cant.access: m.B.I, (compiler.misc.class.file.not.found: m.B$I)",
-               "Test.java:2:56: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("import static p.B.*;",
                "",
                "Test.java:2:1: compiler.err.cant.access: p.B.I, (compiler.misc.bad.class.file.header: B$I.class, (compiler.misc.illegal.start.of.class.file))",

--- a/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
+++ b/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
+++ b/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
@@ -631,8 +631,7 @@ public class ConvenientAccessErrorsTest extends ModuleTestBase {
 
         List<String> expected = Arrays.asList(
                 "Test.java:3:11: compiler.err.cant.resolve.location: kindname.class, Base, , , (compiler.misc.location: kindname.package, api, null)",
-                "Test.java:6:5: compiler.err.cant.resolve.location: kindname.class, Base, , , (compiler.misc.location: kindname.class, test.Test, null)",
-                "2 errors");
+                "1 error");
 
         if (!expected.equals(log))
             throw new Exception("expected output not found; actual: " + log);

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -629,24 +629,27 @@ public class AttrRecovery {
             .sources("""
                      package lib;
                      public class Lib {
-                         public static class Unknown3 {}
+                         public static class Unknown4 {}
                      }
                      """)
                 .outdir(libOut)
                 .run()
                 .writeAll();
 
-        Files.delete(libOut.resolve("lib").resolve("Lib$Unknown3.class"));
+        Files.delete(libOut.resolve("lib").resolve("Lib$Unknown4.class"));
 
         String code = """
                       import unknown.Unknown1;
-                      import java.lang.String.Unknown2;
-                      import lib.Lib.Unknown3;
+                      import java.lang.Unknown2;
+                      import java.lang.String.Unknown3;
+                      import lib.Lib.Unknown4;
                       public class C {
                           Unknown1 u1;
                           Unknown2 u2;
                           Unknown3 u3;
-                          unknown.Unknown4 u4;
+                          Unknown4 u4;
+                          unknown.Unknown5 u5;
+                          java.lang.Unknown6 u6;
                       }
                       """;
         Path out = base.resolve("out");
@@ -694,19 +697,23 @@ public class AttrRecovery {
 
         List<String> expectedTypes = List.of(
             "unknown.Unknown1",
-            "java.lang.String.Unknown2",
-            "lib.Lib.Unknown3",
-            "unknown.Unknown4"
+            "java.lang.Unknown2",
+            "java.lang.String.Unknown3",
+            "lib.Lib.Unknown4",
+            "unknown.Unknown5",
+            "java.lang.Unknown6"
         );
 
         assertEquals(expectedTypes, foundTypes);
 
         List<String> expected = List.of(
             "C.java:1:15: compiler.err.doesnt.exist: unknown",
-            "C.java:2:24: compiler.err.cant.resolve.location: kindname.class, Unknown2, , , (compiler.misc.location: kindname.class, java.lang.String, null)",
-            "C.java:3:15: compiler.err.cant.access: lib.Lib.Unknown3, (compiler.misc.class.file.not.found: lib.Lib$Unknown3)",
-            "C.java:8:12: compiler.err.doesnt.exist: unknown",
-            "4 errors"
+            "C.java:2:17: compiler.err.cant.resolve.location: kindname.class, Unknown2, , , (compiler.misc.location: kindname.package, java.lang, null)",
+            "C.java:3:24: compiler.err.cant.resolve.location: kindname.class, Unknown3, , , (compiler.misc.location: kindname.class, java.lang.String, null)",
+            "C.java:4:15: compiler.err.cant.access: lib.Lib.Unknown4, (compiler.misc.class.file.not.found: lib.Lib$Unknown4)",
+            "C.java:10:12: compiler.err.doesnt.exist: unknown",
+            "C.java:11:14: compiler.err.cant.resolve.location: kindname.class, Unknown6, , , (compiler.misc.location: kindname.package, java.lang, null)",
+            "6 errors"
         );
 
         assertEquals(expected, actual);

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -52,8 +52,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
@@ -623,7 +626,6 @@ public class AttrRecovery {
         Files.createDirectories(libOut);
 
         new JavacTask(tb)
-            .options("-XDrawDiagnostics", "-XDdev")
             .sources("""
                      package lib;
                      public class Lib {
@@ -670,7 +672,14 @@ public class AttrRecovery {
                                     public Void visitVariable(VariableTree tree, Void p) {
                                         VariableElement var = (VariableElement) trees.getElement(getCurrentPath());
 
-                                        foundTypes.add(var.asType().toString());
+                                        assertEquals(TypeKind.ERROR, var.asType().getKind());
+
+                                        Element el = ((ErrorType) var.asType()).asElement();
+
+                                        assertNotNull(el);
+                                        assertEquals(ElementKind.CLASS, el.getKind());
+
+                                        foundTypes.add(((QualifiedNameable) el).getQualifiedName().toString());
 
                                         return super.visitVariable(tree, p);
                                     }
@@ -698,6 +707,87 @@ public class AttrRecovery {
             "C.java:3:15: compiler.err.cant.access: lib.Lib.Unknown3, (compiler.misc.class.file.not.found: lib.Lib$Unknown3)",
             "C.java:8:12: compiler.err.doesnt.exist: unknown",
             "4 errors"
+        );
+
+        assertEquals(expected, actual);
+    }
+
+
+    @Test
+    public void testUnresolvableNamedResolvableOnDemandImport() throws Exception {
+        Path libOut = base.resolve("lib");
+
+        Files.createDirectories(libOut);
+
+        new JavacTask(tb)
+            .sources("""
+                     package lib;
+                     public class Unknown {
+                     }
+                     """)
+                .outdir(libOut)
+                .run()
+                .writeAll();
+
+        String code = """
+                      import unknown.Unknown;
+                      import lib.*;
+                      public class C {
+                          Unknown u;
+                      }
+                      """;
+        Path out = base.resolve("out");
+
+        Files.createDirectories(out);
+
+        List<String> foundTypes = new ArrayList<>();
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDdev",
+                         "-classpath", libOut.toString())
+                .sources(code)
+                .outdir(out)
+                .callback(task -> {
+                    task.addTaskListener(new TaskListener() {
+                        @Override
+                        public void finished(TaskEvent e) {
+                            Trees trees = Trees.instance(task);
+
+                            if (e.getKind() == TaskEvent.Kind.ANALYZE) {
+                                new TreePathScanner<Void, Void>() {
+                                    @Override
+                                    public Void visitVariable(VariableTree tree, Void p) {
+                                        VariableElement var = (VariableElement) trees.getElement(getCurrentPath());
+
+                                        assertEquals(TypeKind.ERROR, var.asType().getKind());
+
+                                        Element el = ((ErrorType) var.asType()).asElement();
+
+                                        assertNotNull(el);
+                                        assertEquals(ElementKind.CLASS, el.getKind());
+
+                                        foundTypes.add(((QualifiedNameable) el).getQualifiedName().toString());
+
+                                        return super.visitVariable(tree, p);
+                                    }
+                                }.scan(e.getCompilationUnit(), null);
+                            }
+                        }
+                    });
+                })
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expectedTypes = List.of(
+            "unknown.Unknown"
+        );
+
+        assertEquals(expectedTypes, foundTypes);
+
+        List<String> expected = List.of(
+            "C.java:1:15: compiler.err.doesnt.exist: unknown",
+            "1 error"
         );
 
         assertEquals(expected, actual);

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox toolbox.JavacTask
- * @run main AttrRecovery
+ * @run junit AttrRecovery
  */
 
 import com.sun.source.tree.IdentifierTree;
@@ -42,13 +42,13 @@ import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.Element;
@@ -58,25 +58,20 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
 import toolbox.JavacTask;
 import toolbox.Task.Expect;
 import toolbox.Task.OutputKind;
-import toolbox.TestRunner;
 import toolbox.ToolBox;
 
-public class AttrRecovery extends TestRunner {
+public class AttrRecovery {
 
-    ToolBox tb;
-
-    public AttrRecovery() {
-        super(System.err);
-        tb = new ToolBox();
-    }
-
-    public static void main(String[] args) throws Exception {
-        AttrRecovery t = new AttrRecovery();
-        t.runTests();
-    }
+    private Path base;
+    private final ToolBox tb = new ToolBox();
 
     @Test
     public void testFlowExits() throws Exception {
@@ -88,11 +83,10 @@ public class AttrRecovery extends TestRunner {
                           }
                       }
                       """;
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics", "-XDdev", "-XDshould-stop.at=FLOW")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .run(Expect.FAIL)
                 .getOutputLines(OutputKind.DIRECT);
 
@@ -102,9 +96,7 @@ public class AttrRecovery extends TestRunner {
                 "2 errors"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -120,12 +112,11 @@ public class AttrRecovery extends TestRunner {
                           public void overridable(C c) {}
                       }
                       """;
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics", "-XDdev",
                          "-XDshould-stop.at=WARN", "-Xlint:this-escape")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .run(Expect.FAIL)
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
@@ -139,9 +130,7 @@ public class AttrRecovery extends TestRunner {
                 "1 warning"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test //JDK-8332230
@@ -158,11 +147,10 @@ public class AttrRecovery extends TestRunner {
                           @interface Ann {}
                       }
                       """;
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics", "-XDdev", "-XDshould-stop.at=FLOW")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .run(Expect.FAIL)
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
@@ -172,9 +160,7 @@ public class AttrRecovery extends TestRunner {
                 "1 error"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test //JDK-8333107
@@ -203,12 +189,11 @@ public class AttrRecovery extends TestRunner {
                           }
                       }
                       """;
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics", "-XDdev",
                          "-XDshould-stop.at=FLOW")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .run(Expect.FAIL)
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
@@ -218,9 +203,7 @@ public class AttrRecovery extends TestRunner {
                 "1 error"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -234,11 +217,10 @@ public class AttrRecovery extends TestRunner {
                           }
                       }
                       """;
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .run(Expect.FAIL, 1)
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
@@ -249,9 +231,7 @@ public class AttrRecovery extends TestRunner {
                 "2 errors"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -261,11 +241,10 @@ public class AttrRecovery extends TestRunner {
                           Undefined1<Undefined2, Undefined3> variable1;
                       }
                       """;
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .callback(task -> {
                     task.addTaskListener(new TaskListener() {
                         @Override
@@ -325,9 +304,7 @@ public class AttrRecovery extends TestRunner {
                 "3 errors"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test //JDK-8351260
@@ -338,13 +315,12 @@ public class AttrRecovery extends TestRunner {
                           }
                       }
                       """;
-        Path curPath = Path.of(".");
         //should not fail with an exception:
         new JavacTask(tb)
             .options("-XDrawDiagnostics",
                      "-XDshould-stop.at=FLOW")
             .sources(code)
-            .outdir(curPath)
+            .outdir(base)
             .run(Expect.FAIL)
             .writeAll();
     }
@@ -384,11 +360,10 @@ public class AttrRecovery extends TestRunner {
                             return null;
                           }
                       }""";
-        Path curPath = Path.of(".");
         List<String> actual = new JavacTask(tb)
                 .options("-XDrawDiagnostics", "-XDshould-stop.at=FLOW")
                 .sources(code)
-                .outdir(curPath)
+                .outdir(base)
                 .run(Expect.FAIL)
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
@@ -398,15 +373,12 @@ public class AttrRecovery extends TestRunner {
                 "1 error"
         );
 
-        if (!Objects.equals(actual, expected)) {
-            error("Expected: " + expected + ", but got: " + actual);
-        }
+        assertEquals(expected, actual);
     }
 
     @Test //JDK-8372336
     public void testCompletionFailureNoBreakInvocation() throws Exception {
-        Path curPath = Path.of(".");
-        Path lib = curPath.resolve("lib");
+        Path lib = base.resolve("lib");
         Path classes = lib.resolve("classes");
         Files.createDirectories(classes);
         new JavacTask(tb)
@@ -457,7 +429,7 @@ public class AttrRecovery extends TestRunner {
                     .options("-XDrawDiagnostics", "-XDdev")
                     .classpath(classes)
                     .sources(tc.code())
-                    .outdir(curPath)
+                    .outdir(base)
                     .callback(task -> {
                         task.addTaskListener(new TaskListener() {
                             @Override
@@ -482,7 +454,7 @@ public class AttrRecovery extends TestRunner {
                                     private void verifyElement() {
                                         Element el = trees.getElement(getCurrentPath());
                                         if (!el.getSimpleName().contentEquals("get")) {
-                                            error("Expected good Element, but got: " + el);
+                                            fail("Expected good Element, but got: " + el);
                                         }
                                     }
                                 }.scan(e.getCompilationUnit(), null);
@@ -495,16 +467,13 @@ public class AttrRecovery extends TestRunner {
 
             List<String> expected = List.of(tc.expectedErrors);
 
-            if (!Objects.equals(actual, expected)) {
-                error("Expected: " + expected + ", but got: " + actual);
-            }
+            assertEquals(expected, actual);
         }
     }
 
     @Test //JDK-8373094
     public void testSensibleAttribution() throws Exception {
-        Path curPath = Path.of(".");
-        Path lib = curPath.resolve("lib");
+        Path lib = base.resolve("lib");
         Path classes = lib.resolve("classes");
         Files.createDirectories(classes);
         new JavacTask(tb)
@@ -570,7 +539,7 @@ public class AttrRecovery extends TestRunner {
                                            tc.options.stream()).toList())
                     .classpath(classes)
                     .sources(tc.code())
-                    .outdir(curPath)
+                    .outdir(base)
                     .callback(task -> {
                         task.addTaskListener(new TaskListener() {
                             @Override
@@ -623,7 +592,7 @@ public class AttrRecovery extends TestRunner {
 
                                         Element el = trees.getElement(getCurrentPath());
                                         if (el == null) {
-                                            error("Unattributed tree: " + getCurrentPath().getLeaf());
+                                            fail("Unattributed tree: " + getCurrentPath().getLeaf());
                                         } else {
                                             attributes.add(el.toString());
                                         }
@@ -638,17 +607,105 @@ public class AttrRecovery extends TestRunner {
 
             List<String> expectedErrors = List.of(tc.expectedErrors);
 
-            if (!Objects.equals(actual, expectedErrors)) {
-                error("Expected: " + expectedErrors + ", but got: " + actual);
-            }
+            assertEquals(expectedErrors, actual);
 
             List<String> expectedAttributes =
                     List.of("println(int)", "println(int)", "err", "java.lang.System", "i");
 
-            if (!Objects.equals(attributes, expectedAttributes)) {
-                error("Expected: " + expectedAttributes + ", but got: " + attributes);
-            }
+            assertEquals(expectedAttributes, attributes);
         }
     }
 
+    @Test
+    public void testImportedUnknownFQN() throws Exception {
+        Path libOut = base.resolve("lib");
+
+        Files.createDirectories(libOut);
+
+        new JavacTask(tb)
+            .options("-XDrawDiagnostics", "-XDdev")
+            .sources("""
+                     package lib;
+                     public class Lib {
+                         public static class Unknown3 {}
+                     }
+                     """)
+                .outdir(libOut)
+                .run()
+                .writeAll();
+
+        Files.delete(libOut.resolve("lib").resolve("Lib$Unknown3.class"));
+
+        String code = """
+                      import unknown.Unknown1;
+                      import java.lang.String.Unknown2;
+                      import lib.Lib.Unknown3;
+                      public class C {
+                          Unknown1 u1;
+                          Unknown2 u2;
+                          Unknown3 u3;
+                          unknown.Unknown4 u4;
+                      }
+                      """;
+        Path out = base.resolve("out");
+
+        Files.createDirectories(out);
+
+        List<String> foundTypes = new ArrayList<>();
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDdev",
+                         "-classpath", libOut.toString())
+                .sources(code)
+                .outdir(out)
+                .callback(task -> {
+                    task.addTaskListener(new TaskListener() {
+                        @Override
+                        public void finished(TaskEvent e) {
+                            Trees trees = Trees.instance(task);
+
+                            if (e.getKind() == TaskEvent.Kind.ANALYZE) {
+                                new TreePathScanner<Void, Void>() {
+                                    @Override
+                                    public Void visitVariable(VariableTree tree, Void p) {
+                                        VariableElement var = (VariableElement) trees.getElement(getCurrentPath());
+
+                                        foundTypes.add(var.asType().toString());
+
+                                        return super.visitVariable(tree, p);
+                                    }
+                                }.scan(e.getCompilationUnit(), null);
+                            }
+                        }
+                    });
+                })
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expectedTypes = List.of(
+            "unknown.Unknown1",
+            "java.lang.String.Unknown2",
+            "lib.Lib.Unknown3",
+            "unknown.Unknown4"
+        );
+
+        assertEquals(expectedTypes, foundTypes);
+
+        List<String> expected = List.of(
+            "C.java:1:15: compiler.err.doesnt.exist: unknown",
+            "C.java:2:24: compiler.err.cant.resolve.location: kindname.class, Unknown2, , , (compiler.misc.location: kindname.class, java.lang.String, null)",
+            "C.java:3:15: compiler.err.cant.access: lib.Lib.Unknown3, (compiler.misc.class.file.not.found: lib.Lib$Unknown3)",
+            "C.java:8:12: compiler.err.doesnt.exist: unknown",
+            "4 errors"
+        );
+
+        assertEquals(expected, actual);
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) throws IOException {
+        base = Path.of(info.getTestMethod().orElseThrow().getName());
+        Files.createDirectories(base);
+    }
 }

--- a/test/langtools/tools/javac/tree/ASTAttributesFilledForReferencesOnMissingTypes.java
+++ b/test/langtools/tools/javac/tree/ASTAttributesFilledForReferencesOnMissingTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/tree/ASTAttributesFilledForReferencesOnMissingTypes.java
+++ b/test/langtools/tools/javac/tree/ASTAttributesFilledForReferencesOnMissingTypes.java
@@ -118,8 +118,7 @@ public class ASTAttributesFilledForReferencesOnMissingTypes {
                }
                """,
                "Test.java:1:9: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
-               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("""
                public class Test {
                    p.A a;
@@ -134,8 +133,7 @@ public class ASTAttributesFilledForReferencesOnMissingTypes {
                }
                """,
                "Test.java:1:9: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.package, p, null)",
-               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("""
                public class Test {
                    p.C c;
@@ -152,8 +150,7 @@ public class ASTAttributesFilledForReferencesOnMissingTypes {
                }
                """,
                "Test.java:1:11: compiler.err.cant.access: p.B.I, (compiler.misc.bad.class.file.header: B$I.class, (compiler.misc.illegal.start.of.class.file))",
-               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("""
                import p.B.M;
                public class Test {
@@ -161,8 +158,7 @@ public class ASTAttributesFilledForReferencesOnMissingTypes {
                }
                """,
                "Test.java:1:11: compiler.err.cant.access: p.B.M, (compiler.misc.class.file.not.found: p.B$M)",
-               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, M, , , (compiler.misc.location: kindname.class, Test, null)",
-               "2 errors");
+               "1 error");
         doTest("""
                public class Test {
                    p.B.I i;


### PR DESCRIPTION
Consider code like:
```
import unknown.Unknown;
class T {
    Unknown u;
}
```

compiling this leads to:
```
$ javac /tmp/T.java 
/tmp/T.java:1: error: package unknown does not exist
import unknown.Unknown;
              ^
/tmp/T.java:3: error: cannot find symbol
    Unknown u;
    ^
  symbol:   class Unknown
  location: class T
2 errors
```

And in the AST the error type for `Unknown` in `Unknown u` does not refer to `unknown.Unknown` at all.

This PR is trying to improve this, by keeping track unresolvable types that are (single-name) imported, and using their symbols when attributing references.

With this patch, the error reported is:
```
$ javac /tmp/T.java 
/tmp/T.java:1: error: package unknown does not exist
import unknown.Unknown;
              ^
1 error
```

And the reference to `Unknown` is attributed as `unknown.Unknown`.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
- [ ]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378102](https://bugs.openjdk.org/browse/JDK-8378102): Validly imported symbols of unresolved types do not have their FQN reflected in the Element/TypeMirror instances passed to annotation processors (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30452/head:pull/30452` \
`$ git checkout pull/30452`

Update a local copy of the PR: \
`$ git checkout pull/30452` \
`$ git pull https://git.openjdk.org/jdk.git pull/30452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30452`

View PR using the GUI difftool: \
`$ git pr show -t 30452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30452.diff">https://git.openjdk.org/jdk/pull/30452.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30452#issuecomment-4135079893)
</details>
