### PR TITLE
8381990: Shenandoah: Create and Use Strong Type HeapWordSize

### DIFF
--- a/src/hotspot/share/utilities/heapSizes.hpp
+++ b/src/hotspot/share/utilities/heapSizes.hpp
@@ -29,41 +29,41 @@
 
 enum class HeapWordUnit : size_t {};
 
-constexpr HeapWordUnit in_HeapWordUnit(size_t size) { return static_cast<HeapWordUnit>(size); }
-constexpr size_t      in_heap_words(HeapWordUnit x)  { return static_cast<size_t>(x); }
+constexpr HeapWordUnit in_HeapWordUnit(size_t size)      { return static_cast<HeapWordUnit>(size); }
+constexpr size_t       in_heap_words(HeapWordUnit x)     { return static_cast<size_t>(x); }
 
-constexpr HeapWordUnit operator + (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) + in_heap_words(y)); }
-constexpr HeapWordUnit operator - (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) - in_heap_words(y)); }
-constexpr HeapWordUnit operator * (HeapWordUnit x, size_t      y) { return in_HeapWordUnit(in_heap_words(x) * y          ); }
-constexpr HeapWordUnit operator / (HeapWordUnit x, size_t      y) { return in_HeapWordUnit(in_heap_words(x) / y          ); }
+constexpr HeapWordUnit operator +  (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) + in_heap_words(y)); }
+constexpr HeapWordUnit operator -  (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) - in_heap_words(y)); }
+constexpr HeapWordUnit operator *  (HeapWordUnit x, size_t       y) { return in_HeapWordUnit(in_heap_words(x) * y               ); }
+constexpr HeapWordUnit operator /  (HeapWordUnit x, size_t       y) { return in_HeapWordUnit(in_heap_words(x) / y               ); }
 
-constexpr bool     operator == (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) == in_heap_words(y); }
-constexpr bool     operator != (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) != in_heap_words(y); }
-constexpr bool     operator > (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) > in_heap_words(y); }
-constexpr bool     operator >= (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) >= in_heap_words(y); }
-constexpr bool     operator < (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) < in_heap_words(y); }
-constexpr bool     operator <= (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) <= in_heap_words(y); }
+constexpr bool operator == (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) == in_heap_words(y); }
+constexpr bool operator != (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) != in_heap_words(y); }
+constexpr bool operator >  (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) >  in_heap_words(y); }
+constexpr bool operator >= (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) >= in_heap_words(y); }
+constexpr bool operator <  (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) <  in_heap_words(y); }
+constexpr bool operator <= (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) <= in_heap_words(y); }
 
-// Heap byte is nothing special than a byte. It's really ByteSize has been extensively used and it's back by a smaller
-// type, int, which is too small for heap bytes usage, so just prepend the Heap to the name.
+// HeapByteUnit is a strongly-typed byte size for the heap. ByteSize (from sizes.hpp)
+// is backed by int, which is too small for heap-scale byte counts.
 enum class HeapByteUnit : size_t {};
 
-constexpr HeapByteUnit  in_HeapByteUnit(size_t size)  { return static_cast<HeapByteUnit>(size); }
-constexpr size_t        in_heap_bytes(HeapByteUnit x)  { return static_cast<size_t>(x); }
+constexpr HeapByteUnit in_HeapByteUnit(size_t size)      { return static_cast<HeapByteUnit>(size); }
+constexpr size_t       in_heap_bytes(HeapByteUnit x)     { return static_cast<size_t>(x); }
 
-constexpr HeapByteUnit operator + (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) + in_heap_bytes(y)); }
-constexpr HeapByteUnit operator - (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) - in_heap_bytes(y)); }
-constexpr HeapByteUnit operator * (HeapByteUnit x, size_t      y) { return in_HeapByteUnit(in_heap_bytes(x) * y          ); }
-constexpr HeapByteUnit operator / (HeapByteUnit x, size_t      y) { return in_HeapByteUnit(in_heap_bytes(x) / y          ); }
+constexpr HeapByteUnit operator +  (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) + in_heap_bytes(y)); }
+constexpr HeapByteUnit operator -  (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) - in_heap_bytes(y)); }
+constexpr HeapByteUnit operator *  (HeapByteUnit x, size_t       y) { return in_HeapByteUnit(in_heap_bytes(x) * y               ); }
+constexpr HeapByteUnit operator /  (HeapByteUnit x, size_t       y) { return in_HeapByteUnit(in_heap_bytes(x) / y               ); }
 
-constexpr bool     operator == (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) == in_heap_bytes(y); }
-constexpr bool     operator != (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) != in_heap_bytes(y); }
-constexpr bool     operator > (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) > in_heap_bytes(y); }
-constexpr bool     operator >= (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) >= in_heap_bytes(y); }
-constexpr bool     operator < (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) < in_heap_bytes(y); }
-constexpr bool     operator <= (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) <= in_heap_bytes(y); }
+constexpr bool operator == (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) == in_heap_bytes(y); }
+constexpr bool operator != (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) != in_heap_bytes(y); }
+constexpr bool operator >  (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) >  in_heap_bytes(y); }
+constexpr bool operator >= (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) >= in_heap_bytes(y); }
+constexpr bool operator <  (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) <  in_heap_bytes(y); }
+constexpr bool operator <= (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) <= in_heap_bytes(y); }
 
-constexpr HeapByteUnit to_HeapByteUnit(HeapWordUnit x) { return in_HeapByteUnit(in_heap_words(x) * HeapWordSize); }
-constexpr HeapWordUnit to_HeapWordUnit(HeapByteUnit x) { return in_HeapWordUnit(in_heap_bytes(x) / HeapWordSize); }
+constexpr HeapByteUnit to_HeapByteUnit(HeapWordUnit x)   { return in_HeapByteUnit(in_heap_words(x) * HeapWordSize); }
+constexpr HeapWordUnit to_HeapWordUnit(HeapByteUnit x)   { return in_HeapWordUnit(in_heap_bytes(x) / HeapWordSize); }
 
 #endif // SHARE_UTILITIES_HEAP_SIZES_HPP

--- a/src/hotspot/share/utilities/heapSizes.hpp
+++ b/src/hotspot/share/utilities/heapSizes.hpp
@@ -35,9 +35,14 @@ constexpr size_t      in_heap_words(HeapWordUnit x)  { return static_cast<size_t
 constexpr HeapWordUnit operator + (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) + in_heap_words(y)); }
 constexpr HeapWordUnit operator - (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) - in_heap_words(y)); }
 constexpr HeapWordUnit operator * (HeapWordUnit x, size_t      y) { return in_HeapWordUnit(in_heap_words(x) * y          ); }
+constexpr HeapWordUnit operator / (HeapWordUnit x, size_t      y) { return in_HeapWordUnit(in_heap_words(x) / y          ); }
 
-constexpr bool     operator == (HeapWordUnit x, size_t     y) { return in_heap_words(x) == y; }
-constexpr bool     operator != (HeapWordUnit x, size_t     y) { return in_heap_words(x) != y; }
+constexpr bool     operator == (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) == in_heap_words(y); }
+constexpr bool     operator != (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) != in_heap_words(y); }
+constexpr bool     operator > (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) > in_heap_words(y); }
+constexpr bool     operator >= (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) >= in_heap_words(y); }
+constexpr bool     operator < (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) < in_heap_words(y); }
+constexpr bool     operator <= (HeapWordUnit x, HeapWordUnit     y) { return in_heap_words(x) <= in_heap_words(y); }
 
 // Heap byte is nothing special than a byte. It's really ByteSize has been extensively used and it's back by a smaller
 // type, int, which is too small for heap bytes usage, so just prepend the Heap to the name.
@@ -49,9 +54,14 @@ constexpr size_t        in_heap_bytes(HeapByteUnit x)  { return static_cast<size
 constexpr HeapByteUnit operator + (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) + in_heap_bytes(y)); }
 constexpr HeapByteUnit operator - (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) - in_heap_bytes(y)); }
 constexpr HeapByteUnit operator * (HeapByteUnit x, size_t      y) { return in_HeapByteUnit(in_heap_bytes(x) * y          ); }
+constexpr HeapByteUnit operator / (HeapByteUnit x, size_t      y) { return in_HeapByteUnit(in_heap_bytes(x) / y          ); }
 
-constexpr bool     operator == (HeapByteUnit x, size_t     y) { return in_heap_bytes(x) == y; }
-constexpr bool     operator != (HeapByteUnit x, size_t     y) { return in_heap_bytes(x) != y; }
+constexpr bool     operator == (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) == in_heap_bytes(y); }
+constexpr bool     operator != (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) != in_heap_bytes(y); }
+constexpr bool     operator > (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) > in_heap_bytes(y); }
+constexpr bool     operator >= (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) >= in_heap_bytes(y); }
+constexpr bool     operator < (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) < in_heap_bytes(y); }
+constexpr bool     operator <= (HeapByteUnit x, HeapByteUnit     y) { return in_heap_bytes(x) <= in_heap_bytes(y); }
 
 constexpr HeapByteUnit to_HeapByteUnit(HeapWordUnit x) { return in_HeapByteUnit(in_heap_words(x) * HeapWordSize); }
 constexpr HeapWordUnit to_HeapWordUnit(HeapByteUnit x) { return in_HeapWordUnit(in_heap_bytes(x) / HeapWordSize); }

--- a/src/hotspot/share/utilities/heapSizes.hpp
+++ b/src/hotspot/share/utilities/heapSizes.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_HEAP_SIZES_HPP
+#define SHARE_UTILITIES_HEAP_SIZES_HPP
+
+#include "utilities/globalDefinitions.hpp"
+
+enum class HeapWordUnit : size_t {};
+
+constexpr HeapWordUnit in_HeapWordUnit(size_t size) { return static_cast<HeapWordUnit>(size); }
+constexpr size_t      in_heap_words(HeapWordUnit x)  { return static_cast<size_t>(x); }
+
+constexpr HeapWordUnit operator + (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) + in_heap_words(y)); }
+constexpr HeapWordUnit operator - (HeapWordUnit x, HeapWordUnit y) { return in_HeapWordUnit(in_heap_words(x) - in_heap_words(y)); }
+constexpr HeapWordUnit operator * (HeapWordUnit x, size_t      y) { return in_HeapWordUnit(in_heap_words(x) * y          ); }
+
+constexpr bool     operator == (HeapWordUnit x, size_t     y) { return in_heap_words(x) == y; }
+constexpr bool     operator != (HeapWordUnit x, size_t     y) { return in_heap_words(x) != y; }
+
+// Heap byte is nothing special than a byte. It's really ByteSize has been extensively used and it's back by a smaller
+// type, int, which is too small for heap bytes usage, so just prepend the Heap to the name.
+enum class HeapByteUnit : size_t {};
+
+constexpr HeapByteUnit  in_HeapByteUnit(size_t size)  { return static_cast<HeapByteUnit>(size); }
+constexpr size_t        in_heap_bytes(HeapByteUnit x)  { return static_cast<size_t>(x); }
+
+constexpr HeapByteUnit operator + (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) + in_heap_bytes(y)); }
+constexpr HeapByteUnit operator - (HeapByteUnit x, HeapByteUnit y) { return in_HeapByteUnit(in_heap_bytes(x) - in_heap_bytes(y)); }
+constexpr HeapByteUnit operator * (HeapByteUnit x, size_t      y) { return in_HeapByteUnit(in_heap_bytes(x) * y          ); }
+
+constexpr bool     operator == (HeapByteUnit x, size_t     y) { return in_heap_bytes(x) == y; }
+constexpr bool     operator != (HeapByteUnit x, size_t     y) { return in_heap_bytes(x) != y; }
+
+constexpr HeapByteUnit to_HeapByteUnit(HeapWordUnit x) { return in_HeapByteUnit(in_heap_words(x) * HeapWordSize); }
+constexpr HeapWordUnit to_HeapWordUnit(HeapByteUnit x) { return in_HeapWordUnit(in_heap_bytes(x) / HeapWordSize); }
+
+#endif // SHARE_UTILITIES_HEAP_SIZES_HPP

--- a/src/hotspot/share/utilities/heapSizes.hpp
+++ b/src/hotspot/share/utilities/heapSizes.hpp
@@ -37,6 +37,9 @@ constexpr HeapWordUnit operator -  (HeapWordUnit x, HeapWordUnit y) { return in_
 constexpr HeapWordUnit operator *  (HeapWordUnit x, size_t       y) { return in_HeapWordUnit(in_heap_words(x) * y               ); }
 constexpr HeapWordUnit operator /  (HeapWordUnit x, size_t       y) { return in_HeapWordUnit(in_heap_words(x) / y               ); }
 
+inline HeapWordUnit& operator += (HeapWordUnit& x, HeapWordUnit y) { return x = x + y; }
+inline HeapWordUnit& operator -= (HeapWordUnit& x, HeapWordUnit y) { return x = x - y; }
+
 constexpr bool operator == (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) == in_heap_words(y); }
 constexpr bool operator != (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) != in_heap_words(y); }
 constexpr bool operator >  (HeapWordUnit x, HeapWordUnit y) { return in_heap_words(x) >  in_heap_words(y); }
@@ -62,6 +65,9 @@ constexpr bool operator >  (HeapByteUnit x, HeapByteUnit y) { return in_heap_byt
 constexpr bool operator >= (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) >= in_heap_bytes(y); }
 constexpr bool operator <  (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) <  in_heap_bytes(y); }
 constexpr bool operator <= (HeapByteUnit x, HeapByteUnit y) { return in_heap_bytes(x) <= in_heap_bytes(y); }
+
+inline HeapByteUnit& operator += (HeapByteUnit& x, HeapByteUnit y) { return x = x + y; }
+inline HeapByteUnit& operator -= (HeapByteUnit& x, HeapByteUnit y) { return x = x - y; }
 
 constexpr HeapByteUnit to_HeapByteUnit(HeapWordUnit x)   { return in_HeapByteUnit(in_heap_words(x) * HeapWordSize); }
 constexpr HeapWordUnit to_HeapWordUnit(HeapByteUnit x)   { return in_HeapWordUnit(in_heap_bytes(x) / HeapWordSize); }


### PR DESCRIPTION
Code sharing purpose. Not ready for a final review yet.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381990](https://bugs.openjdk.org/browse/JDK-8381990): Shenandoah: Create and Use Strong Type HeapWordSize (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30662/head:pull/30662` \
`$ git checkout pull/30662`

Update a local copy of the PR: \
`$ git checkout pull/30662` \
`$ git pull https://git.openjdk.org/jdk.git pull/30662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30662`

View PR using the GUI difftool: \
`$ git pr show -t 30662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30662.diff">https://git.openjdk.org/jdk/pull/30662.diff</a>

</details>
