### PR TITLE
8380389: Test pkcs12/KeytoolOpensslInteropTest.java#GenerateOpensslPKCS12 fails with NPE

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -80,7 +80,7 @@ public class KeytoolOpensslInteropTest {
     public static void main(String[] args) throws Throwable {
         boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
         if (generatePKCS12) {
-            String opensslPath = OpensslArtifactFetcher.getOpensslPath();
+            String opensslPath = OpensslArtifactFetcher.getOpensslPathWithProviderPathPresent();
             generateInitialKeystores(opensslPath);
             testWithJavaCommands();
             testWithOpensslCommands(opensslPath);

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -66,7 +66,7 @@ public class OpensslArtifactFetcher {
             return path;
         }
         path = getArtifactsFromArtifactory();
-        if(path == null) {
+        if (path == null) {
            throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
         }

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -92,12 +92,11 @@ public class OpensslArtifactFetcher {
            throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
         }
-        System.out.println("Artifacts Path is"+path);
+        System.out.println("Artifacts Path is:"+path);
         return path;
     }
 
     private static String getArtifactsFromArtifactory() {
-        System.out.println("reached this point");
         String returnValue = null;
         if (Platform.isX64()) {
             if (Platform.isLinux()) {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -68,8 +68,12 @@ public class OpensslArtifactFetcher {
             return path;
         }
         path = getArtifactsFromArtifactory();
-        throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
+	if(path == null) {
+		throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
+	}
+	System.out.println("Artifacts Path is"+path);
+	return path;
     }
 
     public static String getOpensslPathWithProviderPathPresent() {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -25,9 +25,7 @@ package jdk.test.lib.security;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.io.*;
-import java.nio.*;
-import java.nio.file.*;
+import java.nio.file.Files;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -56,7 +54,7 @@ public class OpensslArtifactFetcher {
      * @throws SkippedException if a valid version of OpenSSL cannot be found
      *         or if OpenSSL is not available on the target platform
      */
-     public static String getOpensslPath() {
+    public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
             System.out.println("Using OpenSSL from system property.");
@@ -64,7 +62,7 @@ public class OpensslArtifactFetcher {
         }
         path = getDefaultSystemOpensslPath(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
-            System.out.println("Using OpenSSL from System Installed Library:"+path);
+            System.out.println("Using OpenSSL from System Installed Library: "+path);
             return path;
         }
         path = getArtifactsFromArtifactory();
@@ -72,7 +70,7 @@ public class OpensslArtifactFetcher {
            throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
         }
-        System.out.println("Artifacts Path is"+path);
+        System.out.println("Artifacts Path is: "+path);
         return path;
     }
 
@@ -92,7 +90,7 @@ public class OpensslArtifactFetcher {
            throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
         }
-        System.out.println("Artifacts Path is:"+path);
+        System.out.println("Artifacts Path is: "+path);
         return path;
     }
 
@@ -147,7 +145,7 @@ public class OpensslArtifactFetcher {
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
             absolutePath = outputAnalyzer.getOutput();
-            System.out.println("absolutePath:"+absolutePath);
+            System.out.println("absolutePath: "+absolutePath);
         } catch(Throwable t) {
             t.printStackTrace();
         }

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -125,9 +125,27 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-        String absolutePath = getOpenSslAbsolutePath();
-        if (verifyOpensslVersion(absolutePath, version)) {
-            return absolutePath;
+        System.out.println("Expected Openssl version is: "+version);
+        if (Platform.isWindows()) {
+            String output = null;
+            String windowsPath = null;
+            String cygwinPath = null;
+            try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("openssl","version","-d");
+            output = outputAnalyzer.getOutput();
+            cygwinPath = output.split(":")[1].trim().replace("\"", "");
+            System.out.println("cygwinPath: "+cygwinPath);
+            OutputAnalyzer windowsOutput = ProcessTools.executeProcess("cygpath", "-w", cygwinPath);
+            System.out.println("windowsPath: "+windowsPath);
+           } catch(Throwable t) {
+             t.printStackTrace();
+           }
+           return windowsPath;
+        } else {
+           String absolutePath = getOpenSslAbsolutePath();
+           if (verifyOpensslVersion(absolutePath, version)) {
+               return absolutePath;
+           }
         }
         return null;
     }

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -25,8 +25,12 @@ package jdk.test.lib.security;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.io.*;
+import java.nio.*;
+import java.nio.file.*;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
 import jtreg.SkippedException;
@@ -52,19 +56,45 @@ public class OpensslArtifactFetcher {
      * @throws SkippedException if a valid version of OpenSSL cannot be found
      *         or if OpenSSL is not available on the target platform
      */
-    public static String getOpensslPath() {
+     public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
             System.out.println("Using OpenSSL from system property.");
             return path;
         }
-
         path = getDefaultSystemOpensslPath(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
-            System.out.println("Using OpenSSL from system.");
+            System.out.println("Using OpenSSL from System Installed Library:"+path);
             return path;
         }
+        path = getArtifactsFromArtifactory();
+        throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
+                OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
+    }
 
+    public static String getOpensslPathWithProviderPathPresent() {
+        String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
+        if (path != null) {
+            System.out.println("Using OpenSSL from system property.");
+            return path;
+        }
+        path = getDefaultSystemOpensslPathWithProviderPathPresent(OPENSSL_BUNDLE_VERSION);
+        if (path != null) {
+            System.out.println("Using OpenSSL from System Installed Library:"+path);
+            return path;
+        }
+        path = getArtifactsFromArtifactory();
+	if(path == null) {
+		throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
+                OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
+        }
+	System.out.println("Artifacts Path is"+path);
+	return path;
+    }
+
+    private static String getArtifactsFromArtifactory() {
+	System.out.println("reached this point");
+	String returnValue = null;
         if (Platform.isX64()) {
             if (Platform.isLinux()) {
                 return fetchOpenssl(LINUX_X64.class);
@@ -81,9 +111,7 @@ public class OpensslArtifactFetcher {
                 return fetchOpenssl(MACOSX_AARCH64.class);
             }
         }
-
-        throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
-                OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
+	return returnValue;
     }
 
     private static String getOpensslFromSystemProp(String version) {
@@ -96,12 +124,30 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-        if (verifyOpensslVersion("openssl", version)) {
-            return "openssl";
-        } else if (verifyOpensslVersion("/usr/local/bin/openssl", version)) {
-            return "/usr/local/bin/openssl";
+	String absolutePath = getOpenSslAbsolutePath();
+        if (verifyOpensslVersion(absolutePath, version)) {
+            return absolutePath;
         }
         return null;
+    }
+
+    private static String getDefaultSystemOpensslPathWithProviderPathPresent(String version) {
+	String absolutePath = getDefaultSystemOpensslPath(version);
+	if(absolutePath != null && isProviderPathPresent(absolutePath) != null) {
+	    return absolutePath;
+        }
+	return null;
+    }
+
+    private static String getOpenSslAbsolutePath() {
+        String absolutePath = null;
+	try {
+	    OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
+	    absolutePath=outputAnalyzer.getOutput();
+	} catch(Throwable t) {
+	    t.printStackTrace();
+	}
+	return absolutePath;
     }
 
     private static boolean verifyOpensslVersion(String path, String version) {
@@ -136,6 +182,15 @@ public class OpensslArtifactFetcher {
             libDir = "lib64";
         }
         return openSslRootPath.resolve(libDir, "ossl-modules");
+    }
+
+    private static Path isProviderPathPresent(String opensslAbsolutePath) {
+	Path osslModulesPath = getProviderPath(opensslAbsolutePath);
+        if(Files.exists(osslModulesPath)) {
+	    return osslModulesPath;
+        } else {
+	    return null;
+	}
     }
 
     public static String getTestOpensslBundleVersion() {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -147,7 +147,7 @@ public class OpensslArtifactFetcher {
         String absolutePath = null;
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
-            absolutePath=outputAnalyzer.getOutput();
+            absolutePath = outputAnalyzer.getOutput();
         } catch(Throwable t) {
             t.printStackTrace();
         }

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -155,7 +155,7 @@ public class OpensslArtifactFetcher {
     private static boolean verifyOpensslVersion(String path, String version) {
         if (path != null) {
             try {
-                System.out.println("path is:"+path+"version is "+version);
+                System.out.println("path is: "+path+"version is: "+version);
                 ProcessTools.executeCommand(path.trim(),"version")
                         .shouldHaveExitValue(0)
                         .shouldContain(version);
@@ -189,7 +189,7 @@ public class OpensslArtifactFetcher {
 
     private static Path isProviderPathPresent(String opensslAbsolutePath) {
         Path osslModulesPath = getProviderPath(opensslAbsolutePath);
-        if(Files.exists(osslModulesPath)) {
+        if (Files.exists(osslModulesPath)) {
              return osslModulesPath;
         } else {
              return null;

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -82,11 +82,11 @@ public class OpensslArtifactFetcher {
         }
         path = getDefaultSystemOpensslPathWithProviderPathPresent(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
-            System.out.println("Using OpenSSL from System Installed Library:"+path);
+            System.out.println("Using OpenSSL from System Installed Library: "+path);
             return path;
         }
         path = getArtifactsFromArtifactory();
-        if(path == null) {
+        if (path == null) {
            throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
         }

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -68,12 +68,12 @@ public class OpensslArtifactFetcher {
             return path;
         }
         path = getArtifactsFromArtifactory();
-	if(path == null) {
-		throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
+        if(path == null) {
+           throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
-	}
-	System.out.println("Artifacts Path is"+path);
-	return path;
+        }
+        System.out.println("Artifacts Path is"+path);
+        return path;
     }
 
     public static String getOpensslPathWithProviderPathPresent() {
@@ -88,17 +88,17 @@ public class OpensslArtifactFetcher {
             return path;
         }
         path = getArtifactsFromArtifactory();
-	if(path == null) {
-		throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
+        if(path == null) {
+           throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
                 OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
         }
-	System.out.println("Artifacts Path is"+path);
-	return path;
+        System.out.println("Artifacts Path is"+path);
+        return path;
     }
 
     private static String getArtifactsFromArtifactory() {
-	System.out.println("reached this point");
-	String returnValue = null;
+        System.out.println("reached this point");
+        String returnValue = null;
         if (Platform.isX64()) {
             if (Platform.isLinux()) {
                 return fetchOpenssl(LINUX_X64.class);
@@ -115,7 +115,7 @@ public class OpensslArtifactFetcher {
                 return fetchOpenssl(MACOSX_AARCH64.class);
             }
         }
-	return returnValue;
+        return returnValue;
     }
 
     private static String getOpensslFromSystemProp(String version) {
@@ -128,7 +128,7 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-	String absolutePath = getOpenSslAbsolutePath();
+    String absolutePath = getOpenSslAbsolutePath();
         if (verifyOpensslVersion(absolutePath, version)) {
             return absolutePath;
         }
@@ -136,22 +136,22 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPathWithProviderPathPresent(String version) {
-	String absolutePath = getDefaultSystemOpensslPath(version);
-	if(absolutePath != null && isProviderPathPresent(absolutePath) != null) {
-	    return absolutePath;
+    String absolutePath = getDefaultSystemOpensslPath(version);
+    if(absolutePath != null && isProviderPathPresent(absolutePath) != null) {
+        return absolutePath;
         }
-	return null;
+    return null;
     }
 
     private static String getOpenSslAbsolutePath() {
         String absolutePath = null;
-	try {
-	    OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
-	    absolutePath=outputAnalyzer.getOutput();
-	} catch(Throwable t) {
-	    t.printStackTrace();
-	}
-	return absolutePath;
+    try {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
+        absolutePath=outputAnalyzer.getOutput();
+    } catch(Throwable t) {
+        t.printStackTrace();
+    }
+    return absolutePath;
     }
 
     private static boolean verifyOpensslVersion(String path, String version) {
@@ -189,12 +189,12 @@ public class OpensslArtifactFetcher {
     }
 
     private static Path isProviderPathPresent(String opensslAbsolutePath) {
-	Path osslModulesPath = getProviderPath(opensslAbsolutePath);
+    Path osslModulesPath = getProviderPath(opensslAbsolutePath);
         if(Files.exists(osslModulesPath)) {
-	    return osslModulesPath;
+        return osslModulesPath;
         } else {
-	    return null;
-	}
+        return null;
+    }
     }
 
     public static String getTestOpensslBundleVersion() {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -128,7 +128,7 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-    String absolutePath = getOpenSslAbsolutePath();
+        String absolutePath = getOpenSslAbsolutePath();
         if (verifyOpensslVersion(absolutePath, version)) {
             return absolutePath;
         }
@@ -136,22 +136,22 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPathWithProviderPathPresent(String version) {
-    String absolutePath = getDefaultSystemOpensslPath(version);
-    if(absolutePath != null && isProviderPathPresent(absolutePath) != null) {
-        return absolutePath;
+        String absolutePath = getDefaultSystemOpensslPath(version);
+        if (absolutePath != null && isProviderPathPresent(absolutePath) != null) {
+          return absolutePath;
         }
-    return null;
+        return null;
     }
 
     private static String getOpenSslAbsolutePath() {
         String absolutePath = null;
-    try {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
-        absolutePath=outputAnalyzer.getOutput();
-    } catch(Throwable t) {
-        t.printStackTrace();
-    }
-    return absolutePath;
+        try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
+            absolutePath=outputAnalyzer.getOutput();
+        } catch(Throwable t) {
+            t.printStackTrace();
+        }
+        return absolutePath;
     }
 
     private static boolean verifyOpensslVersion(String path, String version) {
@@ -189,12 +189,12 @@ public class OpensslArtifactFetcher {
     }
 
     private static Path isProviderPathPresent(String opensslAbsolutePath) {
-    Path osslModulesPath = getProviderPath(opensslAbsolutePath);
+        Path osslModulesPath = getProviderPath(opensslAbsolutePath);
         if(Files.exists(osslModulesPath)) {
-        return osslModulesPath;
+             return osslModulesPath;
         } else {
-        return null;
-    }
+             return null;
+        }
     }
 
     public static String getTestOpensslBundleVersion() {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -163,9 +163,11 @@ public class OpensslArtifactFetcher {
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
             absolutePath = outputAnalyzer.getOutput();
-            System.out.println("absolutePath: "+absolutePath);
         } catch(Throwable t) {
             t.printStackTrace();
+        } finally {
+            System.out.println("absolutePath: "+absolutePath);
+            System.err.println("absolutePath: "+absolutePath);
         }
         return absolutePath;
     }

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -148,6 +148,7 @@ public class OpensslArtifactFetcher {
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess("which","openssl");
             absolutePath = outputAnalyzer.getOutput();
+            System.out.println("absolutePath:"+absolutePath);
         } catch(Throwable t) {
             t.printStackTrace();
         }
@@ -157,7 +158,8 @@ public class OpensslArtifactFetcher {
     private static boolean verifyOpensslVersion(String path, String version) {
         if (path != null) {
             try {
-                ProcessTools.executeCommand(path, "version")
+                System.out.println("path is:"+path+"version is "+version);
+                ProcessTools.executeCommand(path.trim(),"version")
                         .shouldHaveExitValue(0)
                         .shouldContain(version);
                 return true;


### PR DESCRIPTION
Analysis on Issue
======================

There are two calls made in KeytoolOpensslInteropTest.java in Line 83 and Line 84

https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java#L83-L84

       a)      String opensslPath = OpensslArtifactFetcher.getOpensslPath();
       b)     generateInitialKeystores(opensslPath);


1. Call made in https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java#L83  to get openssl path which returns "openssl"

		Execution Flow:
		============
		https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java#L83   calls https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java#L62 calls https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java#L98 and finally returns "openssl" from https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java#L100



2.   return value of  "openssl" is passed as argument to generateInitialKeystores("openssl") and same value is navigated here as well
      https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java#L110 and call made to  
 OpensslArtifactFetcher.getProviderPath("openssl") 
 
https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java#L133 ==> this is the statement where we are seeing error

 Path openSslRootPath = Path.of("openssl").getParent().getParent();

=====> Path.of("openssl").getParent() = null



Solution
==========

1. We can remove complete System Installed Library dependency and rely on artifacts installed through artifactory.
2. Instead of returning "openssl" from https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java#L100 return the absolute path of openssl.


I have opted for Solution 2. and changed the code and i encountered one more situation where ProviderPath doesn't contain "ossl-modules" folder at all.

e.g.

if https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java#L83 returns absolute path "/usr/bin/openssl" then call made to get Provider Path here: https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java#L110 and finally returned value is "/usr/lib/ossl-modules" from here: https://github.com/openjdk/jdk/blob/master/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java#L138

I noticed in some of machines /usr/lib/ossl-modules doesn't exist at all so i checked in my code whether this folder /usr/lib/ossl-modules exist or not.

if /usr/lib/ossl-modules exist then we can rely on system installed /usr/bin/openssl
if /usr/lib/ossl-modules doesn't exist then we can rely on getting openssl path through Artifactory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8380389](https://bugs.openjdk.org/browse/JDK-8380389): Test pkcs12/KeytoolOpensslInteropTest.java#GenerateOpensslPKCS12 fails with NPE (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30561/head:pull/30561` \
`$ git checkout pull/30561`

Update a local copy of the PR: \
`$ git checkout pull/30561` \
`$ git pull https://git.openjdk.org/jdk.git pull/30561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30561`

View PR using the GUI difftool: \
`$ git pr show -t 30561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30561.diff">https://git.openjdk.org/jdk/pull/30561.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30561#issuecomment-4190827500)
</details>
