### PR TITLE
8382050: compiler/intrinsics/klass/CastNullCheckDroppingsTest.java fails with -XX:+StressUnstableIfTraps

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
@@ -25,8 +25,8 @@
  * @test NullCheckDroppingsTest
  * @bug 8054492
  * @summary Casting can result in redundant null checks in generated code
- * @requires vm.hasJFR
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.hasJFR & vm.flavor == "server" & !vm.graal.enabled & vm.flagless
+ *
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -35,9 +35,6 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -Xmixed -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:CompileThreshold=1000
- *                   -XX:+UnlockExperimentalVMOptions -XX:PerMethodTrapLimit=100 -XX:-StressReflectiveCode
- *                   -XX:+UncommonNullCast -XX:-StressMethodHandleLinkerInlining -XX:TypeProfileLevel=0
- *                   -XX:-AlwaysIncrementalInline -XX:-StressIncrementalInlining -XX:-StressUnstableIfTraps
  *                   -XX:CompileCommand=exclude,compiler.intrinsics.klass.CastNullCheckDroppingsTest::runTest
  *                   compiler.intrinsics.klass.CastNullCheckDroppingsTest
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  *                   -Xmixed -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:CompileThreshold=1000
  *                   -XX:+UnlockExperimentalVMOptions -XX:PerMethodTrapLimit=100 -XX:-StressReflectiveCode
  *                   -XX:+UncommonNullCast -XX:-StressMethodHandleLinkerInlining -XX:TypeProfileLevel=0
- *                   -XX:-AlwaysIncrementalInline -XX:-StressIncrementalInlining
+ *                   -XX:-AlwaysIncrementalInline -XX:-StressIncrementalInlining -XX:-StressUnstableIfTraps
  *                   -XX:CompileCommand=exclude,compiler.intrinsics.klass.CastNullCheckDroppingsTest::runTest
  *                   compiler.intrinsics.klass.CastNullCheckDroppingsTest
  */


### PR DESCRIPTION
`compiler/intrinsics/klass/CastNullCheckDroppingsTest.java` invokes a method enough times such that it triggers a C2 compilation:
https://github.com/openjdk/jdk/blob/0acc1d1e4fac4de6b48ed05ba0d83c1170bc4389/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java#L307-L314

We then check in `getNMethod()` that the method was compiled:
https://github.com/openjdk/jdk/blob/0acc1d1e4fac4de6b48ed05ba0d83c1170bc4389/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java#L338-L342

However, when running with `-XX:+StressUnstableIfTraps`, we could hit an unstable if trap and fall back to the interpreter. We have not invoked the method enough times to trigger another compilation again when executing `getNMethod()` and fail because the method is not compiled at that point. We will eventually compile the method again. This could easily be verified by modifying the test to invoke the test again 10000 times and running with `PrintCompilation`:
```
NMethod getNMethod(Method test, Object value) {
    // Because background compilation is disabled, method should now be compiled
    if (!WHITE_BOX.isMethodCompiled(test)) {
        System.out.println("not compiled");
        for (int i = 0; i < 10000; i++) {
            try {
                test.invoke(this, value);
            } catch (Exception e) {
                throw new Error("Unexpected exception: ", e);
            }
        }
        throw new AssertionError(test + " not compiled");
    }
```
Output:
```
15330 1068   !b        compiler.intrinsics.klass.CastNullCheckDroppingsTest::testPrimClassCast (45 bytes)
not compiled
15356 1069   !b        compiler.intrinsics.klass.CastNullCheckDroppingsTest::testPrimClassCast (45 bytes)
java.lang.AssertionError: void compiler.intrinsics.klass.CastNullCheckDroppingsTest.testPrimClassCast(java.lang.Object) not compiled
```

The fix is straight forward to ~not run the test with `-XX:+StressUnstableIfTraps`.~ add `vm.flagless`. This also protects the test against other flags that could make the method not-compiled at the time of checking.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382050](https://bugs.openjdk.org/browse/JDK-8382050): compiler/intrinsics/klass/CastNullCheckDroppingsTest.java fails with -XX:+StressUnstableIfTraps (**Bug** - P5)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30696/head:pull/30696` \
`$ git checkout pull/30696`

Update a local copy of the PR: \
`$ git checkout pull/30696` \
`$ git pull https://git.openjdk.org/jdk.git pull/30696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30696`

View PR using the GUI difftool: \
`$ git pr show -t 30696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30696.diff">https://git.openjdk.org/jdk/pull/30696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30696#issuecomment-4234568216)
</details>
