### PR TITLE
8381650: Vector rotate operations on AArch64 with NEON

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -3224,7 +3224,7 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
     int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
                                       $shift$$constant : -$shift$$constant);
     __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
-                          $src$$FloatRegister, esize, raw_shift & (esize - 1));
+                          $src$$FloatRegister, raw_shift & (esize - 1));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -282,6 +282,12 @@ source %{
           return false;
         }
         break;
+      case Op_RotateLeftV:
+      case Op_RotateRightV:
+        if (length_in_bytes > 16) {
+          return false; // NEON only, since SLI/USHR are not available in SVE
+        }
+        break;
       default:
         break;
     }
@@ -3197,6 +3203,49 @@ instruct vlsra_imm(vReg dst, vReg src, immI_positive shift) %{
     } else { // for S/D
       assert(type2aelembytes(bt) == 4 || type2aelembytes(bt) == 8, "unsupported type");
       __ usra($dst$$FloatRegister, get_arrangement(this), $src$$FloatRegister, con);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector rotate with constant shift count (NEON only)
+// Uses USHR+SLI 2-instruction sequence instead of SHL+USHR+ORR 3-instruction decomposition.
+
+instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
+  predicate(Matcher::vector_length_in_bytes(n) <= 16);
+  match(Set dst (RotateLeftV src shift));
+  match(Set dst (RotateRightV src shift));
+  effect(TEMP_DEF dst);
+  format %{ "vrotateconstant $dst, $src, $shift" %}
+  ins_encode %{
+    int opc = this->ideal_Opcode();
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int esize = type2aelembytes(bt) * BitsPerByte;
+    int raw_shift = (int)$shift$$constant;
+
+    // Compute left and right shift amounts.
+    int lshift, rshift;
+    if (opc == Op_RotateLeftV) {
+      lshift = raw_shift & (esize - 1);
+      rshift = esize - lshift;
+    } else {
+      assert(opc == Op_RotateRightV, "unexpected opcode");
+      rshift = raw_shift & (esize - 1);
+      lshift = esize - rshift;
+    }
+
+    if (lshift == 0 || rshift == 0) {
+      // Rotate by 0 (or by element width) is identity - just copy.
+      uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+      __ orr($dst$$FloatRegister, length_in_bytes == 16 ? __ T16B : __ T8B,
+             $src$$FloatRegister, $src$$FloatRegister);
+    } else {
+      // USHR places the right-shifted bits into dst.
+      // SLI shifts src left and inserts those bits into dst.
+      __ ushr($dst$$FloatRegister, get_arrangement(this),
+              $src$$FloatRegister, rshift);
+      __ sli($dst$$FloatRegister, get_arrangement(this),
+             $src$$FloatRegister, lshift);
     }
   %}
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -3221,32 +3221,12 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
     int opc = this->ideal_Opcode();
     BasicType bt = Matcher::vector_element_basic_type(this);
     int esize = type2aelembytes(bt) * BitsPerByte;
-    int raw_shift = (int)$shift$$constant;
-
-    // Compute left and right shift amounts.
-    int lshift, rshift;
-    if (opc == Op_RotateLeftV) {
-      lshift = raw_shift & (esize - 1);
-      rshift = esize - lshift;
-    } else {
-      assert(opc == Op_RotateRightV, "unexpected opcode");
-      rshift = raw_shift & (esize - 1);
-      lshift = esize - rshift;
-    }
-
-    if (lshift == 0 || rshift == 0) {
-      // Rotate by 0 (or by element width) is identity - just copy.
-      uint length_in_bytes = Matcher::vector_length_in_bytes(this);
-      __ orr($dst$$FloatRegister, length_in_bytes == 16 ? __ T16B : __ T8B,
-             $src$$FloatRegister, $src$$FloatRegister);
-    } else {
-      // USHR places the right-shifted bits into dst.
-      // SLI shifts src left and inserts those bits into dst.
-      __ ushr($dst$$FloatRegister, get_arrangement(this),
-              $src$$FloatRegister, rshift);
-      __ sli($dst$$FloatRegister, get_arrangement(this),
-             $src$$FloatRegister, lshift);
-    }
+    int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
+                                      $shift$$constant : -$shift$$constant);
+    int lshift = raw_shift & (esize - 1);
+    int rshift = -lshift   & (esize - 1);
+    __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
+                          $src$$FloatRegister, lshift, rshift);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -3223,10 +3223,8 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
     int esize = type2aelembytes(bt) * BitsPerByte;
     int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
                                       $shift$$constant : -$shift$$constant);
-    int lshift = raw_shift & (esize - 1);
-    int rshift = -lshift   & (esize - 1);
     __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
-                          $src$$FloatRegister, lshift, rshift);
+                          $src$$FloatRegister, esize, raw_shift & (esize - 1));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -346,6 +346,11 @@ source %{
       case Op_SqrtVHF:
       case Op_FmaVHF:
         return false;
+      // There's no SLI instruction in SVE, so we can't have an optimal vector
+      // rotate with masking when emitting code for SVE.
+      case Op_RotateLeftV:
+      case Op_RotateRightV:
+        return false;
       default:
         break;
     }
@@ -3219,12 +3224,10 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
   format %{ "vrotateconstant $dst, $src, $shift" %}
   ins_encode %{
     int opc = this->ideal_Opcode();
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    int esize = type2aelembytes(bt) * BitsPerByte;
     int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
                                       $shift$$constant : -$shift$$constant);
     __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
-                          $src$$FloatRegister, raw_shift & (esize - 1));
+                          $src$$FloatRegister, raw_shift);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -336,6 +336,11 @@ source %{
       case Op_SqrtVHF:
       case Op_FmaVHF:
         return false;
+      // There's no SLI instruction in SVE, so we can't have an optimal vector
+      // rotate with masking when emitting code for SVE.
+      case Op_RotateLeftV:
+      case Op_RotateRightV:
+        return false;
       default:
         break;
     }
@@ -1955,12 +1960,10 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
   format %{ "vrotateconstant $dst, $src, $shift" %}
   ins_encode %{
     int opc = this->ideal_Opcode();
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    int esize = type2aelembytes(bt) * BitsPerByte;
     int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
                                       $shift$$constant : -$shift$$constant);
     __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
-                          $src$$FloatRegister, raw_shift & (esize - 1));
+                          $src$$FloatRegister, raw_shift);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -272,6 +272,12 @@ source %{
           return false;
         }
         break;
+      case Op_RotateLeftV:
+      case Op_RotateRightV:
+        if (length_in_bytes > 16) {
+          return false; // NEON only, since SLI/USHR are not available in SVE
+        }
+        break;
       default:
         break;
     }
@@ -1933,6 +1939,49 @@ instruct vlsra_imm(vReg dst, vReg src, immI_positive shift) %{
     } else { // for S/D
       assert(type2aelembytes(bt) == 4 || type2aelembytes(bt) == 8, "unsupported type");
       __ usra($dst$$FloatRegister, get_arrangement(this), $src$$FloatRegister, con);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector rotate with constant shift count (NEON only)
+// Uses USHR+SLI 2-instruction sequence instead of SHL+USHR+ORR 3-instruction decomposition.
+
+instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
+  predicate(Matcher::vector_length_in_bytes(n) <= 16);
+  match(Set dst (RotateLeftV src shift));
+  match(Set dst (RotateRightV src shift));
+  effect(TEMP_DEF dst);
+  format %{ "vrotateconstant $dst, $src, $shift" %}
+  ins_encode %{
+    int opc = this->ideal_Opcode();
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int esize = type2aelembytes(bt) * BitsPerByte;
+    int raw_shift = (int)$shift$$constant;
+
+    // Compute left and right shift amounts.
+    int lshift, rshift;
+    if (opc == Op_RotateLeftV) {
+      lshift = raw_shift & (esize - 1);
+      rshift = esize - lshift;
+    } else {
+      assert(opc == Op_RotateRightV, "unexpected opcode");
+      rshift = raw_shift & (esize - 1);
+      lshift = esize - rshift;
+    }
+
+    if (lshift == 0 || rshift == 0) {
+      // Rotate by 0 (or by element width) is identity - just copy.
+      uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+      __ orr($dst$$FloatRegister, length_in_bytes == 16 ? __ T16B : __ T8B,
+             $src$$FloatRegister, $src$$FloatRegister);
+    } else {
+      // USHR places the right-shifted bits into dst.
+      // SLI shifts src left and inserts those bits into dst.
+      __ ushr($dst$$FloatRegister, get_arrangement(this),
+              $src$$FloatRegister, rshift);
+      __ sli($dst$$FloatRegister, get_arrangement(this),
+             $src$$FloatRegister, lshift);
     }
   %}
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -1957,32 +1957,12 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
     int opc = this->ideal_Opcode();
     BasicType bt = Matcher::vector_element_basic_type(this);
     int esize = type2aelembytes(bt) * BitsPerByte;
-    int raw_shift = (int)$shift$$constant;
-
-    // Compute left and right shift amounts.
-    int lshift, rshift;
-    if (opc == Op_RotateLeftV) {
-      lshift = raw_shift & (esize - 1);
-      rshift = esize - lshift;
-    } else {
-      assert(opc == Op_RotateRightV, "unexpected opcode");
-      rshift = raw_shift & (esize - 1);
-      lshift = esize - rshift;
-    }
-
-    if (lshift == 0 || rshift == 0) {
-      // Rotate by 0 (or by element width) is identity - just copy.
-      uint length_in_bytes = Matcher::vector_length_in_bytes(this);
-      __ orr($dst$$FloatRegister, length_in_bytes == 16 ? __ T16B : __ T8B,
-             $src$$FloatRegister, $src$$FloatRegister);
-    } else {
-      // USHR places the right-shifted bits into dst.
-      // SLI shifts src left and inserts those bits into dst.
-      __ ushr($dst$$FloatRegister, get_arrangement(this),
-              $src$$FloatRegister, rshift);
-      __ sli($dst$$FloatRegister, get_arrangement(this),
-             $src$$FloatRegister, lshift);
-    }
+    int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
+                                      $shift$$constant : -$shift$$constant);
+    int lshift = raw_shift & (esize - 1);
+    int rshift = -lshift   & (esize - 1);
+    __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
+                          $src$$FloatRegister, lshift, rshift);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -1959,10 +1959,8 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
     int esize = type2aelembytes(bt) * BitsPerByte;
     int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
                                       $shift$$constant : -$shift$$constant);
-    int lshift = raw_shift & (esize - 1);
-    int rshift = -lshift   & (esize - 1);
     __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
-                          $src$$FloatRegister, lshift, rshift);
+                          $src$$FloatRegister, esize, raw_shift & (esize - 1));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -1960,7 +1960,7 @@ instruct vrotateconstant(vReg dst, vReg src, immI shift) %{
     int raw_shift = checked_cast<int>(opc == Op_RotateLeftV ?
                                       $shift$$constant : -$shift$$constant);
     __ neon_vector_rotate($dst$$FloatRegister, get_arrangement(this),
-                          $src$$FloatRegister, esize, raw_shift & (esize - 1));
+                          $src$$FloatRegister, raw_shift & (esize - 1));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7213,6 +7213,8 @@ void MacroAssembler::fast_unlock(Register obj, Register t1, Register t2, Registe
 // Rotate using USHR and SLI instructions (or copy, if rotate count is zero)
 void MacroAssembler::neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
                                         FloatRegister src, int shift_amount) {
+  assert(src != dst, "did not expect src and dst to be the same register");
+
   int esize = BitsPerByte << (T / 2);
   int lshift = shift_amount & (esize - 1);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7212,11 +7212,9 @@ void MacroAssembler::fast_unlock(Register obj, Register t1, Register t2, Registe
 
 // Rotate using USHR and SLI instructions (or copy, if rotate count is zero)
 void MacroAssembler::neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
-                                        FloatRegister src, int lshift) {
-  // Derive element size in bits from `T`.  `esize=8` for `T8B` and `T16B`,
-  // `esize=16` for `T4H` and `T8H`, and so on.
-  int esize = 8 << (T / 2);
-  assert(lshift >= 0 && lshift < esize, "shift amount is out of range");
+                                        FloatRegister src, int shift_amount) {
+  int esize = BitsPerByte << (T / 2);
+  int lshift = shift_amount & (esize - 1);
 
   if (lshift == 0) {
     // T & 1 == 0 => 64-bit arrangements, else 128-bit arrangements

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7209,3 +7209,18 @@ void MacroAssembler::fast_unlock(Register obj, Register t1, Register t2, Registe
 
   bind(unlocked);
 }
+
+// Rotate using USHR and SLI instructions (or copy, if rotate count is zero)
+void MacroAssembler::neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
+                                        FloatRegister src, int lshift,
+                                        int rshift) {
+  assert(lshift >= 0 && rshift >= 0, "shift amounts must be non-negative");
+
+  if (lshift == 0 || rshift == 0) {
+    // T & 1 == 0 => 64-bit arrangements, else 128-bit arrangements
+    orr(dst, (T & 1) == 0 ? T8B : T16B, src, src);
+  } else {
+    ushr(dst, T, src, rshift);
+    sli(dst, T, src, lshift);
+  }
+}

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7212,15 +7212,15 @@ void MacroAssembler::fast_unlock(Register obj, Register t1, Register t2, Registe
 
 // Rotate using USHR and SLI instructions (or copy, if rotate count is zero)
 void MacroAssembler::neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
-                                        FloatRegister src, int lshift,
-                                        int rshift) {
-  assert(lshift >= 0 && rshift >= 0, "shift amounts must be non-negative");
+                                        FloatRegister src, int esize,
+                                        int lshift) {
+  assert(lshift >= 0 && lshift < esize, "shift amount is out of range");
 
-  if (lshift == 0 || rshift == 0) {
+  if (lshift == 0) {
     // T & 1 == 0 => 64-bit arrangements, else 128-bit arrangements
     orr(dst, (T & 1) == 0 ? T8B : T16B, src, src);
   } else {
-    ushr(dst, T, src, rshift);
+    ushr(dst, T, src, esize - lshift);
     sli(dst, T, src, lshift);
   }
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7212,8 +7212,10 @@ void MacroAssembler::fast_unlock(Register obj, Register t1, Register t2, Registe
 
 // Rotate using USHR and SLI instructions (or copy, if rotate count is zero)
 void MacroAssembler::neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
-                                        FloatRegister src, int esize,
-                                        int lshift) {
+                                        FloatRegister src, int lshift) {
+  // Derive element size in bits from `T`.  `esize=8` for `T8B` and `T16B`,
+  // `esize=16` for `T4H` and `T8H`, and so on.
+  int esize = 8 << (T / 2);
   assert(lshift >= 0 && lshift < esize, "shift amount is out of range");
 
   if (lshift == 0) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1628,10 +1628,9 @@ public:
           const FloatRegister (&stateVectors)[16], int idx1, int idx2,
           int idx3, int idx4);
 
-  // Rotate using ORR (for identity) or USHR + SLI.  `lshift` is the left shift
-  // amount, masked to the appropriate type size by the caller.
+  // Rotate using ORR (for identity) or USHR + SLI.
   void neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
-                          FloatRegister src, int lshift);
+                          FloatRegister src, int shift_amount);
 
   // Place an ISB after code may have been modified due to a safepoint.
   void safepoint_isb();

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1628,6 +1628,9 @@ public:
           const FloatRegister (&stateVectors)[16], int idx1, int idx2,
           int idx3, int idx4);
 
+  void neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
+                          FloatRegister src, int lshift, int rshift);
+
   // Place an ISB after code may have been modified due to a safepoint.
   void safepoint_isb();
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1628,8 +1628,11 @@ public:
           const FloatRegister (&stateVectors)[16], int idx1, int idx2,
           int idx3, int idx4);
 
+  // Rotate using ORR (for identity) or USHR + SLI.  `esize` is the element
+  // width in bits (8, 16, 32, or 64) and `lshift` is the left shift amount,
+  // masked by the caller.
   void neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
-                          FloatRegister src, int lshift, int rshift);
+                          FloatRegister src, int esize, int lshift);
 
   // Place an ISB after code may have been modified due to a safepoint.
   void safepoint_isb();

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1628,11 +1628,10 @@ public:
           const FloatRegister (&stateVectors)[16], int idx1, int idx2,
           int idx3, int idx4);
 
-  // Rotate using ORR (for identity) or USHR + SLI.  `esize` is the element
-  // width in bits (8, 16, 32, or 64) and `lshift` is the left shift amount,
-  // masked by the caller.
+  // Rotate using ORR (for identity) or USHR + SLI.  `lshift` is the left shift
+  // amount, masked to the appropriate type size by the caller.
   void neon_vector_rotate(FloatRegister dst, SIMD_Arrangement T,
-                          FloatRegister src, int esize, int lshift);
+                          FloatRegister src, int lshift);
 
   // Place an ISB after code may have been modified due to a safepoint.
   void safepoint_isb();

--- a/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
@@ -141,8 +141,10 @@
   }
 
   // Does the CPU supports vector constant rotate instructions?
+  // NEON supports constant rotates via USHR+SLI (2-instruction sequence).
+  // The shift value will be masked to the element width in the .ad rule.
   static constexpr bool supports_vector_constant_rotates(int shift) {
-    return false;
+    return true;
   }
 
   // Does the CPU supports vector unsigned comparison instructions?

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorRotateConstantAArch64.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorRotateConstantAArch64.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @summary Test that constant-count vector rotates on AArch64 NEON emit
+ *          RotateLeftV / RotateRightV IR nodes instead of decomposing them.
+ * @requires vm.compiler2.enabled
+ * @requires os.arch == "aarch64" & vm.cpu.features ~= ".*simd.*"
+ * @modules jdk.incubator.vector
+ * @library /test/lib /
+ * @run driver compiler.vectorapi.TestVectorRotateConstantAArch64
+ */
+public class TestVectorRotateConstantAArch64 {
+
+    static final VectorSpecies<Long> L_SPECIES_128 = LongVector.SPECIES_128;
+    static final VectorSpecies<Integer> I_SPECIES_128 = IntVector.SPECIES_128;
+    static final VectorSpecies<Short> S_SPECIES_128 = ShortVector.SPECIES_128;
+    static final VectorSpecies<Byte> B_SPECIES_128 = ByteVector.SPECIES_128;
+
+    static final int SIZE = 256;
+    static final int INT_INCR = I_SPECIES_128.length();
+    static final int BYTE_INCR = B_SPECIES_128.length();
+    static final int LONG_INCR = L_SPECIES_128.length();
+    static final int SHORT_INCR = S_SPECIES_128.length();
+    static final int INT_BOUND = I_SPECIES_128.loopBound(SIZE);
+    static final int BYTE_BOUND = B_SPECIES_128.loopBound(SIZE);
+    static final int LONG_BOUND = L_SPECIES_128.loopBound(SIZE);
+    static final int SHORT_BOUND = S_SPECIES_128.loopBound(SIZE);
+
+    static int[] iinp = new int[SIZE];
+    static int[] iout = new int[SIZE];
+    static byte[] binp = new byte[SIZE];
+    static byte[] bout = new byte[SIZE];
+    static long[] linp = new long[SIZE];
+    static long[] lout = new long[SIZE];
+    static short[] sinp = new short[SIZE];
+    static short[] sout = new short[SIZE];
+
+    static {
+        Random r = new Random(42);
+        for (int i = 0; i < SIZE; i++) {
+            iinp[i] = r.nextInt();
+            linp[i] = r.nextLong();
+            binp[i] = (byte) r.nextInt();
+            sinp[i] = (short) r.nextInt();
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftInt_shift0() {
+        for (int i = 0; i < INT_BOUND; i += INT_INCR) {
+            IntVector.fromArray(I_SPECIES_128, iinp, i)
+                     .lanewise(VectorOperators.ROL, 0)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftInt_shift31() {
+        for (int i = 0; i < INT_BOUND; i += INT_INCR) {
+            IntVector.fromArray(I_SPECIES_128, iinp, i)
+                     .lanewise(VectorOperators.ROL, 31)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftInt_shift37() {
+        for (int i = 0; i < INT_BOUND; i += INT_INCR) {
+            IntVector.fromArray(I_SPECIES_128, iinp, i)
+                     .lanewise(VectorOperators.ROL, 37)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_RIGHT_V, "> 0"})
+    public static void testRotateRightInt_shift13() {
+        for (int i = 0; i < INT_BOUND; i += INT_INCR) {
+            IntVector.fromArray(I_SPECIES_128, iinp, i)
+                     .lanewise(VectorOperators.ROR, 13)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_RIGHT_V, "> 0"})
+    public static void testRotateRightInt_shift31() {
+        for (int i = 0; i < INT_BOUND; i += INT_INCR) {
+            IntVector.fromArray(I_SPECIES_128, iinp, i)
+                     .lanewise(VectorOperators.ROR, 31)
+                     .intoArray(iout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftLong_shift0() {
+        for (int i = 0; i < LONG_BOUND; i += LONG_INCR) {
+            LongVector.fromArray(L_SPECIES_128, linp, i)
+                      .lanewise(VectorOperators.ROL, 0)
+                      .intoArray(lout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftLong_shift63() {
+        for (int i = 0; i < LONG_BOUND; i += LONG_INCR) {
+            LongVector.fromArray(L_SPECIES_128, linp, i)
+                      .lanewise(VectorOperators.ROL, 63)
+                      .intoArray(lout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftLong_shift67() {
+        for (int i = 0; i < LONG_BOUND; i += LONG_INCR) {
+            LongVector.fromArray(L_SPECIES_128, linp, i)
+                      .lanewise(VectorOperators.ROL, 67)
+                      .intoArray(lout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_RIGHT_V, "> 0"})
+    public static void testRotateRightLong_shift13() {
+        for (int i = 0; i < LONG_BOUND; i += LONG_INCR) {
+            LongVector.fromArray(L_SPECIES_128, linp, i)
+                      .lanewise(VectorOperators.ROR, 13)
+                      .intoArray(lout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_RIGHT_V, "> 0"})
+    public static void testRotateRightLong_shift63() {
+        for (int i = 0; i < LONG_BOUND; i += LONG_INCR) {
+            LongVector.fromArray(L_SPECIES_128, linp, i)
+                      .lanewise(VectorOperators.ROR, 63)
+                      .intoArray(lout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftShort_shift0() {
+        for (int i = 0; i < SHORT_BOUND; i += SHORT_INCR) {
+            ShortVector.fromArray(S_SPECIES_128, sinp, i)
+                       .lanewise(VectorOperators.ROL, 0)
+                       .intoArray(sout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftShort_shift7() {
+        for (int i = 0; i < SHORT_BOUND; i += SHORT_INCR) {
+            ShortVector.fromArray(S_SPECIES_128, sinp, i)
+                       .lanewise(VectorOperators.ROL, 7)
+                       .intoArray(sout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftShort_shift15() {
+        for (int i = 0; i < SHORT_BOUND; i += SHORT_INCR) {
+            ShortVector.fromArray(S_SPECIES_128, sinp, i)
+                       .lanewise(VectorOperators.ROL, 15)
+                       .intoArray(sout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftShort_shift16() {
+        for (int i = 0; i < SHORT_BOUND; i += SHORT_INCR) {
+            ShortVector.fromArray(S_SPECIES_128, sinp, i)
+                       .lanewise(VectorOperators.ROL, 16)
+                       .intoArray(sout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftShort_shift19() {
+        for (int i = 0; i < SHORT_BOUND; i += SHORT_INCR) {
+            ShortVector.fromArray(S_SPECIES_128, sinp, i)
+                       .lanewise(VectorOperators.ROL, 19)
+                       .intoArray(sout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_RIGHT_V, "> 0"})
+    public static void testRotateRightShort_shift5() {
+        for (int i = 0; i < SHORT_BOUND; i += SHORT_INCR) {
+            ShortVector.fromArray(S_SPECIES_128, sinp, i)
+                       .lanewise(VectorOperators.ROR, 5)
+                       .intoArray(sout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftByte_shift0() {
+        for (int i = 0; i < BYTE_BOUND; i += BYTE_INCR) {
+            ByteVector.fromArray(B_SPECIES_128, binp, i)
+                      .lanewise(VectorOperators.ROL, 0)
+                      .intoArray(bout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftByte_shift4() {
+        for (int i = 0; i < BYTE_BOUND; i += BYTE_INCR) {
+            ByteVector.fromArray(B_SPECIES_128, binp, i)
+                      .lanewise(VectorOperators.ROL, 4)
+                      .intoArray(bout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftByte_shift7() {
+        for (int i = 0; i < BYTE_BOUND; i += BYTE_INCR) {
+            ByteVector.fromArray(B_SPECIES_128, binp, i)
+                      .lanewise(VectorOperators.ROL, 7)
+                      .intoArray(bout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftByte_shift8() {
+        for (int i = 0; i < BYTE_BOUND; i += BYTE_INCR) {
+            ByteVector.fromArray(B_SPECIES_128, binp, i)
+                      .lanewise(VectorOperators.ROL, 8)
+                      .intoArray(bout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "> 0"})
+    public static void testRotateLeftByte_shift11() {
+        for (int i = 0; i < BYTE_BOUND; i += BYTE_INCR) {
+            ByteVector.fromArray(B_SPECIES_128, binp, i)
+                      .lanewise(VectorOperators.ROL, 11)
+                      .intoArray(bout, i);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ROTATE_RIGHT_V, "> 0"})
+    public static void testRotateRightByte_shift3() {
+        for (int i = 0; i < BYTE_BOUND; i += BYTE_INCR) {
+            ByteVector.fromArray(B_SPECIES_128, binp, i)
+                      .lanewise(VectorOperators.ROR, 3)
+                      .intoArray(bout, i);
+        }
+    }
+
+    @Run(test = {
+                 // Int tests
+                 "testRotateLeftInt_shift0", "testRotateLeftInt_shift31",
+                 "testRotateLeftInt_shift37", "testRotateRightInt_shift13",
+                 "testRotateRightInt_shift31",
+
+                 // Long tests
+                 "testRotateLeftLong_shift0", "testRotateLeftLong_shift63",
+                 "testRotateLeftLong_shift67", "testRotateRightLong_shift13",
+                 "testRotateRightLong_shift63",
+
+                 // Short tests
+                 "testRotateLeftShort_shift0", "testRotateLeftShort_shift7",
+                 "testRotateLeftShort_shift15", "testRotateLeftShort_shift16",
+                 "testRotateLeftShort_shift19", "testRotateRightShort_shift5",
+
+                 // Byte tests
+                 "testRotateLeftByte_shift0", "testRotateLeftByte_shift4",
+                 "testRotateLeftByte_shift7", "testRotateLeftByte_shift8",
+                 "testRotateLeftByte_shift11", "testRotateRightByte_shift3",
+    })
+    public void verifyAllRotates() {
+        testRotateLeftInt_shift0();
+        verifyInt(iout, iinp, 0, true);
+
+        testRotateLeftInt_shift31();
+        verifyInt(iout, iinp, 31, true);
+
+        testRotateLeftInt_shift37();
+        verifyInt(iout, iinp, 37, true);
+
+        testRotateRightInt_shift13();
+        verifyInt(iout, iinp, 13, false);
+
+        testRotateRightInt_shift31();
+        verifyInt(iout, iinp, 31, false);
+
+        testRotateLeftLong_shift0();
+        verifyLong(lout, linp, 0, true);
+
+        testRotateLeftLong_shift63();
+        verifyLong(lout, linp, 63, true);
+
+        testRotateLeftLong_shift67();
+        verifyLong(lout, linp, 67, true);
+
+        testRotateRightLong_shift13();
+        verifyLong(lout, linp, 13, false);
+
+        testRotateRightLong_shift63();
+        verifyLong(lout, linp, 63, false);
+
+        testRotateLeftShort_shift0();
+        verifyShort(sout, sinp, 0, true);
+
+        testRotateLeftShort_shift7();
+        verifyShort(sout, sinp, 7, true);
+
+        testRotateLeftShort_shift15();
+        verifyShort(sout, sinp, 15, true);
+
+        testRotateLeftShort_shift16();
+        verifyShort(sout, sinp, 16, true);
+
+        testRotateLeftShort_shift19();
+        verifyShort(sout, sinp, 19, true);
+
+        testRotateRightShort_shift5();
+        verifyShort(sout, sinp, 5, false);
+
+        testRotateLeftByte_shift0();
+        verifyByte(bout, binp, 0, true);
+
+        testRotateLeftByte_shift4();
+        verifyByte(bout, binp, 4, true);
+
+        testRotateLeftByte_shift7();
+        verifyByte(bout, binp, 7, true);
+
+        testRotateLeftByte_shift8();
+        verifyByte(bout, binp, 8, true);
+
+        testRotateLeftByte_shift11();
+        verifyByte(bout, binp, 11, true);
+
+        testRotateRightByte_shift3();
+        verifyByte(bout, binp, 3, false);
+    }
+
+    static void verifyInt(int[] dst, int[] src, int shift, boolean left) {
+        int bound = I_SPECIES_128.loopBound(src.length);
+        for (int i = 0; i < bound; i++) {
+            int expected = left ? Integer.rotateLeft(src[i], shift)
+                                : Integer.rotateRight(src[i], shift);
+            Asserts.assertEquals(dst[i], expected,
+                "int rotate" + (left ? "Left" : "Right") + " failed at index " + i +
+                ": src=" + Integer.toHexString(src[i]) + " shift=" + shift);
+        }
+    }
+
+    static void verifyLong(long[] dst, long[] src, int shift, boolean left) {
+        int bound = L_SPECIES_128.loopBound(src.length);
+        for (int i = 0; i < bound; i++) {
+            long expected = left ? Long.rotateLeft(src[i], shift)
+                                 : Long.rotateRight(src[i], shift);
+            Asserts.assertEquals(dst[i], expected,
+                "long rotate" + (left ? "Left" : "Right") + " failed at index " + i +
+                ": src=" + Long.toHexString(src[i]) + " shift=" + shift);
+        }
+    }
+
+    static short rotateShort(short val, int shift, boolean left) {
+        int n = left ? (shift & 15) : ((-shift) & 15);
+        int unsigned = val & 0xFFFF;
+        return (short) ((unsigned << n) | (unsigned >>> (16 - n)));
+    }
+
+    static void verifyShort(short[] dst, short[] src, int shift, boolean left) {
+        int bound = S_SPECIES_128.loopBound(src.length);
+        for (int i = 0; i < bound; i++) {
+            short expected = rotateShort(src[i], shift, left);
+            Asserts.assertEquals(dst[i], expected,
+                "short rotate" + (left ? "Left" : "Right") + " failed at index " + i +
+                ": src=" + Integer.toHexString(src[i] & 0xFFFF) + " shift=" + shift);
+        }
+    }
+
+    static byte rotateByte(byte val, int shift, boolean left) {
+        int n = left ? (shift & 7) : ((-shift) & 7);
+        int unsigned = val & 0xFF;
+        return (byte) ((unsigned << n) | (unsigned >>> (8 - n)));
+    }
+
+    static void verifyByte(byte[] dst, byte[] src, int shift, boolean left) {
+        int bound = B_SPECIES_128.loopBound(src.length);
+        for (int i = 0; i < bound; i++) {
+            byte expected = rotateByte(src[i], shift, left);
+            Asserts.assertEquals(dst[i], expected,
+                "byte rotate" + (left ? "Left" : "Right") + " failed at index " + i +
+                ": src=" + Integer.toHexString(src[i] & 0xFF) + " shift=" + shift);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -78,7 +78,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true", "asimd", "true"},
         counts = {IRNode.ROTATE_RIGHT_V, ">0"})
     public int[] intCombinedRotateShift() {
         int[] res = new int[SIZE];
@@ -107,7 +107,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true", "asimd", "true"},
         counts = {IRNode.ROTATE_RIGHT_V, ">0"})
     public long[] longCombinedRotateShift() {
         long[] res = new long[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -78,7 +78,10 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true", "asimd", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true"},
+        counts = {IRNode.ROTATE_RIGHT_V, ">0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "<= 16"},
         counts = {IRNode.ROTATE_RIGHT_V, ">0"})
     public int[] intCombinedRotateShift() {
         int[] res = new int[SIZE];
@@ -107,7 +110,10 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true", "asimd", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true"},
+        counts = {IRNode.ROTATE_RIGHT_V, ">0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "<= 16"},
         counts = {IRNode.ROTATE_RIGHT_V, ">0"})
     public long[] longCombinedRotateShift() {
         long[] res = new long[SIZE];


### PR DESCRIPTION
Before this patch, on AArch64 processors with NEON, `RotateLeftV` nodes
were decomposed to expressions of the form `(x << n) | (x >> (N-n))`,
where `n` is the number of bits to rotate by and `N` is the size of the
type.  `RotateRightV` nodes were similar, with `n` substitued by `N-n`.
This decomposition happens at the level of Ideal graph rewrites, and
these expressions translate to three instructions on NEON: `SHL` for
`x << n`, `USHR` for `x >> (N-n)`, and `ORR` for combining the two
values.

However, NEON supports the `SLI` instruction, which shifts left while
also preserving the destination register's low bits that a pure
left-shift operation would have overwritten with zeroes.  This allows us
to lower a rotate operations into `USHR` + `SLI` instructions, thus
emitting one fewer instruction than before.  Of course, this only works
when the bits to rotate by is a known constant, so this patch does not
modify the lowering of variable-count rotates, letting them decompose
into LeftShift + RightShift + Or nodes as before.

Perhaps of note, this patch enables the optimized lowering for not just
32- and 64-bit integers, but also for subword types (specifically,
`byte` and `short` types).  I've included a good deal of tests for
coverage, but I am unsure whether there is anything in the rest of C2's
compilation that might break from allowing subword types to be lowered
the same way as `int` and `long` types.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381650](https://bugs.openjdk.org/browse/JDK-8381650): Vector rotate operations on AArch64 with NEON (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30574/head:pull/30574` \
`$ git checkout pull/30574`

Update a local copy of the PR: \
`$ git checkout pull/30574` \
`$ git pull https://git.openjdk.org/jdk.git pull/30574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30574`

View PR using the GUI difftool: \
`$ git pr show -t 30574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30574.diff">https://git.openjdk.org/jdk/pull/30574.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30574#issuecomment-4185849279)
</details>
