### PR TITLE
8381900: Test vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001 does not handle frequent GC gracefully

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/ap03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/ap03t001.cpp
@@ -42,6 +42,7 @@ static jvmtiCapabilities caps;
 
 static volatile int obj_free = 0;
 static volatile long obj_count = 0;
+static volatile bool check_object_free = true;
 
 static jlong timeout = 0;
 static int user_data = 0;
@@ -50,6 +51,9 @@ static const jlong DEBUGEE_CLASS_TAG = (jlong)1024;
 
 void JNICALL
 ObjectFree(jvmtiEnv *jvmti_env, jlong tag) {
+    if (!check_object_free) {
+        return;
+    }
     NSK_COMPLAIN1("Received unexpected ObjectFree event for an object with tag %ld\n\n", (long)tag);
     nsk_jvmti_setFailStatus();
     obj_free++;
@@ -190,6 +194,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         } else {
             NSK_DISPLAY1("Number of objects IterateOverObjectsReachableFromObject has found: %d\n\n", obj_count);
         }
+
+        // Ignore late ObjectFree notifications after the resurrected object has
+        // been validated. At this point the test has already proven that the
+        // tagged object survived finalization and is reachable through the catcher.
+        check_object_free = false;
     } while (0);
 
     NSK_DISPLAY0("Let debugee to finish\n");


### PR DESCRIPTION
Hello,

In the development of Automatic Heap Sizing (AHS) for ZGC we have seen vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001 fail intermittently. The main thing in AHS affecting this test is the number of GCs being run. The ap03t001 test seems to not be able to reliably handle GC at any moment.

A naive solution to this problem is to just increase the min/initial heap size to give the test more headroom, but I think we should go with a more robust approach. What we're seeing in failing runs is that not only the "holder" object is beeing freed, but the test-object itself as well.

```Java

public static int run(String argv[], PrintStream out) {
    return new ap03t001().runThis(argv, out);
}

// ...

private int runThis(String argv[], PrintStream out) {
    // ...
    ap03t001 holder = new ap03t001();
    // ...
}
```

I propose we ignore ObjectFree events after having verified that the holder object has been resurrected into the catcher object, which is what this test is all about.  Another alternative could be to disable ObjectFree events entirely after we're done, but I think this approach is easier to follow.

Testing:
* Local testing with AHS, and in mainline, that this test passes when running a bunch of GC. Running with flags: `-Xcomp -XX:-TieredCompilation` and `-XX:+ZCollectionIntervalOnly -XX:ZCollectionIntervalMajor=0.001` to trigger a lot of GCs.
* Oracle's tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381900](https://bugs.openjdk.org/browse/JDK-8381900): Test vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001 does not handle frequent GC gracefully (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30644/head:pull/30644` \
`$ git checkout pull/30644`

Update a local copy of the PR: \
`$ git checkout pull/30644` \
`$ git pull https://git.openjdk.org/jdk.git pull/30644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30644`

View PR using the GUI difftool: \
`$ git pr show -t 30644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30644.diff">https://git.openjdk.org/jdk/pull/30644.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30644#issuecomment-4212884846)
</details>
