### PR TITLE
8378860: C2: PhaseIdealLoop::do_range_check does not work with test that does not exit the loop

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2808,19 +2808,51 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
     Node *iff = loop->_body[i];
     if (iff->Opcode() == Op_If ||
         iff->Opcode() == Op_RangeCheck) { // Test?
-      // Test is an IfNode, has 2 projections.  If BOTH are in the loop
-      // we need loop unswitching instead of iteration splitting.
-      Node *exit = loop->is_loop_exit(iff);
-      if (!exit) continue;
-      int flip = (exit->Opcode() == Op_IfTrue) ? 1 : 0;
+      if (iff->outcnt() != 2) {
+        continue; // Ignore partially dead tests.
+      }
+
+      IfNode* if_node = iff->as_If();
+      ProjNode* if_true_proj = if_node->proj_out(1);
+      ProjNode* if_false_proj = if_node->proj_out(0);
+      if (if_true_proj == nullptr || if_false_proj == nullptr) {
+        continue;
+      }
+
+      // Select the projection to keep in the constrained main loop.
+      // For loop exits, we must keep the in-loop projection as before.
+      // For internal branches (both projections stay in the loop), keep the
+      // hotter projection so the main loop executes the majority path.
+      ProjNode* main_proj = nullptr;
+      Node* exit = loop->is_loop_exit(iff);
+      if (exit != nullptr) {
+        main_proj = (exit->Opcode() == Op_IfTrue) ? if_false_proj : if_true_proj;
+      } else {
+        bool true_in_loop = loop->is_member(get_loop(if_true_proj));
+        bool false_in_loop = loop->is_member(get_loop(if_false_proj));
+        if (!true_in_loop || !false_in_loop) {
+          continue;
+        }
+        // Use branch probability to maximize work in the optimized main loop.
+        // _prob is the probability of taking IfTrue. If unknown, keep IfTrue.
+        float true_prob = if_node->_prob;
+        main_proj = (true_prob == PROB_UNKNOWN || true_prob >= PROB_FAIR) ? if_true_proj : if_false_proj;
+      }
+
+      int keep_con = main_proj->is_IfTrue() ? 1 : 0;
+      bool negate_test = (keep_con == 0);
 
       // Get boolean condition to test
       Node *i1 = iff->in(1);
       if (!i1->is_Bool()) continue;
       BoolNode *bol = i1->as_Bool();
+      if (exit == nullptr && loop->is_invariant(bol)) {
+        // Keep loop-invariant conditions for loop unswitching.
+        continue;
+      }
       BoolTest b_test = bol->_test;
-      // Flip sense of test if exit condition is flipped
-      if (flip) {
+      // Flip sense of test if the kept projection is IfFalse.
+      if (negate_test) {
         b_test = b_test.negate();
       }
       // Get compare
@@ -2882,7 +2914,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
 #ifdef ASSERT
       if (TraceRangeLimitCheck) {
-        tty->print_cr("RC bool node%s", flip ? " flipped:" : ":");
+        tty->print_cr("RC bool node%s", negate_test ? " flipped:" : ":");
         bol->dump(2);
       }
 #endif
@@ -2992,11 +3024,12 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
       // Kill the eliminated test
       C->set_major_progress();
-      Node* kill_con = intcon(1-flip);
+      Node* kill_con = intcon(keep_con);
       _igvn.replace_input_of(iff, 1, kill_con);
       // Find surviving projection
       assert(iff->is_If(), "");
-      ProjNode* dp = ((IfNode*)iff)->proj_out(1-flip);
+      ProjNode* dp = if_node->proj_out(keep_con);
+      assert(dp != nullptr, "missing surviving projection");
       // Find loads off the surviving projection; remove their control edge
       for (DUIterator_Fast imax, i = dp->fast_outs(imax); i < imax; i++) {
         Node* cd = dp->fast_out(i); // Control-dependent node

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2808,21 +2808,16 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
     Node *iff = loop->_body[i];
     if (iff->Opcode() == Op_If ||
         iff->Opcode() == Op_RangeCheck) { // Test?
-      if (iff->outcnt() != 2) {
-        continue; // Ignore partially dead tests.
-      }
+      assert(iff->outcnt() == 2, "IfNode should have two projections");
 
       IfNode* if_node = iff->as_If();
       ProjNode* if_true_proj = if_node->proj_out(1);
       ProjNode* if_false_proj = if_node->proj_out(0);
-      if (if_true_proj == nullptr || if_false_proj == nullptr) {
-        continue;
-      }
 
       // Select the projection to keep in the constrained main loop.
       // For loop exits, we must keep the in-loop projection as before.
       // For internal branches (both projections stay in the loop), keep the
-      // hotter projection so the main loop executes the majority path.
+      // hotter projection only when profiling indicates a clear majority path.
       ProjNode* main_proj = nullptr;
       Node* exit = loop->is_loop_exit(iff);
       if (exit != nullptr) {
@@ -2833,10 +2828,22 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
         if (!true_in_loop || !false_in_loop) {
           continue;
         }
-        // Use branch probability to maximize work in the optimized main loop.
-        // _prob is the probability of taking IfTrue. If unknown, keep IfTrue.
+        // _prob is the probability of taking IfTrue.
+        // Only apply RCE on internal branches when profile is available and
+        // sufficiently biased so the constrained main loop remains effective.
         float true_prob = if_node->_prob;
-        main_proj = (true_prob == PROB_UNKNOWN || true_prob >= PROB_FAIR) ? if_true_proj : if_false_proj;
+        if (true_prob == PROB_UNKNOWN) {
+          continue;
+        }
+
+        const float min_hot_prob = 0.1f;
+        if (true_prob <= min_hot_prob) {
+          main_proj = if_false_proj;
+        } else if (true_prob >= (1.0f - min_hot_prob)) {
+          main_proj = if_true_proj;
+        } else {
+          continue;
+        }
       }
 
       int keep_con = main_proj->is_IfTrue() ? 1 : 0;
@@ -2846,7 +2853,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       Node *i1 = iff->in(1);
       if (!i1->is_Bool()) continue;
       BoolNode *bol = i1->as_Bool();
-      if (exit == nullptr && loop->is_invariant(bol)) {
+      if (loop->is_invariant(bol)) {
         // Keep loop-invariant conditions for loop unswitching.
         continue;
       }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2815,19 +2815,18 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       ProjNode* if_false_proj = if_node->proj_out(0);
 
       // Select the projection to keep in the constrained main loop.
-      // For loop exits, we must keep the in-loop projection as before.
-      // For internal branches (both projections stay in the loop), keep the
-      // hotter projection only when profiling indicates a clear majority path.
+      // The other projection is folded away by RCE.
+      // For loop exits, keep the in-loop projection and fold away the exit.
+      // For internal branches, only apply RCE when profiling is strongly
+      // biased. If several such branches are folded, pre/post-loop work is
+      // governed by the maximum cold path rather than a sum of probabilities.
       ProjNode* main_proj = nullptr;
       Node* exit = loop->is_loop_exit(iff);
       if (exit != nullptr) {
         main_proj = (exit->Opcode() == Op_IfTrue) ? if_false_proj : if_true_proj;
       } else {
-        bool true_in_loop = loop->is_member(get_loop(if_true_proj));
-        bool false_in_loop = loop->is_member(get_loop(if_false_proj));
-        if (!true_in_loop || !false_in_loop) {
-          continue;
-        }
+        assert(loop->is_member(get_loop(if_true_proj)), "IfTrue should stay in loop for internal branch");
+        assert(loop->is_member(get_loop(if_false_proj)), "IfFalse should stay in loop for internal branch");
         // _prob is the probability of taking IfTrue.
         // Only apply RCE on internal branches when profile is available and
         // sufficiently biased so the constrained main loop remains effective.

--- a/test/hotspot/jtreg/compiler/loopopts/TestInternalRangeCheckElimination.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInternalRangeCheckElimination.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.loopopts;
+
+import compiler.lib.generators.Generators;
+import compiler.lib.generators.RestrictableGenerator;
+import compiler.lib.ir_framework.*;
+import java.util.Arrays;
+import java.util.List;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+/*
+ * @test
+ * @bug 8378860
+ * @summary C2 can apply iteration splitting to internal loop branches derived from the iv
+ * @library /test/lib /
+ * @modules jdk.incubator.vector
+ * @run driver ${test.main.class}
+ */
+public class TestInternalRangeCheckElimination {
+    private static final int[] SRC = new int[1024];
+    private static final int[] DST = new int[1024];
+    private static final int SENTINEL = -999_999_937;
+    private static final Generators RND = Generators.G;
+
+    private static final RestrictableGenerator<Integer> BASIC_LIMIT_GEN =
+        RND.mixed(
+            RND.orderedRandomElement(List.of(0, 1, 2, 7, 8, 15, 16, 17,
+                             31, 32, 33, 63, 64, 65, 127, 128, 129,
+                             255, 256, 257, 319, 320, 321, 511, 512)),
+            RND.safeRestrict(RND.ints(), 0, 512),
+            3, 2);
+
+    private static final RestrictableGenerator<Integer> LENGTH_GEN =
+        RND.mixed(
+            RND.orderedRandomElement(List.of(0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64)),
+            RND.safeRestrict(RND.ints(), 0, 64),
+            3, 2);
+
+    private static int lastBasicLimit;
+    private static int lastBasicOffset;
+    private static int lastFalseHotLimit;
+    private static int lastFalseHotOffset;
+    private static int lastIndexInRangeLikeLimit;
+    private static int lastIndexInRangeLikeLength;
+    private static int lastVectorLimit;
+    private static int lastVectorSpeciesLength;
+
+    static {
+        RND.fill(RND.safeRestrict(RND.ints(), -100_000, 100_000), SRC);
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:LoopUnrollLimit=0",
+                                   "--add-modules=jdk.incubator.vector");
+    }
+
+    @DontCompile
+    private static int basicInternalIfRef(int limit, int offset) {
+        int expected = 0;
+        int bound = limit - offset;
+        for (int i = 0; i < limit; i++) {
+            expected += (i < bound) ? i : -i;
+        }
+        return expected;
+    }
+
+    @DontCompile
+    private static int internalIfFalseHotRef(int limit, int offset) {
+        int expected = 0;
+        int bound = limit - offset;
+        for (int i = 0; i < limit; i++) {
+            expected += (i >= bound) ? i : -i;
+        }
+        return expected;
+    }
+
+    @DontCompile
+    private static int indexInRangeLikeRef(int limit, int length) {
+        int expected = 0;
+        for (int i = 0; i < limit; i++) {
+            int value = ((limit - i) >= length) ? (SRC[i] + 1) : (SRC[i] + 2);
+            expected += value;
+        }
+        return expected;
+    }
+
+    @DontCompile
+    private static int vectorIndexInRangeRef(int limit, int speciesLen) {
+        int expected = 0;
+        for (int i = 0; i < limit; i += speciesLen) {
+            expected += SRC[i] + 1;
+        }
+        return expected;
+    }
+
+    @Setup
+    public static Object[] setupBasic(SetupInfo info) {
+        int limit = BASIC_LIMIT_GEN.next();
+        int maxOffset = Math.min(limit, 64);
+        RestrictableGenerator<Integer> offsetGen = RND.mixed(
+                RND.orderedRandomElement(List.of(0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64)),
+                RND.safeRestrict(RND.ints(), 0, maxOffset),
+                3, 2);
+        int offset = RND.safeRestrict(offsetGen, 0, maxOffset).next();
+        return new Object[] {limit, offset};
+    }
+
+    @Test
+    @Arguments(setup = "setupBasic")
+    public static int basicInternalIf(int limit, int offset) {
+        lastBasicLimit = limit;
+        lastBasicOffset = offset;
+        int sum = 0;
+        int bound = limit - offset;
+        for (int i = 0; i < limit; i++) {
+            if (i < bound) {
+                sum += i;
+            } else {
+                sum -= i;
+            }
+        }
+        return sum;
+    }
+
+    @Check(test = "basicInternalIf")
+    public static void checkBasicInternalIf(int actual) {
+        int expected = basicInternalIfRef(lastBasicLimit, lastBasicOffset);
+        if (actual != expected) {
+            throw new RuntimeException("basicInternalIf mismatch: actual=" + actual
+                                       + " expected=" + expected
+                                       + " limit=" + lastBasicLimit
+                                       + " offset=" + lastBasicOffset);
+        }
+    }
+
+    @Setup
+    public static Object[] setupFalseHot(SetupInfo info) {
+        int limit = BASIC_LIMIT_GEN.next();
+        int maxOffset = Math.min(limit, 64);
+        RestrictableGenerator<Integer> offsetGen = RND.mixed(
+                RND.orderedRandomElement(List.of(0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64)),
+                RND.safeRestrict(RND.ints(), 0, maxOffset),
+                3, 2);
+        int offset = RND.safeRestrict(offsetGen, 0, maxOffset).next();
+        return new Object[] {limit, offset};
+    }
+
+    @Test
+    @Arguments(setup = "setupFalseHot")
+    public static int internalIfFalseHot(int limit, int offset) {
+        lastFalseHotLimit = limit;
+        lastFalseHotOffset = offset;
+        int sum = 0;
+        int bound = limit - offset;
+        for (int i = 0; i < limit; i++) {
+            if (i >= bound) {
+                sum += i;
+            } else {
+                sum -= i;
+            }
+        }
+        return sum;
+    }
+
+    @Check(test = "internalIfFalseHot")
+    public static void checkInternalIfFalseHot(int actual) {
+        int expected = internalIfFalseHotRef(lastFalseHotLimit, lastFalseHotOffset);
+        if (actual != expected) {
+            throw new RuntimeException("internalIfFalseHot mismatch: actual=" + actual
+                                       + " expected=" + expected
+                                       + " limit=" + lastFalseHotLimit
+                                       + " offset=" + lastFalseHotOffset);
+        }
+    }
+
+    @Setup
+    public static Object[] setupIndexInRange(SetupInfo info) {
+        int limit = RND.safeRestrict(BASIC_LIMIT_GEN, 0, 512).next();
+        int length = LENGTH_GEN.next();
+        return new Object[] {limit, length};
+    }
+
+    @Test
+    @Arguments(setup = "setupIndexInRange")
+    public static int indexInRangeLike(int limit, int length) {
+        lastIndexInRangeLikeLimit = limit;
+        lastIndexInRangeLikeLength = length;
+        int acc = 0;
+        for (int i = 0; i < limit; i++) {
+            boolean mask = (limit - i) >= length;
+            if (mask) {
+                DST[i] = SRC[i] + 1;
+            } else {
+                DST[i] = SRC[i] + 2;
+            }
+            acc += DST[i];
+        }
+        return acc;
+    }
+
+    @Check(test = "indexInRangeLike")
+    public static void checkIndexInRangeLike(int actual) {
+        int expected = indexInRangeLikeRef(lastIndexInRangeLikeLimit, lastIndexInRangeLikeLength);
+        if (actual != expected) {
+            throw new RuntimeException("indexInRangeLike mismatch: actual=" + actual
+                                       + " expected=" + expected
+                                       + " limit=" + lastIndexInRangeLikeLimit
+                                       + " length=" + lastIndexInRangeLikeLength);
+        }
+    }
+
+    @Setup
+    public static Object[] setupVectorIndexInRange(SetupInfo info) {
+        int len = IntVector.SPECIES_PREFERRED.length();
+        List<Integer> cases = List.of(
+                0,
+                1,
+                Math.max(1, len - 1),
+                len,
+                len + 1,
+                Math.max(0, 2 * len - 1),
+                2 * len,
+                2 * len + 1,
+                255,
+                256,
+                257,
+                319
+        );
+        RestrictableGenerator<Integer> vectorLimitGen = RND.mixed(
+            RND.orderedRandomElement(cases),
+            RND.safeRestrict(RND.ints(), 0, 320),
+            4, 1);
+        int limit = vectorLimitGen.next();
+        return new Object[] {limit};
+    }
+
+    @Test
+    @Arguments(setup = "setupVectorIndexInRange")
+    @IR(counts = {IRNode.LOAD_VECTOR_I, ">= 1",
+                  IRNode.STORE_VECTOR, ">= 1",
+                  IRNode.VECTOR_STORE_MASK, ">= 1"},
+        applyIfCPUFeatureOr = {"avx512", "true", "sve", "true", "asimd", "true"})
+    public static int vectorIndexInRange(int limit) {
+        Arrays.fill(DST, SENTINEL);
+        int acc = 0;
+        VectorSpecies<Integer> species = IntVector.SPECIES_PREFERRED;
+        lastVectorLimit = limit;
+        lastVectorSpeciesLength = species.length();
+        for (int i = 0; i < limit; i += species.length()) {
+            VectorMask<Integer> m = species.indexInRange(i, limit);
+            IntVector v = IntVector.fromArray(species, SRC, i, m);
+            v.add(1).intoArray(DST, i, m);
+            acc += DST[i];
+        }
+        return acc;
+    }
+
+    @Check(test = "vectorIndexInRange")
+    public static void checkVectorIndexInRange(int actual) {
+        int expected = vectorIndexInRangeRef(lastVectorLimit, lastVectorSpeciesLength);
+        if (actual != expected) {
+            throw new RuntimeException("vectorIndexInRange mismatch: actual=" + actual
+                                       + " expected=" + expected
+                                       + " limit=" + lastVectorLimit
+                                       + " speciesLen=" + lastVectorSpeciesLength);
+        }
+        for (int i = 0; i < lastVectorLimit; i++) {
+            int expectedValue = SRC[i] + 1;
+            if (DST[i] != expectedValue) {
+                throw new RuntimeException("vectorIndexInRange wrong lane at index=" + i
+                                           + " got=" + DST[i]
+                                           + " expected=" + expectedValue);
+            }
+        }
+        for (int i = lastVectorLimit; i < DST.length; i++) {
+            if (DST[i] != SENTINEL) {
+                throw new RuntimeException("vectorIndexInRange wrote past limit at index=" + i
+                                           + " value=" + DST[i]);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestInternalRangeCheckElimination.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInternalRangeCheckElimination.java
@@ -28,6 +28,7 @@ import compiler.lib.generators.RestrictableGenerator;
 import compiler.lib.ir_framework.*;
 import java.util.Arrays;
 import java.util.List;
+import jdk.test.lib.Asserts;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorSpecies;
@@ -44,38 +45,72 @@ public class TestInternalRangeCheckElimination {
     private static final int[] SRC = new int[1024];
     private static final int[] DST = new int[1024];
     private static final int SENTINEL = -999_999_937;
+    private static final int RANDOM_ITERATIONS = 200;
     private static final Generators RND = Generators.G;
+
+    private static final List<Integer> BASIC_LIMIT_SPECIALS = List.of(
+            0, 1, 2, 7, 8, 15, 16, 17,
+            31, 32, 33, 63, 64, 65, 127, 128, 129,
+            255, 256, 257, 319, 320, 321, 511, 512);
+
+    private static final List<Integer> LENGTH_SPECIALS = List.of(
+            0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64);
 
     private static final RestrictableGenerator<Integer> BASIC_LIMIT_GEN =
         RND.mixed(
-            RND.orderedRandomElement(List.of(0, 1, 2, 7, 8, 15, 16, 17,
-                             31, 32, 33, 63, 64, 65, 127, 128, 129,
-                             255, 256, 257, 319, 320, 321, 511, 512)),
+            RND.orderedRandomElement(BASIC_LIMIT_SPECIALS),
             RND.safeRestrict(RND.ints(), 0, 512),
             3, 2);
 
     private static final RestrictableGenerator<Integer> LENGTH_GEN =
         RND.mixed(
-            RND.orderedRandomElement(List.of(0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64)),
+            RND.orderedRandomElement(LENGTH_SPECIALS),
             RND.safeRestrict(RND.ints(), 0, 64),
             3, 2);
 
-    private static int lastBasicLimit;
-    private static int lastBasicOffset;
-    private static int lastFalseHotLimit;
-    private static int lastFalseHotOffset;
-    private static int lastIndexInRangeLikeLimit;
-    private static int lastIndexInRangeLikeLength;
-    private static int lastVectorLimit;
-    private static int lastVectorSpeciesLength;
+    private static final List<Integer> OFFSET_SPECIALS = List.of(
+            0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64);
 
     static {
         RND.fill(RND.safeRestrict(RND.ints(), -100_000, 100_000), SRC);
     }
 
+    private static int nextOffset(int limit) {
+        int maxOffset = Math.min(limit, 64);
+        RestrictableGenerator<Integer> offsetGen = RND.mixed(
+                RND.orderedRandomElement(OFFSET_SPECIALS),
+                RND.safeRestrict(RND.ints(), 0, maxOffset),
+                3, 2);
+        return RND.safeRestrict(offsetGen, 0, maxOffset).next();
+    }
+
     public static void main(String[] args) {
         TestFramework.runWithFlags("-XX:LoopUnrollLimit=0",
                                    "--add-modules=jdk.incubator.vector");
+    }
+
+    private static List<Integer> vectorLimitSpecials(int len) {
+        return List.of(
+                0,
+                1,
+                Math.max(1, len - 1),
+                len,
+                len + 1,
+                Math.max(0, 2 * len - 1),
+                2 * len,
+                2 * len + 1,
+                255,
+                256,
+                257,
+                319
+        );
+    }
+
+    private static RestrictableGenerator<Integer> vectorLimitGen(int len) {
+        return RND.mixed(
+                RND.orderedRandomElement(vectorLimitSpecials(len)),
+                RND.safeRestrict(RND.ints(), 0, 320),
+                4, 1);
     }
 
     @DontCompile
@@ -117,23 +152,8 @@ public class TestInternalRangeCheckElimination {
         return expected;
     }
 
-    @Setup
-    public static Object[] setupBasic(SetupInfo info) {
-        int limit = BASIC_LIMIT_GEN.next();
-        int maxOffset = Math.min(limit, 64);
-        RestrictableGenerator<Integer> offsetGen = RND.mixed(
-                RND.orderedRandomElement(List.of(0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64)),
-                RND.safeRestrict(RND.ints(), 0, maxOffset),
-                3, 2);
-        int offset = RND.safeRestrict(offsetGen, 0, maxOffset).next();
-        return new Object[] {limit, offset};
-    }
-
     @Test
-    @Arguments(setup = "setupBasic")
     public static int basicInternalIf(int limit, int offset) {
-        lastBasicLimit = limit;
-        lastBasicOffset = offset;
         int sum = 0;
         int bound = limit - offset;
         for (int i = 0; i < limit; i++) {
@@ -146,34 +166,32 @@ public class TestInternalRangeCheckElimination {
         return sum;
     }
 
-    @Check(test = "basicInternalIf")
-    public static void checkBasicInternalIf(int actual) {
-        int expected = basicInternalIfRef(lastBasicLimit, lastBasicOffset);
-        if (actual != expected) {
-            throw new RuntimeException("basicInternalIf mismatch: actual=" + actual
-                                       + " expected=" + expected
-                                       + " limit=" + lastBasicLimit
-                                       + " offset=" + lastBasicOffset);
+    private static void checkBasicInternalIf(int limit, int offset) {
+        int actual = basicInternalIf(limit, offset);
+        int expected = basicInternalIfRef(limit, offset);
+        Asserts.assertEQ(actual, expected,
+                "basicInternalIf mismatch: limit=" + limit + " offset=" + offset);
+    }
+
+    @Run(test = "basicInternalIf")
+    public void runBasicInternalIf() {
+        for (int limit : BASIC_LIMIT_SPECIALS) {
+            int maxOffset = Math.min(limit, 64);
+            for (int offset : OFFSET_SPECIALS) {
+                if (offset <= maxOffset) {
+                    checkBasicInternalIf(limit, offset);
+                }
+            }
+        }
+        for (int i = 0; i < RANDOM_ITERATIONS; i++) {
+            int limit = BASIC_LIMIT_GEN.next();
+            int offset = nextOffset(limit);
+            checkBasicInternalIf(limit, offset);
         }
     }
 
-    @Setup
-    public static Object[] setupFalseHot(SetupInfo info) {
-        int limit = BASIC_LIMIT_GEN.next();
-        int maxOffset = Math.min(limit, 64);
-        RestrictableGenerator<Integer> offsetGen = RND.mixed(
-                RND.orderedRandomElement(List.of(0, 1, 2, 3, 7, 8, 15, 16, 31, 32, 63, 64)),
-                RND.safeRestrict(RND.ints(), 0, maxOffset),
-                3, 2);
-        int offset = RND.safeRestrict(offsetGen, 0, maxOffset).next();
-        return new Object[] {limit, offset};
-    }
-
     @Test
-    @Arguments(setup = "setupFalseHot")
     public static int internalIfFalseHot(int limit, int offset) {
-        lastFalseHotLimit = limit;
-        lastFalseHotOffset = offset;
         int sum = 0;
         int bound = limit - offset;
         for (int i = 0; i < limit; i++) {
@@ -186,29 +204,32 @@ public class TestInternalRangeCheckElimination {
         return sum;
     }
 
-    @Check(test = "internalIfFalseHot")
-    public static void checkInternalIfFalseHot(int actual) {
-        int expected = internalIfFalseHotRef(lastFalseHotLimit, lastFalseHotOffset);
-        if (actual != expected) {
-            throw new RuntimeException("internalIfFalseHot mismatch: actual=" + actual
-                                       + " expected=" + expected
-                                       + " limit=" + lastFalseHotLimit
-                                       + " offset=" + lastFalseHotOffset);
+    private static void checkInternalIfFalseHot(int limit, int offset) {
+        int actual = internalIfFalseHot(limit, offset);
+        int expected = internalIfFalseHotRef(limit, offset);
+        Asserts.assertEQ(actual, expected,
+                "internalIfFalseHot mismatch: limit=" + limit + " offset=" + offset);
+    }
+
+    @Run(test = "internalIfFalseHot")
+    public void runInternalIfFalseHot() {
+        for (int limit : BASIC_LIMIT_SPECIALS) {
+            int maxOffset = Math.min(limit, 64);
+            for (int offset : OFFSET_SPECIALS) {
+                if (offset <= maxOffset) {
+                    checkInternalIfFalseHot(limit, offset);
+                }
+            }
+        }
+        for (int i = 0; i < RANDOM_ITERATIONS; i++) {
+            int limit = BASIC_LIMIT_GEN.next();
+            int offset = nextOffset(limit);
+            checkInternalIfFalseHot(limit, offset);
         }
     }
 
-    @Setup
-    public static Object[] setupIndexInRange(SetupInfo info) {
-        int limit = RND.safeRestrict(BASIC_LIMIT_GEN, 0, 512).next();
-        int length = LENGTH_GEN.next();
-        return new Object[] {limit, length};
-    }
-
     @Test
-    @Arguments(setup = "setupIndexInRange")
     public static int indexInRangeLike(int limit, int length) {
-        lastIndexInRangeLikeLimit = limit;
-        lastIndexInRangeLikeLength = length;
         int acc = 0;
         for (int i = 0; i < limit; i++) {
             boolean mask = (limit - i) >= length;
@@ -222,44 +243,28 @@ public class TestInternalRangeCheckElimination {
         return acc;
     }
 
-    @Check(test = "indexInRangeLike")
-    public static void checkIndexInRangeLike(int actual) {
-        int expected = indexInRangeLikeRef(lastIndexInRangeLikeLimit, lastIndexInRangeLikeLength);
-        if (actual != expected) {
-            throw new RuntimeException("indexInRangeLike mismatch: actual=" + actual
-                                       + " expected=" + expected
-                                       + " limit=" + lastIndexInRangeLikeLimit
-                                       + " length=" + lastIndexInRangeLikeLength);
+    private static void checkIndexInRangeLike(int limit, int length) {
+        int actual = indexInRangeLike(limit, length);
+        int expected = indexInRangeLikeRef(limit, length);
+        Asserts.assertEQ(actual, expected,
+                "indexInRangeLike mismatch: limit=" + limit + " length=" + length);
+    }
+
+    @Run(test = "indexInRangeLike")
+    public void runIndexInRangeLike() {
+        for (int limit : BASIC_LIMIT_SPECIALS) {
+            for (int length : LENGTH_SPECIALS) {
+                checkIndexInRangeLike(limit, length);
+            }
+        }
+        for (int i = 0; i < RANDOM_ITERATIONS; i++) {
+            int limit = RND.safeRestrict(BASIC_LIMIT_GEN, 0, 512).next();
+            int length = LENGTH_GEN.next();
+            checkIndexInRangeLike(limit, length);
         }
     }
 
-    @Setup
-    public static Object[] setupVectorIndexInRange(SetupInfo info) {
-        int len = IntVector.SPECIES_PREFERRED.length();
-        List<Integer> cases = List.of(
-                0,
-                1,
-                Math.max(1, len - 1),
-                len,
-                len + 1,
-                Math.max(0, 2 * len - 1),
-                2 * len,
-                2 * len + 1,
-                255,
-                256,
-                257,
-                319
-        );
-        RestrictableGenerator<Integer> vectorLimitGen = RND.mixed(
-            RND.orderedRandomElement(cases),
-            RND.safeRestrict(RND.ints(), 0, 320),
-            4, 1);
-        int limit = vectorLimitGen.next();
-        return new Object[] {limit};
-    }
-
     @Test
-    @Arguments(setup = "setupVectorIndexInRange")
     @IR(counts = {IRNode.LOAD_VECTOR_I, ">= 1",
                   IRNode.STORE_VECTOR, ">= 1",
                   IRNode.VECTOR_STORE_MASK, ">= 1"},
@@ -268,8 +273,6 @@ public class TestInternalRangeCheckElimination {
         Arrays.fill(DST, SENTINEL);
         int acc = 0;
         VectorSpecies<Integer> species = IntVector.SPECIES_PREFERRED;
-        lastVectorLimit = limit;
-        lastVectorSpeciesLength = species.length();
         for (int i = 0; i < limit; i += species.length()) {
             VectorMask<Integer> m = species.indexInRange(i, limit);
             IntVector v = IntVector.fromArray(species, SRC, i, m);
@@ -279,28 +282,32 @@ public class TestInternalRangeCheckElimination {
         return acc;
     }
 
-    @Check(test = "vectorIndexInRange")
-    public static void checkVectorIndexInRange(int actual) {
-        int expected = vectorIndexInRangeRef(lastVectorLimit, lastVectorSpeciesLength);
-        if (actual != expected) {
-            throw new RuntimeException("vectorIndexInRange mismatch: actual=" + actual
-                                       + " expected=" + expected
-                                       + " limit=" + lastVectorLimit
-                                       + " speciesLen=" + lastVectorSpeciesLength);
-        }
-        for (int i = 0; i < lastVectorLimit; i++) {
+    private static void checkVectorIndexInRange(int limit) {
+        int actual = vectorIndexInRange(limit);
+        int speciesLen = IntVector.SPECIES_PREFERRED.length();
+        int expected = vectorIndexInRangeRef(limit, speciesLen);
+        Asserts.assertEQ(actual, expected,
+                "vectorIndexInRange mismatch: limit=" + limit + " speciesLen=" + speciesLen);
+        for (int i = 0; i < limit; i++) {
             int expectedValue = SRC[i] + 1;
-            if (DST[i] != expectedValue) {
-                throw new RuntimeException("vectorIndexInRange wrong lane at index=" + i
-                                           + " got=" + DST[i]
-                                           + " expected=" + expectedValue);
-            }
+            Asserts.assertEQ(DST[i], expectedValue,
+                    "vectorIndexInRange wrong lane at index=" + i);
         }
-        for (int i = lastVectorLimit; i < DST.length; i++) {
-            if (DST[i] != SENTINEL) {
-                throw new RuntimeException("vectorIndexInRange wrote past limit at index=" + i
-                                           + " value=" + DST[i]);
-            }
+        for (int i = limit; i < DST.length; i++) {
+            Asserts.assertEQ(DST[i], SENTINEL,
+                    "vectorIndexInRange wrote past limit at index=" + i);
+        }
+    }
+
+    @Run(test = "vectorIndexInRange")
+    public void runVectorIndexInRange() {
+        int len = IntVector.SPECIES_PREFERRED.length();
+        for (int limit : vectorLimitSpecials(len)) {
+            checkVectorIndexInRange(limit);
+        }
+        RestrictableGenerator<Integer> vlimitGen = vectorLimitGen(len);
+        for (int i = 0; i < RANDOM_ITERATIONS; i++) {
+            checkVectorIndexInRange(vlimitGen.next());
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInternalRangeCheckElimination.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInternalRangeCheckElimination.java
@@ -87,6 +87,13 @@ public class TestInternalRangeCheckElimination {
     public static void main(String[] args) {
         TestFramework.runWithFlags("-XX:LoopUnrollLimit=0",
                                    "--add-modules=jdk.incubator.vector");
+        TestFramework.runWithFlags("-XX:LoopUnrollLimit=0",
+                                   "-XX:+UnlockExperimentalVMOptions",
+                                   "-XX:PerMethodSpecTrapLimit=0",
+                                   "-XX:PerMethodTrapLimit=0",
+                                   "-XX:-UseLoopPredicate",
+                                   "-XX:-UseProfiledLoopPredicate",
+                                   "--add-modules=jdk.incubator.vector");
     }
 
     private static List<Integer> vectorLimitSpecials(int len) {
@@ -153,6 +160,73 @@ public class TestInternalRangeCheckElimination {
     }
 
     @Test
+    @IR(failOn = {IRNode.COUNTED_LOOP_MAIN})
+    public static int trueHotInternalIf(int limit) {
+        int sum = 0;
+        for (int i = 0; i < limit; i++) {
+            sum += (i < limit - 1) ? 1 : -1;
+        }
+        return sum;
+    }
+
+    private static void checkTrueHotInternalIf(int limit) {
+        int actual = trueHotInternalIf(limit);
+        int expected = (limit == 0) ? 0 : limit - 2;
+        Asserts.assertEQ(actual, expected,
+                "trueHotInternalIf mismatch: limit=" + limit);
+    }
+
+    @Run(test = "trueHotInternalIf")
+    public void runTrueHotInternalIf() {
+        checkTrueHotInternalIf(1024);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.COUNTED_LOOP_MAIN})
+    public static int falseHotInternalIf(int limit) {
+        int sum = 0;
+        for (int i = 0; i < limit; i++) {
+            sum += (i >= limit - 1) ? 1 : -1;
+        }
+        return sum;
+    }
+
+    private static void checkFalseHotInternalIf(int limit) {
+        int actual = falseHotInternalIf(limit);
+        int expected = (limit == 0) ? 0 : 2 - limit;
+        Asserts.assertEQ(actual, expected,
+                "falseHotInternalIf mismatch: limit=" + limit);
+    }
+
+    @Run(test = "falseHotInternalIf")
+    public void runFalseHotInternalIf() {
+        checkFalseHotInternalIf(1024);
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNTED_LOOP, ">= 1"})
+    public static int balancedInternalIf(int limit) {
+        int sum = 0;
+        for (int i = 0; i < limit; i++) {
+            sum += (i < (limit >> 1)) ? 1 : -1;
+        }
+        return sum;
+    }
+
+    private static void checkBalancedInternalIf(int limit) {
+        int actual = balancedInternalIf(limit);
+        int expected = 2 * (limit >> 1) - limit;
+        Asserts.assertEQ(actual, expected,
+                "balancedInternalIf mismatch: limit=" + limit);
+    }
+
+    @Run(test = "balancedInternalIf")
+    public void runBalancedInternalIf() {
+        checkBalancedInternalIf(1024);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.COUNTED_LOOP_MAIN})
     public static int basicInternalIf(int limit, int offset) {
         int sum = 0;
         int bound = limit - offset;
@@ -191,6 +265,7 @@ public class TestInternalRangeCheckElimination {
     }
 
     @Test
+    @IR(failOn = {IRNode.COUNTED_LOOP_MAIN})
     public static int internalIfFalseHot(int limit, int offset) {
         int sum = 0;
         int bound = limit - offset;
@@ -229,6 +304,7 @@ public class TestInternalRangeCheckElimination {
     }
 
     @Test
+    @IR(failOn = {IRNode.RANGE_CHECK})
     public static int indexInRangeLike(int limit, int length) {
         int acc = 0;
         for (int i = 0; i < limit; i++) {


### PR DESCRIPTION
Enables C2's range check elimination for internal loop branches by using branch probabilities to determine the optimised path during iteration splitting, removing the previous restriction that only loop exits could be processed. Unblocks JDK-8378315. Verified by running my new test on an x86 AVX512-capable device, as well as manually inspecting the generated Ideal Graph of `TestInternalRangeCheckElimination.vectorIndexInRange`.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378860](https://bugs.openjdk.org/browse/JDK-8378860): C2: PhaseIdealLoop::do_range_check does not work with test that does not exit the loop (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30485/head:pull/30485` \
`$ git checkout pull/30485`

Update a local copy of the PR: \
`$ git checkout pull/30485` \
`$ git pull https://git.openjdk.org/jdk.git pull/30485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30485`

View PR using the GUI difftool: \
`$ git pr show -t 30485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30485.diff">https://git.openjdk.org/jdk/pull/30485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30485#issuecomment-4149275955)
</details>
