### PR TITLE
8380651: [ubsan] gc/logging/TestGCId.java triggers runtime error: division by zero in shenandoahAdaptiveHeuristics

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -241,22 +241,22 @@ void ShenandoahAdaptiveHeuristics::add_gc_time(double timestamp, double gc_time)
     _gc_time_first_sample_index = (_gc_time_first_sample_index + 1) % GC_TIME_SAMPLE_SIZE;
   }
 
+  double delta_x;
   if (_gc_time_num_samples == 1) {
     // The predictor is constant (horizontal line)
     _gc_time_m = 0;
     _gc_time_b = gc_time;
     _gc_time_sd = 0.0;
-  } else if (_gc_time_num_samples == 2) {
+  } else if ((_gc_time_num_samples == 2) && ((delta_x = timestamp - _gc_time_timestamps[_gc_time_first_sample_index]) != 0.0)) {
     // Two points define a line
     double delta_y = gc_time - _gc_time_samples[_gc_time_first_sample_index];
-    double delta_x = timestamp - _gc_time_timestamps[_gc_time_first_sample_index];
     _gc_time_m = delta_y / delta_x;
 
     // y = mx + b
     // so b = y0 - mx0
     _gc_time_b = gc_time - _gc_time_m * timestamp;
     _gc_time_sd = 0.0;
-  } else {
+  } else if (_gc_time_num_samples > 2) {
     _gc_time_m = ((_gc_time_num_samples * _gc_time_sum_of_xy - _gc_time_sum_of_timestamps * _gc_time_sum_of_samples) /
                   (_gc_time_num_samples * _gc_time_sum_of_xx - _gc_time_sum_of_timestamps * _gc_time_sum_of_timestamps));
     _gc_time_b = (_gc_time_sum_of_samples - _gc_time_m * _gc_time_sum_of_timestamps) / _gc_time_num_samples;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -209,14 +209,14 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   }
 }
 
-void ShenandoahAdaptiveHeuristics::add_degenerated_gc_time(double timestamp, double gc_time) {
+void ShenandoahAdaptiveHeuristics::add_degenerated_gc_time(double time_at_start, double gc_time) {
   // Conservatively add sample into linear model If this time is above the predicted concurrent gc time
-  if (predict_gc_time(timestamp) < gc_time) {
-    add_gc_time(timestamp, gc_time);
+  if (predict_gc_time(time_at_start) < gc_time) {
+    add_gc_time(time_at_start, gc_time);
   }
 }
 
-void ShenandoahAdaptiveHeuristics::add_gc_time(double timestamp, double gc_time) {
+void ShenandoahAdaptiveHeuristics::add_gc_time(double time_at_start, double gc_time) {
   // Update best-fit linear predictor of GC time
   uint index = (_gc_time_first_sample_index + _gc_time_num_samples) % GC_TIME_SAMPLE_SIZE;
   if (_gc_time_num_samples == GC_TIME_SAMPLE_SIZE) {
@@ -225,10 +225,10 @@ void ShenandoahAdaptiveHeuristics::add_gc_time(double timestamp, double gc_time)
     _gc_time_sum_of_xy -= _gc_time_xy[index];
     _gc_time_sum_of_xx -= _gc_time_xx[index];
   }
-  _gc_time_timestamps[index] = timestamp;
+  _gc_time_timestamps[index] = time_at_start;
   _gc_time_samples[index] = gc_time;
-  _gc_time_xy[index] = timestamp * gc_time;
-  _gc_time_xx[index] = timestamp * timestamp;
+  _gc_time_xy[index] = time_at_start * gc_time;
+  _gc_time_xx[index] = time_at_start * time_at_start;
 
   _gc_time_sum_of_timestamps += _gc_time_timestamps[index];
   _gc_time_sum_of_samples += _gc_time_samples[index];
@@ -247,29 +247,24 @@ void ShenandoahAdaptiveHeuristics::add_gc_time(double timestamp, double gc_time)
     _gc_time_b = gc_time;
     _gc_time_sd = 0.0;
   } else if (_gc_time_num_samples == 2) {
-    double delta_x = timestamp - _gc_time_timestamps[_gc_time_first_sample_index];
-    if  (delta_x != 0.0) {
-      // Two points define a line
-      double delta_y = gc_time - _gc_time_samples[_gc_time_first_sample_index];
-      _gc_time_m = delta_y / delta_x;
-      // y = mx + b
-      // so b = y0 - mx0
-      _gc_time_b = gc_time - _gc_time_m * timestamp;
-      _gc_time_sd = 0.0;
-    } else {
-      // Avoid divide by zero. Predict with a horizontal line at the average value.
-      _gc_time_m = 0;
-      uint first_index = _gc_time_first_sample_index;
-      uint second_index = index;
-      assert(second_index == (first_index + 1) % GC_TIME_SAMPLE_SIZE, "don't break this invariant");
-      _gc_time_b = (_gc_time_samples[first_index] + _gc_time_samples[second_index]) / 2;
-      double deviation = _gc_time_samples[first_index] - _gc_time_b;
-      double sum_of_square_deviations = 2 * deviation * deviation;
-      _gc_time_sd = sqrt(sum_of_square_deviations / 2);
-    }
+
+    assert(time_at_start > _gc_time_timestamps[_gc_time_first_sample_index],
+           "Two GC cycles cannot finish at same time: %.6f vs %.6f, with GC times %.6f and %.6f", time_at_start,
+           _gc_time_timestamps[_gc_time_first_sample_index], gc_time, _gc_time_samples[_gc_time_first_sample_index]);
+
+    // Two points define a line
+    double delta_x = time_at_start - _gc_time_timestamps[_gc_time_first_sample_index];
+    double delta_y = gc_time - _gc_time_samples[_gc_time_first_sample_index];
+    _gc_time_m = delta_y / delta_x;
+    // y = mx + b
+    // so b = y0 - mx0
+    _gc_time_b = gc_time - _gc_time_m * time_at_start;
+    _gc_time_sd = 0.0;
   } else {
+    // Since timestamps are monotonically increasing, denominator does not equal zero.
+    double denominator = _gc_time_num_samples * _gc_time_sum_of_xx - _gc_time_sum_of_timestamps * _gc_time_sum_of_timestamps;
     _gc_time_m = ((_gc_time_num_samples * _gc_time_sum_of_xy - _gc_time_sum_of_timestamps * _gc_time_sum_of_samples) /
-                  (_gc_time_num_samples * _gc_time_sum_of_xx - _gc_time_sum_of_timestamps * _gc_time_sum_of_timestamps));
+                  denominator);
     _gc_time_b = (_gc_time_sum_of_samples - _gc_time_m * _gc_time_sum_of_timestamps) / _gc_time_num_samples;
     double sum_of_squared_deviations = 0.0;
     for (size_t i = 0; i < _gc_time_num_samples; i++) {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -241,22 +241,33 @@ void ShenandoahAdaptiveHeuristics::add_gc_time(double timestamp, double gc_time)
     _gc_time_first_sample_index = (_gc_time_first_sample_index + 1) % GC_TIME_SAMPLE_SIZE;
   }
 
-  double delta_x;
   if (_gc_time_num_samples == 1) {
     // The predictor is constant (horizontal line)
     _gc_time_m = 0;
     _gc_time_b = gc_time;
     _gc_time_sd = 0.0;
-  } else if ((_gc_time_num_samples == 2) && ((delta_x = timestamp - _gc_time_timestamps[_gc_time_first_sample_index]) != 0.0)) {
-    // Two points define a line
-    double delta_y = gc_time - _gc_time_samples[_gc_time_first_sample_index];
-    _gc_time_m = delta_y / delta_x;
-
-    // y = mx + b
-    // so b = y0 - mx0
-    _gc_time_b = gc_time - _gc_time_m * timestamp;
-    _gc_time_sd = 0.0;
-  } else if (_gc_time_num_samples > 2) {
+  } else if (_gc_time_num_samples == 2) {
+    double delta_x = timestamp - _gc_time_timestamps[_gc_time_first_sample_index];
+    if  (delta_x != 0.0) {
+      // Two points define a line
+      double delta_y = gc_time - _gc_time_samples[_gc_time_first_sample_index];
+      _gc_time_m = delta_y / delta_x;
+      // y = mx + b
+      // so b = y0 - mx0
+      _gc_time_b = gc_time - _gc_time_m * timestamp;
+      _gc_time_sd = 0.0;
+    } else {
+      // Avoid divide by zero. Predict with a horizontal line at the average value.
+      _gc_time_m = 0;
+      uint first_index = _gc_time_first_sample_index;
+      uint second_index = index;
+      assert(second_index == (first_index + 1) % GC_TIME_SAMPLE_SIZE, "don't break this invariant");
+      _gc_time_b = (_gc_time_samples[first_index] + _gc_time_samples[second_index]) / 2;
+      double deviation = _gc_time_samples[first_index] - _gc_time_b;
+      double sum_of_square_deviations = 2 * deviation * deviation;
+      _gc_time_sd = sqrt(sum_of_square_deviations / 2);
+    }
+  } else {
     _gc_time_m = ((_gc_time_num_samples * _gc_time_sum_of_xy - _gc_time_sum_of_timestamps * _gc_time_sum_of_samples) /
                   (_gc_time_num_samples * _gc_time_sum_of_xx - _gc_time_sum_of_timestamps * _gc_time_sum_of_timestamps));
     _gc_time_b = (_gc_time_sum_of_samples - _gc_time_m * _gc_time_sum_of_timestamps) / _gc_time_num_samples;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -263,6 +263,8 @@ void ShenandoahAdaptiveHeuristics::add_gc_time(double time_at_start, double gc_t
   } else {
     // Since timestamps are monotonically increasing, denominator does not equal zero.
     double denominator = _gc_time_num_samples * _gc_time_sum_of_xx - _gc_time_sum_of_timestamps * _gc_time_sum_of_timestamps;
+    assert(denominator != 0.0, "Invariant: samples: %u, sum_of_xx: %.6f, sum_of_timestamps: %.6f",
+           _gc_time_num_samples, _gc_time_sum_of_xx, _gc_time_sum_of_timestamps);
     _gc_time_m = ((_gc_time_num_samples * _gc_time_sum_of_xy - _gc_time_sum_of_timestamps * _gc_time_sum_of_samples) /
                   denominator);
     _gc_time_b = (_gc_time_sum_of_samples - _gc_time_m * _gc_time_sum_of_timestamps) / _gc_time_num_samples;

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -292,7 +292,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   }
   heap->increment_total_collections(false);
 
-  ShenandoahGCSession session(cause, heap->global_generation());
+  ShenandoahGCSession session(cause, heap->global_generation(), false, false);
 
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
 
@@ -335,7 +335,7 @@ void ShenandoahControlThread::stop_service() {
 
 void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCSession session(cause, heap->global_generation());
+  ShenandoahGCSession session(cause, heap->global_generation(), false, false);
 
   heap->increment_total_collections(true);
 
@@ -346,7 +346,8 @@ void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
 void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point) {
   assert (point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCSession session(cause, heap->global_generation());
+  ShenandoahGCSession session(cause, heap->global_generation(), true,
+                              point == ShenandoahGC::ShenandoahDegenPoint::_degenerated_outside_cycle);
 
   heap->increment_total_collections(false);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -292,7 +292,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   }
   heap->increment_total_collections(false);
 
-  ShenandoahGCSession session(cause, heap->global_generation(), false, false);
+  ShenandoahGCSession session(cause, heap->global_generation());
 
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
 
@@ -335,7 +335,7 @@ void ShenandoahControlThread::stop_service() {
 
 void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCSession session(cause, heap->global_generation(), false, false);
+  ShenandoahGCSession session(cause, heap->global_generation());
 
   heap->increment_total_collections(true);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -404,7 +404,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
 
   switch (original_state) {
     case ShenandoahOldGeneration::FILLING: {
-      ShenandoahGCSession session(request.cause, old_generation, false, false);
+      ShenandoahGCSession session(request.cause, old_generation);
       assert(gc_mode() == servicing_old, "Filling should be servicing old");
       _allow_old_preemption.set();
       old_generation->entry_coalesce_and_fill();
@@ -450,7 +450,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
       // done by the bootstrapping young cycle.
       set_gc_mode(servicing_old);
     case ShenandoahOldGeneration::MARKING: {
-      ShenandoahGCSession session(request.cause, old_generation, false, false);
+      ShenandoahGCSession session(request.cause, old_generation);
       bool marking_complete = resume_concurrent_old_cycle(old_generation, request.cause);
       if (marking_complete) {
         assert(old_generation->state() != ShenandoahOldGeneration::MARKING, "Should not still be marking");
@@ -542,7 +542,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
   // In either case, we want to age old objects if this is an aging cycle
   maybe_set_aging_cycle();
 
-  ShenandoahGCSession session(cause, generation, false, false);
+  ShenandoahGCSession session(cause, generation);
   TraceCollectorStats tcs(_heap->monitoring_support()->concurrent_collection_counters());
 
   assert(!generation->is_old(), "Old GC takes a different control path");
@@ -619,7 +619,7 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   _heap->increment_total_collections(true);
-  ShenandoahGCSession session(cause, _heap->global_generation(), false, false);
+  ShenandoahGCSession session(cause, _heap->global_generation());
   maybe_set_aging_cycle();
   ShenandoahFullGC gc;
   gc.collect(cause);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -404,7 +404,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
 
   switch (original_state) {
     case ShenandoahOldGeneration::FILLING: {
-      ShenandoahGCSession session(request.cause, old_generation);
+      ShenandoahGCSession session(request.cause, old_generation, false, false);
       assert(gc_mode() == servicing_old, "Filling should be servicing old");
       _allow_old_preemption.set();
       old_generation->entry_coalesce_and_fill();
@@ -450,7 +450,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
       // done by the bootstrapping young cycle.
       set_gc_mode(servicing_old);
     case ShenandoahOldGeneration::MARKING: {
-      ShenandoahGCSession session(request.cause, old_generation);
+      ShenandoahGCSession session(request.cause, old_generation, false, false);
       bool marking_complete = resume_concurrent_old_cycle(old_generation, request.cause);
       if (marking_complete) {
         assert(old_generation->state() != ShenandoahOldGeneration::MARKING, "Should not still be marking");
@@ -542,7 +542,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
   // In either case, we want to age old objects if this is an aging cycle
   maybe_set_aging_cycle();
 
-  ShenandoahGCSession session(cause, generation);
+  ShenandoahGCSession session(cause, generation, false, false);
   TraceCollectorStats tcs(_heap->monitoring_support()->concurrent_collection_counters());
 
   assert(!generation->is_old(), "Old GC takes a different control path");
@@ -619,7 +619,7 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   _heap->increment_total_collections(true);
-  ShenandoahGCSession session(cause, _heap->global_generation());
+  ShenandoahGCSession session(cause, _heap->global_generation(), false, false);
   maybe_set_aging_cycle();
   ShenandoahFullGC gc;
   gc.collect(cause);
@@ -628,11 +628,10 @@ void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause 
 
 void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(const ShenandoahGCRequest& request) {
   assert(_degen_point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
-  request.generation->heuristics()->record_degenerated_cycle_start(ShenandoahGC::ShenandoahDegenPoint::_degenerated_outside_cycle
-                                                                  == _degen_point);
   _heap->increment_total_collections(false);
 
-  ShenandoahGCSession session(request.cause, request.generation);
+  ShenandoahGCSession session(request.cause, request.generation, true,
+                              _degen_point == ShenandoahGC::ShenandoahDegenPoint::_degenerated_outside_cycle);
   ShenandoahDegenGC gc(_degen_point, request.generation);
   gc.collect(request.cause);
   _degen_point = ShenandoahGC::_degenerated_unset;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1650,7 +1650,8 @@ void ShenandoahHeap::set_active_generation(ShenandoahGeneration* generation) {
   _active_generation = generation;
 }
 
-void ShenandoahHeap::on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* generation) {
+void ShenandoahHeap::on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* generation,
+                                    bool is_degenerated, bool is_out_of_cycle) {
   shenandoah_policy()->record_collection_cause(cause);
 
   const GCCause::Cause current = gc_cause();
@@ -1659,7 +1660,11 @@ void ShenandoahHeap::on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* 
 
   set_gc_cause(cause);
 
-  generation->heuristics()->record_cycle_start();
+  if (is_degenerated) {
+    generation->heuristics()->record_degenerated_cycle_start(is_out_of_cycle);
+  } else {
+    generation->heuristics()->record_cycle_start();
+  }
 }
 
 void ShenandoahHeap::on_cycle_end(ShenandoahGeneration* generation) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -563,7 +563,7 @@ public:
     return _evac_tracker;
   }
 
-  void on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* generation);
+  void on_cycle_start(GCCause::Cause cause, ShenandoahGeneration* generation, bool is_degenerated, bool is_out_of_cycle);
   void on_cycle_end(ShenandoahGeneration* generation);
 
   ShenandoahVerifier*        verifier();

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -56,15 +56,14 @@ const char* ShenandoahGCSession::cycle_end_message(ShenandoahGenerationType type
   }
 }
 
-ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation) :
+ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation,
+                                         bool is_degenerated, bool is_out_of_cycle) :
   _heap(ShenandoahHeap::heap()),
   _generation(generation),
   _timer(_heap->gc_timer()),
   _tracer(_heap->tracer()) {
   assert(!ShenandoahGCPhase::is_current_phase_valid(), "No current GC phase");
-
-  _heap->on_cycle_start(cause, _generation);
-
+  _heap->on_cycle_start(cause, _generation, is_degenerated, is_out_of_cycle);
   _timer->register_gc_start();
   _tracer->report_gc_start(cause, _timer->gc_start());
   _heap->trace_heap_before_gc(_tracer);

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -70,7 +70,8 @@ private:
 
   static const char* cycle_end_message(ShenandoahGenerationType type);
 public:
-  ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation, bool is_degenerated, bool is_out_of_cycle);
+  ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation,
+                      bool is_degenerated = false, bool is_out_of_cycle = false);
   ~ShenandoahGCSession();
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -70,7 +70,7 @@ private:
 
   static const char* cycle_end_message(ShenandoahGenerationType type);
 public:
-  ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation);
+  ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation, bool is_degenerated, bool is_out_of_cycle);
   ~ShenandoahGCSession();
 };
 


### PR DESCRIPTION
Fix error that was allowing us to record multiple GC events that supposedly began at the exact same moment in time.  This error was causing ubsan to detect a divide by zero.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380651](https://bugs.openjdk.org/browse/JDK-8380651): [ubsan] gc/logging/TestGCId.java triggers runtime error: division by zero in shenandoahAdaptiveHeuristics (**Bug** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer) Review applies to [639fef8d](https://git.openjdk.org/jdk/pull/30692/files/639fef8d0cf61336ecfd00c4ee53f26ad997e8fa)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30692/head:pull/30692` \
`$ git checkout pull/30692`

Update a local copy of the PR: \
`$ git checkout pull/30692` \
`$ git pull https://git.openjdk.org/jdk.git pull/30692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30692`

View PR using the GUI difftool: \
`$ git pr show -t 30692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30692.diff">https://git.openjdk.org/jdk/pull/30692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30692#issuecomment-4229942552)
</details>
