### PR TITLE
8381882: Convert test/jaxp/javax/xml/jaxp/unittest/stream tests to JUnit

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/stream/AttributeLocalNameTest/AttributeLocalNameTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/AttributeLocalNameTest/AttributeLocalNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,19 +23,19 @@
 
 package stream.AttributeLocalNameTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.AttributeLocalNameTest.AttributeLocalNameTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.AttributeLocalNameTest.AttributeLocalNameTest
  * @summary Test XMLStreamReader.getAttributeLocalName().
  */
 public class AttributeLocalNameTest {
@@ -43,20 +43,15 @@ public class AttributeLocalNameTest {
     static final String XML = "<?xml version=\"1.0\"?>" + "<S:Envelope foo=\"bar\" xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"></S:Envelope>";
 
     @Test
-    public void testOne() {
-        try {
-            XMLInputFactory factory = XMLInputFactory.newInstance();
-            XMLStreamReader reader = factory.createFilteredReader(factory.createXMLStreamReader(new StringReader(XML)), new Filter());
-            reader.next();
-            reader.hasNext(); // force filter to cache
-            Assert.assertTrue(reader.getAttributeLocalName(0) != null);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected Exception: " + e.getMessage());
-        }
+    public void testOne() throws Exception {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        XMLStreamReader reader = factory.createFilteredReader(factory.createXMLStreamReader(new StringReader(XML)), new Filter());
+        reader.next();
+        reader.hasNext(); // force filter to cache
+        assertNotNull(reader.getAttributeLocalName(0));
     }
 
-    class Filter implements StreamFilter {
+    private static class Filter implements StreamFilter {
 
         public boolean accept(XMLStreamReader reader) {
             return true;

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6370703.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6370703.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,45 +23,40 @@
 
 package stream;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6370703
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6370703
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6370703
  * @summary Test StAX parser can parse attribute default value when START_ELEMENT.
  */
 public class Bug6370703 {
 
-    private static String INPUT_FILE = "sgml.xml";
+    private static final String INPUT_FILE = "sgml.xml";
 
     @Test
-    public void testStartElement() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            XMLStreamReader xsr = xif.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE));
+    public void testStartElement() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader xsr = xif.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE));
 
-            while (xsr.hasNext()) {
-                int event = xsr.next();
-                if (event == XMLStreamReader.START_ELEMENT) {
-                    String localName = xsr.getLocalName();
-                    boolean print = "para".equals(localName);
-                    int nrOfAttr = xsr.getAttributeCount();
-                    if (print) {
-                        Assert.assertTrue(nrOfAttr > 0, "Default attribute declared in DTD is missing");
-                    }
-
+        while (xsr.hasNext()) {
+            int event = xsr.next();
+            if (event == XMLStreamReader.START_ELEMENT) {
+                String localName = xsr.getLocalName();
+                boolean print = "para".equals(localName);
+                int nrOfAttr = xsr.getAttributeCount();
+                if (print) {
+                    assertTrue(nrOfAttr > 0, "Default attribute declared in DTD is missing");
                 }
             }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         }
     }
 

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6378422.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6378422.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,28 +23,22 @@
 
 package stream;
 
-import javax.xml.stream.XMLInputFactory;
+import org.junit.jupiter.api.Test;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import javax.xml.stream.XMLInputFactory;
 
 /*
  * @test
  * @bug 6378422
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6378422
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6378422
  * @summary Test setting reuse-instance property on StAX factory.
  */
 public class Bug6378422 {
 
     @Test
     public void testReuseInstanceProp() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            xif.setProperty("reuse-instance", Boolean.valueOf(true));
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty("reuse-instance", true);
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6380870.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6380870.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,35 +23,29 @@
 
 package stream;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /*
  * @test
  * @bug 6380870
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6380870
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6380870
  * @summary Test StAX parser can parse VoiceXML DTD.
  */
 public class Bug6380870 {
 
-    private static String INPUT_FILE = "basic-form.vxml";
+    private static final String INPUT_FILE = "basic-form.vxml";
 
     @Test
-    public void testStreamReader() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            XMLStreamReader reader = xif.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE));
-            while (reader.hasNext())
-                reader.next();
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
+    public void testStreamReader() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader reader = xif.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE));
+        while (reader.hasNext()) {
+            reader.next();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6489502.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6489502.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,60 +23,50 @@
 
 package stream;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
  * @bug 6489502
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6489502
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6489502
  * @summary Test XMLInputFactory works correctly in case it repeats to create reader.
  */
 public class Bug6489502 {
 
     public java.io.File input;
-    public final String filesDir = "./";
     protected XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-    protected XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
 
-    private static String xml = "<?xml version=\"1.0\"?><PLAY><TITLE>The Tragedy of Hamlet, Prince of Denmark</TITLE></PLAY>";
+    private static final String XML = "<?xml version=\"1.0\"?><PLAY><TITLE>The Tragedy of Hamlet, Prince of Denmark</TITLE></PLAY>";
 
     @Test
-    public void testEventReader1() {
-        try {
-            // Check if event reader returns the correct event
-            XMLEventReader e1 = inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.StringReader(xml)));
-            Assert.assertEquals(e1.peek().getEventType(), XMLStreamConstants.START_DOCUMENT);
+    public void testEventReader1() throws Exception {
+        // Check if event reader returns the correct event
+        XMLEventReader e1 = inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.StringReader(XML)));
+        assertEquals(XMLStreamConstants.START_DOCUMENT, e1.peek().getEventType());
 
-            // Repeat same steps to test factory state
-            XMLEventReader e2 = inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.StringReader(xml)));
-            Assert.assertEquals(e2.peek().getEventType(), XMLStreamConstants.START_DOCUMENT);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        // Repeat same steps to test factory state
+        XMLEventReader e2 = inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.StringReader(XML)));
+        assertEquals(XMLStreamConstants.START_DOCUMENT, e2.peek().getEventType());
     }
 
     @Test
-    public void testEventReader2() {
-        try {
-            // Now advance underlying reader and then call peek on event reader
-            XMLStreamReader s1 = inputFactory.createXMLStreamReader(new java.io.StringReader(xml));
-            Assert.assertEquals(s1.getEventType(), XMLStreamConstants.START_DOCUMENT);
-            s1.next();
-            s1.next(); // advance to <TITLE>
-            Assert.assertTrue(s1.getLocalName().equals("TITLE"));
+    public void testEventReader2() throws Exception {
+        // Now advance underlying reader and then call peek on event reader
+        XMLStreamReader s1 = inputFactory.createXMLStreamReader(new java.io.StringReader(XML));
+        assertEquals(XMLStreamConstants.START_DOCUMENT, s1.getEventType());
+        s1.next();
+        s1.next(); // advance to <TITLE>
+        assertEquals("TITLE", s1.getLocalName());
 
-            XMLEventReader e3 = inputFactory.createXMLEventReader(s1);
-            Assert.assertEquals(e3.peek().getEventType(), XMLStreamConstants.START_ELEMENT);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        XMLEventReader e3 = inputFactory.createXMLEventReader(s1);
+        assertEquals(XMLStreamConstants.START_ELEMENT, e3.peek().getEventType());
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6509774.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6509774.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,151 +23,92 @@
 
 package stream;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
  * @bug 6509774
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6509774
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6509774
  * @summary Test Property javax.xml.stream.supportDTD, DTD events are now returned even if supportDTD=false.
  */
 public class Bug6509774 {
 
     @Test
-    public void test0() {
+    public void test0() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty("javax.xml.stream.supportDTD", Boolean.TRUE);
 
-        try {
+        XMLStreamReader xsr = xif.createXMLStreamReader(
+                getClass().getResource("sgml_Bug6509774.xml").toString(),
+                getClass().getResourceAsStream("sgml_Bug6509774.xml"));
 
-            XMLInputFactory xif = XMLInputFactory.newInstance();
+        assertEquals(XMLStreamConstants.START_DOCUMENT, xsr.getEventType());
 
-            xif.setProperty("javax.xml.stream.supportDTD", Boolean.TRUE);
+        int event = xsr.next();
 
-            XMLStreamReader xsr = xif.createXMLStreamReader(
+        // Must be a DTD event since DTDs are supported
+        assertEquals(XMLStreamConstants.DTD, event);
 
-            getClass().getResource("sgml_Bug6509774.xml").toString(),
-
-            getClass().getResourceAsStream("sgml_Bug6509774.xml"));
-
-            Assert.assertTrue(xsr.getEventType() == XMLStreamConstants.START_DOCUMENT);
-
-            int event = xsr.next();
-
-            // Must be a DTD event since DTDs are supported
-
-            Assert.assertTrue(event == XMLStreamConstants.DTD);
-
-            while (xsr.hasNext()) {
-
-                event = xsr.next();
-
-            }
-
-            Assert.assertTrue(event == XMLStreamConstants.END_DOCUMENT);
-
-            xsr.close();
-
+        while (xsr.hasNext()) {
+            event = xsr.next();
         }
 
-        catch (Exception e) {
-
-            Assert.fail(e.getMessage());
-
-        }
-
+        assertEquals(XMLStreamConstants.END_DOCUMENT, event);
+        xsr.close();
     }
 
     @Test
-    public void test1() {
+    public void test1() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty("javax.xml.stream.supportDTD", Boolean.FALSE);
 
-        try {
+        XMLStreamReader xsr = xif.createXMLStreamReader(
+                getClass().getResource("sgml_Bug6509774.xml").toString(),
+                getClass().getResourceAsStream("sgml_Bug6509774.xml"));
 
-            XMLInputFactory xif = XMLInputFactory.newInstance();
+        assertEquals(XMLStreamConstants.START_DOCUMENT, xsr.getEventType());
 
-            xif.setProperty("javax.xml.stream.supportDTD", Boolean.FALSE);
+        int event = xsr.next();
 
-            XMLStreamReader xsr = xif.createXMLStreamReader(
+        // Should not be a DTD event since they are ignored
+        assertEquals(XMLStreamConstants.DTD, event);
 
-            getClass().getResource("sgml_Bug6509774.xml").toString(),
-
-            getClass().getResourceAsStream("sgml_Bug6509774.xml"));
-
-            Assert.assertTrue(xsr.getEventType() == XMLStreamConstants.START_DOCUMENT);
-
-            int event = xsr.next();
-
-            // Should not be a DTD event since they are ignored
-
-            Assert.assertTrue(event == XMLStreamConstants.DTD);
-
-            while (xsr.hasNext()) {
-
-                event = xsr.next();
-
-            }
-
-            Assert.assertTrue(event == XMLStreamConstants.END_DOCUMENT);
-
-            xsr.close();
-
+        while (xsr.hasNext()) {
+            event = xsr.next();
         }
 
-        catch (Exception e) {
-
-            Assert.fail(e.getMessage());
-
-        }
-
+        assertEquals(XMLStreamConstants.END_DOCUMENT, event);
+        xsr.close();
     }
 
     @Test
-    public void test2() {
+    public void test2() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty("javax.xml.stream.supportDTD", Boolean.FALSE);
 
-        try {
+        XMLStreamReader xsr = xif.createXMLStreamReader(
+                getClass().getResource("sgml-bad-systemId.xml").toString(),
+                getClass().getResourceAsStream("sgml-bad-systemId.xml"));
 
-            XMLInputFactory xif = XMLInputFactory.newInstance();
+        assertEquals(XMLStreamConstants.START_DOCUMENT, xsr.getEventType());
 
-            xif.setProperty("javax.xml.stream.supportDTD", Boolean.FALSE);
+        int event = xsr.next();
 
-            XMLStreamReader xsr = xif.createXMLStreamReader(
-
-            getClass().getResource("sgml-bad-systemId.xml").toString(),
-
-            getClass().getResourceAsStream("sgml-bad-systemId.xml"));
-
-            Assert.assertTrue(xsr.getEventType() == XMLStreamConstants.START_DOCUMENT);
-
-            int event = xsr.next();
-
-            // Should not be a DTD event since they are ignored
-
-            Assert.assertTrue(event == XMLStreamConstants.DTD);
-
-            while (xsr.hasNext()) {
-
-                event = xsr.next();
-
-            }
-
-            Assert.assertTrue(event == XMLStreamConstants.END_DOCUMENT);
-
-            xsr.close();
-
+        // Should not be a DTD event since they are ignored
+        assertEquals(XMLStreamConstants.DTD, event);
+        while (xsr.hasNext()) {
+            event = xsr.next();
         }
 
-        catch (Exception e) {
-
-            // Bogus systemId in XML document should not result in exception
-
-            Assert.fail(e.getMessage());
-
-        }
-
+        assertEquals(XMLStreamConstants.END_DOCUMENT, event);
+        xsr.close();
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6688002Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6688002Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,24 @@
 
 package stream;
 
-import static jaxp.library.JAXPTestUtilities.USER_DIR;
-
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
  * @bug 6688002
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6688002Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6688002Test
  * @summary Test single instance of XMLOutputFactory/XMLInputFactory create multiple Writer/Readers in parallel.
  */
 public class Bug6688002Test {
@@ -65,7 +63,7 @@ public class Bug6688002Test {
         }
     }
 
-    public class MyRunnable implements Runnable {
+    private static class MyRunnable implements Runnable {
         final String no;
 
         MyRunnable(int no) {
@@ -74,7 +72,7 @@ public class Bug6688002Test {
 
         public void run() {
             try {
-                FileOutputStream fos = new FileOutputStream(USER_DIR + no);
+                FileOutputStream fos = new FileOutputStream(no);
                 XMLStreamWriter w = getWriter(fos);
                 // System.out.println("Writer="+w+" Thread="+Thread.currentThread());
                 w.writeStartDocument();
@@ -88,7 +86,7 @@ public class Bug6688002Test {
                 w.close();
                 fos.close();
 
-                FileInputStream fis = new FileInputStream(USER_DIR + no);
+                FileInputStream fis = new FileInputStream(no);
                 XMLStreamReader r = getReader(fis);
                 while (r.hasNext()) {
                     r.next();
@@ -96,19 +94,17 @@ public class Bug6688002Test {
                 r.close();
                 fis.close();
             } catch (Exception e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
         }
     }
 
-    public static/* synchronized */XMLStreamReader getReader(InputStream is) throws Exception {
+    public static XMLStreamReader getReader(InputStream is) throws Exception {
         return inputFactory.createXMLStreamReader(is);
-        // return XMLStreamReaderFactory.create(null, is, true);
     }
 
-    public static/* synchronized */XMLStreamWriter getWriter(OutputStream os) throws Exception {
+    public static XMLStreamWriter getWriter(OutputStream os) throws Exception {
         return outputFactory.createXMLStreamWriter(os);
-        // return XMLStreamWriterFactory.createXMLStreamWriter(os);
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6976938Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/Bug6976938Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,21 +23,19 @@
 
 package stream;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.EventFilter;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /*
  * @test
  * @bug 6976938
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.Bug6976938Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.Bug6976938Test
  * @summary Test StAX parser won't throw StackOverflowError while reading valid XML file, in case the text content of an XML element contains many lines like "&lt; ... &gt;".
  */
 public class Bug6976938Test {
@@ -49,50 +47,36 @@ public class Bug6976938Test {
     public static final QName ATTACHMENT_NAME = new QName(VF_GENERIC_TT_NAMESPACE, "attachment");
 
     @Test
-    public void testEventReader() {
+    public void testEventReader() throws Exception {
         XMLInputFactory xif = XMLInputFactory.newInstance();
         xif.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
         eventReaderTest(xif);
     }
 
     @Test
-    public void testEventReader1() {
+    public void testEventReader1() throws Exception {
         XMLInputFactory xif = XMLInputFactory.newInstance();
         eventReaderTest(xif);
     }
 
-    public void eventReaderTest(XMLInputFactory xif) {
-        XMLEventReader eventReader = null;
+    public void eventReaderTest(XMLInputFactory xif) throws Exception {
+        XMLEventReader eventReader = xif.createXMLEventReader(this.getClass().getResourceAsStream(INPUT_FILE));
         try {
-            eventReader = xif.createXMLEventReader(this.getClass().getResourceAsStream(INPUT_FILE));
             XMLEventReader filteredEventReader = xif.createFilteredReader(eventReader, new EventFilter() {
                 public boolean accept(XMLEvent event) {
                     if (!event.isStartElement()) {
                         return false;
                     }
                     QName elementQName = event.asStartElement().getName();
-                    if ((elementQName.getLocalPart().equals(ATTACHMENT_NAME.getLocalPart()) || elementQName.getLocalPart().equals("Attachment"))
-                            && elementQName.getNamespaceURI().equals(VF_GENERIC_TT_NAMESPACE)) {
-                        return true;
-                    }
-                    return false;
+                    return (elementQName.getLocalPart().equals(ATTACHMENT_NAME.getLocalPart()) || elementQName.getLocalPart().equals("Attachment"))
+                            && elementQName.getNamespaceURI().equals(VF_GENERIC_TT_NAMESPACE);
                 }
             });
             if (filteredEventReader.hasNext()) {
                 System.out.println("containsAttachments() returns true");
             }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-
         } finally {
-            if (eventReader != null) {
-                try {
-                    eventReader.close();
-                } catch (XMLStreamException xse) {
-                    // Ignored by intention
-                }
-            }
+            eventReader.close();
         }
     }
 

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/CoalesceTest/CoalesceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/CoalesceTest/CoalesceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,88 +22,54 @@
  */
 package stream.CoalesceTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.CoalesceTest.CoalesceTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.CoalesceTest.CoalesceTest
  * @summary Test Coalesce property works.
  */
 public class CoalesceTest {
 
-    String countryElementContent = "START India  CS}}}}}} India END";
-    String descriptionElementContent = "a&b";
-    String fooElementContent = "&< cdatastart<><>>><>><<<<cdataend entitystart insert entityend";
+    private static final String countryElementContent = "START India  CS}}}}}} India END";
+    private static final String descriptionElementContent = "a&b";
+    private static final String fooElementContent = "&< cdatastart<><>>><>><<<<cdataend entitystart insert entityend";
 
     @Test
-    public void testCoalesceProperty() {
-        try {
-            XMLInputFactory xifactory = XMLInputFactory.newInstance();
-            xifactory.setProperty(XMLInputFactory.IS_COALESCING, new Boolean(true));
-            InputStream xml = this.getClass().getResourceAsStream("coalesce.xml");
-            XMLStreamReader streamReader = xifactory.createXMLStreamReader(xml);
-            while (streamReader.hasNext()) {
-                int eventType = streamReader.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT && streamReader.getLocalName().equals("country")) {
-                    eventType = streamReader.next();
-                    if (eventType == XMLStreamConstants.CHARACTERS) {
-                        String text = streamReader.getText();
-                        if (!text.equals(countryElementContent)) {
-                            System.out.println("String dont match");
-                            System.out.println("text = " + text);
-                            System.out.println("countryElementContent = " + countryElementContent);
-                        }
-                        // assertTrue(text.equals(countryElementContent));
-                    }
+    public void testCoalesceProperty() throws Exception {
+        XMLInputFactory xifactory = XMLInputFactory.newInstance();
+        xifactory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
+        InputStream xml = this.getClass().getResourceAsStream("coalesce.xml");
+        XMLStreamReader streamReader = xifactory.createXMLStreamReader(xml);
+        while (streamReader.hasNext()) {
+            int eventType = streamReader.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT && streamReader.getLocalName().equals("country")) {
+                eventType = streamReader.next();
+                if (eventType == XMLStreamConstants.CHARACTERS) {
+                    assertEquals(countryElementContent, streamReader.getText());
                 }
-                if (eventType == XMLStreamConstants.START_ELEMENT && streamReader.getLocalName().equals("description")) {
-                    eventType = streamReader.next();
-                    if (eventType == XMLStreamConstants.CHARACTERS) {
-                        String text = streamReader.getText();
-                        if (!text.equals(descriptionElementContent)) {
-                            System.out.println("String dont match");
-                            System.out.println("text = " + text);
-                            System.out.println("descriptionElementContent = " + descriptionElementContent);
-                        }
-                        Assert.assertTrue(text.equals(descriptionElementContent));
-                    }
-                }
-                if (eventType == XMLStreamConstants.START_ELEMENT && streamReader.getLocalName().equals("foo")) {
-                    eventType = streamReader.next();
-                    if (eventType == XMLStreamConstants.CHARACTERS) {
-                        String text = streamReader.getText();
-                        if (!text.equals(fooElementContent)) {
-                            System.out.println("String dont match");
-                            System.out.println("text = " + text);
-                            System.out.println("fooElementContent = " + fooElementContent);
-                        }
-
-                        Assert.assertTrue(text.equals(fooElementContent));
-                    }
-                }
-
             }
-        } catch (XMLStreamException ex) {
-
-            if (ex.getNestedException() != null) {
-                ex.getNestedException().printStackTrace();
+            if (eventType == XMLStreamConstants.START_ELEMENT && streamReader.getLocalName().equals("description")) {
+                eventType = streamReader.next();
+                if (eventType == XMLStreamConstants.CHARACTERS) {
+                    assertEquals(descriptionElementContent, streamReader.getText());
+                }
             }
-            // ex.printStackTrace() ;
-        } catch (Exception ex) {
-            ex.printStackTrace();
+            if (eventType == XMLStreamConstants.START_ELEMENT && streamReader.getLocalName().equals("foo")) {
+                eventType = streamReader.next();
+                if (eventType == XMLStreamConstants.CHARACTERS) {
+                    assertEquals(fooElementContent, streamReader.getText());
+                }
+            }
         }
-
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EntitiesTest/EntityTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EntitiesTest/EntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,12 @@
 
 package stream.EntitiesTest;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.events.XMLEvent;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
@@ -30,19 +36,12 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
 
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.events.XMLEvent;
-
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.EntitiesTest.EntityTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.EntitiesTest.EntityTest
  * @summary Test StAX parses entity.
  */
 public class EntityTest {
@@ -50,43 +49,29 @@ public class EntityTest {
     XMLInputFactory factory = null;
     String output = "";
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
-        try {
-            factory = XMLInputFactory.newInstance();
-        } catch (Exception ex) {
-            Assert.fail("Could not create XMLInputFactory");
-        }
-    }
-
-    @AfterMethod
-    public void tearDown() {
-        factory = null;
+        factory = XMLInputFactory.newInstance();
     }
 
     @Test
     public void testProperties() {
-        Assert.assertTrue(factory.isPropertySupported("javax.xml.stream.isReplacingEntityReferences"));
+        assertTrue(factory.isPropertySupported("javax.xml.stream.isReplacingEntityReferences"));
     }
 
     @Test
-    public void testCharacterReferences() {
-        try {
-            URL fileName = EntityTest.class.getResource("testCharRef.xml");
-            URL outputFileName = EntityTest.class.getResource("testCharRef.xml.output");
-            XMLStreamReader xmlr = factory.createXMLStreamReader(new InputStreamReader(fileName.openStream()));
-            int eventType = 0;
-            while (xmlr.hasNext()) {
-                eventType = xmlr.next();
-                handleEvent(xmlr, eventType);
-            }
-            System.out.println("Output:");
-            System.out.println(output);
-            Assert.assertTrue(compareOutput(new InputStreamReader(outputFileName.openStream()), new StringReader(output)));
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail(ex.getMessage());
+    public void testCharacterReferences() throws Exception {
+        URL fileName = EntityTest.class.getResource("testCharRef.xml");
+        URL outputFileName = EntityTest.class.getResource("testCharRef.xml.output");
+        XMLStreamReader xmlr = factory.createXMLStreamReader(new InputStreamReader(fileName.openStream()));
+        int eventType = 0;
+        while (xmlr.hasNext()) {
+            eventType = xmlr.next();
+            handleEvent(xmlr, eventType);
         }
+        System.out.println("Output:");
+        System.out.println(output);
+        assertTrue(compareOutput(new InputStreamReader(outputFileName.openStream()), new StringReader(output)));
     }
 
     private void handleEvent(XMLStreamReader xmlr, int eventType) {

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventReaderDelegateTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventReaderDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,208 +23,144 @@
 
 package stream;
 
-import org.testng.annotations.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-
-import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 import javax.xml.stream.util.EventReaderDelegate;
+import java.io.FileInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.EventReaderDelegateTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.EventReaderDelegateTest
  * @summary Test EventReaderDelegate.
  */
 public class EventReaderDelegateTest {
-
-    public EventReaderDelegateTest(String name) {
-    }
-
     @Test
-    public void testGetElementText() {
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(new File(getClass().getResource("toys.xml").getFile())));
-            EventReaderDelegate delegate = new EventReaderDelegate(reader);
-            while (delegate.hasNext()) {
-                XMLEvent event = (XMLEvent) delegate.next();
-                switch (event.getEventType()) {
-                    case XMLStreamConstants.START_ELEMENT: {
-                        String name = event.asStartElement().getName().toString();
-                        if (name.equals("name") || name.equals("price")) {
-                            System.out.println(delegate.getElementText());
-                        } else {
-                            try {
-                                delegate.getElementText();
-                            } catch (XMLStreamException e) {
-                                System.out.println("Expected XMLStreamException in getElementText()");
-                            }
+    public void testGetElementText() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
+        EventReaderDelegate delegate = new EventReaderDelegate(reader);
+        while (delegate.hasNext()) {
+            XMLEvent event = (XMLEvent) delegate.next();
+            switch (event.getEventType()) {
+                case XMLStreamConstants.START_ELEMENT: {
+                    String name = event.asStartElement().getName().toString();
+                    if (name.equals("name") || name.equals("price")) {
+                        System.out.println(delegate.getElementText());
+                    } else {
+                        try {
+                            delegate.getElementText();
+                        } catch (XMLStreamException e) {
+                            System.out.println("Expected XMLStreamException in getElementText()");
                         }
-
                     }
+
                 }
             }
-            delegate.close();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testGetElementText()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            Assert.fail("XMLStreamException in testGetElementText()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testGetElementText()");
         }
-
+        delegate.close();
     }
 
     @Test
-    public void testRemove() {
+    public void testRemove() throws Exception {
         try {
             XMLInputFactory ifac = XMLInputFactory.newFactory();
-            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(new File(getClass().getResource("toys.xml").getFile())));
+            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
             EventReaderDelegate delegate = new EventReaderDelegate(reader);
             delegate.remove();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testRemove()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            Assert.fail("XMLStreamException in testRemove()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testRemove()");
         } catch (UnsupportedOperationException e) {
             System.out.println("Expected exception in remove()");
         }
-
     }
 
     @Test
-    public void testPeek() {
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(new File(getClass().getResource("toys.xml").getFile())));
-            EventReaderDelegate delegate = new EventReaderDelegate();
-            delegate.setParent(reader);
-            while (delegate.hasNext()) {
-                XMLEvent peekevent = delegate.peek();
-                XMLEvent event = (XMLEvent) delegate.next();
-                if (peekevent != event) {
-                    Assert.fail("peek() does not return same XMLEvent with next()");
-                }
+    public void testPeek() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
+        EventReaderDelegate delegate = new EventReaderDelegate();
+        delegate.setParent(reader);
+        while (delegate.hasNext()) {
+            XMLEvent peekevent = delegate.peek();
+            XMLEvent event = (XMLEvent) delegate.next();
+            if (peekevent != event) {
+                fail("peek() does not return same XMLEvent with next()");
             }
-            delegate.close();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testPeek()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            Assert.fail("XMLStreamException in testPeek()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testPeek()");
         }
+        delegate.close();
     }
 
     @Test
-    public void testNextTag() {
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            ifac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
-            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(new File(getClass().getResource("toys.xml").getFile())));
-            EventReaderDelegate delegate = new EventReaderDelegate(reader);
-            if ((Boolean) (delegate.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) != Boolean.FALSE) {
-                Assert.fail("getProperty() does not return correct value");
-            }
-            while (delegate.hasNext()) {
-                XMLEvent event = delegate.peek();
-                if (event.isEndElement() || event.isStartElement()) {
-                    XMLEvent nextevent = delegate.nextTag();
-                    if (!(nextevent.getEventType() == XMLStreamConstants.START_ELEMENT || nextevent.getEventType() == XMLStreamConstants.END_ELEMENT)) {
-                        Assert.fail("nextTag() does not return correct event type");
-                    }
-                } else {
-                    delegate.next();
-                }
-            }
-            delegate.close();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testNextTag()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            Assert.fail("XMLStreamException in testNextTag()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testNextTag()");
+    public void testNextTag() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        ifac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
+        EventReaderDelegate delegate = new EventReaderDelegate(reader);
+        if (delegate.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES) != Boolean.FALSE) {
+            fail("getProperty() does not return correct value");
         }
+        while (delegate.hasNext()) {
+            XMLEvent event = delegate.peek();
+            if (event.isEndElement() || event.isStartElement()) {
+                XMLEvent nextevent = delegate.nextTag();
+                if (!(nextevent.getEventType() == XMLStreamConstants.START_ELEMENT || nextevent.getEventType() == XMLStreamConstants.END_ELEMENT)) {
+                    fail("nextTag() does not return correct event type");
+                }
+            } else {
+                delegate.next();
+            }
+        }
+        delegate.close();
     }
 
     @Test
-    public void testNextEvent() {
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            ifac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
-            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(new File(getClass().getResource("toys.xml").getFile())));
-            EventReaderDelegate delegate = new EventReaderDelegate();
-            delegate.setParent(reader);
-            if ((Boolean) (delegate.getParent().getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) != Boolean.FALSE) {
-                Assert.fail("XMLEventReader.getProperty() does not return correct value");
-            }
-            if ((Boolean) (delegate.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) != Boolean.FALSE) {
-                Assert.fail("EventReaderDelegate.getProperty() does not return correct value");
-            }
-            while (delegate.hasNext()) {
-                XMLEvent event = delegate.nextEvent();
-                switch (event.getEventType()) {
-                    case XMLStreamConstants.START_ELEMENT: {
-                        System.out.println(event.asStartElement().getName());
-                        break;
-                    }
-                    case XMLStreamConstants.END_ELEMENT: {
-                        System.out.println(event.asEndElement().getName());
-                        break;
-                    }
-                    case XMLStreamConstants.END_DOCUMENT: {
-                        System.out.println(event.isEndDocument());
-                        break;
-                    }
-                    case XMLStreamConstants.START_DOCUMENT: {
-                        System.out.println(event.isStartDocument());
-                        break;
-                    }
-                    case XMLStreamConstants.CHARACTERS: {
-                        System.out.println(event.asCharacters().getData());
-                        break;
-                    }
-                    case XMLStreamConstants.COMMENT: {
-                        System.out.println(event.toString());
-                        break;
-                    }
+    public void testNextEvent() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        ifac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
+        EventReaderDelegate delegate = new EventReaderDelegate();
+        delegate.setParent(reader);
+
+        assertEquals(Boolean.FALSE, delegate.getParent().getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES));
+        assertEquals(Boolean.FALSE, delegate.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES));
+
+        while (delegate.hasNext()) {
+            XMLEvent event = delegate.nextEvent();
+            switch (event.getEventType()) {
+                case XMLStreamConstants.START_ELEMENT: {
+                    System.out.println(event.asStartElement().getName());
+                    break;
                 }
-
+                case XMLStreamConstants.END_ELEMENT: {
+                    System.out.println(event.asEndElement().getName());
+                    break;
+                }
+                case XMLStreamConstants.END_DOCUMENT: {
+                    System.out.println(event.isEndDocument());
+                    break;
+                }
+                case XMLStreamConstants.START_DOCUMENT: {
+                    System.out.println(event.isStartDocument());
+                    break;
+                }
+                case XMLStreamConstants.CHARACTERS: {
+                    System.out.println(event.asCharacters().getData());
+                    break;
+                }
+                case XMLStreamConstants.COMMENT: {
+                    System.out.println(event.toString());
+                    break;
+                }
             }
-            delegate.close();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testNextEvent()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            Assert.fail("XMLStreamException in testNextEvent()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testNextEvent()");
-        }
 
+        }
+        delegate.close();
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventReaderDelegateTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventReaderDelegateTest.java
@@ -34,7 +34,10 @@ import javax.xml.stream.util.EventReaderDelegate;
 import java.io.FileInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
@@ -54,15 +57,10 @@ public class EventReaderDelegateTest {
                 case XMLStreamConstants.START_ELEMENT: {
                     String name = event.asStartElement().getName().toString();
                     if (name.equals("name") || name.equals("price")) {
-                        System.out.println(delegate.getElementText());
+                        assertNotNull(delegate.getElementText());
                     } else {
-                        try {
-                            delegate.getElementText();
-                        } catch (XMLStreamException e) {
-                            System.out.println("Expected XMLStreamException in getElementText()");
-                        }
+                        assertThrows(XMLStreamException.class, delegate::getElementText);
                     }
-
                 }
             }
         }
@@ -71,14 +69,10 @@ public class EventReaderDelegateTest {
 
     @Test
     public void testRemove() throws Exception {
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
-            EventReaderDelegate delegate = new EventReaderDelegate(reader);
-            delegate.remove();
-        } catch (UnsupportedOperationException e) {
-            System.out.println("Expected exception in remove()");
-        }
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
+        EventReaderDelegate delegate = new EventReaderDelegate(reader);
+        assertThrows(UnsupportedOperationException.class, delegate::remove);
     }
 
     @Test
@@ -90,9 +84,7 @@ public class EventReaderDelegateTest {
         while (delegate.hasNext()) {
             XMLEvent peekevent = delegate.peek();
             XMLEvent event = (XMLEvent) delegate.next();
-            if (peekevent != event) {
-                fail("peek() does not return same XMLEvent with next()");
-            }
+            assertSame(peekevent, event, "peek() does not return same XMLEvent with next()");
         }
         delegate.close();
     }
@@ -103,16 +95,12 @@ public class EventReaderDelegateTest {
         ifac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         XMLEventReader reader = ifac.createXMLEventReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
         EventReaderDelegate delegate = new EventReaderDelegate(reader);
-        if (delegate.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES) != Boolean.FALSE) {
-            fail("getProperty() does not return correct value");
-        }
+        assertEquals(Boolean.FALSE, delegate.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES));
         while (delegate.hasNext()) {
             XMLEvent event = delegate.peek();
             if (event.isEndElement() || event.isStartElement()) {
                 XMLEvent nextevent = delegate.nextTag();
-                if (!(nextevent.getEventType() == XMLStreamConstants.START_ELEMENT || nextevent.getEventType() == XMLStreamConstants.END_ELEMENT)) {
-                    fail("nextTag() does not return correct event type");
-                }
+                assertTrue(nextevent.getEventType() == XMLStreamConstants.START_ELEMENT || nextevent.getEventType() == XMLStreamConstants.END_ELEMENT);
             } else {
                 delegate.next();
             }
@@ -135,27 +123,27 @@ public class EventReaderDelegateTest {
             XMLEvent event = delegate.nextEvent();
             switch (event.getEventType()) {
                 case XMLStreamConstants.START_ELEMENT: {
-                    System.out.println(event.asStartElement().getName());
+                    assertNotNull(event.asStartElement().getName());
                     break;
                 }
                 case XMLStreamConstants.END_ELEMENT: {
-                    System.out.println(event.asEndElement().getName());
+                    assertNotNull(event.asEndElement().getName());
                     break;
                 }
                 case XMLStreamConstants.END_DOCUMENT: {
-                    System.out.println(event.isEndDocument());
+                    assertTrue(event.isEndDocument());
                     break;
                 }
                 case XMLStreamConstants.START_DOCUMENT: {
-                    System.out.println(event.isStartDocument());
+                    assertTrue(event.isStartDocument());
                     break;
                 }
                 case XMLStreamConstants.CHARACTERS: {
-                    System.out.println(event.asCharacters().getData());
+                    assertNotNull(event.asCharacters().getData());
                     break;
                 }
                 case XMLStreamConstants.COMMENT: {
-                    System.out.println(event.toString());
+                    assertNotNull(event.toString());
                     break;
                 }
             }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/EventFilterSupportTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/EventFilterSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,22 +23,24 @@
 
 package stream.EventsTest;
 
-import java.io.IOException;
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.EventFilter;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
+import java.io.IOException;
+import java.io.InputStream;
 
-/**
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/*
  * @test
  * @bug 8173111
  * @summary tests that filtering out nested elements doesn't end up in
  *          a StackOverflowException
- * @run testng/othervm stream.EventsTest.EventFilterSupportTest
+ * @run junit/othervm stream.EventsTest.EventFilterSupportTest
  * @author danielfuchs
  */
 public class EventFilterSupportTest {
@@ -49,19 +51,11 @@ public class EventFilterSupportTest {
     // A number high enough to trigger StackOverflowException before the fix.
     static final int MAX = 100_000;
 
-    public static void main(String[] args)
-            throws XMLStreamException, IOException {
-        smokeTest();
-        testNextEvent(MAX);
-        testNextTag(MAX);
-        System.out.println("Tests passed...");
-    }
-
     // The smoke test just verifies that our TestInputStream works as
     // expected and produces the expected stream of characters.
     // Here we test it with 4 nested elements.
     @Test
-    public static void smokeTest() throws IOException {
+    public void smokeTest() throws IOException {
         System.out.println("\nSmoke test...");
         StringBuilder sb = new StringBuilder();
         try (InputStream ts = new TestInputStream(4)) {
@@ -71,20 +65,20 @@ public class EventFilterSupportTest {
                 sb.append((char)c);
             }
         }
-        assertEquals(sb.toString(), SMOKE, "Smoke test failed");
+        assertEquals(SMOKE, sb.toString(), "Smoke test failed");
         System.out.println("\nSmoke test passed\n");
     }
 
     // Test calling XMLEventReader.nextEvent()
     @Test
-    public static void testNextEvent() throws IOException, XMLStreamException {
+    public void testNextEvent() throws XMLStreamException {
         testNextEvent(MAX);
     }
 
     // Without the fix, will cause a StackOverflowException if 'max' is high
     // enough
-    private static void testNextEvent(int max)
-            throws IOException, XMLStreamException {
+    private void testNextEvent(int max)
+            throws XMLStreamException {
         System.out.println("\nTest nextEvent (" + max + ")...");
         XMLEventReader reader = createXmlReader(max);
         XMLEvent event;
@@ -97,14 +91,13 @@ public class EventFilterSupportTest {
 
     // Test calling XMLEventReader.nextTag()
     @Test
-    public static void testNextTag() throws IOException, XMLStreamException {
+    public void testNextTag() throws XMLStreamException {
         testNextTag(MAX);
     }
 
     // Without the fix, will cause a StackOverflowException if 'max' is high
     // enough
-    private static void testNextTag(int max)
-            throws IOException, XMLStreamException {
+    private static void testNextTag(int max) throws XMLStreamException {
         System.out.println("\nTest nextTag (" + max + ")...");
         XMLEventReader reader = createXmlReader(max);
         XMLEvent event;
@@ -163,7 +156,7 @@ public class EventFilterSupportTest {
         }
 
         @Override
-        public int read() throws IOException {
+        public int read() {
             if (n >= 2 * max) return -1;
             if (open == 0) {
                 open = 1;

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue41Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue41Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,12 @@
 
 package stream.EventsTest;
 
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.Iterator;
-import java.util.List;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
@@ -41,73 +37,72 @@ import javax.xml.stream.events.Comment;
 import javax.xml.stream.events.DTD;
 import javax.xml.stream.events.EndDocument;
 import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.EntityDeclaration;
 import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.NotationDeclaration;
 import javax.xml.stream.events.ProcessingInstruction;
 import javax.xml.stream.events.StartDocument;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
  * @bug 6631268
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.EventsTest.Issue41Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.EventsTest.Issue41Test
  * @summary Test XMLEvent.writeAsEncodedUnicode can output the event content.
  */
 public class Issue41Test {
 
     public java.io.File input;
-    public final String filesDir = "./";
     protected XMLInputFactory inputFactory;
-    protected XMLOutputFactory outputFactory;
 
     @Test
-    public void testEvents() {
+    public void testEvents() throws Exception {
         XMLEventFactory f = XMLEventFactory.newInstance();
         final String contents = "test <some> text & more! [[]] --";
         final String prefix = "prefix";
         final String uri = "http://foo";
         final String localName = "elem";
 
-        try {
-            StartDocument sd = f.createStartDocument();
-            writeAsEncodedUnicode(sd);
+        StartDocument sd = f.createStartDocument();
+        writeAsEncodedUnicode(sd);
 
-            Comment c = f.createComment("some comments");
-            writeAsEncodedUnicode(c);
+        Comment c = f.createComment("some comments");
+        writeAsEncodedUnicode(c);
 
-            StartElement se = f.createStartElement(prefix, uri, localName);
+        StartElement se = f.createStartElement(prefix, uri, localName);
 
-            ProcessingInstruction pi = f.createProcessingInstruction("target", "data");
-            writeAsEncodedUnicode(pi);
+        ProcessingInstruction pi = f.createProcessingInstruction("target", "data");
+        writeAsEncodedUnicode(pi);
 
-            Namespace ns = f.createNamespace(prefix, uri);
-            writeAsEncodedUnicode(ns);
+        Namespace ns = f.createNamespace(prefix, uri);
+        writeAsEncodedUnicode(ns);
 
-            Characters characters = f.createCharacters(contents);
-            writeAsEncodedUnicode(characters);
-            // CData
-            Characters cdata = f.createCData(contents);
-            writeAsEncodedUnicode(cdata);
+        Characters characters = f.createCharacters(contents);
+        writeAsEncodedUnicode(characters);
+        // CData
+        Characters cdata = f.createCData(contents);
+        writeAsEncodedUnicode(cdata);
 
-            // Attribute
-            QName attrName = new QName("http://test.com", "attr", "ns");
-            Attribute attr = f.createAttribute(attrName, "value");
-            writeAsEncodedUnicode(attr);
+        // Attribute
+        QName attrName = new QName("http://test.com", "attr", "ns");
+        Attribute attr = f.createAttribute(attrName, "value");
+        writeAsEncodedUnicode(attr);
 
-            // prefix, uri, localName
-            EndElement ee = f.createEndElement(prefix, uri, localName);
-            writeAsEncodedUnicode(ee);
+        // prefix, uri, localName
+        EndElement ee = f.createEndElement(prefix, uri, localName);
+        writeAsEncodedUnicode(ee);
 
-            EndDocument ed = f.createEndDocument();
-            writeAsEncodedUnicode(ed);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
-
+        EndDocument ed = f.createEndDocument();
+        writeAsEncodedUnicode(ed);
     }
 
     /**
@@ -115,47 +110,38 @@ public class Issue41Test {
      * and entity declaration information
      */
     @Test
-    public void testDTDEvent() {
-        String XML = "<?xml version='1.0' ?>" + "<!DOCTYPE root [\n" + "<!ENTITY intEnt 'internal'>\n" + "<!ENTITY extParsedEnt SYSTEM 'url:dummy'>\n"
-                + "<!NOTATION notation PUBLIC 'notation-public-id'>\n" + "<!NOTATION notation2 SYSTEM 'url:dummy'>\n"
-                + "<!ENTITY extUnparsedEnt SYSTEM 'url:dummy2' NDATA notation>\n" + "]>" + "<root />";
+    public void testDTDEvent() throws Exception {
+        String XML = "<?xml version='1.0' ?>"
+                + "<!DOCTYPE root [\n"
+                + "<!ENTITY intEnt 'internal'>\n"
+                + "<!ENTITY extParsedEnt SYSTEM 'url:dummy'>\n"
+                + "<!NOTATION notation PUBLIC 'notation-public-id'>\n"
+                + "<!NOTATION notation2 SYSTEM 'url:dummy'>\n"
+                + "<!ENTITY extUnparsedEnt SYSTEM 'url:dummy2' NDATA notation>\n"
+                + "]>\n"
+                + "<root />";
 
-        try {
-            XMLEventReader er = getReader(XML);
-            XMLEvent evt = er.nextEvent(); // StartDocument
-            evt = er.nextEvent(); // DTD
-            if (evt.getEventType() != XMLStreamConstants.DTD) {
-                Assert.fail("Expected DTD event");
-            }
-            DTD dtd = (DTD) evt;
-            writeAsEncodedUnicode(dtd);
-            List entities = dtd.getEntities();
-            if (entities == null) {
-                Assert.fail("No entity found. Expected 3.");
-            } else {
-                writeAsEncodedUnicode((XMLEvent) entities.get(0));
-                writeAsEncodedUnicode((XMLEvent) entities.get(1));
-                writeAsEncodedUnicode((XMLEvent) entities.get(2));
-            }
+        XMLEventReader er = getReader(XML);
+        assertNotNull(er.nextEvent()); // StartDocument
+        XMLEvent evt = er.nextEvent(); // DTD
+        assertEquals(XMLStreamConstants.DTD, evt.getEventType());
+        DTD dtd = (DTD) evt;
+        writeAsEncodedUnicode(dtd);
+        List<EntityDeclaration> entities = dtd.getEntities();
+        assertEquals(3, entities.size());
+        writeAsEncodedUnicode((XMLEvent) entities.get(0));
+        writeAsEncodedUnicode((XMLEvent) entities.get(1));
+        writeAsEncodedUnicode((XMLEvent) entities.get(2));
 
-            List notations = dtd.getNotations();
-            if (notations == null) {
-                Assert.fail("No notation found. Expected 2.");
-            } else {
-                writeAsEncodedUnicode((XMLEvent) notations.get(0));
-                writeAsEncodedUnicode((XMLEvent) notations.get(1));
-            }
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        List<NotationDeclaration> notations = dtd.getNotations();
+        assertEquals(2, notations.size());
+        writeAsEncodedUnicode((XMLEvent) notations.get(0));
+        writeAsEncodedUnicode((XMLEvent) notations.get(1));
     }
 
     private XMLEventReader getReader(String XML) throws Exception {
         inputFactory = XMLInputFactory.newInstance();
-
-        // Check if event reader returns the correct event
-        XMLEventReader er = inputFactory.createXMLEventReader(new StringReader(XML));
-        return er;
+        return inputFactory.createXMLEventReader(new StringReader(XML));
     }
 
 
@@ -170,8 +156,6 @@ public class Issue41Test {
         }
         StringWriter sw = new StringWriter();
         evt.writeAsEncodedUnicode(sw);
-
-        Assert.assertTrue(sw.toString().length() > 0);
-        System.out.println(sw.toString());
+        assertFalse(sw.toString().isEmpty());
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue48Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue48Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,92 +23,57 @@
 
 package stream.EventsTest;
 
-import java.io.StringReader;
-import java.util.Iterator;
-import java.util.List;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.events.DTD;
 import javax.xml.stream.events.EntityDeclaration;
 import javax.xml.stream.events.NotationDeclaration;
 import javax.xml.stream.events.XMLEvent;
+import java.io.StringReader;
+import java.util.List;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
  * @bug 6620632
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.EventsTest.Issue48Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.EventsTest.Issue48Test
  * @summary Test XMLEventReader can parse notation and entity information from DTD Event.
  */
 public class Issue48Test {
-
-    public java.io.File input;
-    public final String filesDir = "./";
-    protected XMLInputFactory inputFactory;
-    protected XMLOutputFactory outputFactory;
-
     /**
      * DTDEvent instances constructed via event reader are missing the notation
      * and entity declaration information
      */
     @Test
-    public void testDTDEvent() {
+    public void testDTDEvent() throws Exception {
         String XML = "<?xml version='1.0' ?>" + "<!DOCTYPE root [\n" + "<!ENTITY intEnt 'internal'>\n" + "<!ENTITY extParsedEnt SYSTEM 'url:dummy'>\n"
                 + "<!NOTATION notation PUBLIC 'notation-public-id'>\n" + "<!NOTATION notation2 SYSTEM 'url:dummy'>\n"
                 + "<!ENTITY extUnparsedEnt SYSTEM 'url:dummy2' NDATA notation>\n" + "]>" + "<root />";
 
-        try {
-            XMLEventReader er = getReader(XML);
-            XMLEvent evt = er.nextEvent(); // StartDocument
-            evt = er.nextEvent(); // DTD
-            if (evt.getEventType() != XMLStreamConstants.DTD) {
-                Assert.fail("Expected DTD event");
-            }
-            DTD dtd = (DTD) evt;
-            List entities = dtd.getEntities();
-            if (entities == null) {
-                Assert.fail("No entity found. Expected 3.");
-            } else {
-                Assert.assertEquals(entities.size(), 3);
-            }
-            // Let's also verify they are all of right type...
-            testListElems(entities, EntityDeclaration.class);
+        XMLEventReader er = getReader(XML);
+        er.nextEvent(); // StartDocument
+        XMLEvent evt = er.nextEvent(); // DTD
+        assertEquals(XMLStreamConstants.DTD, evt.getEventType());
+        DTD dtd = (DTD) evt;
+        List<EntityDeclaration> entities = dtd.getEntities();
+        assertNotNull(entities);
+        assertEquals(3, entities.size());
 
-            List notations = dtd.getNotations();
-            if (notations == null) {
-                Assert.fail("No notation found. Expected 2.");
-            } else {
-                Assert.assertEquals(notations.size(), 2);
-            }
-            // Let's also verify they are all of right type...
-            testListElems(notations, NotationDeclaration.class);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        List<NotationDeclaration> notations = dtd.getNotations();
+        assertNotNull(notations);
+        assertEquals(2, notations.size());
     }
 
     private XMLEventReader getReader(String XML) throws Exception {
-        inputFactory = XMLInputFactory.newInstance();
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 
         // Check if event reader returns the correct event
-        XMLEventReader er = inputFactory.createXMLEventReader(new StringReader(XML));
-        return er;
+        return inputFactory.createXMLEventReader(new StringReader(XML));
     }
-
-
-    private void testListElems(List l, Class expType) {
-        Iterator it = l.iterator();
-        while (it.hasNext()) {
-            Object o = it.next();
-            Assert.assertNotNull(o);
-            Assert.assertTrue(expType.isAssignableFrom(o.getClass()));
-        }
-    }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue53Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue53Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,17 @@
 
 package stream.EventsTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.events.StartDocument;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.EventsTest.Issue53Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.EventsTest.Issue53Test
  * @summary Test encodingSet/standaloneSet returns correct result in case encoding/standalone is set when constructing StartDocument.
  */
 public class Issue53Test {
@@ -41,30 +42,19 @@ public class Issue53Test {
     public void testEncodingSet() {
         XMLEventFactory f = XMLEventFactory.newInstance();
 
-        try {
-            StartDocument sd = f.createStartDocument("UTF-8");
-            System.out.println("Encoding: " + sd.getCharacterEncodingScheme());
-            System.out.println("Encoding set: " + sd.encodingSet());
-            Assert.assertTrue(sd.encodingSet(), "encoding is set, should return true.");
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
-
+        StartDocument sd = f.createStartDocument("UTF-8");
+        System.out.println("Encoding: " + sd.getCharacterEncodingScheme());
+        System.out.println("Encoding set: " + sd.encodingSet());
+        assertTrue(sd.encodingSet(), "encoding is set, should return true.");
     }
 
     @Test
     public void testStandaloneSet() {
         XMLEventFactory f = XMLEventFactory.newInstance();
 
-        try {
-            StartDocument sd = f.createStartDocument("UTF-8", "1.0", true);
-            System.out.println(sd.isStandalone());
-            System.out.println(sd.standaloneSet());
-            Assert.assertTrue(sd.standaloneSet(), "standalone is set, should return true.");
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
-
+        StartDocument sd = f.createStartDocument("UTF-8", "1.0", true);
+        System.out.println(sd.isStandalone());
+        System.out.println(sd.standaloneSet());
+        assertTrue(sd.standaloneSet(), "standalone is set, should return true.");
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue58Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/EventsTest/Issue58Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,61 +23,46 @@
 
 package stream.EventsTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.events.XMLEvent;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.EventsTest.Issue58Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.EventsTest.Issue58Test
  * @summary Test XMLEvent.getLocation() returns a non-volatile Location.
  */
 public class Issue58Test {
 
-    public java.io.File input;
-    public final String filesDir = "./";
-    protected XMLInputFactory inputFactory;
-    protected XMLOutputFactory outputFactory;
-
     @Test
-    public void testLocation() {
+    public void testLocation() throws Exception {
         String XML = "<?xml version='1.0' ?>" + "<!DOCTYPE root [\n" + "<!ENTITY intEnt 'internal'>\n" + "<!ENTITY extParsedEnt SYSTEM 'url:dummy'>\n"
                 + "<!NOTATION notation PUBLIC 'notation-public-id'>\n" + "<!NOTATION notation2 SYSTEM 'url:dummy'>\n"
                 + "<!ENTITY extUnparsedEnt SYSTEM 'url:dummy2' NDATA notation>\n" + "]>\n" + "<root />";
 
-        try {
-            XMLEventReader er = getReader(XML);
-            XMLEvent evt = er.nextEvent(); // StartDocument
-            Location loc1 = evt.getLocation();
-            System.out.println("Location 1: " + loc1.getLineNumber() + "," + loc1.getColumnNumber());
-            evt = er.nextEvent(); // DTD
-            // loc1 should not change so its line number should still be 1
-            Assert.assertTrue(loc1.getLineNumber() == 1);
-            Location loc2 = evt.getLocation();
-            System.out.println("Location 2: " + loc2.getLineNumber() + "," + loc2.getColumnNumber());
-            evt = er.nextEvent(); // root
-            System.out.println("Location 1: " + loc1.getLineNumber() + "," + loc1.getColumnNumber());
-            Assert.assertTrue(loc1.getLineNumber() == 1);
-            Assert.assertTrue(loc2.getLineNumber() == 7);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        XMLEventReader er = getReader(XML);
+        XMLEvent evt = er.nextEvent(); // StartDocument
+        Location loc1 = evt.getLocation();
+        evt = er.nextEvent(); // DTD
+        // loc1 should not change so its line number should still be 1
+        assertEquals(1, loc1.getLineNumber());
+
+        Location loc2 = evt.getLocation();
+        assertEquals(1, loc1.getLineNumber());
+        assertEquals(7, loc2.getLineNumber());
     }
 
     private XMLEventReader getReader(String XML) throws Exception {
-        inputFactory = XMLInputFactory.newInstance();
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 
         // Check if event reader returns the correct event
-        XMLEventReader er = inputFactory.createXMLEventReader(new StringReader(XML));
-        return er;
+        return inputFactory.createXMLEventReader(new StringReader(XML));
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/FactoryFindTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/FactoryFindTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,123 +23,96 @@
 
 package stream;
 
-import static jaxp.library.JAXPTestUtilities.getSystemProperty;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Properties;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.FactoryFindTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.FactoryFindTest
  * @summary Test SaTX factory using factory property and using ContextClassLoader.
  */
 public class FactoryFindTest {
-
-    boolean myClassLoaderUsed = false;
-
     final static String FACTORY_KEY = "javax.xml.stream.XMLInputFactory";
 
-//    @BeforeClass
-//    public void setup(){
-//        policy.PolicyUtil.changePolicy(getClass().getResource("FactoryFindTest.policy").getFile());
-//    }
-
-    @Test(enabled=false) // due to 8156508
-    public void testFactoryFindUsingStaxProperties() {
+    @Test
+    @Disabled // due to 8156508
+    public void testFactoryFindUsingStaxProperties() throws Exception {
         // If property is defined, will take precendence so this test
         // is ignored :(
-        if (getSystemProperty(FACTORY_KEY) != null) {
-            return;
-        }
+        Assumptions.assumeTrue(System.getProperty(FACTORY_KEY) == null);
 
         Properties props = new Properties();
-        String configFile = getSystemProperty("java.home") + File.separator + "lib" + File.separator + "stax.properties";
+        String configFile = System.getProperty("java.home") + File.separator + "lib" + File.separator + "stax.properties";
 
         File f = new File(configFile);
         if (f.exists()) {
-            try {
-                FileInputStream fis = new FileInputStream(f);
+            try (FileInputStream fis = new FileInputStream(f)) {
                 props.load(fis);
-                fis.close();
-            } catch (FileNotFoundException e) {
-                return;
-            } catch (IOException e) {
-                return;
             }
         } else {
             props.setProperty(FACTORY_KEY, "com.sun.xml.internal.stream.XMLInputFactoryImpl");
-            try {
-                FileOutputStream fos = new FileOutputStream(f);
+            try (FileOutputStream fos = new FileOutputStream(f)) {
                 props.store(fos, null);
-                fos.close();
-                f.deleteOnExit();
-            } catch (FileNotFoundException e) {
-                return;
-            } catch (IOException e) {
-                return;
             }
+            f.deleteOnExit();
         }
 
         XMLInputFactory factory = XMLInputFactory.newInstance();
-        Assert.assertTrue(factory.getClass().getName().equals(props.getProperty(FACTORY_KEY)));
+        assertEquals(factory.getClass().getName(), props.getProperty(FACTORY_KEY));
     }
 
     @Test
     public void testFactoryFind() {
-        try {
-            // setSystemProperty("jaxp.debug", "true");
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        assertNull(factory.getClass().getClassLoader());
 
-            XMLInputFactory factory = XMLInputFactory.newInstance();
-            Assert.assertTrue(factory.getClass().getClassLoader() == null);
+        Thread.currentThread().setContextClassLoader(null);
+        factory = XMLInputFactory.newInstance();
+        assertNull(factory.getClass().getClassLoader());
 
-            Thread.currentThread().setContextClassLoader(null);
-            factory = XMLInputFactory.newInstance();
-            Assert.assertTrue(factory.getClass().getClassLoader() == null);
+        MyClassLoader clInput = new MyClassLoader();
+        Thread.currentThread().setContextClassLoader(clInput);
+        XMLInputFactory.newInstance();
+        // because it's decided by having sm or not in FactoryFind code
+        assertTrue(clInput.wasUsed);
 
-            Thread.currentThread().setContextClassLoader(new MyClassLoader());
-            factory = XMLInputFactory.newInstance();
-            // because it's decided by having sm or not in FactoryFind code
-            if (System.getSecurityManager() == null)
-                Assert.assertTrue(myClassLoaderUsed);
-            else
-                Assert.assertFalse(myClassLoaderUsed);
+        XMLOutputFactory ofactory = XMLOutputFactory.newInstance();
+        assertNull(ofactory.getClass().getClassLoader());
 
-            XMLOutputFactory ofactory = XMLOutputFactory.newInstance();
-            Assert.assertTrue(ofactory.getClass().getClassLoader() == null);
+        Thread.currentThread().setContextClassLoader(null);
+        ofactory = XMLOutputFactory.newInstance();
+        assertNull(ofactory.getClass().getClassLoader());
 
-            Thread.currentThread().setContextClassLoader(null);
-            ofactory = XMLOutputFactory.newInstance();
-            Assert.assertTrue(ofactory.getClass().getClassLoader() == null);
-
-            Thread.currentThread().setContextClassLoader(new MyClassLoader());
-            ofactory = XMLOutputFactory.newInstance();
-            if (System.getSecurityManager() == null)
-                Assert.assertTrue(myClassLoaderUsed);
-            else
-                Assert.assertFalse(myClassLoaderUsed);
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        MyClassLoader clOutput = new MyClassLoader();
+        Thread.currentThread().setContextClassLoader(clOutput);
+        XMLOutputFactory.newInstance();
+        assertTrue(clOutput.wasUsed);
     }
 
-    class MyClassLoader extends URLClassLoader {
+    private static class MyClassLoader extends URLClassLoader {
+        boolean wasUsed = false;
 
         public MyClassLoader() {
             super(new URL[0]);
         }
 
-        public Class loadClass(String name) throws ClassNotFoundException {
-            myClassLoaderUsed = true;
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            wasUsed = true;
             return super.loadClass(name);
         }
     }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/IgnoreExternalDTDTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/IgnoreExternalDTDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,19 +23,18 @@
 
 package stream;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-
-import org.testng.annotations.Test;
+import java.io.StringReader;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.IgnoreExternalDTDTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.IgnoreExternalDTDTest
  * @summary Test feature ignore-external-dtd.
  */
 public class IgnoreExternalDTDTest {
@@ -52,7 +51,7 @@ public class IgnoreExternalDTDTest {
     }
 
     @Test
-    public void testFeatureNegative() throws Exception {
+    public void testFeatureNegative() {
         XMLInputFactory xif = XMLInputFactory.newInstance();
         xif.setProperty(ZEPHYR_PROPERTY_PREFIX + IGNORE_EXTERNAL_DTD, Boolean.FALSE);
         try {

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/ProcessingInstructionTest/ProcessingInstructionTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/ProcessingInstructionTest/ProcessingInstructionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,44 +23,39 @@
 
 package stream.ProcessingInstructionTest;
 
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.ProcessingInstructionTest.ProcessingInstructionTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.ProcessingInstructionTest.ProcessingInstructionTest
  * @summary Test XMLStreamReader parses Processing Instruction.
  */
 public class ProcessingInstructionTest {
 
     @Test
-    public void testPITargetAndData() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            String PITarget = "soffice";
-            String PIData = "WebservicesArchitecture";
-            String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<?" + PITarget + " " + PIData + "?>" + "<foo></foo>";
-            // System.out.println("XML = " + xml) ;
-            InputStream is = new java.io.ByteArrayInputStream(xml.getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.PROCESSING_INSTRUCTION) {
-                    String target = sr.getPITarget();
-                    String data = sr.getPIData();
-                    Assert.assertTrue(target.equals(PITarget) && data.equals(PIData));
-                }
+    public void testPITargetAndData() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        String PITarget = "soffice";
+        String PIData = "WebservicesArchitecture";
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<?" + PITarget + " " + PIData + "?>" + "<foo></foo>";
+        // System.out.println("XML = " + xml) ;
+        InputStream is = new java.io.ByteArrayInputStream(xml.getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.PROCESSING_INSTRUCTION) {
+                String target = sr.getPITarget();
+                String data = sr.getPIData();
+                assertTrue(target.equals(PITarget) && data.equals(PIData));
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
         }
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/StreamReaderDelegateTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/StreamReaderDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,27 +23,28 @@
 
 package stream;
 
-import java.io.File;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.StreamReaderDelegate;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Iterator;
 
-import javax.xml.namespace.NamespaceContext;
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.util.StreamReaderDelegate;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.StreamReaderDelegateTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.StreamReaderDelegateTest
  * @summary Test StreamReaderDelegate.
  */
 public class StreamReaderDelegateTest {
@@ -56,74 +57,51 @@ public class StreamReaderDelegateTest {
      * <![CDATA[<greeting>Hello</greeting>]]> other content </ns1:foo>
      **/
     @Test
-    public void testAttribute() {
-        StreamReaderDelegate delegate = null;
+    public void testAttribute() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(getClass().getResource("testfile1.xml").getFile()));
+        StreamReaderDelegate delegate = new StreamReaderDelegate(reader);
         try {
-            System.out.println("===in testAttribute()===");
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(new File(getClass().getResource("testfile1.xml").getFile())));
-            delegate = new StreamReaderDelegate(reader);
 
-            Assert.assertTrue(delegate.standaloneSet());
-            Assert.assertFalse(delegate.isStandalone());
+            assertTrue(delegate.standaloneSet());
+            assertFalse(delegate.isStandalone());
             while (delegate.hasNext()) {
                 delegate.next();
                 if (delegate.getEventType() == XMLStreamConstants.START_ELEMENT || delegate.getEventType() == XMLStreamConstants.ATTRIBUTE) {
                     if (delegate.getLocalName().equals("foo")) {
-                        Assert.assertTrue(delegate.getAttributeCount() == 5);
-                        Assert.assertTrue(delegate.getAttributeType(1) == "CDATA");
+                        assertEquals(5, delegate.getAttributeCount());
+                        assertSame("CDATA", delegate.getAttributeType(1));
 
-                        Assert.assertTrue(delegate.getAttributeValue(0).equals("defaultAttr1"));
-                        Assert.assertTrue(delegate.getAttributeValue(delegate.getAttributeCount() - 2).equals("defaultAttr2"));
-                        Assert.assertTrue(delegate.getAttributeValue(delegate.getAttributeCount() - 1).equals("defaultAttr3"));
+                        assertEquals("defaultAttr1", delegate.getAttributeValue(0));
+                        assertEquals("defaultAttr2", delegate.getAttributeValue(delegate.getAttributeCount() - 2));
+                        assertEquals("defaultAttr3", delegate.getAttributeValue(delegate.getAttributeCount() - 1));
 
-                        Assert.assertTrue(delegate.getAttributeValue("http://ns1.java.com", "attr1").equals("ns1Attr1"));
-                        Assert.assertTrue(delegate.getAttributeValue("http://ns2.java.com", "attr1").equals("ns2Attr1"));
+                        assertEquals("ns1Attr1", delegate.getAttributeValue("http://ns1.java.com", "attr1"));
+                        assertEquals("ns2Attr1", delegate.getAttributeValue("http://ns2.java.com", "attr1"));
 
-                        Assert.assertTrue(delegate.getAttributeValue(null, "attr2").equals("defaultAttr2"));
-                        Assert.assertTrue(delegate.getAttributeValue(null, "attr3").equals("defaultAttr3"));
+                        assertEquals("defaultAttr2", delegate.getAttributeValue(null, "attr2"));
+                        assertEquals("defaultAttr3", delegate.getAttributeValue(null, "attr3"));
 
-                        Assert.assertTrue(delegate.getAttributeNamespace(0) == null);
-                        Assert.assertTrue(delegate.getAttributeNamespace(1).equals("http://ns1.java.com"));
-                        Assert.assertTrue(delegate.getAttributePrefix(1).equals("ns1"));
-                        Assert.assertTrue(delegate.getAttributeName(1).toString()
-                                .equals("{" + delegate.getAttributeNamespace(1) + "}" + delegate.getAttributeLocalName(1)));
-                        Assert.assertTrue(delegate.getAttributeLocalName(1).equals("attr1"));
+                        assertNull(delegate.getAttributeNamespace(0));
+                        assertEquals("http://ns1.java.com", delegate.getAttributeNamespace(1));
+                        assertEquals("ns1", delegate.getAttributePrefix(1));
+                        assertEquals(delegate.getAttributeName(1).toString(), "{" + delegate.getAttributeNamespace(1) + "}" + delegate.getAttributeLocalName(1));
+                        assertEquals("attr1", delegate.getAttributeLocalName(1));
 
                         // negative test. Should return null for out of
                         // attribute array index
-                        Assert.assertTrue(delegate.getAttributeNamespace(delegate.getAttributeCount()) == null);
-                        Assert.assertTrue(delegate.getAttributePrefix(delegate.getAttributeCount()) == null);
-                        Assert.assertTrue(delegate.getAttributeName(delegate.getAttributeCount()) == null);
-                        Assert.assertTrue(delegate.getAttributeLocalName(delegate.getAttributeCount()) == null);
-                        Assert.assertTrue(delegate.getAttributeType(delegate.getAttributeCount()) == null);
+                        assertNull(delegate.getAttributeNamespace(delegate.getAttributeCount()));
+                        assertNull(delegate.getAttributePrefix(delegate.getAttributeCount()));
+                        assertNull(delegate.getAttributeName(delegate.getAttributeCount()));
+                        assertNull(delegate.getAttributeLocalName(delegate.getAttributeCount()));
+                        assertNull(delegate.getAttributeType(delegate.getAttributeCount()));
                     }
                 } else {
-                    try {
-                        delegate.getAttributeCount();
-                    } catch (IllegalStateException e) {
-                        System.out.println("expected exception for incorrect event type");
-                    }
+                    assertThrows(IllegalStateException.class, delegate::getAttributeCount);
                 }
-
             }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testAttribute()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            System.out.println(delegate.getLocation());
-            Assert.fail("XMLStreamException in testAttribute()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testAttribute()");
         } finally {
-            try {
-                delegate.close();
-            } catch (XMLStreamException e) {
-                e.printStackTrace();
-                Assert.fail("XMLStreamException in testAttribute()");
-            }
+            delegate.close();
         }
     }
 
@@ -134,33 +112,31 @@ public class StreamReaderDelegateTest {
      * <![CDATA[<greeting>Hello</greeting>]]> other content </ns1:foo>
      **/
     @Test
-    public void testNamespace() {
-        StreamReaderDelegate delegate = null;
+    public void testNamespace() throws Exception {
+        XMLStreamReader reader = XMLInputFactory.newFactory().createXMLStreamReader(
+                new FileInputStream(getClass().getResource("testfile2.xml").getFile()));
+        StreamReaderDelegate delegate = new StreamReaderDelegate();
         try {
-            System.out.println("===in testNamespace()===");
-            XMLStreamReader reader = XMLInputFactory.newFactory().createXMLStreamReader(
-                    new FileInputStream(new File(getClass().getResource("testfile2.xml").getFile())));
-            delegate = new StreamReaderDelegate();
             delegate.setParent(reader);
             while (delegate.hasNext()) {
                 delegate.next();
                 if (delegate.getEventType() == XMLStreamConstants.START_ELEMENT || delegate.getEventType() == XMLStreamConstants.ATTRIBUTE) {
 
                     if (delegate.getName().getLocalPart().equals("foo")) {
-                        Assert.assertTrue(("{" + delegate.getNamespaceURI(delegate.getPrefix()) + "}" + delegate.getLocalName()).equals(delegate.getName()
-                                .toString()));
+                        assertEquals(("{" + delegate.getNamespaceURI(delegate.getPrefix()) + "}" + delegate.getLocalName()), delegate.getName()
+                                .toString());
                         System.out.println(delegate.getLocation());
 
-                        Assert.assertTrue(delegate.getNamespaceCount() == 3);
-                        Assert.assertTrue(delegate.getNamespaceURI().equals("http://ns1.java.com"));
-                        Assert.assertTrue(delegate.getNamespaceURI(2).equals("http://ns2.java.com"));
-                        Assert.assertTrue(delegate.getNamespaceURI("ns").equals("http://ns1.java.com"));
+                        assertEquals(3, delegate.getNamespaceCount());
+                        assertEquals("http://ns1.java.com", delegate.getNamespaceURI());
+                        assertEquals("http://ns2.java.com", delegate.getNamespaceURI(2));
+                        assertEquals("http://ns1.java.com", delegate.getNamespaceURI("ns"));
 
-                        Assert.assertTrue(delegate.getNamespacePrefix(1).equals("ns1"));
+                        assertEquals("ns1", delegate.getNamespacePrefix(1));
 
                         NamespaceContext nsCtx = delegate.getNamespaceContext();
                         nsCtx.getNamespaceURI("ns");
-                        Iterator prefixes = nsCtx.getPrefixes("http://ns1.java.com");
+                        Iterator<String> prefixes = nsCtx.getPrefixes("http://ns1.java.com");
                         boolean hasns = false;
                         boolean hasns1 = false;
                         while (prefixes.hasNext()) {
@@ -171,27 +147,12 @@ public class StreamReaderDelegateTest {
                                 hasns1 = true;
                             }
                         }
-                        Assert.assertTrue(hasns && hasns1);
+                        assertTrue(hasns && hasns1);
                     }
                 }
             }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testNamespace()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            System.out.println(delegate.getLocation());
-            Assert.fail("XMLStreamException in testNamespace()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testNamespace()");
         } finally {
-            try {
-                delegate.close();
-            } catch (XMLStreamException e) {
-                e.printStackTrace();
-                Assert.fail("XMLStreamException in testNamespace()");
-            }
+            delegate.close();
         }
     }
 
@@ -202,22 +163,20 @@ public class StreamReaderDelegateTest {
      * other content </ns1:foo>
      **/
     @Test
-    public void testText() {
+    public void testText() throws Exception {
         String property = "javax.xml.stream.isCoalescing";
-        System.out.println("===in testText()====");
-        StreamReaderDelegate delegate = null;
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        ifac.setProperty(property, Boolean.TRUE);
+        XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(getClass().getResource("testfile3.xml").getFile()), "iso8859-1");
+        StreamReaderDelegate delegate = new StreamReaderDelegate();
         try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            ifac.setProperty(property, Boolean.TRUE);
-            XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(new File(getClass().getResource("testfile3.xml").getFile())), "iso8859-1");
-            delegate = new StreamReaderDelegate();
             delegate.setParent(reader);
 
-            Assert.assertTrue(delegate.getParent().equals(reader));
-            Assert.assertTrue(delegate.getProperty(property).equals(Boolean.TRUE));
-            Assert.assertTrue(delegate.getCharacterEncodingScheme().equalsIgnoreCase("utf-8"));
-            Assert.assertTrue(delegate.getEncoding().equalsIgnoreCase("iso8859-1"));
-            Assert.assertTrue(delegate.getVersion().equals("1.0"));
+            assertEquals(delegate.getParent(), reader);
+            assertEquals(Boolean.TRUE, delegate.getProperty(property));
+            assertTrue(delegate.getCharacterEncodingScheme().equalsIgnoreCase("utf-8"));
+            assertTrue(delegate.getEncoding().equalsIgnoreCase("iso8859-1"));
+            assertEquals("1.0", delegate.getVersion());
             while (delegate.hasNext()) {
                 delegate.next();
                 if (delegate.getEventType() == XMLStreamConstants.CHARACTERS) {
@@ -225,96 +184,61 @@ public class StreamReaderDelegateTest {
                     delegate.getTextCharacters(delegate.getTextStart(), target1, 0, target1.length);
                     char[] target2 = delegate.getTextCharacters();
 
-                    Assert.assertTrue(delegate.getText().trim().equals(new String(target1).trim()));
-                    Assert.assertTrue(delegate.getText().trim().equals(new String(target2).trim()));
+                    assertEquals(delegate.getText().trim(), new String(target1).trim());
+                    assertEquals(delegate.getText().trim(), new String(target2).trim());
                 }
             }
-
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testText()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            System.out.println(delegate.getLocation());
-            Assert.fail("XMLStreamException in testText()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testText()");
         } finally {
-            try {
-                delegate.close();
-            } catch (XMLStreamException e) {
-                e.printStackTrace();
-                Assert.fail("XMLStreamException in testText()");
-            }
+            delegate.close();
         }
     }
 
     @Test
-    public void testWhiteSpace() {
-        System.out.println("===in testWhiteSpace()===");
-        StreamReaderDelegate delegate = null;
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            ifac.setProperty("javax.xml.stream.isCoalescing", Boolean.TRUE);
-            XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(new File(getClass().getResource("testfile4.xml").getFile())));
+    public void testWhiteSpace() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        ifac.setProperty("javax.xml.stream.isCoalescing", Boolean.TRUE);
+        XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(getClass().getResource("testfile4.xml").getFile()));
 
-            delegate = new StreamReaderDelegate();
+        StreamReaderDelegate delegate = new StreamReaderDelegate();
+        try {
             delegate.setParent(reader);
             while (delegate.hasNext()) {
                 int i = delegate.next();
                 switch (i) {
                     case XMLStreamConstants.CHARACTERS: {
-                        Assert.assertTrue(delegate.isCharacters());
-                        Assert.assertTrue(delegate.hasText());
-                        Assert.assertTrue(delegate.isWhiteSpace());
+                        assertTrue(delegate.isCharacters());
+                        assertTrue(delegate.hasText());
+                        assertTrue(delegate.isWhiteSpace());
                         break;
                     }
                     case XMLStreamConstants.START_ELEMENT: {
-                        Assert.assertTrue(delegate.isStartElement());
-                        Assert.assertTrue(delegate.isAttributeSpecified(0));
-                        Assert.assertTrue(delegate.hasName());
+                        assertTrue(delegate.isStartElement());
+                        assertTrue(delegate.isAttributeSpecified(0));
+                        assertTrue(delegate.hasName());
                         delegate.require(XMLStreamConstants.START_ELEMENT, delegate.getNamespaceURI(), delegate.getLocalName());
                         break;
                     }
                     case XMLStreamConstants.END_ELEMENT: {
-                        Assert.assertTrue(delegate.isEndElement());
-                        Assert.assertTrue(delegate.hasName());
+                        assertTrue(delegate.isEndElement());
+                        assertTrue(delegate.hasName());
                         delegate.require(XMLStreamConstants.END_ELEMENT, delegate.getNamespaceURI(), delegate.getLocalName());
                         break;
                     }
                 }
             }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testWhiteSpace()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            System.out.println(delegate.getLocation());
-            Assert.fail("XMLStreamException in testWhiteSpace()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testWhiteSpace()");
         } finally {
-            try {
-                delegate.close();
-            } catch (XMLStreamException e) {
-                e.printStackTrace();
-                Assert.fail("XMLStreamException in testWhitespace()");
-            }
+            delegate.close();
         }
 
     }
 
     @Test
-    public void testElementText() {
-        System.out.println("===in testElementText()===");
-        StreamReaderDelegate delegate = null;
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newFactory();
-            XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(new File(getClass().getResource("toys.xml").getFile())));
+    public void testElementText() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newFactory();
+        XMLStreamReader reader = ifac.createXMLStreamReader(new FileInputStream(getClass().getResource("toys.xml").getFile()));
 
-            delegate = new StreamReaderDelegate();
+        StreamReaderDelegate delegate = new StreamReaderDelegate();
+        try {
             delegate.setParent(reader);
             while (delegate.hasNext()) {
                 if (delegate.getEventType() == XMLStreamConstants.START_ELEMENT) {
@@ -326,57 +250,32 @@ public class StreamReaderDelegateTest {
                     delegate.next();
                 }
             }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail("FileNotFoundException in testElementText()");
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            System.out.println(delegate.getLocation());
-            Assert.fail("XMLStreamException in testElementText()");
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-            Assert.fail("FactoryConfigurationError in testElementText()");
         } finally {
-            try {
-                delegate.close();
-            } catch (XMLStreamException e) {
-                e.printStackTrace();
-                Assert.fail("XMLStreamException in testElementText()");
-            }
+            delegate.close();
         }
     }
 
     @Test
-    public void testPITargetAndData() {
-        System.out.println("===in testPITargetAndData()===");
-        StreamReaderDelegate delegate = null;
+    public void testPITargetAndData() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        String PITarget = "soffice";
+        String PIData = "WebservicesArchitecture";
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<?" + PITarget + " " + PIData + "?>" + "<foo></foo>";
+        InputStream is = new java.io.ByteArrayInputStream(xml.getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        StreamReaderDelegate delegate = new StreamReaderDelegate(sr);
         try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            String PITarget = "soffice";
-            String PIData = "WebservicesArchitecture";
-            String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<?" + PITarget + " " + PIData + "?>" + "<foo></foo>";
-            InputStream is = new java.io.ByteArrayInputStream(xml.getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            delegate = new StreamReaderDelegate(sr);
             while (delegate.hasNext()) {
                 int eventType = delegate.next();
                 if (eventType == XMLStreamConstants.PROCESSING_INSTRUCTION) {
                     String target = delegate.getPITarget();
                     String data = delegate.getPIData();
-                    Assert.assertTrue(target.equals(PITarget));
-                    Assert.assertTrue(data.equals(PIData));
+                    assertEquals(PITarget, target);
+                    assertEquals(PIData, data);
                 }
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail("Exception in testPITargetAndData()");
         } finally {
-            try {
-                delegate.close();
-            } catch (XMLStreamException e) {
-                e.printStackTrace();
-                Assert.fail("XMLStreamException in testPITargetAndData()");
-            }
+            delegate.close();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventLocationTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,19 @@
 
 package stream;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.events.XMLEvent;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventLocationTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventLocationTest
  * @summary Test XMLEvent Location.
  */
 public class XMLEventLocationTest {
@@ -42,7 +44,7 @@ public class XMLEventLocationTest {
     public void testNonNullLocation() {
         XMLEventFactory factory = XMLEventFactory.newInstance();
         XMLEvent event = factory.createComment("some comment");
-        Assert.assertNotNull(event.getLocation());
+        assertNotNull(event.getLocation());
     }
 
     @Test
@@ -51,13 +53,10 @@ public class XMLEventLocationTest {
         Location loc = new MyLocation();
         factory.setLocation(loc);
         XMLEvent event = factory.createComment("some comment");
-        Assert.assertEquals(event.getLocation().getLineNumber(), 15);
+        assertEquals(15, event.getLocation().getLineNumber());
     }
 
-    class MyLocation implements Location {
-        public MyLocation() {
-        }
-
+    private static class MyLocation implements Location {
         public int getCharacterOffset() {
             return 5;
         }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6489890.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6489890.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,54 +23,48 @@
 
 package stream.XMLEventReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /*
  * @test
  * @bug 6489890
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug6489890
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug6489890
  * @summary Test XMLEventReader's initial state is an undefined state, and nextEvent() is START_DOCUMENT.
  */
 public class Bug6489890 {
 
     @Test
-    public void test0() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
+    public void test0() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
 
-            XMLStreamReader xsr = xif.createXMLStreamReader(getClass().getResource("sgml.xml").toString(), getClass().getResourceAsStream("sgml.xml"));
+        XMLStreamReader xsr = xif.createXMLStreamReader(getClass().getResource("sgml.xml").toString(), getClass().getResourceAsStream("sgml.xml"));
 
-            XMLEventReader xer = xif.createXMLEventReader(xsr);
+        XMLEventReader xer = xif.createXMLEventReader(xsr);
 
-            Assert.assertTrue(xer.peek().getEventType() == XMLEvent.START_DOCUMENT);
-            Assert.assertTrue(xer.peek() == xer.nextEvent());
-            xsr.close();
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        assertEquals(XMLEvent.START_DOCUMENT, xer.peek().getEventType());
+        assertSame(xer.peek(), xer.nextEvent());
+        xsr.close();
     }
 
     @Test
-    public void test1() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
+    public void test1() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
 
-            XMLStreamReader xsr = xif.createXMLStreamReader(getClass().getResource("sgml.xml").toString(), getClass().getResourceAsStream("sgml.xml"));
+        XMLStreamReader xsr = xif.createXMLStreamReader(getClass().getResource("sgml.xml").toString(), getClass().getResourceAsStream("sgml.xml"));
 
-            XMLEventReader xer = xif.createXMLEventReader(xsr);
+        XMLEventReader xer = xif.createXMLEventReader(xsr);
 
-            Assert.assertTrue(xer.nextEvent().getEventType() == XMLEvent.START_DOCUMENT);
-            xsr.close();
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        assertEquals(XMLEvent.START_DOCUMENT, xer.nextEvent().getEventType());
+        xsr.close();
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6555001.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6555001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,28 @@
  */
 package stream.XMLEventReaderTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.events.EntityReference;
 import javax.xml.stream.events.XMLEvent;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6555001
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug6555001
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug6555001
  * @summary Test StAX parser replaces the entity reference as setting.
  */
 public class Bug6555001 {
-    private static final String XML = ""
-            + "<!DOCTYPE doc SYSTEM 'file:///tmp/this/does/not/exist/but/that/is/ok' ["
-            + "<!ENTITY def '<para/>'>" + "]>" + "<doc>&def;&undef;</doc>";
+    private static final String XML =
+            "<!DOCTYPE doc SYSTEM 'file:///tmp/this/does/not/exist/but/that/is/ok' ["
+                    + "<!ENTITY def '<para/>'>" + "]>" + "<doc>&def;&undef;</doc>";
 
     @Test
     public void testReplacing() throws Exception {
@@ -68,8 +71,8 @@ public class Bug6555001 {
             }
         }
 
-        Assert.assertEquals(false, sawDef);
-        Assert.assertEquals(true, sawUndef);
+        assertFalse(sawDef);
+        assertTrue(sawUndef);
         reader.close();
     }
 
@@ -99,8 +102,8 @@ public class Bug6555001 {
             }
         }
 
-        Assert.assertEquals(true, sawDef);
-        Assert.assertEquals(true, sawUndef);
+        assertTrue(sawDef);
+        assertTrue(sawUndef);
         reader.close();
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6586466Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6586466Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,43 +23,38 @@
 
 package stream.XMLEventReaderTest;
 
-import org.testng.annotations.Test;
-import org.testng.Assert;
-import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
+import java.io.ByteArrayInputStream;
 
 /*
  * @test
  * @bug 6586466
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug6586466Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug6586466Test
  * @summary Test XMLEventReader.nextTag() shall update internal event state.
  */
 public class Bug6586466Test {
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         String xmlData = "<?xml version=\"1.0\"?><Test>Hello</Test>";
-        try {
-            XMLEventReader xmlReader = XMLInputFactory.newInstance().createXMLEventReader(new ByteArrayInputStream(xmlData.getBytes()));
 
-            XMLEvent event = xmlReader.nextEvent();
-            System.out.println(event.getClass());
+        XMLEventReader xmlReader = XMLInputFactory.newInstance().createXMLEventReader(new ByteArrayInputStream(xmlData.getBytes()));
 
-            // xmlReader.peek(); // error in both cases with/without peek()
-            event = xmlReader.nextTag(); // nextEvent() would work fine
-            // nextTag() forgets to set fLastEvent
-            System.out.println(event.getClass());
+        XMLEvent event = xmlReader.nextEvent();
+        System.out.println(event.getClass());
 
-            String text = xmlReader.getElementText();
-            System.out.println(text);
-        } catch (XMLStreamException e) {
-            Assert.fail(e.getMessage());
-        }
+        // xmlReader.peek(); // error in both cases with/without peek()
+        event = xmlReader.nextTag(); // nextEvent() would work fine
+        // nextTag() forgets to set fLastEvent
+        System.out.println(event.getClass());
+
+        String text = xmlReader.getElementText();
+        System.out.println(text);
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6613059Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6613059Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 package stream.XMLEventReaderTest;
 
-import org.testng.annotations.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -35,49 +35,41 @@ import javax.xml.stream.events.XMLEvent;
 /*
  * @test
  * @bug 6613059
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug6613059Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug6613059Test
  * @summary Test XMLEventReader.nextTag() shall update internal event state, same as 6586466.
  */
 public class Bug6613059Test {
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         String xmlFile = "bug6613059.xml";
-        XMLEventReader xer = null;
         XMLInputFactory xif = XMLInputFactory.newInstance();
-        try {
-            xer = xif.createXMLEventReader(xif.createXMLStreamReader(getClass().getResource(xmlFile).getFile(), getClass().getResourceAsStream(xmlFile)));
-        } catch (XMLStreamException e) {
-            System.out.println("Error while reading XML: " + e.getClass().getName() + " " + e.getMessage());
-        }
+        XMLEventReader xer = xif.createXMLEventReader(
+                xif.createXMLStreamReader(getClass().getResource(xmlFile).getFile(), getClass().getResourceAsStream(xmlFile)));
 
-        try {
-            while (xer.hasNext()) {
-                XMLEvent event = xer.nextTag();
-                if (event.isEndElement() && event.asEndElement().getName().equals(new QName("menubar"))) {
-                    break;
-                }
-
-                if (event.asStartElement().getName().equals(new QName("menu"))) {
-                    // nextTag should be used when processing element-only
-                    // content, assuming "addMenu" in
-                    // the user's code handles the menu part properly
-                    addMenu(xer, event);
-                }
-
+        while (xer.hasNext()) {
+            XMLEvent event = xer.nextTag();
+            if (event.isEndElement() && event.asEndElement().getName().equals(new QName("menubar"))) {
+                break;
             }
-        } catch (XMLStreamException e) {
-            Assert.fail("Exception while reading " + xmlFile + ": " + e.getClass().getName() + " " + e.getMessage());
+
+            if (event.asStartElement().getName().equals(new QName("menu"))) {
+                // nextTag should be used when processing element-only
+                // content, assuming "addMenu" in
+                // the user's code handles the menu part properly
+                addMenu(xer);
+            }
+
         }
     }
 
-    void addMenu(XMLEventReader xer, XMLEvent event) throws XMLStreamException {
+    void addMenu(XMLEventReader xer) throws XMLStreamException {
         // user did not submit this part of code, just jump to the end of menu
         // element
         int eventType = 0;
         while (true) {
-            event = xer.nextEvent();
+            XMLEvent event = xer.nextEvent();
             // System.out.println("event: " + event);
             eventType = event.getEventType();
             if (eventType == XMLStreamConstants.END_ELEMENT && event.asEndElement().getName().equals(new QName("menu"))) {

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6668115Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6668115Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,20 +23,20 @@
 
 package stream.XMLEventReaderTest;
 
-import java.io.File;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
+import java.io.File;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
  * @bug 6668115
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug6668115Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug6668115Test
  * @summary Test XMLEventReader.getElementText() shall update last event even if no peek.
  */
 public class Bug6668115Test {
@@ -52,48 +52,33 @@ public class Bug6668115Test {
      * lastEvent
      */
     @Test
-    public void testNextTag() {
-        try {
-            XMLEventReader er = getReader();
-            er.nextTag();
-            er.nextTag();
+    public void testNextTag() throws Exception {
+        XMLEventReader er = getReader();
+        er.nextTag();
+        er.nextTag();
 
-            System.out.println(er.getElementText());
-            er.nextTag();
-            System.out.println(er.getElementText());
-
-        } catch (Exception e) {
-            System.out.println(e.getMessage());
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
+        assertNotNull(er.getElementText());
+        er.nextTag();
+        assertNotNull(er.getElementText());
     }
 
     @Test
-    public void testNextTagWPeek() {
-        try {
-            XMLEventReader er = getReader();
-            er.nextTag();
-            er.nextTag();
+    public void testNextTagWPeek() throws Exception {
+        XMLEventReader er = getReader();
+        er.nextTag();
+        er.nextTag();
 
-            er.peek();
-            System.out.println(er.getElementText());
-            er.nextTag();
-            System.out.println(er.getElementText());
-
-        } catch (Exception e) {
-            System.out.println(e.getMessage());
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
+        er.peek();
+        assertNotNull(er.getElementText());
+        er.nextTag();
+        assertNotNull(er.getElementText());
     }
 
     private XMLEventReader getReader() throws Exception {
         inputFactory = XMLInputFactory.newInstance();
         input = new File(getClass().getResource("play2.xml").getFile());
         // Check if event reader returns the correct event
-        XMLEventReader er = inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.FileInputStream(input), "UTF-8"));
-        return er;
+        return inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.FileInputStream(input), "UTF-8"));
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6846133Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6846133Test.java
@@ -25,8 +25,10 @@ package stream.XMLEventReaderTest;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
@@ -45,7 +47,7 @@ public class Bug6846133Test {
         factory.setXMLResolver(new DTDResolver());
         factory.setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD, true);
         factory.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, true);
-        java.io.ByteArrayInputStream is = new java.io.ByteArrayInputStream(xml.getBytes(UTF_8));
+        ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(UTF_8));
 
         // createXMLEventReader (source) not supported
         // javax.xml.transform.stream.StreamSource source = new
@@ -58,18 +60,14 @@ public class Bug6846133Test {
             javax.xml.stream.events.XMLEvent event = reader.nextEvent();
             if (event.getEventType() == javax.xml.stream.XMLStreamConstants.DTD) {
                 String temp = ((javax.xml.stream.events.DTD) event).getDocumentTypeDeclaration();
-                if (temp.length() < 120) {
-                    fail("DTD truncated");
-                }
-                System.out.println(temp);
+                assertTrue(temp.length() >= 120, "DTD truncated");
             }
         }
     }
 
     private static class DTDResolver implements javax.xml.stream.XMLResolver {
         public Object resolveEntity(String arg0, String arg1, String arg2, String arg3) {
-            System.out.println("DTD is parsed");
-            return new java.io.ByteArrayInputStream(new byte[0]);
+            return new ByteArrayInputStream(new byte[0]);
         }
     }
 

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6846133Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug6846133Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,16 @@
 
 package stream.XMLEventReaderTest;
 
-import javax.xml.stream.XMLStreamException;
+import org.junit.jupiter.api.Test;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
  * @bug 6846133
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug6846133Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug6846133Test
  * @summary Test method getDocumentTypeDeclaration() of DTD Event returns a valid value.
  */
 public class Bug6846133Test {
@@ -40,40 +40,34 @@ public class Bug6846133Test {
             + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" + "<html><body><p>I am some simple html</p></body> </html>";
 
     @Test
-    public void test() {
-        try {
-            javax.xml.stream.XMLInputFactory factory = javax.xml.stream.XMLInputFactory.newInstance();
-            factory.setXMLResolver(new DTDResolver());
-            factory.setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD, true);
-            factory.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, true);
-            java.io.ByteArrayInputStream is = new java.io.ByteArrayInputStream(xml.getBytes("UTF-8"));
+    public void test() throws Exception {
+        javax.xml.stream.XMLInputFactory factory = javax.xml.stream.XMLInputFactory.newInstance();
+        factory.setXMLResolver(new DTDResolver());
+        factory.setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD, true);
+        factory.setProperty(javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, true);
+        java.io.ByteArrayInputStream is = new java.io.ByteArrayInputStream(xml.getBytes(UTF_8));
 
-            // createXMLEventReader (source) not supported
-            // javax.xml.transform.stream.StreamSource source = new
-            // javax.xml.transform.stream.StreamSource (is);
-            // javax.xml.stream.XMLEventReader reader =
-            // factory.createXMLEventReader (source);
+        // createXMLEventReader (source) not supported
+        // javax.xml.transform.stream.StreamSource source = new
+        // javax.xml.transform.stream.StreamSource (is);
+        // javax.xml.stream.XMLEventReader reader =
+        // factory.createXMLEventReader (source);
 
-            javax.xml.stream.XMLEventReader reader = factory.createXMLEventReader(is);
-            while (reader.hasNext()) {
-                javax.xml.stream.events.XMLEvent event = reader.nextEvent();
-                if (event.getEventType() == javax.xml.stream.XMLStreamConstants.DTD) {
-                    String temp = ((javax.xml.stream.events.DTD) event).getDocumentTypeDeclaration();
-                    if (temp.length() < 120) {
-                        Assert.fail("DTD truncated");
-                    }
-                    System.out.println(temp);
+        javax.xml.stream.XMLEventReader reader = factory.createXMLEventReader(is);
+        while (reader.hasNext()) {
+            javax.xml.stream.events.XMLEvent event = reader.nextEvent();
+            if (event.getEventType() == javax.xml.stream.XMLStreamConstants.DTD) {
+                String temp = ((javax.xml.stream.events.DTD) event).getDocumentTypeDeclaration();
+                if (temp.length() < 120) {
+                    fail("DTD truncated");
                 }
+                System.out.println(temp);
             }
-        } catch (XMLStreamException xe) {
-            Assert.fail(xe.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 
-    class DTDResolver implements javax.xml.stream.XMLResolver {
-        public Object resolveEntity(String arg0, String arg1, String arg2, String arg3) throws XMLStreamException {
+    private static class DTDResolver implements javax.xml.stream.XMLResolver {
+        public Object resolveEntity(String arg0, String arg1, String arg2, String arg3) {
             System.out.println("DTD is parsed");
             return new java.io.ByteArrayInputStream(new byte[0]);
         }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug8153781.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Bug8153781.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +23,20 @@
 
 package stream.XMLEventReaderTest;
 
-import java.io.StringReader;
+import com.sun.org.apache.xerces.internal.impl.XMLEntityManager;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import com.sun.org.apache.xerces.internal.impl.XMLEntityManager;
+import java.io.StringReader;
 
 /*
  * @test
  * @bug 8153781
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Bug8153781
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Bug8153781
  * @summary Test if method skipDTD of class XMLDTDScannerImpl will correctly skip the DTD section,
  *          even if a call to XMLEntityScanner.scanData for skipping to the closing ']' returns true.
  */
@@ -54,10 +51,8 @@ public class Bug8153781 {
         xmlcontentbuilder.append("  <!ELEMENT dummy EMPTY>\r\n");
         xmlcontentbuilder.append("  <!--\r\n");
         int doctypelines = DOCTYPE_SECTION_LENGTH / 3;
-        for (int i = 0; i < doctypeoffset; i++)
-            xmlcontentbuilder.append('a');
-        for (int i = 0; i < doctypelines; i++)
-            xmlcontentbuilder.append("a\r\n");
+        xmlcontentbuilder.append("a".repeat(doctypeoffset));
+        xmlcontentbuilder.append("a\r\n".repeat(doctypelines));
         xmlcontentbuilder.append("  -->\r\n");
         xmlcontentbuilder.append("  ]\r\n");
         xmlcontentbuilder.append(">\r\n");
@@ -78,16 +73,11 @@ public class Bug8153781 {
     }
 
     @Test
-    public void test() {
-        try {
-            XMLInputFactory factory = XMLInputFactory.newInstance();
-            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-            for (int i = 0; i < 3; i++) {
-                runReader(factory, i);
-            }
-        } catch (XMLStreamException xe) {
-            xe.printStackTrace();
-            Assert.fail(xe.getMessage());
+    public void test() throws Exception {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        for (int i = 0; i < 3; i++) {
+            runReader(factory, i);
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/EventReaderTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/EventReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,25 +23,28 @@
 
 package stream.XMLEventReaderTest;
 
-import java.io.StringReader;
-import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartDocument;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
+import java.io.StringReader;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 8204329 8256515
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng stream.XMLEventReaderTest.EventReaderTest
+ * @run junit stream.XMLEventReaderTest.EventReaderTest
  * @summary Tests XMLEventReader
  */
 public class EventReaderTest {
-    @Test(expectedExceptions = NoSuchElementException.class)
+    @Test
     public void testNextEvent() throws Exception {
         XMLEventReader eventReader = XMLInputFactory.newFactory().createXMLEventReader(
                 new StringReader("<?xml version='1.0'?><foo/>"));
@@ -50,20 +53,20 @@ public class EventReaderTest {
             eventReader.nextEvent();
         }
         // no more event
-        eventReader.nextEvent();
+        assertThrows(NoSuchElementException.class, eventReader::nextEvent);
     }
 
-    @DataProvider
-    Object[][] standaloneSetTestData() {
-        return new Object[][]{
-                {"<?xml version=\"1.0\"?>", false, false},
-                {"<?xml version=\"1.0\" standalone=\"no\"?>", false, true},
-                {"<?xml version=\"1.0\" standalone=\"yes\"?>", true, true}
+    public static Object[][] standaloneSetTestData() {
+        return new Object[][] {
+                { "<?xml version=\"1.0\"?>", false, false },
+                { "<?xml version=\"1.0\" standalone=\"no\"?>", false, true },
+                { "<?xml version=\"1.0\" standalone=\"yes\"?>", true, true }
         };
     }
 
-    @Test(dataProvider = "standaloneSetTestData")
-    void testStandaloneSet(String xml, boolean standalone, boolean standaloneSet) throws XMLStreamException {
+    @ParameterizedTest
+    @MethodSource("standaloneSetTestData")
+    public void testStandaloneSet(String xml, boolean standalone, boolean standaloneSet) throws XMLStreamException {
         XMLInputFactory factory = XMLInputFactory.newInstance();
         XMLEventReader reader = factory.createXMLEventReader(new StringReader(xml));
         StartDocument startDocumentEvent = (StartDocument) reader.nextEvent();

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Issue40Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/Issue40Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,21 +23,21 @@
 
 package stream.XMLEventReaderTest;
 
-import java.io.File;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.events.XMLEvent;
+import java.io.File;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.Issue40Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.Issue40Test
  * @summary Test XMLEventReader.getElementText() works after calling peek().
  */
 public class Issue40Test {
@@ -51,40 +51,28 @@ public class Issue40Test {
      * test without peek
      */
     @Test
-    public void testWOPeek() {
-        try {
-            XMLEventReader er = getReader();
-            XMLEvent e = er.nextEvent();
-            Assert.assertEquals(e.getEventType(), XMLStreamConstants.START_DOCUMENT);
-            // we have two start elements in this file
-            Assert.assertEquals(er.nextEvent().getEventType(), XMLStreamConstants.START_ELEMENT);
-            Assert.assertEquals(er.nextEvent().getEventType(), XMLStreamConstants.START_ELEMENT);
-            System.out.println(er.getElementText());
-
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+    public void testWOPeek() throws Exception {
+        XMLEventReader er = getReader();
+        XMLEvent e = er.nextEvent();
+        assertEquals(XMLStreamConstants.START_DOCUMENT, e.getEventType());
+        // we have two start elements in this file
+        assertEquals(XMLStreamConstants.START_ELEMENT, er.nextEvent().getEventType());
+        assertEquals(XMLStreamConstants.START_ELEMENT, er.nextEvent().getEventType());
     }
 
     /**
      * test with peek
      */
     @Test
-    public void testWPeek() {
-        try {
-            XMLEventReader er = getReader();
-            XMLEvent e = er.nextEvent();
-            Assert.assertEquals(e.getEventType(), XMLStreamConstants.START_DOCUMENT);
-            // we have two start elements in this file
-            while (er.peek().getEventType() == XMLStreamConstants.START_ELEMENT) {
-                e = er.nextEvent();
-            }
-            Assert.assertEquals(e.getEventType(), XMLStreamConstants.START_ELEMENT);
-            System.out.println(er.getElementText());
-
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
+    public void testWPeek() throws Exception {
+        XMLEventReader er = getReader();
+        XMLEvent e = er.nextEvent();
+        assertEquals(XMLStreamConstants.START_DOCUMENT, e.getEventType());
+        // we have two start elements in this file
+        while (er.peek().getEventType() == XMLStreamConstants.START_ELEMENT) {
+            e = er.nextEvent();
         }
+        assertEquals(XMLStreamConstants.START_ELEMENT, e.getEventType());
     }
 
     private XMLEventReader getReader() throws Exception {
@@ -92,8 +80,7 @@ public class Issue40Test {
         input = new File(getClass().getResource("play.xml").getFile());
 
         // Check if event reader returns the correct event
-        XMLEventReader er = inputFactory.createXMLEventReader(inputFactory.createXMLStreamReader(new java.io.FileInputStream(input), "UTF-8"));
-        return er;
+        return inputFactory.createXMLEventReader(
+                inputFactory.createXMLStreamReader(new java.io.FileInputStream(input), "UTF-8"));
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/JDK8201138.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/JDK8201138.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,25 +23,26 @@
 
 package stream.XMLEventReaderTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLEventReader;
-
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.Comment;
 import javax.xml.stream.events.StartDocument;
 import javax.xml.stream.events.StartElement;
+import java.io.StringReader;
 
-import static org.testng.Assert.assertTrue;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /*
  * @test
  * @bug 8201138
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.JDK8201138
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.JDK8201138
  * @summary Verifies a fix that set the type and data properly in the loop
  */
 public class JDK8201138 {
@@ -52,11 +53,11 @@ public class JDK8201138 {
         String xmlData = "<?xml version=\"1.0\"?><nextEvent><!-- peeked -->aaa<![CDATA[bbb]]>ccc</nextEvent>";
 
         XMLEventReader eventReader = XMLInputFactory.newFactory().createXMLEventReader(new StringReader(xmlData));
-        assertTrue(eventReader.nextEvent() instanceof StartDocument, "shall be StartDocument");
-        assertTrue(eventReader.nextEvent() instanceof StartElement, "shall be StartElement");
-        assertTrue(eventReader.peek() instanceof Comment, "shall be Comment");
+        assertInstanceOf(StartDocument.class, eventReader.nextEvent(), "shall be StartDocument");
+        assertInstanceOf(StartElement.class, eventReader.nextEvent(), "shall be StartElement");
+        assertInstanceOf(Comment.class, eventReader.peek(), "shall be Comment");
         // the following returns empty string before the fix
-        assertTrue(eventReader.getElementText().equals("aaabbbccc"), "The text shall be \"aaabbbccc\"");
+        assertEquals("aaabbbccc", eventReader.getElementText(), "The text shall be \"aaabbbccc\"");
 
         eventReader.close();
     }
@@ -67,11 +68,11 @@ public class JDK8201138 {
         String xmlData = "<?xml version=\"1.0\"?><nextEvent>aaa<!-- comment --></nextEvent>";
 
         XMLEventReader eventReader = XMLInputFactory.newFactory().createXMLEventReader(new StringReader(xmlData));
-        assertTrue(eventReader.nextEvent() instanceof StartDocument, "shall be StartDocument");
-        assertTrue(eventReader.nextEvent() instanceof StartElement, "shall be StartElement");
-        assertTrue(eventReader.peek() instanceof Characters, "shall be Characters");
+        assertInstanceOf(StartDocument.class, eventReader.nextEvent(), "shall be StartDocument");
+        assertInstanceOf(StartElement.class, eventReader.nextEvent(), "shall be StartElement");
+        assertInstanceOf(Characters.class, eventReader.peek(), "shall be Characters");
         // the following throws ClassCastException before the fix
-        assertTrue(eventReader.getElementText().equals("aaa"), "The text shall be \"aaa\"");
+        assertEquals("aaa", eventReader.getElementText(), "The text shall be \"aaa\"");
 
         eventReader.close();
     }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/JDK8209615.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventReaderTest/JDK8209615.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,12 @@
 
 package stream.XMLEventReaderTest;
 
-import org.testng.annotations.Test;
-import javax.xml.stream.*;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -33,8 +37,8 @@ import java.util.Iterator;
 /*
  * @test
  * @bug 8209615
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventReaderTest.JDK8209615
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventReaderTest.JDK8209615
  * @summary Verifies that the parser continues parsing the character data
  */
 public class JDK8209615 {

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventWriterTest/ReaderToWriterTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventWriterTest/ReaderToWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,7 @@
 
 package stream.XMLEventWriterTest;
 
-import static jaxp.library.JAXPTestUtilities.USER_DIR;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
@@ -40,14 +32,20 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventWriterTest.ReaderToWriterTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventWriterTest.ReaderToWriterTest
  * @summary Test XMLEventWriter.
  */
 public class ReaderToWriterTest {
@@ -57,75 +55,59 @@ public class ReaderToWriterTest {
     private static final XMLOutputFactory XML_OUTPUT_FACTORY = XMLOutputFactory.newInstance();
 
     private static final String INPUT_FILE = "W2JDLR4002TestService.wsdl.data";
-    private static final String OUTPUT_FILE = USER_DIR + "Encoded.wsdl";
+    private static final String OUTPUT_FILE = "Encoded.wsdl";
 
     /**
      * Unit test for writing namespaces when namespaceURI == null.
      */
     @Test
-    public void testWriteNamespace() {
+    public void testWriteNamespace() throws Exception {
 
-        /** Platform default encoding. */
+        /* Platform default encoding. */
         final String DEFAULT_CHARSET = java.nio.charset.Charset.defaultCharset().name();
         System.out.println("DEFAULT_CHARSET = " + DEFAULT_CHARSET);
 
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" encoding=\"" + DEFAULT_CHARSET + "\"?><prefix:root xmlns=\"\" xmlns:null=\"\"></prefix:root>";
-        final String EXPECTED_OUTPUT_NO_ENCODING = "<?xml version=\"1.0\"?><prefix:root xmlns=\"\" xmlns:null=\"\"></prefix:root>";
 
         // new Writer
-        XMLEventWriter xmlEventWriter = null;
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        try {
-            xmlEventWriter = XML_OUTPUT_FACTORY.createXMLEventWriter(byteArrayOutputStream);
-        } catch (XMLStreamException xmlStreamException) {
-            xmlStreamException.printStackTrace();
-            Assert.fail(xmlStreamException.toString());
-        }
+        XMLEventWriter xmlEventWriter = XML_OUTPUT_FACTORY.createXMLEventWriter(byteArrayOutputStream);
 
-        try {
-            // start a valid event stream
-            XMLEvent startDocumentEvent = XML_EVENT_FACTORY.createStartDocument(DEFAULT_CHARSET);
-            XMLEvent startElementEvent = XML_EVENT_FACTORY.createStartElement("prefix", "http://example.com", "root");
-            xmlEventWriter.add(startDocumentEvent);
-            xmlEventWriter.add(startElementEvent);
+        // start a valid event stream
+        XMLEvent startDocumentEvent = XML_EVENT_FACTORY.createStartDocument(DEFAULT_CHARSET);
+        XMLEvent startElementEvent = XML_EVENT_FACTORY.createStartElement("prefix", "http://example.com", "root");
+        xmlEventWriter.add(startDocumentEvent);
+        xmlEventWriter.add(startElementEvent);
 
-            // try using a null default namespaceURI
-            XMLEvent namespaceEvent = XML_EVENT_FACTORY.createNamespace(null);
-            xmlEventWriter.add(namespaceEvent);
+        // try using a null default namespaceURI
+        XMLEvent namespaceEvent = XML_EVENT_FACTORY.createNamespace(null);
+        xmlEventWriter.add(namespaceEvent);
 
-            // try using a null prefix'd namespaceURI
-            XMLEvent namespacePrefixEvent = XML_EVENT_FACTORY.createNamespace("null", null);
-            xmlEventWriter.add(namespacePrefixEvent);
+        // try using a null prefix'd namespaceURI
+        XMLEvent namespacePrefixEvent = XML_EVENT_FACTORY.createNamespace("null", null);
+        xmlEventWriter.add(namespacePrefixEvent);
 
-            // close event stream
-            XMLEvent endElementEvent = XML_EVENT_FACTORY.createEndElement("prefix", "http://example.com", "root");
-            XMLEvent endDocumentEvent = XML_EVENT_FACTORY.createEndDocument();
-            xmlEventWriter.add(endElementEvent);
-            xmlEventWriter.add(endDocumentEvent);
-            xmlEventWriter.flush();
-        } catch (XMLStreamException xmlStreamException) {
-            xmlStreamException.printStackTrace();
-            Assert.fail(xmlStreamException.toString());
-        }
+        // close event stream
+        XMLEvent endElementEvent = XML_EVENT_FACTORY.createEndElement("prefix", "http://example.com", "root");
+        XMLEvent endDocumentEvent = XML_EVENT_FACTORY.createEndDocument();
+        xmlEventWriter.add(endElementEvent);
+        xmlEventWriter.add(endDocumentEvent);
+        xmlEventWriter.flush();
 
         // get XML document as String
         String actualOutput = byteArrayOutputStream.toString();
 
         // is output as expected?
-        if (!actualOutput.equals(EXPECTED_OUTPUT) && !actualOutput.equals(EXPECTED_OUTPUT_NO_ENCODING)) {
-            Assert.fail("Expected: " + EXPECTED_OUTPUT + ", actual: " + actualOutput);
-        }
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
      * Test: 6419687 NPE in XMLEventWriterImpl.
      */
     @Test
-    public void testCR6419687() {
-
-        try {
-            InputStream in = getClass().getResourceAsStream("ReaderToWriterTest.wsdl");
-            OutputStream out = new FileOutputStream(USER_DIR + "ReaderToWriterTest-out.xml");
+    public void testCR6419687() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("ReaderToWriterTest.wsdl");
+             OutputStream out = new FileOutputStream("ReaderToWriterTest-out.xml")) {
 
             XMLEventReader reader = XML_INPUT_FACTORY.createXMLEventReader(in);
             XMLEventWriter writer = XML_OUTPUT_FACTORY.createXMLEventWriter(out, "UTF-8");
@@ -135,12 +117,6 @@ public class ReaderToWriterTest {
             }
             reader.close();
             writer.close();
-        } catch (XMLStreamException xmlStreamException) {
-            xmlStreamException.printStackTrace();
-            Assert.fail(xmlStreamException.toString());
-        } catch (FileNotFoundException fileNotFoundException) {
-            fileNotFoundException.printStackTrace();
-            Assert.fail(fileNotFoundException.toString());
         }
     }
 
@@ -148,24 +124,17 @@ public class ReaderToWriterTest {
      * Reads UTF-16 encoding file and writes it to UTF-8 encoded format.
      */
     @Test
-    public void testUTF8Encoding() {
-        try {
-            InputStream in = util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream(INPUT_FILE));
-            OutputStream out = new FileOutputStream(OUTPUT_FILE);
+    public void testUTF8Encoding() throws Exception {
+        try (InputStream in = util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream(INPUT_FILE));
+             OutputStream out = new FileOutputStream(OUTPUT_FILE)) {
 
             XMLEventReader reader = XML_INPUT_FACTORY.createXMLEventReader(in);
             XMLEventWriter writer = XML_OUTPUT_FACTORY.createXMLEventWriter(out, "UTF-8");
 
             writeEvents(reader, writer);
             checkOutput(OUTPUT_FILE);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         } finally {
-            File file = new File(OUTPUT_FILE);
-            if (file.exists())
-                file.delete();
+            Files.deleteIfExists(Path.of(OUTPUT_FILE));
         }
     }
 
@@ -191,25 +160,17 @@ public class ReaderToWriterTest {
      * Reads UTF-16 encoding file and writes it with default encoding.
      */
     @Test
-    public void testNoEncoding() {
-        try {
-            InputStream in = util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream(INPUT_FILE));
-            OutputStream out = new FileOutputStream(OUTPUT_FILE);
+    public void testNoEncoding() throws Exception {
+        try (InputStream in = util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream(INPUT_FILE));
+             OutputStream out = new FileOutputStream(OUTPUT_FILE)) {
 
             XMLEventReader reader = XML_INPUT_FACTORY.createXMLEventReader(in);
             XMLEventWriter writer = XML_OUTPUT_FACTORY.createXMLEventWriter(out);
 
             writeEvents(reader, writer);
             checkOutput(OUTPUT_FILE);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         } finally {
-            File file = new File(OUTPUT_FILE);
-            if (file.exists())
-                file.delete();
+            Files.deleteIfExists(Path.of(OUTPUT_FILE));
         }
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventWriterTest/XMLEventWriterTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLEventWriterTest/XMLEventWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,7 @@
 
 package stream.XMLEventWriterTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -34,14 +32,14 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.events.XMLEvent;
 import javax.xml.transform.stream.StreamSource;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLEventWriterTest.XMLEventWriterTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLEventWriterTest.XMLEventWriterTest
  * @summary Test XMLEventWriter.
  */
 public class XMLEventWriterTest {
@@ -50,25 +48,17 @@ public class XMLEventWriterTest {
      * Test XMLStreamWriter parsing a file with an external entity reference.
      */
     @Test
-    public void testXMLStreamWriter() {
+    public void testXMLStreamWriter() throws Exception {
+        XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
+        XMLEventWriter eventWriter = outputFactory.createXMLEventWriter(System.out);
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+        String file = getClass().getResource("XMLEventWriterTest.xml").getPath();
+        XMLEventReader eventReader = inputFactory.createXMLEventReader(new StreamSource(new File(file)));
 
-        try {
-            XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-            XMLEventWriter eventWriter = outputFactory.createXMLEventWriter(System.out);
-            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-            String file = getClass().getResource("XMLEventWriterTest.xml").getPath();
-            XMLEventReader eventReader = inputFactory.createXMLEventReader(new StreamSource(new File(file)));
-
-            // adds the event to the consumer.
-            eventWriter.add(eventReader);
-            eventWriter.flush();
-            eventWriter.close();
-
-            // expected success
-        } catch (Exception exception) {
-            exception.printStackTrace();
-            Assert.fail(exception.toString());
-        }
+        // adds the event to the consumer.
+        eventWriter.add(eventReader);
+        eventWriter.flush();
+        eventWriter.close();
     }
 
     /**
@@ -76,80 +66,72 @@ public class XMLEventWriterTest {
      * during merge of xml files.
      */
     @Test
-    public void testMerge() {
+    public void testMerge() throws Exception {
+        // Create the XML input factory
+        XMLInputFactory factory = XMLInputFactory.newInstance();
 
-        try {
-            // Create the XML input factory
-            XMLInputFactory factory = XMLInputFactory.newInstance();
+        // Create XML event reader 1
+        InputStream inputStream1 = new FileInputStream(new File(XMLEventWriterTest.class.getResource("merge-1.xml").toURI()));
+        XMLEventReader r1 = factory.createXMLEventReader(inputStream1);
 
-            // Create XML event reader 1
-            InputStream inputStream1 = new FileInputStream(new File(XMLEventWriterTest.class.getResource("merge-1.xml").toURI()));
-            XMLEventReader r1 = factory.createXMLEventReader(inputStream1);
+        // Create XML event reader 2
+        InputStream inputStream2 = new FileInputStream(new File(XMLEventWriterTest.class.getResource("merge-2.xml").toURI()));
+        XMLEventReader r2 = factory.createXMLEventReader(inputStream2);
 
-            // Create XML event reader 2
-            InputStream inputStream2 = new FileInputStream(new File(XMLEventWriterTest.class.getResource("merge-2.xml").toURI()));
-            XMLEventReader r2 = factory.createXMLEventReader(inputStream2);
+        // Create the output factory
+        XMLOutputFactory xmlof = XMLOutputFactory.newInstance();
 
-            // Create the output factory
-            XMLOutputFactory xmlof = XMLOutputFactory.newInstance();
+        // Create XML event writer
+        XMLEventWriter xmlw = xmlof.createXMLEventWriter(System.out);
 
-            // Create XML event writer
-            XMLEventWriter xmlw = xmlof.createXMLEventWriter(System.out);
+        // Read to first <product> element in document 1
+        // and output to result document
+        QName bName = new QName("b");
 
-            // Read to first <product> element in document 1
-            // and output to result document
-            QName bName = new QName("b");
+        while (r1.hasNext()) {
+            // Read event to be written to result document
+            XMLEvent event = r1.nextEvent();
 
-            while (r1.hasNext()) {
-                // Read event to be written to result document
-                XMLEvent event = r1.nextEvent();
+            if (event.getEventType() == XMLEvent.END_ELEMENT) {
 
-                if (event.getEventType() == XMLEvent.END_ELEMENT) {
+                // Start element - stop at <product> element
+                QName name = event.asEndElement().getName();
+                if (name.equals(bName)) {
 
-                    // Start element - stop at <product> element
-                    QName name = event.asEndElement().getName();
-                    if (name.equals(bName)) {
+                    QName zName = new QName("z");
 
-                        QName zName = new QName("z");
+                    boolean isZr = false;
 
-                        boolean isZr = false;
-
-                        while (r2.hasNext()) {
-                            // Read event to be written to result document
-                            XMLEvent event2 = r2.nextEvent();
-                            // Output event
-                            if (event2.getEventType() == XMLEvent.START_ELEMENT && event2.asStartElement().getName().equals(zName)) {
-                                isZr = true;
-                            }
-
-                            if (xmlw != null && isZr) {
-                                xmlw.add(event2);
-                            }
-
-                            // stop adding events after </z>
-                            // i.e. do not write END_DOCUMENT :)
-                            if (isZr && event2.getEventType() == XMLEvent.END_ELEMENT && event2.asEndElement().getName().equals(zName)) {
-                                isZr = false;
-                            }
+                    while (r2.hasNext()) {
+                        // Read event to be written to result document
+                        XMLEvent event2 = r2.nextEvent();
+                        // Output event
+                        if (event2.getEventType() == XMLEvent.START_ELEMENT && event2.asStartElement().getName().equals(zName)) {
+                            isZr = true;
                         }
-                        xmlw.flush();
-                    }
-                }
 
-                // Output event
-                if (xmlw != null) {
-                    xmlw.add(event);
+                        if (xmlw != null && isZr) {
+                            xmlw.add(event2);
+                        }
+
+                        // stop adding events after </z>
+                        // i.e. do not write END_DOCUMENT :)
+                        if (isZr && event2.getEventType() == XMLEvent.END_ELEMENT && event2.asEndElement().getName().equals(zName)) {
+                            isZr = false;
+                        }
+                    }
+                    xmlw.flush();
                 }
             }
 
-            // Read to first <product> element in document 1
-            // without writing to result document
-            xmlw.close();
-
-            // expected success
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail(ex.toString());
+            // Output event
+            if (xmlw != null) {
+                xmlw.add(event);
+            }
         }
+
+        // Read to first <product> element in document 1
+        // without writing to result document
+        xmlw.close();
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/Bug6756677Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/Bug6756677Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,19 @@
 
 package stream.XMLInputFactoryTest;
 
-import java.util.PropertyPermission;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
-import static jaxp.library.JAXPTestUtilities.setSystemProperty;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /*
  * @test
  * @bug 6756677
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @library /javax/xml/jaxp/unittest
  * @compile MyInputFactory.java
- * @run testng/othervm stream.XMLInputFactoryTest.Bug6756677Test
+ * @run junit/othervm stream.XMLInputFactoryTest.Bug6756677Test
  * @summary Test XMLInputFactory.newFactory(String factoryId, ClassLoader classLoader).
  */
 public class Bug6756677Test {
@@ -42,31 +43,20 @@ public class Bug6756677Test {
     @Test
     public void testNewInstance() {
         String myFactory = "stream.XMLInputFactoryTest.MyInputFactory";
-        try {
-            setSystemProperty("MyInputFactory", myFactory);
-            XMLInputFactory xif = XMLInputFactory.newInstance("MyInputFactory", null);
-            System.out.println(xif.getClass().getName());
-            Assert.assertTrue(xif.getClass().getName().equals(myFactory));
-
-        } catch (UnsupportedOperationException oe) {
-            Assert.fail(oe.getMessage());
-        }
+        System.setProperty("MyInputFactory", myFactory);
+        XMLInputFactory xif = XMLInputFactory.newInstance("MyInputFactory", null);
+        System.out.println(xif.getClass().getName());
+        assertEquals(myFactory, xif.getClass().getName());
     }
 
     // newFactory was added in StAX 1.2
     @Test
     public void testNewFactory() {
         String myFactory = "stream.XMLInputFactoryTest.MyInputFactory";
-        ClassLoader cl = null;
-        try {
-            setSystemProperty("MyInputFactory", myFactory);
-            XMLInputFactory xif = XMLInputFactory.newFactory("MyInputFactory", cl);
-            System.out.println(xif.getClass().getName());
-            Assert.assertTrue(xif.getClass().getName().equals(myFactory));
-
-        } catch (UnsupportedOperationException oe) {
-            Assert.fail(oe.getMessage());
-        }
+        System.setProperty("MyInputFactory", myFactory);
+        XMLInputFactory xif = XMLInputFactory.newFactory("MyInputFactory", null);
+        System.out.println(xif.getClass().getName());
+        assertEquals(myFactory, xif.getClass().getName());
     }
 
 
@@ -82,10 +72,10 @@ public class Bug6756677Test {
      * XMLInputFactory
      */
     @Test
-    public void test29() throws Exception {
-        setSystemProperty(XMLInputFactoryID, XMLInputFactoryClassName);
+    public void test29() {
+        System.setProperty(XMLInputFactoryID, XMLInputFactoryClassName);
         XMLInputFactory xif = XMLInputFactory.newInstance(XMLInputFactoryID, CL);
-        Assert.assertTrue(xif instanceof XMLInputFactory, "xif should be an instance of XMLInputFactory");
+        assertInstanceOf(XMLInputFactory.class, xif, "xif should be an instance of XMLInputFactory");
     }
 
     /*
@@ -96,11 +86,11 @@ public class Bug6756677Test {
      * newInstance of XMLInputFactory
      */
     @Test
-    public void test31() throws Exception {
+    public void test31() {
         Bug6756677Test test3 = new Bug6756677Test();
         ClassLoader cl = (test3.getClass()).getClassLoader();
-        setSystemProperty(XMLInputFactoryID, XMLInputFactoryClassName);
+        System.setProperty(XMLInputFactoryID, XMLInputFactoryClassName);
         XMLInputFactory xif = XMLInputFactory.newInstance(XMLInputFactoryID, cl);
-        Assert.assertTrue(xif instanceof XMLInputFactory, "xif should be an instance of XMLInputFactory");
+        assertInstanceOf(XMLInputFactory.class, xif, "xif should be an instance of XMLInputFactory");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/Bug6909759Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/Bug6909759Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,43 +23,33 @@
 
 package stream.XMLInputFactoryTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.stream.StreamSource;
+import java.util.NoSuchElementException;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 6909759
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLInputFactoryTest.Bug6909759Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLInputFactoryTest.Bug6909759Test
  * @summary Test createXMLStreamReader with StreamSource.
  */
 public class Bug6909759Test {
 
-
     @Test
-    public void testCreateXMLStreamReader() {
+    public void testCreateXMLStreamReader() throws Exception {
+        StreamSource ss = new StreamSource(getClass().getResourceAsStream("play.xml"));
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader xsr = xif.createXMLStreamReader(ss);
 
-        try {
-            StreamSource ss = new StreamSource(getClass().getResourceAsStream("play.xml"));
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            // File file = new File("./tests/XMLStreamReader/sgml.xml");
-            // FileInputStream inputStream = new FileInputStream(file);
-            XMLStreamReader xsr;
-            xsr = xif.createXMLStreamReader(ss);
-
-            while (xsr.hasNext()) {
-                int eventType = xsr.next();
-            }
-
-        } catch (UnsupportedOperationException oe) {
-            Assert.fail("StreamSource should be supported");
-        } catch (XMLStreamException ex) {
-            Assert.fail("fix the test");
+        while (xsr.hasNext()) {
+            xsr.next();
         }
+        assertThrows(NoSuchElementException.class, xsr::next);
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/InputFactoryTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/InputFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,37 +22,39 @@
  */
 package stream.XMLInputFactoryTest;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
  * @bug 8276050
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLInputFactoryTest.InputFactoryTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLInputFactoryTest.InputFactoryTest
  * @summary Test XMLInputFactory functionalities.
  */
 public class InputFactoryTest {
-    @DataProvider(name = "AEProperties")
-    public Object[][] getAEProperties() throws Exception {
-        return new Object[][]{
-            {XMLConstants.ACCESS_EXTERNAL_DTD, "all", "all"},
-            {XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all", "all"},
-            {XMLConstants.ACCESS_EXTERNAL_DTD, "", ""},
-            {XMLConstants.ACCESS_EXTERNAL_SCHEMA, "", ""},
+    public static Object[][] getAEProperties() {
+        return new Object[][] {
+                { XMLConstants.ACCESS_EXTERNAL_DTD, "all", "all" },
+                { XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all", "all" },
+                { XMLConstants.ACCESS_EXTERNAL_DTD, "", "" },
+                { XMLConstants.ACCESS_EXTERNAL_SCHEMA, "", "" },
         };
     }
 
     /*
      * Verifies that the XMLInputFactory returns security properties correctly.
-    */
-    @Test(dataProvider = "AEProperties")
+     */
+    @ParameterizedTest
+    @MethodSource("getAEProperties")
     public void testProperty(String name, String value, String expected) {
         XMLInputFactory xif = XMLInputFactory.newInstance();
         xif.setProperty(name, value);
-        Assert.assertEquals(expected, (String)xif.getProperty(name));
+        assertEquals(expected, xif.getProperty(name));
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/IssueTracker38.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLInputFactoryTest/IssueTracker38.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,68 +23,52 @@
 
 package stream.XMLInputFactoryTest;
 
-import javax.xml.stream.XMLEventReader;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLInputFactoryTest.IssueTracker38
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLInputFactoryTest.IssueTracker38
  * @summary Test createXMLEventReader from DOM or SAX source is unsupported.
  */
 public class IssueTracker38 {
 
     @Test
-    public void testXMLEventReaderFromDOMSource() throws Exception {
-        try {
-                createEventReaderFromSource(new DOMSource());
-            Assert.fail("Expected UnsupportedOperationException not thrown");
-        } catch (UnsupportedOperationException e) {
-        }
+    public void testXMLEventReaderFromDOMSource() {
+        assertThrows(UnsupportedOperationException.class, () -> createEventReaderFromSource(new DOMSource()));
     }
 
     @Test
-    public void testXMLStreamReaderFromDOMSource() throws Exception {
-        try {
-                createStreamReaderFromSource(new DOMSource());
-            Assert.fail("Expected UnsupportedOperationException not thrown");
-        } catch (UnsupportedOperationException oe) {
-        }
+    public void testXMLStreamReaderFromDOMSource() {
+        assertThrows(UnsupportedOperationException.class, () -> createStreamReaderFromSource(new DOMSource()));
     }
 
     @Test
-    public void testXMLEventReaderFromSAXSource() throws Exception {
-        try {
-                createEventReaderFromSource(new SAXSource());
-            Assert.fail("Expected UnsupportedOperationException not thrown");
-        } catch (UnsupportedOperationException e) {
-        }
+    public void testXMLEventReaderFromSAXSource() {
+        assertThrows(UnsupportedOperationException.class, () -> createEventReaderFromSource(new SAXSource()));
     }
 
     @Test
-    public void testXMLStreamReaderFromSAXSource() throws Exception {
-        try {
-                createStreamReaderFromSource(new SAXSource());
-            Assert.fail("Expected UnsupportedOperationException not thrown");
-        } catch (UnsupportedOperationException oe) {
-        }
+    public void testXMLStreamReaderFromSAXSource() {
+        assertThrows(UnsupportedOperationException.class, () -> createStreamReaderFromSource(new SAXSource()));
     }
 
     private void createEventReaderFromSource(Source source) throws Exception {
         XMLInputFactory xIF = XMLInputFactory.newInstance();
-        xIF.createXMLEventReader(source);
+        assertNotNull(xIF.createXMLEventReader(source));
     }
 
     private void createStreamReaderFromSource(Source source) throws Exception {
         XMLInputFactory xIF = XMLInputFactory.newInstance();
-        xIF.createXMLStreamReader(source);
+        assertNotNull(xIF.createXMLStreamReader(source));
     }
 
 

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLOutputFactoryTest/Bug6846132Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLOutputFactoryTest/Bug6846132Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,20 +23,19 @@
 
 package stream.XMLOutputFactoryTest;
 
-import javax.xml.stream.XMLEventWriter;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.helpers.DefaultHandler;
+
 import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.sax.SAXResult;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.xml.sax.helpers.DefaultHandler;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 6846132
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLOutputFactoryTest.Bug6846132Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLOutputFactoryTest.Bug6846132Test
  * @summary Test createXMLStreamWriter with SAXResult won't throw a NullPointerException.
  */
 public class Bug6846132Test {
@@ -44,45 +43,17 @@ public class Bug6846132Test {
     @Test
     public void testSAXResult() {
         DefaultHandler handler = new DefaultHandler();
-
-        final String EXPECTED_OUTPUT = "<?xml version=\"1.0\"?><root></root>";
-        try {
-            SAXResult saxResult = new SAXResult(handler);
-            // saxResult.setSystemId("jaxp-ri/unit-test/javax/xml/stream/XMLOutputFactoryTest/cr6846132.xml");
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            XMLStreamWriter writer = ofac.createXMLStreamWriter(saxResult);
-            writer.writeStartDocument("1.0");
-            writer.writeStartElement("root");
-            writer.writeEndElement();
-            writer.writeEndDocument();
-            writer.flush();
-            writer.close();
-        } catch (Exception e) {
-            if (e instanceof UnsupportedOperationException) {
-                // expected
-            } else {
-                e.printStackTrace();
-                Assert.fail(e.toString());
-            }
-        }
+        SAXResult saxResult = new SAXResult(handler);
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        assertThrows(UnsupportedOperationException.class, () -> ofac.createXMLStreamWriter(saxResult));
     }
 
     @Test
     public void testSAXResult1() {
         DefaultHandler handler = new DefaultHandler();
-
-        try {
-            SAXResult saxResult = new SAXResult(handler);
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            XMLEventWriter writer = ofac.createXMLEventWriter(saxResult);
-        } catch (Exception e) {
-            if (e instanceof UnsupportedOperationException) {
-                // expected
-            } else {
-                e.printStackTrace();
-                Assert.fail(e.toString());
-            }
-        }
+        SAXResult saxResult = new SAXResult(handler);
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        assertThrows(UnsupportedOperationException.class, () -> ofac.createXMLEventWriter(saxResult));
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLOutputFactoryTest/DuplicateNSDeclarationTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLOutputFactoryTest/DuplicateNSDeclarationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,60 +23,53 @@
 
 package stream.XMLOutputFactoryTest;
 
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLOutputFactoryTest.DuplicateNSDeclarationTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLOutputFactoryTest.DuplicateNSDeclarationTest
  * @summary Test the writing of duplicate namespace declarations when IS_REPAIRING_NAMESPACES is ture.
  */
 public class DuplicateNSDeclarationTest {
 
     @Test
-    public void testDuplicateNSDeclaration() {
+    public void testDuplicateNSDeclaration() throws Exception {
 
         // expect only 1 Namespace Declaration
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<ns1:foo" + " xmlns:ns1=\"http://example.com/\">" + "</ns1:foo>";
 
         // have XMLOutputFactory repair Namespaces
         XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-        ofac.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
+        ofac.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
 
         // send output to a Stream
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         StreamResult sr = new StreamResult(buffer);
-        XMLStreamWriter w = null;
 
         // write a duplicate Namespace Declaration
-        try {
-            w = ofac.createXMLStreamWriter(sr);
-            w.writeStartDocument();
-            w.writeStartElement("ns1", "foo", "http://example.com/");
-            w.writeNamespace("ns1", "http://example.com/");
-            w.writeNamespace("ns1", "http://example.com/");
-            w.writeEndElement();
-            w.writeEndDocument();
-            w.close();
-        } catch (XMLStreamException xmlStreamException) {
-            xmlStreamException.printStackTrace();
-            Assert.fail(xmlStreamException.toString());
-        }
+        XMLStreamWriter w = ofac.createXMLStreamWriter(sr);
+        w.writeStartDocument();
+        w.writeStartElement("ns1", "foo", "http://example.com/");
+        w.writeNamespace("ns1", "http://example.com/");
+        w.writeNamespace("ns1", "http://example.com/");
+        w.writeEndElement();
+        w.writeEndDocument();
+        w.close();
 
         // debugging output for humans
         System.out.println();
-        System.out.println("actual:   \"" + buffer.toString() + "\"");
+        System.out.println("actual:   \"" + buffer + "\"");
         System.out.println("expected: \"" + EXPECTED_OUTPUT + "\"");
 
         // are results as expected?
-        Assert.assertEquals(EXPECTED_OUTPUT, buffer.toString());
+        assertEquals(EXPECTED_OUTPUT, buffer.toString());
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLOutputFactoryTest/StreamResultTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLOutputFactoryTest/StreamResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,7 @@
 
 package stream.XMLOutputFactoryTest;
 
-import static jaxp.library.JAXPTestUtilities.getSystemProperty;
-
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
@@ -33,129 +31,108 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stax.StAXResult;
 import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLOutputFactoryTest.StreamResultTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLOutputFactoryTest.StreamResultTest
  * @summary Test create XMLWriter with variant Result.
  */
 public class StreamResultTest {
 
     @Test
-    public void testStreamResult() {
+    public void testStreamResult() throws Exception {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\"?><root></root>";
-        try {
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            StreamResult sr = new StreamResult(buffer);
-            XMLStreamWriter writer = ofac.createXMLStreamWriter(sr);
-            writer.writeStartDocument("1.0");
-            writer.writeStartElement("root");
-            writer.writeEndElement();
-            writer.writeEndDocument();
-            writer.close();
-            Assert.assertEquals(buffer.toString(), EXPECTED_OUTPUT);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        StreamResult sr = new StreamResult(buffer);
+        XMLStreamWriter writer = ofac.createXMLStreamWriter(sr);
+        writer.writeStartDocument("1.0");
+        writer.writeStartElement("root");
+        writer.writeEndElement();
+        writer.writeEndDocument();
+        writer.close();
+        assertEquals(EXPECTED_OUTPUT, buffer.toString());
     }
 
     @Test
-    public void testStreamWriterWithStAXResultNStreamWriter() {
+    public void testStreamWriterWithStAXResultNStreamWriter() throws Exception {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\"?><root></root>";
 
-        try {
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            XMLStreamWriter writer = ofac.createXMLStreamWriter(buffer);
-            StAXResult res = new StAXResult(writer);
-            writer = ofac.createXMLStreamWriter(res);
-            writer.writeStartDocument("1.0");
-            writer.writeStartElement("root");
-            writer.writeEndElement();
-            writer.writeEndDocument();
-            writer.close();
-            Assert.assertEquals(buffer.toString(), EXPECTED_OUTPUT);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        XMLStreamWriter writer = ofac.createXMLStreamWriter(buffer);
+        StAXResult res = new StAXResult(writer);
+        writer = ofac.createXMLStreamWriter(res);
+        writer.writeStartDocument("1.0");
+        writer.writeStartElement("root");
+        writer.writeEndElement();
+        writer.writeEndDocument();
+        writer.close();
+        assertEquals(EXPECTED_OUTPUT, buffer.toString());
     }
 
     @Test
-    public void testEventWriterWithStAXResultNStreamWriter() {
+    public void testEventWriterWithStAXResultNStreamWriter() throws Exception {
         String encoding = "";
-        if (getSystemProperty("file.encoding").equals("UTF-8")) {
+        if (Charset.defaultCharset().equals(StandardCharsets.UTF_8)) {
             encoding = " encoding=\"UTF-8\"";
         }
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\"" + encoding + "?><root></root>";
 
-        try {
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            XMLStreamWriter swriter = ofac.createXMLStreamWriter(buffer);
-            StAXResult res = new StAXResult(swriter);
-            XMLEventWriter writer = ofac.createXMLEventWriter(res);
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        XMLStreamWriter swriter = ofac.createXMLStreamWriter(buffer);
+        StAXResult res = new StAXResult(swriter);
+        XMLEventWriter writer = ofac.createXMLEventWriter(res);
 
-            XMLEventFactory efac = XMLEventFactory.newInstance();
-            writer.add(efac.createStartDocument(null, "1.0"));
-            writer.add(efac.createStartElement("", "", "root"));
-            writer.add(efac.createEndElement("", "", "root"));
-            writer.add(efac.createEndDocument());
-            writer.close();
+        XMLEventFactory efac = XMLEventFactory.newInstance();
+        writer.add(efac.createStartDocument(null, "1.0"));
+        writer.add(efac.createStartElement("", "", "root"));
+        writer.add(efac.createEndElement("", "", "root"));
+        writer.add(efac.createEndDocument());
+        writer.close();
 
-            Assert.assertEquals(buffer.toString(), EXPECTED_OUTPUT);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        assertEquals(buffer.toString(), EXPECTED_OUTPUT);
     }
 
     @Test
-    public void testEventWriterWithStAXResultNEventWriter() {
+    public void testEventWriterWithStAXResultNEventWriter() throws Exception {
         String encoding = "";
-        if (getSystemProperty("file.encoding").equals("UTF-8")) {
+        if (Charset.defaultCharset().equals(StandardCharsets.UTF_8)) {
             encoding = " encoding=\"UTF-8\"";
         }
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\"" + encoding + "?><root></root>";
 
-        try {
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            XMLEventWriter writer = ofac.createXMLEventWriter(buffer);
-            StAXResult res = new StAXResult(writer);
-            writer = ofac.createXMLEventWriter(res);
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        XMLEventWriter writer = ofac.createXMLEventWriter(buffer);
+        StAXResult res = new StAXResult(writer);
+        writer = ofac.createXMLEventWriter(res);
 
-            XMLEventFactory efac = XMLEventFactory.newInstance();
-            writer.add(efac.createStartDocument(null, "1.0"));
-            writer.add(efac.createStartElement("", "", "root"));
-            writer.add(efac.createEndElement("", "", "root"));
-            writer.add(efac.createEndDocument());
-            writer.close();
+        XMLEventFactory efac = XMLEventFactory.newInstance();
+        writer.add(efac.createStartDocument(null, "1.0"));
+        writer.add(efac.createStartElement("", "", "root"));
+        writer.add(efac.createEndElement("", "", "root"));
+        writer.add(efac.createEndDocument());
+        writer.close();
 
-            Assert.assertEquals(buffer.toString(), EXPECTED_OUTPUT);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        assertEquals(buffer.toString(), EXPECTED_OUTPUT);
     }
 
     @Test
     public void testStreamWriterWithStAXResultNEventWriter() throws Exception {
-        try {
-            XMLOutputFactory ofac = XMLOutputFactory.newInstance();
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            XMLEventWriter writer = ofac.createXMLEventWriter(buffer);
-            StAXResult res = new StAXResult(writer);
-            XMLStreamWriter swriter = ofac.createXMLStreamWriter(res);
-            Assert.fail("Expected an Exception as XMLStreamWriter can't be created " + "with a StAXResult which has EventWriter.");
-        } catch (Exception e) {
-            System.out.println(e.toString());
-        }
+        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        XMLEventWriter writer = ofac.createXMLEventWriter(buffer);
+        StAXResult res = new StAXResult(writer);
+        assertThrows(UnsupportedOperationException.class, () -> ofac.createXMLStreamWriter(res));
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLResolverTest/XMLResolverTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLResolverTest/XMLResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,73 +23,54 @@
 
 package stream.XMLResolverTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLResolver;
 import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLResolverTest.XMLResolverTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLResolverTest.XMLResolverTest
  * @summary Test XMLResolver.
  */
 public class XMLResolverTest {
 
     @Test
-    public void testXMLResolver() {
-        try {
-            XMLInputFactory xifactory = XMLInputFactory.newInstance();
-            xifactory.setProperty(XMLInputFactory.RESOLVER, new MyStaxResolver());
-            File file = new File(getClass().getResource("XMLResolverTest.xml").getFile());
-            String systemId = file.toURI().toString();
-            InputStream entityxml = new FileInputStream(file);
-            XMLStreamReader streamReader = xifactory.createXMLStreamReader(systemId, entityxml);
-            while (streamReader.hasNext()) {
-                int eventType = streamReader.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    eventType = streamReader.next();
-                    if (eventType == XMLStreamConstants.CHARACTERS) {
-                        String text = streamReader.getText();
-                        Assert.assertTrue(text.contains("replace2"));
-                    }
+    public void testXMLResolver() throws Exception {
+        XMLInputFactory xifactory = XMLInputFactory.newInstance();
+        xifactory.setProperty(XMLInputFactory.RESOLVER, new MyStaxResolver());
+        File file = new File(getClass().getResource("XMLResolverTest.xml").getFile());
+        String systemId = file.toURI().toString();
+        InputStream entityxml = new FileInputStream(file);
+        XMLStreamReader streamReader = xifactory.createXMLStreamReader(systemId, entityxml);
+        while (streamReader.hasNext()) {
+            int eventType = streamReader.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                eventType = streamReader.next();
+                if (eventType == XMLStreamConstants.CHARACTERS) {
+                    String text = streamReader.getText();
+                    assertTrue(text.contains("replace2"));
                 }
             }
-        } catch (XMLStreamException ex) {
-
-            if (ex.getNestedException() != null) {
-                ex.getNestedException().printStackTrace();
-            }
-            // ex.printStackTrace() ;
-        } catch (Exception io) {
-            io.printStackTrace();
         }
     }
 
-    class MyStaxResolver implements XMLResolver {
+    private static class MyStaxResolver implements XMLResolver {
 
-        public MyStaxResolver() {
-
-        }
-
-        public Object resolveEntity(String publicId, String systemId, String baseURI, String namespace) throws javax.xml.stream.XMLStreamException {
-
-            Object object = null;
+        public Object resolveEntity(String publicId, String systemId, String baseURI, String namespace) {
             try {
-                object = new FileInputStream(getClass().getResource("replace2.txt").getFile());
+                return new FileInputStream(getClass().getResource("replace2.txt").getFile());
             } catch (Exception ex) {
-                ex.printStackTrace();
+                throw new RuntimeException(ex);
             }
-            return object;
         }
-
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamExceptionTest/ExceptionCauseTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamExceptionTest/ExceptionCauseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,17 @@
 
 package stream.XMLStreamExceptionTest;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamExceptionTest.ExceptionCauseTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamExceptionTest.ExceptionCauseTest
  * @summary Test XMLStreamException constructor initializes chained exception
  */
 public class ExceptionCauseTest {
@@ -54,6 +53,6 @@ public class ExceptionCauseTest {
         XMLStreamException e = new XMLStreamException("message", location, cause);
 
         // Verify cause
-        Assert.assertSame(e.getCause(), cause, "XMLStreamException has the wrong cause");
+        assertSame(e.getCause(), cause, "XMLStreamException has the wrong cause");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamExceptionTest/ExceptionTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamExceptionTest/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,30 +23,25 @@
 
 package stream.XMLStreamExceptionTest;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamExceptionTest.ExceptionTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamExceptionTest.ExceptionTest
  * @summary Test XMLStreamException contains the message of the wrapped exception.
  */
 public class ExceptionTest {
 
     @Test
     public void testException() {
-
-        final String EXPECTED_OUTPUT = "Test XMLStreamException";
-        try {
-            Exception ex = new IOException("Test XMLStreamException");
-            throw new XMLStreamException(ex);
-        } catch (XMLStreamException e) {
-            Assert.assertTrue(e.getMessage().contains(EXPECTED_OUTPUT), "XMLStreamException does not contain the message " + "of the wrapped exception");
-        }
+        String expectedOutput = "Test XMLStreamException";
+        XMLStreamException wrapped = new XMLStreamException(new IOException(expectedOutput));
+        assertTrue(wrapped.getMessage().contains(expectedOutput), "XMLStreamException does not contain the message of the wrapped exception");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/Bug6481615.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/Bug6481615.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,43 +23,37 @@
 
 package stream.XMLStreamFilterTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6481615
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamFilterTest.Bug6481615
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamFilterTest.Bug6481615
  * @summary Test Filtered XMLStreamReader can return the event type if current state is START_ELEMENT.
  */
 public class Bug6481615 {
 
-    static final String XML = "<?xml version=\"1.0\"?>" + "<S:Envelope foo=\"bar\" xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"></S:Envelope>";
+    private static final String XML = "<?xml version=\"1.0\"?>" + "<S:Envelope foo=\"bar\" xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"></S:Envelope>";
 
-    private XMLInputFactory factory = XMLInputFactory.newInstance();
+    private final XMLInputFactory factory = XMLInputFactory.newInstance();
 
     @Test
-    public void test() {
-        try {
-            XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(XML));
-            reader.next(); // advance to START_ELEMENT
-            XMLStreamReader filter = factory.createFilteredReader(reader, new Filter());
-            Assert.assertTrue(filter.getEventType() != -1);
-        } catch (Exception e) {
-            e.printStackTrace();
-            // Assert.fail("Unexpected Exception: " + e.getMessage());
-        }
+    public void test() throws Exception {
+        XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(XML));
+        reader.next(); // advance to START_ELEMENT
+        XMLStreamReader filter = factory.createFilteredReader(reader, new Filter());
+        assertTrue(filter.getEventType() != -1);
     }
 
-    class Filter implements StreamFilter {
-
+    private static class Filter implements StreamFilter {
         public boolean accept(XMLStreamReader reader) {
             return true;
         }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/Bug6481678.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/Bug6481678.java
@@ -36,8 +36,6 @@ import javax.xml.stream.events.XMLEvent;
 import java.io.InputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
@@ -103,99 +101,82 @@ public class Bug6481678 {
      * testRootElementNamespace.
      */
     @Test
-    public void testReadingNamespace() {
+    public void testReadingNamespace() throws Exception {
         is = new java.io.ByteArrayInputStream(getXML().getBytes());
-        try {
-            XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), (StreamFilter) filter);
+        XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), filter);
 
-            while (sr.hasNext()) {
-                int eventType = sr.getEventType();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(rootElement)) {
-                        assertTrue(sr.getNamespacePrefix(0).equals(prefixApple) && sr.getNamespaceURI(0).equals(namespaceURIApple));
-                    }
+        while (sr.hasNext()) {
+            int eventType = sr.getEventType();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(rootElement)) {
+                    assertEquals(prefixApple, sr.getNamespacePrefix(0));
+                    assertEquals(namespaceURIApple, sr.getNamespaceURI(0));
                 }
-                eventType = sr.next();
             }
-        } catch (Exception ex) {
-            fail("Exception: " + ex.getMessage());
+            sr.next();
         }
     }
 
     @Test
-    public void testRootElementNamespace() {
+    public void testRootElementNamespace() throws Exception {
         is = new java.io.ByteArrayInputStream(getXML().getBytes());
-        try {
-            XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), (StreamFilter) filter);
+        XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), filter);
 
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(rootElement)) {
-                        assertTrue(sr.getNamespacePrefix(0).equals(prefixApple) && sr.getNamespaceURI(0).equals(namespaceURIApple));
-                    }
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(rootElement)) {
+                    assertEquals(prefixApple, sr.getNamespacePrefix(0));
+                    assertEquals(namespaceURIApple, sr.getNamespaceURI(0));
                 }
             }
-        } catch (Exception ex) {
-            fail("Exception: " + ex.getMessage());
         }
     }
 
     @Test
-    public void testChildElementNamespace() {
+    public void testChildElementNamespace() throws Exception {
         is = new java.io.ByteArrayInputStream(getXML().getBytes());
-        try {
-            XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), (StreamFilter) filter);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(childElement)) {
-                        QName qname = sr.getName();
-                        assertTrue(qname.getPrefix().equals(prefixApple) && qname.getNamespaceURI().equals(namespaceURIApple)
-                                && qname.getLocalPart().equals(childElement));
-                    }
+        XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), filter);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(childElement)) {
+                    QName qname = sr.getName();
+                    assertEquals(prefixApple, qname.getPrefix());
+                    assertEquals(namespaceURIApple, qname.getNamespaceURI());
+                    assertEquals(childElement, qname.getLocalPart());
                 }
             }
-        } catch (Exception ex) {
-            fail("Exception: " + ex.getMessage());
         }
     }
 
     @Test
-    public void testNamespaceContext() {
+    public void testNamespaceContext() throws Exception {
         is = new java.io.ByteArrayInputStream(getXML().getBytes());
-        try {
-            XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), (StreamFilter) filter);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(childElement)) {
-                        NamespaceContext context = sr.getNamespaceContext();
-                        assertEquals(context.getPrefix(namespaceURIApple), prefixApple);
-                    }
+        XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), filter);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(childElement)) {
+                    NamespaceContext context = sr.getNamespaceContext();
+                    assertEquals(context.getPrefix(namespaceURIApple), prefixApple);
                 }
             }
-        } catch (Exception ex) {
-            fail("Exception: " + ex.getMessage());
         }
     }
 
     @Test
-    public void testNamespaceCount() {
+    public void testNamespaceCount() throws Exception {
         is = new java.io.ByteArrayInputStream(getXML().getBytes());
-        try {
-            XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), (StreamFilter) filter);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(rootElement)) {
-                        int count = sr.getNamespaceCount();
-                        assertEquals(3, count);
-                    }
+        XMLStreamReader sr = factory.createFilteredReader(factory.createXMLStreamReader(is), filter);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(rootElement)) {
+                    int count = sr.getNamespaceCount();
+                    assertEquals(3, count);
                 }
             }
-        } catch (Exception ex) {
-            fail("Exception: " + ex.getMessage());
         }
     }
 

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/Bug6481678.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/Bug6481678.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package stream.XMLStreamFilterTest;
 
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
@@ -33,15 +33,17 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
  * @bug 6481678
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamFilterTest.Bug6481678
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamFilterTest.Bug6481678
  * @summary Test Filtered XMLStreamReader parses namespace correctly.
  */
 public class Bug6481678 {
@@ -58,19 +60,14 @@ public class Bug6481678 {
     XMLInputFactory factory;
     InputStream is;
 
-    /** Creates a new instance of NamespaceTest */
-    public Bug6481678(java.lang.String testName) {
-        init();
-    }
-
-    private void init() {
+    public Bug6481678() {
         factory = XMLInputFactory.newInstance();
         factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
         filter = createFilter();
     }
 
     String getXML() {
-        StringBuffer sbuffer = new StringBuffer();
+        StringBuilder sbuffer = new StringBuilder();
         sbuffer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         sbuffer.append("<" + rootElement + " state=\"WA\"");
         sbuffer.append(" xmlns:" + prefixApple + "=\"" + namespaceURIApple + "\"");
@@ -85,7 +82,7 @@ public class Bug6481678 {
         return sbuffer.toString();
     }
 
-    public TypeFilter createFilter() {
+    TypeFilter createFilter() {
 
         TypeFilter f = new TypeFilter();
 
@@ -115,13 +112,13 @@ public class Bug6481678 {
                 int eventType = sr.getEventType();
                 if (eventType == XMLStreamConstants.START_ELEMENT) {
                     if (sr.getLocalName().equals(rootElement)) {
-                        Assert.assertTrue(sr.getNamespacePrefix(0).equals(prefixApple) && sr.getNamespaceURI(0).equals(namespaceURIApple));
+                        assertTrue(sr.getNamespacePrefix(0).equals(prefixApple) && sr.getNamespaceURI(0).equals(namespaceURIApple));
                     }
                 }
                 eventType = sr.next();
             }
         } catch (Exception ex) {
-            Assert.fail("Exception: " + ex.getMessage());
+            fail("Exception: " + ex.getMessage());
         }
     }
 
@@ -135,12 +132,12 @@ public class Bug6481678 {
                 int eventType = sr.next();
                 if (eventType == XMLStreamConstants.START_ELEMENT) {
                     if (sr.getLocalName().equals(rootElement)) {
-                        Assert.assertTrue(sr.getNamespacePrefix(0).equals(prefixApple) && sr.getNamespaceURI(0).equals(namespaceURIApple));
+                        assertTrue(sr.getNamespacePrefix(0).equals(prefixApple) && sr.getNamespaceURI(0).equals(namespaceURIApple));
                     }
                 }
             }
         } catch (Exception ex) {
-            Assert.fail("Exception: " + ex.getMessage());
+            fail("Exception: " + ex.getMessage());
         }
     }
 
@@ -154,13 +151,13 @@ public class Bug6481678 {
                 if (eventType == XMLStreamConstants.START_ELEMENT) {
                     if (sr.getLocalName().equals(childElement)) {
                         QName qname = sr.getName();
-                        Assert.assertTrue(qname.getPrefix().equals(prefixApple) && qname.getNamespaceURI().equals(namespaceURIApple)
+                        assertTrue(qname.getPrefix().equals(prefixApple) && qname.getNamespaceURI().equals(namespaceURIApple)
                                 && qname.getLocalPart().equals(childElement));
                     }
                 }
             }
         } catch (Exception ex) {
-            Assert.fail("Exception: " + ex.getMessage());
+            fail("Exception: " + ex.getMessage());
         }
     }
 
@@ -174,12 +171,12 @@ public class Bug6481678 {
                 if (eventType == XMLStreamConstants.START_ELEMENT) {
                     if (sr.getLocalName().equals(childElement)) {
                         NamespaceContext context = sr.getNamespaceContext();
-                        Assert.assertTrue(context.getPrefix(namespaceURIApple).equals(prefixApple));
+                        assertEquals(context.getPrefix(namespaceURIApple), prefixApple);
                     }
                 }
             }
         } catch (Exception ex) {
-            Assert.fail("Exception: " + ex.getMessage());
+            fail("Exception: " + ex.getMessage());
         }
     }
 
@@ -193,21 +190,18 @@ public class Bug6481678 {
                 if (eventType == XMLStreamConstants.START_ELEMENT) {
                     if (sr.getLocalName().equals(rootElement)) {
                         int count = sr.getNamespaceCount();
-                        Assert.assertTrue(count == 3);
+                        assertEquals(3, count);
                     }
                 }
             }
         } catch (Exception ex) {
-            Assert.fail("Exception: " + ex.getMessage());
+            fail("Exception: " + ex.getMessage());
         }
     }
 
-    class TypeFilter implements EventFilter, StreamFilter {
+    static class TypeFilter implements EventFilter, StreamFilter {
 
         protected boolean[] types = new boolean[20];
-
-        public TypeFilter() {
-        }
 
         public void addType(int type) {
             types[type] = true;

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/HasNextTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/HasNextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,24 +23,28 @@
 
 package stream.XMLStreamFilterTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamFilterTest.HasNextTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamFilterTest.HasNextTest
  * @summary Test Filtered XMLStreamReader hasNext() always return the correct value if repeat to call it.
  */
 public class HasNextTest {
 
-    private static String INPUT_FILE = "HasNextTest.xml";
+    private static final String INPUT_FILE = "HasNextTest.xml";
 
     private HasNextTypeFilter createFilter() {
 
@@ -57,88 +61,37 @@ public class HasNextTest {
         return f;
     }
 
-    private XMLStreamReader createStreamReader(HasNextTypeFilter f) {
-
-        try {
-            XMLInputFactory factory = XMLInputFactory.newInstance();
-            factory = XMLInputFactory.newInstance();
-            return factory.createFilteredReader(factory.createXMLStreamReader(this.getClass().getResourceAsStream(INPUT_FILE)), (StreamFilter) f);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected Exception: " + e.getMessage());
-            return null;
-        }
+    private XMLStreamReader createStreamReader(HasNextTypeFilter f) throws XMLStreamException {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        return factory.createFilteredReader(factory.createXMLStreamReader(this.getClass().getResourceAsStream(INPUT_FILE)), (StreamFilter) f);
     }
 
-    private void checkHasNext(XMLStreamReader r1) throws XMLStreamException {
-
+    private boolean checkHasNext(XMLStreamReader r1) {
         // try asking 3 times, insure all results are the same
-        boolean hasNext_1 = r1.hasNext();
-        boolean hasNext_2 = r1.hasNext();
-        boolean hasNext_3 = r1.hasNext();
-
-        System.out.println("XMLStreamReader.hasNext() (1): " + hasNext_1);
-        System.out.println("XMLStreamReader.hasNext() (2): " + hasNext_2);
-        System.out.println("XMLStreamReader.hasNext() (3): " + hasNext_3);
-
-        Assert.assertTrue((hasNext_1 == hasNext_2) && (hasNext_1 == hasNext_3),
-                "XMLStreamReader.hasNext() returns inconsistent values for each subsequent call: " + hasNext_1 + ", " + hasNext_2 + ", " + hasNext_3);
+        boolean hasNext = assertDoesNotThrow(r1::hasNext);
+        assertEquals(hasNext, assertDoesNotThrow(r1::hasNext));
+        assertEquals(hasNext, assertDoesNotThrow(r1::hasNext));
+        return hasNext;
     }
 
     @Test
-    public void testFilterUsingNextTag() {
-
-        try {
-            HasNextTypeFilter f = createFilter();
-            XMLStreamReader r1 = createStreamReader(f);
-
-            while (r1.hasNext()) {
-                try {
-                    r1.nextTag();
-                } catch (Exception e) {
-                    System.err.println("Expected Exception: " + e.getMessage());
-                    e.printStackTrace();
-                }
-
-                checkHasNext(r1);
+    public void testFilterUsingNextTag() throws Exception {
+        HasNextTypeFilter f = createFilter();
+        XMLStreamReader r1 = createStreamReader(f);
+        XMLStreamException expected = assertThrows(XMLStreamException.class, () -> {
+            while (checkHasNext(r1)) {
+                r1.nextTag();
             }
-
-        } catch (XMLStreamException e) {
-            System.err.println("Unexpected Exception: " + e.getMessage());
-            e.printStackTrace();
-            Assert.fail("Unexpected Exception: " + e.toString());
-        } catch (Exception e) {
-            // if this is END_DOCUMENT, it is expected
-            if (e.toString().indexOf("END_DOCUMENT") != -1) {
-                // expected
-                System.err.println("Expected Exception:");
-                e.printStackTrace();
-            } else {
-                // unexpected
-                System.err.println("Unexpected Exception: " + e.getMessage());
-                e.printStackTrace();
-                Assert.fail("Unexpected Exception: " + e.toString());
-            }
-        }
+        });
+        assertTrue(expected.toString().contains("END_ELEMENT"));
     }
 
     @Test
-    public void testFilterUsingNext() {
-
-        try {
-            HasNextTypeFilter f = createFilter();
-            XMLStreamReader r1 = createStreamReader(f);
-
-            while (r1.hasNext()) {
-                r1.next();
-                checkHasNext(r1);
-            }
-
-        } catch (Exception e) {
-            // unexpected
-            System.err.println("Unexpected Exception: " + e.getMessage());
-            e.printStackTrace();
-            Assert.fail("Unexpected Exception: " + e.toString());
+    public void testFilterUsingNext() throws Exception {
+        HasNextTypeFilter f = createFilter();
+        XMLStreamReader r1 = createStreamReader(f);
+        while (checkHasNext(r1)) {
+            r1.next();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/XMLStreamReaderFilterTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamFilterTest/XMLStreamReaderFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,25 @@
 
 package stream.XMLStreamFilterTest;
 
-import static org.testng.Assert.assertThrows;
-
-import java.io.Reader;
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
-* @test
-* @bug 8255918
-* @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
-* @run testng stream.XMLStreamFilterTest.XMLStreamReaderFilterTest
-* @summary Test the implementation of {@code XMLStreamReader} using a {@code StreamFilter}
-*/
+ * @test
+ * @bug 8255918
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run junit stream.XMLStreamFilterTest.XMLStreamReaderFilterTest
+ * @summary Test the implementation of {@code XMLStreamReader} using a {@code StreamFilter}
+ */
 public class XMLStreamReaderFilterTest {
 
     static final String XMLSOURCE1 = "<root>\n"

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/BOMTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/BOMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,16 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /*
  * @test
  * @bug 6218794
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.BOMTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.BOMTest
  * @summary Test XMLStreamReader parses BOM UTF-8 and BOM UTF-16 big endian stream.
  */
 public class BOMTest {
@@ -43,24 +42,17 @@ public class BOMTest {
     private static final String INPUT_FILE2 = "UTF16-BE.wsdl.data";
 
     @Test
-    public void testBOM() {
+    public void testBOM() throws Exception {
         XMLInputFactory ifac = XMLInputFactory.newInstance();
-        try {
-            XMLStreamReader re = ifac.createXMLStreamReader(this.getClass().getResource(INPUT_FILE1).toExternalForm(),
-                        util.BOMInputStream.createStream("UTF-8", this.getClass().getResourceAsStream(INPUT_FILE1)));
-            while (re.hasNext()) {
-                int event = re.next();
-            }
-            XMLStreamReader re2 = ifac.createXMLStreamReader(this.getClass().getResource(INPUT_FILE2).toExternalForm(),
-                        util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream(INPUT_FILE2)));
-            while (re2.hasNext()) {
-
-                int event = re2.next();
-
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
+        XMLStreamReader re = ifac.createXMLStreamReader(this.getClass().getResource(INPUT_FILE1).toExternalForm(),
+                util.BOMInputStream.createStream("UTF-8", this.getClass().getResourceAsStream(INPUT_FILE1)));
+        while (re.hasNext()) {
+            int event = re.next();
+        }
+        XMLStreamReader re2 = ifac.createXMLStreamReader(this.getClass().getResource(INPUT_FILE2).toExternalForm(),
+                util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream(INPUT_FILE2)));
+        while (re2.hasNext()) {
+            int event = re2.next();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6388460.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6388460.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -33,43 +33,34 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.xml.sax.InputSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 
 /*
  * @test
  * @bug 6388460
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Bug6388460
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Bug6388460
  * @summary Test StAX parser can parse UTF-16 wsdl.
  */
 public class Bug6388460 {
 
     @Test
-    public void test() {
-        try {
+    public void test() throws Exception {
+        Source source = new StreamSource(util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream("Hello.wsdl.data")),
+                this.getClass().getResource("Hello.wsdl.data").toExternalForm());
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        TransformerFactory factory = TransformerFactory.newInstance();
+        Transformer transformer = factory.newTransformer();
+        transformer.transform(source, new StreamResult(baos));
+        ByteArrayInputStream bis = new ByteArrayInputStream(baos.toByteArray());
+        InputSource inSource = new InputSource(bis);
 
-            Source source = new StreamSource(util.BOMInputStream.createStream("UTF-16BE", this.getClass().getResourceAsStream("Hello.wsdl.data")),
-                        this.getClass().getResource("Hello.wsdl.data").toExternalForm());
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            TransformerFactory factory = TransformerFactory.newInstance();
-            Transformer transformer = factory.newTransformer();
-            transformer.transform(source, new StreamResult(baos));
-            System.out.println(new String(baos.toByteArray()));
-            ByteArrayInputStream bis = new ByteArrayInputStream(baos.toByteArray());
-            InputSource inSource = new InputSource(bis);
-
-            XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
-            xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
-            XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(inSource.getSystemId(), inSource.getByteStream());
-            while (reader.hasNext()) {
-                reader.next();
-            }
-        } catch (Exception ex) {
-            ex.printStackTrace(System.err);
-            Assert.fail("Exception occured: " + ex.getMessage());
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+        XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(inSource.getSystemId(), inSource.getByteStream());
+        while (reader.hasNext()) {
+            reader.next();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6472982Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6472982Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,20 +23,20 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /*
  * @test
  * @bug 6472982
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Bug6472982Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Bug6472982Test
  * @summary Test XMLStreamReader.getNamespaceContext().getPrefix("") won't throw IllegalArgumentException.
  */
 public class Bug6472982Test {
@@ -46,24 +46,17 @@ public class Bug6472982Test {
     String prefix = "a";
 
     @Test
-    public void testNamespaceContext() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
-            InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            NamespaceContext context = sr.getNamespaceContext();
-            Assert.assertTrue(context.getPrefix("") == null);
-
-        } catch (IllegalArgumentException iae) {
-            Assert.fail("NamespacePrefix#getPrefix() should not throw an IllegalArgumentException for empty uri. ");
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
+    public void testNamespaceContext() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+        InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        NamespaceContext context = sr.getNamespaceContext();
+        assertNull(context.getPrefix(""));
     }
 
     String getXML() {
-        StringBuffer sbuffer = new StringBuffer();
+        StringBuilder sbuffer = new StringBuilder();
         sbuffer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         sbuffer.append("<" + rootElement + " xmlns:");
         sbuffer.append(prefix);

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6767322Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6767322Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,53 +23,39 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import java.io.ByteArrayInputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /*
  * @test
  * @bug 6767322
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Bug6767322Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Bug6767322Test
  * @summary Test XMLStreamReader.getVersion() returns null if a version isn't declared.
  */
 public class Bug6767322Test {
     private static final String INPUT_FILE = "Bug6767322.xml";
 
     @Test
-    public void testVersionSet() {
-        try {
-            XMLStreamReader r = XMLInputFactory.newInstance().createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE));
+    public void testVersionSet() throws Exception {
+        XMLStreamReader r = XMLInputFactory.newInstance().createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE));
 
-            String version = r.getVersion();
-            System.out.println("Bug6767322.xml: " + version);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+        String version = r.getVersion();
+        System.out.println("Bug6767322.xml: " + version);
     }
 
     @Test
-    public void testVersionNotSet() {
-        try {
-            String xmlText = "Version not declared";
-            XMLStreamReader r = XMLInputFactory.newInstance().createXMLStreamReader(new ByteArrayInputStream(xmlText.getBytes()));
-            String version = r.getVersion();
-            System.out.println("Version for text \"" + xmlText + "\": " + version);
-            if (version != null) {
-                Assert.fail("getVersion should return null");
-            }
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+    public void testVersionNotSet() throws Exception {
+        String xmlText = "Version not declared";
+        XMLStreamReader r = XMLInputFactory.newInstance().createXMLStreamReader(new ByteArrayInputStream(xmlText.getBytes()));
+        String version = r.getVersion();
+        System.out.println("Version for text \"" + xmlText + "\": " + version);
+        assertNull(version, "getVersion should return null");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6847819Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Bug6847819Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,46 +23,29 @@
 
 package stream.XMLStreamReaderTest;
 
-import org.testng.annotations.Test;
-import org.testng.Assert;
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 6847819
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Bug6847819Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Bug6847819Test
  * @summary Test StAX parser shall throw XMLStreamException for illegal xml declaration.
  */
 public class Bug6847819Test {
 
     @Test
-    public void testIllegalDecl() throws XMLStreamException {
+    public void testIllegalDecl() {
         String xml = "<?xml ?><root>abc]]>xyz</root>";
-        String msg = "illegal declaration";
-        try {
-            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-            inputFactory.createXMLStreamReader(new StringReader(xml));
-            Assert.fail("Expected an exception for " + msg);
-        } catch (XMLStreamException ex) { // good
-            System.out.println("Expected failure: '" + ex.getMessage() + "' " + "(matching message: '" + msg + "')");
-        } catch (Exception ex2) { // ok; iff links to XMLStreamException
-            Throwable t = ex2;
-            while (t.getCause() != null && !(t instanceof XMLStreamException)) {
-                t = t.getCause();
-            }
-            if (t instanceof XMLStreamException) {
-                System.out.println("Expected failure: '" + ex2.getMessage() + "' " + "(matching message: '" + msg + "')");
-            }
-            if (t == ex2) {
-                Assert.fail("Expected an XMLStreamException (either direct, or getCause() of a primary exception) for " + msg + ", got: " + ex2);
-            }
-            Assert.fail("Expected an XMLStreamException (either direct, or getCause() of a primary exception) for " + msg + ", got: " + ex2 + " (root: " + t + ")");
-        }
-
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+        assertThrows(
+                XMLStreamException.class,
+                () -> inputFactory.createXMLStreamReader(new StringReader(xml)));
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/BugTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/BugTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,22 +23,22 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.StringReader;
-import javax.xml.stream.XMLEventReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
  * @bug 8069098
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.BugTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.BugTest
  * @summary Test StAX parser can parse xml without declaration.
  */
 public class BugTest {
@@ -52,17 +52,18 @@ public class BugTest {
      * @param type2 the type of the 2nd event
      * @throws Exception if the test fails to run properly
      */
-    @Test(dataProvider = "xmls")
-    public static void test1(String xml, int type1, int type2) throws Exception {
-       XMLInputFactory factory = XMLInputFactory.newFactory();
+    @ParameterizedTest
+    @MethodSource("getXMLs")
+    public void test1(String xml, int type1, int type2) throws Exception {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
 
-       XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(xml));
-       int type1stEvent = reader.getEventType();
-       int type2ndEvent = reader.next();
-       System.out.println("First event: " + type1stEvent);
-       System.out.println("2nd event: " + type2ndEvent);
-       Assert.assertEquals(type1, type1stEvent);
-       Assert.assertEquals(type2, type2ndEvent);
+        XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(xml));
+        int type1stEvent = reader.getEventType();
+        int type2ndEvent = reader.next();
+        System.out.println("First event: " + type1stEvent);
+        System.out.println("2nd event: " + type2ndEvent);
+        assertEquals(type1, type1stEvent);
+        assertEquals(type2, type2ndEvent);
     }
 
 
@@ -75,25 +76,25 @@ public class BugTest {
      * @param type2 the type of the 2nd event
      * @throws Exception if the test fails to run properly
      */
-    @Test(dataProvider = "xmls")
-    public static void test2(String xml, int type1, int type2) throws Exception {
-       XMLInputFactory factory = XMLInputFactory.newFactory();
+    @ParameterizedTest
+    @MethodSource("getXMLs")
+    public void test2(String xml, int type1, int type2) throws Exception {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
 
-       XMLEventReader reader = factory.createXMLEventReader(new StringReader(xml));
-       int type1stEvent = reader.nextEvent().getEventType();
-       int type2ndEvent = reader.nextEvent().getEventType();
-       System.out.println("First event: " + type1stEvent);
-       System.out.println("2nd event: " + type2ndEvent);
-       Assert.assertEquals(type1, type1stEvent);
-       Assert.assertEquals(type2, type2ndEvent);
+        XMLEventReader reader = factory.createXMLEventReader(new StringReader(xml));
+        int type1stEvent = reader.nextEvent().getEventType();
+        int type2ndEvent = reader.nextEvent().getEventType();
+        System.out.println("First event: " + type1stEvent);
+        System.out.println("2nd event: " + type2ndEvent);
+        assertEquals(type1, type1stEvent);
+        assertEquals(type2, type2ndEvent);
     }
 
     /*
        DataProvider: for testing beginning event type
        Data: xml, 1st event type, 2nd event type
      */
-    @DataProvider(name = "xmls")
-    public Object[][] getXMLs() {
+    public static Object[][] getXMLs() {
 
         return new Object[][]{
             {"<?xml version='1.0'?><foo/>",

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/DefaultAttributeTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/DefaultAttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +23,24 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.util.Iterator;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
+import java.util.Iterator;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.DefaultAttributeTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.DefaultAttributeTest
  * @summary Test StAX parses namespace and attribute.
  */
 public class DefaultAttributeTest {
@@ -47,61 +48,51 @@ public class DefaultAttributeTest {
     private static final String INPUT_FILE = "ExternalDTD.xml";
 
     @Test
-    public void testStreamReader() {
+    public void testStreamReader() throws Exception {
         XMLInputFactory ifac = XMLInputFactory.newInstance();
-        XMLOutputFactory ofac = XMLOutputFactory.newInstance();
 
-        try {
-            ifac.setProperty(ifac.IS_REPLACING_ENTITY_REFERENCES, new Boolean(false));
+        ifac.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, Boolean.FALSE);
 
-            XMLStreamReader re = ifac.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE));
+        XMLStreamReader re = ifac.createXMLStreamReader(
+                this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE));
 
-            while (re.hasNext()) {
-                int event = re.next();
-                if (event == XMLStreamConstants.START_ELEMENT && re.getLocalName().equals("bookurn")) {
-                    Assert.assertTrue(re.getAttributeCount() == 0, "No attributes are expected for <bookurn> ");
-                    Assert.assertTrue(re.getNamespaceCount() == 2, "Two namespaces are expected for <bookurn> ");
-                }
+        while (re.hasNext()) {
+            int event = re.next();
+            if (event == XMLStreamConstants.START_ELEMENT && re.getLocalName().equals("bookurn")) {
+                assertEquals(0, re.getAttributeCount(), "No attributes are expected for <bookurn> ");
+                assertEquals(2, re.getNamespaceCount(), "Two namespaces are expected for <bookurn> ");
             }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         }
     }
 
     @Test
-    public void testEventReader() {
-        try {
-            XMLInputFactory ifac = XMLInputFactory.newInstance();
-            XMLEventReader read = ifac.createXMLEventReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE));
-            while (read.hasNext()) {
-                XMLEvent event = read.nextEvent();
-                if (event.isStartElement()) {
-                    StartElement startElement = event.asStartElement();
-                    if (startElement.getName().getLocalPart().equals("bookurn")) {
-                        Iterator iterator = startElement.getNamespaces();
-                        int count = 0;
-                        while (iterator.hasNext()) {
-                            iterator.next();
-                            count++;
-                        }
-                        Assert.assertTrue(count == 2, "Two namespaces are expected for <bookurn> ");
-
-                        Iterator attributes = startElement.getAttributes();
-                        count = 0;
-                        while (attributes.hasNext()) {
-                            iterator.next();
-                            count++;
-                        }
-                        Assert.assertTrue(count == 0, "Zero attributes are expected for <bookurn> ");
+    public void testEventReader() throws Exception {
+        XMLInputFactory ifac = XMLInputFactory.newInstance();
+        XMLEventReader read = ifac.createXMLEventReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE));
+        while (read.hasNext()) {
+            XMLEvent event = read.nextEvent();
+            if (event.isStartElement()) {
+                StartElement startElement = event.asStartElement();
+                if (startElement.getName().getLocalPart().equals("bookurn")) {
+                    Iterator<Namespace> iterator = startElement.getNamespaces();
+                    int count = 0;
+                    while (iterator.hasNext()) {
+                        iterator.next();
+                        count++;
                     }
+                    assertEquals(2, count, "Two namespaces are expected for <bookurn> ");
+
+                    Iterator<Attribute> attributes = startElement.getAttributes();
+                    count = 0;
+                    while (attributes.hasNext()) {
+                        iterator.next();
+                        count++;
+                    }
+                    assertEquals(0, count, "Zero attributes are expected for <bookurn> ");
                 }
             }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/DoubleXmlnsTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/DoubleXmlnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,95 +23,54 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.DoubleXmlnsTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.DoubleXmlnsTest
  * @summary Test double namespaces and nested namespaces.
  */
 public class DoubleXmlnsTest {
 
     @Test
     public void testDoubleNS() throws Exception {
-
         final String INVALID_XML = "<foo xmlns:xmli='http://www.w3.org/XML/1998/namespacei' xmlns:xmli='http://www.w3.org/XML/1998/namespacei' />";
-
-        try {
-            XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(INVALID_XML));
-
-            while (xsr.hasNext()) {
-                xsr.next();
-            }
-
-            Assert.fail("Wellformedness error expected: " + INVALID_XML);
-        } catch (XMLStreamException e) {
-            ; // this is expected
-        }
+        XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(INVALID_XML));
+        assertThrows(XMLStreamException.class, () -> consumeAllEvents(xsr));
     }
 
     @Test
     public void testNestedNS() throws Exception {
-
         final String VALID_XML = "<foo xmlns:xmli='http://www.w3.org/XML/1998/namespacei'><bar xmlns:xmli='http://www.w3.org/XML/1998/namespaceii'></bar></foo>";
-
-        try {
-            XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(VALID_XML));
-
-            while (xsr.hasNext()) {
-                xsr.next();
-            }
-
-            // expected success
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-
-            Assert.fail("Wellformedness error is not expected: " + VALID_XML + ", " + e.getMessage());
-        }
+        XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(VALID_XML));
+        consumeAllEvents(xsr);
     }
 
     @Test
     public void testDoubleXmlns() throws Exception {
-
         final String INVALID_XML = "<foo xmlns:xml='http://www.w3.org/XML/1998/namespace' xmlns:xml='http://www.w3.org/XML/1998/namespace' ></foo>";
-
-        try {
-            XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(INVALID_XML));
-
-            while (xsr.hasNext()) {
-                xsr.next();
-            }
-
-            Assert.fail("Wellformedness error expected :" + INVALID_XML);
-        } catch (XMLStreamException e) {
-            ; // this is expected
-        }
+        XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(INVALID_XML));
+        assertThrows(XMLStreamException.class, () -> consumeAllEvents(xsr));
     }
 
     @Test
     public void testNestedXmlns() throws Exception {
-
         final String VALID_XML = "<foo xmlns:xml='http://www.w3.org/XML/1998/namespace'><bar xmlns:xml='http://www.w3.org/XML/1998/namespace'></bar></foo>";
+        XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(VALID_XML));
+        consumeAllEvents(xsr);
+    }
 
-        try {
-            XMLStreamReader xsr = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(VALID_XML));
-
-            while (xsr.hasNext()) {
-                xsr.next();
-            }
-
-            // expected success
-        } catch (XMLStreamException e) {
-            e.printStackTrace();
-            Assert.fail("Wellformedness error is not expected: " + VALID_XML + ", " + e.getMessage());
+    private static void consumeAllEvents(XMLStreamReader xsr) throws XMLStreamException {
+        while (xsr.hasNext()) {
+            xsr.next();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IsValidatingTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IsValidatingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,20 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6440324
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.IsValidatingTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.IsValidatingTest
  * @summary Test StAX can accept non-existent DTD if IS_VALIDATING if false.
  */
 public class IsValidatingTest {
@@ -60,45 +62,30 @@ public class IsValidatingTest {
      * This is not required for DTD validation, but for entity resolution.
      * The XML specification allows the optional reading of an external DTD
      * even for non-validating processors.
-     *
      */
     @Test
-    public void testStAXIsValidatingFalse() {
+    public void testStAXIsValidatingFalse() throws Exception {
 
-        XMLStreamReader reader = null;
-        Boolean isValidating = null;
-        String propertyValues = null;
         boolean dtdEventOccured = false;
 
         XMLInputFactory xif = XMLInputFactory.newInstance();
         xif.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
 
-        try {
-            reader = xif.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(), this.getClass().getResourceAsStream(INPUT_FILE));
+        XMLStreamReader reader = xif.createXMLStreamReader(
+                this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE));
 
-            isValidating = (Boolean) reader.getProperty(XMLInputFactory.IS_VALIDATING);
-            propertyValues = "IS_VALIDATING=" + isValidating;
+        assertEquals(Boolean.FALSE, reader.getProperty(XMLInputFactory.IS_VALIDATING));
 
-            while (reader.hasNext()) {
-                int e = reader.next();
-                if (e == XMLEvent.DTD) {
-                    dtdEventOccured = true;
-                    System.out.println("testStAXIsValidatingFalse(): " + "reader.getText() with Event == DTD: " + reader.getText());
-                }
+        while (reader.hasNext()) {
+            int e = reader.next();
+            if (e == XMLEvent.DTD) {
+                dtdEventOccured = true;
             }
-
-            // expected success
-
-            // should have see DTD Event
-            if (!dtdEventOccured) {
-                Assert.fail("Unexpected failure: did not see DTD event");
-            }
-        } catch (Exception e) {
-            // unexpected failure
-            System.err.println("Exception with reader.getEventType(): " + reader.getEventType());
-            e.printStackTrace();
-            Assert.fail("Unexpected failure with " + propertyValues + ", " + e.toString());
         }
+
+        // should have see DTD Event
+        assertTrue(dtdEventOccured, "did not see DTD event");
     }
 
     /**
@@ -108,11 +95,7 @@ public class IsValidatingTest {
      * Test should pass.
      */
     @Test
-    public void testStAXIsValidatingFalseInternalSubset() {
-
-        XMLStreamReader reader = null;
-        Boolean isValidating = null;
-        String propertyValues = null;
+    public void testStAXIsValidatingFalseInternalSubset() throws Exception {
         boolean dtdEventOccured = false;
         boolean entityReferenceEventOccured = false;
 
@@ -120,45 +103,32 @@ public class IsValidatingTest {
         xif.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
         xif.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, Boolean.FALSE);
 
-        try {
-            reader = xif.createXMLStreamReader(this.getClass().getResource(INPUT_FILE).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE_INTERNAL_SUBSET));
+        XMLStreamReader reader = xif.createXMLStreamReader(
+                this.getClass().getResource(INPUT_FILE).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE_INTERNAL_SUBSET));
 
-            isValidating = (Boolean) reader.getProperty(XMLInputFactory.IS_VALIDATING);
-            propertyValues = "IS_VALIDATING=" + isValidating;
+        assertEquals(Boolean.FALSE, reader.getProperty(XMLInputFactory.IS_VALIDATING));
 
-            while (reader.hasNext()) {
-                int e = reader.next();
-                if (e == XMLEvent.DTD) {
-                    dtdEventOccured = true;
-                    System.out.println("testStAXIsValidatingFalseInternalSubset(): " + "reader.getText() with Event == DTD: " + reader.getText());
-                } else if (e == XMLEvent.ENTITY_REFERENCE) {
-                    // expected ENTITY_REFERENCE values?
-                    if (reader.getLocalName().equals("foo") && reader.getText().equals("bar")) {
-                        entityReferenceEventOccured = true;
-                    }
-
-                    System.out.println("testStAXIsValidatingFalseInternalSubset(): " + "reader.get(LocalName, Text)() with Event " + " == ENTITY_REFERENCE: "
-                            + reader.getLocalName() + " = " + reader.getText());
+        while (reader.hasNext()) {
+            int e = reader.next();
+            if (e == XMLEvent.DTD) {
+                dtdEventOccured = true;
+                System.out.println("testStAXIsValidatingFalseInternalSubset(): " + "reader.getText() with Event == DTD: " + reader.getText());
+            } else if (e == XMLEvent.ENTITY_REFERENCE) {
+                // expected ENTITY_REFERENCE values?
+                if (reader.getLocalName().equals("foo") && reader.getText().equals("bar")) {
+                    entityReferenceEventOccured = true;
                 }
-            }
 
-            // expected success
-
-            // should have see DTD Event
-            if (!dtdEventOccured) {
-                Assert.fail("Unexpected failure: did not see DTD event");
+                System.out.println("testStAXIsValidatingFalseInternalSubset(): " + "reader.get(LocalName, Text)() with Event " + " == ENTITY_REFERENCE: "
+                        + reader.getLocalName() + " = " + reader.getText());
             }
-
-            // should have seen an ENITY_REFERENCE Event
-            if (!entityReferenceEventOccured) {
-                Assert.fail("Unexpected failure: did not see ENTITY_REFERENCE event");
-            }
-        } catch (Exception e) {
-            // unexpected failure
-            System.err.println("Exception with reader.getEventType(): " + reader.getEventType());
-            e.printStackTrace();
-            Assert.fail("Unexpected failure with " + propertyValues + ", " + e.toString());
         }
+
+        // should have see DTD Event
+        assertTrue(dtdEventOccured, "did not see DTD event");
+
+        // should have seen an ENITY_REFERENCE Event
+        assertTrue(entityReferenceEventOccured, "did not see ENTITY_REFERENCE event");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Issue44Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Issue44Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,36 +23,27 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 6631262
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Issue44Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Issue44Test
  * @summary Test XMLStreamReader.getName() shall throw IllegalStateException if current event is not start/end element.
  */
 public class Issue44Test {
 
     @Test
-    public void testStartElement() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            // File file = new File("./tests/XMLStreamReader/sgml.xml");
-            // FileInputStream inputStream = new FileInputStream(file);
-            XMLStreamReader xsr = xif.createXMLStreamReader(this.getClass().getResourceAsStream("sgml.xml"));
-
-            xsr.getName();
-        } catch (IllegalStateException ise) {
-            // expected
-            System.out.println(ise.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+    public void testStartElement() throws XMLStreamException {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader xsr = xif.createXMLStreamReader(this.getClass().getResourceAsStream("sgml.xml"));
+        assertThrows(IllegalStateException.class, xsr::getName);
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Issue47Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Issue47Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,66 +23,48 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.AssertJUnit;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6631265
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Issue47Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Issue47Test
  * @summary Test XMLStreamReader.standaloneSet() presents if input document has a value for "standalone" attribute in xml declaration.
  */
 public class Issue47Test {
 
     @Test
-    public void testStandaloneSet() {
+    public void testStandaloneSet() throws XMLStreamException {
         final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><prefix:root xmlns=\"\" xmlns:null=\"\"></prefix:root>";
 
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            XMLStreamReader r = xif.createXMLStreamReader(new StringReader(xml));
-            Assert.assertTrue(!r.standaloneSet() && !r.isStandalone());
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader r = xif.createXMLStreamReader(new StringReader(xml));
+        assertTrue(!r.standaloneSet() && !r.isStandalone());
     }
 
     @Test
-    public void testStandaloneSet1() {
+    public void testStandaloneSet1() throws XMLStreamException {
         final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><prefix:root xmlns=\"\" xmlns:null=\"\"></prefix:root>";
 
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            XMLStreamReader r = xif.createXMLStreamReader(new StringReader(xml));
-            Assert.assertTrue(r.standaloneSet() && !r.isStandalone());
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader r = xif.createXMLStreamReader(new StringReader(xml));
+        assertTrue(r.standaloneSet() && !r.isStandalone());
     }
 
     @Test
-    public void testStandaloneSet2() {
+    public void testStandaloneSet2() throws XMLStreamException {
         final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><prefix:root xmlns=\"\" xmlns:null=\"\"></prefix:root>";
 
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            XMLStreamReader r = xif.createXMLStreamReader(new StringReader(xml));
-            AssertJUnit.assertTrue(r.standaloneSet() && r.isStandalone());
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLStreamReader r = xif.createXMLStreamReader(new StringReader(xml));
+        assertTrue(r.standaloneSet() && r.isStandalone());
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IssueTracker24.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IssueTracker24.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,18 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.StringReader;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.IssueTracker24
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.IssueTracker24
  * @summary Test no prefix is represented by "", not null.
  */
 public class IssueTracker24 {
@@ -48,13 +48,13 @@ public class IssueTracker24 {
         r.require(XMLStreamReader.START_DOCUMENT, null, null);
         r.next();
         r.require(XMLStreamReader.START_ELEMENT, null, "root");
-        Assert.assertEquals(r.getPrefix(), "", "prefix should be empty string");
+        assertEquals("", r.getPrefix(), "prefix should be empty string");
         r.next();
         r.require(XMLStreamReader.START_ELEMENT, null, "child");
         r.next();
         r.next();
         r.require(XMLStreamReader.START_ELEMENT, null, "anotherchild");
-        Assert.assertEquals(r.getPrefix(), "", "prefix should be empty string");
+        assertEquals("", r.getPrefix(), "prefix should be empty string");
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IssueTracker35.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IssueTracker35.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,19 +23,19 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.IssueTracker35
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.IssueTracker35
  * @summary Test StAX parse xsd document including external DTD.
  */
 public class IssueTracker35 {
@@ -43,16 +43,14 @@ public class IssueTracker35 {
     @Test
     public void testSkippingExternalDTD() throws Exception {
         XMLInputFactory xif = XMLInputFactory.newInstance();
-        try(
-                InputStream is= getClass().getResourceAsStream("XMLSchema.xsd");
-        ) {
-                XMLStreamReader reader = xif.createXMLStreamReader(getClass().getResource("XMLSchema.xsd").getFile(), is);
-                int e;
-                while ((e = reader.next()) == XMLStreamConstants.COMMENT);
+        try (InputStream is = getClass().getResourceAsStream("XMLSchema.xsd")) {
+            XMLStreamReader reader = xif.createXMLStreamReader(getClass().getResource("XMLSchema.xsd").getFile(), is);
+            int e;
+            while ((e = reader.next()) == XMLStreamConstants.COMMENT) ;
 
-                Assert.assertEquals(e, XMLStreamConstants.DTD, "should be DTD");
-                reader.nextTag();
-                Assert.assertEquals(reader.getLocalName(), "schema", "next tag should be schema");
+            assertEquals(XMLStreamConstants.DTD, e, "should be DTD");
+            reader.nextTag();
+            assertEquals("schema", reader.getLocalName(), "next tag should be schema");
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IssueTracker70.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/IssueTracker70.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,38 +23,37 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import java.io.File;
+import java.io.FileInputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.IssueTracker70
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.IssueTracker70
  * @summary Test it can retrieve attribute with null or empty name space.
  */
 public class IssueTracker70 {
 
-    static private final File testFile = new File(IssueTracker70.class.getResource("IssueTracker70.xml").getFile());
+    private static final File testFile = new File(IssueTracker70.class.getResource("IssueTracker70.xml").getFile());
 
     @Test
     public void testGetAttributeValueWithNullNs() throws Exception {
-        testGetAttributeValueWithNs(null, "attribute2", this::checkNull);
+        testGetAttributeValueWithNs(null, "attribute2");
     }
 
     @Test
     public void testGetAttributeValueWithEmptyNs() throws Exception {
-        testGetAttributeValueWithNs("", "attribute1", this::checkNull);
+        testGetAttributeValueWithNs("", "attribute1");
     }
 
 
-    private void testGetAttributeValueWithNs(String nameSpace, String attrName, Consumer<String> checker) throws Exception {
+    private void testGetAttributeValueWithNs(String nameSpace, String attrName) throws Exception {
         XMLInputFactory xif = XMLInputFactory.newInstance();
         XMLStreamReader xsr = xif.createXMLStreamReader(new FileInputStream(testFile));
 
@@ -63,13 +62,8 @@ public class IssueTracker70 {
             if (xsr.isStartElement()) {
                 String v;
                 v = xsr.getAttributeValue(nameSpace, attrName);
-                checker.accept(v);
+                assertNotNull(v, "should have attribute value");
             }
         }
-    }
-
-    private void checkNull(String value)
-    {
-        Assert.assertNotNull(value, "should have attribute value");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Jsr173MR1Req5Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Jsr173MR1Req5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,18 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Jsr173MR1Req5Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Jsr173MR1Req5Test
  * @summary Test XMLStreamReader parses namespace declaration within element when NamespaceAware turns off and on.
  */
 public class Jsr173MR1Req5Test {
@@ -41,50 +42,40 @@ public class Jsr173MR1Req5Test {
     private static final String INPUT_FILE1 = "Jsr173MR1Req5.xml";
 
     @Test
-    public void testAttributeCountNoNS() {
+    public void testAttributeCountNoNS() throws Exception {
         XMLInputFactory ifac = XMLInputFactory.newInstance();
 
-        try {
-            // Turn off NS awareness to count xmlns as attributes
-            ifac.setProperty("javax.xml.stream.isNamespaceAware", Boolean.FALSE);
+        // Turn off NS awareness to count xmlns as attributes
+        ifac.setProperty("javax.xml.stream.isNamespaceAware", Boolean.FALSE);
 
-            XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE1));
-            while (re.hasNext()) {
-                int event = re.next();
-                if (event == XMLStreamConstants.START_ELEMENT) {
-                    // System.out.println("#attrs = " + re.getAttributeCount());
-                    Assert.assertTrue(re.getAttributeCount() == 3);
-                }
+        XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE1));
+        while (re.hasNext()) {
+            int event = re.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                // System.out.println("#attrs = " + re.getAttributeCount());
+                assertEquals(3, re.getAttributeCount());
             }
-            re.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         }
+        re.close();
     }
 
     @Test
-    public void testAttributeCountNS() {
+    public void testAttributeCountNS() throws Exception {
         XMLInputFactory ifac = XMLInputFactory.newInstance();
 
-        try {
-            // Turn on NS awareness to not count xmlns as attributes
-            ifac.setProperty("javax.xml.stream.isNamespaceAware", Boolean.TRUE);
+        // Turn on NS awareness to not count xmlns as attributes
+        ifac.setProperty("javax.xml.stream.isNamespaceAware", Boolean.TRUE);
 
-            XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE1));
-            while (re.hasNext()) {
-                int event = re.next();
-                if (event == XMLStreamConstants.START_ELEMENT) {
-                    // System.out.println("#attrs = " + re.getAttributeCount());
-                    Assert.assertTrue(re.getAttributeCount() == 1);
-                }
+        XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE1));
+        while (re.hasNext()) {
+            int event = re.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                // System.out.println("#attrs = " + re.getAttributeCount());
+                assertEquals(1, re.getAttributeCount());
             }
-            re.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         }
+        re.close();
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Jsr173MR1Req8Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/Jsr173MR1Req8Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,18 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.Jsr173MR1Req8Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.Jsr173MR1Req8Test
  * @summary Test XMLStreamReader parses attribute with namespace aware.
  */
 public class Jsr173MR1Req8Test {
@@ -41,28 +42,23 @@ public class Jsr173MR1Req8Test {
     private static final String INPUT_FILE1 = "Jsr173MR1Req8.xml";
 
     @Test
-    public void testDefaultAttrNS() {
+    public void testDefaultAttrNS() throws Exception {
         XMLInputFactory ifac = XMLInputFactory.newInstance();
 
-        try {
-            XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE1));
-            while (re.hasNext()) {
-                int event = re.next();
-                if (event == XMLStreamConstants.START_ELEMENT) {
-                    // System.out.println("#attrs = " + re.getAttributeCount());
-                    Assert.assertTrue(re.getAttributeCount() == 2);
-                    // This works if "" is replaced by null too
-                    // System.out.println("attr1 = " + re.getAttributeValue("",
-                    // "attr1"));
-                    Assert.assertTrue(re.getAttributeValue("", "attr1").equals("pass"));
-                }
+        XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE1));
+        while (re.hasNext()) {
+            int event = re.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                // System.out.println("#attrs = " + re.getAttributeCount());
+                assertEquals(2, re.getAttributeCount());
+                // This works if "" is replaced by null too
+                // System.out.println("attr1 = " + re.getAttributeValue("",
+                // "attr1"));
+                assertEquals("pass", re.getAttributeValue("", "attr1"));
             }
-            re.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
         }
+        re.close();
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/NamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/NamespaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,36 +23,33 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.NamespaceTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.NamespaceTest
  * @summary Test StAX parser processes namespace.
  */
 public class NamespaceTest {
 
-    String namespaceURI = "foobar.com";
-    String rootElement = "foo";
-    String childElement = "foochild";
-    String prefix = "a";
-
-    // Add test methods here, they have to start with 'test' name.
-    // for example:
-    // public void testHello() {}
+    private static final String namespaceURI = "foobar.com";
+    private static final String rootElement = "foo";
+    private static final String childElement = "foochild";
+    private static final String prefix = "a";
 
     String getXML() {
-        StringBuffer sbuffer = new StringBuffer();
+        StringBuilder sbuffer = new StringBuilder();
         sbuffer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         sbuffer.append("<" + rootElement + " xmlns:");
         sbuffer.append(prefix);
@@ -66,87 +63,70 @@ public class NamespaceTest {
     }
 
     @Test
-    public void testRootElementNamespace() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
-            InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(rootElement)) {
-                        Assert.assertTrue(sr.getNamespacePrefix(0).equals(prefix) && sr.getNamespaceURI(0).equals(namespaceURI));
-                    }
+    public void testRootElementNamespace() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+        InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(rootElement)) {
+                    assertTrue(sr.getNamespacePrefix(0).equals(prefix) && sr.getNamespaceURI(0).equals(namespaceURI));
                 }
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
         }
     }
 
     @Test
-    public void testChildElementNamespace() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
-            InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(childElement)) {
-                        QName qname = sr.getName();
-                        Assert.assertTrue(qname.getPrefix().equals(prefix) && qname.getNamespaceURI().equals(namespaceURI)
-                                && qname.getLocalPart().equals(childElement));
-                    }
+    public void testChildElementNamespace() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+        InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(childElement)) {
+                    QName qname = sr.getName();
+                    assertTrue(qname.getPrefix().equals(prefix) && qname.getNamespaceURI().equals(namespaceURI)
+                            && qname.getLocalPart().equals(childElement));
                 }
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
         }
     }
 
     @Test
-    public void testNamespaceContext() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
-            InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(childElement)) {
-                        NamespaceContext context = sr.getNamespaceContext();
-                        Assert.assertTrue(context.getPrefix(namespaceURI).equals(prefix));
-                    }
+    public void testNamespaceContext() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+        InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(childElement)) {
+                    NamespaceContext context = sr.getNamespaceContext();
+                    assertEquals(prefix, context.getPrefix(namespaceURI));
                 }
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
         }
     }
 
     @Test
-    public void testNamespaceCount() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
-            InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
-            XMLStreamReader sr = xif.createXMLStreamReader(is);
-            while (sr.hasNext()) {
-                int eventType = sr.next();
-                if (eventType == XMLStreamConstants.START_ELEMENT) {
-                    if (sr.getLocalName().equals(rootElement)) {
-                        int count = sr.getNamespaceCount();
-                        Assert.assertTrue(count == 1);
-                    }
+    public void testNamespaceCount() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+        InputStream is = new java.io.ByteArrayInputStream(getXML().getBytes());
+        XMLStreamReader sr = xif.createXMLStreamReader(is);
+        while (sr.hasNext()) {
+            int eventType = sr.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT) {
+                if (sr.getLocalName().equals(rootElement)) {
+                    int count = sr.getNamespaceCount();
+                    assertEquals(1, count);
                 }
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
         }
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/NamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/NamespaceTest.java
@@ -33,7 +33,6 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.InputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
@@ -72,7 +71,8 @@ public class NamespaceTest {
             int eventType = sr.next();
             if (eventType == XMLStreamConstants.START_ELEMENT) {
                 if (sr.getLocalName().equals(rootElement)) {
-                    assertTrue(sr.getNamespacePrefix(0).equals(prefix) && sr.getNamespaceURI(0).equals(namespaceURI));
+                    assertEquals(prefix, sr.getNamespacePrefix(0));
+                    assertEquals(namespaceURI, sr.getNamespaceURI(0));
                 }
             }
         }
@@ -89,8 +89,9 @@ public class NamespaceTest {
             if (eventType == XMLStreamConstants.START_ELEMENT) {
                 if (sr.getLocalName().equals(childElement)) {
                     QName qname = sr.getName();
-                    assertTrue(qname.getPrefix().equals(prefix) && qname.getNamespaceURI().equals(namespaceURI)
-                            && qname.getLocalPart().equals(childElement));
+                    assertEquals(prefix, qname.getPrefix());
+                    assertEquals(namespaceURI, qname.getNamespaceURI());
+                    assertEquals(childElement, qname.getLocalPart());
                 }
             }
         }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/StreamReaderTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/StreamReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,28 @@
  */
 package stream.XMLStreamReaderTest;
 
-import java.io.StringReader;
-import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
+import java.util.NoSuchElementException;
 
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 8167340 8204329
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.StreamReaderTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.StreamReaderTest
  * @summary Verifies patches for StreamReader bugs
  */
 public class StreamReaderTest {
-    @Test(expectedExceptions = NoSuchElementException.class)
+    @Test
     public void testNext() throws Exception {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
         XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(
@@ -50,7 +53,7 @@ public class StreamReaderTest {
             int event = xmlStreamReader.next();
         }
         // no more event
-        xmlStreamReader.next();
+        assertThrows(NoSuchElementException.class, xmlStreamReader::next);
     }
 
 
@@ -59,9 +62,9 @@ public class StreamReaderTest {
      * is initialized properly (the listener was not registered in this case).
      *
      * @param path the path to XML source
-     * @throws Exception
      */
-    @Test(dataProvider = "getPaths")
+    @ParameterizedTest
+    @MethodSource("getPaths")
     public void testSwitchXMLVersions(String path) throws Exception {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
         xmlInputFactory.setProperty("javax.xml.stream.isCoalescing", true);
@@ -73,8 +76,7 @@ public class StreamReaderTest {
             if (event == XMLStreamConstants.START_ELEMENT) {
                 if (xmlStreamReader.getLocalName().equals("body")) {
                     String elementText = xmlStreamReader.getElementText();
-                    Assert.assertTrue(!elementText.contains("</body>"),
-                            "Fail: elementText contains </body>");
+                    assertFalse(elementText.contains("</body>"), "Fail: elementText contains </body>");
                 }
             }
         }
@@ -93,23 +95,18 @@ public class StreamReaderTest {
                 this.getClass().getResourceAsStream("ExternalDTD.xml"));
         while (r.next() != XMLStreamConstants.ENTITY_REFERENCE) {
             System.out.println("event type: " + r.getEventType());
-            continue;
         }
-        if (r.hasName()) {
-            System.out.println("hasName returned true on ENTITY_REFERENCE event.");
-        }
-        Assert.assertFalse(r.hasName()); // fails
+        assertFalse(r.hasName(), "hasName returned true on ENTITY_REFERENCE event.");
     }
 
     /*
        DataProvider: provides paths to xml sources
        Data: path to xml source
      */
-    @DataProvider(name = "getPaths")
-    public Object[][] getPaths() {
-        return new Object[][]{
-            {"Bug8167340_1-0.xml"},
-            {"Bug8167340_1-1.xml"}
+    public static Object[][] getPaths() {
+        return new Object[][] {
+                { "Bug8167340_1-0.xml" },
+                { "Bug8167340_1-1.xml" }
         };
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/SupportDTDTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/SupportDTDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,7 @@
 
 package stream.XMLStreamReaderTest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.StringReader;
-import java.util.List;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -36,14 +33,18 @@ import javax.xml.stream.events.DTD;
 import javax.xml.stream.events.EntityDeclaration;
 import javax.xml.stream.events.EntityReference;
 import javax.xml.stream.events.XMLEvent;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.StringReader;
+import java.util.List;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.SupportDTDTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.SupportDTDTest
  * @summary Test SUPPORT_DTD and IS_REPLACING_ENTITY_REFERENCES.
  */
 
@@ -92,123 +93,111 @@ public class SupportDTDTest {
     final int ENTITY_EXTERNAL_ONLY = 2;
     final int ENTITY_BOTH = 3;
 
-    boolean _DTDReturned = false;
-    boolean _EntityEventReturned = false;
-    boolean _hasEntityDelaration = false;
-    boolean _exceptionThrown = false;
-
-    /** Creates a new instance of StreamReader */
-    public SupportDTDTest(String name) {
-    }
-
-    void reset() {
-        _DTDReturned = false;
-        _EntityEventReturned = false;
-        _hasEntityDelaration = false;
-        _exceptionThrown = false;
-    }
+    private boolean _DTDReturned = false;
+    private boolean _EntityEventReturned = false;
+    private boolean _hasEntityDelaration = false;
+    private boolean _exceptionThrown = false;
 
     // tests 1-4 test internal entities only
     @Test
-    public void test1() {
+    public void test1() throws Exception {
         supportDTD(true, true, ENTITY_INTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(true, _hasEntityDelaration);
-        Assert.assertEquals(false, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertTrue(_hasEntityDelaration);
+        assertFalse(_EntityEventReturned);
     }
 
     @Test
-    public void test2() {
+    public void test2() throws Exception {
         supportDTD(true, false, ENTITY_INTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(true, _hasEntityDelaration);
-        Assert.assertEquals(true, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertTrue(_hasEntityDelaration);
+        assertTrue(_EntityEventReturned);
     }
 
     @Test
-    public void test3() {
+    public void test3() throws Exception {
         supportDTD(false, true, ENTITY_INTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(false, _hasEntityDelaration);
-        Assert.assertEquals(true, _exceptionThrown);
+        assertTrue(_DTDReturned);
+        assertFalse(_hasEntityDelaration);
+        assertTrue(_exceptionThrown);
     }
 
     @Test
-    public void test4() {
+    public void test4() throws Exception {
         supportDTD(false, false, ENTITY_INTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(false, _hasEntityDelaration);
-        Assert.assertEquals(true, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertFalse(_hasEntityDelaration);
+        assertTrue(_EntityEventReturned);
     }
 
     // tests 5-8 test external entities only
     @Test
-    public void test5() {
+    public void test5() throws Exception {
         supportDTD(true, true, ENTITY_EXTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(true, _hasEntityDelaration);
-        Assert.assertEquals(false, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertTrue(_hasEntityDelaration);
+        assertFalse(_EntityEventReturned);
     }
 
     @Test
-    public void test6() {
+    public void test6() throws Exception {
         supportDTD(true, false, ENTITY_EXTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(true, _hasEntityDelaration);
-        Assert.assertEquals(true, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertTrue(_hasEntityDelaration);
+        assertTrue(_EntityEventReturned);
     }
 
     @Test
-    public void test7() {
+    public void test7() throws Exception {
         supportDTD(false, true, ENTITY_EXTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(false, _hasEntityDelaration);
-        Assert.assertEquals(true, _exceptionThrown);
+        assertTrue(_DTDReturned);
+        assertFalse(_hasEntityDelaration);
+        assertTrue(_exceptionThrown);
     }
 
     @Test
-    public void test8() {
+    public void test8() throws Exception {
         supportDTD(false, false, ENTITY_EXTERNAL_ONLY);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(false, _hasEntityDelaration);
-        Assert.assertEquals(true, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertFalse(_hasEntityDelaration);
+        assertTrue(_EntityEventReturned);
     }
 
     // tests 9-12 test both internal and external entities
     @Test
-    public void test9() {
+    public void test9() throws Exception {
         supportDTD(true, true, ENTITY_BOTH);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(true, _hasEntityDelaration);
-        Assert.assertEquals(false, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertTrue(_hasEntityDelaration);
+        assertFalse(_EntityEventReturned);
     }
 
     @Test
-    public void test10() {
+    public void test10() throws Exception {
         supportDTD(true, false, ENTITY_BOTH);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(true, _hasEntityDelaration);
-        Assert.assertEquals(true, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertTrue(_hasEntityDelaration);
+        assertTrue(_EntityEventReturned);
     }
 
     @Test
-    public void test11() {
+    public void test11() throws Exception {
         supportDTD(false, true, ENTITY_BOTH);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(false, _hasEntityDelaration);
-        Assert.assertEquals(true, _exceptionThrown);
+        assertTrue(_DTDReturned);
+        assertFalse(_hasEntityDelaration);
+        assertTrue(_exceptionThrown);
     }
 
     @Test
-    public void test12() {
+    public void test12() throws Exception {
         supportDTD(false, false, ENTITY_BOTH);
-        Assert.assertEquals(true, _DTDReturned);
-        Assert.assertEquals(false, _hasEntityDelaration);
-        Assert.assertEquals(true, _EntityEventReturned);
+        assertTrue(_DTDReturned);
+        assertFalse(_hasEntityDelaration);
+        assertTrue(_EntityEventReturned);
     }
 
-    public void supportDTD(boolean supportDTD, boolean replaceEntity, int inputType) {
-        reset();
+    public void supportDTD(boolean supportDTD, boolean replaceEntity, int inputType) throws Exception {
         print("\n");
         print((supportDTD ? "SupportDTD=true" : "SupportDTD=false") + ", " + (replaceEntity ? "replaceEntity=true" : "replaceEntity=false"));
         try {
@@ -265,14 +254,14 @@ public class SupportDTDTest {
     }
 
     void DisplayEntities(DTD event) {
-        List entities = event.getEntities();
+        List<EntityDeclaration> entities = event.getEntities();
         if (entities == null) {
             _hasEntityDelaration = false;
             print("No entity found.");
         } else {
             _hasEntityDelaration = true;
             for (int i = 0; i < entities.size(); i++) {
-                EntityDeclaration entity = (EntityDeclaration) entities.get(i);
+                EntityDeclaration entity = entities.get(i);
                 print(entity.getName());
             }
         }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/VoiceXMLDTDTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/VoiceXMLDTDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,15 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.VoiceXMLDTDTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.VoiceXMLDTDTest
  * @summary Test parsing Voice XML DTD.
  */
 public class VoiceXMLDTDTest {
@@ -40,18 +39,13 @@ public class VoiceXMLDTDTest {
     private static final String INPUT_FILE1 = "voicexml.xml";
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         XMLInputFactory ifac = XMLInputFactory.newInstance();
 
-        try {
-            XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
-                    this.getClass().getResourceAsStream(INPUT_FILE1));
-            while (re.hasNext()) {
-                int event = re.next();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
+        XMLStreamReader re = ifac.createXMLStreamReader(getClass().getResource(INPUT_FILE1).toExternalForm(),
+                this.getClass().getResourceAsStream(INPUT_FILE1));
+        while (re.hasNext()) {
+            int event = re.next();
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/XML11Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/XML11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,31 +23,24 @@
 
 package stream.XMLStreamReaderTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamReaderTest.XML11Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamReaderTest.XML11Test
  * @summary Test parsing xml 1.1.
  */
 public class XML11Test {
 
     @Test
-    public void test() {
-        try {
-            XMLInputFactory xif = XMLInputFactory.newInstance();
-            XMLEventReader reader = xif.createXMLEventReader(this.getClass().getResourceAsStream("xml11.xml.data"));
-            while (reader.hasNext())
-                reader.next();
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+    public void test() throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        XMLEventReader reader = xif.createXMLEventReader(this.getClass().getResourceAsStream("xml11.xml.data"));
+        while (reader.hasNext())
+            reader.next();
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/AttributeEscapeTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/AttributeEscapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,25 +23,19 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.AttributeEscapeTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.AttributeEscapeTest
  * @summary Test XMLStreamWriter shall escape the illegal characters.
  */
 public class AttributeEscapeTest {
@@ -52,51 +46,36 @@ public class AttributeEscapeTest {
     private static final String XML_CONTENT = "Testing escaping: lt=<, gt=>, amp=&, apos=', dquote=\"";
 
     @Test
-    public void testCR6420953() {
+    public void testCR6420953() throws Exception {
+        XMLOutputFactory xof = XMLOutputFactory.newInstance();
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter w = xof.createXMLStreamWriter(sw);
 
-        try {
-            XMLOutputFactory xof = XMLOutputFactory.newInstance();
-            StringWriter sw = new StringWriter();
-            XMLStreamWriter w = xof.createXMLStreamWriter(sw);
+        w.writeStartDocument();
+        w.writeStartElement("element");
 
-            w.writeStartDocument();
-            w.writeStartElement("element");
+        w.writeDefaultNamespace(XML_CONTENT);
+        w.writeNamespace("prefix", XML_CONTENT);
 
-            w.writeDefaultNamespace(XML_CONTENT);
-            w.writeNamespace("prefix", XML_CONTENT);
+        w.writeAttribute("attribute", XML_CONTENT);
+        w.writeAttribute(XML_CONTENT, "attribute2", XML_CONTENT);
+        w.writeAttribute("prefix", XML_CONTENT, "attribute3", XML_CONTENT);
 
-            w.writeAttribute("attribute", XML_CONTENT);
-            w.writeAttribute(XML_CONTENT, "attribute2", XML_CONTENT);
-            w.writeAttribute("prefix", XML_CONTENT, "attribute3", XML_CONTENT);
+        w.writeCharacters("\n");
+        w.writeCharacters(XML_CONTENT);
+        w.writeCharacters("\n");
+        w.writeCharacters(XML_CONTENT.toCharArray(), 0, XML_CONTENT.length());
+        w.writeCharacters("\n");
 
-            w.writeCharacters("\n");
-            w.writeCharacters(XML_CONTENT);
-            w.writeCharacters("\n");
-            w.writeCharacters(XML_CONTENT.toCharArray(), 0, XML_CONTENT.length());
-            w.writeCharacters("\n");
+        w.writeEndElement();
+        w.writeEndDocument();
+        w.flush();
 
-            w.writeEndElement();
-            w.writeEndDocument();
-            w.flush();
+        System.out.println(sw);
 
-            System.out.println(sw);
-
-            // make sure that the generated XML parses
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
-            dbf.newDocumentBuilder().parse(new InputSource(new StringReader(sw.toString())));
-        } catch (XMLStreamException xmlStreamException) {
-            xmlStreamException.printStackTrace();
-            Assert.fail(xmlStreamException.toString());
-        } catch (SAXException saxException) {
-            saxException.printStackTrace();
-            Assert.fail(saxException.toString());
-        } catch (ParserConfigurationException parserConfigurationException) {
-            parserConfigurationException.printStackTrace();
-            Assert.fail(parserConfigurationException.toString());
-        } catch (IOException ioException) {
-            ioException.printStackTrace();
-            Assert.fail(ioException.toString());
-        }
+        // make sure that the generated XML parses
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.newDocumentBuilder().parse(new InputSource(new StringReader(sw.toString())));
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug6452107.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug6452107.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,21 +23,18 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 
 /*
  * @test
  * @bug 6452107
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.Bug6452107
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.Bug6452107
  * @summary Test StAX can write ISO-8859-1 encoding XML.
  */
 public class Bug6452107 {
@@ -48,16 +45,12 @@ public class Bug6452107 {
      * inspected, this test throws an exception.
      */
     @Test
-    public void test() {
+    public void test() throws Exception {
         final String ENCODING = "ISO-8859-1";
 
-        try {
-            OutputStream out = new ByteArrayOutputStream();
-            XMLOutputFactory factory = XMLOutputFactory.newInstance();
-            XMLStreamWriter writer = factory.createXMLStreamWriter(out, ENCODING);
-            writer.writeStartDocument(ENCODING, "1.0");
-        } catch (XMLStreamException e) {
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+        OutputStream out = new ByteArrayOutputStream();
+        XMLOutputFactory factory = XMLOutputFactory.newInstance();
+        XMLStreamWriter writer = factory.createXMLStreamWriter(out, ENCODING);
+        writer.writeStartDocument(ENCODING, "1.0");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug6600882Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug6600882Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,36 +23,31 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6600882
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.Bug6600882Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.Bug6600882Test
  * @summary Test toString(), hashCode() of XMLStreamWriter .
  */
 public class Bug6600882Test {
 
-
     @Test
-    public void test() {
-        try {
-            XMLOutputFactory of = XMLOutputFactory.newInstance();
-            XMLStreamWriter w = of.createXMLStreamWriter(new ByteArrayOutputStream());
-            XMLStreamWriter w1 = of.createXMLStreamWriter(new ByteArrayOutputStream());
-            System.out.println(w);
-            Assert.assertTrue(w.equals(w) && w.hashCode() == w.hashCode());
-            Assert.assertFalse(w1.equals(w));
-        } catch (Throwable ex) {
-            Assert.fail(ex.toString());
-        }
+    public void test() throws Exception {
+        XMLOutputFactory of = XMLOutputFactory.newInstance();
+        XMLStreamWriter w = of.createXMLStreamWriter(new ByteArrayOutputStream());
+        XMLStreamWriter w1 = of.createXMLStreamWriter(new ByteArrayOutputStream());
+        assertTrue(w.equals(w) && w.hashCode() == w.hashCode());
+        assertNotEquals(w1, w);
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug6675332Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug6675332Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,22 +23,21 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import util.BaseStAXUT;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.StringWriter;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import util.BaseStAXUT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
  * @bug 6675332
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.Bug6675332Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.Bug6675332Test
  * @summary Test XMLStreamWriter writeAttribute when IS_REPAIRING_NAMESPACES is true.
  */
 public class Bug6675332Test extends BaseStAXUT {
@@ -46,118 +45,108 @@ public class Bug6675332Test extends BaseStAXUT {
     private static final XMLOutputFactory XML_OUTPUT_FACTORY = XMLOutputFactory.newInstance();
 
     @Test
-    public void test() {
-        final String URL_P1 = "http://p1.org";
+    public void test() throws Exception {
         final String URL_DEF = "urn:default";
         final String ATTR_VALUE = "'value\"";
-        final String ATTR_VALUE2 = "<tag>";
 
-        final String TEXT = "  some text\n";
         XML_OUTPUT_FACTORY.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
 
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root></root>";
         XMLStreamWriter w = null;
         StringWriter strw = new StringWriter();
-        try {
-            w = XML_OUTPUT_FACTORY.createXMLStreamWriter(strw);
 
-            w.writeStartDocument();
+        w = XML_OUTPUT_FACTORY.createXMLStreamWriter(strw);
 
-            /*
-             * Calling this method should be optional; but if we call it,
-             * exceptation is that it does properly bind the prefix and URL as
-             * the 'preferred' combination. In this case we'll just try to make
-             * URL bound as the default namespace
-             */
-            w.setDefaultNamespace(URL_DEF);
-            w.writeStartElement(URL_DEF, "test"); // root
+        w.writeStartDocument();
 
-            /*
-             * And let's further make element and attribute(s) belong to that
-             * same namespace
-             */
-            w.writeStartElement("", "leaf", URL_DEF); // 1st leaf
-            w.writeAttribute("", URL_DEF, "attr", ATTR_VALUE);
-            w.writeAttribute(URL_DEF, "attr2", ATTR_VALUE);
-            w.writeEndElement();
+        /*
+         * Calling this method should be optional; but if we call it,
+         * exceptation is that it does properly bind the prefix and URL as
+         * the 'preferred' combination. In this case we'll just try to make
+         * URL bound as the default namespace
+         */
+        w.setDefaultNamespace(URL_DEF);
+        w.writeStartElement(URL_DEF, "test"); // root
 
-            // w.writeEmptyElement("", "leaf"); // 2nd leaf; in empty/no
-            // namespace!
+        /*
+         * And let's further make element and attribute(s) belong to that
+         * same namespace
+         */
+        w.writeStartElement("", "leaf", URL_DEF); // 1st leaf
+        w.writeAttribute("", URL_DEF, "attr", ATTR_VALUE);
+        w.writeAttribute(URL_DEF, "attr2", ATTR_VALUE);
+        w.writeEndElement();
 
-            w.writeStartElement(URL_DEF, "leaf"); // 3rd leaf
-            // w.writeAttribute("", "attr2", ATTR_VALUE2); // in empty/no
-            // namespace
-            w.writeEndElement();
+        // w.writeEmptyElement("", "leaf"); // 2nd leaf; in empty/no
+        // namespace!
 
-            w.writeEndElement(); // root elem
-            w.writeEndDocument();
-            w.close();
-            System.out.println("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\\n");
-            System.out.println(strw.toString());
+        w.writeStartElement(URL_DEF, "leaf"); // 3rd leaf
+        // w.writeAttribute("", "attr2", ATTR_VALUE2); // in empty/no
+        // namespace
+        w.writeEndElement();
 
-            // And then let's parse and verify it all:
-            // System.err.println("testAttributes: doc = '"+strw+"'");
+        w.writeEndElement(); // root elem
+        w.writeEndDocument();
+        w.close();
+        System.out.println("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\\n");
+        System.out.println(strw.toString());
 
-            XMLStreamReader sr = constructNsStreamReader(strw.toString());
-            assertTokenType(START_DOCUMENT, sr.getEventType(), sr);
+        // And then let's parse and verify it all:
+        // System.err.println("testAttributes: doc = '"+strw+"'");
 
-            // root element
-            assertTokenType(START_ELEMENT, sr.next(), sr);
-            Assert.assertEquals("test", sr.getLocalName());
-            Assert.assertEquals(URL_DEF, sr.getNamespaceURI());
+        XMLStreamReader sr = constructNsStreamReader(strw.toString());
+        assertTokenType(START_DOCUMENT, sr.getEventType(), sr);
 
-            // first leaf:
-            assertTokenType(START_ELEMENT, sr.next(), sr);
-            Assert.assertEquals("leaf", sr.getLocalName());
-            Assert.assertEquals(URL_DEF, sr.getNamespaceURI());
-            System.out.println(sr.getAttributeLocalName(0));
-            System.out.println(sr.getAttributeLocalName(1));
-            Assert.assertEquals(2, sr.getAttributeCount());
-            Assert.assertEquals("attr", sr.getAttributeLocalName(0));
+        // root element
+        assertTokenType(START_ELEMENT, sr.next(), sr);
+        assertEquals("test", sr.getLocalName());
+        assertEquals(URL_DEF, sr.getNamespaceURI());
 
-            String uri = sr.getAttributeNamespace(0);
-            if (!URL_DEF.equals(uri)) {
-                Assert.fail("Expected attribute 'attr' to have NS '" + URL_DEF + "', was " + valueDesc(uri) + "; input = '" + strw + "'");
-            }
-            Assert.assertEquals(ATTR_VALUE, sr.getAttributeValue(0));
-            assertTokenType(END_ELEMENT, sr.next(), sr);
-            Assert.assertEquals("leaf", sr.getLocalName());
-            Assert.assertEquals(URL_DEF, sr.getNamespaceURI());
+        // first leaf:
+        assertTokenType(START_ELEMENT, sr.next(), sr);
+        assertEquals("leaf", sr.getLocalName());
+        assertEquals(URL_DEF, sr.getNamespaceURI());
+        System.out.println(sr.getAttributeLocalName(0));
+        System.out.println(sr.getAttributeLocalName(1));
+        assertEquals(2, sr.getAttributeCount());
+        assertEquals("attr", sr.getAttributeLocalName(0));
 
-            // 2nd/empty leaf
-            /**
-             * assertTokenType(START_ELEMENT, sr.next(), sr);
-             * assertEquals("leaf", sr.getLocalName()); assertNoNsURI(sr);
-             * assertTokenType(END_ELEMENT, sr.next(), sr); assertEquals("leaf",
-             * sr.getLocalName()); assertNoNsURI(sr);
-             */
-            // third leaf
-            assertTokenType(START_ELEMENT, sr.next(), sr);
-            Assert.assertEquals("leaf", sr.getLocalName());
-            Assert.assertEquals(URL_DEF, sr.getNamespaceURI());
+        String uri = sr.getAttributeNamespace(0);
+        assertEquals(URL_DEF, uri, "Expected attribute 'attr' to have NS '" + URL_DEF + "', was " + valueDesc(uri) + "; input = '" + strw + "'");
+        assertEquals(ATTR_VALUE, sr.getAttributeValue(0));
+        assertTokenType(END_ELEMENT, sr.next(), sr);
+        assertEquals("leaf", sr.getLocalName());
+        assertEquals(URL_DEF, sr.getNamespaceURI());
 
-            /*
-             * attr in 3rd leaf, in empty/no namespace assertEquals(1,
-             * sr.getAttributeCount()); assertEquals("attr2",
-             * sr.getAttributeLocalName(0));
-             * assertNoAttrNamespace(sr.getAttributeNamespace(0));
-             * assertEquals(ATTR_VALUE2, sr.getAttributeValue(0));
-             */
-            assertTokenType(END_ELEMENT, sr.next(), sr);
-            Assert.assertEquals("leaf", sr.getLocalName());
-            Assert.assertEquals(URL_DEF, sr.getNamespaceURI());
+        // 2nd/empty leaf
+        /*
+         * assertTokenType(START_ELEMENT, sr.next(), sr);
+         * assertEquals("leaf", sr.getLocalName()); assertNoNsURI(sr);
+         * assertTokenType(END_ELEMENT, sr.next(), sr); assertEquals("leaf",
+         * sr.getLocalName()); assertNoNsURI(sr);
+         */
+        // third leaf
+        assertTokenType(START_ELEMENT, sr.next(), sr);
+        assertEquals("leaf", sr.getLocalName());
+        assertEquals(URL_DEF, sr.getNamespaceURI());
 
-            // closing root element
-            assertTokenType(END_ELEMENT, sr.next(), sr);
-            Assert.assertEquals("test", sr.getLocalName());
-            Assert.assertEquals(URL_DEF, sr.getNamespaceURI());
+        /*
+         * attr in 3rd leaf, in empty/no namespace assertEquals(1,
+         * sr.getAttributeCount()); assertEquals("attr2",
+         * sr.getAttributeLocalName(0));
+         * assertNoAttrNamespace(sr.getAttributeNamespace(0));
+         * assertEquals(ATTR_VALUE2, sr.getAttributeValue(0));
+         */
+        assertTokenType(END_ELEMENT, sr.next(), sr);
+        assertEquals("leaf", sr.getLocalName());
+        assertEquals(URL_DEF, sr.getNamespaceURI());
 
-            assertTokenType(END_DOCUMENT, sr.next(), sr);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        // closing root element
+        assertTokenType(END_ELEMENT, sr.next(), sr);
+        assertEquals("test", sr.getLocalName());
+        assertEquals(URL_DEF, sr.getNamespaceURI());
 
+        assertTokenType(END_DOCUMENT, sr.next(), sr);
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug7037352Test.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/Bug7037352Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,42 +23,34 @@
 
 package stream.XMLStreamWriterTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stream.StreamResult;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /*
  * @test
  * @bug 7037352
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.Bug7037352Test
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.Bug7037352Test
  * @summary Test XMLStreamWriter.getNamespaceContext().getPrefix with XML_NS_URI and XMLNS_ATTRIBUTE_NS_URI.
  */
 public class Bug7037352Test {
 
     @Test
-    public void test() {
-        try {
-            XMLOutputFactory xof = XMLOutputFactory.newInstance();
-            StreamResult sr = new StreamResult();
-            XMLStreamWriter xsw = xof.createXMLStreamWriter(sr);
-            NamespaceContext nc = xsw.getNamespaceContext();
-            System.out.println(nc.getPrefix(XMLConstants.XML_NS_URI));
-            System.out.println("  expected result: " + XMLConstants.XML_NS_PREFIX);
-            System.out.println(nc.getPrefix(XMLConstants.XMLNS_ATTRIBUTE_NS_URI));
-            System.out.println("  expected result: " + XMLConstants.XMLNS_ATTRIBUTE);
+    public void test() throws Exception {
+        XMLOutputFactory xof = XMLOutputFactory.newInstance();
+        StreamResult sr = new StreamResult();
+        XMLStreamWriter xsw = xof.createXMLStreamWriter(sr);
+        NamespaceContext nc = xsw.getNamespaceContext();
 
-            Assert.assertTrue(nc.getPrefix(XMLConstants.XML_NS_URI) == XMLConstants.XML_NS_PREFIX);
-            Assert.assertTrue(nc.getPrefix(XMLConstants.XMLNS_ATTRIBUTE_NS_URI) == XMLConstants.XMLNS_ATTRIBUTE);
-
-        } catch (Throwable ex) {
-            Assert.fail(ex.toString());
-        }
+        assertSame(XMLConstants.XML_NS_PREFIX, nc.getPrefix(XMLConstants.XML_NS_URI));
+        assertSame(XMLConstants.XMLNS_ATTRIBUTE, nc.getPrefix(XMLConstants.XMLNS_ATTRIBUTE_NS_URI));
     }
 
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/CustomImplTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/CustomImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,17 @@
 
 package stream.XMLStreamWriterTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.stax.StAXResult;
-import org.testng.annotations.Test;
 
 /*
  * @test
  * @bug 8230094
- * @run testng stream.XMLStreamWriterTest.CustomImplTest
+ * @run junit stream.XMLStreamWriterTest.CustomImplTest
  * @summary Verifies custom implementation of the XMLStreamWriter.
  */
 public class CustomImplTest {
@@ -47,175 +47,128 @@ public class CustomImplTest {
     static class StreamWriterFilter implements XMLStreamWriter
     {
         @Override
-        public void writeStartElement(String localName)
-                throws XMLStreamException
-        {
+        public void writeStartElement(String localName) {
         }
 
         @Override
-        public void writeStartElement(String namespaceURI, String localName)
-                throws XMLStreamException
-        {
+        public void writeStartElement(String namespaceURI, String localName) {
         }
 
         @Override
         public void writeStartElement(
-                String prefix, String localName, String namespaceURI)
-                throws XMLStreamException
-        {
+                String prefix, String localName, String namespaceURI) {
         }
 
         @Override
-        public void writeEmptyElement(String namespaceURI, String localName)
-                throws XMLStreamException
-        {
+        public void writeEmptyElement(String namespaceURI, String localName) {
         }
 
         @Override
         public void writeEmptyElement(
-                String prefix, String localName, String namespaceURI)
-                throws XMLStreamException
-        {
+                String prefix, String localName, String namespaceURI) {
         }
 
         @Override
-        public void writeEmptyElement(String localName)
-                throws XMLStreamException
-        {
+        public void writeEmptyElement(String localName) {
         }
 
         @Override
-        public void writeEndElement() throws XMLStreamException
-        {
+        public void writeEndElement() {
         }
 
         @Override
-        public void writeEndDocument() throws XMLStreamException
-        {
+        public void writeEndDocument() {
         }
 
         @Override
-        public void close() throws XMLStreamException
-        {
+        public void close() {
         }
 
         @Override
-        public void flush() throws XMLStreamException
-        {
+        public void flush() {
         }
 
         @Override
-        public void writeAttribute(String localName, String value)
-                throws XMLStreamException
-        {
+        public void writeAttribute(String localName, String value) {
         }
 
         @Override
         public void writeAttribute(
-                String prefix, String namespaceURI, String localName, String value)
-                throws XMLStreamException
-        {
+                String prefix, String namespaceURI, String localName, String value) {
         }
 
         @Override
         public void writeAttribute(
-                String namespaceURI, String localName, String value)
-                throws XMLStreamException
-        {
+                String namespaceURI, String localName, String value) {
         }
 
         @Override
-        public void writeNamespace(String prefix, String namespaceURI)
-                throws XMLStreamException
-        {
+        public void writeNamespace(String prefix, String namespaceURI) {
         }
 
         @Override
-        public void writeDefaultNamespace(String namespaceURI)
-                throws XMLStreamException
-        {
+        public void writeDefaultNamespace(String namespaceURI) {
         }
 
         @Override
-        public void writeComment(String data) throws XMLStreamException
-        {
+        public void writeComment(String data) {
         }
 
         @Override
-        public void writeProcessingInstruction(String target)
-                throws XMLStreamException
-        {
+        public void writeProcessingInstruction(String target) {
         }
 
         @Override
-        public void writeProcessingInstruction(String target, String data)
-                throws XMLStreamException
-        {
+        public void writeProcessingInstruction(String target, String data) {
         }
 
         @Override
-        public void writeCData(String data) throws XMLStreamException
-        {
+        public void writeCData(String data) {
         }
 
         @Override
-        public void writeDTD(String dtd) throws XMLStreamException
-        {
+        public void writeDTD(String dtd) {
         }
 
         @Override
-        public void writeEntityRef(String name) throws XMLStreamException
-        {
+        public void writeEntityRef(String name) {
         }
 
         @Override
-        public void writeStartDocument() throws XMLStreamException
-        {
+        public void writeStartDocument() {
         }
 
         @Override
-        public void writeStartDocument(String version) throws XMLStreamException
-        {
+        public void writeStartDocument(String version) {
         }
 
         @Override
-        public void writeStartDocument(String encoding, String version)
-                throws XMLStreamException
-        {
+        public void writeStartDocument(String encoding, String version) {
         }
 
         @Override
-        public void writeCharacters(String text) throws XMLStreamException
-        {
+        public void writeCharacters(String text) {
         }
 
         @Override
-        public void writeCharacters(char[] text, int start, int len)
-                throws XMLStreamException
-        {
+        public void writeCharacters(char[] text, int start, int len) {
         }
 
         @Override
-        public String getPrefix(String uri) throws XMLStreamException
-        {
+        public String getPrefix(String uri) {
             return null;
         }
 
         @Override
-        public void setPrefix(String prefix, String uri)
-                throws XMLStreamException
-        {
+        public void setPrefix(String prefix, String uri) {
         }
 
         @Override
-        public void setDefaultNamespace(String uri) throws XMLStreamException
-        {
+        public void setDefaultNamespace(String uri) {
         }
 
         @Override
-        public void setNamespaceContext(NamespaceContext context)
-                throws XMLStreamException
-        {
+        public void setNamespaceContext(NamespaceContext context) {
         }
 
         @Override

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/DomUtilTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/DomUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,33 +23,24 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintStream;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.Result;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import org.testng.annotations.Test;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.DomUtilTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.DomUtilTest
  * @summary Test XMLStreamWriter writes a soap message.
  */
 public class DomUtilTest {
@@ -67,57 +58,23 @@ public class DomUtilTest {
         setup();
 
         File f = new File(this.getClass().getResource(INPUT_FILE1).getFile());
-        System.out.println("***********" + f.getName() + "***********");
         DOMSource src = makeDomSource(f);
         Node node = src.getNode();
         XMLStreamWriter writer = staxOut.createXMLStreamWriter(new PrintStream(System.out));
         DOMUtil.serializeNode((Element) node.getFirstChild(), writer);
         writer.close();
-        assert (true);
-        System.out.println("*****************************************");
-
     }
 
     public static DOMSource makeDomSource(File f) throws Exception {
         InputStream is = new FileInputStream(f);
-        DOMSource domSource = new DOMSource(createDOMNode(is));
-        return domSource;
+        return new DOMSource(createDOMNode(is));
     }
 
-    public static void printNode(Node node) {
-        DOMSource source = new DOMSource(node);
-        String msgString = null;
-        try {
-            Transformer xFormer = TransformerFactory.newInstance().newTransformer();
-            xFormer.setOutputProperty("omit-xml-declaration", "yes");
-            ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-            Result result = new StreamResult(outStream);
-            xFormer.transform(source, result);
-            outStream.writeTo(System.out);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-    }
-
-    public static Node createDOMNode(InputStream inputStream) {
+    public static Node createDOMNode(InputStream inputStream) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
         dbf.setValidating(false);
-        try {
-            DocumentBuilder builder = dbf.newDocumentBuilder();
-            try {
-                return builder.parse(inputStream);
-            } catch (SAXException e) {
-                e.printStackTrace();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        } catch (ParserConfigurationException pce) {
-            IllegalArgumentException iae = new IllegalArgumentException(pce.getMessage());
-            iae.initCause(pce);
-            throw iae;
-        }
-        return null;
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        return builder.parse(inputStream);
     }
-
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/EmptyElementTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/EmptyElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,18 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.EmptyElementTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.EmptyElementTest
  * @summary Test XMLStreamWriter writes namespace and attribute after writeEmptyElement.
  */
 public class EmptyElementTest {
@@ -51,34 +51,22 @@ public class EmptyElementTest {
     public void testWriterOnLinux() throws Exception {
 
         // setup XMLStreamWriter
-        try {
-            byteArrayOutputStream = new ByteArrayOutputStream();
-            xmlOutputFactory = XMLOutputFactory.newInstance();
-            xmlOutputFactory.setProperty(xmlOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream);
-        } catch (Exception e) {
-            System.err.println("Unexpected Exception: " + e.toString());
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        xmlOutputFactory = XMLOutputFactory.newInstance();
+        xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
+        xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream);
 
         // create & write a document
-        try {
-            xmlStreamWriter.writeStartDocument();
-            xmlStreamWriter.writeStartElement("hello");
-            xmlStreamWriter.writeDefaultNamespace("http://hello");
-            xmlStreamWriter.writeEmptyElement("world");
-            xmlStreamWriter.writeDefaultNamespace("http://world");
-            xmlStreamWriter.writeAttribute("prefixes", "foo bar");
-            xmlStreamWriter.writeEndElement();
-            xmlStreamWriter.writeEndDocument();
-            xmlStreamWriter.flush();
-            String actualOutput = byteArrayOutputStream.toString();
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            System.err.println("Unexpected Exception: " + e.toString());
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        xmlStreamWriter.writeStartDocument();
+        xmlStreamWriter.writeStartElement("hello");
+        xmlStreamWriter.writeDefaultNamespace("http://hello");
+        xmlStreamWriter.writeEmptyElement("world");
+        xmlStreamWriter.writeDefaultNamespace("http://world");
+        xmlStreamWriter.writeAttribute("prefixes", "foo bar");
+        xmlStreamWriter.writeEndElement();
+        xmlStreamWriter.writeEndDocument();
+        xmlStreamWriter.flush();
+        String actualOutput = byteArrayOutputStream.toString();
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/EncodingTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,23 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.EncodingTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.EncodingTest
  * @summary Test XMLStreamWriter writes a document with encoding setting.
  */
 public class EncodingTest {
@@ -45,30 +50,23 @@ public class EncodingTest {
      * Tests writing a document with UTF-8 encoding, by setting UTF-8 on writer.
      */
     @Test
-    public void testWriteStartDocumentUTF8() {
+    public void testWriteStartDocumentUTF8() throws Exception {
 
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root></root>";
         XMLStreamWriter writer = null;
         ByteArrayOutputStream byteArrayOutputStream = null;
 
-        try {
-            byteArrayOutputStream = new ByteArrayOutputStream();
-            writer = XML_OUTPUT_FACTORY.createXMLStreamWriter(byteArrayOutputStream, "UTF-8");
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        writer = XML_OUTPUT_FACTORY.createXMLStreamWriter(byteArrayOutputStream, "UTF-8");
 
-            writer.writeStartDocument("UTF-8", "1.0");
-            writer.writeStartElement("root");
-            writer.writeEndElement();
-            writer.writeEndDocument();
-            writer.flush();
+        writer.writeStartDocument("UTF-8", "1.0");
+        writer.writeStartElement("root");
+        writer.writeEndElement();
+        writer.writeEndDocument();
+        writer.flush();
 
-            String actualOutput = byteArrayOutputStream.toString();
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
-
+        String actualOutput = byteArrayOutputStream.toString();
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /*
@@ -76,34 +74,17 @@ public class EncodingTest {
      * This scenario should result in an exception as default encoding is ASCII.
      */
     @Test
-    public void testWriteStartDocumentUTF8Fail() {
-
-        XMLStreamWriter writer = null;
-        ByteArrayOutputStream byteArrayOutputStream = null;
-
+    public void testWriteStartDocumentUTF8Fail() throws Exception {
         // pick a different encoding to use v. default encoding
-        String defaultCharset = java.nio.charset.Charset.defaultCharset().name();
-        String useCharset = "UTF-8";
-        if (useCharset.equals(defaultCharset)) {
-            useCharset = "US-ASCII";
-        }
+        Charset defaultCharset = Charset.defaultCharset();
+        Charset useCharset = defaultCharset.equals(UTF_8) ? US_ASCII : UTF_8;
 
         System.out.println("defaultCharset = " + defaultCharset + ", useCharset = " + useCharset);
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        XMLStreamWriter writer = XML_OUTPUT_FACTORY.createXMLStreamWriter(byteArrayOutputStream);
 
-        try {
-            byteArrayOutputStream = new ByteArrayOutputStream();
-            writer = XML_OUTPUT_FACTORY.createXMLStreamWriter(byteArrayOutputStream);
-
-            writer.writeStartDocument(useCharset, "1.0");
-            writer.writeStartElement("root");
-            writer.writeEndElement();
-            writer.writeEndDocument();
-            writer.flush();
-
-            Assert.fail("Expected XMLStreamException as default underlying stream encoding of " + defaultCharset
-                    + " differs from explicitly specified encoding of " + useCharset);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        assertThrows(XMLStreamException.class, () -> writer.writeStartDocument(useCharset.toString(), "1.0"),
+                "Expected XMLStreamException as default underlying stream encoding of " + defaultCharset
+                        + " differs from explicitly specified encoding of " + useCharset);
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/NamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/NamespaceTest.java
@@ -35,7 +35,6 @@ import java.io.ByteArrayOutputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
@@ -54,7 +53,7 @@ public class NamespaceTest {
     ByteArrayOutputStream byteArrayOutputStream = null;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
 
         // want a Factory that repairs Namespaces
         xmlOutputFactory = XMLOutputFactory.newInstance();
@@ -64,25 +63,16 @@ public class NamespaceTest {
         byteArrayOutputStream = new ByteArrayOutputStream();
 
         // new Writer
-        try {
-            xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "utf-8");
-
-        } catch (XMLStreamException xmlStreamException) {
-            fail(xmlStreamException.toString());
-        }
+        xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "utf-8");
     }
 
     /**
      * Reset Writer for reuse.
      */
-    private void resetWriter() {
+    private void resetWriter() throws Exception {
         // reset the Writer
-        try {
-            byteArrayOutputStream.reset();
-            xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "utf-8");
-        } catch (XMLStreamException xmlStreamException) {
-            fail(xmlStreamException.toString());
-        }
+        byteArrayOutputStream.reset();
+        xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "utf-8");
     }
 
     @Test
@@ -704,8 +694,8 @@ public class NamespaceTest {
     public void testSamePrefixDifferentURI() throws Exception {
 
         /*
-          writeAttribute("p", "http://example.org/URI-ONE", "attr1", "value");
-          writeAttribute("p", "http://example.org/URI-TWO", "attr2", "value");
+         * writeAttribute("p", "http://example.org/URI-ONE", "attr1", "value");
+         * writeAttribute("p", "http://example.org/URI-TWO", "attr2", "value");
          */
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root" + " xmlns=\"\"" + " xmlns:p=\"http://example.org/URI-ONE\"" + " p:attr1=\"value\">"
                 + " xmlns:{generated prefix}=\"http://example.org/URI-TWO\"" + " {generated prefix}:attr2=\"value\">"
@@ -729,9 +719,8 @@ public class NamespaceTest {
         assertEquals(3, actualOutput.split(":attr").length, "Expected 2 :attr, actual output: " + actualOutput);
 
         /*
-          writeStartElement("p", "localName", "http://example.org/URI-ONE");
-          writeAttribute("p", "http://example.org/URI-TWO", "attrName",
-          "value");
+         * writeStartElement("p", "localName", "http://example.org/URI-ONE");
+         * writeAttribute("p", "http://example.org/URI-TWO", "attrName", "value");
          */
         final String EXPECTED_OUTPUT_2 = "<?xml version=\"1.0\" ?>" + "<root" + " xmlns=\"\">" + "<p:localName" + " xmlns:p=\"http://example.org/URI-ONE\""
                 + " xmlns:{generated prefix}=\"http://example.org/URI-TWO\"" + " {generated prefix}:attrName=\"value\">" + "</p:localName>" + "</root>";
@@ -758,9 +747,8 @@ public class NamespaceTest {
         assertEquals(2, actualOutput.split(":attrName").length, "Expected 1 :attrName, actual output: " + actualOutput);
 
         /*
-          writeNamespace("p", "http://example.org/URI-ONE");
-          writeAttribute("p", "http://example.org/URI-TWO", "attrName",
-          "value");
+         * writeNamespace("p", "http://example.org/URI-ONE");
+         * writeAttribute("p", "http://example.org/URI-TWO", "attrName", "value");
          */
         final String EXPECTED_OUTPUT_3 = "<?xml version=\"1.0\" ?>" + "<root" + " xmlns=\"\"" + " xmlns:p=\"http://example.org/URI-ONE\""
                 + " xmlns:{generated prefix}=\"http://example.org/URI-TWO\"" + " {generated prefix}:attrName=\"value\">" + "</root>";
@@ -784,8 +772,8 @@ public class NamespaceTest {
         assertEquals(2, actualOutput.split(":attrName").length, "Expected a :attrName, actual output: " + actualOutput);
 
         /*
-          writeNamespace("xmlns", ""); writeStartElement("", "localName",
-          "http://example.org/URI-TWO");
+         * writeNamespace("xmlns", ""); writeStartElement("", "localName",
+         * "http://example.org/URI-TWO");
          */
         final String EXPECTED_OUTPUT_4 = "<?xml version=\"1.0\" ?>" + "<root xmlns=\"\">" + "<localName xmlns=\"http://example.org/URI-TWO\">"
                 + "xmlns declaration =\"http://example.org/URI-TWO\"" + "</localName" + "</root>";

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/NamespaceTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/NamespaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,28 +23,27 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.NamespaceTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.NamespaceTest
  * @summary Test the writing of Namespaces.
  */
 public class NamespaceTest {
-
-    /** debug output? */
-    private static final boolean DEBUG = true;
-
     /** Factory to reuse. */
     XMLOutputFactory xmlOutputFactory = null;
 
@@ -54,7 +53,7 @@ public class NamespaceTest {
     /** OutputStream to reuse. */
     ByteArrayOutputStream byteArrayOutputStream = null;
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
 
         // want a Factory that repairs Namespaces
@@ -69,7 +68,7 @@ public class NamespaceTest {
             xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "utf-8");
 
         } catch (XMLStreamException xmlStreamException) {
-            Assert.fail(xmlStreamException.toString());
+            fail(xmlStreamException.toString());
         }
     }
 
@@ -82,55 +81,41 @@ public class NamespaceTest {
             byteArrayOutputStream.reset();
             xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "utf-8");
         } catch (XMLStreamException xmlStreamException) {
-            Assert.fail(xmlStreamException.toString());
+            fail(xmlStreamException.toString());
         }
     }
 
     @Test
-    public void testDoubleXmlNs() {
-        try {
-
-            xmlStreamWriter.writeStartDocument();
-            xmlStreamWriter.writeStartElement("foo");
-            xmlStreamWriter.writeNamespace("xml", XMLConstants.XML_NS_URI);
-            xmlStreamWriter.writeAttribute("xml", XMLConstants.XML_NS_URI, "lang", "ja_JP");
-            xmlStreamWriter.writeCharacters("Hello");
-            xmlStreamWriter.writeEndElement();
-            xmlStreamWriter.writeEndDocument();
-
-            xmlStreamWriter.flush();
-            String actualOutput = byteArrayOutputStream.toString();
-
-            if (DEBUG) {
-                System.out.println("testDoubleXmlNs(): actualOutput: " + actualOutput);
-            }
-
-            // there should be no xmlns:xml
-            Assert.assertTrue(actualOutput.split("xmlns:xml").length == 1, "Expected 0 xmlns:xml, actual output: " + actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void testDuplicateNamespaceURI() throws Exception {
-
+    public void testDoubleXmlNs() throws XMLStreamException {
         xmlStreamWriter.writeStartDocument();
-        xmlStreamWriter.writeStartElement(new String(""), "localName", new String("nsUri"));
-        xmlStreamWriter.writeNamespace(new String(""), new String("nsUri"));
+        xmlStreamWriter.writeStartElement("foo");
+        xmlStreamWriter.writeNamespace("xml", XMLConstants.XML_NS_URI);
+        xmlStreamWriter.writeAttribute("xml", XMLConstants.XML_NS_URI, "lang", "ja_JP");
+        xmlStreamWriter.writeCharacters("Hello");
         xmlStreamWriter.writeEndElement();
         xmlStreamWriter.writeEndDocument();
 
         xmlStreamWriter.flush();
         String actualOutput = byteArrayOutputStream.toString();
 
-        if (DEBUG) {
-            System.out.println("testDuplicateNamespaceURI(): actualOutput: " + actualOutput);
-        }
+        // there should be no xmlns:xml
+        assertEquals(1, actualOutput.split("xmlns:xml").length, "Expected 0 xmlns:xml, actual output: " + actualOutput);
+    }
+
+    @Test
+    public void testDuplicateNamespaceURI() throws Exception {
+
+        xmlStreamWriter.writeStartDocument();
+        xmlStreamWriter.writeStartElement("", "localName", "nsUri");
+        xmlStreamWriter.writeNamespace("", "nsUri");
+        xmlStreamWriter.writeEndElement();
+        xmlStreamWriter.writeEndDocument();
+
+        xmlStreamWriter.flush();
+        String actualOutput = byteArrayOutputStream.toString();
 
         // there must be only 1 xmlns=...
-        Assert.assertTrue(actualOutput.split("xmlns").length == 2, "Expected 1 xmlns=, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns").length, "Expected 1 xmlns=, actual output: " + actualOutput);
     }
 
     // TODO: test with both "" & null
@@ -172,12 +157,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("requires no fixup");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultEmptyPrefix(): actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -202,12 +182,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns:prefix");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultSpecifiedPrefix(): actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -234,13 +209,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("not necessary to generate a declaration");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultSpecifiedPrefixNoDeclarationGeneration(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultSpecifiedPrefixNoDeclarationGeneration():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -263,13 +232,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultSpecifiedDefault(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultSpecifiedDefault():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -290,13 +253,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("requires no fixup");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultEmptyPrefixWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultEmptyPrefixWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -321,13 +278,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns:p=\"http://example.org/myURI\"");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultSpecifiedPrefixWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultSpecifiedPrefixWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -354,13 +305,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("not necessary to generate a declaration");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultSpecifiedPrefixWriteAttributeNoDeclarationGeneration(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultSpecifiedPrefixWriteAttributeNoDeclarationGeneration():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -394,19 +339,14 @@ public class NamespaceTest {
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
 
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultUnspecifiedPrefixWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultUnspecifiedPrefixWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
         // there must be one xmlns=
-        Assert.assertTrue(actualOutput.split("xmlns=").length == 2, "Expected 1 xmlns=, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns=").length, "Expected 1 xmlns=, actual output: " + actualOutput);
 
         // there must be one xmlns:{generated prefix}="..."
-        Assert.assertTrue(actualOutput.split("xmlns:").length == 2, "Expected 1 xmlns:{generated prefix}=\"\", actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns:").length, "Expected 1 xmlns:{generated prefix}=\"\", actual output: " + actualOutput);
 
         // there must be one {generated prefix}:attrName="value"
-        Assert.assertTrue(actualOutput.split(":attrName=\"value\"").length == 2, "Expected 1 {generated prefix}:attrName=\"value\", actual output: "
+        assertEquals(2, actualOutput.split(":attrName=\"value\"").length, "Expected 1 {generated prefix}:attrName=\"value\", actual output: "
                 + actualOutput);
     }
 
@@ -441,13 +381,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("no prefix generation");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultEmptyPrefixSpecifiedNamespaceURIWriteAttributeNoPrefixGeneration(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultEmptyPrefixSpecifiedNamespaceURIWriteAttributeNoPrefixGeneration():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     // ---------------- Current default namespace is
@@ -488,13 +422,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns=\"\"");
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultEmptyPrefix(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultEmptyPrefix():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -519,13 +447,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns:p=\"http://example.org/myURI\"");
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultSpecifiedPrefix(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultSpecifiedPrefix():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -552,13 +474,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("not necessary to generate a declaration");
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixNoPrefixGeneration(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixNoPrefixGeneration():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -581,13 +497,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns=\"http://example.org/myURI\"");
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultEmptyPrefixSpecifiedNamespaceURI(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultEmptyPrefixSpecifiedNamespaceURI():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -609,13 +519,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("requires no fixup");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultEmptyPrefixWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultEmptyPrefixWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -643,13 +547,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("generate xmlns:p=\"http://example.org/myURI\"");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -677,13 +575,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("not necessary to generate a declaration");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixWriteAttributeNoDeclarationGeneration(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixWriteAttributeNoDeclarationGeneration():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /**
@@ -711,14 +603,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("requires no fixup");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixSpecifiedNamespaceURIWriteAttribute: expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixSpecifiedNamespaceURIWriteAttribute: expectedOutput: " + EXPECTED_OUTPUT_2);
-            System.out.println("testSpecifiedDefaultSpecifiedPrefixSpecifiedNamespaceURIWriteAttribute:   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertTrue(actualOutput.equals(EXPECTED_OUTPUT) || actualOutput.equals(EXPECTED_OUTPUT_2), "Expected: " + EXPECTED_OUTPUT + "\n" + "Actual: "
+        assertTrue(actualOutput.equals(EXPECTED_OUTPUT) || actualOutput.equals(EXPECTED_OUTPUT_2), "Expected: " + EXPECTED_OUTPUT + "\n" + "Actual: "
                 + actualOutput);
     }
 
@@ -753,19 +638,14 @@ public class NamespaceTest {
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
 
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultEmptyPrefixSpecifiedNamespaceURIWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultEmptyPrefixSpecifiedNamespaceURIWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
         // there must be one xmlns=
-        Assert.assertTrue(actualOutput.split("xmlns=").length == 2, "Expected 1 xmlns=, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns=").length, "Expected 1 xmlns=, actual output: " + actualOutput);
 
         // there must be one xmlns:{generated prefix}="..."
-        Assert.assertTrue(actualOutput.split("xmlns:").length == 2, "Expected 1 xmlns:{generated prefix}=\"\", actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns:").length, "Expected 1 xmlns:{generated prefix}=\"\", actual output: " + actualOutput);
 
         // there must be one {generated prefix}:attrName="value"
-        Assert.assertTrue(actualOutput.split(":attrName=\"value\"").length == 2, "Expected 1 {generated prefix}:attrName=\"value\", actual output: "
+        assertEquals(2, actualOutput.split(":attrName=\"value\"").length, "Expected 1 {generated prefix}:attrName=\"value\", actual output: "
                 + actualOutput);
     }
 
@@ -800,13 +680,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("no prefix needs to be assigned");
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultEmptyPrefixSpecifiedNamespaceURIWriteAttributeNoPrefixGeneration(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultEmptyPrefixSpecifiedNamespaceURIWriteAttributeNoPrefixGeneration():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     // --------------- Serializations, sequences ---------------
@@ -829,9 +703,9 @@ public class NamespaceTest {
     @Test
     public void testSamePrefixDifferentURI() throws Exception {
 
-        /**
-         * writeAttribute("p", "http://example.org/URI-ONE", "attr1", "value");
-         * writeAttribute("p", "http://example.org/URI-TWO", "attr2", "value");
+        /*
+          writeAttribute("p", "http://example.org/URI-ONE", "attr1", "value");
+          writeAttribute("p", "http://example.org/URI-TWO", "attr2", "value");
          */
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root" + " xmlns=\"\"" + " xmlns:p=\"http://example.org/URI-ONE\"" + " p:attr1=\"value\">"
                 + " xmlns:{generated prefix}=\"http://example.org/URI-TWO\"" + " {generated prefix}:attr2=\"value\">"
@@ -845,24 +719,19 @@ public class NamespaceTest {
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
 
-        if (DEBUG) {
-            System.out.println("testSamePrefixDifferentURI(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSamePrefixDifferentURI():   actualOutput: " + actualOutput);
-        }
-
         // there must be 1 xmlns=
-        Assert.assertTrue(actualOutput.split("xmlns=").length == 2, "Expected 1 xmlns=, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns=").length, "Expected 1 xmlns=, actual output: " + actualOutput);
 
         // there must be 2 xmlns:
-        Assert.assertTrue(actualOutput.split("xmlns:").length == 3, "Expected 2 xmlns:, actual output: " + actualOutput);
+        assertEquals(3, actualOutput.split("xmlns:").length, "Expected 2 xmlns:, actual output: " + actualOutput);
 
         // there must be 2 :attr
-        Assert.assertTrue(actualOutput.split(":attr").length == 3, "Expected 2 :attr, actual output: " + actualOutput);
+        assertEquals(3, actualOutput.split(":attr").length, "Expected 2 :attr, actual output: " + actualOutput);
 
-        /**
-         * writeStartElement("p", "localName", "http://example.org/URI-ONE");
-         * writeAttribute("p", "http://example.org/URI-TWO", "attrName",
-         * "value");
+        /*
+          writeStartElement("p", "localName", "http://example.org/URI-ONE");
+          writeAttribute("p", "http://example.org/URI-TWO", "attrName",
+          "value");
          */
         final String EXPECTED_OUTPUT_2 = "<?xml version=\"1.0\" ?>" + "<root" + " xmlns=\"\">" + "<p:localName" + " xmlns:p=\"http://example.org/URI-ONE\""
                 + " xmlns:{generated prefix}=\"http://example.org/URI-TWO\"" + " {generated prefix}:attrName=\"value\">" + "</p:localName>" + "</root>";
@@ -876,27 +745,22 @@ public class NamespaceTest {
 
         actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
 
-        if (DEBUG) {
-            System.out.println("testSamePrefixDifferentURI(): expectedOutput: " + EXPECTED_OUTPUT_2);
-            System.out.println("testSamePrefixDifferentURI():   actualOutput: " + actualOutput);
-        }
-
         // there must be 1 xmlns=
-        Assert.assertTrue(actualOutput.split("xmlns=").length == 2, "Expected 1 xmlns=, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns=").length, "Expected 1 xmlns=, actual output: " + actualOutput);
 
         // there must be 2 xmlns:
-        Assert.assertTrue(actualOutput.split("xmlns:").length == 3, "Expected 2 xmlns:, actual output: " + actualOutput);
+        assertEquals(3, actualOutput.split("xmlns:").length, "Expected 2 xmlns:, actual output: " + actualOutput);
 
         // there must be 2 p:localName
-        Assert.assertTrue(actualOutput.split("p:localName").length == 3, "Expected 2 p:localName, actual output: " + actualOutput);
+        assertEquals(3, actualOutput.split("p:localName").length, "Expected 2 p:localName, actual output: " + actualOutput);
 
         // there must be 1 :attrName
-        Assert.assertTrue(actualOutput.split(":attrName").length == 2, "Expected 1 :attrName, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split(":attrName").length, "Expected 1 :attrName, actual output: " + actualOutput);
 
-        /**
-         * writeNamespace("p", "http://example.org/URI-ONE");
-         * writeAttribute("p", "http://example.org/URI-TWO", "attrName",
-         * "value");
+        /*
+          writeNamespace("p", "http://example.org/URI-ONE");
+          writeAttribute("p", "http://example.org/URI-TWO", "attrName",
+          "value");
          */
         final String EXPECTED_OUTPUT_3 = "<?xml version=\"1.0\" ?>" + "<root" + " xmlns=\"\"" + " xmlns:p=\"http://example.org/URI-ONE\""
                 + " xmlns:{generated prefix}=\"http://example.org/URI-TWO\"" + " {generated prefix}:attrName=\"value\">" + "</root>";
@@ -910,23 +774,18 @@ public class NamespaceTest {
 
         actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
 
-        if (DEBUG) {
-            System.out.println("testSamePrefixDifferentURI(): expectedOutput: " + EXPECTED_OUTPUT_3);
-            System.out.println("testSamePrefixDifferentURI():   actualOutput: " + actualOutput);
-        }
-
         // there must be 1 xmlns=
-        Assert.assertTrue(actualOutput.split("xmlns=").length == 2, "Expected 1 xmlns=, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split("xmlns=").length, "Expected 1 xmlns=, actual output: " + actualOutput);
 
         // there must be 2 xmlns:
-        Assert.assertTrue(actualOutput.split("xmlns:").length == 3, "Expected 2 xmlns:, actual output: " + actualOutput);
+        assertEquals(3, actualOutput.split("xmlns:").length, "Expected 2 xmlns:, actual output: " + actualOutput);
 
         // there must be 1 :attrName
-        Assert.assertTrue(actualOutput.split(":attrName").length == 2, "Expected a :attrName, actual output: " + actualOutput);
+        assertEquals(2, actualOutput.split(":attrName").length, "Expected a :attrName, actual output: " + actualOutput);
 
-        /**
-         * writeNamespace("xmlns", ""); writeStartElement("", "localName",
-         * "http://example.org/URI-TWO");
+        /*
+          writeNamespace("xmlns", ""); writeStartElement("", "localName",
+          "http://example.org/URI-TWO");
          */
         final String EXPECTED_OUTPUT_4 = "<?xml version=\"1.0\" ?>" + "<root xmlns=\"\">" + "<localName xmlns=\"http://example.org/URI-TWO\">"
                 + "xmlns declaration =\"http://example.org/URI-TWO\"" + "</localName" + "</root>";
@@ -942,19 +801,14 @@ public class NamespaceTest {
 
         actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
 
-        if (DEBUG) {
-            System.out.println("testSamePrefixDifferentURI(): expectedOutput: " + EXPECTED_OUTPUT_4);
-            System.out.println("testSamePrefixDifferentURI():   actualOutput: " + actualOutput);
-        }
-
         // there must be 2 xmlns=
-        Assert.assertTrue(actualOutput.split("xmlns=").length == 3, "Expected 2 xmlns=, actual output: " + actualOutput);
+        assertEquals(3, actualOutput.split("xmlns=").length, "Expected 2 xmlns=, actual output: " + actualOutput);
 
         // there must be 0 xmlns:
-        Assert.assertTrue(actualOutput.split("xmlns:").length == 1, "Expected 0 xmlns:, actual output: " + actualOutput);
+        assertEquals(1, actualOutput.split("xmlns:").length, "Expected 0 xmlns:, actual output: " + actualOutput);
 
         // there must be 0 :localName
-        Assert.assertTrue(actualOutput.split(":localName").length == 1, "Expected 0 :localName, actual output: " + actualOutput);
+        assertEquals(1, actualOutput.split(":localName").length, "Expected 0 :localName, actual output: " + actualOutput);
     }
 
     // ---------------- Misc ----------------
@@ -979,13 +833,7 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("never requires fixup");
 
         String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testEmptyDefaultEmptyPrefixEmptyNamespaceURIWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testEmptyDefaultEmptyPrefixEmptyNamespaceURIWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
@@ -1000,29 +848,14 @@ public class NamespaceTest {
         xmlStreamWriter.writeCharacters("never requires fixup");
 
         String actualOutput = endDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-
-        if (DEBUG) {
-            System.out.println("testSpecifiedDefaultEmptyPrefixEmptyNamespaceURIWriteAttribute(): expectedOutput: " + EXPECTED_OUTPUT);
-            System.out.println("testSpecifiedDefaultEmptyPrefixEmptyNamespaceURIWriteAttribute():   actualOutput: " + actualOutput);
-        }
-
-        Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /*--------------- Negative tests with isRepairingNamespaces as FALSE ---------------------- */
 
-    private void setUpForNoRepair() {
-
+    private void setUpForNoRepair() throws XMLStreamException {
         xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.FALSE);
-
-        // new Writer
-        try {
-            xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream);
-
-        } catch (XMLStreamException xmlStreamException) {
-            xmlStreamException.printStackTrace();
-            Assert.fail(xmlStreamException.toString());
-        }
+        xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream);
     }
 
     /*
@@ -1032,17 +865,12 @@ public class NamespaceTest {
      * "attrName", "value");
      */
     @Test
-    public void testEmptyDefaultEmptyPrefixSpecifiedURIWriteAttributeNoRepair() {
-        try {
-            setUpForNoRepair();
-            startDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            xmlStreamWriter.writeAttribute("", "http://example.org/myURI", "attrName", "value");
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testEmptyDefaultEmptyPrefixSpecifiedURIWriteAttributeNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeAttribute("", "http://example.org/myURI", "attrName", "value"));
     }
 
     /*
@@ -1052,17 +880,12 @@ public class NamespaceTest {
      * "http://example.org/myURI", "attrName", "value");
      */
     @Test
-    public void testSpecifiedDefaultEmptyPrefixSpecifiedURIWriteAttributeNoRepair() {
-        try {
-            setUpForNoRepair();
-            startDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-            xmlStreamWriter.writeAttribute("", "http://example.org/uniqueURI", "attrName", "value");
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testSpecifiedDefaultEmptyPrefixSpecifiedURIWriteAttributeNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeAttribute("", "http://example.org/uniqueURI", "attrName", "value"));
     }
 
     /*
@@ -1072,17 +895,12 @@ public class NamespaceTest {
      * "http://example.org/uniqueURI", "attrName", "value");
      */
     @Test
-    public void testSpecifiedDefaultEmptyPrefixSpecifiedDifferentURIWriteAttributeNoRepair() {
-        try {
-            setUpForNoRepair();
-            startDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-            xmlStreamWriter.writeAttribute("", "http://example.org/myURI", "attrName", "value");
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testSpecifiedDefaultEmptyPrefixSpecifiedDifferentURIWriteAttributeNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeAttribute("", "http://example.org/myURI", "attrName", "value"));
     }
 
     /*
@@ -1092,18 +910,13 @@ public class NamespaceTest {
      * "http://example.org/URI-TWO", "attr2", "value");
      */
     @Test
-    public void testSamePrefixDiffrentURIWriteAttributeNoRepair() {
-        try {
-            setUpForNoRepair();
-            startDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            xmlStreamWriter.writeAttribute("p", "http://example.org/URI-ONE", "attr1", "value");
-            xmlStreamWriter.writeAttribute("p", "http://example.org/URI-TWO", "attr2", "value");
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testSamePrefixDiffrentURIWriteAttributeNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        xmlStreamWriter.writeAttribute("p", "http://example.org/URI-ONE", "attr1", "value");
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeAttribute("p", "http://example.org/URI-TWO", "attr2", "value"));
     }
 
     /*
@@ -1113,19 +926,13 @@ public class NamespaceTest {
      * writeAttribute("p", "http://example.org/URI-TWO", "attrName", "value")
      */
     @Test
-    public void testSamePrefixDiffrentURIWriteElemAndWriteAttributeNoRepair() {
-        try {
-            setUpForNoRepair();
-            startDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/URI-ONE");
-            xmlStreamWriter.writeAttribute("p", "http://example.org/URI-TWO", "attrName", "value");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testSamePrefixDiffrentURIWriteElemAndWriteAttributeNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/URI-ONE");
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeAttribute("p", "http://example.org/URI-TWO", "attrName", "value"));
     }
 
     /*
@@ -1134,20 +941,12 @@ public class NamespaceTest {
      * />
      */
     @Test
-    public void testDefaultNamespaceDiffrentURIWriteElementNoRepair() {
-        try {
-            System.out.println("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-            setUpForNoRepair();
-            startDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
-            xmlStreamWriter.writeNamespace("", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testDefaultNamespaceDiffrentURIWriteElementNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocumentSpecifiedDefaultNamespace(xmlStreamWriter);
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeNamespace("", "http://example.org/myURI"));
     }
 
     /*--------------------------------------------------------------------------
@@ -1161,59 +960,41 @@ public class NamespaceTest {
     }
 
     @Test
-    public void testSpecifiedPrefixSpecifiedURIWriteElementNoRepair() {
-
+    public void testSpecifiedPrefixSpecifiedURIWriteElementNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>" + "<p:localName></p:localName>" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Caught an unexpected exception" + e.getMessage());
-        }
+
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSpecifiedPrefixSpecifiedURIWriteAttributeNoRepair() {
-
+    public void testSpecifiedPrefixSpecifiedURIWriteAttributeNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root p:attrName=\"value\">" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeAttribute("p", "http://example.org/myURI", "attrName", "value");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Caught an unexpected exception" + e.getMessage());
-        }
+
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeAttribute("p", "http://example.org/myURI", "attrName", "value");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSpecifiedPrefixSpecifiedURISpecifiedNamespcaeWriteElementNoRepair() {
-
+    public void testSpecifiedPrefixSpecifiedURISpecifiedNamespcaeWriteElementNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>" + "<p:localName xmlns:p=\"http://example.org/myURI\"></p:localName>" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
 
-            xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Caught an unexpected exception" + e.getMessage());
-        }
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+
+        xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
+        xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /*
@@ -1224,210 +1005,150 @@ public class NamespaceTest {
      */
 
     @Test
-    public void testSpecifiedPrefixSpecifiedURISpecifiedDifferentNamespcaeWriteElementNoRepair() {
-
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("p", "http://example.org/uniqueURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.fail("XMLStreamException is expected as 'p' is rebinded to a different URI in same namespace context");
-        } catch (Exception e) {
-            System.out.println("Caught an expected exception" + e.getMessage());
-        }
+    public void testSpecifiedPrefixSpecifiedURISpecifiedDifferentNamespcaeWriteElementNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeNamespace("p", "http://example.org/uniqueURI"));
     }
 
     @Test
-    public void testEmptyPrefixEmptyURIWriteAttributeNoRepair() {
+    public void testEmptyPrefixEmptyURIWriteAttributeNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>" + "<localName attrName=\"value\"></localName>" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("localName");
-            xmlStreamWriter.writeAttribute("", "", "attrName", "value");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Caught an unexpected exception" + e.getMessage());
-        }
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("localName");
+        xmlStreamWriter.writeAttribute("", "", "attrName", "value");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testEmptyPrefixNullURIWriteAttributeNoRepair() {
-        final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>" + "<localName attrName=\"value\"></localName>" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("localName");
-            xmlStreamWriter.writeAttribute(null, null, "attrName", "value");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.fail("XMLStreamException is expected, actualOutput: " + actualOutput);
-        } catch (Exception e) {
-            System.out.println("PASS: caught an expected exception" + e.getMessage());
-            e.printStackTrace();
-        }
+    public void testEmptyPrefixNullURIWriteAttributeNoRepair() throws XMLStreamException {
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("localName");
+        assertThrows(
+                XMLStreamException.class,
+                () -> xmlStreamWriter.writeAttribute(null, null, "attrName", "value"));
     }
 
     @Test
-    public void testDoubleXmlNsNoRepair() {
-        try {
-            // reset to known state
-            setUpForNoRepair();
+    public void testDoubleXmlNsNoRepair() throws XMLStreamException {
+        // reset to known state
+        setUpForNoRepair();
 
-            xmlStreamWriter.writeStartDocument();
-            xmlStreamWriter.writeStartElement("foo");
-            xmlStreamWriter.writeNamespace("xml", XMLConstants.XML_NS_URI);
-            xmlStreamWriter.writeAttribute("xml", XMLConstants.XML_NS_URI, "lang", "ja_JP");
-            xmlStreamWriter.writeCharacters("Hello");
-            xmlStreamWriter.writeEndElement();
-            xmlStreamWriter.writeEndDocument();
+        xmlStreamWriter.writeStartDocument();
+        xmlStreamWriter.writeStartElement("foo");
+        xmlStreamWriter.writeNamespace("xml", XMLConstants.XML_NS_URI);
+        xmlStreamWriter.writeAttribute("xml", XMLConstants.XML_NS_URI, "lang", "ja_JP");
+        xmlStreamWriter.writeCharacters("Hello");
+        xmlStreamWriter.writeEndElement();
+        xmlStreamWriter.writeEndDocument();
 
-            xmlStreamWriter.flush();
-            String actualOutput = byteArrayOutputStream.toString();
-
-            if (DEBUG) {
-                System.out.println("testDoubleXmlNsNoRepair(): actualOutput: " + actualOutput);
-            }
-
-            // there should be no xmlns:xml
-            Assert.assertTrue(actualOutput.split("xmlns:xml").length == 1, "Expected 0 xmlns:xml, actual output: " + actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
+        xmlStreamWriter.flush();
+        String actualOutput = byteArrayOutputStream.toString();
+        // there should be no xmlns:xml
+        assertEquals(1, actualOutput.split("xmlns:xml").length, "Expected 0 xmlns:xml, actual output: " + actualOutput);
     }
 
     @Test
-    public void testSpecifiedURIWriteAttributeNoRepair() {
+    public void testSpecifiedURIWriteAttributeNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>" + "<p:localName p:attrName=\"value\"></p:localName>" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
-            xmlStreamWriter.writeAttribute("http://example.org/myURI", "attrName", "value");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            System.out.println("Caught an expected exception" + e.getMessage());
-        }
+
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
+        xmlStreamWriter.writeAttribute("http://example.org/myURI", "attrName", "value");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSpecifiedURIWriteAttributeWithRepair() {
+    public void testSpecifiedURIWriteAttributeWithRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>"
                 + "<p:localName xmlns:p=\"http://example.org/myURI\" p:attrName=\"value\"></p:localName>" + "</root>";
-        try {
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
-            xmlStreamWriter.writeAttribute("http://example.org/myURI", "attrName", "value");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("p", "localName", "http://example.org/myURI");
+        xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
+        xmlStreamWriter.writeAttribute("http://example.org/myURI", "attrName", "value");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSpecifiedDefaultInDifferentElementsNoRepair() {
+    public void testSpecifiedDefaultInDifferentElementsNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root>" + "<localName xmlns=\"http://example.org/myURI\">"
                 + "<child xmlns=\"http://example.org/uniqueURI\"></child>" + "</localName>" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.writeStartElement("localName");
-            xmlStreamWriter.writeDefaultNamespace("http://example.org/myURI");
-            xmlStreamWriter.writeStartElement("child");
-            xmlStreamWriter.writeDefaultNamespace("http://example.org/uniqueURI");
-            xmlStreamWriter.writeEndElement();
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Exception occured: " + e.getMessage());
-        }
+
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.writeStartElement("localName");
+        xmlStreamWriter.writeDefaultNamespace("http://example.org/myURI");
+        xmlStreamWriter.writeStartElement("child");
+        xmlStreamWriter.writeDefaultNamespace("http://example.org/uniqueURI");
+        xmlStreamWriter.writeEndElement();
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     /*------------- Tests for setPrefix() and setDefaultNamespace() methods --------------------*/
 
     @Test
-    public void testSetPrefixWriteNamespaceNoRepair() {
+    public void testSetPrefixWriteNamespaceNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root xmlns:p=\"http://example.org/myURI\">" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.setPrefix("p", "http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            System.out.println("Caught an expected exception" + e.getMessage());
-        }
+
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.setPrefix("p", "http://example.org/myURI");
+        xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        System.out.println("actualOutput: " + actualOutput);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSetPrefixWriteNamespaceWithRepair() {
+    public void testSetPrefixWriteNamespaceWithRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root xmlns:p=\"http://example.org/myURI\">" + "</root>";
-        try {
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.setPrefix("p", "http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            System.out.println("Caught an expected exception" + e.getMessage());
-        }
+
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.setPrefix("p", "http://example.org/myURI");
+        xmlStreamWriter.writeNamespace("p", "http://example.org/myURI");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSetDefaultNamespaceWriteNamespaceNoRepair() {
+    public void testSetDefaultNamespaceWriteNamespaceNoRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root xmlns=\"http://example.org/myURI\">" + "</root>";
-        try {
-            setUpForNoRepair();
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.setDefaultNamespace("http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            System.out.println("Caught an expected exception" + e.getMessage());
-        }
+
+        setUpForNoRepair();
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.setDefaultNamespace("http://example.org/myURI");
+        xmlStreamWriter.writeNamespace("", "http://example.org/myURI");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 
     @Test
-    public void testSetDefaultNamespaceWriteNamespaceWithRepair() {
+    public void testSetDefaultNamespaceWriteNamespaceWithRepair() throws XMLStreamException {
         final String EXPECTED_OUTPUT = "<?xml version=\"1.0\" ?>" + "<root xmlns=\"http://example.org/myURI\">" + "</root>";
-        try {
-            startDocument(xmlStreamWriter);
-            xmlStreamWriter.setDefaultNamespace("http://example.org/myURI");
-            xmlStreamWriter.writeNamespace("", "http://example.org/myURI");
-            xmlStreamWriter.writeEndElement();
-            String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
-            System.out.println("actualOutput: " + actualOutput);
-            Assert.assertEquals(EXPECTED_OUTPUT, actualOutput);
-        } catch (Exception e) {
-            System.out.println("Caught an expected exception" + e.getMessage());
-        }
+
+        startDocument(xmlStreamWriter);
+        xmlStreamWriter.setDefaultNamespace("http://example.org/myURI");
+        xmlStreamWriter.writeNamespace("", "http://example.org/myURI");
+        xmlStreamWriter.writeEndElement();
+        String actualOutput = endDocumentEmptyDefaultNamespace(xmlStreamWriter);
+        assertEquals(EXPECTED_OUTPUT, actualOutput);
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/NullUriDetectionTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/NullUriDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,19 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.StringWriter;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /*
  * @test
  * @bug 6391922
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.NullUriDetectionTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.NullUriDetectionTest
  * @summary Test XMLStreamWriter can writeDefaultNamespace(null).
  */
 public class NullUriDetectionTest {
@@ -47,7 +48,6 @@ public class NullUriDetectionTest {
         XMLStreamWriter w = xof.createXMLStreamWriter(sw);
         w.writeStartDocument();
         w.writeStartElement("foo", "bar", "zot");
-        w.writeDefaultNamespace(null);
-        w.writeCharacters("---");
+        assertDoesNotThrow(() -> w.writeDefaultNamespace(null));
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/SqeLinuxTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/SqeLinuxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,18 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.SqeLinuxTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.SqeLinuxTest
  * @summary Test XMLStreamWriter can output multiple declarations if IS_REPAIRING_NAMESPACES is false.
  */
 public class SqeLinuxTest {
@@ -52,36 +52,24 @@ public class SqeLinuxTest {
     public void testWriterOnLinux() throws Exception {
 
         // setup XMLStreamWriter
-        try {
-            byteArrayOutputStream = new ByteArrayOutputStream();
-            xmlOutputFactory = XMLOutputFactory.newInstance();
-            xmlOutputFactory.setProperty(xmlOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(false));
-            xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "ASCII");
-        } catch (Exception e) {
-            System.err.println("Unexpected Exception: " + e.toString());
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        xmlOutputFactory = XMLOutputFactory.newInstance();
+        xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.FALSE);
+        xmlStreamWriter = xmlOutputFactory.createXMLStreamWriter(byteArrayOutputStream, "ASCII");
 
         // create & write a document
-        try {
-            xmlStreamWriter.writeStartDocument();
-            xmlStreamWriter.writeStartDocument("wStDoc_ver");
-            xmlStreamWriter.writeStartDocument("ASCII", "wStDoc_ver2");
-            xmlStreamWriter.writeStartDocument(null, null);
+        xmlStreamWriter.writeStartDocument();
+        xmlStreamWriter.writeStartDocument("wStDoc_ver");
+        xmlStreamWriter.writeStartDocument("ASCII", "wStDoc_ver2");
+        xmlStreamWriter.writeStartDocument(null, null);
 
-            // orignal SQE test used reset() before flush()
-            // believe this is false as reset() throws away output before
-            // flush() writes any cached output
-            // it is valid for a XMLStreamWriter to write its output at any
-            // time, flush() just garuntees it
-            // byteArrayOutputStream.reset();
-            xmlStreamWriter.flush();
-            Assert.assertEquals(EXPECTED_OUTPUT, byteArrayOutputStream.toString());
-        } catch (Exception e) {
-            System.err.println("Unexpected Exception: " + e.toString());
-            e.printStackTrace();
-            Assert.fail(e.toString());
-        }
+        // orignal SQE test used reset() before flush()
+        // believe this is false as reset() throws away output before
+        // flush() writes any cached output
+        // it is valid for a XMLStreamWriter to write its output at any
+        // time, flush() just garuntees it
+        // byteArrayOutputStream.reset();
+        xmlStreamWriter.flush();
+        assertEquals(EXPECTED_OUTPUT, byteArrayOutputStream.toString());
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/SurrogatesTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/SurrogatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,8 @@
 
 package stream.XMLStreamWriterTest;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
@@ -34,16 +32,19 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 8145974
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.SurrogatesTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.SurrogatesTest
  * @summary Check that XMLStreamWriter generates valid xml with surrogate pair
  *  used within element text
  */
@@ -52,18 +53,18 @@ public class SurrogatesTest {
 
     // Test that valid surrogate characters can be written/readen by xml stream
     // reader/writer
-    @Test(dataProvider = "validData")
+    @ParameterizedTest
+    @MethodSource("getValidData")
     public void xmlWithValidSurrogatesTest(String content)
             throws Exception {
         generateAndReadXml(content);
     }
 
     // Test that unbalanced surrogate character will
-    @Test(dataProvider = "invalidData",
-            expectedExceptions = XMLStreamException.class)
-    public void xmlWithUnbalancedSurrogatesTest(String content)
-            throws Exception {
-        generateAndReadXml(content);
+    @ParameterizedTest
+    @MethodSource("getInvalidData")
+    public void xmlWithUnbalancedSurrogatesTest(String content) {
+        assertThrows(XMLStreamException.class, () -> generateAndReadXml(content));
     }
 
     // Generates xml content with XMLStreamWriter and read it to check
@@ -135,8 +136,7 @@ public class SurrogatesTest {
                             || ename.equals("writeCharactersWithArray")) {
                         inTestElement = false;
                         String content = sb.toString();
-                        System.out.println(ename + " text:'" + content + "' expected:'" + expectedContent+"'");
-                        Assert.assertEquals(content, expectedContent);
+                        assertEquals(expectedContent, content);
                         sb.setLength(0);
                     }
                     break;
@@ -150,8 +150,7 @@ public class SurrogatesTest {
         }
     }
 
-    @DataProvider(name = "validData")
-    public Object[][] getValidData() {
+    public static Object[][] getValidData() {
         return new Object[][] {
             {"Don't Worry Be \uD83D\uDE0A"},
             {"BMP characters \uE000\uFFFD"},
@@ -159,8 +158,7 @@ public class SurrogatesTest {
         };
     }
 
-    @DataProvider(name = "invalidData")
-    public Object[][] getInvalidData() {
+    public static Object[][] getInvalidData() {
         return new Object[][] {
             {"Unbalanced surrogate \uD83D"},
             {"Unbalanced surrogate \uD83Dis here"},

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/UnprefixedNameTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/UnprefixedNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,102 +23,68 @@
 
 package stream.XMLStreamWriterTest;
 
+import org.junit.jupiter.api.Test;
+
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /*
  * @test
  * @bug 6394074
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.UnprefixedNameTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.UnprefixedNameTest
  * @summary Test XMLStreamWriter namespace prefix with writeDefaultNamespace.
  */
 public class UnprefixedNameTest {
 
     @Test
     public void testUnboundPrefix() throws Exception {
-
-        try {
-            XMLOutputFactory xof = XMLOutputFactory.newInstance();
-            XMLStreamWriter w = xof.createXMLStreamWriter(System.out);
-            // here I'm trying to write
-            // <bar xmlns="foo" />
-            w.writeStartDocument();
-            w.writeStartElement("foo", "bar");
-            w.writeDefaultNamespace("foo");
-            w.writeCharacters("---");
-            w.writeEndElement();
-            w.writeEndDocument();
-            w.close();
-
-            // Unexpected success
-            String FAIL_MSG = "Unexpected success.  Expected: " + "XMLStreamException - " + "if the namespace URI has not been bound to a prefix "
-                    + "and javax.xml.stream.isPrefixDefaulting has not been " + "set to true";
-            System.err.println(FAIL_MSG);
-            Assert.fail(FAIL_MSG);
-        } catch (XMLStreamException xmlStreamException) {
-            // Expected Exception
-            System.out.println("Expected XMLStreamException: " + xmlStreamException.toString());
-        }
+        XMLOutputFactory xof = XMLOutputFactory.newInstance();
+        XMLStreamWriter w = xof.createXMLStreamWriter(System.out);
+        // here I'm trying to write
+        // <bar xmlns="foo" />
+        w.writeStartDocument();
+        assertThrows(XMLStreamException.class, () -> w.writeStartElement("foo", "bar"),
+                "Expected: XMLStreamException if the namespace URI has not been bound to a prefix "
+                        + "and javax.xml.stream.isPrefixDefaulting has not been " + "set to true");
     }
 
     @Test
     public void testBoundPrefix() throws Exception {
-
-        try {
-            XMLOutputFactory xof = XMLOutputFactory.newInstance();
-            XMLStreamWriter w = xof.createXMLStreamWriter(System.out);
-            // here I'm trying to write
-            // <bar xmlns="foo" />
-            w.writeStartDocument();
-            w.writeStartElement("foo", "bar", "http://namespace");
-            w.writeCharacters("---");
-            w.writeEndElement();
-            w.writeEndDocument();
-            w.close();
-
-            // Expected success
-            System.out.println("Expected success.");
-        } catch (Exception exception) {
-            // Unexpected Exception
-            String FAIL_MSG = "Unexpected Exception: " + exception.toString();
-            System.err.println(FAIL_MSG);
-            Assert.fail(FAIL_MSG);
-        }
+        XMLOutputFactory xof = XMLOutputFactory.newInstance();
+        XMLStreamWriter w = xof.createXMLStreamWriter(System.out);
+        // here I'm trying to write
+        // <bar xmlns="foo" />
+        w.writeStartDocument();
+        w.writeStartElement("foo", "bar", "http://namespace");
+        w.writeCharacters("---");
+        w.writeEndElement();
+        w.writeEndDocument();
+        w.close();
     }
 
     @Test
     public void testRepairingPrefix() throws Exception {
+        // repair namespaces
+        // use new XMLOutputFactory as changing its property settings
+        XMLOutputFactory xof = XMLOutputFactory.newInstance();
+        xof.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        XMLStreamWriter w = xof.createXMLStreamWriter(System.out);
 
-        try {
+        // here I'm trying to write
+        // <bar xmlns="foo" />
+        w.writeStartDocument();
+        w.writeStartElement("foo", "bar");
+        w.writeDefaultNamespace("foo");
+        w.writeCharacters("---");
+        w.writeEndElement();
+        w.writeEndDocument();
+        w.close();
 
-            // repair namespaces
-            // use new XMLOutputFactory as changing its property settings
-            XMLOutputFactory xof = XMLOutputFactory.newInstance();
-            xof.setProperty(xof.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            XMLStreamWriter w = xof.createXMLStreamWriter(System.out);
-
-            // here I'm trying to write
-            // <bar xmlns="foo" />
-            w.writeStartDocument();
-            w.writeStartElement("foo", "bar");
-            w.writeDefaultNamespace("foo");
-            w.writeCharacters("---");
-            w.writeEndElement();
-            w.writeEndDocument();
-            w.close();
-
-            // Expected success
-            System.out.println("Expected success.");
-        } catch (Exception exception) {
-            // Unexpected Exception
-            String FAIL_MSG = "Unexpected Exception: " + exception.toString();
-            System.err.println(FAIL_MSG);
-            Assert.fail(FAIL_MSG);
-        }
+        // Expected success
+        System.out.println("Expected success.");
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/WriterTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/WriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,12 @@
 
 package stream.XMLStreamWriterTest;
 
-import static jaxp.library.JAXPTestUtilities.USER_DIR;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -34,725 +38,566 @@ import java.io.Reader;
 import java.net.URL;
 import java.util.Iterator;
 
-import javax.xml.namespace.NamespaceContext;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamWriter;
-
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.WriterTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.WriterTest
  * @summary Test XMLStreamWriter functionality.
  */
 public class WriterTest {
 
-    final String ENCODING = "UTF-8";
-    XMLOutputFactory outputFactory = null;
-    XMLInputFactory inputFactory = null;
-    XMLStreamWriter xtw = null;
-    String[] files = new String[] { "testOne.xml", "testTwo.xml", "testThree.xml", "testFour.xml", "testFive.xml", "testSix.xml", "testSeven.xml",
+    private static final String ENCODING = "UTF-8";
+    private XMLOutputFactory outputFactory = null;
+    private XMLStreamWriter xtw = null;
+    private static final String[] files = new String[] { "testOne.xml", "testTwo.xml", "testThree.xml", "testFour.xml", "testFive.xml", "testSix.xml", "testSeven.xml",
             "testEight.xml", "testNine.xml", "testTen.xml", "testEleven.xml", "testTwelve.xml", "testDefaultNS.xml", null, "testFixAttr.xml" };
 
-    String output = "";
-
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
-        try {
-            outputFactory = XMLOutputFactory.newInstance();
-            inputFactory = XMLInputFactory.newInstance();
-        } catch (Exception ex) {
-            Assert.fail("Could not create XMLInputFactory");
-        }
+        outputFactory = XMLOutputFactory.newInstance();
     }
 
-    @AfterMethod
-    public void tearDown() {
-        outputFactory = null;
-        inputFactory = null;
+    // Test StreamWriter with out any namespace functionality.
+    @Test
+    public void testOne() throws Exception {
+        String outputFile = files[0] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.writeStartElement("elmeOne");
+        xtw.writeStartElement("elemTwo");
+        xtw.writeStartElement("elemThree");
+        xtw.writeStartElement("elemFour");
+        xtw.writeStartElement("elemFive");
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+
+        assertTrue(checkResults(outputFile, files[0] + ".org"));
+    }
+
+    // Test StreamWriter's Namespace Context.
+    @Test
+    public void testTwo() throws Exception {
+        String outputFile = files[1] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(System.out);
+        xtw.writeStartDocument();
+        xtw.writeStartElement("elemTwo");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeEndDocument();
+        NamespaceContext nc = xtw.getNamespaceContext();
+        // Got a Namespace Context.class
+
+        XMLStreamWriter xtw1 = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+
+        xtw1.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw1.setNamespaceContext(nc);
+        xtw1.writeStartDocument("utf-8", "1.0");
+        xtw1.setPrefix("htmlOne", "http://www.w3.org/TR/REC-html40");
+        NamespaceContext nc1 = xtw1.getNamespaceContext();
+        xtw1.close();
+        Iterator<String> it = nc1.getPrefixes("http://www.w3.org/TR/REC-html40");
+
+        // FileWriter fw = new FileWriter(outputFile);
+        while (it.hasNext()) {
+            System.out.println("Prefixes :" + it.next());
+            // fw.write((String)it.next());
+            // fw.write(";");
+        }
+        // fw.close();
+        // assertTrue(checkResults(testTwo+".out", testTwo+".org"));
+    }
+
+    // Test StreamWriter for proper element sequence.
+    @Test
+    public void testThree() throws Exception {
+        String outputFile = files[2] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.writeStartElement("elmeOne");
+        xtw.writeStartElement("elemTwo");
+        xtw.writeEmptyElement("emptyElem");
+        xtw.writeStartElement("elemThree");
+        xtw.writeStartElement("elemFour");
+        xtw.writeStartElement("elemFive");
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+
+        assertTrue(checkResults(outputFile, files[2] + ".org"));
+    }
+
+    // Test StreamWriter with elements,attribute and element content.
+    @Test
+    public void testFour() throws Exception {
+        String outputFile = files[3] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.writeStartElement("elmeOne");
+        xtw.writeStartElement("elemTwo");
+        xtw.writeEmptyElement("emptyElem");
+        xtw.writeAttribute("testAttr", "testValue");
+        xtw.writeStartElement("elemThree");
+        xtw.writeStartElement("elemFour");
+        xtw.writeCharacters("TestCharacterData");
+        xtw.writeStartElement("elemFive");
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+
+        assertTrue(checkResults(outputFile, files[3] + ".org"));
+    }
+
+    // Test StreamWriter's Namespace Context.
+    @Test
+    public void testFive() throws Exception {
+        String outputFile = files[4] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(System.out);
+        xtw.writeStartDocument();
+        xtw.writeStartElement("elemTwo");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+        // xtw.writeEndDocument();
+        NamespaceContext nc = xtw.getNamespaceContext();
+        // Got a Namespace Context.class
+
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.setNamespaceContext(nc);
+        xtw.writeStartDocument("utf-8", "1.0");
+        // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        assertTrue(checkResults(outputFile, files[4] + ".org"));
+        System.out.println("Done");
+    }
+
+    // Test StreamWriter, uses the Namespace Context set by the user to resolve namespaces.
+    @Test
+    public void testSix() throws Exception {
+        String outputFile = files[5] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(System.out);
+        xtw.writeStartDocument();
+        xtw.writeStartElement("elemTwo");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeEndDocument();
+        NamespaceContext nc = xtw.getNamespaceContext();
+        // Got a Namespace Context information.
+
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.setNamespaceContext(nc);
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.setPrefix("htmlNewPrefix", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        assertTrue(checkResults(outputFile, files[5] + ".org"));
+        System.out.println("Done");
+    }
+
+    // Test StreamWriter supplied with correct namespace information.
+    @Test
+    public void testSeven() throws Exception {
+        String outputFile = files[6] + ".out";
+        System.out.println("Writing output to " + outputFile);
+
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        assertTrue(checkResults(outputFile, files[6] + ".org"));
+        System.out.println("Done");
+    }
+
+    // Test StreamWriter supplied with correct namespace information and" + "isRepairingNamespace is set to true.
+    @Test
+    public void testEight() throws Exception {
+        String outputFile = files[7] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        assertTrue(checkResults(outputFile, files[7] + ".org"));
+        System.out.println("Done");
+    }
+
+    // Test StreamWriter supplied with correct namespace information and isRepairingNamespace
+    // is set to true. Pass namespace information using writenamespace function.
+    @Test
+    public void testNine() throws Exception {
+        String outputFile = files[8] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
+        // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        assertTrue(checkResults(outputFile, files[7] + ".org"));
+        System.out.println("Done");
+    }
+
+    // Test StreamWriter supplied with no namespace information and isRepairingNamespace is set to true.
+    @Test
+    public void testTen() throws Exception {
+        String outputFile = files[9] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
+        // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        // prefix is generated while it was defined in the 'org' file, the
+        // following comparison method needs a rewrite.
+        // assertTrue(checkResults(files[9]+".out",files[7]+".org"));
+        System.out.println("Done");
+    }
+
+    // Test StreamWriter supplied with namespace information passed through startElement and
+    // isRepairingNamespace is set to true.
+    @Test
+    public void testEleven() throws Exception {
+        String outputFile = files[10] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
+        // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("html", "html", "http://www.w3.org/TR/REC-html40");
+        // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
+
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
+
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        assertTrue(checkResults(outputFile, files[7] + ".org"));
+        System.out.println("Done");
     }
 
     @Test
-    public void testOne() {
+    public void testTwelve() throws Exception {
+        String outputFile = files[11] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
 
-        System.out.println("Test StreamWriter with out any namespace functionality");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
 
-        try {
-            String outputFile = USER_DIR + files[0] + ".out";
-            System.out.println("Writing output to " + outputFile);
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
 
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.writeStartElement("elmeOne");
-            xtw.writeStartElement("elemTwo");
-            xtw.writeStartElement("elemThree");
-            xtw.writeStartElement("elemFour");
-            xtw.writeStartElement("elemFive");
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
 
-            Assert.assertTrue(checkResults(outputFile, files[0] + ".org"));
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
 
-        } catch (Exception ex) {
-            Assert.fail("testOne Failed " + ex);
-            ex.printStackTrace();
-        }
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
 
+        xtw.writeEndElement();
+
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        // assertTrue(checkResults(files[10]+".out",files[7]+".org"));
+        System.out.println("Done");
     }
 
     @Test
-    public void testTwo() {
+    public void testDefaultNamespace() throws Exception {
+        String outputFile = files[12] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
 
-        System.out.println("Test StreamWriter's Namespace Context");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
+        xtw.writeDefaultNamespace("http://www.w3.org/TR/REC-html40");
 
-        try {
-            String outputFile = USER_DIR + files[1] + ".out";
-            System.out.println("Writing output to " + outputFile);
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
 
-            xtw = outputFactory.createXMLStreamWriter(System.out);
-            xtw.writeStartDocument();
-            xtw.writeStartElement("elemTwo");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeEndDocument();
-            NamespaceContext nc = xtw.getNamespaceContext();
-            // Got a Namespace Context.class
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
 
-            XMLStreamWriter xtw1 = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
 
-            xtw1.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw1.setNamespaceContext(nc);
-            xtw1.writeStartDocument("utf-8", "1.0");
-            xtw1.setPrefix("htmlOne", "http://www.w3.org/TR/REC-html40");
-            NamespaceContext nc1 = xtw1.getNamespaceContext();
-            xtw1.close();
-            Iterator it = nc1.getPrefixes("http://www.w3.org/TR/REC-html40");
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
 
-            // FileWriter fw = new FileWriter(outputFile);
-            while (it.hasNext()) {
-                System.out.println("Prefixes :" + it.next());
-                // fw.write((String)it.next());
-                // fw.write(";");
-            }
-            // fw.close();
-            // assertTrue(checkResults(testTwo+".out", testTwo+".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testTwo Failed " + ex);
-            ex.printStackTrace();
-        }
+        xtw.writeEndElement();
 
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        // assertTrue(checkResults(files[10]+".out",files[7]+".org"));
+        System.out.println("Done");
     }
 
     @Test
-    public void testThree() {
+    public void testRepairNamespace() throws Exception {
+        String outputFile = files[14] + ".out";
+        System.out.println("Writing output to " + outputFile);
+        outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.TRUE);
+        xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
+        xtw.writeComment("all elements here are explicitly in the HTML namespace");
+        xtw.writeStartDocument("utf-8", "1.0");
+        xtw.writeStartElement("html", "html", "http://www.w3.org/TR/REC-html40");
+        // xtw.writeStartElement("http://www.w3.org/TR/REC-html40","html");
+        // xtw.writeDefaultNamespace("http://www.w3.org/TR/REC-html40");
+        xtw.writeAttribute("html", "testPrefix", "attr1", "http://frob.com");
+        xtw.writeAttribute("html", "testPrefix", "attr2", "http://frob2.com");
+        xtw.writeAttribute("html", "http://www.w3.org/TR/REC-html40", "attr4", "http://frob4.com");
 
-        System.out.println("Test StreamWriter for proper element sequence.");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
+        xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
 
-        try {
-            String outputFile = USER_DIR + files[2] + ".out";
-            System.out.println("Writing output to " + outputFile);
+        xtw.writeCharacters("Frobnostication");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
 
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.writeStartElement("elmeOne");
-            xtw.writeStartElement("elemTwo");
-            xtw.writeEmptyElement("emptyElem");
-            xtw.writeStartElement("elemThree");
-            xtw.writeStartElement("elemFour");
-            xtw.writeStartElement("elemFive");
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
+        xtw.writeCharacters("Moved to");
+        xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
+        xtw.writeAttribute("href", "http://frob.com");
 
-            Assert.assertTrue(checkResults(outputFile, files[2] + ".org"));
+        xtw.writeCharacters("here");
+        xtw.writeEndElement();
+        xtw.writeEndElement();
+        xtw.writeEndElement();
 
-        } catch (Exception ex) {
-            Assert.fail("testThree Failed " + ex);
-            ex.printStackTrace();
-        }
+        xtw.writeEndElement();
 
+        xtw.writeEndDocument();
+        xtw.flush();
+        xtw.close();
+        // check against testSeven.xml.org
+        // assertTrue(checkResults(files[10]+".out",files[7]+".org"));
+        System.out.println("Done");
     }
 
-    @Test
-    public void testFour() {
-
-        System.out.println("Test StreamWriter with elements,attribute and element content.");
-
-        try {
-
-            String outputFile = USER_DIR + files[3] + ".out";
-            System.out.println("Writing output to " + outputFile);
-
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.writeStartElement("elmeOne");
-            xtw.writeStartElement("elemTwo");
-            xtw.writeEmptyElement("emptyElem");
-            xtw.writeAttribute("testAttr", "testValue");
-            xtw.writeStartElement("elemThree");
-            xtw.writeStartElement("elemFour");
-            xtw.writeCharacters("TestCharacterData");
-            xtw.writeStartElement("elemFive");
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-
-            Assert.assertTrue(checkResults(outputFile, files[3] + ".org"));
-
-        } catch (Exception ex) {
-            Assert.fail("testFour Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testFive() {
-
-        System.out.println("Test StreamWriter's Namespace Context.");
-
-        try {
-
-            String outputFile = USER_DIR + files[4] + ".out";
-            System.out.println("Writing output to " + outputFile);
-
-            xtw = outputFactory.createXMLStreamWriter(System.out);
-            xtw.writeStartDocument();
-            xtw.writeStartElement("elemTwo");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-            // xtw.writeEndDocument();
-            NamespaceContext nc = xtw.getNamespaceContext();
-            // Got a Namespace Context.class
-
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.setNamespaceContext(nc);
-            xtw.writeStartDocument("utf-8", "1.0");
-            // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            Assert.assertTrue(checkResults(outputFile, files[4] + ".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testFive Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testSix() {
-
-        System.out.println("Test StreamWriter, uses the Namespace Context set by the user to resolve namespaces.");
-
-        try {
-
-            String outputFile = USER_DIR + files[5] + ".out";
-            System.out.println("Writing output to " + outputFile);
-
-            xtw = outputFactory.createXMLStreamWriter(System.out);
-            xtw.writeStartDocument();
-            xtw.writeStartElement("elemTwo");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeEndDocument();
-            NamespaceContext nc = xtw.getNamespaceContext();
-            // Got a Namespace Context information.
-
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.setNamespaceContext(nc);
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.setPrefix("htmlNewPrefix", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            Assert.assertTrue(checkResults(outputFile, files[5] + ".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testSix Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testSeven() {
-
-        System.out.println("Test StreamWriter supplied with correct namespace information");
-
-        try {
-
-            String outputFile = USER_DIR + files[6] + ".out";
-            System.out.println("Writing output to " + outputFile);
-
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            Assert.assertTrue(checkResults(outputFile, files[6] + ".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testSeven Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testEight() {
-
-        System.out.println("Test StreamWriter supplied with correct namespace information and" + "isRepairingNamespace is set to true.");
-
-        try {
-
-            String outputFile = USER_DIR + files[7] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            Assert.assertTrue(checkResults(outputFile, files[7] + ".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail("testEight Failed " + ex);
-
-        }
-
-    }
-
-    @Test
-    public void testNine() {
-
-        System.out.println("Test StreamWriter supplied with correct namespace information and" + "isRepairingNamespace is set to true."
-                + "pass namespace information using" + "writenamespace function");
-
-        try {
-
-            String outputFile = USER_DIR + files[8] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-            // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            Assert.assertTrue(checkResults(outputFile, files[7] + ".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testNine Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testTen() {
-
-        System.out.println("Test StreamWriter supplied with no namespace information and" + "isRepairingNamespace is set to true.");
-        try {
-
-            String outputFile = USER_DIR + files[9] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-            // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            // prefix is generated while it was defined in the 'org' file, the
-            // following comparison method needs a rewrite.
-            // assertTrue(checkResults(files[9]+".out",files[7]+".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testTen Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testEleven() {
-
-        System.out.println("Test StreamWriter supplied with  namespace information passed through startElement and" + "isRepairingNamespace is set to true.");
-        try {
-
-            String outputFile = USER_DIR + files[10] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-            // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("html", "html", "http://www.w3.org/TR/REC-html40");
-            // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            Assert.assertTrue(checkResults(outputFile, files[7] + ".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testEleven Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testTwelve() {
-
-        System.out.println("Test StreamWriter supplied with  namespace information set at few places");
-
-        try {
-
-            String outputFile = USER_DIR + files[11] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            // xtw.writeNamespace("html", "http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            // assertTrue(checkResults(files[10]+".out",files[7]+".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            Assert.fail("testtwelve Failed " + ex);
-            ex.printStackTrace();
-        }
-
-    }
-
-    @Test
-    public void testDefaultNamespace() {
-
-        System.out.println("Test StreamWriter supplied with  namespace information set at few places");
-
-        try {
-
-            String outputFile = USER_DIR + files[12] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "html");
-            xtw.writeDefaultNamespace("http://www.w3.org/TR/REC-html40");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            // xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            // assertTrue(checkResults(files[10]+".out",files[7]+".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail("testDefaultNamespace Failed " + ex);
-
-        }
-
-    }
-
-    @Test
-    public void testRepairNamespace() {
-
-        System.out.println("Test StreamWriter supplied with  namespace information set at few places");
-
-        try {
-
-            String outputFile = USER_DIR + files[14] + ".out";
-            System.out.println("Writing output to " + outputFile);
-            outputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, new Boolean(true));
-            xtw = outputFactory.createXMLStreamWriter(new FileOutputStream(outputFile), ENCODING);
-            xtw.writeComment("all elements here are explicitly in the HTML namespace");
-            xtw.writeStartDocument("utf-8", "1.0");
-            xtw.writeStartElement("html", "html", "http://www.w3.org/TR/REC-html40");
-            // xtw.writeStartElement("http://www.w3.org/TR/REC-html40","html");
-            // xtw.writeDefaultNamespace("http://www.w3.org/TR/REC-html40");
-            xtw.writeAttribute("html", "testPrefix", "attr1", "http://frob.com");
-            xtw.writeAttribute("html", "testPrefix", "attr2", "http://frob2.com");
-            xtw.writeAttribute("html", "http://www.w3.org/TR/REC-html40", "attr4", "http://frob4.com");
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "head");
-            xtw.setPrefix("html", "http://www.w3.org/TR/REC-html40");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "title");
-
-            xtw.writeCharacters("Frobnostication");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "body");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "p");
-            xtw.writeCharacters("Moved to");
-            xtw.writeStartElement("http://www.w3.org/TR/REC-html40", "a");
-            xtw.writeAttribute("href", "http://frob.com");
-
-            xtw.writeCharacters("here");
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-            xtw.writeEndElement();
-
-            xtw.writeEndElement();
-
-            xtw.writeEndDocument();
-            xtw.flush();
-            xtw.close();
-            // check against testSeven.xml.org
-            // assertTrue(checkResults(files[10]+".out",files[7]+".org"));
-            System.out.println("Done");
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail("testDefaultNamespace Failed " + ex);
-
-        }
-
-    }
-
-    protected boolean checkResults(String checkFile, String orgFile) {
-        try {
-            URL fileName = WriterTest.class.getResource(orgFile);
-            // URL outputFileName = WriterTest.class.getResource(checkFile);
-            return compareOutput(new InputStreamReader(fileName.openStream()), new InputStreamReader(new FileInputStream(checkFile)));
-
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail(ex.getMessage());
-        }
-        return false;
+    protected boolean checkResults(String checkFile, String orgFile) throws Exception {
+        URL fileName = WriterTest.class.getResource(orgFile);
+        // URL outputFileName = WriterTest.class.getResource(checkFile);
+        return compareOutput(new InputStreamReader(fileName.openStream()), new InputStreamReader(new FileInputStream(checkFile)));
     }
 
     protected boolean compareOutput(Reader expected, Reader actual) throws IOException {
@@ -773,13 +618,9 @@ public class WriterTest {
                 }
             }
             return true;
-        } catch (IOException ex) {
-            System.err.println("Error  occured while comparing results.");
-            throw ex;
         } finally {
             expectedOutput.close();
             actualOutput.close();
-
         }
     }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/XMLStreamWriterTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/XMLStreamWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,28 +22,28 @@
  */
 package stream.XMLStreamWriterTest;
 
-import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
-
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.events.XMLEvent;
 import javax.xml.transform.dom.DOMResult;
+import java.io.StringWriter;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.w3c.dom.Document;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @bug 6347190 8139584 8216408
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm stream.XMLStreamWriterTest.XMLStreamWriterTest
+ * @library /javax/xml/jaxp/unittest
+ * @run junit/othervm stream.XMLStreamWriterTest.XMLStreamWriterTest
  * @summary Tests XMLStreamWriter.
  */
 public class XMLStreamWriterTest {
@@ -63,9 +63,9 @@ public class XMLStreamWriterTest {
         XMLEvent event = eventFactory.createStartDocument("iso-8859-15", "1.0", true);
         eventWriter.add(event);
         eventWriter.flush();
-        Assert.assertTrue(stringWriter.toString().contains("encoding=\"iso-8859-15\""));
-        Assert.assertTrue(stringWriter.toString().contains("version=\"1.0\""));
-        Assert.assertTrue(stringWriter.toString().contains("standalone=\"yes\""));
+        assertTrue(stringWriter.toString().contains("encoding=\"iso-8859-15\""));
+        assertTrue(stringWriter.toString().contains("version=\"1.0\""));
+        assertTrue(stringWriter.toString().contains("standalone=\"yes\""));
     }
 
     /**
@@ -73,8 +73,7 @@ public class XMLStreamWriterTest {
      * Verifies that the resulting XML contains the standalone setting.
      */
     @Test
-    public void testCreateStartDocument_DOMWriter()
-            throws ParserConfigurationException, XMLStreamException {
+    public void testCreateStartDocument_DOMWriter() throws Exception {
 
         XMLOutputFactory xof = XMLOutputFactory.newInstance();
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -85,47 +84,41 @@ public class XMLStreamWriterTest {
         XMLEvent event = eventFactory.createStartDocument("iso-8859-15", "1.0", true);
         eventWriter.add(event);
         eventWriter.flush();
-        Assert.assertEquals(doc.getXmlEncoding(), "iso-8859-15");
-        Assert.assertEquals(doc.getXmlVersion(), "1.0");
-        Assert.assertTrue(doc.getXmlStandalone());
+        assertEquals("iso-8859-15", doc.getXmlEncoding());
+        assertEquals("1.0", doc.getXmlVersion());
+        assertTrue(doc.getXmlStandalone());
     }
 
     /**
      * Verifies that the StAX Writer won't insert comment into the element tag.
      */
     @Test
-    public void testWriteComment() {
-        try {
-            String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                    + "<a:html href=\"http://java.sun.com\">"
-                    + "<!--This is comment-->java.sun.com</a:html>";
-            XMLOutputFactory f = XMLOutputFactory.newInstance();
-            // f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-            // Boolean.TRUE);
-            StringWriter sw = new StringWriter();
-            XMLStreamWriter writer = f.createXMLStreamWriter(sw);
-            writer.writeStartDocument("UTF-8", "1.0");
-            writer.writeStartElement("a", "html", "http://www.w3.org/TR/REC-html40");
-            writer.writeAttribute("href", "http://java.sun.com");
-            writer.writeComment("This is comment");
-            writer.writeCharacters("java.sun.com");
-            writer.writeEndElement();
-            writer.writeEndDocument();
-            writer.flush();
-            sw.flush();
-            StringBuffer sb = sw.getBuffer();
-            System.out.println("sb:" + sb.toString());
-            Assert.assertTrue(sb.toString().equals(xml));
-        } catch (Exception ex) {
-            Assert.fail("Exception: " + ex.getMessage());
-        }
+    public void testWriteComment() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<a:html href=\"http://java.sun.com\">"
+                + "<!--This is comment-->java.sun.com</a:html>";
+        XMLOutputFactory f = XMLOutputFactory.newInstance();
+        // f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
+        // Boolean.TRUE);
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter writer = f.createXMLStreamWriter(sw);
+        writer.writeStartDocument("UTF-8", "1.0");
+        writer.writeStartElement("a", "html", "http://www.w3.org/TR/REC-html40");
+        writer.writeAttribute("href", "http://java.sun.com");
+        writer.writeComment("This is comment");
+        writer.writeCharacters("java.sun.com");
+        writer.writeEndElement();
+        writer.writeEndDocument();
+        writer.flush();
+        sw.flush();
+        StringBuffer sb = sw.getBuffer();
+        System.out.println("sb:" + sb.toString());
+        assertEquals(xml, sb.toString());
     }
 
     /**
      * @bug 8216408
      * Verifies that setDefaultNamespace accepts null.
-     *
-     * @throws Exception
      */
     @Test
     public void testSetDefaultNamespace() throws Exception {

--- a/test/jaxp/javax/xml/jaxp/unittest/util/BaseStAXUT.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/util/BaseStAXUT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,9 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
 
-import org.testng.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Base class for all StaxTest unit test classes. Contains shared
@@ -55,22 +57,22 @@ public class BaseStAXUT implements XMLStreamConstants {
      */
     final static String PROP_REPORT_CDATA = "http://java.sun.com/xml/stream/properties/report-cdata-event";
 
-    final static HashMap mTokenTypes = new HashMap();
+    final static HashMap<Integer, String> mTokenTypes = new HashMap<>();
     static {
-        mTokenTypes.put(new Integer(START_ELEMENT), "START_ELEMENT");
-        mTokenTypes.put(new Integer(END_ELEMENT), "END_ELEMENT");
-        mTokenTypes.put(new Integer(START_DOCUMENT), "START_DOCUMENT");
-        mTokenTypes.put(new Integer(END_DOCUMENT), "END_DOCUMENT");
-        mTokenTypes.put(new Integer(CHARACTERS), "CHARACTERS");
-        mTokenTypes.put(new Integer(CDATA), "CDATA");
-        mTokenTypes.put(new Integer(COMMENT), "COMMENT");
-        mTokenTypes.put(new Integer(PROCESSING_INSTRUCTION), "PROCESSING_INSTRUCTION");
-        mTokenTypes.put(new Integer(DTD), "DTD");
-        mTokenTypes.put(new Integer(SPACE), "SPACE");
-        mTokenTypes.put(new Integer(ENTITY_REFERENCE), "ENTITY_REFERENCE");
-        mTokenTypes.put(new Integer(NAMESPACE), "NAMESPACE_DECLARATION");
-        mTokenTypes.put(new Integer(NOTATION_DECLARATION), "NOTATION_DECLARATION");
-        mTokenTypes.put(new Integer(ENTITY_DECLARATION), "ENTITY_DECLARATION");
+        mTokenTypes.put(START_ELEMENT, "START_ELEMENT");
+        mTokenTypes.put(END_ELEMENT, "END_ELEMENT");
+        mTokenTypes.put(START_DOCUMENT, "START_DOCUMENT");
+        mTokenTypes.put(END_DOCUMENT, "END_DOCUMENT");
+        mTokenTypes.put(CHARACTERS, "CHARACTERS");
+        mTokenTypes.put(CDATA, "CDATA");
+        mTokenTypes.put(COMMENT, "COMMENT");
+        mTokenTypes.put(PROCESSING_INSTRUCTION, "PROCESSING_INSTRUCTION");
+        mTokenTypes.put(DTD, "DTD");
+        mTokenTypes.put(SPACE, "SPACE");
+        mTokenTypes.put(ENTITY_REFERENCE, "ENTITY_REFERENCE");
+        mTokenTypes.put(NAMESPACE, "NAMESPACE_DECLARATION");
+        mTokenTypes.put(NOTATION_DECLARATION, "NOTATION_DECLARATION");
+        mTokenTypes.put(ENTITY_DECLARATION, "ENTITY_DECLARATION");
     }
 
     /*
@@ -146,7 +148,7 @@ public class BaseStAXUT implements XMLStreamConstants {
     protected static XMLStreamReader constructStreamReaderForFile(XMLInputFactory f, String filename) throws IOException, XMLStreamException {
         File inf = new File(filename);
         XMLStreamReader sr = f.createXMLStreamReader(inf.toURL().toString(), new FileReader(inf));
-        Assert.assertEquals(START_DOCUMENT, sr.getEventType());
+        assertEquals(START_DOCUMENT, sr.getEventType());
         return sr;
     }
 
@@ -168,19 +170,19 @@ public class BaseStAXUT implements XMLStreamConstants {
      * factory //////////////////////////////////////////////////
      */
 
-    protected static boolean isCoalescing(XMLInputFactory f) throws XMLStreamException {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_COALESCING)).booleanValue();
+    protected static boolean isCoalescing(XMLInputFactory f) {
+        return (Boolean) f.getProperty(XMLInputFactory.IS_COALESCING);
     }
 
     protected static void setCoalescing(XMLInputFactory f, boolean state) throws XMLStreamException {
         Boolean b = state ? Boolean.TRUE : Boolean.FALSE;
         f.setProperty(XMLInputFactory.IS_COALESCING, b);
         // Let's just double-check it...
-        Assert.assertEquals(state, isCoalescing(f));
+        assertEquals(state, isCoalescing(f));
     }
 
-    protected static boolean isValidating(XMLInputFactory f) throws XMLStreamException {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_VALIDATING)).booleanValue();
+    protected static boolean isValidating(XMLInputFactory f) {
+        return (Boolean) f.getProperty(XMLInputFactory.IS_VALIDATING);
     }
 
     protected static void setValidating(XMLInputFactory f, boolean state) throws XMLStreamException {
@@ -188,14 +190,14 @@ public class BaseStAXUT implements XMLStreamConstants {
             Boolean b = state ? Boolean.TRUE : Boolean.FALSE;
             f.setProperty(XMLInputFactory.IS_VALIDATING, b);
         } catch (IllegalArgumentException iae) {
-            Assert.fail("Could not set DTD validating mode to " + state + ": " + iae);
+            fail("Could not set DTD validating mode to " + state + ": " + iae);
             // throw new XMLStreamException(iae.getMessage(), iae);
         }
-        Assert.assertEquals(state, isValidating(f));
+        assertEquals(state, isValidating(f));
     }
 
-    protected static boolean isNamespaceAware(XMLInputFactory f) throws XMLStreamException {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_NAMESPACE_AWARE)).booleanValue();
+    protected static boolean isNamespaceAware(XMLInputFactory f) {
+        return (Boolean) f.getProperty(XMLInputFactory.IS_NAMESPACE_AWARE);
     }
 
     /**
@@ -222,24 +224,24 @@ public class BaseStAXUT implements XMLStreamConstants {
         }
     }
 
-    protected static void setReplaceEntities(XMLInputFactory f, boolean state) throws XMLStreamException {
+    protected static void setReplaceEntities(XMLInputFactory f, boolean state) {
         Boolean b = state ? Boolean.TRUE : Boolean.FALSE;
         f.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, b);
-        Assert.assertEquals(b, f.getProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES));
+        assertEquals(b, f.getProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES));
     }
 
-    protected static void setSupportDTD(XMLInputFactory f, boolean state) throws XMLStreamException {
+    protected static void setSupportDTD(XMLInputFactory f, boolean state) {
         Boolean b = state ? Boolean.TRUE : Boolean.FALSE;
         f.setProperty(XMLInputFactory.SUPPORT_DTD, b);
-        Assert.assertEquals(b, f.getProperty(XMLInputFactory.SUPPORT_DTD));
+        assertEquals(b, f.getProperty(XMLInputFactory.SUPPORT_DTD));
     }
 
-    protected static boolean setSupportExternalEntities(XMLInputFactory f, boolean state) throws XMLStreamException {
+    protected static boolean setSupportExternalEntities(XMLInputFactory f, boolean state) {
         Boolean b = state ? Boolean.TRUE : Boolean.FALSE;
         try {
             f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, b);
             Object act = f.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES);
-            return (act instanceof Boolean) && ((Boolean) act).booleanValue() == state;
+            return (act instanceof Boolean) && (Boolean) act == state;
         } catch (IllegalArgumentException e) {
             /*
              * Let's assume, then, that the property (or specific value for it)
@@ -249,11 +251,11 @@ public class BaseStAXUT implements XMLStreamConstants {
         }
     }
 
-    protected static void setResolver(XMLInputFactory f, XMLResolver resolver) throws XMLStreamException {
+    protected static void setResolver(XMLInputFactory f, XMLResolver resolver) {
         f.setProperty(XMLInputFactory.RESOLVER, resolver);
     }
 
-    protected static boolean setReportCData(XMLInputFactory f, boolean state) throws XMLStreamException {
+    protected static boolean setReportCData(XMLInputFactory f, boolean state) {
 
         Boolean b = state ? Boolean.TRUE : Boolean.FALSE;
         if (f.isPropertySupported(PROP_REPORT_CDATA)) {
@@ -272,7 +274,7 @@ public class BaseStAXUT implements XMLStreamConstants {
      * Method that not only gets currently available text from the reader, but
      * also checks that its consistenly accessible using different StAX methods.
      */
-    protected static String getAndVerifyText(XMLStreamReader sr) throws XMLStreamException {
+    protected static String getAndVerifyText(XMLStreamReader sr) {
         String text = sr.getText();
 
         /*
@@ -282,7 +284,7 @@ public class BaseStAXUT implements XMLStreamConstants {
          */
         int type = sr.getEventType();
         if (type != ENTITY_REFERENCE && type != DTD) {
-            Assert.assertNotNull("getText() should never return null.", text);
+            assertNotNull(text, "getText() should never return null.");
             int expLen = sr.getTextLength();
             /*
              * Hmmh. Can only return empty text for CDATA (since empty blocks
@@ -296,14 +298,14 @@ public class BaseStAXUT implements XMLStreamConstants {
              */
             if (sr.getEventType() == CHARACTERS) {
                 if (expLen == 0) {
-                    Assert.fail("Stream reader should never return empty Strings.");
+                    fail("Stream reader should never return empty Strings.");
                 }
             }
-            Assert.assertEquals(expLen, text.length(), "Expected text length of " + expLen + ", got " + text.length());
+            assertEquals(expLen, text.length(), "Expected text length of " + expLen + ", got " + text.length());
             char[] textChars = sr.getTextCharacters();
             int start = sr.getTextStart();
             String text2 = new String(textChars, start, expLen);
-            Assert.assertEquals("Expected getText() and getTextCharacters() to return same value for event of type (" + tokenTypeDesc(sr.getEventType()) + ")",
+            assertEquals("Expected getText() and getTextCharacters() to return same value for event of type (" + tokenTypeDesc(sr.getEventType()) + ")",
                     text, text2);
         } else { // DTD or ENTITY_REFERENCE
             // not sure if null is legal for these either, but...
@@ -353,25 +355,25 @@ public class BaseStAXUT implements XMLStreamConstants {
         if (expType == actType) {
             return;
         }
-        Assert.fail("Expected token " + tokenTypeDesc(expType) + "; got " + tokenTypeDesc(actType) + ".");
+        fail("Expected token " + tokenTypeDesc(expType) + "; got " + tokenTypeDesc(actType) + ".");
     }
 
     protected static void assertTokenType(int expType, int actType, XMLStreamReader sr) {
         if (expType == actType) {
             return;
         }
-        Assert.fail("Expected token " + tokenTypeDesc(expType) + "; got " + tokenTypeDesc(actType, sr) + ".");
+        fail("Expected token " + tokenTypeDesc(expType) + "; got " + tokenTypeDesc(actType, sr) + ".");
     }
 
     protected static void assertTextualTokenType(int actType) {
         if (actType != CHARACTERS && actType != SPACE && actType != CDATA) {
-            Assert.fail("Expected textual token (CHARACTERS, SPACE or CDATA)" + "; got " + tokenTypeDesc(actType) + ".");
+            fail("Expected textual token (CHARACTERS, SPACE or CDATA)" + "; got " + tokenTypeDesc(actType) + ".");
         }
     }
 
     protected static void failStrings(String msg, String exp, String act) {
         // !!! TODO: Indicate position where Strings differ
-        Assert.fail(msg + ": expected " + quotedPrintable(exp) + ", got " + quotedPrintable(act));
+        fail(msg + ": expected " + quotedPrintable(exp) + ", got " + quotedPrintable(act));
     }
 
     /**
@@ -383,23 +385,23 @@ public class BaseStAXUT implements XMLStreamConstants {
      * 1.6 indicate, the current understanding is that <b>null</b> is the
      * ultimate right answer here.
      */
-    protected static void assertNoPrefix(XMLStreamReader sr) throws XMLStreamException {
+    protected static void assertNoPrefix(XMLStreamReader sr) {
         String prefix = sr.getPrefix();
         if (prefix != null) {
             if (prefix.length() != 0) {
-                Assert.fail("Current element should not have a prefix: got '" + prefix + "'");
+                fail("Current element should not have a prefix: got '" + prefix + "'");
             } else {
-                Assert.fail("Expected null to signify missing prefix (see XMLStreamReader#getPrefix() JavaDocs): got empty String");
+                fail("Expected null to signify missing prefix (see XMLStreamReader#getPrefix() JavaDocs): got empty String");
             }
         }
     }
 
-    protected static void assertNoAttrPrefix(String attrPrefix) throws XMLStreamException {
+    protected static void assertNoAttrPrefix(String attrPrefix) {
         if (attrPrefix != null) {
             if (attrPrefix.length() != 0) {
-                Assert.fail("Attribute should not have a prefix: got '" + attrPrefix + "'");
+                fail("Attribute should not have a prefix: got '" + attrPrefix + "'");
             } else {
-                Assert.fail("Expected null to signify missing attribute prefix (see XMLStreamReader#getAttributePrefix() JavaDocs): got empty String");
+                fail("Expected null to signify missing attribute prefix (see XMLStreamReader#getAttributePrefix() JavaDocs): got empty String");
             }
         }
     }
@@ -408,21 +410,21 @@ public class BaseStAXUT implements XMLStreamConstants {
      * Similar to {@link #assertNoPrefix}, but here we do know that unbound
      * namespace URI should be indicated as empty String.
      */
-    protected static void assertNoNsURI(XMLStreamReader sr) throws XMLStreamException {
+    protected static void assertNoNsURI(XMLStreamReader sr) {
         String uri = sr.getNamespaceURI();
         if (uri == null) {
-            Assert.fail("Expected empty String to indicate \"no namespace\": got null");
+            fail("Expected empty String to indicate \"no namespace\": got null");
         } else if (uri.length() != 0) {
-            Assert.fail("Expected empty String to indicate \"no namespace\": got '" + uri + "'");
+            fail("Expected empty String to indicate \"no namespace\": got '" + uri + "'");
         }
     }
 
-    protected static void assertNoAttrNamespace(String attrNsURI) throws XMLStreamException {
+    protected static void assertNoAttrNamespace(String attrNsURI) {
         if (attrNsURI == null) {
             // refer to 6903561; accept null for now.
             // fail("Expected empty String to indicate \"no namespace\" (for attribute): got null");
         } else if (attrNsURI.length() != 0) {
-            Assert.fail("Expected empty String to indicate \"no namespace\" (for attribute): got '" + attrNsURI + "'");
+            fail("Expected empty String to indicate \"no namespace\" (for attribute): got '" + attrNsURI + "'");
         }
     }
 
@@ -437,7 +439,7 @@ public class BaseStAXUT implements XMLStreamConstants {
      */
     protected static void assertNullOrEmpty(String str) {
         if (str != null && str.length() > 0) {
-            Assert.fail("Expected String to be empty or null; was '" + str + "' (length " + str.length() + ")");
+            fail("Expected String to be empty or null; was '" + str + "' (length " + str.length() + ")");
         }
     }
 
@@ -447,7 +449,7 @@ public class BaseStAXUT implements XMLStreamConstants {
      */
 
     protected static String tokenTypeDesc(int tt) {
-        String desc = (String) mTokenTypes.get(new Integer(tt));
+        String desc = (String) mTokenTypes.get(tt);
         if (desc == null) {
             return "[" + tt + "]";
         }


### PR DESCRIPTION
Convert and tidy-up unit tests in test/jaxp/javax/xml/jaxp/unittest/stream.

It is recommended to set the diff settings in github to hide whitespace (cog-wheel menu).

There are a lot of cases where manual catch blocks with explicit fail are removed to just allow the test to fail idiomatically by throwing the exception normally. This causes thousands of lines to be un-indented (with no other change).

About 200 explicit uses of `fail()` were either removed or converted to appropriate JUnit asserts.

There are also several non-trivial changes in this PR related to bad tests where, for example, catching and ignoring exceptions allowed the test to pass under all situations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8381882](https://bugs.openjdk.org/browse/JDK-8381882): Convert test/jaxp/javax/xml/jaxp/unittest/stream tests to JUnit (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30643/head:pull/30643` \
`$ git checkout pull/30643`

Update a local copy of the PR: \
`$ git checkout pull/30643` \
`$ git pull https://git.openjdk.org/jdk.git pull/30643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30643`

View PR using the GUI difftool: \
`$ git pr show -t 30643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30643.diff">https://git.openjdk.org/jdk/pull/30643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30643#issuecomment-4213252203)
</details>
