### PR TITLE
8380989: HttpRequest.Builder#headers() throws an exception if an empty array is passed

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestBuilderImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,7 +145,7 @@ public class HttpRequestBuilderImpl implements HttpRequest.Builder {
     @Override
     public HttpRequestBuilderImpl headers(String... params) {
         requireNonNull(params);
-        if (params.length == 0 || params.length % 2 != 0) {
+        if (params.length % 2 != 0) {
             throw newIAE("wrong number, %d, of parameters", params.length);
         }
         for (int i = 0; i < params.length; i += 2) {

--- a/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,8 +112,8 @@ public class HttpRequestBuilderTest {
         builder = test1("headers", builder, builder::headers, (String[]) null,
                         NullPointerException.class);
 
-        builder = test1("headers", builder, builder::headers, new String[0],
-                        IllegalArgumentException.class);
+        builder = test1("headers", builder, builder::headers, new String[0]
+                        /* no expected exceptions */);
 
         builder = test1("headers", builder, builder::headers,
                         (String[]) new String[] {null, "bar"},

--- a/test/jdk/java/net/httpclient/RequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/RequestBuilderTest.java
@@ -202,11 +202,10 @@ public class RequestBuilderTest {
     public void testHeaders() {
         HttpRequest.Builder builder = newBuilder(uri);
 
-        String[] empty = new String[0];
-        assertThrows(IAE, () -> builder.headers(empty).build());
         assertThrows(IAE, () -> builder.headers("1").build());
         assertThrows(IAE, () -> builder.headers("1", "2", "3").build());
         assertThrows(IAE, () -> builder.headers("1", "2", "3", "4", "5").build());
+        assertEquals(0, builder.headers(new String[0]).build().headers().map().size());
         assertEquals(0, builder.build().headers().map().size());
 
         List<HttpRequest> requests = List.of(


### PR DESCRIPTION
Allow empty arrays in `HttpRequest.Builder#headers()`.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8382145](https://bugs.openjdk.org/browse/JDK-8382145) to be approved

### Issues
 * [JDK-8380989](https://bugs.openjdk.org/browse/JDK-8380989): HttpRequest.Builder#headers() throws an exception if an empty array is passed (**Bug** - P4)
 * [JDK-8382145](https://bugs.openjdk.org/browse/JDK-8382145): HttpRequest.Builder#headers() throws an exception if an empty array is passed (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30708/head:pull/30708` \
`$ git checkout pull/30708`

Update a local copy of the PR: \
`$ git checkout pull/30708` \
`$ git pull https://git.openjdk.org/jdk.git pull/30708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30708`

View PR using the GUI difftool: \
`$ git pr show -t 30708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30708.diff">https://git.openjdk.org/jdk/pull/30708.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30708#issuecomment-4237016835)
</details>
