### PR TITLE
8381012: Add warning for == for MemorySegment.NULL

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1552,6 +1552,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * The {@linkplain MemorySegment#maxByteAlignment() maximum byte alignment} for
      * the {@code NULL} segment is of 2<sup>62</sup>.
+     *
+     * @apiNote Clients should avoid using {@code ==} to compare a segment with
+     *          {@code MemorySegment.NULL}. A segment with address {@code 0L} may be
+     *          {@linkplain #ofAddress(long) created independently} and may therefore
+     *          have a different identity.
      */
     MemorySegment NULL = MemorySegment.ofAddress(0L);
 


### PR DESCRIPTION
This PR proposes to improve the documentation for `MemorySegment.NULL`, adding an `@apiNote` discouraging the use of `==` on `MemorySegment.NULL`.

This PR superseeds https://github.com/openjdk/jdk/pull/30501

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381012](https://bugs.openjdk.org/browse/JDK-8381012): Add warning for == for MemorySegment.NULL (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30653/head:pull/30653` \
`$ git checkout pull/30653`

Update a local copy of the PR: \
`$ git checkout pull/30653` \
`$ git pull https://git.openjdk.org/jdk.git pull/30653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30653`

View PR using the GUI difftool: \
`$ git pr show -t 30653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30653.diff">https://git.openjdk.org/jdk/pull/30653.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30653#issuecomment-4215354509)
</details>
