### PR TITLE
8382048: JFR: RecordingFile::write doesn't truncate when overwriting

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/RecordingOutput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/RecordingOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.internal.consumer.filter;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
@@ -39,6 +40,9 @@ final class RecordingOutput implements Closeable {
     private long position;
 
     public RecordingOutput(File file) throws IOException {
+        // Truncates existing file if it exists
+        var fos = new FileOutputStream(file);
+        fos.close();
         this.file = new RandomAccessFile(file, "rw");
     }
 


### PR DESCRIPTION
Could I have a review for a PR that truncates the file if it already exists? If the file isn’t truncated, leftovers from earlier may remain at the end of the file.

Testing: jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382048](https://bugs.openjdk.org/browse/JDK-8382048): JFR: RecordingFile::write doesn't truncate when overwriting (**Bug** - P2)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30693/head:pull/30693` \
`$ git checkout pull/30693`

Update a local copy of the PR: \
`$ git checkout pull/30693` \
`$ git pull https://git.openjdk.org/jdk.git pull/30693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30693`

View PR using the GUI difftool: \
`$ git pr show -t 30693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30693.diff">https://git.openjdk.org/jdk/pull/30693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30693#issuecomment-4230333213)
</details>
