### PR TITLE
8382087: aarch64: remove unused function declarations in macroAssembler_aarch64.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1000,30 +1000,6 @@ public:
     f(0b0101010, 31, 25), f(0, 24), sf(offset, 23, 5), f(0, 4), f(cond, 3, 0);
   }
 
-#define INSN(NAME, cond)                        \
-  void NAME(address dest) {                     \
-    br(cond, dest);                             \
-  }
-
-  INSN(beq, EQ);
-  INSN(bne, NE);
-  INSN(bhs, HS);
-  INSN(bcs, CS);
-  INSN(blo, LO);
-  INSN(bcc, CC);
-  INSN(bmi, MI);
-  INSN(bpl, PL);
-  INSN(bvs, VS);
-  INSN(bvc, VC);
-  INSN(bhi, HI);
-  INSN(bls, LS);
-  INSN(bge, GE);
-  INSN(blt, LT);
-  INSN(bgt, GT);
-  INSN(ble, LE);
-  INSN(bal, AL);
-  INSN(bnv, NV);
-
   void br(Condition cc, Label &L);
 
 #undef INSN

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -890,10 +890,6 @@ public:
   // thread in the default location (rthread)
   void reset_last_Java_frame(bool clear_fp);
 
-  // Stores
-  void store_check(Register obj);                // store check for obj - register is destroyed afterwards
-  void store_check(Register obj, Address dst);   // same as above, dst is exact store location (reg. is destroyed)
-
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
   void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 


### PR DESCRIPTION
Hi, please consider this trivial change removing two unused function declarations.

This seems like leftover of JDK-8199417: Modularize interpreter GC barriers.

Testing: fastdebug & release build fine after this change on linux-aarch64.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382087](https://bugs.openjdk.org/browse/JDK-8382087): aarch64: remove unused function declarations in macroAssembler_aarch64.hpp (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30705/head:pull/30705` \
`$ git checkout pull/30705`

Update a local copy of the PR: \
`$ git checkout pull/30705` \
`$ git pull https://git.openjdk.org/jdk.git pull/30705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30705`

View PR using the GUI difftool: \
`$ git pr show -t 30705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30705.diff">https://git.openjdk.org/jdk/pull/30705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30705#issuecomment-4236614275)
</details>
