### PR TITLE
8381418: Clarifying the identity Parameter in the Java Stream.reduce() Method Documentation

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1002,8 +1002,8 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
 
     /**
      * Performs a <a href="package-summary.html#Reduction">reduction</a> on the
-     * elements of this stream, using the provided identity, accumulation and
-     * combining functions.  This is equivalent to:
+     * elements of this stream using the provided identity value, accumulation
+     * function, and combining function.  This is equivalent to:
      * <pre>{@code
      *     U result = identity;
      *     for (T element : this stream)


### PR DESCRIPTION
Clarifying the Stream::reduce Javadoc



---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381418](https://bugs.openjdk.org/browse/JDK-8381418): Clarifying the identity Parameter in the Java Stream.reduce() Method Documentation (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30700/head:pull/30700` \
`$ git checkout pull/30700`

Update a local copy of the PR: \
`$ git checkout pull/30700` \
`$ git pull https://git.openjdk.org/jdk.git pull/30700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30700`

View PR using the GUI difftool: \
`$ git pr show -t 30700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30700.diff">https://git.openjdk.org/jdk/pull/30700.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30700#issuecomment-4235682924)
</details>
