### PR TITLE
8380105: Test vmTestbase/nsk/jdi/ThreadReference/ownedMonitorsAndFrames/ownedMonitorsAndFrames003/ownedMonitorsAndFrames003.java failed

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1902,7 +1902,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
     // An event could have been enabled after notification, in this case
     // a thread will have TS_ENTER state and posting the event may hit a suspension point.
     // From a debugging perspective, it is more important to have no missing events.
-    if (interruptible && JvmtiExport::should_post_monitor_waited() && node.TState != ObjectWaiter::TS_ENTER) {
+    if (interruptible && node.TState != ObjectWaiter::TS_ENTER) {
 
       // Process suspend requests now if any, before posting the event.
       {

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1902,7 +1902,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
     // An event could have been enabled after notification, in this case
     // a thread will have TS_ENTER state and posting the event may hit a suspension point.
     // From a debugging perspective, it is more important to have no missing events.
-    if (interruptible && node.TState != ObjectWaiter::TS_ENTER) {
+    if (interruptible && JvmtiExport::should_post_monitor_waited() && node.TState != ObjectWaiter::TS_ENTER) {
 
       // Process suspend requests now if any, before posting the event.
       {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/locks/LockingThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/locks/LockingThread.java
@@ -442,7 +442,7 @@ public class LockingThread extends Thread {
                     try {
                         // This is to prevent a case when the LockingThread parks inside of wait(0) below BEFORE
                         // the main thread executes _ParkEvent->unpark() in JavaThread::interrupt().
-                        Thread.sleep(500);
+                        Thread.sleep(100);
                     } catch (InterruptedException e) {
                     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/locks/LockingThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/locks/LockingThread.java
@@ -439,6 +439,13 @@ public class LockingThread extends Thread {
                     // but to be sure that LockingThread have reached required state method waitState() should be called
                     // and this method waits when LockingThred change state to 'Thread.State.WAITING'
 
+                    try {
+                        // This is to prevent a case when the LockingThread parks inside of wait(0) below BEFORE
+                        // the main thread executes _ParkEvent->unpark() in JavaThread::interrupt().
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                    }
+
                     while (relinquishMonitor)
                         relinquishedMonitor.wait(0);
 


### PR DESCRIPTION
Hi, please consider the following changes:

There is a race in the test: `LockingThread` might already park in the `wait(0)` call before the main thread executes `_ParkEvent->unpark()` in `JavaThread::interrupt()`. The interrupt call will also have the side effect of waking up `LockingThread` from the `wait(0)` call. As a result, the main thread is able to acquire the monitor first (in `waitState()`), and then proceed to wait for the next debugger command (which will be the breakpoint that forces suspension). However, a suspended thread is not supposed to be allowed to acquire a monitor.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380105](https://bugs.openjdk.org/browse/JDK-8380105): Test vmTestbase/nsk/jdi/ThreadReference/ownedMonitorsAndFrames/ownedMonitorsAndFrames003/ownedMonitorsAndFrames003.java failed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30676/head:pull/30676` \
`$ git checkout pull/30676`

Update a local copy of the PR: \
`$ git checkout pull/30676` \
`$ git pull https://git.openjdk.org/jdk.git pull/30676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30676`

View PR using the GUI difftool: \
`$ git pr show -t 30676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30676.diff">https://git.openjdk.org/jdk/pull/30676.diff</a>

</details>
