### PR TITLE
8381939: G1: Fix marking state verification at the end of a concurrent start pause

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
@@ -187,7 +187,10 @@ inline void G1HeapRegion::apply_to_marked_objects(G1CMBitMap* bitmap, ApplyToMar
     }
   }
 
-  assert(next_addr == limit, "Should stop the scan at the limit.");
+  assert(next_addr == limit ||
+         (is_starts_humongous() && bitmap->is_marked(bottom()) && next_addr == (bottom() + cast_to_oop<HeapWord*>(bottom())->size())),
+         "Should stop the scan at the limit or end of humongous object. r %u (%s) ",
+         hrm_index(), get_short_type_str());
 }
 
 inline HeapWord* G1HeapRegion::par_allocate(size_t min_word_size,

--- a/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
@@ -194,7 +194,7 @@ inline void G1HeapRegion::apply_to_marked_objects(G1CMBitMap* bitmap, ApplyToMar
            "Should stop the scan at limit or end of humongous object. r %u (%s)",
            hrm_index(), get_short_type_str());
   } else {
-    assert(next_addr == limit, "Should stop the scan at the limit.");
+    assert(next_addr == limit, "Should stop the scan at the limit. r %u (%s)", hrm_index(), get_short_type_str());
   }
 #endif
 }

--- a/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
@@ -187,10 +187,16 @@ inline void G1HeapRegion::apply_to_marked_objects(G1CMBitMap* bitmap, ApplyToMar
     }
   }
 
-  assert(next_addr == limit ||
-         (is_starts_humongous() && bitmap->is_marked(bottom()) && next_addr == (bottom() + cast_to_oop<HeapWord*>(bottom())->size())),
-         "Should stop the scan at the limit or end of humongous object. r %u (%s) ",
-         hrm_index(), get_short_type_str());
+#ifdef ASSERT
+  if (is_starts_humongous() && bitmap->is_marked(bottom())) {
+    HeapWord* humongous_end = bottom() + cast_to_oop(bottom())->size();
+    assert(next_addr == MAX2(limit, humongous_end),
+           "Should stop the scan at limit or end of humongous object. r %u (%s)",
+           hrm_index(), get_short_type_str());
+  } else {
+    assert(next_addr == limit, "Should stop the scan at the limit.");
+  }
+#endif
 }
 
 inline HeapWord* G1HeapRegion::par_allocate(size_t min_word_size,

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -466,28 +466,21 @@ public:
 
     if (part_of_marking) {
       guarantee(r->bottom() != top_at_mark_start,
-                "region %u (%s) does not have TAMS set",
+                "region %u (%s) does not have TAMS set although it's going to be marked through",
                 r->hrm_index(), r->get_short_type_str());
-      size_t marked_bytes = cm->live_bytes(r->hrm_index());
 
       MarkedBytesClosure cl;
       r->apply_to_marked_objects(cm->mark_bitmap(), &cl);
 
+      size_t marked_bytes = cm->live_bytes(r->hrm_index());
       guarantee(cl.marked_bytes() == marked_bytes,
                 "region %u (%s) live bytes actual %zu and cache %zu differ",
                 r->hrm_index(), r->get_short_type_str(), cl.marked_bytes(), marked_bytes);
     } else {
-      guarantee(r->bottom() == top_at_mark_start,
-                "region %u (%s) has TAMS set " PTR_FORMAT " " PTR_FORMAT,
-                r->hrm_index(), r->get_short_type_str(), p2i(r->bottom()), p2i(top_at_mark_start));
-      guarantee(cm->live_bytes(r->hrm_index()) == 0,
-                "region %u (%s) has %zu live bytes recorded",
-                r->hrm_index(), r->get_short_type_str(), cm->live_bytes(r->hrm_index()));
-      guarantee(cm->mark_bitmap()->get_next_marked_addr(r->bottom(), r->end()) == r->end(),
-                "region %u (%s) has mark",
-                r->hrm_index(), r->get_short_type_str());
-      guarantee(cm->is_root_region(r),
-                "region %u (%s) should be root region",
+      // We can't say anything about TAMS or the live bytes here: for reused regions,
+      // both may be set. At least check that there are no marks above TAMS.
+      guarantee(cm->mark_bitmap()->get_next_marked_addr(top_at_mark_start, r->end()) == r->end(),
+                "region %u (%s) has mark from TAMS to top",
                 r->hrm_index(), r->get_short_type_str());
     }
     return false;

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -461,7 +461,7 @@ public:
 
     G1ConcurrentMark* cm = G1CollectedHeap::heap()->concurrent_mark();
 
-    bool part_of_marking = r->is_old_or_humongous() && !r->is_collection_set_candidate();
+    bool part_of_marking = r->is_old_or_humongous() && !r->is_collection_set_candidate() && !cm->is_root_region(r);
     HeapWord* top_at_mark_start = cm->top_at_mark_start(r);
 
     if (part_of_marking) {

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -461,14 +461,14 @@ public:
 
     G1ConcurrentMark* cm = G1CollectedHeap::heap()->concurrent_mark();
 
-    bool part_of_marking = !cm->is_root_region(r);
     HeapWord* top_at_mark_start = cm->top_at_mark_start(r);
 
-    if (part_of_marking) {
-      guarantee(r->bottom() != top_at_mark_start,
-                "region %u (%s) does not have TAMS set although it's going to be marked through",
-                r->hrm_index(), r->get_short_type_str());
-
+    if (r->is_old_or_humongous()) {
+      if (!cm->is_root_region(r)) {
+        guarantee(r->bottom() != top_at_mark_start,
+            "region %u (%s) does not have TAMS set although it's going to be marked through",
+            r->hrm_index(), r->get_short_type_str());
+      }
       MarkedBytesClosure cl;
       r->apply_to_marked_objects(cm->mark_bitmap(), &cl);
 
@@ -476,13 +476,19 @@ public:
       guarantee(cl.marked_bytes() == marked_bytes,
                 "region %u (%s) live bytes actual %zu and cache %zu differ",
                 r->hrm_index(), r->get_short_type_str(), cl.marked_bytes(), marked_bytes);
-    } else {
-      // We can't say anything about TAMS or the live bytes here: for reused regions,
-      // both may be set. At least check that there are no marks above TAMS.
-      guarantee(cm->mark_bitmap()->get_next_marked_addr(top_at_mark_start, r->end()) == r->end(),
-                "region %u (%s) has mark from TAMS to top",
-                r->hrm_index(), r->get_short_type_str());
+    } else if (r->is_young()) {
+      guarantee(r->bottom() == top_at_mark_start,
+                "region %u (%s) has TAMS set " PTR_FORMAT " " PTR_FORMAT,
+                r->hrm_index(), r->get_short_type_str(), p2i(r->bottom()), p2i(top_at_mark_start));
+      guarantee(cm->live_bytes(r->hrm_index()) == 0,
+                "region %u (%s) has %zu live bytes recorded",
+                r->hrm_index(), r->get_short_type_str(), cm->live_bytes(r->hrm_index()));
+      guarantee(cm->is_root_region(r), "must be for %u (%s)", r->hrm_index(), r->get_short_type_str());
     }
+
+    guarantee(cm->mark_bitmap()->get_next_marked_addr(top_at_mark_start, r->end()) == r->end(),
+            "region %u (%s) has mark from TAMS to top",
+            r->hrm_index(), r->get_short_type_str());
     return false;
   }
 };

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -461,7 +461,7 @@ public:
 
     G1ConcurrentMark* cm = G1CollectedHeap::heap()->concurrent_mark();
 
-    bool part_of_marking = r->is_old_or_humongous() && !r->is_collection_set_candidate() && !cm->is_root_region(r);
+    bool part_of_marking = !cm->is_root_region(r);
     HeapWord* top_at_mark_start = cm->top_at_mark_start(r);
 
     if (part_of_marking) {


### PR DESCRIPTION
Hi all,

  please review this fix that fixes some verification that has always been broken, but never(?) actually exeucted. With the upcoming JDK-8381413 it will be executed, and after-gc verification will almost always fail during a concurrent start gc (every time a new old gen region is allocated).

See the CR description for more detail.

Tell me if you think I should just bundle this with JDK-8381413, but it seemed fairly unrelated to me.

Testing: gha, does not fail with upcoming JDK-8381413 any more

Thanks,
  Thomas

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381939](https://bugs.openjdk.org/browse/JDK-8381939): G1: Fix marking state verification at the end of a concurrent start pause (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30654/head:pull/30654` \
`$ git checkout pull/30654`

Update a local copy of the PR: \
`$ git checkout pull/30654` \
`$ git pull https://git.openjdk.org/jdk.git pull/30654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30654`

View PR using the GUI difftool: \
`$ git pr show -t 30654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30654.diff">https://git.openjdk.org/jdk/pull/30654.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30654#issuecomment-4215451545)
</details>
