### PR TITLE
8381314: Small System.dump_map improvements

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -141,7 +141,7 @@ void DCmd::register_dcmds() {
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<TrimCLibcHeapDCmd>(full_export));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<MallocInfoDcmd>(full_export));
 #endif // LINUX
-#if defined(LINUX) || defined(_WIN64) || defined(__APPLE__)
+#if defined(LINUX) || defined(_WINDOWS) || defined(__APPLE__)
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<SystemMapDCmd>(full_export));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<SystemDumpMapDCmd>(full_export));
 #endif // LINUX or WINDOWS or MacOS
@@ -1180,7 +1180,7 @@ void CompilationMemoryStatisticDCmd::execute(DCmdSource source, TRAPS) {
   CompilationMemoryStatistic::print_jcmd_report(output(), _verbose.value(), _legend.value(), minsize);
 }
 
-#if defined(LINUX) || defined(_WIN64) || defined(__APPLE__)
+#if defined(LINUX) || defined(_WINDOWS) || defined(__APPLE__)
 
 SystemMapDCmd::SystemMapDCmd(outputStream* output, bool heap) : DCmd(output, heap) {}
 
@@ -1195,11 +1195,9 @@ SystemDumpMapDCmd::SystemDumpMapDCmd(outputStream* output, bool heap) :
 }
 
 void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
-  char* name = make_log_name(_filename.value(), nullptr);
-  if (name == nullptr || name[0] == 0) {
-    output()->print_cr("filename is empty or not specified.  No file written");
-    return;
-  }
+  char* name = _filename.value();
+  assert(name != nullptr && strlen(name) > 0, "Sanity"); // since we specify a default file name
+  name = make_log_name(name, nullptr);
   fileStream fs(name);
   if (fs.is_open()) {
     if (!MemTracker::enabled()) {
@@ -1216,4 +1214,4 @@ void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
   os::free(name);
 }
 
-#endif // LINUX
+#endif // LINUX || WINDOWS || MacOS

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1188,16 +1188,14 @@ void SystemMapDCmd::execute(DCmdSource source, TRAPS) {
   MemMapPrinter::print_all_mappings(output());
 }
 
-static constexpr char default_filename[] = "vm_memory_map_%p.txt";
-
 SystemDumpMapDCmd::SystemDumpMapDCmd(outputStream* output, bool heap) :
   DCmdWithParser(output, heap),
-  _filename("-F", "file path", "FILE", false, default_filename) {
-  _dcmdparser.add_dcmd_option(&_filename);
+  _filename("filename", "file name of the dump", "FILE", false, default_filename) {
+  _dcmdparser.add_dcmd_argument(&_filename);
 }
 
 void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
-  const char* name = _filename.value();
+  char* name = make_log_name(_filename.value(), nullptr);
   if (name == nullptr || name[0] == 0) {
     output()->print_cr("filename is empty or not specified.  No file written");
     return;
@@ -1210,12 +1208,12 @@ void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
     MemMapPrinter::print_all_mappings(&fs);
     // For the readers convenience, resolve path name.
     char tmp[JVM_MAXPATHLEN];
-    const char* absname = os::realpath(name, tmp, sizeof(tmp));
-    name = absname != nullptr ? absname : name;
-    output()->print_cr("Memory map dumped to \"%s\".", name);
+    char* absname = os::realpath(name, tmp, sizeof(tmp));
+    output()->print_cr("Memory map dumped to \"%s\".", absname != nullptr ? absname : name);
   } else {
     output()->print_cr("Failed to open \"%s\" for writing (%s).", name, os::strerror(errno));
   }
+  os::free(name);
 }
 
 #endif // LINUX

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -855,6 +855,7 @@ public:
 };
 
 class SystemDumpMapDCmd : public DCmdWithParser {
+  static constexpr char default_filename[] = "vm_memory_map_pid%p_%t.txt";
   DCmdArgument<char*> _filename;
 public:
   static int num_arguments() { return 1; }

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -841,14 +841,14 @@ public:
   virtual void execute(DCmdSource source, TRAPS);
 };
 
-#if defined(LINUX) || defined(_WIN64) || defined(__APPLE__)
+#if defined(LINUX) || defined(_WINDOWS) || defined(__APPLE__)
 
 class SystemMapDCmd : public DCmd {
 public:
   SystemMapDCmd(outputStream* output, bool heap);
   static const char* name() { return "System.map"; }
   static const char* description() {
-    return "Prints an annotated process memory map of the VM process (linux, Windows and MacOS only).";
+    return "Prints an annotated process memory map of the VM process.";
   }
   static const char* impact() { return "Medium; can be high for very large java heaps."; }
   virtual void execute(DCmdSource source, TRAPS);
@@ -862,7 +862,7 @@ public:
   SystemDumpMapDCmd(outputStream* output, bool heap);
   static const char* name() { return "System.dump_map"; }
   static const char* description() {
-    return "Dumps an annotated process memory map to an output file (linux, Windows and MacOS only).";
+    return "Dumps an annotated process memory map to an output file.";
   }
   static const char* impact() { return "Medium; can be high for very large java heaps."; }
   virtual void execute(DCmdSource source, TRAPS);

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -473,7 +473,7 @@ static char* get_datetime_string(char *buf, size_t len) {
   return buf;
 }
 
-static const char* make_log_name_internal(const char* log_name, const char* force_directory,
+static char* make_log_name_internal(const char* log_name, const char* force_directory,
                                                 int pid, const char* tms) {
   const char* basename = log_name;
   char file_sep = os::file_separator()[0];
@@ -576,7 +576,7 @@ static const char* make_log_name_internal(const char* log_name, const char* forc
 // -XX:DumpLoadedClassList=<file_name>
 // in log_name, %p => pid1234 and
 //              %t => YYYY-MM-DD_HH-MM-SS
-const char* make_log_name(const char* log_name, const char* force_directory) {
+char* make_log_name(const char* log_name, const char* force_directory) {
   char timestr[32];
   get_datetime_string(timestr, sizeof(timestr));
   return make_log_name_internal(log_name, force_directory, os::current_process_id(),

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -349,7 +349,12 @@ void ostream_init();
 void ostream_init_log();
 void ostream_exit();
 void ostream_abort();
-const char* make_log_name(const char* log_name, const char* force_directory);
+
+// Given a name, replace %p with current PID, %t with current timestamp in the form "YYYY-MM-DD_HH-MM-SS".
+// Returns result string in C-heap.
+// If force_directory is not nullptr, log_name is assumed to be a file name whose directory
+// stem is ignored; the resulting name will be <force_directory>/<resolved_log_name>.
+char* make_log_name(const char* log_name, const char* force_directory);
 
 // In the non-fixed buffer case an underlying buffer will be created and
 // managed in C heap. Not MT-safe.

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
@@ -51,13 +51,14 @@ public class SystemDumpMapTest extends SystemMapTestBase {
 
     private void run_test(CommandExecutor executor, boolean useDefaultFileName) {
 
-        String filenameOption = useDefaultFileName ? "" : "-F=test-map.txt";
+        String filenameOption = useDefaultFileName ? "" : "test-map.txt";
 
         OutputAnalyzer output = executor.execute("System.dump_map " + filenameOption);
         output.reportDiagnosticSummary();
 
         String filename = useDefaultFileName ?
-            output.firstMatch("Memory map dumped to \"(\\S*vm_memory_map_\\d+\\.txt)\".*", 1) :
+            //                                          e.g.  "vm_memory_map_pid598766_2026-03-30_14-20-58.txt"
+            output.firstMatch("Memory map dumped to \"(\\S*vm_memory_map_pid\\d+_.*\\.txt)\".*", 1) :
             output.firstMatch("Memory map dumped to \"(\\S*test-map.txt)\".*", 1);
 
         if (filename == null) {


### PR DESCRIPTION
Some small QOL improvement and trivial fixes:
- System.dump_map now takes the filename as a positional argument, which makes for less awkward handling
- System.dump_map now allows %t as a placeholder in its filename, and the default filename now contains a timestamp (reusing the logic in `make_log_name` for this)
- `make_log_name` returns a C-heap allocated array and therefore should not return a `const char*` but a `char*`.
- Used the more common - in our code base - `_WINDOWS` instead of `_WIN64`
- Removed the "(linux, Windows and MacOS only)" output since this code never runs on other platforms (not compiled for AIX or *BSD)
- since the filename argument has a default value if omitted by the user, it can never be empty - assert that instead of doing runtime checks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8381314](https://bugs.openjdk.org/browse/JDK-8381314): Small System.dump_map improvements (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30497/head:pull/30497` \
`$ git checkout pull/30497`

Update a local copy of the PR: \
`$ git checkout pull/30497` \
`$ git pull https://git.openjdk.org/jdk.git pull/30497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30497`

View PR using the GUI difftool: \
`$ git pr show -t 30497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30497.diff">https://git.openjdk.org/jdk/pull/30497.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30497#issuecomment-4160065708)
</details>
