### PR TITLE
8381924: Fix include guard in lambdaProxyClassDictionary.hpp

### DIFF
--- a/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
+++ b/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef SHARE_CDS_LAMBDAPROXYCLASSINFO_HPP
-#define SHARE_CDS_LAMBDAPROXYCLASSINFO_HPP
+#ifndef SHARE_CDS_LAMBDAPROXYCLASSDICTIONARY_HPP
+#define SHARE_CDS_LAMBDAPROXYCLASSDICTIONARY_HPP
 
 #include "cds/aotCompressedPointers.hpp"
 #include "cds/aotMetaspace.hpp"
@@ -331,4 +331,4 @@ public:
   static void print_statistics(outputStream* st,  bool is_static_archive);
 };
 
-#endif // SHARE_CDS_LAMBDAPROXYCLASSINFO_HPP
+#endif // SHARE_CDS_LAMBDAPROXYCLASSDICTIONARY_HPP


### PR DESCRIPTION
# changes
Fix mismatched include guard name in `LambdaProxyClassDictionary.hpp`
 
## Test
- Verified that `make images` completes without errors.
- Confirmed that `Tier1` tests pass successfully.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381924](https://bugs.openjdk.org/browse/JDK-8381924): Fix include guard in lambdaProxyClassDictionary.hpp (**Enhancement** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30689/head:pull/30689` \
`$ git checkout pull/30689`

Update a local copy of the PR: \
`$ git checkout pull/30689` \
`$ git pull https://git.openjdk.org/jdk.git pull/30689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30689`

View PR using the GUI difftool: \
`$ git pr show -t 30689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30689.diff">https://git.openjdk.org/jdk/pull/30689.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30689#issuecomment-4228503194)
</details>
