### PR TITLE
8382604: Remove unused kscratch temp register from mask_opers_evex

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -24960,12 +24960,11 @@ instruct long_to_mask_evex(kReg dst, rRegL src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct mask_opers_evex(kReg dst, kReg src1, kReg src2, kReg kscratch) %{
+instruct mask_opers_evex(kReg dst, kReg src1, kReg src2) %{
   match(Set dst (AndVMask src1 src2));
   match(Set dst (OrVMask src1 src2));
   match(Set dst (XorVMask src1 src2));
-  effect(TEMP kscratch);
-  format %{ "mask_opers_evex $dst, $src1, $src2\t! using $kscratch as TEMP" %}
+  format %{ "mask_opers_evex $dst, $src1, $src2" %}
   ins_encode %{
     const MachNode* mask1 = static_cast<const MachNode*>(this->in(this->operand_index($src1)));
     const MachNode* mask2 = static_cast<const MachNode*>(this->in(this->operand_index($src2)));


### PR DESCRIPTION
The `kReg` scratch operand was declared as TEMP but never referenced in the encoding block,
needlessly reserving a k-register and potentially causing unnecessary spilling to stack.

Disclosure: I used AI assistance when troubleshooting this issue. I noticed stack spilling
even when not all k-registers were visible in the disassembled code and I used an AI assistant
when searching for the root cause. The change itself was coded manually. 

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382604](https://bugs.openjdk.org/browse/JDK-8382604): Remove unused kscratch temp register from mask_opers_evex (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30487/head:pull/30487` \
`$ git checkout pull/30487`

Update a local copy of the PR: \
`$ git checkout pull/30487` \
`$ git pull https://git.openjdk.org/jdk.git pull/30487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30487`

View PR using the GUI difftool: \
`$ git pr show -t 30487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30487.diff">https://git.openjdk.org/jdk/pull/30487.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30487#issuecomment-4287644102)
</details>
