### PR TITLE
8378462: Build fails with --enable-linktime-gc set when using some devkits/toolchains

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -371,7 +371,6 @@ ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
   # particular files anyway, so lower optimization level.
   BUILD_LIBFONTMANAGER_hb-subset.cc_OPTIMIZATION := SIZE
   BUILD_LIBFONTMANAGER_hb-subset-plan.cc_OPTIMIZATION := SIZE
-  LIBFONTMANAGER_CXXFLAGS := -fno-rtti -fno-exceptions
 endif
 
 ifeq ($(call isTargetOs, windows), true)
@@ -395,7 +394,9 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     EXCLUDE_FILES := $(LIBFONTMANAGER_EXCLUDE_FILES) \
         AccelGlyphCache.c, \
     CFLAGS := $(LIBFONTMANAGER_CFLAGS), \
-    CXXFLAGS := $(LIBFONTMANAGER_CFLAGS) $(LIBFONTMANAGER_CXXFLAGS), \
+    CXXFLAGS := $(LIBFONTMANAGER_CFLAGS), \
+    CXXFLAGS_gcc := -fno-rtti -fno-exceptions, \
+    CXXFLAGS_clang := -fno-rtti -fno-exceptions, \
     OPTIMIZATION := HIGHEST, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \

--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -371,6 +371,7 @@ ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
   # particular files anyway, so lower optimization level.
   BUILD_LIBFONTMANAGER_hb-subset.cc_OPTIMIZATION := SIZE
   BUILD_LIBFONTMANAGER_hb-subset-plan.cc_OPTIMIZATION := SIZE
+  LIBFONTMANAGER_CXXFLAGS := -fno-rtti -fno-exceptions
 endif
 
 ifeq ($(call isTargetOs, windows), true)
@@ -394,7 +395,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     EXCLUDE_FILES := $(LIBFONTMANAGER_EXCLUDE_FILES) \
         AccelGlyphCache.c, \
     CFLAGS := $(LIBFONTMANAGER_CFLAGS), \
-    CXXFLAGS := $(LIBFONTMANAGER_CFLAGS), \
+    CXXFLAGS := $(LIBFONTMANAGER_CFLAGS) $(LIBFONTMANAGER_CXXFLAGS), \
     OPTIMIZATION := HIGHEST, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \


### PR DESCRIPTION
On some gcc - based Linux devkits like older Fedora with gcc 14, the build on Linux x86_64 fails with --enable-linktime-gc set (ltgc enabled).

Error output :
support_native_java.desktop_libfontmanager_BUILD_LIBFONTMANAGER_run_ld :

```
/devkits/x86_64-linux-gnu-to-x86_64-linux-gnu-fedora27-gcc14.2.0/bin/../lib/gcc/x86_64-linux-gnu/14.2.0/../../../../x86_64-linux-gnu/lib/../lib64/libstdc++.a(eh_throw.o)(.note.stapsdt+0x14):
error: relocation refers to local symbol ".text.__cxa_throw" [5], which is defined in a discarded section
```

Seems we can disable exceptions and rtti too on this lib when using the gcc and clang toolchains. This makes the error disappear.
And it also helps to get the lib a little smaller, even without ltgc  .

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378462](https://bugs.openjdk.org/browse/JDK-8378462): Build fails with --enable-linktime-gc set when using some devkits/toolchains (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [d2899c16](https://git.openjdk.org/jdk/pull/30701/files/d2899c16825b2e264d914a7183db2ba58909665e)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30701/head:pull/30701` \
`$ git checkout pull/30701`

Update a local copy of the PR: \
`$ git checkout pull/30701` \
`$ git pull https://git.openjdk.org/jdk.git pull/30701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30701`

View PR using the GUI difftool: \
`$ git pr show -t 30701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30701.diff">https://git.openjdk.org/jdk/pull/30701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30701#issuecomment-4242562320)
</details>
