### PR TITLE
8381237: Use integer_cast_permit_tautology instead of conditionally tautological checked_cast

### DIFF
--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #include "utilities/align.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/integerCast.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include CPU_HEADER_INLINE(gc/z/zAddress)
@@ -47,18 +48,21 @@
   /* Arithmetic operators for offset_type */                                              \
                                                                                           \
 inline offset_type operator+(offset_type offset, size_t size) {                           \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type>>(size);        \
+  using U = std::underlying_type_t<offset_type>;                                          \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   return to_##offset_type(untype(offset) + size_value);                                   \
 }                                                                                         \
                                                                                           \
 inline offset_type& operator+=(offset_type& offset, size_t size) {                        \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type>>(size);        \
+  using U = std::underlying_type_t<offset_type>;                                          \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   offset = to_##offset_type(untype(offset) + size_value);                                 \
   return offset;                                                                          \
 }                                                                                         \
                                                                                           \
 inline offset_type operator-(offset_type offset, size_t size) {                           \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type>>(size);        \
+  using U = std::underlying_type_t<offset_type>;                                          \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   return to_##offset_type(untype(offset) - size_value);                                   \
 }                                                                                         \
                                                                                           \
@@ -67,7 +71,8 @@ inline size_t operator-(offset_type first, offset_type second) {                
 }                                                                                         \
                                                                                           \
 inline offset_type& operator-=(offset_type& offset, size_t size) {                        \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type>>(size);        \
+  using U = std::underlying_type_t<offset_type>;                                          \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   offset = to_##offset_type(untype(offset) - size_value);                                 \
   return offset;                                                                          \
 }                                                                                         \
@@ -75,18 +80,21 @@ inline offset_type& operator-=(offset_type& offset, size_t size) {              
   /* Arithmetic operators for offset_type##_end */                                        \
                                                                                           \
 inline offset_type##_end operator+(offset_type##_end offset, size_t size) {               \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type##_end>>(size);  \
+  using U = std::underlying_type_t<offset_type##_end>;                                    \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   return to_##offset_type##_end(untype(offset) + size_value);                             \
 }                                                                                         \
                                                                                           \
 inline offset_type##_end& operator+=(offset_type##_end& offset, size_t size) {            \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type##_end>>(size);  \
+  using U = std::underlying_type_t<offset_type##_end>;                                    \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   offset = to_##offset_type##_end(untype(offset) + size_value);                           \
   return offset;                                                                          \
 }                                                                                         \
                                                                                           \
 inline offset_type##_end operator-(offset_type##_end first, size_t size) {                \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type##_end>>(size);  \
+  using U = std::underlying_type_t<offset_type##_end>;                                    \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   return to_##offset_type##_end(untype(first) - size_value);                              \
 }                                                                                         \
                                                                                           \
@@ -95,7 +103,8 @@ inline size_t operator-(offset_type##_end first, offset_type##_end second) {    
 }                                                                                         \
                                                                                           \
 inline offset_type##_end& operator-=(offset_type##_end& offset, size_t size) {            \
-  const auto size_value = checked_cast<std::underlying_type_t<offset_type##_end>>(size);  \
+  using U = std::underlying_type_t<offset_type##_end>;                                    \
+  const auto size_value = integer_cast_permit_tautology<U>(size);                         \
   offset = to_##offset_type##_end(untype(offset) - size_value);                           \
   return offset;                                                                          \
 }                                                                                         \

--- a/src/hotspot/share/gc/z/zBitField.hpp
+++ b/src/hotspot/share/gc/z/zBitField.hpp
@@ -27,6 +27,7 @@
 #include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/integerCast.hpp"
 
 //
 //  Example
@@ -74,7 +75,7 @@ public:
 
   static ContainerType encode(ValueType value) {
     assert(((ContainerType)value & (FieldMask << ValueShift)) == (ContainerType)value, "Invalid value");
-    return checked_cast<ContainerType>(((ContainerType)value >> ValueShift) << FieldShift);
+    return integer_cast_permit_tautology<ContainerType>(((ContainerType)value >> ValueShift) << FieldShift);
   }
 };
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -94,6 +94,7 @@
 #include "utilities/checkedCast.hpp"
 #include "utilities/events.hpp"
 #include "utilities/growableArray.hpp"
+#include "utilities/integerCast.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/preserveException.hpp"
 #include "utilities/xmlstream.hpp"
@@ -1106,7 +1107,7 @@ protected:
       objArrayOop cache = CacheType::cache(ik);
       assert(cache->length() > 0, "Empty cache");
       _low = BoxType::value(cache->obj_at(0));
-      _high = checked_cast<PrimitiveType>(_low + cache->length() - 1);
+      _high = integer_cast_permit_tautology<PrimitiveType>(_low + cache->length() - 1);
       _cache = JNIHandles::make_global(Handle(thread, cache));
     }
   }
@@ -1125,7 +1126,7 @@ public:
   }
   oop lookup(PrimitiveType value) {
     if (_low <= value && value <= _high) {
-      int offset = checked_cast<int>(value - _low);
+      int offset = integer_cast_permit_tautology<int>(value - _low);
       return objArrayOop(JNIHandles::resolve_non_null(_cache))->obj_at(offset);
     }
     return nullptr;

--- a/src/hotspot/share/utilities/align.hpp
+++ b/src/hotspot/share/utilities/align.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@
 
 #include "cppstdlib/type_traits.hpp"
 #include "metaprogramming/enableIf.hpp"
-#include "utilities/checkedCast.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/integerCast.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 // Compute mask to use for aligning to or testing alignment.
@@ -79,7 +79,7 @@ constexpr bool can_align_up(T size, A alignment) {
 template<typename T, typename A, ENABLE_IF(std::is_integral<T>::value)>
 constexpr T align_up(T size, A alignment) {
   assert(can_align_up(size, alignment), "precondition");
-  T adjusted = checked_cast<T>(size + alignment_mask(alignment));
+  T adjusted = integer_cast_permit_tautology<T>(size + alignment_mask(alignment));
   return align_down(adjusted, alignment);
 }
 

--- a/src/hotspot/share/utilities/population_count.hpp
+++ b/src/hotspot/share/utilities/population_count.hpp
@@ -27,9 +27,9 @@
 
 #include "cppstdlib/type_traits.hpp"
 #include "metaprogramming/enableIf.hpp"
-#include "utilities/checkedCast.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/integerCast.hpp"
 
 // Returns the population count of x, i.e., the number of bits set in x.
 //
@@ -64,7 +64,8 @@ constexpr unsigned population_count(T x) {
   // The preceding multiply by z_ones is the only place where the intermediate
   // calculations can exceed the range of T. We need to discard any such excess
   // before the right-shift, hence the conversion back to T.
-  return checked_cast<unsigned>(static_cast<T>(r) >> (((sizeof(T) - 1) * BitsPerByte)));
+  T res = static_cast<T>(r) >> ((sizeof(T) - 1) * BitsPerByte);
+  return integer_cast_permit_tautology<unsigned>(res);
 }
 
 #endif // SHARE_UTILITIES_POPULATION_COUNT_HPP


### PR DESCRIPTION
Please review this change that replaces conditionally tautological uses of
checked_cast with uses of integer_cast_permit_tautology.

These were discovered by locally changing checked_cast to use the new
integer_cast for integral conversions, and noting which calls failed to
compile because of the anti-tautology check in the latter.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8381237](https://bugs.openjdk.org/browse/JDK-8381237): Use integer_cast_permit_tautology instead of conditionally tautological checked_cast (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30483/head:pull/30483` \
`$ git checkout pull/30483`

Update a local copy of the PR: \
`$ git checkout pull/30483` \
`$ git pull https://git.openjdk.org/jdk.git pull/30483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30483`

View PR using the GUI difftool: \
`$ git pr show -t 30483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30483.diff">https://git.openjdk.org/jdk/pull/30483.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30483#issuecomment-4147813549)
</details>
