### PR TITLE
8381397: G1: Inline initiate_conc_mark/record_conc_mark_init_end

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -690,11 +690,6 @@ void G1Policy::record_young_collection_start() {
   assert(_g1h->collection_set()->verify_young_ages(), "region age verification failed");
 }
 
-void G1Policy::record_concurrent_mark_init_end() {
-  assert(!collector_state()->initiate_conc_mark_if_possible(), "we should have cleared it by now");
-  collector_state()->set_in_normal_young_gc();
-}
-
 void G1Policy::record_concurrent_mark_remark_end() {
   double end_time_sec = os::elapsedTime();
   double start_time_sec = cur_pause_start_sec();
@@ -795,7 +790,8 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
   bool is_young_only_pause = G1CollectorState::is_young_only_pause(this_pause);
 
   if (G1CollectorState::is_concurrent_start_pause(this_pause)) {
-    record_concurrent_mark_init_end();
+    assert(!collector_state()->initiate_conc_mark_if_possible(), "we should have cleared it by now");
+    collector_state()->set_in_normal_young_gc();
   } else {
     maybe_start_marking(allocation_word_size);
   }
@@ -1245,10 +1241,6 @@ bool G1Policy::force_concurrent_start_if_outside_cycle(GCCause::Cause gc_cause) 
   }
 }
 
-void G1Policy::initiate_conc_mark() {
-  collector_state()->set_in_concurrent_start_gc();
-}
-
 static const char* requester_for_mixed_abort(GCCause::Cause cause) {
   if (cause == GCCause::_wb_breakpoint) {
     return "run_to breakpoint";
@@ -1283,22 +1275,19 @@ void G1Policy::decide_on_concurrent_start_pause() {
       log_debug(gc, ergo)("Do not initiate concurrent cycle (whitebox controlled)");
     } else if (!about_to_start_mixed_phase() && collector_state()->is_in_young_only_phase()) {
       // Initiate a new concurrent start if there is no marking or reclamation going on.
-      initiate_conc_mark();
+      collector_state()->set_in_concurrent_start_gc();
       log_debug(gc, ergo)("Initiate concurrent cycle (concurrent cycle initiation requested)");
     } else if (_g1h->is_user_requested_concurrent_full_gc(cause) ||
                GCCause::is_codecache_requested_gc(cause) ||
                (cause == GCCause::_wb_breakpoint)) {
-      // Initiate a concurrent start.  A concurrent start must be a young only
-      // GC, so the collector state must be updated to reflect this.
-      collector_state()->set_in_normal_young_gc();
-
+      // Force concurrent start.
+      collector_state()->set_in_concurrent_start_gc();
       // We might have ended up coming here about to start a mixed phase with a collection set
       // active. The following remark might change the change the "evacuation efficiency" of
       // the regions in this set, leading to failing asserts later.
       // Since the concurrent cycle will recreate the collection set anyway, simply drop it here.
       abandon_collection_set_candidates();
       abort_time_to_mixed_tracking();
-      initiate_conc_mark();
       log_debug(gc, ergo)("Initiate concurrent cycle (%s requested concurrent cycle)",
                           requester_for_mixed_abort(cause));
     } else {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -313,9 +313,6 @@ public:
   void record_full_collection_start();
   void record_full_collection_end(size_t allocation_word_size);
 
-  // Must currently be called while the world is stopped.
-  void record_concurrent_mark_init_end();
-
   void record_concurrent_mark_remark_end();
 
   // Record start, end, and completion of cleanup.
@@ -331,11 +328,6 @@ private:
   // Predict the number of bytes of surviving objects from survivor and old
   // regions and update the associated members.
   void update_survival_estimates_for_next_collection();
-
-  // Set the state to start a concurrent marking cycle and clear
-  // _initiate_conc_mark_if_possible because it has now been
-  // acted on.
-  void initiate_conc_mark();
 
 public:
   // This sets the initiate_conc_mark_if_possible() flag to start a


### PR DESCRIPTION
Hi all,

  please review this simple inlining of one-line-one-use local helpers related to concurrent start (named conc_init here still) for `G1Policy`.

Testing: local compilation, gha

Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381397](https://bugs.openjdk.org/browse/JDK-8381397): G1: Inline initiate_conc_mark/record_conc_mark_init_end (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30511/head:pull/30511` \
`$ git checkout pull/30511`

Update a local copy of the PR: \
`$ git checkout pull/30511` \
`$ git pull https://git.openjdk.org/jdk.git pull/30511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30511`

View PR using the GUI difftool: \
`$ git pr show -t 30511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30511.diff">https://git.openjdk.org/jdk/pull/30511.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30511#issuecomment-4162317721)
</details>
