### PR TITLE
8381898: SwitchBootstraps::typeSwitch() not accepting Float, Double types

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -131,14 +131,14 @@ public final class SwitchBootstraps {
 
     /**
      * Bootstrap method for linking an {@code invokedynamic} call site that
-     * implements a {@code switch} on a target of a reference type.  The static
-     * arguments are an array of case labels which must be non-null and of type
-     * {@code String}, {@code Integer}, {@code Long}, {@code Float}, {@code Double},
-     * {@code Boolean}, {@code Class}, or {@code EnumDesc}.
+     * implements a {@code switch} on a target. The static arguments are an array
+     * of case labels which must be non-null and of type {@code String},
+     * {@code Integer}, {@code Long}, {@code Float}, {@code Double}, {@code Boolean},
+     * {@code Class}, or {@code EnumDesc}.
      * <p>
      * The type of the returned {@code CallSite}'s method handle will have
      * a return type of {@code int}.   It has two parameters: the first argument
-     * will be an {@code Object} instance ({@code target}) and the second
+     * will be an instance or value of the ({@code target}) type and the second
      * will be {@code int} ({@code restart}).
      * <p>
      * If the {@code target} is {@code null}, then the method of the call site
@@ -163,16 +163,19 @@ public final class SwitchBootstraps {
      * the length of the {@code labels} array (inclusive),
      * both  or an {@link IndexOutOfBoundsException} is thrown.
      *
-     * @apiNote
-     * Case labels of type {@code Long}, {@code Float}, {@code Double}, or {@code Boolean}
-     * are allowed only when preview features are enabled.
+     * <div class="preview-block">
+     *   <div class="preview-comment">
+     *     Case labels of type {@code Long}, {@code Float}, {@code Double}, or
+     *     {@code Boolean} are allowed only when preview features are enabled.
+     *   </div>
+     * </div>
      *
      * @param lookup Represents a lookup context with the accessibility
      *               privileges of the caller.  When used with {@code invokedynamic},
      *               this is stacked automatically by the VM.
      * @param invocationName unused, {@code null} is permitted
      * @param invocationType The invocation type of the {@code CallSite} with two parameters,
-     *                       a reference type, an {@code int}, and {@code int} as a return type.
+     *                       a target type, an {@code int}, and {@code int} as a return type.
      * @param labels case labels - {@code String}, {@code Integer}, {@code Long},
      *               {@code Float}, {@code Double}, and {@code Boolean} constants
      *               and {@code Class} and {@code EnumDesc} instances, in any combination
@@ -185,10 +188,8 @@ public final class SwitchBootstraps {
      * @throws IllegalArgumentException if {@code labels} contains an element that is not of type {@code String},
      *                                  {@code Integer}, {@code Long}, {@code Float}, {@code Double}, {@code Boolean},
      *                                  {@code Class} or {@code EnumDesc}
-     * @throws IllegalArgumentException with preview features disabled and if {@code labels} contains an element
+     * @throws IllegalArgumentException if preview features are disabled and if {@code labels} contains an element
      *                                  that is of type {@code Long}, {@code Float}, {@code Double}, or {@code Boolean}
-     * @throws IllegalArgumentException if {@code labels} contains an element that is not of type {@code Boolean}
-     *                                  when {@code target} is a {@code Boolean.class}
      * @jvms 4.4.6 The CONSTANT_NameAndType_info Structure
      * @jvms 4.4.10 The CONSTANT_Dynamic_info and CONSTANT_InvokeDynamic_info Structures
      */
@@ -229,7 +230,6 @@ public final class SwitchBootstraps {
               labelClass != Long.class &&
               labelClass != Double.class &&
               labelClass != Boolean.class) ||
-              ((selectorType.equals(boolean.class) || selectorType.equals(Boolean.class)) && labelClass != Boolean.class && labelClass != Class.class) ||
              !previewEnabled) &&
 
             labelClass != EnumDesc.class) {

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -139,7 +139,7 @@ public final class SwitchBootstraps {
      * <p>
      * The type of the returned {@code CallSite}'s method handle will have
      * a return type of {@code int}.   It has two parameters: the first argument
-     * will be an instance or value of the ({@code target}) type and the second
+     * will be a value of the ({@code target}) type and the second
      * will be {@code int} ({@code restart}).
      * <p>
      * If the {@code target} is {@code null}, then the method of the call site
@@ -155,10 +155,10 @@ public final class SwitchBootstraps {
      *       (matched by content using {@code equals})</li>
      *   <li>the element is of type {@code Integer} and equals to the target
      *       (matched by value comparison using {@code ==} after unboxing if necessary)</li>
-     *   <li>the element is of type {@code Long} or {@code Boolean} (preview)
+     *   <li>(Preview) the element is of type {@code Long} or {@code Boolean}
      *       and equals to the target (matched by value comparison using {@code ==}
      *       after unboxing if necessary)</li>
-     *   <li>the element is of type {@code Float} or {@code Double} (preview)
+     *   <li>(Preview) the element is of type {@code Float} or {@code Double}
      *       and equals to the target (matched by representation equivalence using
      *       {@code equals} on boxed values)</li>
      *   <li>the element is of type {@code EnumDesc}, that describes a constant

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -133,7 +133,8 @@ public final class SwitchBootstraps {
      * Bootstrap method for linking an {@code invokedynamic} call site that
      * implements a {@code switch} on a target of a reference type.  The static
      * arguments are an array of case labels which must be non-null and of type
-     * {@code String} or {@code Integer} or {@code Class} or {@code EnumDesc}.
+     * {@code String}, {@code Integer}, {@code Long}, {@code Float}, {@code Double},
+     * {@code Boolean}, {@code Class}, or {@code EnumDesc}.
      * <p>
      * The type of the returned {@code CallSite}'s method handle will have
      * a return type of {@code int}.   It has two parameters: the first argument
@@ -149,8 +150,8 @@ public final class SwitchBootstraps {
      * <ul>
      *   <li>the element is of type {@code Class} that is assignable
      *       from the target's class; or</li>
-     *   <li>the element is of type {@code String} or {@code Integer} and
-     *       equals to the target.</li>
+     *   <li>the element is of type {@code String}, {@code Integer}, {@code Long},
+     *       {@code Float}, {@code Double}, or {@code Boolean} and equals to the target.</li>
      *   <li>the element is of type {@code EnumDesc}, that describes a constant that is
      *       equals to the target.</li>
      * </ul>
@@ -162,13 +163,18 @@ public final class SwitchBootstraps {
      * the length of the {@code labels} array (inclusive),
      * both  or an {@link IndexOutOfBoundsException} is thrown.
      *
+     * @apiNote
+     * Case labels of type {@code Long}, {@code Float}, {@code Double}, or {@code Boolean}
+     * are allowed only when preview features are enabled.
+     *
      * @param lookup Represents a lookup context with the accessibility
      *               privileges of the caller.  When used with {@code invokedynamic},
      *               this is stacked automatically by the VM.
      * @param invocationName unused, {@code null} is permitted
      * @param invocationType The invocation type of the {@code CallSite} with two parameters,
      *                       a reference type, an {@code int}, and {@code int} as a return type.
-     * @param labels case labels - {@code String} and {@code Integer} constants
+     * @param labels case labels - {@code String}, {@code Integer}, {@code Long},
+     *               {@code Float}, {@code Double}, and {@code Boolean} constants
      *               and {@code Class} and {@code EnumDesc} instances, in any combination
      * @return a {@code CallSite} returning the first matching element as described above
      *
@@ -179,6 +185,8 @@ public final class SwitchBootstraps {
      * @throws IllegalArgumentException if {@code labels} contains an element that is not of type {@code String},
      *                                  {@code Integer}, {@code Long}, {@code Float}, {@code Double}, {@code Boolean},
      *                                  {@code Class} or {@code EnumDesc}
+     * @throws IllegalArgumentException with preview features disabled and if {@code labels} contains an element
+     *                                  that is of type {@code Long}, {@code Float}, {@code Double}, or {@code Boolean}
      * @throws IllegalArgumentException if {@code labels} contains an element that is not of type {@code Boolean}
      *                                  when {@code target} is a {@code Boolean.class}
      * @jvms 4.4.6 The CONSTANT_NameAndType_info Structure

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -131,10 +131,11 @@ public final class SwitchBootstraps {
 
     /**
      * Bootstrap method for linking an {@code invokedynamic} call site that
-     * implements a {@code switch} on a target. The static arguments are an array
-     * of case labels which must be non-null and of type {@code String},
-     * {@code Integer}, {@code Long}, {@code Float}, {@code Double}, {@code Boolean},
-     * {@code Class}, or {@code EnumDesc}.
+     * implements a {@code switch} over a target value. The static arguments
+     * {@code labels} are an array of case labels which must be non-null and of
+     * type {@code String}, {@code Integer}, {@code Class}, or {@code EnumDesc}.
+     * In addition, when preview features are enabled, {@code Long}, {@code Float},
+     * {@code Double}, and {@code Boolean} labels are also permitted.
      * <p>
      * The type of the returned {@code CallSite}'s method handle will have
      * a return type of {@code int}.   It has two parameters: the first argument
@@ -149,11 +150,19 @@ public final class SwitchBootstraps {
      * the {@code restart} index matching one of the following conditions:
      * <ul>
      *   <li>the element is of type {@code Class} that is assignable
-     *       from the target's class; or</li>
-     *   <li>the element is of type {@code String}, {@code Integer}, {@code Long},
-     *       {@code Float}, {@code Double}, or {@code Boolean} and equals to the target.</li>
-     *   <li>the element is of type {@code EnumDesc}, that describes a constant that is
-     *       equals to the target.</li>
+     *       from the target's class</li>
+     *   <li>the element is of type {@code String} and equals to the target
+     *       (matched by content using {@code equals})</li>
+     *   <li>the element is of type {@code Integer} and equals to the target
+     *       (matched by value comparison using {@code ==} after unboxing if necessary)</li>
+     *   <li>the element is of type {@code Long} or {@code Boolean} (preview)
+     *       and equals to the target (matched by value comparison using {@code ==}
+     *       after unboxing if necessary)</li>
+     *   <li>the element is of type {@code Float} or {@code Double} (preview)
+     *       and equals to the target (matched by representation equivalence using
+     *       {@code equals} on boxed values)</li>
+     *   <li>the element is of type {@code EnumDesc}, that describes a constant
+     *       that is equal to the target (matched using {@code ==} on enum constants)</li>
      * </ul>
      * <p>
      * If no element in the {@code labels} array matches the target, then
@@ -163,22 +172,13 @@ public final class SwitchBootstraps {
      * the length of the {@code labels} array (inclusive),
      * both  or an {@link IndexOutOfBoundsException} is thrown.
      *
-     * <div class="preview-block">
-     *   <div class="preview-comment">
-     *     Case labels of type {@code Long}, {@code Float}, {@code Double}, or
-     *     {@code Boolean} are allowed only when preview features are enabled.
-     *   </div>
-     * </div>
-     *
      * @param lookup Represents a lookup context with the accessibility
      *               privileges of the caller.  When used with {@code invokedynamic},
      *               this is stacked automatically by the VM.
      * @param invocationName unused, {@code null} is permitted
      * @param invocationType The invocation type of the {@code CallSite} with two parameters,
      *                       a target type, an {@code int}, and {@code int} as a return type.
-     * @param labels case labels - {@code String}, {@code Integer}, {@code Long},
-     *               {@code Float}, {@code Double}, and {@code Boolean} constants
-     *               and {@code Class} and {@code EnumDesc} instances, in any combination
+     * @param labels case labels as described above
      * @return a {@code CallSite} returning the first matching element as described above
      *
      * @throws NullPointerException     if any argument is {@code null}, unless noted otherwise

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -151,18 +151,15 @@ public final class SwitchBootstraps {
      * <ul>
      *   <li>the element is of type {@code Class} that is assignable
      *       from the target's class</li>
-     *   <li>the element is of type {@code String} and equals to the target
-     *       (matched by content using {@code equals})</li>
-     *   <li>the element is of type {@code Integer} and equals to the target
-     *       (matched by value comparison using {@code ==} after unboxing if necessary)</li>
+     *   <li>the element is of type {@code String} and {@code equals} to the target</li>
+     *   <li>the element is of type {@code Integer} and {@code ==} to the target after
+     *       unboxing if necessary</li>
      *   <li>(Preview) the element is of type {@code Long} or {@code Boolean}
-     *       and equals to the target (matched by value comparison using {@code ==}
-     *       after unboxing if necessary)</li>
+     *       and {@code ==} to the target after unboxing if necessary</li>
      *   <li>(Preview) the element is of type {@code Float} or {@code Double}
-     *       and equals to the target (matched by representation equivalence using
-     *       {@code equals} on boxed values)</li>
-     *   <li>the element is of type {@code EnumDesc}, that describes a constant
-     *       that is equal to the target (matched using {@code ==} on enum constants)</li>
+     *       and {@code equals} to the target after boxing if necessary</li>
+     *   <li>the element is of type {@code EnumDesc}, that describes an enum constant
+     *       that is {@code ==} to the target</li>
      * </ul>
      * <p>
      * If no element in the {@code labels} array matches the target, then


### PR DESCRIPTION
With the `SwitchBootstraps.typeSwitch(...)` method, there is a specification issue (difference between what is written in the method's Javadoc and its actual behaviour) causing some JCK tests to fail.

The proposal here is:
Adjust the Javadoc of the `SwitchBootstraps.typeSwitch(...)` method to reflect the following changes in the behaviour of the method:
- the method no longer requires a `target` to be of a reference type (primitive type targets are allowed now)
- primitive type `labels` are allowed now if the preview features are enabled


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8382163](https://bugs.openjdk.org/browse/JDK-8382163) to be approved

### Issues
 * [JDK-8381898](https://bugs.openjdk.org/browse/JDK-8381898): SwitchBootstraps::typeSwitch() not accepting Float, Double types (**Bug** - P2)
 * [JDK-8376162](https://bugs.openjdk.org/browse/JDK-8376162): SwitchBoostraps.typeSwitch does not throw IAE as expected (**Bug** - P3)
 * [JDK-8382163](https://bugs.openjdk.org/browse/JDK-8382163): SwitchBootstraps::typeSwitch() not accepting Float, Double types (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - **Reviewer**) Review applies to [3d8b1c5a](https://git.openjdk.org/jdk/pull/30703/files/3d8b1c5a41687d365af1bdc9c7e98b2b648a6658)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30703/head:pull/30703` \
`$ git checkout pull/30703`

Update a local copy of the PR: \
`$ git checkout pull/30703` \
`$ git pull https://git.openjdk.org/jdk.git pull/30703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30703`

View PR using the GUI difftool: \
`$ git pr show -t 30703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30703.diff">https://git.openjdk.org/jdk/pull/30703.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30703#issuecomment-4236387625)
</details>
