### PR TITLE
8382084: Use dynamic chunk sizes in PartialArraySplitter

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2173,8 +2173,7 @@ void G1CMTask::reset_for_restart() {
 void G1CMTask::register_partial_array_splitter() {
 
   ::new (&_partial_array_splitter) PartialArraySplitter(_cm->partial_array_state_manager(),
-                                                        _cm->max_num_tasks(),
-                                                        ObjArrayMarkingStride);
+                                                        _cm->max_num_tasks());
 }
 
 void G1CMTask::unregister_partial_array_splitter() {
@@ -2359,7 +2358,7 @@ size_t G1CMTask::start_partial_array_processing(objArrayOop obj) {
   process_klass(obj->klass());
 
   size_t array_length = obj->length();
-  size_t initial_chunk_size = _partial_array_splitter.start(_task_queue, obj, nullptr, array_length);
+  size_t initial_chunk_size = _partial_array_splitter.start(_task_queue, obj, nullptr, array_length, ObjArrayMarkingStride);
 
   process_array_chunk(obj, 0, initial_chunk_size);
 
@@ -2917,7 +2916,7 @@ G1CMTask::G1CMTask(uint worker_id,
   _cm(cm),
   _mark_bitmap(nullptr),
   _task_queue(task_queue),
-  _partial_array_splitter(_cm->partial_array_state_manager(), _cm->max_num_tasks(), ObjArrayMarkingStride),
+  _partial_array_splitter(_cm->partial_array_state_manager(), _cm->max_num_tasks()),
   _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize),
   _calls(0),
   _time_target_ms(0.0),

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -39,7 +39,7 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _worker_id(worker_id),
     _bitmap(collector->mark_bitmap()),
     _task_queue(),
-    _partial_array_splitter(collector->partial_array_state_manager(), collector->workers(), ObjArrayMarkingStride),
+    _partial_array_splitter(collector->partial_array_state_manager(), collector->workers()),
     _mark_closure(worker_id, this, ClassLoaderData::_claim_stw_fullgc_mark, G1CollectedHeap::heap()->ref_processor_stw()),
     _stack_closure(this),
     _cld_closure(mark_closure(), ClassLoaderData::_claim_stw_fullgc_mark),
@@ -65,7 +65,7 @@ void G1FullGCMarker::start_partial_array_processing(objArrayOop obj) {
   // Don't push empty arrays to avoid unnecessary work.
   size_t array_length = obj->length();
   if (array_length > 0) {
-    size_t initial_chunk_size = _partial_array_splitter.start(task_queue(), obj, nullptr, array_length);
+    size_t initial_chunk_size = _partial_array_splitter.start(task_queue(), obj, nullptr, array_length, ObjArrayMarkingStride);
     process_array_chunk(obj, 0, initial_chunk_size);
   }
 }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -78,7 +78,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _surviving_young_words(nullptr),
     _surviving_words_length(collection_set->young_region_length() + 1),
     _old_gen_is_full(false),
-    _partial_array_splitter(g1h->partial_array_state_manager(), num_workers, ParGCArrayScanChunk),
+    _partial_array_splitter(g1h->partial_array_state_manager(), num_workers),
     _string_dedup_requests(),
     _max_num_optional_regions(collection_set->num_optional_regions()),
     _numa(g1h->numa()),
@@ -253,7 +253,7 @@ void G1ParScanThreadState::start_partial_objarray(oop from_obj,
   size_t array_length = to_array->length();
   size_t initial_chunk_size =
     // The source array is unused when processing states.
-    _partial_array_splitter.start(_task_queue, nullptr, to_array, array_length);
+    _partial_array_splitter.start(_task_queue, nullptr, to_array, array_length, ParGCArrayScanChunk);
 
   assert(_scanner.skip_card_mark_set(), "must be");
   // Process the initial chunk.  No need to process the type in the

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ PreservedMarksSet* ParCompactionManager::_preserved_marks_set = nullptr;
 ParCompactionManager::ParCompactionManager(PreservedMarks* preserved_marks,
                                            ReferenceProcessor* ref_processor,
                                            uint parallel_gc_threads)
-  :_partial_array_splitter(_partial_array_state_manager, parallel_gc_threads, ObjArrayMarkingStride),
+  :_partial_array_splitter(_partial_array_state_manager, parallel_gc_threads),
    _mark_and_push_closure(this, ref_processor) {
 
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
@@ -126,7 +126,7 @@ void ParCompactionManager::push_objArray(oop obj) {
   objArrayOop obj_array = objArrayOop(obj);
   size_t array_length = obj_array->length();
   size_t initial_chunk_size =
-    _partial_array_splitter.start(&_marking_stack, obj_array, nullptr, array_length);
+    _partial_array_splitter.start(&_marking_stack, obj_array, nullptr, array_length, ObjArrayMarkingStride);
   follow_array(obj_array, 0, initial_chunk_size);
 }
 

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,7 +158,7 @@ PartialArrayTaskStats* PSPromotionManager::partial_array_task_stats() {
 
 // Most members are initialized either by initialize() or reset().
 PSPromotionManager::PSPromotionManager()
-  : _partial_array_splitter(_partial_array_state_manager, ParallelGCThreads, ParGCArrayScanChunk)
+  : _partial_array_splitter(_partial_array_state_manager, ParallelGCThreads)
 {
   // We set the old lab's start array.
   _old_lab.set_start_array(old_gen()->start_array());
@@ -273,7 +273,7 @@ void PSPromotionManager::push_objArray(oop old_obj, oop new_obj) {
   size_t array_length = to_array->length();
   size_t initial_chunk_size =
     // The source array is unused when processing states.
-    _partial_array_splitter.start(&_claimed_stack_depth, nullptr, to_array, array_length);
+    _partial_array_splitter.start(&_claimed_stack_depth, nullptr, to_array, array_length, ParGCArrayScanChunk);
 
   process_array_chunk(to_array, 0, initial_chunk_size);
 }

--- a/src/hotspot/share/gc/shared/partialArraySplitter.cpp
+++ b/src/hotspot/share/gc/shared/partialArraySplitter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,9 @@
 #include "utilities/macros.hpp"
 
 PartialArraySplitter::PartialArraySplitter(PartialArrayStateManager* manager,
-                                           uint num_workers,
-                                           size_t chunk_size)
+                                           uint num_workers)
   : _allocator(manager),
-    _stepper(num_workers, chunk_size)
+    _stepper(num_workers)
     TASKQUEUE_STATS_ONLY(COMMA _stats())
 {}
 

--- a/src/hotspot/share/gc/shared/partialArraySplitter.hpp
+++ b/src/hotspot/share/gc/shared/partialArraySplitter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,7 @@ class PartialArraySplitter {
 
 public:
   PartialArraySplitter(PartialArrayStateManager* manager,
-                       uint num_workers,
-                       size_t chunk_size);
+                       uint num_workers);
   ~PartialArraySplitter() = default;
 
   NONCOPYABLE(PartialArraySplitter);
@@ -59,6 +58,8 @@ public:
   // if a copy of from_array is not required.
   //
   // length is their length in elements.
+  //
+  // chunk_size the size of a single chunk.
   //
   // If t is a ScannerTask, queue->push(t) must be a valid expression.  The
   // result of that expression is ignored.
@@ -76,7 +77,8 @@ public:
   size_t start(Queue* queue,
                objArrayOop from_array,
                objArrayOop to_array,
-               size_t length);
+               size_t length,
+               size_t chunk_size);
 
   // Result type for claim(), carrying multiple values.  Provides the claimed
   // chunk's start and end array indices.

--- a/src/hotspot/share/gc/shared/partialArraySplitter.inline.hpp
+++ b/src/hotspot/share/gc/shared/partialArraySplitter.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,16 @@ template<typename Queue>
 size_t PartialArraySplitter::start(Queue* queue,
                                    objArrayOop source,
                                    objArrayOop destination,
-                                   size_t length) {
-  PartialArrayTaskStepper::Step step = _stepper.start(length);
+                                   size_t length,
+                                   size_t chunk_size) {
+  precond(chunk_size > 0);
+  PartialArrayTaskStepper::Step step = _stepper.start(length, chunk_size);
   // Push initial partial scan tasks.
   if (step._ncreate > 0) {
     TASKQUEUE_STATS_ONLY(_stats.inc_split(););
     TASKQUEUE_STATS_ONLY(_stats.inc_pushed(step._ncreate);)
     PartialArrayState* state =
-      _allocator.allocate(source, destination, step._index, length, step._ncreate);
+      _allocator.allocate(source, destination, step._index, length, chunk_size, step._ncreate);
     for (uint i = 0; i < step._ncreate; ++i) {
       queue->push(ScannerTask(state));
     }
@@ -75,9 +77,10 @@ PartialArraySplitter::claim(PartialArrayState* state, Queue* queue, bool stolen)
       queue->push(ScannerTask(state));
     }
   }
+  size_t chunk_size = state->chunk_size();
   // Release state, decrementing refcount, now that we're done with it.
   _allocator.release(state);
-  return Claim{step._index, step._index + _stepper.chunk_size()};
+  return Claim{step._index, step._index + chunk_size};
 }
 
 #endif // SHARE_GC_SHARED_PARTIALARRAYSPLITTER_INLINE_HPP

--- a/src/hotspot/share/gc/shared/partialArrayState.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,12 @@
 
 PartialArrayState::PartialArrayState(oop src, oop dst,
                                      size_t index, size_t length,
+                                     size_t chunk_size,
                                      size_t initial_refcount)
   : _source(src),
     _destination(dst),
     _length(length),
+    _chunk_size(chunk_size),
     _index(index),
     _refcount(initial_refcount)
 {
@@ -77,6 +79,7 @@ PartialArrayStateAllocator::~PartialArrayStateAllocator() {
 PartialArrayState* PartialArrayStateAllocator::allocate(oop src, oop dst,
                                                         size_t index,
                                                         size_t length,
+                                                        size_t chunk_size,
                                                         size_t initial_refcount) {
   void* p;
   FreeListEntry* head = _free_list;
@@ -87,7 +90,7 @@ PartialArrayState* PartialArrayStateAllocator::allocate(oop src, oop dst,
     head->~FreeListEntry();
     p = head;
   }
-  return ::new (p) PartialArrayState(src, dst, index, length, initial_refcount);
+  return ::new (p) PartialArrayState(src, dst, index, length, chunk_size, initial_refcount);
 }
 
 void PartialArrayStateAllocator::release(PartialArrayState* state) {

--- a/src/hotspot/share/gc/shared/partialArrayState.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayState.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ class PartialArrayState {
   oop _source;
   oop _destination;
   size_t _length;
+  size_t _chunk_size;
   Atomic<size_t> _index;
   Atomic<size_t> _refcount;
 
@@ -68,7 +69,7 @@ class PartialArrayState {
 
   PartialArrayState(oop src, oop dst,
                     size_t index, size_t length,
-                    size_t initial_refcount);
+                    size_t chunk_size, size_t initial_refcount);
 
 public:
   // Deleted to require management by allocator object.
@@ -88,6 +89,8 @@ public:
 
   // The length of the array oop.
   size_t length() const { return _length; }
+
+  size_t chunk_size() const { return _chunk_size; }
 
   // A pointer to the start index for the next segment to process, for atomic
   // update.
@@ -130,6 +133,7 @@ public:
   // from the associated manager.
   PartialArrayState* allocate(oop src, oop dst,
                               size_t index, size_t length,
+                              size_t chunk_size,
                               size_t initial_refcount);
 
   // Decrement the state's refcount.  If the new refcount is zero, add the

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,7 @@ static uint compute_task_fanout(uint task_limit) {
   return result;
 }
 
-PartialArrayTaskStepper::PartialArrayTaskStepper(uint n_workers, size_t chunk_size) :
-  _chunk_size(chunk_size),
+PartialArrayTaskStepper::PartialArrayTaskStepper(uint n_workers) :
   _task_limit(compute_task_limit(n_workers)),
   _task_fanout(compute_task_fanout(_task_limit))
 {}

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,19 +40,19 @@ class PartialArrayState;
 // substantially expand the task queues.
 class PartialArrayTaskStepper {
 public:
-  PartialArrayTaskStepper(uint n_workers, size_t chunk_size);
+  PartialArrayTaskStepper(uint n_workers);
 
   struct Step {
     size_t _index;              // Array index for the step.
     uint _ncreate;              // Number of new tasks to create.
   };
 
-  // Called with the length of the array to be processed.  Returns a Step with
-  // _index being the end of the initial chunk, which the caller should
-  // process.  This is also the starting index for the next chunk to process.
+  // Called with the length of the array to be processed and chunk size.
+  // Returns a Step with _index being the end of the initial chunk, which the
+  // caller should process.  This is also the starting index for the next chunk to process.
   // The _ncreate is the number of tasks to enqueue to continue processing the
   // array.  If _ncreate is zero then _index will be length.
-  inline Step start(size_t length) const;
+  inline Step start(size_t length, size_t chunk_size) const;
 
   // Atomically increment state's index by chunk_size() to claim the next
   // chunk.  Returns a Step with _index being the starting index of the
@@ -60,21 +60,16 @@ public:
   // to enqueue.
   inline Step next(PartialArrayState* state) const;
 
-  // The size of chunks to claim for each task.
-  inline size_t chunk_size() const;
-
   class TestSupport;            // For unit tests
 
 private:
-  // Size (number of elements) of a chunk to process.
-  size_t _chunk_size;
   // Limit on the number of partial array tasks to create for a given array.
   uint _task_limit;
   // Maximum number of new tasks to create when processing an existing task.
   uint _task_fanout;
 
   // For unit tests.
-  inline Step next_impl(size_t length, Atomic<size_t>* index_addr) const;
+  inline Step next_impl(size_t length, size_t chunk_size, Atomic<size_t>* index_addr) const;
 };
 
 #endif // SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_HPP

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,9 @@
 #include "utilities/checkedCast.hpp"
 #include "utilities/debug.hpp"
 
-size_t PartialArrayTaskStepper::chunk_size() const {
-  return _chunk_size;
-}
-
 PartialArrayTaskStepper::Step
-PartialArrayTaskStepper::start(size_t length) const {
-  size_t end = length % _chunk_size; // End of initial chunk.
+PartialArrayTaskStepper::start(size_t length, size_t chunk_size) const {
+  size_t end = length % chunk_size; // End of initial chunk.
   // If the initial chunk is the complete array, then don't need any partial
   // tasks.  Otherwise, start with just one partial task; see new task
   // calculation in next().
@@ -45,24 +41,24 @@ PartialArrayTaskStepper::start(size_t length) const {
 }
 
 PartialArrayTaskStepper::Step
-PartialArrayTaskStepper::next_impl(size_t length, Atomic<size_t>* index_addr) const {
+PartialArrayTaskStepper::next_impl(size_t length, size_t chunk_size, Atomic<size_t>* index_addr) const {
   // The start of the next task is in the state's index.
   // Atomically increment by the chunk size to claim the associated chunk.
   // Because we limit the number of enqueued tasks to being no more than the
   // number of remaining chunks to process, we can use an atomic add for the
   // claim, rather than a CAS loop.
-  size_t start = index_addr->fetch_then_add(_chunk_size, memory_order_relaxed);
+  size_t start = index_addr->fetch_then_add(chunk_size, memory_order_relaxed);
 
   assert(start < length, "invariant: start %zu, length %zu", start, length);
-  assert(((length - start) % _chunk_size) == 0,
+  assert(((length - start) % chunk_size) == 0,
          "invariant: start %zu, length %zu, chunk size %zu",
-         start, length, _chunk_size);
+         start, length, chunk_size);
 
   // Determine the number of new tasks to create.
   // Zero-based index for this partial task.  The initial task isn't counted.
-  uint task_num = checked_cast<uint>(start / _chunk_size);
+  uint task_num = checked_cast<uint>(start / chunk_size);
   // Number of tasks left to process, including this one.
-  uint remaining_tasks = checked_cast<uint>((length - start) / _chunk_size);
+  uint remaining_tasks = checked_cast<uint>((length - start) / chunk_size);
   assert(remaining_tasks > 0, "invariant");
   // Compute number of pending tasks, including this one.  The maximum number
   // of tasks is a function of task_num (N) and _task_fanout (F).
@@ -89,7 +85,7 @@ PartialArrayTaskStepper::next_impl(size_t length, Atomic<size_t>* index_addr) co
 
 PartialArrayTaskStepper::Step
 PartialArrayTaskStepper::next(PartialArrayState* state) const {
-  return next_impl(state->length(), state->index_addr());
+  return next_impl(state->length(), state->chunk_size(), state->index_addr());
 }
 
 #endif // SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_INLINE_HPP

--- a/test/hotspot/gtest/gc/shared/test_partialArrayTaskStepper.cpp
+++ b/test/hotspot/gtest/gc/shared/test_partialArrayTaskStepper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,9 @@ class PartialArrayTaskStepper::TestSupport : AllStatic {
 public:
   static Step next(const Stepper* stepper,
                    size_t length,
+                   size_t chunk_size,
                    Atomic<size_t>* to_length_addr) {
-    return stepper->next_impl(length, to_length_addr);
+    return stepper->next_impl(length, chunk_size, to_length_addr);
   }
 };
 
@@ -43,23 +44,24 @@ using StepperSupport = PartialArrayTaskStepper::TestSupport;
 
 static uint simulate(const Stepper* stepper,
                      size_t length,
+                     size_t chunk_size,
                      Atomic<size_t>* to_length_addr) {
-  Step init = stepper->start(length);
+  Step init = stepper->start(length, chunk_size);
   to_length_addr->store_relaxed(init._index);
   uint queue_count = init._ncreate;
   uint task = 0;
   for ( ; queue_count > 0; ++task) {
     --queue_count;
-    Step step = StepperSupport::next(stepper, length, to_length_addr);
+    Step step = StepperSupport::next(stepper, length, chunk_size, to_length_addr);
     queue_count += step._ncreate;
   }
   return task;
 }
 
 static void run_test(size_t length, size_t chunk_size, uint n_workers) {
-  const PartialArrayTaskStepper stepper(n_workers, chunk_size);
+  const PartialArrayTaskStepper stepper(n_workers);
   Atomic<size_t> to_length;
-  uint tasks = simulate(&stepper, length, &to_length);
+  uint tasks = simulate(&stepper, length, chunk_size, &to_length);
   ASSERT_EQ(length, to_length.load_relaxed());
   ASSERT_EQ(tasks, length / chunk_size);
 }


### PR DESCRIPTION
Hi,

Please review this change to add dynamic chunk sizes to PartialArraySplitter.

Testing: Tiers 1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382084](https://bugs.openjdk.org/browse/JDK-8382084): Use dynamic chunk sizes in PartialArraySplitter (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Contributors
 * Thomas Schatzl `<tschatzl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30702/head:pull/30702` \
`$ git checkout pull/30702`

Update a local copy of the PR: \
`$ git checkout pull/30702` \
`$ git pull https://git.openjdk.org/jdk.git pull/30702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30702`

View PR using the GUI difftool: \
`$ git pr show -t 30702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30702.diff">https://git.openjdk.org/jdk/pull/30702.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30702#issuecomment-4236125242)
</details>
