### PR TITLE
8381364: Update the java tool specification for CompileCommand compile levels

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1800,6 +1800,35 @@ performed by the Java HotSpot VM.
         You can suppress this by specifying the `-XX:CompileCommand=quiet`
         option before other `-XX:CompileCommand` options.
 
+    Compilation levels can be specified in the `compileonly`, `exclude`, `print`,
+    and `break` commands using a bitmask as an optional value:
+
+    ```
+    -XX:CompileCommand=exclude,java/lang/String.indexOf,11
+    -XX:CompileCommand=compileonly,java/lang/String.indexOf,4
+    -XX:CompileCommand=print,java/lang/String.indexOf,4
+    -XX:CompileCommand=break,java/lang/StringBuffer.append,8
+    ```
+
+    The bitmask is calculated by summing the desired compilation level values:
+
+    `1`
+    : C1 JIT compiler without profiling.
+
+    `2`
+    : C1 JIT compiler with limited profiling.
+
+    `4`
+    : C1 JIT compiler with full profiling.
+
+    `8`
+    : C2 JIT compiler: no profiling, full optimization.
+
+    If the bitmask is not specified, all levels are assumed.
+
+    Note: Excluding specific compilation levels may disrupt normal state transitions
+    between the levels, as the VM will not automatically work around the excluded ones.
+
 [`-XX:CompileCommandFile=`]{#-XX_CompileCommandFile}*filename*
 :   Sets the file from which JIT compiler commands are read. By default, the
     `.hotspot_compiler` file is used to store commands performed by the JIT

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1804,10 +1804,10 @@ performed by the Java HotSpot VM.
     and `break` commands using a bitmask as an optional value:
 
     ```
-    -XX:CompileCommand=exclude,java/lang/String.indexOf,11
-    -XX:CompileCommand=compileonly,java/lang/String.indexOf,4
-    -XX:CompileCommand=print,java/lang/String.indexOf,4
-    -XX:CompileCommand=break,java/lang/StringBuffer.append,8
+    -XX:CompileCommand=exclude,java/lang/String.indexOf,1011
+    -XX:CompileCommand=compileonly,java/lang/String.indexOf,100
+    -XX:CompileCommand=print,java/lang/String.indexOf,100
+    -XX:CompileCommand=break,java/lang/StringBuffer.append,1000
     ```
 
     The bitmask is calculated by summing the desired compilation level values:
@@ -1815,13 +1815,13 @@ performed by the Java HotSpot VM.
     `1`
     : C1 JIT compiler without profiling.
 
-    `2`
+    `10`
     : C1 JIT compiler with limited profiling.
 
-    `4`
+    `100`
     : C1 JIT compiler with full profiling.
 
-    `8`
+    `1000`
     : C2 JIT compiler: no profiling, full optimization.
 
     If the bitmask is not specified, all levels are assumed.


### PR DESCRIPTION
This PR is a spin-off from https://github.com/openjdk/jdk/pull/30352. It contains only documentation changes.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381364](https://bugs.openjdk.org/browse/JDK-8381364): Update the java tool specification for CompileCommand compile levels (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30509/head:pull/30509` \
`$ git checkout pull/30509`

Update a local copy of the PR: \
`$ git checkout pull/30509` \
`$ git pull https://git.openjdk.org/jdk.git pull/30509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30509`

View PR using the GUI difftool: \
`$ git pr show -t 30509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30509.diff">https://git.openjdk.org/jdk/pull/30509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30509#issuecomment-4159169635)
</details>
