### PR TITLE
8382054: TestLoopPeelingDisabled.java fails with -DVerifyIR=false

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
@@ -49,19 +49,22 @@ public class TestLoopPeelingDisabled {
 
         // Then, run the same test with loop peeling disabled, which should
         // elide the {BEFORE,AFTER}_LOOP_PEELING compilation phases, causing the
-        // test to throw an IRViolationException. We then check whether the
+        // test to throw an IRViolationException.  We then check whether the
         // exception message matches our expectation (that the loop peeling
-        // phase was not found).
-        try {
-            TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
-                                       "-XX:LoopPeeling=0");
-            Asserts.fail("Expected IRViolationException");
-        } catch (IRViolationException e) {
-            String info = e.getExceptionInfo();
-            if (!info.contains("NO compilation output found for this phase")) {
-                Asserts.fail("Unexpected IR violation: " + info);
-            }
-            System.out.println("Loop peeling correctly disabled");
+        // phase was not found).  If IR verification is disabled, this test will
+        // not throw IRViolationException.
+        if (Boolean.parseBoolean(System.getProperty("VerifyIR", "true"))) {
+          try {
+              TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
+                                         "-XX:LoopPeeling=0");
+              Asserts.fail("Expected IRViolationException");
+          } catch (IRViolationException e) {
+              String info = e.getExceptionInfo();
+              if (!info.contains("NO compilation output found for this phase")) {
+                  Asserts.fail("Unexpected IR violation: " + info);
+              }
+              System.out.println("Loop peeling correctly disabled");
+          }
         }
 
         // Finally, run the same test with loop peeling disabled only when

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
@@ -55,7 +55,7 @@ public class TestLoopPeelingDisabled {
         // not throw IRViolationException.
         try {
             TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
-                                        "-XX:LoopPeeling=0");
+                                       "-XX:LoopPeeling=0");
             String verifyIR = System.getProperty("VerifyIR", "true");
             String msg = "Expected IRViolationException when performing IR matching";
             Asserts.assertFalse(Boolean.parseBoolean(verifyIR), msg);

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
@@ -49,22 +49,22 @@ public class TestLoopPeelingDisabled {
 
         // Then, run the same test with loop peeling disabled, which should
         // elide the {BEFORE,AFTER}_LOOP_PEELING compilation phases, causing the
-        // test to throw an IRViolationException.  We then check whether the
+        // test to throw IRViolationException. We then check whether the
         // exception message matches our expectation (that the loop peeling
-        // phase was not found).  If IR verification is disabled, this test will
+        // phase was not found). If IR verification is disabled, this test will
         // not throw IRViolationException.
-        if (Boolean.parseBoolean(System.getProperty("VerifyIR", "true"))) {
-          try {
-              TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
-                                         "-XX:LoopPeeling=0");
-              Asserts.fail("Expected IRViolationException");
-          } catch (IRViolationException e) {
-              String info = e.getExceptionInfo();
-              if (!info.contains("NO compilation output found for this phase")) {
-                  Asserts.fail("Unexpected IR violation: " + info);
-              }
-              System.out.println("Loop peeling correctly disabled");
-          }
+        try {
+            TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
+                                        "-XX:LoopPeeling=0");
+            String verifyIR = System.getProperty("VerifyIR", "true");
+            String msg = "Expected IRViolationException when performing IR matching";
+            Asserts.assertFalse(Boolean.parseBoolean(verifyIR), msg);
+        } catch (IRViolationException e) {
+            String info = e.getExceptionInfo();
+            if (!info.contains("NO compilation output found for this phase")) {
+                Asserts.fail("Unexpected IR violation: " + info);
+            }
+            System.out.println("Loop peeling correctly disabled");
         }
 
         // Finally, run the same test with loop peeling disabled only when

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopPeelingDisabled.java
@@ -49,10 +49,10 @@ public class TestLoopPeelingDisabled {
 
         // Then, run the same test with loop peeling disabled, which should
         // elide the {BEFORE,AFTER}_LOOP_PEELING compilation phases, causing the
-        // test to throw IRViolationException. We then check whether the
+        // test to throw an IRViolationException. We then check whether the
         // exception message matches our expectation (that the loop peeling
         // phase was not found). If IR verification is disabled, this test will
-        // not throw IRViolationException.
+        // not throw an IRViolationException.
         try {
             TestFramework.runWithFlags("-XX:+UnlockDiagnosticVMOptions",
                                        "-XX:LoopPeeling=0");


### PR DESCRIPTION
TestLoopPeelingDisabled.java contains a test that expects an IR
violation exception when loop peeling is disabled.  Specifically, the
test has an `@IR` annotation that checks for the presence of loop
peeling phases and we expect this IR check to fail when loop peeling is
disabled.  But when IR checks are disabled using `-DVerifyIR=false`, the
framework skips checking the annotation, resulting in no IR violation
exception, causing the test to fail.

This patch adds a guard so that only when `VerifyIR` is set that we look
for the IR violation exception.

Credit to Tobias Hartmann for discovering and reporing the issue.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382054](https://bugs.openjdk.org/browse/JDK-8382054): TestLoopPeelingDisabled.java fails with -DVerifyIR=false (**Bug** - P5)


### Reviewers
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30713/head:pull/30713` \
`$ git checkout pull/30713`

Update a local copy of the PR: \
`$ git checkout pull/30713` \
`$ git pull https://git.openjdk.org/jdk.git pull/30713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30713`

View PR using the GUI difftool: \
`$ git pr show -t 30713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30713.diff">https://git.openjdk.org/jdk/pull/30713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30713#issuecomment-4238311763)
</details>
