### PR TITLE
8381842: Refactor remaining TestNG tests under java/net/ to use JUnit

### DIFF
--- a/test/jdk/java/net/DatagramPacket/Constructor.java
+++ b/test/jdk/java/net/DatagramPacket/Constructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,19 @@
  * @bug 4091803 7021373
  * @summary this tests that the constructor of DatagramPacket rejects
  *          bogus arguments properly.
- * @run testng Constructor
+ * @run junit ${test.main.class}
  */
 
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Constructor {
 
@@ -48,35 +49,33 @@ public class Constructor {
 
     @Test
     public void testNullPacket() {
-        expectThrows(NPE,
+        assertThrows(NPE,
                 () -> new DatagramPacket(null, 100));
     }
     @Test
     public void testNull() throws Exception {
-        expectThrows(NPE, () -> new DatagramPacket(null, 100));
-        expectThrows(NPE, () -> new DatagramPacket(null, 0, 10));
-        expectThrows(NPE, () -> new DatagramPacket(null, 0, 10, LOOPBACK, 80));
-        expectThrows(NPE, () -> new DatagramPacket(null, 10, LOOPBACK, 80));
-        expectThrows(NPE, () -> new DatagramPacket(null, 0, 10, new InetSocketAddress(80)));
-        expectThrows(NPE, () -> new DatagramPacket(null, 10, new InetSocketAddress(80)));
+        assertThrows(NPE, () -> new DatagramPacket(null, 100));
+        assertThrows(NPE, () -> new DatagramPacket(null, 0, 10));
+        assertThrows(NPE, () -> new DatagramPacket(null, 0, 10, LOOPBACK, 80));
+        assertThrows(NPE, () -> new DatagramPacket(null, 10, LOOPBACK, 80));
+        assertThrows(NPE, () -> new DatagramPacket(null, 0, 10, new InetSocketAddress(80)));
+        assertThrows(NPE, () -> new DatagramPacket(null, 10, new InetSocketAddress(80)));
 
         // no Exception expected for null addresses
-        new DatagramPacket(buf, 10, null, 0);
-        new DatagramPacket(buf, 10, 10, null, 0);
+        assertDoesNotThrow(() -> new DatagramPacket(buf, 10, null, 0));
+        assertDoesNotThrow(() -> new DatagramPacket(buf, 10, 10, null, 0));
     }
 
     @Test
     public void testNegativeBufferLength() {
         /* length lesser than buffer length */
-        expectThrows(IAE,
-                () -> new DatagramPacket(buf, -128));
+        assertThrows(IAE, () -> new DatagramPacket(buf, -128));
     }
 
     @Test
     public void testPacketLengthTooLarge() {
         /* length greater than buffer length */
-        expectThrows(IAE,
-                () -> new DatagramPacket(buf, 256));
+        assertThrows(IAE, () -> new DatagramPacket(buf, 256));
     }
 
     @Test
@@ -84,14 +83,14 @@ public class Constructor {
         /* negative port */
         InetAddress addr = InetAddress.getLocalHost();
 
-        expectThrows(IAE,
+        assertThrows(IAE,
                 () -> new DatagramPacket(buf, 100, addr, -1));
     }
 
     @Test
     public void testPortValueTooLarge() {
         /* invalid port value */
-        expectThrows(IAE,
+        assertThrows(IAE,
                 () -> new DatagramPacket(buf, 128, LOOPBACK, Integer.MAX_VALUE));
     }
 
@@ -101,8 +100,9 @@ public class Constructor {
         int length = 50;
         DatagramPacket pkt = new DatagramPacket(buf, offset, length);
 
-        assertFalse((pkt.getData() != buf || pkt.getOffset() != offset ||
-                pkt.getLength() != length), "simple constructor failed");
+        assertSame(buf, pkt.getData());
+        assertEquals(offset, pkt.getOffset());
+        assertEquals(length, pkt.getLength());
     }
 
     @Test
@@ -112,20 +112,21 @@ public class Constructor {
         int port = 8080;
         DatagramPacket packet = new DatagramPacket(buf, offset, length, LOOPBACK, port);
 
-        assertFalse((packet.getData() != buf || packet.getOffset() != offset ||
-                packet.getLength() != length ||
-                packet.getAddress() != LOOPBACK ||
-                packet.getPort() != port), "full constructor failed");
+        assertSame(buf, packet.getData());
+        assertEquals(offset, packet.getOffset());
+        assertEquals(length, packet.getLength());
+        assertSame(LOOPBACK, packet.getAddress());
+        assertEquals(port, packet.getPort());
     }
 
     @Test
     public void testDefaultValues() {
         DatagramPacket packet = new DatagramPacket(buf, 0);
-        assertTrue(packet.getAddress() == null);
-        assertTrue(packet.getPort() == 0);
+        assertNull(packet.getAddress());
+        assertEquals(0, packet.getPort());
 
         DatagramPacket packet1 = new DatagramPacket(buf, 0, 0);
-        assertTrue(packet1.getAddress() == null);
-        assertTrue(packet1.getPort() == 0);
+        assertNull(packet1.getAddress());
+        assertEquals(0, packet1.getPort());
     }
 }

--- a/test/jdk/java/net/DatagramPacket/Getters.java
+++ b/test/jdk/java/net/DatagramPacket/Getters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +24,15 @@
 /* @test
  * @bug 8237890
  * @summary Check that DatagramPacket's get methods perform as expected
- * @run testng Getters
+ * @run junit ${test.main.class}
  */
-
-import org.testng.annotations.Test;
 
 import java.net.DatagramPacket;
 import java.net.InetSocketAddress;
 
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Getters {
 
@@ -42,6 +42,6 @@ public class Getters {
         InetSocketAddress addr = (InetSocketAddress)packet.getSocketAddress();
 
         assertTrue(addr.getAddress().isAnyLocalAddress());
-        assertTrue(addr.getPort() == 0);
+        assertEquals(0, addr.getPort());
     }
 }

--- a/test/jdk/java/net/DatagramPacket/Setters.java
+++ b/test/jdk/java/net/DatagramPacket/Setters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,18 @@
  * @bug 7021373
  * @summary check that the DatagramPacket setter methods
  *          throw the correct exceptions
- * @run testng Setters
+ * @run junit ${test.main.class}
  */
 
 
 import java.net.DatagramPacket;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Setters {
 
@@ -53,8 +54,7 @@ public class Setters {
         assertTrue(pkt.getAddress() == null);
     }
 
-    @DataProvider
-    Object[][] data() { // add checks for setAddress with null - add getAddress to verify
+    static Object[][] data() { // add checks for setAddress with null - add getAddress to verify
         return new Object[][]{
                 { buf,          0,      -1,     IAE  },
                 { buf,          -1,     1,      IAE  },
@@ -66,24 +66,24 @@ public class Setters {
         };
     }
 
-    @Test(dataProvider = "data")
+    @ParameterizedTest
+    @MethodSource("data")
     public void testSetData(byte[] buf,
                             int offset,
                             int length,
                             Class<? extends Exception> exception) {
         DatagramPacket pkt = new DatagramPacket(new byte[8], 8);
 
+
         if (exception != null) {
-            expectThrows(exception, () -> pkt.setData(buf, offset, length));
-        } else if (buf == null) {
-            expectThrows(exception, () -> pkt.setData(buf));
+            assertThrows(exception, () -> pkt.setData(buf, offset, length));
+            if (buf == null) assertThrows(exception, () -> pkt.setData(buf));
         } else {
-            pkt.setData(buf, offset, length);
+            assertDoesNotThrow(() -> pkt.setData(buf, offset, length));
         }
     }
 
-    @DataProvider
-    Object[][] lengths() {
+    static Object[][] lengths() {
         return new Object[][]{
                 { 0,     -1,     IAE  },
                 { 8,     1,      IAE  },
@@ -94,20 +94,20 @@ public class Setters {
         };
     }
 
-    @Test(dataProvider = "lengths")
+    @ParameterizedTest
+    @MethodSource("lengths")
     public void testSetLength(int offset, int length,
                               Class<? extends Exception> exception) {
         DatagramPacket pkt = new DatagramPacket(new byte[8], offset, 0);
 
         if (exception != null) {
-            expectThrows(exception, () -> pkt.setLength(length));
+            assertThrows(exception, () -> pkt.setLength(length));
         } else {
-            pkt.setLength(length);
+            assertDoesNotThrow(() -> pkt.setLength(length));
         }
     }
 
-    @DataProvider
-    Object[][] ports() {
+    static Object[][] ports() {
         return new Object[][]{
                 { -1,                IAE  },
                 { -666,              IAE  },
@@ -122,14 +122,15 @@ public class Setters {
         };
     }
 
-    @Test(dataProvider = "ports")
+    @ParameterizedTest
+    @MethodSource("ports")
     public void testSetPort(int port, Class<? extends Exception> exception) {
         DatagramPacket pkt = new DatagramPacket(new byte[8], 0);
 
         if (exception != null) {
-            expectThrows(exception, () -> pkt.setPort(port));
+            assertThrows(exception, () -> pkt.setPort(port));
         } else {
-            pkt.setPort(port);
+            assertDoesNotThrow(() -> pkt.setPort(port));
         }
     }
 }

--- a/test/jdk/java/net/DatagramPacket/Setters.java
+++ b/test/jdk/java/net/DatagramPacket/Setters.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -51,7 +52,7 @@ public class Setters {
 
         // No Exception expected for null addresses
         pkt.setAddress(null);
-        assertTrue(pkt.getAddress() == null);
+        assertNull(pkt.getAddress());
     }
 
     static Object[][] data() { // add checks for setAddress with null - add getAddress to verify

--- a/test/jdk/java/net/InetAddress/HostsFileOrderingTest.java
+++ b/test/jdk/java/net/InetAddress/HostsFileOrderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,9 @@ import java.util.stream.Stream;
 
 import jdk.test.lib.net.IPSupport;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import org.testng.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /* @test
@@ -46,23 +46,23 @@ import org.testng.Assert;
  * @summary Test that "jdk.net.hosts.file" NameService implementation returns addresses
  *          with respect to "java.net.preferIPv4Stack" and "java.net.preferIPv6Addresses" system
  *          property values
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=true HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=system HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=notVALID HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=false HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=system HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt
- *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=notVALID HostsFileOrderingTest
- * @run testng/othervm -Djdk.net.hosts.file=TestHostsFile.txt HostsFileOrderingTest
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=true ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=system ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=notVALID ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=false ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=system ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt
+ *    -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=notVALID ${test.main.class}
+ * @run junit/othervm -Djdk.net.hosts.file=TestHostsFile.txt ${test.main.class}
  */
 
 public class HostsFileOrderingTest {
@@ -70,8 +70,8 @@ public class HostsFileOrderingTest {
     /*
      * Generate hosts file with the predefined list of IP addresses
      */
-    @BeforeClass
-    public void generateHostsFile() throws Exception {
+    @BeforeAll
+    public static void generateHostsFile() throws Exception {
         String content = ADDRESSES_LIST.stream()
                 .map(addr -> addr + " " + TEST_HOST_NAME)
                 .collect(
@@ -97,7 +97,7 @@ public class HostsFileOrderingTest {
         } else {
             System.err.printf("Expected addresses:%n%s%n", Arrays.deepToString(expectedAddresses));
             System.err.printf("Resolved addresses:%n%s%n", Arrays.deepToString(resolvedAddresses));
-            Assert.fail("Wrong host resolution result is returned");
+            fail("Wrong host resolution result is returned");
         }
     }
 

--- a/test/jdk/java/net/InetSocketAddress/ToString.java
+++ b/test/jdk/java/net/InetSocketAddress/ToString.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ToString {
@@ -85,12 +87,13 @@ public class ToString {
     }
 
     @Test
-    // InetSocketAddress.toString() throws NPE with unresolved address
     public void NPETest() {
-        System.out.println(new InetSocketAddress("unresolved", 12345));
+        // Test that InetSocketAddress.toString() does not throw NPE with unresolved address
+        assertDoesNotThrow(() -> System.out.println(
+                new InetSocketAddress("unresolved", 12345)));
     }
 
-    public static Object[][] createArgs1() {
+    public static Object[][] fromHostStringAndPort() {
         return new Object[][]{
                 // hostname, port number, expected string in format
                 // <hostname>/<IP literal>:<port> or
@@ -107,37 +110,33 @@ public class ToString {
     }
 
     @ParameterizedTest
-    @MethodSource("createArgs1")
+    @MethodSource("fromHostStringAndPort")
     public void testConstructor(String host, int port, String string) {
         String received = new InetSocketAddress(host, port).toString();
         assertEquals(string, received);
     }
 
-    public static Object[][] createArgs2() {
+    public static Object[][] fromInetAddressAndPort() throws UnknownHostException {
         InetAddress nullAddr = null;
-        try {
-            return new Object[][]{
-                    // InetAddress, port number, expected string
-                    {InetAddress.getLoopbackAddress(), 80, "localhost/" + loopbackAddr + ":80"},
-                    {InetAddress.getLocalHost(), 80, localAddr + ":80"},
-                    {InetAddress.getByAddress(new byte[]{1, 1, 1, 1}), 80, "/1.1.1.1:80"},
-                    {InetAddress.getByAddress(new byte[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}), 80, "/[101:101:101:101:101:101:101:101]:80"},
-                    {InetAddress.getByName("225.225.225.0"), 80, "/225.225.225.0:80"},
-                    {nullAddr, 80, wildcardAddr + ":80"}
-            };
-        } catch (UnknownHostException uhe) {
-            throw new RuntimeException("Data provider creation failed: " + uhe, uhe);
-        }
+        return new Object[][]{
+                // InetAddress, port number, expected string
+                {InetAddress.getLoopbackAddress(), 80, "localhost/" + loopbackAddr + ":80"},
+                {InetAddress.getLocalHost(), 80, localAddr + ":80"},
+                {InetAddress.getByAddress(new byte[]{1, 1, 1, 1}), 80, "/1.1.1.1:80"},
+                {InetAddress.getByAddress(new byte[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}), 80, "/[101:101:101:101:101:101:101:101]:80"},
+                {InetAddress.getByName("225.225.225.0"), 80, "/225.225.225.0:80"},
+                {nullAddr, 80, wildcardAddr + ":80"}
+        };
     }
 
     @ParameterizedTest
-    @MethodSource("createArgs2")
+    @MethodSource("fromInetAddressAndPort")
     public void testConstructor(InetAddress addr, int port, String string) {
         String received = new InetSocketAddress(addr, port).toString();
         assertEquals(string, received);
     }
 
-    public static Object[][] createArgs3() {
+    public static Object[][] unresolvedFromHostStringAndPort() {
         return new Object[][]{
                 // hostname, port number, expected string
                 {"::1", 80, "::1/<unresolved>:80"},
@@ -153,7 +152,7 @@ public class ToString {
     }
 
     @ParameterizedTest
-    @MethodSource("createArgs3")
+    @MethodSource("unresolvedFromHostStringAndPort")
     public void testCreateUnresolved(String host, int port, String string) {
         String received = InetSocketAddress.createUnresolved(host, port).toString();
         assertEquals(string, received);

--- a/test/jdk/java/net/InetSocketAddress/ToString.java
+++ b/test/jdk/java/net/InetSocketAddress/ToString.java
@@ -26,20 +26,24 @@
  * @bug 8225499 4464064
  * @library /test/lib
  * @summary InetSocketAddress::toString not friendly to IPv6 literal addresses
- * @run testng/othervm ToString
- * @run testng/othervm -Djava.net.preferIPv4Stack=true ToString
- * @run testng/othervm -Djava.net.preferIPv6Addresses=true ToString
+ * @run junit/othervm ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv6Addresses=true ${test.main.class}
  */
 
-import java.net.*;
-import java.util.Optional;
-
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 
 import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ToString {
 
@@ -75,22 +79,18 @@ public class ToString {
         }
     }
 
-    @BeforeTest
-    public void setup() {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
     }
 
     @Test
     // InetSocketAddress.toString() throws NPE with unresolved address
-    public static void NPETest() {
+    public void NPETest() {
         System.out.println(new InetSocketAddress("unresolved", 12345));
     }
 
-    @DataProvider(name = "hostPortArgs")
-    public Object[][] createArgs1() {
+    public static Object[][] createArgs1() {
         return new Object[][]{
                 // hostname, port number, expected string in format
                 // <hostname>/<IP literal>:<port> or
@@ -106,17 +106,14 @@ public class ToString {
         };
     }
 
-    @Test(dataProvider = "hostPortArgs")
-    public static void testConstructor(String host, int port, String string) {
+    @ParameterizedTest
+    @MethodSource("createArgs1")
+    public void testConstructor(String host, int port, String string) {
         String received = new InetSocketAddress(host, port).toString();
-
-        if (!string.equals(received)) {
-            throw new RuntimeException("Expected: " + string + " Received: " + received);
-        }
+        assertEquals(string, received);
     }
 
-    @DataProvider(name = "addrPortArgs")
-    public Object[][] createArgs2() {
+    public static Object[][] createArgs2() {
         InetAddress nullAddr = null;
         try {
             return new Object[][]{
@@ -133,17 +130,14 @@ public class ToString {
         }
     }
 
-    @Test(dataProvider = "addrPortArgs")
-    public static void testConstructor(InetAddress addr, int port, String string) {
+    @ParameterizedTest
+    @MethodSource("createArgs2")
+    public void testConstructor(InetAddress addr, int port, String string) {
         String received = new InetSocketAddress(addr, port).toString();
-
-        if (!string.equals(received)) {
-            throw new RuntimeException("Expected: " + string + " Received: " + received);
-        }
+        assertEquals(string, received);
     }
 
-    @DataProvider(name = "unresolved")
-    public Object[][] createArgs3() {
+    public static Object[][] createArgs3() {
         return new Object[][]{
                 // hostname, port number, expected string
                 {"::1", 80, "::1/<unresolved>:80"},
@@ -158,12 +152,10 @@ public class ToString {
         };
     }
 
-    @Test(dataProvider = "unresolved")
-    public static void testCreateUnresolved(String host, int port, String string) {
+    @ParameterizedTest
+    @MethodSource("createArgs3")
+    public void testCreateUnresolved(String host, int port, String string) {
         String received = InetSocketAddress.createUnresolved(host, port).toString();
-
-        if (!string.equals(received)) {
-            throw new RuntimeException("Expected: " + string + " Received: " + received);
-        }
+        assertEquals(string, received);
     }
 }

--- a/test/jdk/java/net/NetworkInterface/NullMacAddress.java
+++ b/test/jdk/java/net/NetworkInterface/NullMacAddress.java
@@ -26,34 +26,30 @@
  * @summary Test that querrying the mac address of the loopback interface
  *          returns null and doesn't throw a SocketException.
  * @library /test/lib
- * @run testng/othervm NullMacAddress
- * @run testng/othervm -Djava.net.preferIPv6Addresses=true NullMacAddress
- * @run testng/othervm -Djava.net.preferIPv4Stack=true NullMacAddress
+ * @run junit/othervm ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv6Addresses=true ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
 
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
-import static org.testng.Assert.*;
 
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.Locale;
-import java.util.Optional;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 public class NullMacAddress {
 
-    @BeforeTest
-    void setup() {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
     }
 
     @Test
@@ -64,13 +60,13 @@ public class NullMacAddress {
     private void testMacAddress(NetworkInterface ni) {
         try {
             var name = ni.getDisplayName();
-            System.out.println("Testing: " + name);
+            System.err.println("Testing: " + name);
             var loopback = ni.isLoopback();
             var macAddress = ni.getHardwareAddress();
             var hdr = macAddress == null ? "null"
                     : "0x" + new BigInteger(1, macAddress)
                     .toString(16).toUpperCase(Locale.ROOT);
-            System.out.println("   MAC address: " + hdr + (loopback ? " (loopback)" : ""));
+            System.err.println("   MAC address: " + hdr + (loopback ? " (loopback)" : ""));
             if (loopback) {
                 assertNull(macAddress, "Loopback interface \""
                         + name + "\" doesn't have a null MAC Address");

--- a/test/jdk/java/net/SocketOption/AfterClose.java
+++ b/test/jdk/java/net/SocketOption/AfterClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,11 @@
  * @test
  * @bug 8224477
  * @summary Ensures that IOException is thrown after the socket is closed
- * @run testng AfterClose
+ * @run junit ${test.main.class}
  */
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.net.DatagramSocket;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
@@ -48,11 +47,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.Boolean.*;
 import static java.net.StandardSocketOptions.*;
-import static org.testng.Assert.expectThrows;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AfterClose {
 
@@ -117,8 +117,7 @@ public class AfterClose {
 
     // -- Socket
 
-    @DataProvider(name = "socketOptionValues")
-    public Object[][] socketOptionValues() throws Exception {
+    public static Object[][] socketOptionValues() throws Exception {
         try (Socket s = new Socket()) {
             return s.supportedOptions().stream()
                     .map(so -> new Object[] {so, OPTION_VALUES_MAP.get(so)})
@@ -126,49 +125,51 @@ public class AfterClose {
         }
     }
 
-    @Test(dataProvider = "socketOptionValues")
+    @ParameterizedTest
+    @MethodSource("socketOptionValues")
     public <T> void closedSocketImplUncreated(SocketOption<T> option, List<T> values)
         throws IOException
     {
         Socket socket = createClosedSocketImplUncreated();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                expectThrows(IOE, () -> socket.setOption(option, value));
-                expectThrows(IOE, () -> socket.getOption(option));
+                assertThrows(IOE, () -> socket.setOption(option, value));
+                assertThrows(IOE, () -> socket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "socketOptionValues")
+    @ParameterizedTest
+    @MethodSource("socketOptionValues")
     public <T> void closedSocketImplCreated(SocketOption<T> option, List<T> values)
         throws IOException
     {
         Socket socket = createClosedSocketImplCreated();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                expectThrows(IOE, () -> socket.setOption(option, value));
-                expectThrows(IOE, () -> socket.getOption(option));
+                assertThrows(IOE, () -> socket.setOption(option, value));
+                assertThrows(IOE, () -> socket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "socketOptionValues")
+    @ParameterizedTest
+    @MethodSource("socketOptionValues")
     public <T> void closedSocketAdapter(SocketOption<T> option, List<T> values)
         throws IOException
     {
         Socket socket = createClosedSocketFromAdapter();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> socket.setOption(option, value));
-                expectThrows(IOE, () -> socket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> socket.setOption(option, value));
+                assertThrows(IOE, () -> socket.getOption(option));
             }
         }
     }
 
     // -- ServerSocket
 
-    @DataProvider(name = "serverSocketOptionValues")
-    public Object[][] serverSocketOptionValues() throws Exception {
+    public static Object[][] serverSocketOptionValues() throws Exception {
         try (ServerSocket ss = new ServerSocket()) {
             return ss.supportedOptions().stream()
                      .map(so -> new Object[] {so, OPTION_VALUES_MAP.get(so)})
@@ -176,33 +177,36 @@ public class AfterClose {
         }
     }
 
-    @Test(dataProvider = "serverSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("serverSocketOptionValues")
     public <T> void closedServerSocketImplUncreated(SocketOption<T> option, List<T> values)
         throws IOException
     {
         ServerSocket serverSocket = createClosedServerSocketImplUncreated();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                expectThrows(IOE, () -> serverSocket.setOption(option, value));
-                expectThrows(IOE, () -> serverSocket.getOption(option));
+                assertThrows(IOE, () -> serverSocket.setOption(option, value));
+                assertThrows(IOE, () -> serverSocket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "serverSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("serverSocketOptionValues")
     public <T> void closedServerSocketImplCreated(SocketOption<T> option, List<T> values)
         throws IOException
     {
         ServerSocket serverSocket = createClosedServerSocketImplCreated();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                expectThrows(IOE, () -> serverSocket.setOption(option, value));
-                expectThrows(IOE, () -> serverSocket.getOption(option));
+                assertThrows(IOE, () -> serverSocket.setOption(option, value));
+                assertThrows(IOE, () -> serverSocket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "serverSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("serverSocketOptionValues")
     public <T> void closedServerSocketAdapter(SocketOption<T> option, List<T> values)
         throws IOException
     {
@@ -212,16 +216,15 @@ public class AfterClose {
         ServerSocket serverSocket = createClosedServerSocketFromAdapter();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> serverSocket.setOption(option, value));
-                expectThrows(IOE, () -> serverSocket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> serverSocket.setOption(option, value));
+                assertThrows(IOE, () -> serverSocket.getOption(option));
             }
         }
     }
 
     // -- DatagramSocket
 
-    @DataProvider(name = "datagramSocketOptionValues")
-    public Object[][] datagramSocketOptionValues() throws Exception {
+    public static Object[][] datagramSocketOptionValues() throws Exception {
         try (DatagramSocket ds = new DatagramSocket()) {
             return ds.supportedOptions().stream()
                      .map(so -> new Object[] {so, OPTION_VALUES_MAP.get(so)})
@@ -229,49 +232,51 @@ public class AfterClose {
         }
     }
 
-    @Test(dataProvider = "datagramSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("datagramSocketOptionValues")
     public <T> void closedUnboundDatagramSocket(SocketOption<T> option, List<T> values)
         throws IOException
     {
         DatagramSocket datagramSocket = createClosedUnboundDatagramSocket();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> datagramSocket.setOption(option, value));
-                expectThrows(IOE, () -> datagramSocket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> datagramSocket.setOption(option, value));
+                assertThrows(IOE, () -> datagramSocket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "datagramSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("datagramSocketOptionValues")
     public <T> void closedBoundDatagramSocket(SocketOption<T> option, List<T> values)
         throws IOException
     {
         DatagramSocket datagramSocket = createClosedBoundDatagramSocket();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> datagramSocket.setOption(option, value));
-                expectThrows(IOE, () -> datagramSocket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> datagramSocket.setOption(option, value));
+                assertThrows(IOE, () -> datagramSocket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "datagramSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("datagramSocketOptionValues")
     public <T> void closedDatagramAdapter(SocketOption<T> option, List<T> values)
         throws IOException
     {
         DatagramSocket datagramSocket = createClosedBoundDatagramSocket();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> datagramSocket.setOption(option, value));
-                expectThrows(IOE, () -> datagramSocket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> datagramSocket.setOption(option, value));
+                assertThrows(IOE, () -> datagramSocket.getOption(option));
             }
         }
     }
 
     // -- MulticastSocket
 
-    @DataProvider(name = "multicastSocketOptionValues")
-    public Object[][] multicastSocketOptionValues() throws Exception {
+    public static Object[][] multicastSocketOptionValues() throws Exception {
         try (MulticastSocket ms = new MulticastSocket()) {
             return ms.supportedOptions().stream()
                      .map(so -> new Object[] {so, OPTION_VALUES_MAP.get(so)})
@@ -279,28 +284,30 @@ public class AfterClose {
         }
     }
 
-    @Test(dataProvider = "multicastSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("multicastSocketOptionValues")
     public <T> void closedUnboundMulticastSocket(SocketOption<T> option, List<T> values)
         throws IOException
     {
         MulticastSocket multicastSocket = createClosedUnboundMulticastSocket();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> multicastSocket.setOption(option, value));
-                expectThrows(IOE, () -> multicastSocket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> multicastSocket.setOption(option, value));
+                assertThrows(IOE, () -> multicastSocket.getOption(option));
             }
         }
     }
 
-    @Test(dataProvider = "multicastSocketOptionValues")
+    @ParameterizedTest
+    @MethodSource("multicastSocketOptionValues")
     public <T> void closedBoundMulticastSocket(SocketOption<T> option, List<T> values)
         throws IOException
     {
         MulticastSocket multicastSocket = createClosedBoundMulticastSocket();
         for (int i=0; i<3; i++); {
             for (T value : values) {
-                if (!RO.equals(value)) expectThrows(IOE, () -> multicastSocket.setOption(option, value));
-                expectThrows(IOE, () -> multicastSocket.getOption(option));
+                if (!RO.equals(value)) assertThrows(IOE, () -> multicastSocket.setOption(option, value));
+                assertThrows(IOE, () -> multicastSocket.getOption(option));
             }
         }
     }

--- a/test/jdk/java/net/SocketOption/CachedImplOptions.java
+++ b/test/jdk/java/net/SocketOption/CachedImplOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8241988
  * @summary Checks that the caching of options does not affect other impls
- * @run testng/othervm CachedImplOptions
- * @run testng/othervm -Djava.net.preferIPv4Stack=true CachedImplOptions
+ * @run junit/othervm ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
 
 import java.io.IOException;
@@ -46,8 +46,11 @@ import java.net.SocketImpl;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.util.Set;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CachedImplOptions {
 
@@ -58,16 +61,16 @@ public class CachedImplOptions {
             assertTrue(impl.supportedOptions().contains(StandardSocketOptions.SO_SNDBUF));
         }
         try (var impl = new DatagramSocket(new FooDatagramSocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(FooDatagramSocketImpl.FOO_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(FooDatagramSocketImpl.FOO_OPTION));
+            assertEquals(Set.of(FooDatagramSocketImpl.FOO_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(FooDatagramSocketImpl.FOO_OPTION), impl.supportedOptions());
         }
         try (var impl = new DatagramSocket(new BarDatagramSocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(BarDatagramSocketImpl.BAR_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(BarDatagramSocketImpl.BAR_OPTION));
+            assertEquals(Set.of(BarDatagramSocketImpl.BAR_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(BarDatagramSocketImpl.BAR_OPTION), impl.supportedOptions());
         }
         try (var impl = new DatagramSocket(new BazDatagramSocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(BazDatagramSocketImpl.BAZ_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(BazDatagramSocketImpl.BAZ_OPTION));
+            assertEquals(Set.of(BazDatagramSocketImpl.BAZ_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(BazDatagramSocketImpl.BAZ_OPTION), impl.supportedOptions());
         }
         try (var impl = new DatagramSocket()) {
             assertTrue(impl.supportedOptions().contains(StandardSocketOptions.SO_SNDBUF));
@@ -86,8 +89,8 @@ public class CachedImplOptions {
         DatagramSocket.setDatagramSocketImplFactory(() -> new FooDatagramSocketImpl());
 
         try (var impl = new MulticastSocket()) {
-            assertEquals(impl.supportedOptions(), Set.of(FooDatagramSocketImpl.FOO_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(FooDatagramSocketImpl.FOO_OPTION));
+            assertEquals(Set.of(FooDatagramSocketImpl.FOO_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(FooDatagramSocketImpl.FOO_OPTION), impl.supportedOptions());
         }
     }
 
@@ -144,16 +147,16 @@ public class CachedImplOptions {
             assertTrue(impl.supportedOptions().contains(StandardSocketOptions.SO_SNDBUF));
         }
         try (var impl = new Socket(new LarrySocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(LarrySocketImpl.LARRY_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(LarrySocketImpl.LARRY_OPTION));
+            assertEquals(Set.of(LarrySocketImpl.LARRY_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(LarrySocketImpl.LARRY_OPTION), impl.supportedOptions());
         }
         try (var impl = new Socket(new CurlySocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(CurlySocketImpl.CURLY_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(CurlySocketImpl.CURLY_OPTION));
+            assertEquals(Set.of(CurlySocketImpl.CURLY_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(CurlySocketImpl.CURLY_OPTION), impl.supportedOptions());
         }
         try (var impl = new Socket(new MoeSocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(MoeSocketImpl.MOE_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(MoeSocketImpl.MOE_OPTION));
+            assertEquals(Set.of(MoeSocketImpl.MOE_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(MoeSocketImpl.MOE_OPTION), impl.supportedOptions());
         }
         try (var impl = new Socket()) {
             assertTrue(impl.supportedOptions().contains(StandardSocketOptions.SO_SNDBUF));
@@ -168,16 +171,16 @@ public class CachedImplOptions {
             assertTrue(impl.supportedOptions().contains(StandardSocketOptions.SO_RCVBUF));
         }
         try (var impl = new ServerSocket(new LarrySocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(LarrySocketImpl.LARRY_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(LarrySocketImpl.LARRY_OPTION));
+            assertEquals(Set.of(LarrySocketImpl.LARRY_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(LarrySocketImpl.LARRY_OPTION), impl.supportedOptions());
         }
         try (var impl = new ServerSocket(new CurlySocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(CurlySocketImpl.CURLY_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(CurlySocketImpl.CURLY_OPTION));
+            assertEquals(Set.of(CurlySocketImpl.CURLY_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(CurlySocketImpl.CURLY_OPTION), impl.supportedOptions());
         }
         try (var impl = new ServerSocket(new MoeSocketImpl()) {}) {
-            assertEquals(impl.supportedOptions(), Set.of(MoeSocketImpl.MOE_OPTION));
-            assertEquals(impl.supportedOptions(), Set.of(MoeSocketImpl.MOE_OPTION));
+            assertEquals(Set.of(MoeSocketImpl.MOE_OPTION), impl.supportedOptions());
+            assertEquals(Set.of(MoeSocketImpl.MOE_OPTION), impl.supportedOptions());
         }
         try (var impl = new ServerSocket()) {
             assertTrue(impl.supportedOptions().contains(StandardSocketOptions.SO_RCVBUF));

--- a/test/jdk/java/net/SocketOption/ImmutableOptions.java
+++ b/test/jdk/java/net/SocketOption/ImmutableOptions.java
@@ -26,69 +26,83 @@
  * @bug 8148609
  * @library /test/lib
  * @summary Assert that the set of socket options are immutable
- * @run testng/othervm ImmutableOptions
- * @run testng/othervm -Djava.net.preferIPv4Stack=true ImmutableOptions
+ * @run junit/othervm ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.*;
-import java.util.Optional;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.DatagramSocketImpl;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketImpl;
+import java.net.SocketImplFactory;
+import java.net.SocketOption;
 import java.util.Set;
-
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
 
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class ImmutableOptions {
 
-    @BeforeTest
-    void setupServerSocketFactory() throws IOException {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setupServerSocketFactory() throws IOException {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
         ServerSocket.setSocketFactory(new ServerSocketImplFactory());
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void socketThrows() throws IOException {
         CustomSocketImpl impl = new CustomSocketImpl();
         Socket socket = new CustomSocket(impl);
-        socket.supportedOptions().clear();
+        assertThrows(UnsupportedOperationException.class,
+                () -> socket.supportedOptions().clear());
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void socketImplThrows() throws IOException {
         CustomSocketImpl impl = new CustomSocketImpl();
-        impl.supportedOptions().clear();
+        assertThrows(UnsupportedOperationException.class,
+                () -> impl.supportedOptions().clear());
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void serverSocketThrows() throws IOException {
         ServerSocket ss = new ServerSocket();
-        ss.supportedOptions().clear();
+        assertThrows(UnsupportedOperationException.class,
+                () -> ss.supportedOptions().clear());
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void serverSocketImplThrows() throws IOException {
         ServerSocket ss = new ServerSocket();
-        ServerSocketImplFactory.mostRecentlyCreated.supportedOptions().clear();
+        assertThrows(UnsupportedOperationException.class,
+                () -> ServerSocketImplFactory.mostRecentlyCreated.supportedOptions().clear());
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void datagramSocketThrows() throws IOException {
         CustomDatagramSocketImpl impl = new CustomDatagramSocketImpl();
         DatagramSocket socket = new CustomDatagramSocket(impl);
-        socket.supportedOptions().clear();
+        assertThrows(UnsupportedOperationException.class,
+                () -> socket.supportedOptions().clear());
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void datagramSocketImplThrows() throws IOException {
         CustomDatagramSocketImpl impl = new CustomDatagramSocketImpl();
-        impl.supportedOptions().clear();
+        assertThrows(UnsupportedOperationException.class,
+                () -> impl.supportedOptions().clear());
     }
 
 

--- a/test/jdk/java/net/SocketOption/ImmutableOptions.java
+++ b/test/jdk/java/net/SocketOption/ImmutableOptions.java
@@ -72,8 +72,8 @@ public class ImmutableOptions {
     @Test
     public void socketImplThrows() throws IOException {
         CustomSocketImpl impl = new CustomSocketImpl();
-        assertThrows(UnsupportedOperationException.class,
-                () -> impl.supportedOptions().clear());
+        var options = impl.supportedOptions();
+        assertThrows(UnsupportedOperationException.class, options::clear);
     }
 
     @Test

--- a/test/jdk/java/net/SocketOption/ImmutableOptions.java
+++ b/test/jdk/java/net/SocketOption/ImmutableOptions.java
@@ -65,8 +65,8 @@ public class ImmutableOptions {
     public void socketThrows() throws IOException {
         CustomSocketImpl impl = new CustomSocketImpl();
         Socket socket = new CustomSocket(impl);
-        assertThrows(UnsupportedOperationException.class,
-                () -> socket.supportedOptions().clear());
+        Set<SocketOption<?>> options = socket.supportedOptions();
+        assertThrows(UnsupportedOperationException.class, options::clear);
     }
 
     @Test
@@ -79,30 +79,31 @@ public class ImmutableOptions {
     @Test
     public void serverSocketThrows() throws IOException {
         ServerSocket ss = new ServerSocket();
-        assertThrows(UnsupportedOperationException.class,
-                () -> ss.supportedOptions().clear());
+        Set<SocketOption<?>> options = ss.supportedOptions();
+        assertThrows(UnsupportedOperationException.class, options::clear);
     }
 
     @Test
     public void serverSocketImplThrows() throws IOException {
         ServerSocket ss = new ServerSocket();
-        assertThrows(UnsupportedOperationException.class,
-                () -> ServerSocketImplFactory.mostRecentlyCreated.supportedOptions().clear());
+        Set<SocketOption<?>> options =
+                ServerSocketImplFactory.mostRecentlyCreated.supportedOptions();
+        assertThrows(UnsupportedOperationException.class, options::clear);
     }
 
     @Test
     public void datagramSocketThrows() throws IOException {
         CustomDatagramSocketImpl impl = new CustomDatagramSocketImpl();
         DatagramSocket socket = new CustomDatagramSocket(impl);
-        assertThrows(UnsupportedOperationException.class,
-                () -> socket.supportedOptions().clear());
+        Set<SocketOption<?>> options = socket.supportedOptions();
+        assertThrows(UnsupportedOperationException.class, options::clear);
     }
 
     @Test
     public void datagramSocketImplThrows() throws IOException {
         CustomDatagramSocketImpl impl = new CustomDatagramSocketImpl();
-        assertThrows(UnsupportedOperationException.class,
-                () -> impl.supportedOptions().clear());
+        Set<SocketOption<?>> options = impl.supportedOptions();
+        assertThrows(UnsupportedOperationException.class, options::clear);
     }
 
 

--- a/test/jdk/java/net/SocketOption/NullsAndBadValues.java
+++ b/test/jdk/java/net/SocketOption/NullsAndBadValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8224477
  * @summary Basic test for NPE, UOE, and IAE for get/setOption
- * @run testng NullsAndBadValues
- * @run testng/othervm -Dsun.net.useExclusiveBind=false NullsAndBadValues
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Dsun.net.useExclusiveBind=false ${test.main.class}
  */
 
 import java.net.DatagramSocket;
@@ -43,11 +43,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.Boolean.*;
 import static java.net.StandardSocketOptions.*;
-import static org.testng.Assert.expectThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NullsAndBadValues {
 
@@ -58,46 +60,46 @@ public class NullsAndBadValues {
     @Test
     public void nulls() throws Exception {
         try (Socket s = new Socket()) {
-            expectThrows(NPE, () -> s.setOption(null, null));
-            expectThrows(NPE, () -> s.setOption(null, ""));
-            expectThrows(NPE, () -> s.setOption(null, 1));
-            expectThrows(NPE, () -> s.getOption(null));
+            assertThrows(NPE, () -> s.setOption(null, null));
+            assertThrows(NPE, () -> s.setOption(null, ""));
+            assertThrows(NPE, () -> s.setOption(null, 1));
+            assertThrows(NPE, () -> s.getOption(null));
         }
         try (ServerSocket ss = new ServerSocket()) {
-            expectThrows(NPE, () -> ss.setOption(null, null));
-            expectThrows(NPE, () -> ss.setOption(null, ""));
-            expectThrows(NPE, () -> ss.setOption(null, 1));
-            expectThrows(NPE, () -> ss.getOption(null));
+            assertThrows(NPE, () -> ss.setOption(null, null));
+            assertThrows(NPE, () -> ss.setOption(null, ""));
+            assertThrows(NPE, () -> ss.setOption(null, 1));
+            assertThrows(NPE, () -> ss.getOption(null));
         }
         try (DatagramSocket ds = new DatagramSocket()) {
-            expectThrows(NPE, () -> ds.setOption(null, null));
-            expectThrows(NPE, () -> ds.setOption(null, ""));
-            expectThrows(NPE, () -> ds.setOption(null, 1));
-            expectThrows(NPE, () -> ds.getOption(null));
+            assertThrows(NPE, () -> ds.setOption(null, null));
+            assertThrows(NPE, () -> ds.setOption(null, ""));
+            assertThrows(NPE, () -> ds.setOption(null, 1));
+            assertThrows(NPE, () -> ds.getOption(null));
         }
         try (MulticastSocket ms = new MulticastSocket()) {
-            expectThrows(NPE, () -> ms.setOption(null, null));
-            expectThrows(NPE, () -> ms.setOption(null, ""));
-            expectThrows(NPE, () -> ms.setOption(null, 1));
-            expectThrows(NPE, () -> ms.getOption(null));
+            assertThrows(NPE, () -> ms.setOption(null, null));
+            assertThrows(NPE, () -> ms.setOption(null, ""));
+            assertThrows(NPE, () -> ms.setOption(null, 1));
+            assertThrows(NPE, () -> ms.getOption(null));
         }
         try (Socket sa = SocketChannel.open().socket()) {
-            expectThrows(NPE, () -> sa.setOption(null, null));
-            expectThrows(NPE, () -> sa.setOption(null, ""));
-            expectThrows(NPE, () -> sa.setOption(null, 1));
-            expectThrows(NPE, () -> sa.getOption(null));
+            assertThrows(NPE, () -> sa.setOption(null, null));
+            assertThrows(NPE, () -> sa.setOption(null, ""));
+            assertThrows(NPE, () -> sa.setOption(null, 1));
+            assertThrows(NPE, () -> sa.getOption(null));
         }
         try (ServerSocket ssa = ServerSocketChannel.open().socket()) {
-            expectThrows(NPE, () -> ssa.setOption(null, null));
-            expectThrows(NPE, () -> ssa.setOption(null, ""));
-            expectThrows(NPE, () -> ssa.setOption(null, 1));
-            expectThrows(NPE, () -> ssa.getOption(null));
+            assertThrows(NPE, () -> ssa.setOption(null, null));
+            assertThrows(NPE, () -> ssa.setOption(null, ""));
+            assertThrows(NPE, () -> ssa.setOption(null, 1));
+            assertThrows(NPE, () -> ssa.getOption(null));
         }
         try (DatagramSocket dsa = DatagramChannel.open().socket()) {
-            expectThrows(NPE, () -> dsa.setOption(null, null));
-            expectThrows(NPE, () -> dsa.setOption(null, ""));
-            expectThrows(NPE, () -> dsa.setOption(null, 1));
-            expectThrows(NPE, () -> dsa.getOption(null));
+            assertThrows(NPE, () -> dsa.setOption(null, null));
+            assertThrows(NPE, () -> dsa.setOption(null, ""));
+            assertThrows(NPE, () -> dsa.setOption(null, 1));
+            assertThrows(NPE, () -> dsa.getOption(null));
         }
     }
 
@@ -114,67 +116,67 @@ public class NullsAndBadValues {
     @Test
     public void uoe() throws Exception {
         try (Socket s = new Socket()) {
-            expectThrows(UOE, () -> s.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> s.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> s.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> s.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> s.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> s.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> s.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> s.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> s.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> s.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> s.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> s.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> s.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> s.getOption(RAW_SOCK_OPT));
         }
         try (ServerSocket ss = new ServerSocket()) {
-            expectThrows(UOE, () -> ss.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> ss.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> ss.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> ss.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> ss.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> ss.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> ss.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> ss.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> ss.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> ss.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> ss.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> ss.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> ss.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> ss.getOption(RAW_SOCK_OPT));
         }
         try (DatagramSocket ds = new DatagramSocket()) {
-            expectThrows(UOE, () -> ds.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> ds.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> ds.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> ds.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> ds.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> ds.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> ds.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> ds.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> ds.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> ds.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> ds.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> ds.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> ds.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> ds.getOption(RAW_SOCK_OPT));
         }
         try (MulticastSocket ms = new MulticastSocket()) {
-            expectThrows(UOE, () -> ms.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> ms.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> ms.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> ms.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> ms.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> ms.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> ms.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> ms.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> ms.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> ms.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> ms.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> ms.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> ms.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> ms.getOption(RAW_SOCK_OPT));
         }
         try (Socket sa = SocketChannel.open().socket()) {
-            expectThrows(UOE, () -> sa.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> sa.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> sa.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> sa.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> sa.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> sa.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> sa.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> sa.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> sa.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> sa.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> sa.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> sa.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> sa.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> sa.getOption(RAW_SOCK_OPT));
         }
         try (ServerSocket ssa = ServerSocketChannel.open().socket()) {
-            expectThrows(UOE, () -> ssa.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> ssa.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> ssa.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> ssa.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> ssa.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> ssa.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> ssa.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> ssa.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> ssa.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> ssa.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> ssa.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> ssa.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> ssa.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> ssa.getOption(RAW_SOCK_OPT));
         }
         try (DatagramSocket dsa = DatagramChannel.open().socket()) {
-            expectThrows(UOE, () -> dsa.setOption(FAKE_SOCK_OPT, null));
-            expectThrows(UOE, () -> dsa.setOption(FAKE_SOCK_OPT, TRUE));
-            expectThrows(UOE, () -> dsa.setOption(FAKE_SOCK_OPT, FALSE));
-            expectThrows(UOE, () -> dsa.setOption(RAW_SOCK_OPT, ""));
-            expectThrows(UOE, () -> dsa.setOption(RAW_SOCK_OPT, 1));
-            expectThrows(UOE, () -> dsa.getOption(FAKE_SOCK_OPT));
-            expectThrows(UOE, () -> dsa.getOption(RAW_SOCK_OPT));
+            assertThrows(UOE, () -> dsa.setOption(FAKE_SOCK_OPT, null));
+            assertThrows(UOE, () -> dsa.setOption(FAKE_SOCK_OPT, TRUE));
+            assertThrows(UOE, () -> dsa.setOption(FAKE_SOCK_OPT, FALSE));
+            assertThrows(UOE, () -> dsa.setOption(RAW_SOCK_OPT, ""));
+            assertThrows(UOE, () -> dsa.setOption(RAW_SOCK_OPT, 1));
+            assertThrows(UOE, () -> dsa.getOption(FAKE_SOCK_OPT));
+            assertThrows(UOE, () -> dsa.getOption(RAW_SOCK_OPT));
         }
     }
 
@@ -200,8 +202,7 @@ public class NullsAndBadValues {
 
     // -- Socket
 
-    @DataProvider(name = "socketBadOptionValues")
-    public Object[][] socketBadOptionValues() throws Exception {
+    public static Object[][] socketBadOptionValues() throws Exception {
         try (Socket s = new Socket()) {
             return s.supportedOptions().stream()
                     .flatMap(NullsAndBadValues::socketOptionToBadValues)
@@ -209,28 +210,29 @@ public class NullsAndBadValues {
         }
     }
 
-    @Test(dataProvider = "socketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("socketBadOptionValues")
     public <T> void socket(SocketOption<T> option, T value)
         throws Exception
     {
         try (Socket s = new Socket()) {
-            expectThrows(IAE, () -> s.setOption(option, value));
+            assertThrows(IAE, () -> s.setOption(option, value));
         }
     }
 
-    @Test(dataProvider = "socketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("socketBadOptionValues")
     public <T> void socketAdapter(SocketOption<T> option, T value)
         throws Exception
     {
         try (Socket s = SocketChannel.open().socket()) {
-            expectThrows(IAE, () -> s.setOption(option, value));
+            assertThrows(IAE, () -> s.setOption(option, value));
         }
     }
 
     // -- ServerSocket
 
-    @DataProvider(name = "serverSocketBadOptionValues")
-    public Object[][] serverSocketBadOptionValues() throws Exception {
+    public static Object[][] serverSocketBadOptionValues() throws Exception {
         try (ServerSocket ss = new ServerSocket()) {
             return ss.supportedOptions().stream()
                      .flatMap(NullsAndBadValues::socketOptionToBadValues)
@@ -238,16 +240,18 @@ public class NullsAndBadValues {
         }
     }
 
-    @Test(dataProvider = "serverSocketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("serverSocketBadOptionValues")
     public <T> void serverSocket(SocketOption<T> option, T value)
         throws Exception
     {
         try (ServerSocket ss = new ServerSocket()) {
-            expectThrows(IAE, () -> ss.setOption(option, value));
+            assertThrows(IAE, () -> ss.setOption(option, value));
         }
     }
 
-    @Test(dataProvider = "serverSocketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("serverSocketBadOptionValues")
     public <T> void serverSocketAdapter(SocketOption<T> option, T value)
         throws Exception
     {
@@ -255,14 +259,13 @@ public class NullsAndBadValues {
             return;  // SSC does not support IP_TOS
 
         try (ServerSocket ss = ServerSocketChannel.open().socket()) {
-            expectThrows(IAE, () -> ss.setOption(option, value));
+            assertThrows(IAE, () -> ss.setOption(option, value));
         }
     }
 
     // -- DatagramSocket
 
-    @DataProvider(name = "datagramSocketBadOptionValues")
-    public Object[][] datagramSocketBadOptionValues() throws Exception {
+    public static Object[][] datagramSocketBadOptionValues() throws Exception {
         try (DatagramSocket ds = new DatagramSocket()) {
             return ds.supportedOptions().stream()
                      .flatMap(NullsAndBadValues::socketOptionToBadValues)
@@ -270,28 +273,29 @@ public class NullsAndBadValues {
         }
     }
 
-    @Test(dataProvider = "datagramSocketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("datagramSocketBadOptionValues")
     public <T> void datagramSocket(SocketOption<T> option, T value)
         throws Exception
     {
         try (DatagramSocket ds = new DatagramSocket()) {
-            expectThrows(IAE, () -> ds.setOption(option, value));
+            assertThrows(IAE, () -> ds.setOption(option, value));
         }
     }
 
-    @Test(dataProvider = "datagramSocketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("datagramSocketBadOptionValues")
     public <T> void datagramSocketAdapter(SocketOption<T> option, T value)
         throws Exception
     {
         try (DatagramSocket ds = DatagramChannel.open().socket()) {
-            expectThrows(IAE, () -> ds.setOption(option, value));
+            assertThrows(IAE, () -> ds.setOption(option, value));
         }
     }
 
     // -- MulticastSocket
 
-    @DataProvider(name = "multicastSocketBadOptionValues")
-    public Object[][] multicastSocketBadOptionValues() throws Exception {
+    public static Object[][] multicastSocketBadOptionValues() throws Exception {
         try (MulticastSocket ms = new MulticastSocket()) {
             return ms.supportedOptions().stream()
                      .flatMap(NullsAndBadValues::socketOptionToBadValues)
@@ -299,12 +303,13 @@ public class NullsAndBadValues {
         }
     }
 
-    @Test(dataProvider = "multicastSocketBadOptionValues")
+    @ParameterizedTest
+    @MethodSource("multicastSocketBadOptionValues")
     public <T> void multicastSocket(SocketOption<T> option, T value)
         throws Exception
     {
         try (MulticastSocket ms = new MulticastSocket()) {
-            expectThrows(IAE, () -> ms.setOption(option, value));
+            assertThrows(IAE, () -> ms.setOption(option, value));
         }
     }
 

--- a/test/jdk/java/net/SocketOption/RequiredOptions.java
+++ b/test/jdk/java/net/SocketOption/RequiredOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,17 +33,18 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
 
 import static java.net.StandardSocketOptions.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
  * @bug 8235141
  * @summary verifies that our implementation supports the set
  *          of SocketOptions that are required by the API documentation.
- * @run testng/othervm RequiredOptions
+ * @run junit/othervm ${test.main.class}
  */
 public class RequiredOptions {
 
@@ -60,7 +61,6 @@ public class RequiredOptions {
         return Set.of(Stream.of(options).flatMap(Set::stream).distinct().toArray(SocketOption[]::new));
     }
 
-    @DataProvider(name = "sockets")
     static Object[][] provider() throws IOException {
         return new Object[][] {
                 // UDP
@@ -76,7 +76,8 @@ public class RequiredOptions {
         };
     }
 
-    @Test(dataProvider = "sockets")
+    @ParameterizedTest
+    @MethodSource("provider")
     public <R, E extends Exception>
     void test(Configurable<R,E> socket, Set<SocketOption<?>> options) throws E {
         try (var s = socket) {

--- a/test/jdk/java/net/SocketPermission/Ctor.java
+++ b/test/jdk/java/net/SocketPermission/Ctor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,14 @@
  * @bug 4391898 8230407
  * @summary SocketPermission(":",...) throws ArrayIndexOutOfBoundsException
  *          SocketPermission constructor argument checks
- * @run testng Ctor
+ * @run junit ${test.main.class}
  */
 
 import java.net.SocketPermission;
-import org.testng.annotations.Test;
-import static java.lang.System.out;
-import static org.testng.Assert.*;
+import static java.lang.System.err;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Ctor {
 
@@ -48,39 +49,39 @@ public class Ctor {
     @Test
     public void npe() {
         NullPointerException e;
-        e = expectThrows(NPE, () -> new SocketPermission(null, null));
-        out.println("caught expected NPE: " + e);
-        e = expectThrows(NPE, () -> new SocketPermission("foo", null));
-        out.println("caught expected NPE: " + e);
-        e = expectThrows(NPE, () -> new SocketPermission(null, "connect"));
-        out.println("caught expected NPE: " + e);
+        e = assertThrows(NPE, () -> new SocketPermission(null, null));
+        err.println("caught expected NPE: " + e);
+        e = assertThrows(NPE, () -> new SocketPermission("foo", null));
+        err.println("caught expected NPE: " + e);
+        e = assertThrows(NPE, () -> new SocketPermission(null, "connect"));
+        err.println("caught expected NPE: " + e);
     }
 
     @Test
     public void iae() {
         IllegalArgumentException e;
         // host
-        e = expectThrows(IAE, () -> new SocketPermission("1:2:3:4", "connect"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo:5-4", "connect"));
-        out.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("1:2:3:4", "connect"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo:5-4", "connect"));
+        err.println("caught expected IAE: " + e);
 
         // actions
-        e = expectThrows(IAE, () -> new SocketPermission("foo", ""));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", "badAction"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", "badAction,connect"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", "badAction,,connect"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", ",connect"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", ",,connect"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", "connect,"));
-        out.println("caught expected IAE: " + e);
-        e = expectThrows(IAE, () -> new SocketPermission("foo", "connect,,"));
-        out.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", ""));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", "badAction"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", "badAction,connect"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", "badAction,,connect"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", ",connect"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", ",,connect"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", "connect,"));
+        err.println("caught expected IAE: " + e);
+        e = assertThrows(IAE, () -> new SocketPermission("foo", "connect,,"));
+        err.println("caught expected IAE: " + e);
     }
 }

--- a/test/jdk/java/net/Socks/SocksIPv6Test.java
+++ b/test/jdk/java/net/Socks/SocksIPv6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
  * @bug 7100957
  * @modules jdk.httpserver
  * @library /test/lib
+ * @build SocksServer
  * @summary Java doesn't correctly handle the SOCKS protocol when used over IPv6.
- * @run testng SocksIPv6Test
+ * @run junit ${test.main.class}
  */
 
 import java.io.BufferedReader;
@@ -45,28 +46,28 @@ import java.net.SocketException;
 import java.net.NetworkInterface;
 import java.util.Collections;
 import java.util.List;
-import com.sun.net.httpserver.*;
 import java.io.BufferedWriter;
-import org.testng.SkipException;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
+import com.sun.net.httpserver.HttpServer;
 import jdk.test.lib.NetworkConfiguration;
 
-import static org.testng.Assert.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SocksIPv6Test {
 
-    private HttpServer server;
-    private SocksServer socks;
-    private String response = "Hello.";
+    static private HttpServer server;
+    static private SocksServer socks;
+    private static String response = "Hello.";
 
-    @BeforeClass
-    public void setUp() throws Exception {
+    @BeforeAll
+    public static void setUp() throws Exception {
         if (!ensureInet6AddressFamily() || !ensureIPv6OnLoopback()) {
             NetworkConfiguration.printSystemConfiguration(System.out);
-            throw new SkipException("Host does not support IPv6");
+            Assumptions.abort("Host does not support IPv6");
         }
 
         server = HttpServer.create(new InetSocketAddress("::1", 0), 0);
@@ -93,7 +94,7 @@ public class SocksIPv6Test {
         });
     }
 
-    private boolean ensureIPv6OnLoopback() throws Exception {
+    private static boolean ensureIPv6OnLoopback() throws Exception {
         boolean ipv6 = false;
 
         List<NetworkInterface> nics = Collections.list(NetworkInterface.getNetworkInterfaces());
@@ -114,7 +115,7 @@ public class SocksIPv6Test {
         return ipv6;
     }
 
-    private boolean ensureInet6AddressFamily() throws IOException {
+    private static boolean ensureInet6AddressFamily() throws IOException {
         try (ServerSocket s = new ServerSocket()) {
             s.bind(new InetSocketAddress("::1", 0));
             return true;
@@ -124,7 +125,7 @@ public class SocksIPv6Test {
         return false;
     }
 
-    @Test(groups = "unit")
+    @Test
     public void testSocksOverIPv6() throws Exception {
         Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("::1",
                 socks.getPort()));
@@ -135,10 +136,10 @@ public class SocksIPv6Test {
                 new InputStreamReader(conn.getInputStream()))) {
             actual = reader.readLine();
         }
-        assertEquals(actual, response);
+        assertEquals(response, actual);
     }
 
-    @Test(groups = "unit")
+    @Test
     public void testSocksOverIPv6Hostname() throws Exception {
         InetAddress ipv6Loopback = InetAddress.getByName("::1");
         String ipv6Hostname = ipv6Loopback.getHostName();
@@ -155,24 +156,24 @@ public class SocksIPv6Test {
             ipv4HostAddress = null;
         }
 
-        System.out.println("ipv6Hostname: " + ipv6Hostname + " / " + ipv6HostAddress);
-        System.out.println("ipv4Hostname: " + ipv4Hostname + " / " + ipv4HostAddress);
+        System.err.println("ipv6Hostname: " + ipv6Hostname + " / " + ipv6HostAddress);
+        System.err.println("ipv4Hostname: " + ipv4Hostname + " / " + ipv4HostAddress);
 
         if (ipv6Hostname.equals(ipv6HostAddress)) {
-            System.out.println("Unable to get the hostname of the IPv6 loopback "
+            Assumptions.abort("Unable to get the hostname of the IPv6 loopback "
                     + "address. Skipping test case.");
             return;
         }
 
         if (ipv4Hostname != null && ipv6Hostname.equals(ipv4Hostname)) {
-            System.out.println("IPv6 and IPv4 loopback addresses map to the"
+            Assumptions.abort("IPv6 and IPv4 loopback addresses map to the"
                     + " same hostname. Skipping test case.");
             return;
         }
 
         if (!InetAddress.getByName(ipv6Hostname).getHostAddress()
                 .equals(ipv6HostAddress)) {
-            System.out.println(ipv6Hostname + " resolves to \""
+            Assumptions.abort(ipv6Hostname + " resolves to \""
                     + InetAddress.getByName(ipv6Hostname).getHostAddress()
                     + "\", not \"" + ipv6HostAddress +
                     "\". Skipping test case.");
@@ -188,11 +189,11 @@ public class SocksIPv6Test {
                 new InputStreamReader(conn.getInputStream()))) {
             actual = reader.readLine();
         }
-        assertEquals(actual, response);
+        assertEquals(response, actual);
     }
 
-    @AfterClass
-    public void tearDown() {
+    @AfterAll
+    public static void tearDown() {
         if (server != null) {
             server.stop(1);
         }

--- a/test/jdk/java/net/Socks/SocksIPv6Test.java
+++ b/test/jdk/java/net/Socks/SocksIPv6Test.java
@@ -59,9 +59,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SocksIPv6Test {
 
-    static private HttpServer server;
-    static private SocksServer socks;
-    private static String response = "Hello.";
+    private static HttpServer server;
+    private static SocksServer socks;
+    private static final String response = "Hello.";
 
     @BeforeAll
     public static void setUp() throws Exception {

--- a/test/jdk/java/net/Socks/SocksSocketImplTest.java
+++ b/test/jdk/java/net/Socks/SocksSocketImplTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -73,11 +75,8 @@ public class SocksSocketImplTest {
     public void testIOEOnProxySelection() throws Exception {
         final int backlog = -1;
         final int port = 0;
-        try (ServerSocket ss = new ServerSocket(port, backlog, InetAddress.getLoopbackAddress());
-             Socket s1 = new Socket(ss.getInetAddress(), ss.getLocalPort());
-             Socket s2 = ss.accept()) {
-                fail("IOException was expected to be thrown, but wasn't");
-        } catch (IOException ioe) {
+        try (ServerSocket ss = new ServerSocket(port, backlog, InetAddress.getLoopbackAddress())) {
+             IOException ioe = assertThrows(IOException.class, () -> new Socket(ss.getInetAddress(), ss.getLocalPort()));
             // expected
             // now verify the IOE was thrown for the correct expected reason
             if (!(ioe.getCause() instanceof IllegalArgumentException)) {

--- a/test/jdk/java/net/Socks/SocksSocketImplTest.java
+++ b/test/jdk/java/net/Socks/SocksSocketImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,6 @@
  * questions.
  */
 
-import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 import sun.net.spi.DefaultProxySelector;
 
 import java.io.IOException;
@@ -37,25 +33,31 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
 /**
  * @test
  * @bug 8230310
  * @summary Tests java.net.SocksSocketImpl
- * @run testng SocksSocketImplTest
+ * @run junit ${test.main.class}
  * @modules java.base/sun.net.spi:+open
  */
 public class SocksSocketImplTest {
 
-    private ProxySelector previousDefault;
+    private static ProxySelector previousDefault;
 
-    @BeforeTest
-    public void beforeTest() {
+    @BeforeAll
+    public static void beforeTest() {
         previousDefault = ProxySelector.getDefault();
         ProxySelector.setDefault(new SchemeStrippedProxySelector());
     }
 
-    @AfterTest
-    public void afterTest() {
+    @AfterAll
+    public static void afterTest() {
         ProxySelector.setDefault(previousDefault);
     }
 
@@ -65,7 +67,7 @@ public class SocksSocketImplTest {
      * which throws a {@link IllegalArgumentException}. This test then verifies that this IAE gets wrapped
      * by {@code java.net.SocksSocketImpl} into an {@link IOException} before being thrown
      *
-     * @throws Exception
+     * @throws Exception if the test fails
      */
     @Test
     public void testIOEOnProxySelection() throws Exception {
@@ -74,7 +76,7 @@ public class SocksSocketImplTest {
         try (ServerSocket ss = new ServerSocket(port, backlog, InetAddress.getLoopbackAddress());
              Socket s1 = new Socket(ss.getInetAddress(), ss.getLocalPort());
              Socket s2 = ss.accept()) {
-            Assert.fail("IOException was expected to be thrown, but wasn't");
+                fail("IOException was expected to be thrown, but wasn't");
         } catch (IOException ioe) {
             // expected
             // now verify the IOE was thrown for the correct expected reason
@@ -96,7 +98,7 @@ public class SocksSocketImplTest {
 
         @Override
         public List<Proxy> select(final URI uri) {
-            System.out.println("Proxy selection for " + uri);
+            System.err.println("Proxy selection for " + uri);
             final URI schemeStrippedURI;
             try {
                 // strip the scheme and pass the rest
@@ -104,7 +106,7 @@ public class SocksSocketImplTest {
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
-            System.out.println("Scheme stripped URI " + schemeStrippedURI + " is being used to select a proxy");
+            System.err.println("Scheme stripped URI " + schemeStrippedURI + " is being used to select a proxy");
             return super.select(schemeStrippedURI);
         }
     }

--- a/test/jdk/java/net/UnixDomainSocketAddress/AddressTest.java
+++ b/test/jdk/java/net/UnixDomainSocketAddress/AddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,16 @@
  * @test
  * @bug 8231358
  * @compile ../../nio/file/spi/testfsp/testfsp/TestProvider.java AddressTest.java
- * @run testng/othervm AddressTest
+ * @run junit/othervm ${test.main.class}
  */
 
 import java.net.UnixDomainSocketAddress;
 import java.net.URI;
 import java.nio.file.FileSystems;
-import java.nio.file.spi.FileSystemProvider;
 import java.nio.file.Path;
 
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Verify that UnixDomainSocketAddress.of(path) throws IAE
@@ -50,7 +48,7 @@ public class AddressTest {
         IllegalArgumentException.class;
 
     @Test
-    public static void runTest() throws Exception {
+    public void runTest() throws Exception {
         var fsp = new testfsp.TestProvider(FileSystems.getDefault().provider());
         Path path = fsp.getPath(URI.create("file:/"));
         assertThrows(IAE, () -> UnixDomainSocketAddress.of(path));

--- a/test/jdk/java/net/UnixDomainSocketAddress/LengthTest.java
+++ b/test/jdk/java/net/UnixDomainSocketAddress/LengthTest.java
@@ -46,9 +46,7 @@ public class LengthTest {
     private static final int namelen = 100;    // length close to max
 
     public static List<String> strings() {
-        if (namelen == -1)
-            return List.of("");
-
+        assert namelen > 0;
         return List.of(
                 "",
                 "x".repeat(100),

--- a/test/jdk/java/net/UnixDomainSocketAddress/LengthTest.java
+++ b/test/jdk/java/net/UnixDomainSocketAddress/LengthTest.java
@@ -51,9 +51,9 @@ public class LengthTest {
 
         return List.of(
                 "",
-                new String(new char[100]).replaceAll("\0", "x"),
-                new String(new char[namelen]).replaceAll("\0", "x"),
-                new String(new char[namelen-1]).replaceAll("\0", "x")
+                "x".repeat(100),
+                "x".repeat(namelen),
+                "x".repeat(namelen - 1)
         );
     }
 

--- a/test/jdk/java/net/UnixDomainSocketAddress/LengthTest.java
+++ b/test/jdk/java/net/UnixDomainSocketAddress/LengthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,61 +25,56 @@
  * @test
  * @summary Test UnixDomainSocketAddress constructor
  * @library /test/lib
- * @run testng/othervm LengthTest
+ * @run junit/othervm ${test.main.class}
  */
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
-import static java.lang.System.out;
-import static java.net.StandardProtocolFamily.UNIX;
-import static jdk.test.lib.Asserts.assertTrue;
+import static java.lang.System.err;
 
 import java.net.UnixDomainSocketAddress;
-import java.io.IOException;
-import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LengthTest {
-    final int namelen = 100;    // length close to max
+    private static final int namelen = 100;    // length close to max
 
-    @DataProvider(name = "strings")
-    public Object[][] strings() {
+    public static List<String> strings() {
         if (namelen == -1)
-            return new Object[][] {new String[]{""}};
+            return List.of("");
 
-        return new Object[][]{
-                {""},
-                {new String(new char[100]).replaceAll("\0", "x")},
-                {new String(new char[namelen]).replaceAll("\0", "x")},
-                {new String(new char[namelen-1]).replaceAll("\0", "x")},
-        };
+        return List.of(
+                "",
+                new String(new char[100]).replaceAll("\0", "x"),
+                new String(new char[namelen]).replaceAll("\0", "x"),
+                new String(new char[namelen-1]).replaceAll("\0", "x")
+        );
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     public void expectPass(String s) {
         var addr = UnixDomainSocketAddress.of(s);
-        assertTrue(addr.getPath().toString().equals(s), "getPathName.equals(s)");
+        assertEquals(s, addr.getPath().toString(), "getPathName.equals(s)");
         var p = Path.of(s);
         addr = UnixDomainSocketAddress.of(p);
-        assertTrue(addr.getPath().equals(p), "getPath.equals(p)");
+        assertEquals(p, addr.getPath(), "getPath.equals(p)");
     }
 
     @Test
     public void expectNPE() {
-        try {
-            String s = null;
-            UnixDomainSocketAddress.of(s);
-            throw new RuntimeException("Expected NPE");
-        } catch (NullPointerException npe) {
-            out.println("\tCaught expected exception: " + npe);
-        }
-        try {
-            Path p = null;
-            UnixDomainSocketAddress.of(p);
-            throw new RuntimeException("Expected NPE");
-        } catch (NullPointerException npe) {
-            out.println("\tCaught expected exception: " + npe);
-        }
+        String s = null;
+        NullPointerException npe =
+                assertThrows(NullPointerException.class, () -> UnixDomainSocketAddress.of(s));
+        err.println("\tCaugth expected NPE for UnixDomainSocketAddress.of(s): " + npe);
+        Path p = null;
+        npe = assertThrows(NullPointerException.class, () -> UnixDomainSocketAddress.of(p));
+        err.println("\tCaugth expected NPE for UnixDomainSocketAddress.of(p): " + npe);
     }
 }

--- a/test/jdk/java/net/UnixDomainSocketAddress/UnixDomainSocketAddressSerializationTest.java
+++ b/test/jdk/java/net/UnixDomainSocketAddress/UnixDomainSocketAddressSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -35,51 +34,56 @@ import java.io.Serializable;
 import java.net.UnixDomainSocketAddress;
 import java.nio.file.Path;
 import static java.io.ObjectStreamConstants.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
  * @summary UnixDomainSocketAddress serialization test
- * @run testng/othervm UnixDomainSocketAddressSerializationTest
+ * @run junit/othervm ${test.main.class}
  */
 
-@Test
 public class UnixDomainSocketAddressSerializationTest {
     private static final UnixDomainSocketAddress addr =
             UnixDomainSocketAddress.of(Path.of("test.sock"));
 
-    public static void test() throws Exception {
-        assertTrue(addr instanceof Serializable);
+    @Test
+    public void test() throws Exception {
+        assertInstanceOf(Serializable.class, addr);
 
         byte[] serialized = serialize(addr);
         assertTrue(serialized.length > 0);
 
         UnixDomainSocketAddress deserialized =
                 deserialize(serialized, UnixDomainSocketAddress.class);
-        assertEquals(deserialized.getPath(), addr.getPath());
-        assertEquals(deserialized.toString(), addr.toString());
-        assertEquals(deserialized.hashCode(), addr.hashCode());
-        assertEquals(deserialized, addr);
+        assertEquals(addr.getPath(), deserialized.getPath());
+        assertEquals(addr.toString(), deserialized.toString());
+        assertEquals(addr.hashCode(), deserialized.hashCode());
+        assertEquals(addr, deserialized);
     }
 
     static final Class<InvalidObjectException> IOE = InvalidObjectException.class;
     static final Class<NullPointerException> NPE = NullPointerException.class;
 
     /** Tests that UnixDomainSocketAddress in the byte-stream is disallowed. */
-    public static void testUnixDomainSocketAddressInStream() throws Exception {
+    @Test
+    public void testUnixDomainSocketAddressInStream() throws Exception {
         long suid = ObjectStreamClass.lookup(UnixDomainSocketAddress.class).getSerialVersionUID();
         byte[] bytes = byteStreamFor(UnixDomainSocketAddress.class.getName(), suid);
-        expectThrows(IOE, () -> deserialize(bytes, UnixDomainSocketAddress.class));
+        assertThrows(IOE, () -> deserialize(bytes, UnixDomainSocketAddress.class));
     }
 
     /** Tests that SerialProxy with a null/absent path value in the byte-stream is disallowed. */
-    public static void testSerialProxyNoStreamValues() throws Exception {
+    @Test
+    public void testSerialProxyNoStreamValues() throws Exception {
         Class<?> c = Class.forName("java.net.UnixDomainSocketAddress$Ser");
         long suid = ObjectStreamClass.lookup(c).getSerialVersionUID();
         byte[] bytes = byteStreamFor(c.getName(), suid);
-        expectThrows(NPE, () -> deserialize(bytes, UnixDomainSocketAddress.class));
+        assertThrows(NPE, () -> deserialize(bytes, UnixDomainSocketAddress.class));
     }
 
     private static <T extends Serializable> byte[] serialize(T t)


### PR DESCRIPTION
Hi, may I get a review for this change that converts the remaining TestNG tests under test/jdk/java/net to JUnit.

An exception is `java/net/NetworkInterface/NetworkInterfaceStreamTest.java` which depends on library classes depending on TestNG. Converting that test is not done here but is tracked by [JDK-8381848](https://bugs.openjdk.org/browse/JDK-8381848)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381842](https://bugs.openjdk.org/browse/JDK-8381842): Refactor remaining TestNG tests under java/net/ to use JUnit (**Sub-task** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30681/head:pull/30681` \
`$ git checkout pull/30681`

Update a local copy of the PR: \
`$ git checkout pull/30681` \
`$ git pull https://git.openjdk.org/jdk.git pull/30681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30681`

View PR using the GUI difftool: \
`$ git pr show -t 30681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30681.diff">https://git.openjdk.org/jdk/pull/30681.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30681#issuecomment-4225669179)
</details>
