### PR TITLE
8316439: Several jvmti tests fail with -Xcheck:jni

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe007/popframe007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe007/popframe007.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ static jvmtiEventCallbacks callbacks;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 static jmethodID mid;
+static jclass testThreadClass = nullptr;
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         jthread thread, jmethodID method, jlocation location) {
@@ -166,6 +167,8 @@ Java_nsk_jvmti_PopFrame_popframe007_getReady(JNIEnv *env,
         return;
     }
 
+    testThreadClass = (jclass)env->NewGlobalRef(clazz);
+
     err = jvmti->SetBreakpoint(mid, 0);
     if (err != JVMTI_ERROR_NONE) {
         printf("(SetBreakpoint) unexpected error: %s (%d)\n",
@@ -191,7 +194,7 @@ Java_nsk_jvmti_PopFrame_popframe007_getRes(JNIEnv *env, jclass cls) {
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_PopFrame_popframe007_B(JNIEnv *env, jclass cls) {
     if (mid != nullptr) {
-        env->CallStaticVoidMethod(cls, mid);
+        env->CallStaticVoidMethod(testThreadClass, mid);
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
@@ -114,6 +114,7 @@ ClassFileLoadHook (
         return;
 
     if (jni->ExceptionCheck()) {
+        jni->ExceptionDescribe();
         jni->ExceptionClear();
         return;
     }
@@ -125,11 +126,8 @@ ClassFileLoadHook (
     if (!NSK_VERIFY((class_name_string = jni->NewStringUTF(name)) != nullptr))
         return;
 
-    jni->CallStaticObjectMethod(callback_class, method_id, class_name_string, agent_id);
-
-    if (jni->ExceptionCheck()) {
-        jni->ExceptionClear();
-    }
+    if (!NSK_JNI_VERIFY_VOID(jni, jni->CallStaticVoidMethod(callback_class, method_id, class_name_string, agent_id)))
+        return;
 }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,11 @@ ClassFileLoadHook (
             loader, method_id, class_name_string)) != nullptr))
         return;
 
+    if (jni->ExceptionCheck()) {
+        jni->ExceptionClear();
+        return;
+    }
+
     if (!NSK_VERIFY((method_id = jni->GetStaticMethodID(
             callback_class, "callback", "(Ljava/lang/String;I)V")) != nullptr))
         return;
@@ -121,6 +126,10 @@ ClassFileLoadHook (
         return;
 
     jni->CallStaticObjectMethod(callback_class, method_id, class_name_string, agent_id);
+
+    if (jni->ExceptionCheck()) {
+        jni->ExceptionClear();
+    }
 }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
@@ -126,8 +126,7 @@ ClassFileLoadHook (
     if (!NSK_VERIFY((class_name_string = jni->NewStringUTF(name)) != nullptr))
         return;
 
-    if (!NSK_JNI_VERIFY_VOID(jni, jni->CallStaticVoidMethod(callback_class, method_id, class_name_string, agent_id)))
-        return;
+    NSK_JNI_VERIFY_VOID(jni, jni->CallStaticVoidMethod(callback_class, method_id, class_name_string, agent_id));
 }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/aod.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/aod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
 extern "C" {
 
 static volatile int internalError = 0;
+
+/*
+ * Check for pending JNI exceptions after a JNI call.
+ * If an exception is found, describe it, clear it, and return failure.
+ */
+static int nsk_aod_checkJNIException(JNIEnv* jni) {
+    if (jni->ExceptionCheck()) {
+        jni->ExceptionDescribe();
+        jni->ExceptionClear();
+        NSK_COMPLAIN0("Unexpected exception after JNI call\n");
+        return NSK_FALSE;
+    }
+    return NSK_TRUE;
+}
 
 /*
  * This function can be used to inform AOD framework that some non critical for test logic
@@ -227,6 +241,10 @@ int nsk_aod_agentLoaded(JNIEnv* jni, const char* agentName) {
 
     jni->CallStaticVoidMethod(targetAppClass, agentLoadedMethod, agentNameString);
 
+    if (!nsk_aod_checkJNIException(jni)) {
+        return NSK_FALSE;
+    }
+
     return NSK_TRUE;
 }
 
@@ -262,6 +280,10 @@ int nsk_aod_agentFinished(JNIEnv* jni, const char* agentName, int success) {
         return NSK_FALSE;
 
     jni->CallStaticVoidMethod(targetAppClass, agentFinishedMethod, agentNameString, success ? JNI_TRUE : JNI_FALSE);
+
+    if (!nsk_aod_checkJNIException(jni)) {
+        return NSK_FALSE;
+    }
 
     return NSK_TRUE;
 }


### PR DESCRIPTION
Fixed three test files that fail with -Xcheck:jni on debug builds:

popframe007.cpp: CallStaticVoidMethod in native B() was called with the declaring class (popframe007) instead of TestThread where the method ID belongs. Stored TestThread class as a global ref in getReady() and used it in B()

aod.cpp: nsk_aod_agentLoaded() and nsk_aod_agentFinished() call CallStaticVoidMethod without checking for pending exceptions. Added nsk_aod_checkJNIException wrapper that describes, clears, and fails on unexpected exceptions. Fixes all 13 AttachOnDemand tests

retransform003.cpp: ClassFileLoadHook callback calls CallObjectMethod and CallStaticObjectMethod without checking for pending exceptions. Added ExceptionCheck/ExceptionClear after both calls

bi02t001 and bi03t001 pass without changes, NMT corruption issue from JDK 22 appears resolved on JDK 27

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316439](https://bugs.openjdk.org/browse/JDK-8316439): Several jvmti tests fail with -Xcheck:jni (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [28000a06](https://git.openjdk.org/jdk/pull/30711/files/28000a06e0bc20726eb8bf782c206154d7f634f9)
 * [Ekaterina Pavlova](https://openjdk.org/census#epavlova) (@katyapav - Committer) Review applies to [28000a06](https://git.openjdk.org/jdk/pull/30711/files/28000a06e0bc20726eb8bf782c206154d7f634f9)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [28000a06](https://git.openjdk.org/jdk/pull/30711/files/28000a06e0bc20726eb8bf782c206154d7f634f9)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30711/head:pull/30711` \
`$ git checkout pull/30711`

Update a local copy of the PR: \
`$ git checkout pull/30711` \
`$ git pull https://git.openjdk.org/jdk.git pull/30711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30711`

View PR using the GUI difftool: \
`$ git pr show -t 30711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30711.diff">https://git.openjdk.org/jdk/pull/30711.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30711#issuecomment-4237877314)
</details>
