### PR TITLE
8382018: test/jdk/java/nio/file/spi/SetDefaultProvider.java leaves a directory in /tmp

### DIFF
--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -61,9 +61,5 @@ public class Main {
 
         // exercise the file type detector
         String fileType = Files.probeContentType(Path.of("."));
-
-        // Cleanup in tempdir
-        Files.deleteIfExists(foo);
-        Files.deleteIfExists(dir);
     }
 }

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -41,7 +41,7 @@ public class Main {
             throw new RuntimeException("FileSystemProvider not overridden");
 
         // exercise the file system
-        Path dir = Files.createTempDirectory("tmp");
+        Path dir = Files.createTempDirectory(Path.of(""), "tmp");
         if (dir.getFileSystem() != fs)
             throw new RuntimeException("'dir' not in default file system");
         System.out.println("created: " + dir);

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -61,5 +61,9 @@ public class Main {
 
         // exercise the file type detector
         String fileType = Files.probeContentType(Path.of("."));
+
+        // Cleanup in tempdir
+        Files.deleteIfExists(foo);
+        Files.deleteIfExists(dir);
     }
 }


### PR DESCRIPTION
The test leaves SetDefaultProvider leaves a directory in /tmp that contains a file named "foo". 
We can simply clean this directory and file after executing the test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382018](https://bugs.openjdk.org/browse/JDK-8382018): test/jdk/java/nio/file/spi/SetDefaultProvider.java leaves a directory in /tmp (**Enhancement** - P5)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [e30eb713](https://git.openjdk.org/jdk/pull/30674/files/e30eb7138e1bc9e6bee14f4854708867eccb91c0)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30674/head:pull/30674` \
`$ git checkout pull/30674`

Update a local copy of the PR: \
`$ git checkout pull/30674` \
`$ git pull https://git.openjdk.org/jdk.git pull/30674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30674`

View PR using the GUI difftool: \
`$ git pr show -t 30674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30674.diff">https://git.openjdk.org/jdk/pull/30674.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30674#issuecomment-4224227110)
</details>
