### PR TITLE
8381775: ZGC: Optimize segmented array clearing to improve time to safepoint

### DIFF
--- a/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
@@ -32,10 +32,6 @@
 ZObjArrayAllocator::ZObjArrayAllocator(Klass* klass, size_t word_size, int length, bool do_zero, Thread* thread)
   : ObjArrayAllocator(klass, word_size, length, do_zero, thread) {}
 
-void ZObjArrayAllocator::yield_for_safepoint() const {
-  ThreadBlockInVM tbivm(JavaThread::cast(_thread));
-}
-
 oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
   // ZGC specializes the initialization by performing segmented clearing
   // to allow shorter time-to-safepoints.
@@ -107,33 +103,41 @@ oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
   bool seen_gc_safepoint = false;
 
   auto initialize_memory = [&]() {
-    for (size_t processed = 0; processed < process_size; processed += segment_max) {
-      // Clear segment
-      uintptr_t* const start = (uintptr_t*)(mem + process_start_offset + processed);
-      const size_t remaining = process_size - processed;
-      const size_t segment = MIN2(remaining, segment_max);
-      // Usually, the young marking code has the responsibility to color
-      // raw nulls, before they end up in the old generation. However, the
-      // invisible roots are hidden from the marking code, and therefore
-      // we must color the nulls already here in the initialization. The
-      // color we choose must be store bad for any subsequent stores, regardless
-      // of how many GC flips later it will arrive. That's why we OR in 11
-      // (ZPointerRememberedMask) in the remembered bits, similar to how
-      // forgotten old oops also have 11, for the very same reason.
-      // However, we opportunistically try to color without the 11 remembered
-      // bits, hoping to not get interrupted in the middle of a GC safepoint.
-      // Most of the time, we manage to do that, and can the avoid having GC
-      // barriers trigger slow paths for this.
-      const uintptr_t colored_null = seen_gc_safepoint ? (ZPointerStoreGoodMask | ZPointerRememberedMask)
-                                                       : ZPointerStoreGoodMask;
-      const uintptr_t fill_value = is_reference_type(element_type) ? colored_null : 0;
-      ZUtils::fill(start, segment, fill_value);
+    // Usually, the young marking code has the responsibility to color
+    // raw nulls, before they end up in the old generation. However, the
+    // invisible roots are hidden from the marking code, and therefore
+    // we must color the nulls already here in the initialization. The
+    // color we choose must be store bad for any subsequent stores, regardless
+    // of how many GC flips later it will arrive. That's why we OR in 11
+    // (ZPointerRememberedMask) in the remembered bits, similar to how
+    // forgotten old oops also have 11, for the very same reason.
+    // However, we opportunistically try to color without the 11 remembered
+    // bits, hoping to not get interrupted in the middle of a GC safepoint.
+    // Most of the time, we manage to do that, and can the avoid having GC
+    // barriers trigger slow paths for this.
+    const uintptr_t colored_null = seen_gc_safepoint ? (ZPointerStoreGoodMask | ZPointerRememberedMask)
+                                                     : ZPointerStoreGoodMask;
+    const uintptr_t fill_value = is_reference_type(element_type) ? colored_null : 0;
 
-      // Safepoint
-      yield_for_safepoint();
+    if (seen_gc_safepoint || !is_reference_type(element_type)) {
+      ThreadBlockInVM tbivm(JavaThread::cast(_thread));
+      uintptr_t* const start = (uintptr_t*)(mem + process_start_offset);
+      ZUtils::fill(start, process_size, fill_value);
+      return true;
+    }
+
+    for (size_t processed = 0; processed < process_size; processed += segment_max) {
+      {
+        ThreadBlockInVM tbivm(JavaThread::cast(_thread));
+        // Clear segment
+        uintptr_t* const start = (uintptr_t*)(mem + process_start_offset + processed);
+        const size_t remaining = process_size - processed;
+        const size_t segment = MIN2(remaining, segment_max);
+        ZUtils::fill(start, segment, fill_value);
+      }
 
       // Deal with safepoints
-      if (is_reference_type(element_type) && !seen_gc_safepoint && gc_safepoint_happened()) {
+      if (!seen_gc_safepoint && gc_safepoint_happened()) {
         // The first time we observe a GC safepoint in the yield point,
         // we have to restart processing with 11 remembered bits.
         seen_gc_safepoint = true;

--- a/src/hotspot/share/gc/z/zObjArrayAllocator.hpp
+++ b/src/hotspot/share/gc/z/zObjArrayAllocator.hpp
@@ -30,8 +30,6 @@ class ZObjArrayAllocator : public ObjArrayAllocator {
 private:
   virtual oop initialize(HeapWord* mem) const override;
 
-  void yield_for_safepoint() const;
-
 public:
   ZObjArrayAllocator(Klass* klass, size_t word_size, int length, bool do_zero, Thread* thread);
 };


### PR DESCRIPTION
The change is to improve prolonged time to safepoint caused by large array clearing after being allocated from heap.

Current impl yields for safepoint after clearing one segment of the array content by calling `ZObjArrayAllocator::yield_for_safepoint` method which simply creates stack object like `ThreadBlockInVM tbivm(JavaThread::cast(_thread));`. The issue with approach is current mutator thread stay in  state `_thread_blocked` for very small time, if there is safepoint gobal poll, but local poll of the thread has not been armed, the mutator thread won't be blocked at waiter barrier until next invoke of `yield_for_safepoint`. If we know thread thread is going to do some work which is safepoint safe, the work should be done in the ThreadBlockInVM block like:

```
{
    ThreadBlockInVM tbivm(JavaThread::cast(_thread));
    <do-the-works-are-safepoint-safe-here>
}
```

I have run the reproducers attached in the JBS ticket on MacOS with M3 Pro chips, here are the result for comparison:

LargeArrayInit test with the fix:
```
./images/jdk/bin/java -Xms8G -Xmx8G -XX:+UseZGC -Xlog:safepoint\* ~/LargeArrayInit.java | grep -Eo "Reaching safepoint:.+?ns"
Reaching safepoint: 640084 ns
Reaching safepoint: 4250 ns
Reaching safepoint: 3584 ns
Reaching safepoint: 3500 ns
Reaching safepoint: 12959 ns
Reaching safepoint: 3417 ns
Reaching safepoint: 4084 ns
Reaching safepoint: 3708 ns
Reaching safepoint: 292 ns
Reaching safepoint: 5334 ns
Reaching safepoint: 24209 ns
Reaching safepoint: 4834 ns
Reaching safepoint: 3125 ns
Reaching safepoint: 7500 ns
Reaching safepoint: 7042 ns
Reaching safepoint: 10791 ns
Reaching safepoint: 28458 ns
Reaching safepoint: 3083 ns
Reaching safepoint: 2958 ns
Reaching safepoint: 3583 ns
Reaching safepoint: 1125 ns
Reaching safepoint: 709 ns
Reaching safepoint: 9875 ns
Reaching safepoint: 1750 ns
Reaching safepoint: 8459 ns
Reaching safepoint: 8292 ns
Reaching safepoint: 2459 ns
Reaching safepoint: 1167 ns
```
LargeArrayInit test w/o the fix:

```
./images/jdk/bin/java -Xms8G -Xmx8G -XX:+UseZGC -Xlog:safepoint\* ~/LargeArrayInit.java | grep -Eo "Reaching safepoint:.+?ns"
Reaching safepoint: 29666 ns
Reaching safepoint: 20833 ns
Reaching safepoint: 33584 ns
Reaching safepoint: 29709 ns
Reaching safepoint: 28833 ns
Reaching safepoint: 29250 ns
Reaching safepoint: 28125 ns
Reaching safepoint: 25917 ns
Reaching safepoint: 25583 ns
Reaching safepoint: 27167 ns
Reaching safepoint: 28958 ns
Reaching safepoint: 27084 ns
Reaching safepoint: 25292 ns
Reaching safepoint: 38125 ns
Reaching safepoint: 21500 ns
Reaching safepoint: 39500 ns
Reaching safepoint: 3580500 ns
Reaching safepoint: 146667 ns
Reaching safepoint: 7099208 ns
Reaching safepoint: 4778792 ns
Reaching safepoint: 2274167 ns
Reaching safepoint: 29083 ns
Reaching safepoint: 2268916 ns
Reaching safepoint: 20125 ns
Reaching safepoint: 2261667 ns
Reaching safepoint: 50792 ns
Reaching safepoint: 17334 ns
Reaching safepoint: 36542 ns

```

LargeObjectArrayInit with the fix:

```
images/jdk/bin/java -Xms8G -Xmx8G -XX:+UseZGC -Xlog:safepoint\* ~/LargeObjectArrayInit.java | grep -Eo "Reaching safepoint:.+?ns"
Reaching safepoint: 180333 ns
Reaching safepoint: 3917 ns
Reaching safepoint: 1125 ns
Reaching safepoint: 3875 ns
Reaching safepoint: 8333 ns
Reaching safepoint: 4458 ns
Reaching safepoint: 9792 ns
Reaching safepoint: 4292 ns
Reaching safepoint: 2333 ns
Reaching safepoint: 3459 ns
Reaching safepoint: 2709 ns
Reaching safepoint: 15666 ns
Reaching safepoint: 4416 ns
Reaching safepoint: 8500 ns
Reaching safepoint: 2875 ns
Reaching safepoint: 10250 ns
Reaching safepoint: 7375 ns
Reaching safepoint: 2208 ns
Reaching safepoint: 4208 ns
Reaching safepoint: 4000 ns
Reaching safepoint: 4042 ns
Reaching safepoint: 416 ns
Reaching safepoint: 709 ns
Reaching safepoint: 4417 ns
Reaching safepoint: 3541 ns
Reaching safepoint: 4208 ns
Reaching safepoint: 3041 ns
Reaching safepoint: 833 ns
Reaching safepoint: 2250 ns
Reaching safepoint: 140375 ns
Reaching safepoint: 4708 ns
Reaching safepoint: 2667 ns
Reaching safepoint: 4541 ns
Reaching safepoint: 1875 ns
Reaching safepoint: 667 ns
Reaching safepoint: 3875 ns
Reaching safepoint: 15917 ns
Reaching safepoint: 4125 ns
Reaching safepoint: 5042 ns
```

LargeObjectArrayInit w/o the fix:
```
./images/jdk/bin/java -Xms8G -Xmx8G -XX:+UseZGC -Xlog:safepoint\* ~/LargeObjectArrayInit.java | grep -Eo "Reaching safepoint:.+?ns"
Reaching safepoint: 160459 ns
Reaching safepoint: 28167 ns
Reaching safepoint: 25333 ns
Reaching safepoint: 39584 ns
Reaching safepoint: 32083 ns
Reaching safepoint: 31750 ns
Reaching safepoint: 29375 ns
Reaching safepoint: 26958 ns
Reaching safepoint: 40084 ns
Reaching safepoint: 38583 ns
Reaching safepoint: 27916 ns
Reaching safepoint: 29958 ns
Reaching safepoint: 27500 ns
Reaching safepoint: 30458 ns
Reaching safepoint: 26750 ns
Reaching safepoint: 31958 ns
Reaching safepoint: 27875 ns
Reaching safepoint: 262875 ns
Reaching safepoint: 3625 ns
Reaching safepoint: 2292 ns
Reaching safepoint: 18041 ns
Reaching safepoint: 25125 ns
Reaching safepoint: 39125 ns
Reaching safepoint: 67250 ns
Reaching safepoint: 22292 ns
Reaching safepoint: 16000 ns
Reaching safepoint: 880958 ns
Reaching safepoint: 236041 ns
Reaching safepoint: 3750 ns
Reaching safepoint: 1834 ns
Reaching safepoint: 542 ns
Reaching safepoint: 2333 ns
Reaching safepoint: 19958 ns
Reaching safepoint: 4625 ns
Reaching safepoint: 15625 ns
Reaching safepoint: 18291 ns
Reaching safepoint: 30959 ns
Reaching safepoint: 17250 ns
Reaching safepoint: 15000 ns
Reaching safepoint: 19667 ns
Reaching safepoint: 18958 ns
```


- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

### Other tests
- [x] GHA
- [x] specjbb run with fastdebug build(stress)
- [x] tier1 with ZGC: `make test TEST=tier1 JTREG="VM_OPTIONS=-XX:+UseZGC"`
- [x] hotspot tier2 with: `make test TEST=hotspot:tier2 JTREG="VM_OPTIONS=-XX:+UseZGC"`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381775](https://bugs.openjdk.org/browse/JDK-8381775): ZGC: Optimize segmented array clearing to improve time to safepoint (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30619/head:pull/30619` \
`$ git checkout pull/30619`

Update a local copy of the PR: \
`$ git checkout pull/30619` \
`$ git pull https://git.openjdk.org/jdk.git pull/30619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30619`

View PR using the GUI difftool: \
`$ git pr show -t 30619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30619.diff">https://git.openjdk.org/jdk/pull/30619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30619#issuecomment-4209044472)
</details>
