### PR TITLE
8381233: Linker does not need to be value based class

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,7 @@ import java.util.Optional;
  * {@linkplain Linker#upcallStub(MethodHandle, FunctionDescriptor, Arena, Linker.Option...) upcall stubs}.
  *
  * @implSpec
- * Implementing classes are immutable, thread-safe and
- * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * Implementing classes are immutable, thread-safe.
  *
  * @see MemoryLayout
  * @since 22

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,8 @@ import java.util.Optional;
  * {@linkplain Linker#upcallStub(MethodHandle, FunctionDescriptor, Arena, Linker.Option...) upcall stubs}.
  *
  * @implSpec
- * Implementing classes are immutable, thread-safe.
+ * Implementing classes are immutable, thread-safe and
+ * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @see MemoryLayout
  * @since 22

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -551,8 +551,7 @@ import java.util.function.Consumer;
  * upcall is typically executed in the context of a downcall method handle invocation.
  *
  * @implSpec
- * Implementations of this interface are immutable, thread-safe and
- * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * Implementations of this interface are immutable, thread-safe.
  *
  * @since 22
  */

--- a/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 package jdk.internal.foreign;
 
+import jdk.internal.ValueBased;
+
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -43,6 +45,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @implSpec This class and its subclasses are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  */
+@ValueBased
 public final class FunctionDescriptorImpl implements FunctionDescriptor {
 
     private final MemoryLayout resLayout; // Nullable


### PR DESCRIPTION
On the review for [JDK-8380955](https://bugs.openjdk.org/browse/JDK-8380955) (#30443), `Linker` and `FunctionDescriptor` do not need to be value based class because they would not be treated as "value".
`Linker` is defined as providing a way to look up the canonical layouts associated with the data types used by the ABI. `FunctionDescriptor` represents the signature of a foreign function. They are not "value".

Actually they and their child (final) classes do not have `@ValueBased`, thus `javac` and `-XX:DiagnoseSyncOnValueBasedClasses` cannot identify if they are used in anti-pattern of value based class. Thus this change does not change behavior, just documentation updates.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8381234](https://bugs.openjdk.org/browse/JDK-8381234) to be approved

### Issues
 * [JDK-8381233](https://bugs.openjdk.org/browse/JDK-8381233): Linker does not need to be value based class (**Bug** - P4)
 * [JDK-8381234](https://bugs.openjdk.org/browse/JDK-8381234): Linker does not need to be value based class (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30481/head:pull/30481` \
`$ git checkout pull/30481`

Update a local copy of the PR: \
`$ git checkout pull/30481` \
`$ git pull https://git.openjdk.org/jdk.git pull/30481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30481`

View PR using the GUI difftool: \
`$ git pr show -t 30481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30481.diff">https://git.openjdk.org/jdk/pull/30481.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30481#issuecomment-4146424805)
</details>
