### PR TITLE
8381934: Wrong type passed to FREE_C_HEAP_ARRAY deallocating G1CardSetMemoryManager

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -90,7 +90,7 @@ G1CardSetMemoryManager::~G1CardSetMemoryManager() {
   for (uint i = 0; i < num_mem_object_types(); i++) {
     _allocators[i].~G1CardSetAllocator();
   }
-  FREE_C_HEAP_ARRAY(G1CardSetAllocator<G1CardSetContainer>, _allocators);
+  FREE_C_HEAP_ARRAY(G1CardSetAllocator, _allocators);
 }
 
 void G1CardSetMemoryManager::free(uint type, void* value) {


### PR DESCRIPTION
Hi all,

  please review this trivial change fixing the type of the memory chunk passed to `FREE_C_HEAP_ARRAY`.

It does not really matter because it is thrown away, but it may be confusing to the user.

Testing: local compilation, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381934](https://bugs.openjdk.org/browse/JDK-8381934): Wrong type passed to FREE_C_HEAP_ARRAY deallocating G1CardSetMemoryManager (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30710/head:pull/30710` \
`$ git checkout pull/30710`

Update a local copy of the PR: \
`$ git checkout pull/30710` \
`$ git pull https://git.openjdk.org/jdk.git pull/30710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30710`

View PR using the GUI difftool: \
`$ git pr show -t 30710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30710.diff">https://git.openjdk.org/jdk/pull/30710.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30710#issuecomment-4241987296)
</details>
