### PR TITLE
8381871: GenShen: ShenandoahGCHeuristics flag not reset after ignoring non-adaptive value

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -200,6 +200,7 @@ void ShenandoahArguments::initialize() {
       && strcmp(ShenandoahGCHeuristics, "adaptive") != 0) {
     log_warning(gc)("Ignoring -XX:ShenandoahGCHeuristics input: %s, because generational shenandoah only"
       " supports adaptive heuristics", ShenandoahGCHeuristics);
+    FLAG_SET_DEFAULT(ShenandoahGCHeuristics, "adaptive");
   }
 
   FullGCForwarding::initialize_flags(MaxHeapSize);

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -200,7 +200,7 @@ void ShenandoahArguments::initialize() {
       && strcmp(ShenandoahGCHeuristics, "adaptive") != 0) {
     log_warning(gc)("Ignoring -XX:ShenandoahGCHeuristics input: %s, because generational shenandoah only"
       " supports adaptive heuristics", ShenandoahGCHeuristics);
-    FLAG_SET_DEFAULT(ShenandoahGCHeuristics, "adaptive");
+    FLAG_SET_ERGO(ShenandoahGCHeuristics, "adaptive");
   }
 
   FullGCForwarding::initialize_flags(MaxHeapSize);

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestGenerationalHeuristics.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestGenerationalHeuristics.java
@@ -24,7 +24,7 @@
 
 /*
  * @test id=generational
- * @summary Test that ShenandoahGCHeuristics flags are reset after providing non-adaptive value
+ * @summary Test that ShenandoahGCHeuristics is always adaptive in generational mode
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @run driver TestGenerationalHeuristics
@@ -39,10 +39,42 @@ public class TestGenerationalHeuristics {
             OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
                 "-XX:+UseShenandoahGC",
                 "-XX:ShenandoahGCMode=generational",
+                "-XX:ShenandoahGCHeuristics=adaptive",
+                "-XX:+PrintFlagsFinal",
+                "-version");
+            output.shouldMatch("ShenandoahGCHeuristics(.*)= adaptive ");
+            output.shouldHaveExitValue(0);
+        }
+
+        {
+            OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
+                "-XX:+UseShenandoahGC",
+                "-XX:ShenandoahGCMode=generational",
                 "-XX:ShenandoahGCHeuristics=static",
                 "-XX:+PrintFlagsFinal",
                 "-version");
+            output.shouldMatch("ShenandoahGCHeuristics(.*)= adaptive ");
+            output.shouldHaveExitValue(0);
+        }
 
+        {
+            OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
+                "-XX:+UseShenandoahGC",
+                "-XX:ShenandoahGCMode=generational",
+                "-XX:ShenandoahGCHeuristics=aggressive",
+                "-XX:+PrintFlagsFinal",
+                "-version");
+            output.shouldMatch("ShenandoahGCHeuristics(.*)= adaptive ");
+            output.shouldHaveExitValue(0);
+        }
+
+        {
+            OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
+                "-XX:+UseShenandoahGC",
+                "-XX:ShenandoahGCMode=generational",
+                "-XX:ShenandoahGCHeuristics=compact",
+                "-XX:+PrintFlagsFinal",
+                "-version");
             output.shouldMatch("ShenandoahGCHeuristics(.*)= adaptive ");
             output.shouldHaveExitValue(0);
         }

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestGenerationalHeuristics.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestGenerationalHeuristics.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=generational
+ * @summary Test that ShenandoahGCHeuristics flags are reset after providing non-adaptive value
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @run driver TestGenerationalHeuristics
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestGenerationalHeuristics {
+    public static void main(String[] args) throws Exception {
+        {
+            OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
+                "-XX:+UseShenandoahGC",
+                "-XX:ShenandoahGCMode=generational",
+                "-XX:ShenandoahGCHeuristics=static",
+                "-XX:+PrintFlagsFinal",
+                "-version");
+
+            output.shouldMatch("ShenandoahGCHeuristics(.*)= adaptive ");
+            output.shouldHaveExitValue(0);
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestGenerationalHeuristics.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestGenerationalHeuristics.java
@@ -24,6 +24,7 @@
 
 /*
  * @test id=generational
+ * @bug 8381871
  * @summary Test that ShenandoahGCHeuristics is always adaptive in generational mode
  * @requires vm.gc.Shenandoah
  * @library /test/lib


### PR DESCRIPTION
Reset ShenandoahGCHeuristics flag to "adaptive" after a non-adaptive value is set for ShenandoahGCHeuristics when using Generational Shenandoah.

### Testing
Created a test file `TestGenerationalHeuristics.java` that checks if ShenandoahGCHeuristics flag is always adaptive for Generational Shenandoah.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (4 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 3 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381871](https://bugs.openjdk.org/browse/JDK-8381871): GenShen: ShenandoahGCHeuristics flag not reset after ignoring non-adaptive value (**Bug** - P5)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**) Review applies to [3f636be2](https://git.openjdk.org/jdk/pull/30714/files/3f636be214ee50ef57f2502608d11afab2f8ad9d)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30714/head:pull/30714` \
`$ git checkout pull/30714`

Update a local copy of the PR: \
`$ git checkout pull/30714` \
`$ git pull https://git.openjdk.org/jdk.git pull/30714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30714`

View PR using the GUI difftool: \
`$ git pr show -t 30714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30714.diff">https://git.openjdk.org/jdk/pull/30714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30714#issuecomment-4238884177)
</details>
