### PR TITLE
8382034: JFR: jdk-agents view is missing information

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,7 +281,9 @@ TRACE_REQUEST_FUNC(SystemProcess) {
 
 #if INCLUDE_JVMTI
 template <typename AgentEvent>
-static void send_agent_event(AgentEvent& event, const JvmtiAgent* agent) {
+static void send_agent_event(AgentEvent& event, const JvmtiAgent* agent, Ticks& timestamp) {
+  event.set_starttime(timestamp);
+  event.set_endtime(timestamp);
   event.set_name(agent->name());
   event.set_options(agent->options());
   event.set_dynamic(agent->is_dynamic());
@@ -292,29 +294,31 @@ static void send_agent_event(AgentEvent& event, const JvmtiAgent* agent) {
 
 TRACE_REQUEST_FUNC(JavaAgent) {
   JvmtiAgentList::Iterator it = JvmtiAgentList::java_agents();
+  Ticks ticks = timestamp();
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     assert(agent->is_jplis(), "invariant");
     EventJavaAgent event;
-    send_agent_event(event, agent);
+    send_agent_event(event, agent, ticks);
   }
 }
 
-static void send_native_agent_events(JvmtiAgentList::Iterator& it) {
+static void send_native_agent_events(JvmtiAgentList::Iterator& it, Ticks& timestamp) {
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     assert(!agent->is_jplis(), "invariant");
     EventNativeAgent event;
     event.set_path(agent->os_lib_path());
-    send_agent_event(event, agent);
+    send_agent_event(event, agent, timestamp);
   }
 }
 
 TRACE_REQUEST_FUNC(NativeAgent) {
+  Ticks ticks = timestamp();
   JvmtiAgentList::Iterator native_agents_it = JvmtiAgentList::native_agents();
-  send_native_agent_events(native_agents_it);
+  send_native_agent_events(native_agents_it, ticks);
   JvmtiAgentList::Iterator xrun_agents_it = JvmtiAgentList::xrun_agents();
-  send_native_agent_events(xrun_agents_it);
+  send_native_agent_events(xrun_agents_it, ticks);
 }
 #else  // INCLUDE_JVMTI
 TRACE_REQUEST_FUNC(JavaAgent)   {}

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -433,8 +433,8 @@ form = "COLUMN 'Successful Samples', 'Failed Samples', 'Biased Samples', 'Total 
 label = "JDK Agents"
 table = "COLUMN 'Time', 'Initialization', 'Name', 'Options'
          FORMAT none, none, truncate-beginning;cell-height:10, cell-height:10
-         SELECT LAST(initializationTime) AS t, LAST(initializationDuration), LAST(name), LAST(JavaAgent.options)
-         FROM JavaAgent, NativeAgent
+         SELECT LAST_BATCH(initializationTime) AS t, LAST_BATCH(initializationDuration), LAST_BATCH(name), LAST_BATCH(options)
+         FROM JavaAgent, NativeAgent GROUP BY initializationTime
          ORDER BY t"
 
 [environment.jvm-flags]

--- a/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,12 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testNativeStatic
+ *
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps
+ *                   -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0
+ *                   -javaagent:JavaAgent.jar=foo=bar
+ *      jdk.jfr.event.runtime.TestAgentEvent
+ *      testMultipleAgents
  */
 public final class TestAgentEvent {
     @StackTrace(false)
@@ -177,6 +183,27 @@ public final class TestAgentEvent {
             Events.assertField(events.get(2), "options").equal(null);
             Events.assertField(events.get(3), "options").equal("");
             Events.assertField(events.get(4), "options").equal("=");
+        }
+    }
+
+    private static void testMultipleAgents() throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(EventNames.NativeAgent).with("period", "endChunk");
+            r.enable(EventNames.JavaAgent).with("period", "endChunk");
+            r.start();
+            r.stop();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            if (events.size() != 2) {
+                throw new Exception("Expected two agents");
+            }
+            Instant timestamp = events.getFirst().getStartTime();
+            for (RecordedEvent event : events) {
+                if (!event.getStartTime().equals(timestamp) ||
+                    !event.getEndTime().equals(timestamp))  {
+                    System.out.println(events);
+                    throw new Exception("Expected agent to have the same start and end time");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Could I have. review of PR that fixes the jdk-agents view when multiple agents are in use.

Testing: jdk/jdk/jfr + tier1

Thanks
Erik

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

---------

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382034](https://bugs.openjdk.org/browse/JDK-8382034): JFR: jdk-agents view is missing information (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30682/head:pull/30682` \
`$ git checkout pull/30682`

Update a local copy of the PR: \
`$ git checkout pull/30682` \
`$ git pull https://git.openjdk.org/jdk.git pull/30682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30682`

View PR using the GUI difftool: \
`$ git pr show -t 30682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30682.diff">https://git.openjdk.org/jdk/pull/30682.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30682#issuecomment-4230047520)
</details>
