### PR TITLE
8381377: Reflection APIs should throw NoSuchMethodError for missing classfile methods

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.GenericSignatureFormatError;
 import java.lang.reflect.InvocationTargetException;
@@ -1471,7 +1470,7 @@ public final class Class<T> implements java.io.Serializable,
                 }
             }
 
-            throw new InternalError("Enclosing method not found");
+            throw new NoSuchMethodError(enclosingCandidate.getName() + "." + enclosingInfo.getName() + enclosingInfo.getDescriptor());
         }
     }
 
@@ -1544,12 +1543,6 @@ public final class Class<T> implements java.io.Serializable,
         }
     }
 
-    private static Class<?> toClass(Type o) {
-        if (o instanceof GenericArrayType gat)
-            return toClass(gat.getGenericComponentType()).arrayType();
-        return (Class<?>)o;
-     }
-
     /**
      * If this {@code Class} object represents a local or anonymous
      * class within a constructor, returns a {@link
@@ -1593,7 +1586,7 @@ public final class Class<T> implements java.io.Serializable,
                 }
             }
 
-            throw new InternalError("Enclosing constructor not found");
+            throw new NoSuchMethodError(enclosingCandidate.getName() + "." + enclosingInfo.getName() + enclosingInfo.getDescriptor());
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1470,7 +1470,7 @@ public final class Class<T> implements java.io.Serializable,
                 }
             }
 
-            throw new NoSuchMethodError(enclosingCandidate.getName() + "." + enclosingInfo.getName() + enclosingInfo.getDescriptor());
+            throw enclosingInfo.newResolutionError();
         }
     }
 
@@ -1541,6 +1541,11 @@ public final class Class<T> implements java.io.Serializable,
             }
             return descriptor;
         }
+
+        NoSuchMethodError newResolutionError() {
+            // Call getDescriptor to ensure we throw format error before resolution error
+            throw new NoSuchMethodError(enclosingClass.getName() + "." + name + getDescriptor());
+        }
     }
 
     /**
@@ -1586,7 +1591,7 @@ public final class Class<T> implements java.io.Serializable,
                 }
             }
 
-            throw new NoSuchMethodError(enclosingCandidate.getName() + "." + enclosingInfo.getName() + enclosingInfo.getDescriptor());
+            throw enclosingInfo.newResolutionError();
         }
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
+++ b/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,6 +168,10 @@ public final class RecordComponent implements AnnotatedElement {
      * component
      */
     public Method getAccessor() {
+        if (accessor == null) {
+            // Hotspot passes null for "not found" accessors
+            throw new NoSuchMethodError(getDeclaringRecord().getName() + "." + getName());
+        }
         return accessor;
     }
 

--- a/test/jdk/java/lang/Class/getEnclosingMethod/BadEnclosingMethodTest.java
+++ b/test/jdk/java/lang/Class/getEnclosingMethod/BadEnclosingMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8350704
+ * @bug 8350704 8381377
  * @summary Test behaviors with various bad EnclosingMethod attribute
  * @library /test/lib
  * @run junit BadEnclosingMethodTest
@@ -111,7 +111,7 @@ class BadEnclosingMethodTest {
      * valid, but refers to a class or interface that cannot be found.
      */
     @Test
-    void testAbsentMethods() throws Exception {
+    void testAbsentTypeInMethods() throws Exception {
         var absentMethodType = loadTestClass("methodName", "(Ldoes/not/Exist;)V");
         var ex = assertThrows(TypeNotPresentException.class,
                 absentMethodType::getEnclosingMethod);
@@ -122,8 +122,29 @@ class BadEnclosingMethodTest {
                 absentConstructorType::getEnclosingConstructor);
         assertEquals("does.not.Exist", ex.typeName());
     }
+
+    /**
+     * Test reflective behaviors when the EnclosingMethod attribute uses valid
+     * class and method names and types, but the method does not exist.
+     */
+    @Test
+    void testAbsentMethods() throws Exception {
+        var absentMethodType = loadTestClass("work", "(I)V");
+        var ex = assertThrows(NoSuchMethodError.class,
+                absentMethodType::getEnclosingMethod);
+        var message = ex.getMessage();
+        assertTrue(message.contains("Encloser.work(I)V"));
+
+        var absentConstructorType = loadTestClass(INIT_NAME, "(I)V");
+        ex = assertThrows(NoSuchMethodError.class,
+                absentConstructorType::getEnclosingConstructor);
+        message = ex.getMessage();
+        assertTrue(message.contains("Encloser.<init>(I)V"));
+    }
+
 }
 
+// These guys are compiled to serve as templates for bytecode transformation
 class Encloser {
     private static void work() {
         class Enclosed {

--- a/test/jdk/java/lang/reflect/records/IsRecordTest.java
+++ b/test/jdk/java/lang/reflect/records/IsRecordTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8255560
+ * @bug 8255560 8381377
  * @summary Class::isRecord should check that the current class is final and not abstract
  * @library /test/lib
  * @run junit/othervm IsRecordTest
@@ -154,6 +154,25 @@ public class IsRecordTest {
         final class B { }
         assertFalse(B.class.isRecord());
         assertNull(B.class.getRecordComponents());
+    }
+
+    /** Tests record component behavior with missing accessors. */
+    @Test
+    public void testMissingAccessor() throws Exception {
+        var missingAccessorBytes = generateClassBytes("MissingAccessor", true, false, "java/lang/Record", List.of(RecordComponentInfo.of("x", CD_int)));
+        var missingAccessor = ByteCodeLoader.load("MissingAccessor", missingAccessorBytes);
+
+        assertTrue(missingAccessor.isRecord());
+        assertEquals(1, missingAccessor.getRecordComponents().length);
+
+        var component = missingAccessor.getRecordComponents()[0];
+        assertEquals("x", component.getName());
+        assertSame(int.class, component.getType());
+        assertSame(int.class, component.getGenericType());
+        assertNull(component.getGenericSignature());
+        var nsme = assertThrows(NoSuchMethodError.class, () -> component.getAccessor());
+        var message = nsme.getMessage();
+        assertTrue(message.contains("MissingAccessor.x"), message);
     }
 
     // --  infra


### PR DESCRIPTION
Some core reflection APIs look for methods in classfile format that are expected to be present from the Java compiler. These APIs are: `Class.getEnclosingMethod`/`Constructor` and `RecordComponent.getAccessor`.

Currently, the Class ones throw `InternalError`, and the RecordComponent one returns null. These are not suitable behaviors as `InternalError` indicates an unrecoverable VM error, and a null return can propagate the error downstream and is not informative.

I propose to make these methods all throw `NoSuchMethodError`, a subtype of `LinkageError` and `IncompatibleClassChangeError`, which more accurately reflects the cause of these scenarios. This is also more in line with other failure modes of APIs like `Class.getDeclaringClass`, which throws `NoClassDefFoundError`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change requires CSR request [JDK-8381378](https://bugs.openjdk.org/browse/JDK-8381378) to be approved
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8381377](https://bugs.openjdk.org/browse/JDK-8381377): Reflection APIs should throw NoSuchMethodError for missing classfile methods (**Bug** - P4)
 * [JDK-8381378](https://bugs.openjdk.org/browse/JDK-8381378): Reflection APIs should throw NoSuchMethodError for missing classfile methods (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) 🔄 Re-review required (review applies to [29427874](https://git.openjdk.org/jdk/pull/30506/files/29427874c6b7f52e901bfd2731fd0d598552c584))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30506/head:pull/30506` \
`$ git checkout pull/30506`

Update a local copy of the PR: \
`$ git checkout pull/30506` \
`$ git pull https://git.openjdk.org/jdk.git pull/30506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30506`

View PR using the GUI difftool: \
`$ git pr show -t 30506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30506.diff">https://git.openjdk.org/jdk/pull/30506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30506#issuecomment-4158667330)
</details>
