### PR TITLE
8381012: Add warning for == for MemorySegment.NULL

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1552,6 +1552,14 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * The {@linkplain MemorySegment#maxByteAlignment() maximum byte alignment} for
      * the {@code NULL} segment is of 2<sup>62</sup>.
+     *
+     * @apiNote Clients should avoid using {@code ==} to compare a segment with
+     *          {@code MemorySegment.NULL}. A segment with address {@code 0L} may be
+     *          created independently and may therefore have a different identity
+     *          from {@code MemorySegment.NULL}. Furthermore, if {@code MemorySegment}
+     *          becomes a value class in the future, a segment's lifecycle might also
+     *          factor into the comparison. Instead, {@link #equals(Object)} should be
+     *          used to compare a segment with {@code MemorySegment.NULL}.
      */
     MemorySegment NULL = MemorySegment.ofAddress(0L);
 
@@ -1565,6 +1573,10 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * On 32-bit platforms, the given address value will be normalized such that the
      * highest-order ("leftmost") 32 bits of the {@link MemorySegment#address() address}
      * of the returned memory segment are set to zero.
+     *
+     * @apiNote If {@code address == 0L}, the returned segment should not be compared
+     *          with {@code MemorySegment.NULL} using {@code ==}, since it may have
+     *          a different identity while still modeling the same address.
      *
      * @param address the address of the returned native segment
      * @return a zero-length native segment with the given address


### PR DESCRIPTION
When comparing a `MemorySegment` to `MemorySegment.NULL` using `==`, the comparison may fail because a segment with address `0` can be created independently and will therefore have a different identity from `MemorySegment.NULL`. 

This PR adds JavaDocs that explain this issue and warn against using `==` to compare segments to `MemorySegment.NULL`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/jar/JarEntry/test.jar)

### Issue
 * [JDK-8381012](https://bugs.openjdk.org/browse/JDK-8381012): Add warning for == for MemorySegment.NULL (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30501/head:pull/30501` \
`$ git checkout pull/30501`

Update a local copy of the PR: \
`$ git checkout pull/30501` \
`$ git pull https://git.openjdk.org/jdk.git pull/30501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30501`

View PR using the GUI difftool: \
`$ git pr show -t 30501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30501.diff">https://git.openjdk.org/jdk/pull/30501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30501#issuecomment-4156699806)
</details>
