### PR TITLE
8380636: Add static asserts for mirrored library constants

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -40,6 +40,8 @@
 // Inlined from <linux/magic.h> for portability.
 #ifndef CGROUP2_SUPER_MAGIC
 #  define CGROUP2_SUPER_MAGIC 0x63677270
+#else
+  STATIC_ASSERT(CGROUP2_SUPER_MAGIC == 0x63677270);
 #endif
 
 // controller names have to match the *_IDX indices


### PR DESCRIPTION
A trivial change to ensure the in-lined macro definition doesn't silently change. Thoughts?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380636](https://bugs.openjdk.org/browse/JDK-8380636): Add static asserts for mirrored library constants (**Bug** - P3)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30678/head:pull/30678` \
`$ git checkout pull/30678`

Update a local copy of the PR: \
`$ git checkout pull/30678` \
`$ git pull https://git.openjdk.org/jdk.git pull/30678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30678`

View PR using the GUI difftool: \
`$ git pr show -t 30678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30678.diff">https://git.openjdk.org/jdk/pull/30678.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30678#issuecomment-4224795885)
</details>
