### PR TITLE
8349772: C2 hits MemLimit during incremental inlining

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
@@ -57,7 +57,7 @@
  *
  * @requires vm.debug
  *
- * @run main/othervm/timeout=480 -XX:CompileCommand=MemLimit,*.*,2G~crash vm.mlvm.meth.stress.compiler.i2c_c2i.Test
+ * @run main/othervm/timeout=480 -XX:CompileCommand=MemLimit,*.*,2G~crash ${test.main.class}
  */
 
 /*
@@ -72,7 +72,7 @@
  *
  * @requires !vm.debug
  *
- * @run main/othervm/timeout=480 vm.mlvm.meth.stress.compiler.i2c_c2i.Test
+ * @run main/othervm/timeout=480 ${test.main.class}
  */
 
 package vm.mlvm.meth.stress.compiler.i2c_c2i;

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
@@ -156,7 +156,6 @@ public class Test extends MlvmTest {
 
         final Argument[] finalArgs = RandomArgumentsGen.createRandomArgs(true,
                 mhM.type());
-        System.out.println("SIZEEEEEE: " + finalArgs.length + ", 2: " + RandomArgumentsGen.createRandomArgs(true, mhB.type()).length);
 
         Thread[] threads = new Thread[THREADS];
         for (int t = 0; t < THREADS; t++) {

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java
@@ -50,7 +50,29 @@
  * @build vm.mlvm.meth.stress.compiler.i2c_c2i.Test
  * @run driver vm.mlvm.share.IndifiedClassesBuilder
  *
- * @run main/othervm/timeout=480 -XX:CompileCommand=MemLimit,*.*,0 vm.mlvm.meth.stress.compiler.i2c_c2i.Test
+ * @comment
+ * In debug builds, use an explicit larger MemLimit to avoid intermittent failures
+ * due to 1G default MemLimit being crossed.
+ * In non-debug builds, do not set MemLimit explicitly.
+ *
+ * @requires vm.debug
+ *
+ * @run main/othervm/timeout=480 -XX:CompileCommand=MemLimit,*.*,2G~crash vm.mlvm.meth.stress.compiler.i2c_c2i.Test
+ */
+
+/*
+ * @test
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ *
+ * @comment build test class and indify classes
+ * @build vm.mlvm.meth.stress.compiler.i2c_c2i.Test
+ * @run driver vm.mlvm.share.IndifiedClassesBuilder
+ *
+ * @requires !vm.debug
+ *
+ * @run main/othervm/timeout=480 vm.mlvm.meth.stress.compiler.i2c_c2i.Test
  */
 
 package vm.mlvm.meth.stress.compiler.i2c_c2i;
@@ -134,6 +156,7 @@ public class Test extends MlvmTest {
 
         final Argument[] finalArgs = RandomArgumentsGen.createRandomArgs(true,
                 mhM.type());
+        System.out.println("SIZEEEEEE: " + finalArgs.length + ", 2: " + RandomArgumentsGen.createRandomArgs(true, mhB.type()).length);
 
         Thread[] threads = new Thread[THREADS];
         for (int t = 0; t < THREADS; t++) {


### PR DESCRIPTION
The issue was very intermittent but an old run that reproduced (for the crash with `-XX:-TieredCompilation -XX:+AlwaysIncrementalInline`) suggested the following was happening:
The test builds a very long MH adapter chain (in some runs up to ~10,000 transformations). Many small MH adapters are late-inlined, and C2 performs repeated incremental-inline/prune/IGVN rounds.
In each round, parser/IR/support data is allocated from compile arenas. Even when pruning removes dead nodes (live node count seems to remain moderate, e.g. ~13k), arena usage appears to be reclaimed only when the compilation ends.
So, for runs with long/complex chains, peak arena usage seems to cross MemLimit, which triggers a crash in debug (or a compilation bailout in product/non-crash mode).
Disabling/stopping late inlining at that point would probably only postpone the resource failure to a later phase.
[JDK-8349820](https://bugs.openjdk.org/browse/JDK-8349820) disabled the explicit test-level MemLimit override. This change keeps a safeguard by using a larger explicit limit (2G) in debug builds.

Testing: tier1-3+

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349772](https://bugs.openjdk.org/browse/JDK-8349772): C2 hits MemLimit during incremental inlining (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) 🔄 Re-review required (review applies to [bbc67b51](https://git.openjdk.org/jdk/pull/30555/files/bbc67b51a1fc12b51bac2cf6cc08f8afb2275228))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30555/head:pull/30555` \
`$ git checkout pull/30555`

Update a local copy of the PR: \
`$ git checkout pull/30555` \
`$ git pull https://git.openjdk.org/jdk.git pull/30555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30555`

View PR using the GUI difftool: \
`$ git pr show -t 30555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30555.diff">https://git.openjdk.org/jdk/pull/30555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30555#issuecomment-4215169051)
</details>
