### PR TITLE
8381925: Separating type annotations on qualified type names

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -30,6 +30,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.type.TypeKind;
 import javax.tools.JavaFileObject;
 
+import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.RecordComponent;
@@ -79,6 +80,7 @@ import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCTypeUnion;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.JCTree.Tag;
+import com.sun.tools.javac.tree.Pretty;
 import com.sun.tools.javac.tree.TreeInfo;
 import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Assert;
@@ -490,31 +492,12 @@ public class TypeAnnotations {
                 alternatives.addAll(ut.alternatives_field.tail);
                 ret = new UnionClassType((ClassType) ut.getLub(), alternatives.toList());
             } else {
+                JCTree enclTr = enclTr(typetree, !onlyTypeAnnotations.isEmpty());
                 Type enclTy = type;
                 Element enclEl = type.asElement();
-                JCTree enclTr = typetree;
-
-                while (enclEl != null &&
-                        enclEl.getKind() != ElementKind.PACKAGE &&
-                        enclTy != null &&
-                        enclTy.getKind() != TypeKind.NONE &&
-                        (enclTr.getKind() == JCTree.Kind.MEMBER_SELECT ||
-                                enclTr.getKind() == JCTree.Kind.PARAMETERIZED_TYPE ||
-                                enclTr.getKind() == JCTree.Kind.ANNOTATED_TYPE)) {
-                    // Iterate also over the type tree, not just the type: the type is already
-                    // completely resolved and we cannot distinguish where the annotation
-                    // belongs for a nested type.
-                    if (enclTr.getKind() == JCTree.Kind.MEMBER_SELECT) {
-                        // only change encl in this case.
-                        enclTy = enclTy.getEnclosingType();
-                        enclEl = enclEl.getEnclosingElement();
-                        enclTr = ((JCFieldAccess)enclTr).getExpression();
-                    } else if (enclTr.getKind() == JCTree.Kind.PARAMETERIZED_TYPE) {
-                        enclTr = ((JCTypeApply)enclTr).getType();
-                    } else {
-                        // only other option because of while condition
-                        enclTr = ((JCAnnotatedType)enclTr).getUnderlyingType();
-                    }
+                while (!enclTy.hasTag(TypeTag.NONE) && enclTr.type != null && enclTr.type.tsym != enclEl) {
+                    enclTy = enclTy.getEnclosingType();
+                    enclEl = enclEl.getEnclosingElement();
                 }
 
                 /** We are trying to annotate some enclosing type,
@@ -574,6 +557,19 @@ public class TypeAnnotations {
             return ret;
         }
 
+        private static JCTree enclTr(JCTree tree, boolean onlyTypeAnnotations) {
+            return switch (tree.getKind()) {
+                case MEMBER_SELECT -> {
+                    JCExpression selected = ((JCFieldAccess) tree).selected;
+                    yield selected.type.hasTag(TypeTag.CLASS) || onlyTypeAnnotations
+                            ? enclTr(selected, onlyTypeAnnotations) : tree;
+                }
+                case PARAMETERIZED_TYPE -> enclTr(((JCTypeApply) tree).getType(), onlyTypeAnnotations);
+                case ANNOTATED_TYPE -> enclTr(((JCAnnotatedType) tree).getUnderlyingType(), onlyTypeAnnotations);
+                default -> tree;
+            };
+        }
+
         /**
          * Create a copy of the {@code Type type} with the help of the Tree for a type
          * {@code JCTree typetree} inserting all type annotations in {@code annotations} to the
@@ -625,7 +621,7 @@ public class TypeAnnotations {
                     // assert that t.constValue() == null?
                     if (t == stopAt ||
                         t.getEnclosingType() == Type.noType) {
-                        return t.annotatedType(s);
+                        return annotate(t, s);
                     } else {
                         ClassType ret = new ClassType(t.getEnclosingType().accept(this, s),
                                                       t.typarams_field, t.tsym,
@@ -692,13 +688,29 @@ public class TypeAnnotations {
 
                 @Override
                 public Type visitErrorType(ErrorType t, List<TypeCompound> s) {
-                    return t.annotatedType(s);
+                    return annotate(t, s);
                 }
 
                 @Override
                 public Type visitType(Type t, List<TypeCompound> s) {
                     return t.annotatedType(s);
                 }
+
+                private static Type annotate(ClassType t, List<TypeCompound> s) {
+                    TypeMetadata.Annotations existing = t.getMetadata(TypeMetadata.Annotations.class);
+                    if (existing != null) {
+                        // The type may have existing annotations if it is referred to by its qualified name,
+                        // and the simple name part of the name has an explicit type annotation, and the type
+                        // is part of a declaration with a dual declaration and TYPE_USE annotation:
+                        //
+                        // @DeclAndTypeUseAnno java.lang.@TypeUseAnno String f;
+                        //
+                        existing.annotationBuffer().addAll(s);
+                        return t;
+                    }
+                    return t.annotatedType(s);
+                }
+
             };
 
             return type.accept(visitor, annotations);

--- a/test/langtools/tools/javac/annotations/typeAnnotations/QualifiedNameTypeAnnotations.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/QualifiedNameTypeAnnotations.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8381925
+ * @summary Separating type annotations on qualified type names
+ * @library /tools/lib
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @modules jdk.compiler/com.sun.tools.javac.api jdk.compiler/com.sun.tools.javac.main
+ * @run main QualifiedNameTypeAnnotations
+ */
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.lang.model.type.TypeMirror;
+
+public class QualifiedNameTypeAnnotations extends TestRunner {
+
+    private ToolBox tb;
+
+    public static void main(String[] args) throws Exception {
+        new QualifiedNameTypeAnnotations().runTests();
+    }
+
+    QualifiedNameTypeAnnotations() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public void runTests() throws Exception {
+        runTests(m -> new Object[] {Paths.get(m.getName())});
+    }
+
+    @Test
+    public void testTypeAnnotations(Path base) throws Exception {
+        Path current = base.resolve(".");
+        Path src = current.resolve("src");
+        Path classes = current.resolve("classes");
+        tb.writeJavaFiles(
+                src,
+                """
+                package test;
+
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                class Test {
+
+                  class Inner {}
+
+                  @Target({ElementType.TYPE_USE, ElementType.FIELD})
+                  @Retention(RetentionPolicy.RUNTIME)
+                  @interface TA {}
+
+                  @Target({ElementType.TYPE_USE, ElementType.FIELD})
+                  @Retention(RetentionPolicy.RUNTIME)
+                  @interface TB {}
+
+                  @TA Inner i;
+                  @TA Test.@TB Inner j;
+                  @TA test.Test.@TB Inner k;
+                }
+                """);
+
+        Files.createDirectories(classes);
+
+        AtomicBoolean seenAnnotationMirror = new AtomicBoolean();
+
+        List<String> actual = new ArrayList<>();
+
+        class Scanner extends TreePathScanner<Void, Void> {
+
+            private final Trees trees;
+
+            Scanner(Trees trees) {
+                this.trees = trees;
+            }
+
+            @Override
+            public Void visitVariable(VariableTree node, final Void unused) {
+                TypeMirror type = trees.getTypeMirror(getCurrentPath());
+                actual.add(String.format("%s: %s", node.getName(), type));
+                return null;
+            }
+        }
+
+        new JavacTask(tb)
+                .outdir(classes)
+                .callback(
+                        task -> {
+                            task.addTaskListener(
+                                    new TaskListener() {
+                                        @Override
+                                        public void finished(TaskEvent e) {
+                                            if (e.getKind() != TaskEvent.Kind.ANALYZE) {
+                                                return;
+                                            }
+                                            System.err.println(e);
+                                            new Scanner(Trees.instance(task))
+                                                    .scan(e.getCompilationUnit(), null);
+                                        }
+                                    });
+                        })
+                .files(tb.findJavaFiles(src))
+                .run(Task.Expect.SUCCESS)
+                .writeAll();
+
+        List<String> expected =
+                List.of(
+                        "i: test.Test.@test.Test.TA Inner",
+                        "j: test.@test.Test.TA Test.@test.Test.TB Inner",
+                        "k: test.@test.Test.TA Test.@test.Test.TB Inner");
+        if (!expected.equals(actual)) {
+            throw new AssertionError("expected: " + expected + ", actual: " + actual);
+        }
+    }
+}


### PR DESCRIPTION
Please consider this fix to the logic that associates annotations that have both declaration and `TYPE_USE` targets with the correct tree.

Consider an annotation like `@Target({ElementType.FIELD, ElementType.TYPE_USE}) @interface A {}` that is applied to a field declaration:

```
@TA java.lang.String f;
```

The annotation is allowed to appear before the package part of the name, because it is a dual declaration and `TYPE_USE` annotation. The logic in `TypeAnnotations` needs to associate it with the class part of the name, and interpret the type annotation as equivalent to `java.lang.@TA String`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8381925](https://bugs.openjdk.org/browse/JDK-8381925): Separating type annotations on qualified type names (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30650/head:pull/30650` \
`$ git checkout pull/30650`

Update a local copy of the PR: \
`$ git checkout pull/30650` \
`$ git pull https://git.openjdk.org/jdk.git pull/30650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30650`

View PR using the GUI difftool: \
`$ git pr show -t 30650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30650.diff">https://git.openjdk.org/jdk/pull/30650.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30650#issuecomment-4214756404)
</details>
