### PR TITLE
8382057: C2: "assert((ptr->bottom_type() == Type::TOP) || ((base == Compile::current()->top()) == (ptr->bottom_type()->make_ptr()->isa_oopptr() == nullptr))) failed: base input only needed for heap addresses" with -XX:+CountCompiledCalls

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -1081,13 +1081,13 @@ void Parse::catch_inline_exceptions(SafePointNode* ex_map) {
 
 #ifndef PRODUCT
 void Parse::count_compiled_calls(bool at_method_entry, bool is_inline) {
-  if( CountCompiledCalls ) {
-    if( at_method_entry ) {
+  if (CountCompiledCalls) {
+    if (at_method_entry) {
       // bump invocation counter if top method (for statistics)
       if (CountCompiledCalls && depth() == 1) {
         const TypePtr* addr_type = TypeMetadataPtr::make(method());
         Node* adr1 = makecon(addr_type);
-        Node* adr2 = basic_plus_adr(adr1, adr1, in_bytes(Method::compiled_invocation_counter_offset()));
+        Node* adr2 = off_heap_plus_addr(adr1, in_bytes(Method::compiled_invocation_counter_offset()));
         increment_counter(adr2);
       }
     } else if (is_inline) {

--- a/test/hotspot/jtreg/compiler/debug/TestCountCompiledCalls.java
+++ b/test/hotspot/jtreg/compiler/debug/TestCountCompiledCalls.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8382057
+ * @requires vm.debug == true
+ *
+ * @run main/othervm -Xbatch -XX:+CountCompiledCalls ${test.main.class}
+ */
+
+package compiler.debug;
+
+public class TestCountCompiledCalls {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}


### PR DESCRIPTION
When adding verification for the base input of `AddP` ( [JDK-8373343](https://bugs.openjdk.org/browse/JDK-8373343)), we missed to update one path when running with `-XX:+CountCompiledCalls`. This is fixed with this patch. I additionally added a hello world test to exercise the flag.

I also noticed that `CountCompiledCalls` is only counting C2 compiled methods but not C1 compiled methods. I guess we should either rename the flag to `CountC2CompiledCalls` or add support for C1 as well - or drop the flag since it does not look like it is used often - otherwise, we would have noticed this bug earlier.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382057](https://bugs.openjdk.org/browse/JDK-8382057): C2: "assert((ptr-&gt;bottom_type() == Type::TOP) || ((base == Compile::current()-&gt;top()) == (ptr-&gt;bottom_type()-&gt;make_ptr()-&gt;isa_oopptr() == nullptr))) failed: base input only needed for heap addresses" with -XX:+CountCompiledCalls (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Benoît Maillard](https://openjdk.org/census#bmaillard) (@benoitmaillard - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30699/head:pull/30699` \
`$ git checkout pull/30699`

Update a local copy of the PR: \
`$ git checkout pull/30699` \
`$ git pull https://git.openjdk.org/jdk.git pull/30699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30699`

View PR using the GUI difftool: \
`$ git pr show -t 30699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30699.diff">https://git.openjdk.org/jdk/pull/30699.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30699#issuecomment-4234897980)
</details>
