### PR TITLE
8381991: LotsOfEntries.java should skip when inotify max_user_watches limit is hit

### DIFF
--- a/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,8 @@
  * @bug 8330077
  * @summary Tests WatchService behavior with more entries in a watched directory
  *     than the default event limit
- * @library ..
+ * @library .. /test/lib
+ * @build jtreg.SkippedException
  * @run main/othervm LotsOfEntries 600 fail
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=invalid LotsOfEntries 600 fail
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=-5 LotsOfEntries 5 fail
@@ -35,13 +36,28 @@
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=3000000000 LotsOfEntries 600 pass
  */
 
-import java.nio.file.*;
 import static java.nio.file.StandardWatchEventKinds.*;
-import java.util.*;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import jtreg.SkippedException;
+
 public class LotsOfEntries {
+
+    /** LinuxWatchService message when fs.inotify.max_user_watches is exhausted. */
+    private static final String INOTIFY_WATCH_LIMIT_MSG =
+            "User limit of inotify watches reached";
 
     static void testCreateLotsOfEntries(Path dir, int numEvents, boolean fail) throws Exception {
         try (WatchService watcher = FileSystems.getDefault().newWatchService()) {
@@ -113,6 +129,11 @@ public class LotsOfEntries {
         boolean fail = args[1].equals("fail");
         try {
             testCreateLotsOfEntries(dir, numEvents, fail);
+        } catch (IOException e) {
+            if (INOTIFY_WATCH_LIMIT_MSG.equals(e.getMessage())) {
+                throw new SkippedException(e.getMessage(), e);
+            }
+            throw e;
         } finally {
             TestUtil.removeAll(dir);
         }


### PR DESCRIPTION
Hi all,

On Linux, hitting fs.inotify.max_user_watches causes LinuxWatchService to throw IOException with message "java.io.IOException: User limit of inotify watches reached". Currently the test will report failure in this situation, I think it's environmental issue. So it's better to catch the "java.io.IOException: User limit of inotify watches reached" and throw jtreg.SkippedException rather than report test failure.

Change has been verified locally on linux-x64, both with fs.inotify.max_user_watches hausted and fs.inotify.max_user_watches sufficient.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381991](https://bugs.openjdk.org/browse/JDK-8381991): LotsOfEntries.java should skip when inotify max_user_watches limit is hit (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30663/head:pull/30663` \
`$ git checkout pull/30663`

Update a local copy of the PR: \
`$ git checkout pull/30663` \
`$ git pull https://git.openjdk.org/jdk.git pull/30663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30663`

View PR using the GUI difftool: \
`$ git pr show -t 30663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30663.diff">https://git.openjdk.org/jdk/pull/30663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30663#issuecomment-4219855617)
</details>
