### PR TITLE
8381238: Remove tautological uses of checked_cast

### DIFF
--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public:
   void write_on(CompressedWriteStream* stream) {
     stream->write_int(value());
     if(is_callee_saved() || is_derived_oop()) {
-      stream->write_int(checked_cast<int>(content_reg()->value()));
+      stream->write_int(content_reg()->value());
     }
   }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1458,7 +1458,7 @@ static void split_regions_for_worker(size_t start, size_t end,
   size_t remainder = num_regions % num_workers;
   // The first few workers will get one extra.
   *worker_start = start + worker_id * num_regions_per_worker
-                  + MIN2(checked_cast<size_t>(worker_id), remainder);
+                  + MIN2<size_t>(worker_id, remainder);
   *worker_end = *worker_start + num_regions_per_worker
                 + (worker_id < remainder ? 1 : 0);
 }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1506,7 +1506,7 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
   Node* long_zero = longcon(0);
   Node* int_zero = intcon(0);
   Node* long_one = longcon(1);
-  Node* int_stride = intcon(checked_cast<int>(stride_con));
+  Node* int_stride = intcon(stride_con);
 
   for (uint i = 0; i < range_checks.size(); i++) {
     ProjNode* proj = range_checks.at(i)->as_Proj();


### PR DESCRIPTION
Please review this change that removes uses of checked_cast that are
unnecessary because they are tautological.

These were discovered by locally changing checked_cast to use the new
integer_cast for integral conversions, and noting which calls failed to
compile because of the anti-tautology check in the latter.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8381238](https://bugs.openjdk.org/browse/JDK-8381238): Remove tautological uses of checked_cast (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30482/head:pull/30482` \
`$ git checkout pull/30482`

Update a local copy of the PR: \
`$ git checkout pull/30482` \
`$ git pull https://git.openjdk.org/jdk.git pull/30482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30482`

View PR using the GUI difftool: \
`$ git pr show -t 30482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30482.diff">https://git.openjdk.org/jdk/pull/30482.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30482#issuecomment-4147803154)
</details>
