### PR TITLE
8379129: C2 crash in LoadNode::can_split_through_phi_base during Escape Analysis (JDK 25.0.1+8)

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1671,11 +1671,15 @@ bool LoadNode::can_split_through_phi_base(PhaseGVN* phase) {
   intptr_t ignore  = 0;
   Node*    base    = AddPNode::Ideal_base_and_offset(address, phase, ignore);
 
+  if (base == nullptr) {
+    return false;
+  }
+
   if (base->is_CastPP()) {
     base = base->in(1);
   }
 
-  if (req() > 3 || base == nullptr || !base->is_Phi()) {
+  if (req() > 3 || !base->is_Phi()) {
     return false;
   }
 


### PR DESCRIPTION
This PR fixes a null pointer dereference crash in C2 during escape analysis.

Upon construction of the connection graph, the scalar replaceability of objects is adjusted. After [JDK-8287061](https://bugs.openjdk.org/browse/JDK-8287061), some allocation merges patterns are supported by the scalar replacement engine, and in `can_reduce_check_users` this check is performed. The `Phi -> AddP -> Load` case is supported when the load node can be split through the phi and, in order to check this, `can_split_through_phi_base` (essentially a copy of the validations performed by `split_through_phi`) is called.

In order to perform its checks, `can_split_through_phi_base` obtains the base of the `AddP` through `Ideal_base_and_offset`, which may return `nullptr` if the offset is not constant or the base is neither `top()` nor equal to the address. Either of those cases are allowed until now by the more global escape analysis checks, and encountering them will result in a null pointer dereference crash when trying to do `base->is_CastPP()`.

A thorough analysis was performed to try to obtain an IR shape similar to the one in the bug report, without success. In any case, it is possible to arrive to such a point with `base = nullptr`, and a defensive check such as the one proposed by this changeset can already be found in `split_through_phi`.

**Testing:** tiers 1-4, compiler stress tests

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379129](https://bugs.openjdk.org/browse/JDK-8379129): C2 crash in LoadNode::can_split_through_phi_base during Escape Analysis (JDK 25.0.1+8) (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30620/head:pull/30620` \
`$ git checkout pull/30620`

Update a local copy of the PR: \
`$ git checkout pull/30620` \
`$ git pull https://git.openjdk.org/jdk.git pull/30620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30620`

View PR using the GUI difftool: \
`$ git pr show -t 30620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30620.diff">https://git.openjdk.org/jdk/pull/30620.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30620#issuecomment-4245020316)
</details>
