### PR TITLE
8380164: Fix implicit conversion in nativeInst_aarch64.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -181,8 +181,8 @@ public:
     int64_t offset = dest - instruction_address();
     jint insn = 0b100101 << 26;
     assert((offset & 3) == 0, "should be");
+    Instruction_aarch64::spatch(reinterpret_cast<address>(&insn), 25, 0, offset >> 2);
     set_int_at(displacement_offset, insn);
-    Instruction_aarch64::spatch(instruction_address(), 25, 0, offset >> 2);
   }
 
   void verify_alignment() { ; }

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -30,7 +30,6 @@
 #include "runtime/icache.hpp"
 #include "runtime/os.hpp"
 #include "runtime/os.hpp"
-#include "utilities/integerCast.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciExceptions.hpp"
 #endif

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -97,7 +97,7 @@ protected:
 #define MACOS_WX_WRITE MACOS_AARCH64_ONLY(os::thread_wx_enable_write())
   void set_char_at(int offset, char c)     { MACOS_WX_WRITE;  *addr_at(offset) = (u_char)c; }
   void set_int_at(int offset, jint i)      { MACOS_WX_WRITE;  *(jint*)addr_at(offset) = i; }
-  void set_uint_at(int offset, jint i)     { MACOS_WX_WRITE;  *(juint*)addr_at(offset) = i; }
+  void set_uint_at(int offset, juint i)    { MACOS_WX_WRITE;  *(juint*)addr_at(offset) = i; }
   void set_ptr_at(int offset, address ptr) { MACOS_WX_WRITE;  *(address*)addr_at(offset) = ptr; }
   void set_oop_at(int offset, oop o)       { MACOS_WX_WRITE;  *(oop*)addr_at(offset) = o; }
 #undef MACOS_WX_WRITE
@@ -179,10 +179,10 @@ public:
 
   void set_destination(address dest) {
     int64_t offset = dest - instruction_address();
-    jint insn = 0b100101 << 26;
+    juint insn = 0b100101u << 26u;
     assert((offset & 3) == 0, "should be");
     Instruction_aarch64::spatch(reinterpret_cast<address>(&insn), 25, 0, offset >> 2);
-    set_int_at(displacement_offset, insn);
+    set_uint_at(displacement_offset, insn);
   }
 
   void verify_alignment() { ; }

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -180,6 +180,7 @@ public:
   void set_destination(address dest) {
     int64_t offset = dest - instruction_address();
     assert((offset & 3) == 0, "should be");
+    assert(is_call(), "we should always spatch a call instruction");
     Instruction_aarch64::spatch(instruction_address(), 25, 0, offset >> 2);
   }
 

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -179,13 +179,9 @@ public:
   address destination() const;
 
   void set_destination(address dest) {
-    int offset = integer_cast<int>(dest - instruction_address());
-    int insn = 0b100101 << 26;
+    int64_t offset = dest - instruction_address();
     assert((offset & 3) == 0, "should be");
-    offset >>= 2;
-    offset &= (1 << 26) - 1; // mask off insn part
-    insn |= offset;
-    set_int_at(displacement_offset, insn);
+    Instruction_aarch64::spatch(instruction_address(), 25, 0, offset >> 2);
   }
 
   void verify_alignment() { ; }

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -30,6 +30,7 @@
 #include "runtime/icache.hpp"
 #include "runtime/os.hpp"
 #include "runtime/os.hpp"
+#include "utilities/integerCast.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciExceptions.hpp"
 #endif
@@ -178,8 +179,8 @@ public:
   address destination() const;
 
   void set_destination(address dest) {
-    int offset = dest - instruction_address();
-    unsigned int insn = 0b100101 << 26;
+    int offset = integer_cast<int>(dest - instruction_address());
+    int insn = 0b100101 << 26;
     assert((offset & 3) == 0, "should be");
     offset >>= 2;
     offset &= (1 << 26) - 1; // mask off insn part

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -179,8 +179,9 @@ public:
 
   void set_destination(address dest) {
     int64_t offset = dest - instruction_address();
+    jint insn = 0b100101 << 26;
     assert((offset & 3) == 0, "should be");
-    assert(is_call(), "we should always spatch a call instruction");
+    set_int_at(displacement_offset, insn);
     Instruction_aarch64::spatch(instruction_address(), 25, 0, offset >> 2);
   }
 


### PR DESCRIPTION
`void set_destination(address dest)` is doing two implicit narrowing conversions `int offset = dest - instruction_address();` and  `set_int_at(displacement_offset, insn);`. I will make the first one an explicit `integer_cast`, and make the second one go away by changing the type of `insn` to a signed `int`. The new code will do all bit operations on signed integers which I think is the cleanest alternative (changing it all to unsigned, although more my style, is harder to review and will add more explicit casts).
 
This is one of a series of fixes that tries to do less implicit narrowing conversions, and adding stricter warning flags.

Tested on tier1-3 with no relevant failure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380164](https://bugs.openjdk.org/browse/JDK-8380164): Fix implicit conversion in nativeInst_aarch64.hpp (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author) Review applies to [822dff0a](https://git.openjdk.org/jdk/pull/30492/files/822dff0a30fc19c47f8cfa9902884849bbcee6d9)

### Contributors
 * Andrew Haley `<aph@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30492/head:pull/30492` \
`$ git checkout pull/30492`

Update a local copy of the PR: \
`$ git checkout pull/30492` \
`$ git pull https://git.openjdk.org/jdk.git pull/30492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30492`

View PR using the GUI difftool: \
`$ git pr show -t 30492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30492.diff">https://git.openjdk.org/jdk/pull/30492.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30492#issuecomment-4152883471)
</details>
