### PR TITLE
8381723: Crash in fastdebug VM: assert(strlen(name1) + strlen(name2) < sizeof(stub_id)) failed

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -357,9 +357,12 @@ void RuntimeBlob::trace_new_stub(RuntimeBlob* stub, const char* name1, const cha
   if (stub != nullptr && (PrintStubCode ||
                        Forte::is_enabled() ||
                        JvmtiExport::should_post_dynamic_code_generated())) {
-    char stub_id[256];
-    assert(strlen(name1) + strlen(name2) < sizeof(stub_id), "");
-    jio_snprintf(stub_id, sizeof(stub_id), "%s%s", name1, name2);
+    ResourceMark rm;
+    const size_t name1_len = strlen(name1);
+    const size_t name2_len = strlen(name2);
+    const size_t stub_id_size = name1_len + name2_len + 1;
+    char* stub_id = NEW_RESOURCE_ARRAY(char, stub_id_size);
+    jio_snprintf(stub_id, stub_id_size, "%s%s", name1, name2);
     if (PrintStubCode) {
       ttyLocker ttyl;
       tty->print_cr("- - - [BEGIN] - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");


### PR DESCRIPTION
This PR proposes to use a variable-sized array to avoid a problem in debug mode.

There is already a test in `TestLargeStub`.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381723](https://bugs.openjdk.org/browse/JDK-8381723): Crash in fastdebug VM: assert(strlen(name1) + strlen(name2) &lt; sizeof(stub_id)) failed (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30651/head:pull/30651` \
`$ git checkout pull/30651`

Update a local copy of the PR: \
`$ git checkout pull/30651` \
`$ git pull https://git.openjdk.org/jdk.git pull/30651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30651`

View PR using the GUI difftool: \
`$ git pr show -t 30651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30651.diff">https://git.openjdk.org/jdk/pull/30651.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30651#issuecomment-4214936939)
</details>
