### PR TITLE
8381644: Locale matching APIs should describe `null` element behavior

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3489,8 +3489,8 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of {@code Locale} instances for matching language tags
      *     sorted in descending order based on priority or weight, or an empty
      *     list if nothing matches. The list is modifiable.
-     * @throws NullPointerException if {@code priorityList} or {@code locales}
-     *     is {@code null}
+     * @throws NullPointerException if {@code priorityList}, {@code locales}, or
+     *     any elements within either are {@code null}.
      * @throws IllegalArgumentException if one or more extended language ranges
      *     are included in the given list when
      *     {@link FilteringMode#REJECT_EXTENDED_RANGES} is specified
@@ -3500,6 +3500,8 @@ public final class Locale implements Cloneable, Serializable {
     public static List<Locale> filter(List<LanguageRange> priorityList,
                                       Collection<Locale> locales,
                                       FilteringMode mode) {
+        Objects.requireNonNull(priorityList);
+        Objects.requireNonNull(locales);
         return LocaleMatcher.filter(priorityList, locales, mode);
     }
 
@@ -3518,13 +3520,15 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of {@code Locale} instances for matching language tags
      *     sorted in descending order based on priority or weight, or an empty
      *     list if nothing matches. The list is modifiable.
-     * @throws NullPointerException if {@code priorityList} or {@code locales}
-     *     is {@code null}
+     * @throws NullPointerException if {@code priorityList}, {@code locales}, or
+     *     any elements within either are {@code null}.
      *
      * @since 1.8
      */
     public static List<Locale> filter(List<LanguageRange> priorityList,
                                       Collection<Locale> locales) {
+        Objects.requireNonNull(priorityList);
+        Objects.requireNonNull(locales);
         return filter(priorityList, locales, FilteringMode.AUTOSELECT_FILTERING);
     }
 
@@ -3550,8 +3554,8 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of matching language tags sorted in descending order
      *     based on priority or weight, or an empty list if nothing matches.
      *     The list is modifiable.
-     * @throws NullPointerException if {@code priorityList} or {@code tags} is
-     *     {@code null}
+     * @throws NullPointerException if {@code priorityList}, {@code tags}, or
+     *     any elements within either are {@code null}.
      * @throws IllegalArgumentException if one or more extended language ranges
      *     are included in the given list when
      *     {@link FilteringMode#REJECT_EXTENDED_RANGES} is specified
@@ -3561,6 +3565,8 @@ public final class Locale implements Cloneable, Serializable {
     public static List<String> filterTags(List<LanguageRange> priorityList,
                                           Collection<String> tags,
                                           FilteringMode mode) {
+        Objects.requireNonNull(priorityList);
+        Objects.requireNonNull(tags);
         return LocaleMatcher.filterTags(priorityList, tags, mode);
     }
 
@@ -3587,13 +3593,14 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of matching language tags sorted in descending order
      *     based on priority or weight, or an empty list if nothing matches.
      *     The list is modifiable.
-     * @throws NullPointerException if {@code priorityList} or {@code tags} is
-     *     {@code null}
-     *
+     * @throws NullPointerException if {@code priorityList}, {@code tags}, or
+     *     any elements within either are {@code null}.
      * @since 1.8
      */
     public static List<String> filterTags(List<LanguageRange> priorityList,
                                           Collection<String> tags) {
+        Objects.requireNonNull(priorityList);
+        Objects.requireNonNull(tags);
         return filterTags(priorityList, tags, FilteringMode.AUTOSELECT_FILTERING);
     }
 
@@ -3606,13 +3613,14 @@ public final class Locale implements Cloneable, Serializable {
      * @param locales {@code Locale} instances used for matching
      * @return the best matching {@code Locale} instance chosen based on
      *     priority or weight, or {@code null} if nothing matches.
-     * @throws NullPointerException if {@code priorityList} or {@code locales} is
-     *     {@code null}
-     *
+     * @throws NullPointerException if {@code priorityList}, {@code locales}, or
+     *     any elements within either are {@code null}.
      * @since 1.8
      */
     public static Locale lookup(List<LanguageRange> priorityList,
                                 Collection<Locale> locales) {
+        Objects.requireNonNull(priorityList);
+        Objects.requireNonNull(locales);
         return LocaleMatcher.lookup(priorityList, locales);
     }
 
@@ -3628,13 +3636,15 @@ public final class Locale implements Cloneable, Serializable {
      * @param tags language tags used for matching
      * @return the best matching language tag chosen based on priority or
      *     weight, or {@code null} if nothing matches.
-     * @throws NullPointerException if {@code priorityList} or {@code tags} is
-     *     {@code null}
+     * @throws NullPointerException if {@code priorityList}, {@code tags}, or
+     *     any elements within either are {@code null}.
      *
      * @since 1.8
      */
     public static String lookupTag(List<LanguageRange> priorityList,
                                    Collection<String> tags) {
+        Objects.requireNonNull(priorityList);
+        Objects.requireNonNull(tags);
         return LocaleMatcher.lookupTag(priorityList, tags);
     }
 

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3489,8 +3489,9 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of {@code Locale} instances for matching language tags
      *     sorted in descending order based on priority or weight, or an empty
      *     list if nothing matches. The list is modifiable.
-     * @throws NullPointerException if {@code priorityList}, {@code locales}, or
-     *     any elements within either are {@code null}.
+     * @throws NullPointerException if {@code priorityList} or {@code locales}
+     *      are {@code null}. {@code NullPointerException} may be thrown if any
+     *      elements within either {@code Collection} are {@code null}.
      * @throws IllegalArgumentException if one or more extended language ranges
      *     are included in the given list when
      *     {@link FilteringMode#REJECT_EXTENDED_RANGES} is specified
@@ -3520,8 +3521,9 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of {@code Locale} instances for matching language tags
      *     sorted in descending order based on priority or weight, or an empty
      *     list if nothing matches. The list is modifiable.
-     * @throws NullPointerException if {@code priorityList}, {@code locales}, or
-     *     any elements within either are {@code null}.
+     * @throws NullPointerException if {@code priorityList} or {@code locales}
+     *      are {@code null}. {@code NullPointerException} may be thrown if any
+     *      elements within either {@code Collection} are {@code null}.
      *
      * @since 1.8
      */
@@ -3554,8 +3556,9 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of matching language tags sorted in descending order
      *     based on priority or weight, or an empty list if nothing matches.
      *     The list is modifiable.
-     * @throws NullPointerException if {@code priorityList}, {@code tags}, or
-     *     any elements within either are {@code null}.
+     * @throws NullPointerException if {@code priorityList} or {@code tags}
+     *      are {@code null}. {@code NullPointerException} may be thrown if any
+     *      elements within either {@code Collection} are {@code null}.
      * @throws IllegalArgumentException if one or more extended language ranges
      *     are included in the given list when
      *     {@link FilteringMode#REJECT_EXTENDED_RANGES} is specified
@@ -3593,8 +3596,9 @@ public final class Locale implements Cloneable, Serializable {
      * @return a list of matching language tags sorted in descending order
      *     based on priority or weight, or an empty list if nothing matches.
      *     The list is modifiable.
-     * @throws NullPointerException if {@code priorityList}, {@code tags}, or
-     *     any elements within either are {@code null}.
+     * @throws NullPointerException if {@code priorityList} or {@code tags}
+     *      are {@code null}. {@code NullPointerException} may be thrown if any
+     *      elements within either {@code Collection} are {@code null}.
      * @since 1.8
      */
     public static List<String> filterTags(List<LanguageRange> priorityList,
@@ -3613,8 +3617,9 @@ public final class Locale implements Cloneable, Serializable {
      * @param locales {@code Locale} instances used for matching
      * @return the best matching {@code Locale} instance chosen based on
      *     priority or weight, or {@code null} if nothing matches.
-     * @throws NullPointerException if {@code priorityList}, {@code locales}, or
-     *     any elements within either are {@code null}.
+     * @throws NullPointerException if {@code priorityList} or {@code locales}
+     *      are {@code null}. {@code NullPointerException} may be thrown if any
+     *      elements within either {@code Collection} are {@code null}.
      * @since 1.8
      */
     public static Locale lookup(List<LanguageRange> priorityList,
@@ -3636,9 +3641,9 @@ public final class Locale implements Cloneable, Serializable {
      * @param tags language tags used for matching
      * @return the best matching language tag chosen based on priority or
      *     weight, or {@code null} if nothing matches.
-     * @throws NullPointerException if {@code priorityList}, {@code tags}, or
-     *     any elements within either are {@code null}.
-     *
+     * @throws NullPointerException if {@code priorityList} or {@code tags}
+     *      are {@code null}. {@code NullPointerException} may be thrown if any
+     *      elements within either {@code Collection} are {@code null}.
      * @since 1.8
      */
     public static String lookupTag(List<LanguageRange> priorityList,

--- a/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,17 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Locale.*;
-import static java.util.Locale.FilteringMode.*;
-import static java.util.Locale.LanguageRange.*;
+import java.util.Locale.FilteringMode;
+import java.util.Locale.LanguageRange;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.Objects;
+
+import static java.util.Locale.FilteringMode.AUTOSELECT_FILTERING;
+import static java.util.Locale.FilteringMode.EXTENDED_FILTERING;
+import static java.util.Locale.FilteringMode.MAP_EXTENDED_RANGES;
+import static java.util.Locale.FilteringMode.REJECT_EXTENDED_RANGES;
+import static java.util.Locale.LanguageRange.MAX_WEIGHT;
+import static java.util.Locale.LanguageRange.MIN_WEIGHT;
 
 /**
  * Implementation for BCP47 Locale matching
@@ -47,6 +52,8 @@ public final class LocaleMatcher {
                                       Collection<Locale> locales,
                                       FilteringMode mode) {
         if (priorityList.isEmpty() || locales.isEmpty()) {
+            requireNonNullElements(priorityList);
+            requireNonNullElements(locales);
             return new ArrayList<>(); // need to return a empty mutable List
         }
 
@@ -72,6 +79,8 @@ public final class LocaleMatcher {
                                           Collection<String> tags,
                                           FilteringMode mode) {
         if (priorityList.isEmpty() || tags.isEmpty()) {
+            requireNonNullElements(priorityList);
+            requireNonNullElements(tags);
             return new ArrayList<>(); // need to return a empty mutable List
         }
 
@@ -311,6 +320,8 @@ public final class LocaleMatcher {
     public static Locale lookup(List<LanguageRange> priorityList,
                                 Collection<Locale> locales) {
         if (priorityList.isEmpty() || locales.isEmpty()) {
+            requireNonNullElements(priorityList);
+            requireNonNullElements(locales);
             return null;
         }
 
@@ -333,6 +344,8 @@ public final class LocaleMatcher {
     public static String lookupTag(List<LanguageRange> priorityList,
                                    Collection<String> tags) {
         if (priorityList.isEmpty() || tags.isEmpty()) {
+            requireNonNullElements(priorityList);
+            requireNonNullElements(tags);
             return null;
         }
 
@@ -664,6 +677,12 @@ public final class LocaleMatcher {
         }
 
         return list;
+    }
+
+    private static void requireNonNullElements(Collection<?> vals) {
+        for (var val : vals) {
+            Objects.requireNonNull(val);
+        }
     }
 
     private LocaleMatcher() {}

--- a/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
@@ -52,8 +52,6 @@ public final class LocaleMatcher {
                                       Collection<Locale> locales,
                                       FilteringMode mode) {
         if (priorityList.isEmpty() || locales.isEmpty()) {
-            requireNonNullElements(priorityList);
-            requireNonNullElements(locales);
             return new ArrayList<>(); // need to return a empty mutable List
         }
 
@@ -79,8 +77,6 @@ public final class LocaleMatcher {
                                           Collection<String> tags,
                                           FilteringMode mode) {
         if (priorityList.isEmpty() || tags.isEmpty()) {
-            requireNonNullElements(priorityList);
-            requireNonNullElements(tags);
             return new ArrayList<>(); // need to return a empty mutable List
         }
 
@@ -320,8 +316,6 @@ public final class LocaleMatcher {
     public static Locale lookup(List<LanguageRange> priorityList,
                                 Collection<Locale> locales) {
         if (priorityList.isEmpty() || locales.isEmpty()) {
-            requireNonNullElements(priorityList);
-            requireNonNullElements(locales);
             return null;
         }
 
@@ -344,8 +338,6 @@ public final class LocaleMatcher {
     public static String lookupTag(List<LanguageRange> priorityList,
                                    Collection<String> tags) {
         if (priorityList.isEmpty() || tags.isEmpty()) {
-            requireNonNullElements(priorityList);
-            requireNonNullElements(tags);
             return null;
         }
 
@@ -677,12 +669,6 @@ public final class LocaleMatcher {
         }
 
         return list;
-    }
-
-    private static void requireNonNullElements(Collection<?> vals) {
-        for (var val : vals) {
-            Objects.requireNonNull(val);
-        }
     }
 
     private LocaleMatcher() {}

--- a/test/jdk/java/util/Locale/LocaleMatchingTest.java
+++ b/test/jdk/java/util/Locale/LocaleMatchingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,18 @@
 
 /*
  * @test
- * @bug 7069824 8042360 8032842 8175539 8210443 8242010 8276302
+ * @bug 7069824 8042360 8032842 8175539 8210443 8242010 8276302 8381644
  * @summary Verify implementation for Locale matching.
  * @run junit/othervm LocaleMatchingTest
  */
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -41,6 +43,7 @@ import java.util.Locale;
 import java.util.Locale.FilteringMode;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.util.Locale.FilteringMode.*;
 import static java.util.Locale.LanguageRange.*;
@@ -200,12 +203,24 @@ public class LocaleMatchingTest {
         };
     }
 
-    static Object[][] LFilterNPEData() {
-        return new Object[][] {
-                // Range, LanguageTags, FilteringMode
-                {"en;q=0.2, ja-*-JP, fr-JP", null, REJECT_EXTENDED_RANGES},
-                {null, "de-DE, en, ja-JP-hepburn, fr, he, ja-Latn-JP", REJECT_EXTENDED_RANGES},
-        };
+    static Stream<Arguments> LFilterLookupNPEData() {
+        // Arbitrary value to exercise path with a non-empty collection
+        var validPrioList = LanguageRange.parse("en");
+        var validTagList = List.of("en");
+        return Stream.of(
+                // null Locale list
+                Arguments.of(List.of(), null),
+                Arguments.of(validPrioList, null),
+                // null priority list
+                Arguments.of(null, List.of()),
+                Arguments.of(null, validTagList),
+                // Priority list with null element
+                Arguments.of(Collections.singletonList(null), validTagList),
+                Arguments.of(Collections.singletonList(null), List.of()),
+                // Locale list with null element
+                Arguments.of(List.of(), Collections.singletonList(null)),
+                Arguments.of(validPrioList, Collections.singletonList(null))
+        );
     }
 
     static Object[][] LFilterTagsData() {
@@ -392,19 +407,12 @@ public class LocaleMatchingTest {
                 ranges, tags, expectedLocales, actualLocales));
     }
 
-    @MethodSource("LFilterNPEData")
+    @MethodSource("LFilterLookupNPEData")
     @ParameterizedTest
-    void testLFilterNPE(String ranges, String tags, FilteringMode mode) {
-        if (ranges == null) {
-            // Ranges are null
-            assertThrows(NullPointerException.class, () -> LanguageRange.parse(ranges));
-        } else {
-            // Tags are null
-            List<LanguageRange> priorityList = LanguageRange.parse(ranges);
-            List<Locale> tagList = generateLocales(tags);
-            assertThrows(NullPointerException.class,
-                    () -> showLocales(Locale.filter(priorityList, tagList, mode)));
-        }
+    void testLFilterNPE(List<LanguageRange> priorityList, List<String> locList) {
+        assertThrows(NullPointerException.class, () -> Locale.filter(priorityList, toLocaleList(locList)));
+        // Exercise 3-arg variant
+        assertThrows(NullPointerException.class, () -> Locale.filter(priorityList, toLocaleList(locList), REJECT_EXTENDED_RANGES));
     }
 
     @Test
@@ -433,6 +441,14 @@ public class LocaleMatchingTest {
                         ranges, tags, expectedTags, actualTags));
     }
 
+    @MethodSource("LFilterLookupNPEData")
+    @ParameterizedTest
+    void testLFilterTagsNPE(List<LanguageRange> priorityList, List<String> tagList) {
+        assertThrows(NullPointerException.class, () -> Locale.filterTags(priorityList, tagList));
+        // Exercise 3-arg variant
+        assertThrows(NullPointerException.class, () -> Locale.filterTags(priorityList, tagList, REJECT_EXTENDED_RANGES));
+    }
+
     @Test
     void testLFilterTagsIAE() {
         String ranges = "de-*-DE";
@@ -454,6 +470,12 @@ public class LocaleMatchingTest {
                 ranges, tags, expectedLocale, actualLocale));
     }
 
+    @MethodSource("LFilterLookupNPEData")
+    @ParameterizedTest
+    void testLLookupNPE(List<LanguageRange> priorityList, List<String> locList) {
+        assertThrows(NullPointerException.class, () -> Locale.lookup(priorityList, toLocaleList(locList)));
+    }
+
     @MethodSource("LLookupTagData")
     @ParameterizedTest
     void testLLookupTag(String ranges, String tags, String expectedTag) {
@@ -462,6 +484,34 @@ public class LocaleMatchingTest {
         String actualTag = Locale.lookupTag(priorityList, tagList);
         assertEquals(expectedTag, actualTag, showErrorMessage("    L.LookupTag()",
                 ranges, tags, expectedTag, actualTag));
+    }
+
+    @MethodSource("LFilterLookupNPEData")
+    @ParameterizedTest
+    void testLLookupTagsNPE(List<LanguageRange> priorityList, List<String> tagList) {
+        assertThrows(NullPointerException.class, () -> Locale.lookupTag(priorityList, tagList));
+    }
+
+    // Converts a list of tags to a list of locales.
+    // This conversion is null safe for both the list itself and elements.
+    private static List<Locale> toLocaleList(List<String> tags) {
+        if (tags != null) {
+            if (tags.isEmpty()) {
+                return List.of();
+            } else {
+                List<Locale> locs = new ArrayList<>(tags.size());
+                for (var tag : tags) {
+                    if (tag == null) {
+                        locs.add(null);
+                    } else {
+                        locs.add(Locale.forLanguageTag(tag));
+                    }
+                }
+                return locs;
+            }
+        } else {
+            return null;
+        }
     }
 
     private static List<Locale> generateLocales(String tags) {

--- a/test/jdk/java/util/Locale/LocaleMatchingTest.java
+++ b/test/jdk/java/util/Locale/LocaleMatchingTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -204,22 +203,11 @@ public class LocaleMatchingTest {
     }
 
     static Stream<Arguments> LFilterLookupNPEData() {
-        // Arbitrary value to exercise path with a non-empty collection
-        var validPrioList = LanguageRange.parse("en");
-        var validTagList = List.of("en");
         return Stream.of(
                 // null Locale list
                 Arguments.of(List.of(), null),
-                Arguments.of(validPrioList, null),
                 // null priority list
-                Arguments.of(null, List.of()),
-                Arguments.of(null, validTagList),
-                // Priority list with null element
-                Arguments.of(Collections.singletonList(null), validTagList),
-                Arguments.of(Collections.singletonList(null), List.of()),
-                // Locale list with null element
-                Arguments.of(List.of(), Collections.singletonList(null)),
-                Arguments.of(validPrioList, Collections.singletonList(null))
+                Arguments.of(null, List.of())
         );
     }
 
@@ -409,10 +397,10 @@ public class LocaleMatchingTest {
 
     @MethodSource("LFilterLookupNPEData")
     @ParameterizedTest
-    void testLFilterNPE(List<LanguageRange> priorityList, List<String> locList) {
-        assertThrows(NullPointerException.class, () -> Locale.filter(priorityList, toLocaleList(locList)));
+    void testLFilterNPE(List<LanguageRange> priorityList, List<Locale> locList) {
+        assertThrows(NullPointerException.class, () -> Locale.filter(priorityList, locList));
         // Exercise 3-arg variant
-        assertThrows(NullPointerException.class, () -> Locale.filter(priorityList, toLocaleList(locList), REJECT_EXTENDED_RANGES));
+        assertThrows(NullPointerException.class, () -> Locale.filter(priorityList, locList, REJECT_EXTENDED_RANGES));
     }
 
     @Test
@@ -472,8 +460,8 @@ public class LocaleMatchingTest {
 
     @MethodSource("LFilterLookupNPEData")
     @ParameterizedTest
-    void testLLookupNPE(List<LanguageRange> priorityList, List<String> locList) {
-        assertThrows(NullPointerException.class, () -> Locale.lookup(priorityList, toLocaleList(locList)));
+    void testLLookupNPE(List<LanguageRange> priorityList, List<Locale> locList) {
+        assertThrows(NullPointerException.class, () -> Locale.lookup(priorityList, locList));
     }
 
     @MethodSource("LLookupTagData")
@@ -490,28 +478,6 @@ public class LocaleMatchingTest {
     @ParameterizedTest
     void testLLookupTagsNPE(List<LanguageRange> priorityList, List<String> tagList) {
         assertThrows(NullPointerException.class, () -> Locale.lookupTag(priorityList, tagList));
-    }
-
-    // Converts a list of tags to a list of locales.
-    // This conversion is null safe for both the list itself and elements.
-    private static List<Locale> toLocaleList(List<String> tags) {
-        if (tags != null) {
-            if (tags.isEmpty()) {
-                return List.of();
-            } else {
-                List<Locale> locs = new ArrayList<>(tags.size());
-                for (var tag : tags) {
-                    if (tag == null) {
-                        locs.add(null);
-                    } else {
-                        locs.add(Locale.forLanguageTag(tag));
-                    }
-                }
-                return locs;
-            }
-        } else {
-            return null;
-        }
     }
 
     private static List<Locale> generateLocales(String tags) {


### PR DESCRIPTION
This PR standardizes the null related behavior for the `Locale` filtering and lookup APIs.

There are two issues. First, null elements within either `Collection` which are passed to these APIs may cause NPE, but this is not specified. Second, if the `tags` or `locales` list is null and `priorityList` empty, NPE is not thrown (even though it is specified to).

For example, this is the current null related behavior for `Locale:lookup(List<LanguageRange>, Collection<Locale>)`,

> [], null -> NPE not thrown
> [en], null
> null, []
> null, [en]
> [null], [en]
> [null], [] -> NPE not thrown
> [], [null] -> NPE not thrown
> [en], [null]


This update fixes the empty case to correctly throw NPE. Additionally, there is a specification update to make the `null` element NPE apparent (and implementation dependent).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8381863](https://bugs.openjdk.org/browse/JDK-8381863) to be approved

### Issues
 * [JDK-8381644](https://bugs.openjdk.org/browse/JDK-8381644): Locale matching APIs should describe `null` element behavior (**Bug** - P4)
 * [JDK-8381863](https://bugs.openjdk.org/browse/JDK-8381863): Locale matching APIs should describe `null` element behavior (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30632/head:pull/30632` \
`$ git checkout pull/30632`

Update a local copy of the PR: \
`$ git checkout pull/30632` \
`$ git pull https://git.openjdk.org/jdk.git pull/30632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30632`

View PR using the GUI difftool: \
`$ git pr show -t 30632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30632.diff">https://git.openjdk.org/jdk/pull/30632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30632#issuecomment-4208170053)
</details>
