### PR TITLE
8381985: Shenandoah: allocation rate sample could be wrong in some rare cases

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -829,19 +829,20 @@ double ShenandoahAllocationRate::force_sample(size_t allocated, size_t &unaccoun
   const double MinSampleTime = 0.002;    // Do not sample if time since last update is less than 2 ms
   double now = os::elapsedTime();
   double time_since_last_update = now - _last_sample_time;
+  double rate = 0.0;
   if (time_since_last_update < MinSampleTime) {
     unaccounted_bytes_allocated = allocated - _last_sample_value;
-    _last_sample_value = 0;
-    return 0.0;
   } else {
-    double rate = instantaneous_rate(now, allocated);
+    rate = instantaneous_rate(now, allocated);
     _rate.add(rate);
     _rate_avg.add(_rate.avg());
     _last_sample_time = now;
-    _last_sample_value = allocated;
     unaccounted_bytes_allocated = 0;
-    return rate;
   }
+  // force sample is done before when reset allocated since gc start,
+  // _last_sample_value must be reset 0.
+  _last_sample_value = 0;
+  return rate;
 }
 
 double ShenandoahAllocationRate::sample(size_t allocated) {
@@ -890,9 +891,7 @@ bool ShenandoahAllocationRate::is_spiking(double rate, double threshold) const {
 }
 
 double ShenandoahAllocationRate::instantaneous_rate(double time, size_t allocated) const {
-  size_t last_value = _last_sample_value;
-  double last_time = _last_sample_time;
-  size_t allocation_delta = (allocated > last_value) ? (allocated - last_value) : 0;
-  double time_delta_sec = time - last_time;
-  return (time_delta_sec > 0)  ? (allocation_delta / time_delta_sec) : 0;
+  assert(allocated >= _last_sample_value, "Must be");
+  assert(time > _last_sample_time, "Must be");
+  return (allocated - _last_sample_value) / (time - _last_sample_time);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -831,6 +831,11 @@ double ShenandoahAllocationRate::force_sample(size_t allocated, size_t &unaccoun
   double time_since_last_update = now - _last_sample_time;
   double rate = 0.0;
   if (time_since_last_update < MinSampleTime) {
+    // If we choose not to sample right now, the unaccounted_bytes_allocated will be added
+    // into the next sample taken. These unaccounted_bytes_allocated will be added to
+    // any additional bytes that are allocated during this GC cycle at the time the rate is
+    // next sampled. We do not overwrite _last_sample_time on this path, because the
+    // unaccounted_bytes_allocated were allocated following _last_sample_time.
     unaccounted_bytes_allocated = allocated - _last_sample_value;
   } else {
     rate = instantaneous_rate(now, allocated);
@@ -839,8 +844,12 @@ double ShenandoahAllocationRate::force_sample(size_t allocated, size_t &unaccoun
     _last_sample_time = now;
     unaccounted_bytes_allocated = 0;
   }
-  // force sample is done before when reset allocated since gc start,
-  // _last_sample_value must be reset 0.
+  // force_sample() is called when resetting bytes allocated since gc start. All subsequent
+  // requests to sample allocated bytes during this GC cycle are measured as a delta from
+  // _last_sample_value. In the case that we choose not to sample now, we will count the
+  // unaccounted_bytes_allocated as if they were allocated following the start of this GC
+  // cycle (but the time span over which these bytes were allocated begins at
+  // _last_sample_time, which we do not overwrite).
   _last_sample_value = 0;
   return rate;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -681,8 +681,8 @@ public:
 
   inline size_t get_bytes_allocated_since_previous_sample() {
     const size_t total_bytes_allocated = get_total_bytes_allocated();
-    // Total_bytes_allocated could overflow (wraps around) size_t in rare condition, we are relying on
-    // wrap-around arithmetic of size_t type to produce meaningful results when total_bytes_allocated overflows
+    // total_bytes_allocated could overflow (wraps around) size_t in rare condition, we are relying on
+    // wrap-around arithmetic of size_t type to produce meaningful result when total_bytes_allocated overflows
     // its 64-bit counter. The expression below is equivalent to code:
     // if (total_bytes < _mutator_bytes_at_last_sample) {
     //   return total_bytes + (SIZE_T_MAX - _mutator_bytes_at_last_sample) + 1;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -685,6 +685,7 @@ public:
     // wrap-around arithmetic of size_t type to produce meaningful result when total_bytes_allocated overflows
     // its 64-bit counter. The expression below is equivalent to code:
     // if (total_bytes < _mutator_bytes_at_last_sample) {
+    //   // overflow
     //   return total_bytes + (SIZE_T_MAX - _mutator_bytes_at_last_sample) + 1;
     // } else {
     //   return total_bytes - _mutator_bytes_at_last_sample;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -680,32 +680,17 @@ public:
   }
 
   inline size_t get_bytes_allocated_since_previous_sample() {
-    size_t total_bytes = get_total_bytes_allocated();
-    size_t result;
-    if (total_bytes < _mutator_bytes_at_last_sample) {
-      // This rare condition may occur if bytes allocated overflows (wraps around) size_t tally of allocations.
-      // This may also occur in the very rare situation that get_total_bytes_allocated() is queried in the middle of
-      // reset_bytes_allocated_since_gc_start().  Note that there is no lock to assure that the two global variables
-      // it modifies are modified atomically (_total_bytes_previously_allocated and _mutator_byts_allocated_since_gc_start)
-      // This has been observed to occur when an out-of-cycle degenerated cycle is starting (and thus calls
-      // reset_bytes_allocated_since_gc_start()) at the same time that the control (non-generational mode) or
-      // regulator (generational-mode) thread calls should_start_gc() (which invokes get_bytes_allocated_since_previous_sample()).
-      //
-      // Handle this rare situation by responding with the "innocent" value 0 and resetting internal state so that the
-      // the next query can recalibrate.
-      result = 0;
-    } else {
-      // Note: there's always the possibility that the tally of total allocations exceeds the 64-bit capacity of our size_t
-      // counter.  We assume that the difference between relevant samples does not exceed this count.  Example:
-      //   Suppose _mutator_words_at_last_sample is 0xffff_ffff_ffff_fff0 (18,446,744,073,709,551,600 Decimal)
-      //                        and _total_words is 0x0000_0000_0000_0800 (                    32,768 Decimal)
-      // Then, total_words - _mutator_words_at_last_sample can be done adding 1's complement of subtrahend:
-      //   1's complement of _mutator_words_at_last_sample is: 0x0000_0000_0000_0010 (    16 Decimal))
-      //                                     plus total_words: 0x0000_0000_0000_0800 (32,768 Decimal)
-      //                                                  sum: 0x0000_0000_0000_0810 (32,784 Decimal)
-      result = total_bytes - _mutator_bytes_at_last_sample;
-    }
-    _mutator_bytes_at_last_sample = total_bytes;
+    const size_t total_bytes_allocated = get_total_bytes_allocated();
+    // Total_bytes_allocated could overflow (wraps around) size_t in rare condition, we are relying on
+    // wrap-around arithmetic of size_t type to produce meaningful results when total_bytes_allocated overflows
+    // its 64-bit counter. The expression below is equivalent to code:
+    // if (total_bytes < _mutator_bytes_at_last_sample) {
+    //   return total_bytes + (SIZE_T_MAX - _mutator_bytes_at_last_sample) + 1;
+    // } else {
+    //   return total_bytes - _mutator_bytes_at_last_sample;
+    // }
+    const size_t result = total_bytes_allocated - _mutator_bytes_at_last_sample;
+    _mutator_bytes_at_last_sample = total_bytes_allocated;
     return result;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2315,9 +2315,8 @@ address ShenandoahHeap::in_cset_fast_test_addr() {
 
 void ShenandoahHeap::reset_bytes_allocated_since_gc_start() {
   // It is important to force_alloc_rate_sample() before the associated generation's bytes_allocated has been reset.
-  // Note that there is no lock to prevent additional allocations between sampling bytes_allocated_since_gc_start() and
-  // reset_bytes_allocated_since_gc_start().  If additional allocations happen, they will be ignored in the average
-  // allocation rate computations.  This effect is considered to be negligible.
+  // Note that it holds heap lock to prevent additional allocations between sampling bytes_allocated_since_gc_start()
+  // and reset_bytes_allocated_since_gc_start()
   {
     ShenandoahHeapLocker locker(lock());
     // unaccounted_bytes is the bytes not accounted for by our forced sample.  If the sample interval is too short,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2315,24 +2315,24 @@ address ShenandoahHeap::in_cset_fast_test_addr() {
 
 void ShenandoahHeap::reset_bytes_allocated_since_gc_start() {
   // It is important to force_alloc_rate_sample() before the associated generation's bytes_allocated has been reset.
-  // Note that there is no lock to prevent additional alloations between sampling bytes_allocated_since_gc_start() and
+  // Note that there is no lock to prevent additional allocations between sampling bytes_allocated_since_gc_start() and
   // reset_bytes_allocated_since_gc_start().  If additional allocations happen, they will be ignored in the average
-  // allocation rate computations.  This effect is considered to be be negligible.
-
-  // unaccounted_bytes is the bytes not accounted for by our forced sample.  If the sample interval is too short,
-  // the "forced sample" will not happen, and any recently allocated bytes are "unaccounted for".  We pretend these
-  // bytes are allocated after the start of subsequent gc.
-  size_t unaccounted_bytes;
-  ShenandoahFreeSet* _free_set = free_set();
-  size_t bytes_allocated = _free_set->get_bytes_allocated_since_gc_start();
-  if (mode()->is_generational()) {
-    unaccounted_bytes = young_generation()->heuristics()->force_alloc_rate_sample(bytes_allocated);
-  } else {
-    // Single-gen Shenandoah uses global heuristics.
-    unaccounted_bytes = heuristics()->force_alloc_rate_sample(bytes_allocated);
+  // allocation rate computations.  This effect is considered to be negligible.
+  {
+    ShenandoahHeapLocker locker(lock());
+    // unaccounted_bytes is the bytes not accounted for by our forced sample.  If the sample interval is too short,
+    // the "forced sample" will not happen, and any recently allocated bytes are "unaccounted for".  We pretend these
+    // bytes are allocated after the start of subsequent gc.
+    size_t unaccounted_bytes;
+    size_t bytes_allocated = _free_set->get_bytes_allocated_since_gc_start();
+    if (mode()->is_generational()) {
+      unaccounted_bytes = young_generation()->heuristics()->force_alloc_rate_sample(bytes_allocated);
+    } else {
+      // Single-gen Shenandoah uses global heuristics.
+      unaccounted_bytes = heuristics()->force_alloc_rate_sample(bytes_allocated);
+    }
+    _free_set->reset_bytes_allocated_since_gc_start(unaccounted_bytes);
   }
-  ShenandoahHeapLocker locker(lock());
-  _free_set->reset_bytes_allocated_since_gc_start(unaccounted_bytes);
 }
 
 void ShenandoahHeap::set_degenerated_gc_in_progress(bool in_progress) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2315,7 +2315,7 @@ address ShenandoahHeap::in_cset_fast_test_addr() {
 
 void ShenandoahHeap::reset_bytes_allocated_since_gc_start() {
   // It is important to force_alloc_rate_sample() before the associated generation's bytes_allocated has been reset.
-  // Note that it holds heap lock to prevent additional allocations between sampling bytes_allocated_since_gc_start()
+  // Note that we obtain heap lock to prevent additional allocations between sampling bytes_allocated_since_gc_start()
   // and reset_bytes_allocated_since_gc_start()
   {
     ShenandoahHeapLocker locker(lock());


### PR DESCRIPTION
Hi, 
This PR is to fix the bug where the _last_sample_value is not reset to 0 in the force_sample, which may lead to one wrong rate sample after concurrent GC starts(force_sample is called before concurrent GC starts).

Another sampling related bug in function ShenandoahFreeSet::get_bytes_allocated_since_previous_sample is also fixed, the effect of the bug is same, but caused by the way how we handle size overflow. 

### Test
- [x] jtreg suite hotspot_gc_shenandoah
- [x] GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381985](https://bugs.openjdk.org/browse/JDK-8381985): Shenandoah: allocation rate sample could be wrong in some rare cases (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30661/head:pull/30661` \
`$ git checkout pull/30661`

Update a local copy of the PR: \
`$ git checkout pull/30661` \
`$ git pull https://git.openjdk.org/jdk.git pull/30661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30661`

View PR using the GUI difftool: \
`$ git pr show -t 30661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30661.diff">https://git.openjdk.org/jdk/pull/30661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30661#issuecomment-4218761248)
</details>
