### PR TITLE
8381385: nsk/jdi/ClassLoaderReference/visibleClasses/visibleclasses002/ fails with --enable-preview and Java Usage Tracker enabled

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassLoaderReference/visibleClasses/visibleclasses002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassLoaderReference/visibleClasses/visibleclasses002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,7 +138,9 @@ public class visibleclasses002 {
                             }
                         }
                     } catch (ClassNotLoadedException e) {
-                        throw new Failure("Unexpected ClassNotLoadedException while getting componentType() of : " + refType);
+                        // ArrayType.componentType() can throw ClassNotLoadedException if the
+                        // type is loaded but not yet prepared. Just swallow the exception.
+                        display("ClassNotLoadedException while getting componentType() of " + refType);
                     }
 
                 }


### PR DESCRIPTION
The test was sometimes failing with ClassNotLoadedException of java.time.LocalDateTime. VirtualMachine.visibleClasses() returns all visible classes, even if not yet prepared. However, if one of those classes is an array type and ArrayType.componentType() is called on it, it may not find the component type if it is not already prepared. Callers of  ArrayType.componentType() need to properly handle the thrown ClassNotLoadedException in this case.

The test now produces the following output instead of failing:

```
[21:27:16.65] debugger > Getting visibleClasses list.
[21:27:16.69] debugger > Searching for debuggee's ReferenceType in the list...
[21:27:16.85] debugger > ClassNotLoadedException while getting componentType() of array class java.time.LocalDateTime[] (no class loader)
[21:27:16.112] debugger > visibleclasses002a ClassType is found in visibleClasses() list of ClassLoaderReference mirror.
[21:27:16.114] debugger > visibleclasses002a[] ArrayType is found in visibleClasses() list of ClassLoaderReference mirror.
[21:27:16.119] debugger > visibleclasses002a[][] ArrayType is found in visibleClasses() list of ClassLoaderReference mirror. 
```

Tested in Valhalla with --enable-preview and usagetracker, which is where this commonly shows up. Also tested by modifying the debuggee to create the situation where LocalDateTime is loaded but not prepared (see diff in the CR). Ran tier2 and tier5 svc tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381385](https://bugs.openjdk.org/browse/JDK-8381385): nsk/jdi/ClassLoaderReference/visibleClasses/visibleclasses002/ fails with --enable-preview and Java Usage Tracker enabled (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30687/head:pull/30687` \
`$ git checkout pull/30687`

Update a local copy of the PR: \
`$ git checkout pull/30687` \
`$ git pull https://git.openjdk.org/jdk.git pull/30687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30687`

View PR using the GUI difftool: \
`$ git pr show -t 30687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30687.diff">https://git.openjdk.org/jdk/pull/30687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30687#issuecomment-4227296211)
</details>
