### PR TITLE
8382043: Add missing @Override annotations in "javax.print.attribute" package

### DIFF
--- a/src/java.desktop/share/classes/javax/print/attribute/AttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/AttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,6 +249,7 @@ public interface AttributeSet {
      * @return {@code true} if the specified object is equal to this attribute
      *         set
      */
+    @Override
     public boolean equals(Object object);
 
     /**
@@ -261,5 +262,6 @@ public interface AttributeSet {
      *
      * @return the hash code value for this attribute set
      */
+    @Override
     public int hashCode();
 }

--- a/src/java.desktop/share/classes/javax/print/attribute/AttributeSetUtilities.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/AttributeSetUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,54 +101,67 @@ public final class AttributeSetUtilities {
             attrset = attributeSet;
         }
 
+        @Override
         public Attribute get(Class<?> key) {
             return attrset.get(key);
         }
 
+        @Override
         public boolean add(Attribute attribute) {
             throw new UnmodifiableSetException();
         }
 
+        @Override
         public synchronized boolean remove(Class<?> category) {
             throw new UnmodifiableSetException();
         }
 
+        @Override
         public boolean remove(Attribute attribute) {
             throw new UnmodifiableSetException();
         }
 
+        @Override
         public boolean containsKey(Class<?> category) {
             return attrset.containsKey(category);
         }
 
+        @Override
         public boolean containsValue(Attribute attribute) {
             return attrset.containsValue(attribute);
         }
 
+        @Override
         public boolean addAll(AttributeSet attributes) {
             throw new UnmodifiableSetException();
         }
 
+        @Override
         public int size() {
             return attrset.size();
         }
 
+        @Override
         public Attribute[] toArray() {
             return attrset.toArray();
         }
 
+        @Override
         public void clear() {
             throw new UnmodifiableSetException();
         }
 
+        @Override
         public boolean isEmpty() {
             return attrset.isEmpty();
         }
 
+        @Override
         public boolean equals(Object o) {
             return attrset.equals (o);
         }
 
+        @Override
         public int hashCode() {
             return attrset.hashCode();
         }
@@ -366,54 +379,67 @@ public final class AttributeSetUtilities {
             attrset = attributeSet;
         }
 
+        @Override
         public synchronized Attribute get(Class<?> category) {
             return attrset.get(category);
         }
 
+        @Override
         public synchronized boolean add(Attribute attribute) {
             return attrset.add(attribute);
         }
 
+        @Override
         public synchronized boolean remove(Class<?> category) {
             return attrset.remove(category);
         }
 
+        @Override
         public synchronized boolean remove(Attribute attribute) {
             return attrset.remove(attribute);
         }
 
+        @Override
         public synchronized boolean containsKey(Class<?> category) {
             return attrset.containsKey(category);
         }
 
+        @Override
         public synchronized boolean containsValue(Attribute attribute) {
             return attrset.containsValue(attribute);
         }
 
+        @Override
         public synchronized boolean addAll(AttributeSet attributes) {
             return attrset.addAll(attributes);
         }
 
+        @Override
         public synchronized int size() {
             return attrset.size();
         }
 
+        @Override
         public synchronized Attribute[] toArray() {
             return attrset.toArray();
         }
 
+        @Override
         public synchronized void clear() {
             attrset.clear();
         }
 
+        @Override
         public synchronized boolean isEmpty() {
             return attrset.isEmpty();
         }
 
+        @Override
         public synchronized boolean equals(Object o) {
             return attrset.equals (o);
         }
 
+        @Override
         public synchronized int hashCode() {
             return attrset.hashCode();
         }

--- a/src/java.desktop/share/classes/javax/print/attribute/DateTimeSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/DateTimeSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,7 @@ public abstract class DateTimeSyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this date-time
      *         attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         return object instanceof DateTimeSyntax other &&
                 value.equals(other.value);
@@ -123,6 +124,7 @@ public abstract class DateTimeSyntax implements Serializable, Cloneable {
      * Returns a hash code value for this date-time attribute. The hashcode is
      * that of this attribute's {@code java.util.Date} value.
      */
+    @Override
     public int hashCode() {
         return value.hashCode();
     }
@@ -132,6 +134,7 @@ public abstract class DateTimeSyntax implements Serializable, Cloneable {
      * string value is just this attribute's {@code java.util.Date} value
      * converted to a string.
      */
+    @Override
     public String toString() {
         return "" + value;
     }

--- a/src/java.desktop/share/classes/javax/print/attribute/DocAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/DocAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@ public interface DocAttributeSet extends AttributeSet {
      *         interface {@link DocAttribute DocAttribute}
      * @throws NullPointerException if the {@code attribute} is {@code null}
      */
+    @Override
     public boolean add(Attribute attribute);
 
     /**
@@ -88,5 +89,6 @@ public interface DocAttributeSet extends AttributeSet {
      * @throws NullPointerException if the specified set is {@code null}
      * @see #add(Attribute)
      */
+    @Override
     public boolean addAll(AttributeSet attributes);
 }

--- a/src/java.desktop/share/classes/javax/print/attribute/EnumSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/EnumSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,6 +145,7 @@ public abstract class EnumSyntax implements Serializable, Cloneable {
      * semantics of enumeration values is the same object as this enumeration
      * value.
      */
+    @Override
     public Object clone() {
         return this;
     }
@@ -153,6 +154,7 @@ public abstract class EnumSyntax implements Serializable, Cloneable {
      * Returns a hash code value for this enumeration value. The hash code is
      * just this enumeration value's integer value.
      */
+    @Override
     public int hashCode() {
         return value;
     }
@@ -160,6 +162,7 @@ public abstract class EnumSyntax implements Serializable, Cloneable {
     /**
      * Returns a string value corresponding to this enumeration value.
      */
+    @Override
     public String toString() {
 
         String[] theTable = getStringTable();

--- a/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,6 +255,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *         {@link Class Class} that implements interface
      *         {@link Attribute Attribute}
      */
+    @Override
     public Attribute get(Class<?> category) {
         return attrMap.get(AttributeSetUtilities.
                            verifyAttributeCategory(category,
@@ -274,6 +275,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @throws UnmodifiableSetException if this attribute set does not support
      *         the {@code add()} operation
      */
+    @Override
     public boolean add(Attribute attribute) {
         Object oldAttribute =
             attrMap.put(attribute.getCategory(),
@@ -294,6 +296,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @throws UnmodifiableSetException if this attribute set does not support
      *         the {@code remove()} operation
      */
+    @Override
     public boolean remove(Class<?> category) {
         return
             category != null &&
@@ -314,6 +317,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @throws UnmodifiableSetException if this attribute set does not support
      *         the {@code remove()} operation
      */
+    @Override
     public boolean remove(Attribute attribute) {
         return
             attribute != null &&
@@ -328,6 +332,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @return {@code true} if this attribute set contains an attribute value
      *         for the specified category
      */
+    @Override
     public boolean containsKey(Class<?> category) {
         return
             category != null &&
@@ -344,6 +349,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @return {@code true} if this attribute set contains the given attribute
      *         value
      */
+    @Override
     public boolean containsValue(Attribute attribute) {
         return attribute != null &&
                 attribute.equals(attrMap.get(attribute.getCategory()));
@@ -371,6 +377,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *         {@code null}, or the set is {@code null}
      * @see #add(Attribute)
      */
+    @Override
     public boolean addAll(AttributeSet attributes) {
 
         Attribute []attrs = attributes.toArray();
@@ -392,6 +399,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *
      * @return the number of attributes in this attribute set
      */
+    @Override
     public int size() {
         return attrMap.size();
     }
@@ -402,6 +410,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @return the attributes contained in this set as an array, zero length if
      *         the {@code AttributeSet} is empty
      */
+    @Override
     public Attribute[] toArray() {
         Attribute []attrs = new Attribute[size()];
         attrMap.values().toArray(attrs);
@@ -414,6 +423,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @throws UnmodifiableSetException if this attribute set does not support
      *         the {@code clear()} operation
      */
+    @Override
     public void clear() {
         attrMap.clear();
     }
@@ -423,6 +433,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *
      * @return {@code true} if this attribute set contains no attributes
      */
+    @Override
     public boolean isEmpty() {
         return attrMap.isEmpty();
     }
@@ -438,6 +449,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      * @return {@code true} if the specified object is equal to this attribute
      *         set
      */
+    @Override
     public boolean equals(Object object) {
         if (!(object instanceof AttributeSet aset)) {
             return false;
@@ -466,6 +478,7 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *
      * @return the hash code value for this attribute set
      */
+    @Override
     public int hashCode() {
         int hcode = 0;
         Attribute[] attrs = toArray();

--- a/src/java.desktop/share/classes/javax/print/attribute/IntegerSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/IntegerSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,7 @@ public abstract class IntegerSyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this integer
      *         attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         return object instanceof IntegerSyntax other &&
                 value == other.value;
@@ -116,6 +117,7 @@ public abstract class IntegerSyntax implements Serializable, Cloneable {
      * Returns a hash code value for this integer attribute. The hash code is
      * just this integer attribute's integer value.
      */
+    @Override
     public int hashCode() {
         return value;
     }
@@ -125,6 +127,7 @@ public abstract class IntegerSyntax implements Serializable, Cloneable {
      * string value is just this integer attribute's integer value converted to
      * a string.
      */
+    @Override
     public String toString() {
         return "" + value;
     }

--- a/src/java.desktop/share/classes/javax/print/attribute/PrintJobAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/PrintJobAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@ public interface PrintJobAttributeSet extends AttributeSet {
      *         interface {@link PrintJobAttribute PrintJobAttribute}
      * @throws NullPointerException if the {@code attribute} is {@code null}
      */
+    @Override
     public boolean add(Attribute attribute);
 
     /**
@@ -88,5 +89,6 @@ public interface PrintJobAttributeSet extends AttributeSet {
      * @throws NullPointerException if the specified set is {@code null}
      * @see #add(Attribute)
      */
+    @Override
     public boolean addAll(AttributeSet attributes);
 }

--- a/src/java.desktop/share/classes/javax/print/attribute/PrintRequestAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/PrintRequestAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public interface PrintRequestAttributeSet extends AttributeSet {
      *         interface {@link PrintRequestAttribute PrintRequestAttribute}
      * @throws NullPointerException if the {@code attribute} is {@code null}
      */
+    @Override
     public boolean add(Attribute attribute);
 
     /**
@@ -90,5 +91,6 @@ public interface PrintRequestAttributeSet extends AttributeSet {
      * @throws NullPointerException if the specified set is {@code null}
      * @see #add(Attribute)
      */
+    @Override
     public boolean addAll(AttributeSet attributes);
 }

--- a/src/java.desktop/share/classes/javax/print/attribute/PrintServiceAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/PrintServiceAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public interface PrintServiceAttributeSet extends AttributeSet {
      *         interface {@link PrintServiceAttribute PrintServiceAttribute}
      * @throws NullPointerException if the {@code attribute} is {@code null}
      */
+    @Override
     public boolean add(Attribute attribute);
 
     /**
@@ -90,5 +91,6 @@ public interface PrintServiceAttributeSet extends AttributeSet {
      * @throws NullPointerException if the specified set is {@code null}
      * @see #add(Attribute)
      */
+    @Override
     public boolean addAll(AttributeSet attributes);
 }

--- a/src/java.desktop/share/classes/javax/print/attribute/ResolutionSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/ResolutionSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,6 +266,7 @@ public abstract class ResolutionSyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this resolution
      *         attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         return object instanceof ResolutionSyntax other &&
                 this.crossFeedResolution == other.crossFeedResolution &&
@@ -275,6 +276,7 @@ public abstract class ResolutionSyntax implements Serializable, Cloneable {
     /**
      * Returns a hash code value for this resolution attribute.
      */
+    @Override
     public int hashCode() {
         return(((crossFeedResolution & 0x0000FFFF)) |
                ((feedResolution      & 0x0000FFFF) << 16));
@@ -286,6 +288,7 @@ public abstract class ResolutionSyntax implements Serializable, Cloneable {
      * cross feed direction resolution and <i>F</i> is the feed direction
      * resolution. The values are reported in the internal units of dphi.
      */
+    @Override
     public String toString() {
         StringBuilder result = new StringBuilder();
         result.append(crossFeedResolution);

--- a/src/java.desktop/share/classes/javax/print/attribute/SetOfIntegerSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/SetOfIntegerSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -482,6 +482,7 @@ public abstract class SetOfIntegerSyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this
      *         set-of-integer attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         if (object instanceof SetOfIntegerSyntax other) {
             int[][] myMembers = this.members;
@@ -509,6 +510,7 @@ public abstract class SetOfIntegerSyntax implements Serializable, Cloneable {
      * code is the sum of the lower and upper bounds of the ranges in the
      * canonical array form, or 0 for an empty set.
      */
+    @Override
     public int hashCode() {
         int result = 0;
         int n = members.length;
@@ -526,6 +528,7 @@ public abstract class SetOfIntegerSyntax implements Serializable, Cloneable {
      * the lower bound equals the upper bound or
      * <code>"<i>i</i>-<i>j</i>"</code> otherwise.
      */
+    @Override
     public String toString() {
         StringBuilder result = new StringBuilder();
         int n = members.length;

--- a/src/java.desktop/share/classes/javax/print/attribute/Size2DSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/Size2DSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,7 @@ public abstract class Size2DSyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this
      *         two-dimensional size attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         return object instanceof Size2DSyntax size2DSyntax &&
                 this.x == size2DSyntax.x &&
@@ -272,6 +273,7 @@ public abstract class Size2DSyntax implements Serializable, Cloneable {
     /**
      * Returns a hash code value for this two-dimensional size attribute.
      */
+    @Override
     public int hashCode() {
         return (((x & 0x0000FFFF)      ) |
                 ((y & 0x0000FFFF) << 16));
@@ -283,6 +285,7 @@ public abstract class Size2DSyntax implements Serializable, Cloneable {
      * is the {@code X} dimension and <i>Y</i> is the {@code Y} dimension. The
      * values are reported in the internal units of micrometers.
      */
+    @Override
     public String toString() {
         StringBuilder result = new StringBuilder();
         result.append(x);

--- a/src/java.desktop/share/classes/javax/print/attribute/TextSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/TextSyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,6 +112,7 @@ public abstract class TextSyntax implements Serializable, Cloneable {
      *
      * @return a hashcode value for this object
      */
+    @Override
     public int hashCode() {
         return value.hashCode() ^ locale.hashCode();
     }
@@ -131,6 +132,7 @@ public abstract class TextSyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this text
      *         attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         return object instanceof TextSyntax other &&
                 this.value.equals(other.value) &&
@@ -143,6 +145,7 @@ public abstract class TextSyntax implements Serializable, Cloneable {
      *
      * @return a {@code String} identifying this object
      */
+    @Override
     public String toString(){
         return value;
     }

--- a/src/java.desktop/share/classes/javax/print/attribute/URISyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/URISyntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public abstract class URISyntax implements Serializable, Cloneable {
      *
      * @return a hashcode value for this object
      */
+    @Override
     public int hashCode() {
         return uri.hashCode();
     }
@@ -100,6 +101,7 @@ public abstract class URISyntax implements Serializable, Cloneable {
      * @return {@code true} if {@code object} is equivalent to this {@code URI}
      *         attribute, {@code false} otherwise
      */
+    @Override
     public boolean equals(Object object) {
         return object instanceof URISyntax other &&
                 this.uri.equals(other.uri);
@@ -112,6 +114,7 @@ public abstract class URISyntax implements Serializable, Cloneable {
      *
      * @return a {@code String} identifying this object
      */
+    @Override
     public String toString() {
         return uri.toString();
     }


### PR DESCRIPTION
This patch adds missing `@Override` annotations to methods in the `javax.print.attribute` package that override methods from a superclass or interface.
Only source annotations are added; there are no behavioral changes.

The previous patch for `com.sun.beans` can be found here: https://github.com/openjdk/jdk/pull/27887.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382043](https://bugs.openjdk.org/browse/JDK-8382043): Add missing @<!---->Override annotations in "javax.print.attribute" package (**Enhancement** - P5)


### Reviewers
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30688/head:pull/30688` \
`$ git checkout pull/30688`

Update a local copy of the PR: \
`$ git checkout pull/30688` \
`$ git pull https://git.openjdk.org/jdk.git pull/30688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30688`

View PR using the GUI difftool: \
`$ git pr show -t 30688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30688.diff">https://git.openjdk.org/jdk/pull/30688.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30688#issuecomment-4240907856)
</details>
