### PR TITLE
8381937: Make exceptions in Java_sun_security_mscapi_CKeyPairGenerator generateCKeyPair more specific

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1375,7 +1375,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_mscapi_CKeyPairGenerator_00024RSA_ge
                 PROV_RSA_FULL,
                 CRYPT_NEWKEYSET) == FALSE)
             {
-                ThrowException(env, KEY_EXCEPTION, GetLastError());
+                ThrowExceptionWithMessageAndErrcode(env, KEY_EXCEPTION, "CryptAcquireContext failure", GetLastError());
                 __leave;
             }
         }
@@ -1387,7 +1387,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_mscapi_CKeyPairGenerator_00024RSA_ge
            dwFlags,
            &hKeyPair) == FALSE)
         {
-            ThrowException(env, KEY_EXCEPTION, GetLastError());
+            ThrowExceptionWithMessageAndErrcode(env, KEY_EXCEPTION, "CryptGenKey failure", GetLastError());
             __leave;
         }
 


### PR DESCRIPTION
Currently in some specific Windows environment, I run into this error/exception (test sun/security/mscapi/EncodingMutability.java) :
java.security.ProviderException: java.security.KeyException: error 2, The system cannot find the file specified.

```
at jdk.crypto.mscapi/sun.security.mscapi.CKeyPairGenerator$RSA.generateKeyPair(CKeyPairGenerator.java:126)
at java.base/java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:723)
at EncodingMutability.main(EncodingMutability.java:38)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:335)
at java.base/java.lang.Thread.run(Thread.java:1527)
Caused by: java.security.KeyException: error 2, The system cannot find the file specified.

at jdk.crypto.mscapi/sun.security.mscapi.CKeyPairGenerator$RSA.generateCKeyPair(Native Method)
at jdk.crypto.mscapi/sun.security.mscapi.CKeyPairGenerator$RSA.generateKeyPair(CKeyPairGenerator.java:121)
```

Unfortunately in the native generateCKeyPair method we get only the GetLastError output in the exception text. It would be better to also get a hint about the failing method CryptAcquireContext or CryptGenKey.
For this we could use the existing helper ThrowExceptionWithMessageAndErrcode .

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381937](https://bugs.openjdk.org/browse/JDK-8381937): Make exceptions in Java_sun_security_mscapi_CKeyPairGenerator generateCKeyPair more specific (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30666/head:pull/30666` \
`$ git checkout pull/30666`

Update a local copy of the PR: \
`$ git checkout pull/30666` \
`$ git pull https://git.openjdk.org/jdk.git pull/30666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30666`

View PR using the GUI difftool: \
`$ git pr show -t 30666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30666.diff">https://git.openjdk.org/jdk/pull/30666.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30666#issuecomment-4222981871)
</details>
