### PR TITLE
8382081: AOT tests fail in add_stub_entries without JVMCI

### DIFF
--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -604,7 +604,7 @@ class DeoptimizationBlob: public SingletonBlob {
   );
 
  public:
-  static const int ENTRY_COUNT = 4 JVMTI_ONLY(+ 2);
+  static const int ENTRY_COUNT = 4 JVMCI_ONLY(+ 2);
   // Creation
   static DeoptimizationBlob* create(
     CodeBuffer* cb,


### PR DESCRIPTION
This was a single character error (so, very easy to fix ;-).

The entry count was being initialized using `= 4 JVMTI_ONLY(+ 2)` when it should have been `= 4 JVMCI_ONLY(+ 2)`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382081](https://bugs.openjdk.org/browse/JDK-8382081): AOT tests fail in add_stub_entries without JVMCI (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30707/head:pull/30707` \
`$ git checkout pull/30707`

Update a local copy of the PR: \
`$ git checkout pull/30707` \
`$ git pull https://git.openjdk.org/jdk.git pull/30707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30707`

View PR using the GUI difftool: \
`$ git pr show -t 30707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30707.diff">https://git.openjdk.org/jdk/pull/30707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30707#issuecomment-4236786968)
</details>
