### PR TITLE
8179187: Misleading compilation error on annotated fully-qualified classname

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5270,11 +5270,15 @@ public class Attr extends JCTree.Visitor {
 
     public void visitAnnotatedType(JCAnnotatedType tree) {
         attribAnnotationTypes(tree.annotations, env);
-        Type underlyingType = attribType(tree.underlyingType, env);
-        Type annotatedType = underlyingType.preannotatedType();
+        Type underlyingType = attribTree(tree.underlyingType, env, resultInfo);
+        if (underlyingType.getTag() == PACKAGE) {
+            result = tree.type = underlyingType;
+        } else {
+            Type annotatedType = underlyingType.preannotatedType();
 
-        annotate.annotateTypeSecondStage(tree, tree.annotations, annotatedType);
-        result = tree.type = annotatedType;
+            annotate.annotateTypeSecondStage(tree, tree.annotations, annotatedType);
+            result = tree.type = annotatedType;
+        }
     }
 
     public void visitErroneous(JCErroneous tree) {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotatePackages.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotatePackages.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8026564 8043226 8334055
+ * @bug 8026564 8043226 8334055 8179187
  * @summary The parts of a fully-qualified type can't be annotated.
  * @author Werner Dietl
  * @compile/fail/ref=CantAnnotatePackages.out -XDrawDiagnostics CantAnnotatePackages.java

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotatePackages.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotatePackages.out
@@ -1,5 +1,5 @@
-CantAnnotatePackages.java:16:14: compiler.err.cant.resolve.location: kindname.class, java, , , (compiler.misc.location: kindname.class, CantAnnotatePackages, null)
-CantAnnotatePackages.java:17:9: compiler.err.cant.resolve.location: kindname.class, lang, , , (compiler.misc.location: kindname.package, java, null)
-CantAnnotatePackages.java:18:14: compiler.err.cant.resolve.location: kindname.class, lang, , , (compiler.misc.location: kindname.package, java, null)
 CantAnnotatePackages.java:14:18: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), java.lang, @TA java.lang.Object
+CantAnnotatePackages.java:16:14: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), java.lang, @TA java.lang.Object
+CantAnnotatePackages.java:17:9: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), java.lang, @TA java.lang.Object
+CantAnnotatePackages.java:18:14: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), java.lang, @TA java.lang.Object
 4 errors

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateScoping.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateScoping.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8006733 8006775 8043226 8334055
+ * @bug 8006733 8006775 8043226 8334055 8179187
  * @summary Ensure behavior for nested types is correct.
  * @author Werner Dietl
  * @compile/fail/ref=CantAnnotateScoping.out -XDrawDiagnostics CantAnnotateScoping.java

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateScoping.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateScoping.out
@@ -1,12 +1,13 @@
-CantAnnotateScoping.java:63:9: compiler.err.cant.resolve.location: kindname.class, lang, , , (compiler.misc.location: kindname.package, java, null)
-CantAnnotateScoping.java:68:9: compiler.err.cant.resolve.location: kindname.class, XXX, , , (compiler.misc.location: kindname.package, java, null)
-CantAnnotateScoping.java:71:9: compiler.err.cant.resolve.location: kindname.class, lang, , , (compiler.misc.location: kindname.package, java, null)
+CantAnnotateScoping.java:68:18: compiler.err.doesnt.exist: java.XXX
 CantAnnotateScoping.java:38:14: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), Test.Outer, @TA Test.Outer.SInner
 CantAnnotateScoping.java:51:18: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), java.lang, @TA java.lang.Object
 CantAnnotateScoping.java:60:37: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation: @TA,@TA2), java.lang, @DTA @TA @TA2 java.lang.Object
 CantAnnotateScoping.java:40:14: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), Test.Outer, @TA Test.Outer.SInner
+CantAnnotateScoping.java:63:11: compiler.err.annotation.type.not.applicable.to.type: DA
+CantAnnotateScoping.java:68:11: compiler.err.annotation.type.not.applicable.to.type: DA
+CantAnnotateScoping.java:71:9: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), java.lang, @TA java.lang.Object
 CantAnnotateScoping.java:44:34: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation: @TA,@TA2), Test.Outer, @TA @TA2 Test.Outer.SInner
 CantAnnotateScoping.java:44:25: compiler.err.annotation.type.not.applicable.to.type: DA
 CantAnnotateScoping.java:48:38: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @TA), Test.Outer, @TA Test.Outer.SInner
 CantAnnotateScoping.java:48:34: compiler.err.annotation.type.not.applicable.to.type: DA
-11 errors
+12 errors


### PR DESCRIPTION
Consider the following code snippet:
```
import java.lang.annotation.*;
import java.util.List;

class Test {
    @TA java.lang.Object f1;
    List<@TA java.lang.Object> f2;
}

@Target(ElementType.TYPE_USE)
@interface TA { }
```
While the error reported for the line with the `f1` declaration correctly mentions the root case of the problem which is an incorrectly placed type annotation
```
Test.java:5: error: type annotation @TA is not expected here
    @TA java.lang.Object of1;
                 ^
  (to annotate a qualified type, write java.lang.@TA Object)
```
the error reported for the similar problem on the line with the `f2` declaration is different and quite misleading
```
Test.java:6: error: cannot find symbol
    List<@TA java.lang.Object> f2;
             ^
  symbol:   class java
  location: class Test
```
Closer observation shows that the correct error message would be reported also for the later line but its printing is suppressed due to existing error already printed on the same position.

The proposal here is:
Prevent reporting of the `ResolveError` while attributing the `JCAnnotatedType.underlayingType` (by not strictly requiring the attribution result to be a type) and allow for a better error message to be displayed later when validating annotations.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8179187](https://bugs.openjdk.org/browse/JDK-8179187): Misleading compilation error on annotated fully-qualified classname (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30672/head:pull/30672` \
`$ git checkout pull/30672`

Update a local copy of the PR: \
`$ git checkout pull/30672` \
`$ git pull https://git.openjdk.org/jdk.git pull/30672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30672`

View PR using the GUI difftool: \
`$ git pr show -t 30672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30672.diff">https://git.openjdk.org/jdk/pull/30672.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30672#issuecomment-4222497156)
</details>
