### PR TITLE
8380971: New -Werror syntax does not exclude categories

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -440,7 +440,7 @@ public class JavaCompiler {
                         options.isSet(G_CUSTOM, "lines");
         devVerbose    = options.isSet("dev");
         processPcks   = options.isSet("process.packages");
-        werrorAny     = options.isSet(WERROR) || options.isSet(WERROR_CUSTOM, Option.LINT_CUSTOM_ALL);
+        werrorNonLint = options.isSet(WERROR) || options.isSet(WERROR_CUSTOM, Option.LINT_CUSTOM_ALL);
         werrorLint    = options.getLintCategoriesOf(WERROR, LintCategory::newEmptySet);
 
         verboseCompilePolicy = options.isSet("verboseCompilePolicy");
@@ -510,9 +510,9 @@ public class JavaCompiler {
      */
     protected boolean processPcks;
 
-    /** Switch: treat any kind of warning (lint or non-lint) as an error.
+    /** Switch: treat non-lint warnings as errors. Set by either "-Werror" or "-Werror:all".
      */
-    protected boolean werrorAny;
+    protected boolean werrorNonLint;
 
     /** Switch: treat lint warnings in the specified {@link LintCategory}s as errors.
      */
@@ -583,7 +583,7 @@ public class JavaCompiler {
     public int errorCount() {
         log.reportOutstandingWarnings();
         if (log.nerrors == 0 && log.nwarnings > 0 &&
-                (werrorAny || werrorLint.clone().removeAll(log.lintWarnings))) {
+              ((werrorNonLint && log.nonLintWarnings > 0) || werrorLint.clone().removeAll(log.lintWarnings))) {
             log.error(Errors.WarningsAndWerror);
         }
         return log.nerrors;
@@ -593,7 +593,7 @@ public class JavaCompiler {
      * Should warnings in the given lint category be treated as errors due to a {@code -Werror} flag?
      */
     public boolean isWerror(LintCategory lc) {
-        return werrorAny || werrorLint.contains(lc);
+        return werrorLint.contains(lc);
     }
 
     protected final <T> Queue<T> stopIfError(CompileState cs, Queue<T> queue) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -566,6 +566,10 @@ public class Log extends AbstractLog {
      */
     public int nwarnings = 0;
 
+    /** The total number of non-lint warnings encountered so far.
+     */
+    public int nonLintWarnings = 0;
+
     /** Tracks whether any warnings have been encountered in each {@link LintCategory}.
      */
     public final EnumSet<LintCategory> lintWarnings = LintCategory.newEmptySet();
@@ -896,6 +900,7 @@ public class Log extends AbstractLog {
         lintWarnings.clear();
         nerrors = 0;
         nwarnings = 0;
+        nonLintWarnings = 0;
         nsuppressederrors = 0;
         nsuppressedwarns = 0;
         while (diagnosticHandler.prev != null)
@@ -989,7 +994,7 @@ public class Log extends AbstractLog {
             nwarnings++;
             Optional.of(diag)
               .map(JCDiagnostic::getLintCategory)
-              .ifPresent(lintWarnings::add);
+              .ifPresentOrElse(lintWarnings::add, () -> nonLintWarnings++);
             break;
         case ERROR:
             nerrors++;
@@ -1129,6 +1134,7 @@ public class Log extends AbstractLog {
         }
         prompt();
         nwarnings++;
+        nonLintWarnings++;
         warnWriter.flush();
     }
 

--- a/test/langtools/tools/javac/warnings/WerrorLint2.fail1.out
+++ b/test/langtools/tools/javac/warnings/WerrorLint2.fail1.out
@@ -1,0 +1,4 @@
+WerrorLint2.java:16:30: compiler.warn.empty.if
+- compiler.err.warnings.and.werror
+1 error
+1 warning

--- a/test/langtools/tools/javac/warnings/WerrorLint2.fail2.out
+++ b/test/langtools/tools/javac/warnings/WerrorLint2.fail2.out
@@ -1,0 +1,5 @@
+WerrorLint2.java:16:30: compiler.warn.empty.if
+WerrorLint2.java:17:28: compiler.warn.diamond.redundant.args
+- compiler.err.warnings.and.werror
+1 error
+2 warnings

--- a/test/langtools/tools/javac/warnings/WerrorLint2.java
+++ b/test/langtools/tools/javac/warnings/WerrorLint2.java
@@ -1,0 +1,19 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8380971
+ *
+ * @compile/fail/ref=WerrorLint2.fail1.out  -XDrawDiagnostics -Xlint:all                 -Werror:all        WerrorLint2.java
+ * @compile/ref=WerrorLint2.warn1.out       -XDrawDiagnostics -Xlint:all                 -Werror:all,-empty WerrorLint2.java
+ * @compile/ref=WerrorLint2.warn1.out       -XDrawDiagnostics -Xlint:all                 -Werror:-empty     WerrorLint2.java
+ * @compile/fail/ref=WerrorLint2.fail1.out  -XDrawDiagnostics -Xlint:all -XDfind=diamond -Werror:all        WerrorLint2.java
+ * @compile/fail/ref=WerrorLint2.fail2.out  -XDrawDiagnostics -Xlint:all -XDfind=diamond -Werror:all,-empty WerrorLint2.java
+ * @compile/ref=WerrorLint2.warn2.out       -XDrawDiagnostics -Xlint:all -XDfind=diamond -Werror:-empty     WerrorLint2.java
+ */
+
+class WerrorLint2 {
+    ThreadLocal<Void> t;
+    void m() {
+        if (hashCode() == 1) ;       // warning: [empty] empty statement after if
+        t = new ThreadLocal<Void>(); // warning: Redundant type arguments in new expression (use diamond operator instead).
+    }
+}

--- a/test/langtools/tools/javac/warnings/WerrorLint2.warn1.out
+++ b/test/langtools/tools/javac/warnings/WerrorLint2.warn1.out
@@ -1,0 +1,2 @@
+WerrorLint2.java:16:30: compiler.warn.empty.if
+1 warning

--- a/test/langtools/tools/javac/warnings/WerrorLint2.warn2.out
+++ b/test/langtools/tools/javac/warnings/WerrorLint2.warn2.out
@@ -1,0 +1,3 @@
+WerrorLint2.java:16:30: compiler.warn.empty.if
+WerrorLint2.java:17:28: compiler.warn.diamond.redundant.args
+2 warnings


### PR DESCRIPTION
Issue [JDK-8349847](https://bugs.openjdk.org/browse/JDK-8349847) added support for applying `-Werror` on a per-lint-category basis. That change has a bug that causes `-Werror:all,-foo` to not work. In other words, `-Werror:all,-foo` behaves just like `-Werror:all` (or just plain `-Werror`, which means the same thing).

The confusion was caused by the fact that `-Werror:all` is supposed to enable errors not only for all int categories, but also for non-lint warnings, in order to stay consistent with its previous behavior. But in the compiler, the flag that enables errors for non-lint warnings (`werrorAny`) was enabling them for lint warnings as well, causing any `-foo` exclusions to be ignored.

This patch adjusts the logic to replace the over-eager `werrorAny` flag with a new `werrorNonLint` flag which only does what it's supposed to. This requires adding an explicit counter for non-lint warnings.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380971](https://bugs.openjdk.org/browse/JDK-8380971): New -Werror syntax does not exclude categories (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30457/head:pull/30457` \
`$ git checkout pull/30457`

Update a local copy of the PR: \
`$ git checkout pull/30457` \
`$ git pull https://git.openjdk.org/jdk.git pull/30457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30457`

View PR using the GUI difftool: \
`$ git pr show -t 30457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30457.diff">https://git.openjdk.org/jdk/pull/30457.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30457#issuecomment-4137393306)
</details>
