### PR TITLE
8375322: Improve DomainKeyStore.java coverage

### DIFF
--- a/test/jdk/sun/security/provider/KeyStore/DKSSystemPropertiesTest.java
+++ b/test/jdk/sun/security/provider/KeyStore/DKSSystemPropertiesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8007755 8374808
+ * @library /test/lib
+ * @summary Support the logical grouping of keystores
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.security.DomainLoadStoreParameter;
+import java.security.KeyStore;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+// Load and store entries in domain keystores
+
+public class DKSSystemPropertiesTest {
+
+    private static final String TEST_SRC = System.getProperty("test.src");
+    private static final String USER_DIR = System.getProperty("user.dir", ".");
+    private static final String CONFIG = Paths.get(
+            TEST_SRC, "domains.cfg").toUri().toString();
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            // Environment variable and system properties referred in domains.cfg used by this Test.
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                    List.of("-Dtest.src=" + TEST_SRC, "-Duser.dir=" + USER_DIR,
+                            "DKSSystemPropertiesTest", "run"));
+            pb.environment().putAll(System.getenv());
+            pb.environment().put("KEYSTORE_PWD", "test12");
+            pb.environment().put("TRUSTSTORE_PWD", "changeit");
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            output.shouldHaveExitValue(0);
+            output.outputTo(System.out);
+            return;
+        }
+
+        /*
+         * domain keystore: system_env
+         */
+        URI config = new URI(CONFIG + "#system_env");
+        KeyStore keystore = KeyStore.getInstance("DKS");
+        // load entries
+        keystore.load(
+                new DomainLoadStoreParameter(config,
+                        Collections.<String, KeyStore.ProtectionParameter>emptyMap()));
+
+        int expected = keystore.size();
+
+        System.out.println("\nLoading domain keystore: " + config + "\t[" +
+                           expected + " entries]");
+        checkEntries(keystore, expected);
+    }
+
+    static void checkEntries(KeyStore keystore, int expectedCount)
+            throws Exception {
+        int currCount = 0;
+        for (String alias : Collections.list(keystore.aliases())) {
+            System.out.print(".");
+            currCount++;
+
+            // check creation date and instant
+            if (!keystore.getCreationDate(alias).equals(
+                    Date.from(keystore.getCreationInstant(alias)))
+            ) {
+                throw new RuntimeException(
+                        "Creation Date is not the same as Instant timestamp");
+            }
+        }
+        System.out.println();
+        // Check if current count is expected
+        if (expectedCount != currCount) {
+            throw new RuntimeException("Error: unexpected entry count in " +
+                                       "keystore: loaded=" + currCount + ", " +
+                                       "expected=" + expectedCount);
+        }
+    }
+
+}

--- a/test/jdk/sun/security/provider/KeyStore/DKSTest.java
+++ b/test/jdk/sun/security/provider/KeyStore/DKSTest.java
@@ -26,6 +26,7 @@
  * @bug 8007755 8374808
  * @library /test/lib
  * @summary Support the logical grouping of keystores
+ * @run junit DKSTest
  */
 
 import java.io.File;
@@ -34,21 +35,32 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DomainLoadStoreParameter;
 import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // Load and store entries in domain keystores
 
@@ -56,195 +68,346 @@ public class DKSTest {
 
     private static final String TEST_SRC = System.getProperty("test.src");
     private static final String USER_DIR = System.getProperty("user.dir", ".");
+    private static final Path SCRATCH_FOLDER = Path.of(".");
     private static final String CERT = Paths.get(
             TEST_SRC, "..", "..", "pkcs12", "trusted.pem").toAbsolutePath().toString();
     private static final String CONFIG = Paths.get(
             TEST_SRC, "domains.cfg").toUri().toString();
+    private static final char[] KEYSTORE_PASSWORD = "test123".toCharArray();
     private static final Map<String, KeyStore.ProtectionParameter> PASSWORDS =
-        new HashMap<String, KeyStore.ProtectionParameter>() {{
-            put("keystore",
-                new KeyStore.PasswordProtection("test123".toCharArray()));
-            put("policy_keystore",
-                new KeyStore.PasswordProtection(
-                    "Alias.password".toCharArray()));
-            put("pw_keystore",
-                new KeyStore.PasswordProtection("test12".toCharArray()));
-            put("eckeystore1",
-                new KeyStore.PasswordProtection("password".toCharArray()));
-            put("truststore",
-                new KeyStore.PasswordProtection("changeit".toCharArray()));
-            put("empty",
-                new KeyStore.PasswordProtection("passphrase".toCharArray()));
-        }};
+            new HashMap<>() {{
+                put("keystore",
+                        new KeyStore.PasswordProtection(KEYSTORE_PASSWORD));
+                put("policy_keystore",
+                        new KeyStore.PasswordProtection(
+                                "Alias.password".toCharArray()));
+                put("pw_keystore",
+                        new KeyStore.PasswordProtection("test12".toCharArray()));
+                put("eckeystore1",
+                        new KeyStore.PasswordProtection("password".toCharArray()));
+                put("truststore",
+                        new KeyStore.PasswordProtection("changeit".toCharArray()));
+                put("empty",
+                        new KeyStore.PasswordProtection("passphrase".toCharArray()));
+            }};
 
     private static final Map<String, KeyStore.ProtectionParameter>
-        WRONG_PASSWORDS = new HashMap<String, KeyStore.ProtectionParameter>() {{
-            put("policy_keystore",
-                new KeyStore.PasswordProtection(
-                    "wrong".toCharArray()));
-            put("pw_keystore",
-                new KeyStore.PasswordProtection("wrong".toCharArray()));
-            put("eckeystore1",
-                new KeyStore.PasswordProtection("wrong".toCharArray()));
-        }};
+            WRONG_PASSWORDS = new HashMap<>() {{
+                put("policy_keystore",
+                        new KeyStore.PasswordProtection(
+                                "wrong".toCharArray()));
+                put("pw_keystore",
+                        new KeyStore.PasswordProtection("wrong".toCharArray()));
+                put("eckeystore1",
+                        new KeyStore.PasswordProtection("wrong".toCharArray()));
+            }};
 
-    public static void main(String[] args) throws Exception {
-        if (args.length == 0) {
-            // Environment variable and system properties referred in domains.cfg used by this Test.
-            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(List.of(
-                    "-Dtest.src=" + TEST_SRC , "-Duser.dir=" + USER_DIR, "DKSTest", "run"));
-            pb.environment().putAll(System.getenv());
-            pb.environment().put("KEYSTORE_PWD", "test12");
-            pb.environment().put("TRUSTSTORE_PWD", "changeit");
-            OutputAnalyzer output = ProcessTools.executeProcess(pb);
-            output.shouldHaveExitValue(0);
-            output.outputTo(System.out);
-            return;
-        }
-        /*
-         * domain keystore: keystores with wrong passwords
-         */
-        try {
-            URI config = new URI(CONFIG + "#keystores");
-            KeyStore ks = KeyStore.getInstance("DKS");
-            ks.load(new DomainLoadStoreParameter(config, WRONG_PASSWORDS));
-            throw new RuntimeException("Expected exception not thrown");
-        } catch (IOException e) {
-            System.out.println("Expected exception: " + e);
-            if (!causedBy(e, UnrecoverableKeyException.class)) {
-                e.printStackTrace(System.out);
-                throw new RuntimeException("Unexpected cause");
-            }
+    /*
+     * domain keystore: keystores with wrong passwords
+     */
+    @Test
+    public void keystoresWithWrongPasswordTest() throws Exception {
+            final URI config = new URI(CONFIG + "#keystores");
+            final KeyStore ks = KeyStore.getInstance("DKS");
+
+            var e = assertThrows(IOException.class,
+                    () -> ks.load(new DomainLoadStoreParameter(
+                            config, WRONG_PASSWORDS)));
+            assertTrue(causedBy(e, UnrecoverableKeyException.class),
+                    "Unexpected cause");
             System.out.println("Expected cause: " + e);
-        }
+    }
 
-        /*
-         * domain keystore: system
-         */
-        URI config = new URI(CONFIG + "#system");
-        int cacertsCount;
-        int expected;
-        KeyStore keystore = KeyStore.getInstance("DKS");
+    /*
+     * domain keystore: system
+     */
+    @Test
+    public void keystoreSystemTest() throws Exception {
+        final URI config = new URI(CONFIG + "#system");
+        final KeyStore keystore = KeyStore.getInstance("DKS");
         // load entries
         keystore.load(new DomainLoadStoreParameter(config, PASSWORDS));
-        cacertsCount = expected = keystore.size();
+        final int expected = keystore.size();
         System.out.println("\nLoading domain keystore: " + config + "\t[" +
-            expected + " entries]");
-        checkEntries(keystore, expected);
+                           expected + " entries]");
+        DKSSystemPropertiesTest.checkEntries(keystore, expected);
+    }
 
-        /*
-         * domain keystore: system_plus
-         */
-        config = new URI(CONFIG + "#system_plus");
-        expected = cacertsCount + 1;
-        keystore = KeyStore.getInstance("DKS");
+    /*
+     * domain keystore: system_plus
+     */
+    @Test
+    public void keystoreSystemPlusTest() throws Exception {
+        final URI config = new URI(CONFIG + "#system_plus");
+        final KeyStore keystore = KeyStore.getInstance("DKS");
         // load entries
         keystore.load(new DomainLoadStoreParameter(config, PASSWORDS));
+        final int expected = keystore.size();
         System.out.println("\nLoading domain keystore: " + config + "\t[" +
-            expected + " entries]");
-        checkEntries(keystore, expected);
+                           expected + " entries]");
+        DKSSystemPropertiesTest.checkEntries(keystore, expected);
+    }
 
-        /*
-         * domain keystore: system_env
-         */
-        config = new URI(CONFIG + "#system_env");
-        expected = 1 + cacertsCount;
-        keystore = KeyStore.getInstance("DKS");
-        // load entries
-        keystore.load(
-            new DomainLoadStoreParameter(config,
-                Collections.<String, KeyStore.ProtectionParameter>emptyMap()));
-        System.out.println("\nLoading domain keystore: " + config + "\t[" +
-            expected + " entries]");
-        checkEntries(keystore, expected);
-
-        /*
-         * domain keystore: empty
-         */
-        KeyStore empty = KeyStore.getInstance("JKS");
+    /*
+     * domain keystore: empty
+     */
+    @Test
+    public void keystoreEmptyTest() throws Exception {
+        final KeyStore empty = KeyStore.getInstance("JKS");
         empty.load(null, null);
 
         try (OutputStream outStream =
-            new FileOutputStream(new File(USER_DIR, "empty.jks"))) {
+                     new FileOutputStream(new File(USER_DIR, "empty.jks"))) {
             empty.store(outStream, "passphrase".toCharArray());
         }
-        config = new URI(CONFIG + "#empty");
-        expected = 0;
-        keystore = KeyStore.getInstance("DKS");
+        final URI config = new URI(CONFIG + "#empty");
+        final KeyStore keystore = KeyStore.getInstance("DKS");
         // load entries
         keystore.load(new DomainLoadStoreParameter(config, PASSWORDS));
-        System.out.println("\nLoading domain keystore: " + config + "\t[" +
-            expected + " entries]");
-        checkEntries(keystore, expected);
+        System.out.println("\nLoading domain keystore: " + config +
+                           "\t[0 entries]");
+        DKSSystemPropertiesTest.checkEntries(keystore, 0);
 
-        /*
-         * domain keystore: keystores
-         */
-        config = new URI(CONFIG + "#keystores");
-        expected = 2 + 1 + 1;
-        keystore = KeyStore.getInstance("DKS");
+    }
+
+    /*
+     * domain keystore: keystores
+     */
+    @Test
+    public void multipleKeystoresTest() throws Exception {
+
+        URI config = new URI(CONFIG + "#keystores");
+        int expected = 2 + 1 + 1;
+        KeyStore keystore = KeyStore.getInstance("DKS");
         // load entries
         keystore.load(new DomainLoadStoreParameter(config, PASSWORDS));
         System.out.println("\nLoading domain keystore: " + config + "\t[" +
-            expected + " entries]");
-        checkEntries(keystore, expected);
+                           expected + " entries]");
+        DKSSystemPropertiesTest.checkEntries(keystore, expected);
         // set a new trusted certificate entry
         Certificate cert = loadCertificate(CERT);
         String alias = "pw_keystore tmp-cert";
         System.out.println("Setting new trusted certificate entry: " + alias);
         keystore.setEntry(alias,
-            new KeyStore.TrustedCertificateEntry(cert), null);
+                new KeyStore.TrustedCertificateEntry(cert), null);
         expected++;
         // store entries
         config = new URI(CONFIG + "#keystores_tmp");
         System.out.println("Storing domain keystore: " + config + "\t[" +
-            expected + " entries]");
+                           expected + " entries]");
         keystore.store(new DomainLoadStoreParameter(config, PASSWORDS));
         keystore = KeyStore.getInstance("DKS");
         // reload entries
         keystore.load(new DomainLoadStoreParameter(config, PASSWORDS));
         System.out.println("Reloading domain keystore: " + config + "\t[" +
-            expected + " entries]");
-        checkEntries(keystore, expected);
+                           expected + " entries]");
+        DKSSystemPropertiesTest.checkEntries(keystore, expected);
         // get the new trusted certificate entry
         System.out.println("Getting new trusted certificate entry: " + alias);
-        if (!keystore.isCertificateEntry(alias)) {
-            throw new Exception("Error: cannot retrieve certificate entry: " +
-                alias);
-        }
+        assertTrue(keystore.isCertificateEntry(alias),
+                "Error: cannot retrieve certificate entry: " + alias);
+
         keystore.setEntry(alias,
-            new KeyStore.TrustedCertificateEntry(cert), null);
+                new KeyStore.TrustedCertificateEntry(cert), null);
     }
 
-    private static void checkEntries(KeyStore keystore, int expectedCount)
-        throws Exception {
-        int currCount = 0;
-        for (String alias : Collections.list(keystore.aliases())) {
-            System.out.print(".");
-            currCount++;
+    @Test
+    public void keystoreGetKeyTest() throws Exception {
 
-            // check creation date and instant
-            if(!keystore.getCreationDate(alias).equals(
-                    Date.from(keystore.getCreationInstant(alias)))
-            ){
-                throw new RuntimeException(
-                        "Creation Date is not the same as Instant timestamp");
-            }
+        final SecretKey expected = generateSecretKey();
+        final SecretKey expected2 = generateSecretKey();
+        final KeyStore dks = generateKeystores(expected, expected2);
+
+        SecretKey actual =
+                (SecretKey) dks.getKey("firstPkcs12 alias1",
+                        KEYSTORE_PASSWORD);
+        assertNotNull(actual);
+        assertArrayEquals(expected.getEncoded(), actual.getEncoded());
+
+        actual = (SecretKey) dks.getKey("alias2", KEYSTORE_PASSWORD);
+        assertNotNull(actual);
+        assertArrayEquals(expected2.getEncoded(), actual.getEncoded());
+
+        assertNull(dks.getKey("missingAlias", KEYSTORE_PASSWORD));
+    }
+
+    @Test
+    public void keystoreContainsAliasTest() throws Exception {
+
+        final KeyStore dks = generateKeystores(
+                generateSecretKey(),
+                generateSecretKey());
+
+        assertTrue(dks.containsAlias("firstPkcs12 alias1"));
+        assertTrue(dks.containsAlias("alias2"));
+        assertFalse(dks.containsAlias("missingAlias"));
+        assertFalse(dks.containsAlias("unknown alias2"));
+    }
+
+    @Test
+    public void keystoreIsKeyEntryTest() throws Exception {
+
+        final KeyStore dks = generateKeystores(
+                generateSecretKey(),
+                generateSecretKey());
+
+        assertTrue(dks.isKeyEntry("firstPkcs12 alias1"));
+        assertTrue(dks.isKeyEntry("alias2"));
+        assertFalse(dks.isKeyEntry("missingAlias"));
+        assertFalse(dks.isKeyEntry("unknown alias2"));
+    }
+
+    @Test
+    public void keystoreIsCertificateEntryTest() throws Exception {
+
+        final KeyStore dks = generateKeyStoreFromPKCS12(generateSecretKey(),
+                loadCertificate(CERT));
+
+        assertTrue(dks.isCertificateEntry("firstPkcs12 alias1"));
+        assertFalse(dks.isCertificateEntry("missingAlias"));
+        assertFalse(dks.isCertificateEntry("unknown alias2"));
+    }
+
+    @Test
+    public void keystoreGetCertificateAliasEntryTest() throws Exception {
+
+        final Certificate certificate = loadCertificate(CERT);
+        final KeyStore dks = generateKeyStoreFromPKCS12(generateSecretKey(),
+                certificate);
+
+        assertEquals("alias1", dks.getCertificateAlias(certificate));
+    }
+
+    @Test
+    public void keystoreGetCertificateTest() throws Exception {
+
+        final Certificate certificate = loadCertificate(CERT);
+        final KeyStore dks = generateKeyStoreFromPKCS12(generateSecretKey(),
+                certificate);
+
+        assertEquals(certificate, dks.getCertificate("alias1"));
+    }
+
+    private KeyStore generateKeystores(final SecretKey secretKey,
+                                       final SecretKey secretKey2)
+            throws Exception {
+
+        final Path firstPkcs12 =
+                generatePKCS12("firstPkcs12.p12", "alias1",
+                        KEYSTORE_PASSWORD, secretKey);
+        final Path secondPkcs12 =
+                generatePKCS12("secondPkcs12.p12", "alias2",
+                        KEYSTORE_PASSWORD, secretKey2);
+        final Path thirdPkcs12 =
+                generatePKCS12("thirdPkcs12.p12", null,
+                        null, null);
+
+        final Map<String, KeyStore.ProtectionParameter> protectionParameters =
+                new LinkedHashMap<>();
+        protectionParameters.put("firstPkcs12",
+                new KeyStore.PasswordProtection(KEYSTORE_PASSWORD));
+        protectionParameters.put("secondPkcs12",
+                new KeyStore.PasswordProtection(KEYSTORE_PASSWORD));
+
+
+        final KeyStore dks = KeyStore.getInstance("DKS");
+        final Path config = createDomainConfig(Map.of(
+                "firstPkcs12", firstPkcs12,
+                "secondPkcs12", secondPkcs12,
+                "thirdPkcs12", thirdPkcs12));
+        dks.load(new DomainLoadStoreParameter(config.toUri(),
+                protectionParameters));
+
+        return dks;
+    }
+
+    private KeyStore generateKeyStoreFromPKCS12(final SecretKey secretKey,
+                                                final Certificate certificate) throws Exception {
+
+        // keystore with cert
+        final KeyStore keystore = KeyStore.getInstance("PKCS12");
+        keystore.load(null, null);
+        keystore.setEntry("alias1",
+                new KeyStore.TrustedCertificateEntry(certificate), null);
+        final Path firstPkcs12 = SCRATCH_FOLDER.resolve("firstPkcs12.p12");
+        try (OutputStream output = Files.newOutputStream(firstPkcs12)) {
+            keystore.store(output, KEYSTORE_PASSWORD);
         }
-        System.out.println();
-        // Check if current count is expected
-        if (expectedCount != currCount) {
-            throw new Exception("Error: unexpected entry count in keystore: " +
-                "loaded=" + currCount + ", expected=" + expectedCount);
+
+        final Path secondPkcs12 =
+                generatePKCS12("secondPkcs12.p12", "alias2",
+                        KEYSTORE_PASSWORD, secretKey);
+        final Path thirdPkcs12 =
+                generatePKCS12("thirdPkcs12.p12", null,
+                        null, null);
+
+        final Map<String, KeyStore.ProtectionParameter> protectionParameters =
+                new LinkedHashMap<>();
+        protectionParameters.put("firstPkcs12",
+                new KeyStore.PasswordProtection(KEYSTORE_PASSWORD));
+        protectionParameters.put("secondPkcs12",
+                new KeyStore.PasswordProtection(KEYSTORE_PASSWORD));
+
+
+        final KeyStore dks = KeyStore.getInstance("DKS");
+        final Path config = createDomainConfig(Map.of(
+                "firstPkcs12", firstPkcs12,
+                "secondPkcs12", secondPkcs12,
+                "thirdPkcs12", thirdPkcs12));
+        dks.load(new DomainLoadStoreParameter(config.toUri(),
+                protectionParameters));
+
+        return dks;
+    }
+
+    private SecretKey generateSecretKey() throws NoSuchAlgorithmException {
+        final KeyGenerator generator = KeyGenerator.getInstance("AES");
+        generator.init(128);
+        return generator.generateKey();
+    }
+
+    private Path createDomainConfig(Map<String, Path> parts) throws Exception {
+        final StringBuilder config = new StringBuilder();
+        config.append("domain TestDomain keystoreType=\"PKCS12\" {\n");
+        for (final Map.Entry<String, Path> entry : parts.entrySet()) {
+            config.append("    keystore ")
+                    .append(entry.getKey())
+                    .append(" keystoreURI=\"")
+                    .append(entry.getValue().toUri())
+                    .append("\";\n");
         }
+        config.append("};\n");
+
+        Path path = SCRATCH_FOLDER.resolve("domain.cfg");
+        Files.writeString(path, config.toString());
+        return path;
+    }
+
+    private Path generatePKCS12(final String fileName,
+                                final String alias,
+                                final char[] entryPassword,
+                                final SecretKey secretKey) throws Exception {
+        final KeyStore keystore = KeyStore.getInstance("PKCS12");
+        keystore.load(null, null);
+
+        if (alias != null) {
+            keystore.setEntry(alias, new KeyStore.SecretKeyEntry(secretKey),
+                    new KeyStore.PasswordProtection(entryPassword));
+        }
+
+        final Path path = SCRATCH_FOLDER.resolve(fileName);
+        try (OutputStream output = Files.newOutputStream(path)) {
+            keystore.store(output, KEYSTORE_PASSWORD);
+        }
+        return path;
     }
 
     private static Certificate loadCertificate(String certFile)
-        throws Exception {
+            throws Exception {
         X509Certificate cert = null;
         try (FileInputStream certStream = new FileInputStream(certFile)) {
             CertificateFactory factory =
-                CertificateFactory.getInstance("X.509");
+                    CertificateFactory.getInstance("X.509");
             return factory.generateCertificate(certStream);
         }
     }

--- a/test/jdk/sun/security/provider/KeyStore/DKSTest.java
+++ b/test/jdk/sun/security/provider/KeyStore/DKSTest.java
@@ -106,7 +106,7 @@ public class DKSTest {
      * domain keystore: keystores with wrong passwords
      */
     @Test
-    public void keystoresWithWrongPasswordTest() throws Exception {
+    public void wrongPasswordTest() throws Exception {
             final URI config = new URI(CONFIG + "#keystores");
             final KeyStore ks = KeyStore.getInstance("DKS");
 
@@ -122,7 +122,7 @@ public class DKSTest {
      * domain keystore: system
      */
     @Test
-    public void keystoreSystemTest() throws Exception {
+    public void SystemTest() throws Exception {
         final URI config = new URI(CONFIG + "#system");
         final KeyStore keystore = KeyStore.getInstance("DKS");
         // load entries
@@ -137,7 +137,7 @@ public class DKSTest {
      * domain keystore: system_plus
      */
     @Test
-    public void keystoreSystemPlusTest() throws Exception {
+    public void SystemPlusTest() throws Exception {
         final URI config = new URI(CONFIG + "#system_plus");
         final KeyStore keystore = KeyStore.getInstance("DKS");
         // load entries
@@ -212,7 +212,7 @@ public class DKSTest {
     }
 
     @Test
-    public void keystoreGetKeyTest() throws Exception {
+    public void getKeyTest() throws Exception {
 
         final SecretKey expected = generateSecretKey();
         final SecretKey expected2 = generateSecretKey();
@@ -232,7 +232,7 @@ public class DKSTest {
     }
 
     @Test
-    public void keystoreContainsAliasTest() throws Exception {
+    public void containsAliasTest() throws Exception {
 
         final KeyStore dks = generateKeystores(
                 generateSecretKey(),
@@ -245,7 +245,7 @@ public class DKSTest {
     }
 
     @Test
-    public void keystoreIsKeyEntryTest() throws Exception {
+    public void isKeyEntryTest() throws Exception {
 
         final KeyStore dks = generateKeystores(
                 generateSecretKey(),
@@ -258,7 +258,7 @@ public class DKSTest {
     }
 
     @Test
-    public void keystoreIsCertificateEntryTest() throws Exception {
+    public void isCertificateEntryTest() throws Exception {
 
         final KeyStore dks = generateKeyStoreFromPKCS12(generateSecretKey(),
                 loadCertificate(CERT));
@@ -269,7 +269,7 @@ public class DKSTest {
     }
 
     @Test
-    public void keystoreGetCertificateAliasEntryTest() throws Exception {
+    public void getCertificateAliasEntryTest() throws Exception {
 
         final Certificate certificate = loadCertificate(CERT);
         final KeyStore dks = generateKeyStoreFromPKCS12(generateSecretKey(),
@@ -279,7 +279,7 @@ public class DKSTest {
     }
 
     @Test
-    public void keystoreGetCertificateTest() throws Exception {
+    public void getCertificateTest() throws Exception {
 
         final Certificate certificate = loadCertificate(CERT);
         final KeyStore dks = generateKeyStoreFromPKCS12(generateSecretKey(),


### PR DESCRIPTION
* Improving the coverage of the `DomainKeyStore.java`
* converting existing tests to junit in order to make logs easier to read
* Further coverage for `DomainKeyStore.java` would be required, but should be done as a separate [ticket](https://bugs.openjdk.org/browse/JDK-8382096)  

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8375322](https://bugs.openjdk.org/browse/JDK-8375322): Improve DomainKeyStore.java coverage (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30712/head:pull/30712` \
`$ git checkout pull/30712`

Update a local copy of the PR: \
`$ git checkout pull/30712` \
`$ git pull https://git.openjdk.org/jdk.git pull/30712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30712`

View PR using the GUI difftool: \
`$ git pr show -t 30712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30712.diff">https://git.openjdk.org/jdk/pull/30712.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30712#issuecomment-4237863783)
</details>
