### PR TITLE
8374629: Type test pattern with array type in switch fails to parse

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3434,9 +3434,17 @@ public class JavacParser implements Parser {
                 case GT:
                     typeDepth--;
                     if (typeDepth == 0 && !peekToken(lookahead, DOT)) {
-                         return peekToken(lookahead, LAX_IDENTIFIER) ||
-                                peekToken(lookahead, tk -> tk == LPAREN) ? PatternResult.PATTERN
-                                                                         : PatternResult.EXPRESSION;
+                         if(peekToken(lookahead, LAX_IDENTIFIER) ||
+                            peekToken(lookahead, tk -> tk == LPAREN)) {
+                             return PatternResult.PATTERN;
+                         }
+                         else if (peekToken(lookahead, LBRACKET) ||
+                                  peekToken(lookahead, MONKEYS_AT)) {
+                             break;
+                         }
+                         else {
+                             return PatternResult.EXPRESSION;
+                         }
                     } else if (typeDepth < 0) return PatternResult.EXPRESSION;
                     break;
                 case MONKEYS_AT:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3434,7 +3434,7 @@ public class JavacParser implements Parser {
                 case GT:
                     typeDepth--;
                     if (typeDepth == 0 && !peekToken(lookahead, DOT)) {
-                         if(peekToken(lookahead, LAX_IDENTIFIER) ||
+                         if (peekToken(lookahead, LAX_IDENTIFIER) ||
                             peekToken(lookahead, tk -> tk == LPAREN)) {
                              return PatternResult.PATTERN;
                          }

--- a/test/langtools/tools/javac/patterns/DisambiguatePatterns.java
+++ b/test/langtools/tools/javac/patterns/DisambiguatePatterns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,26 @@ public class DisambiguatePatterns {
                                  ExpressionType.PATTERN);
         test.disambiguationTest("R(int x) when (x > 0)",
                                  ExpressionType.PATTERN);
+        test.disambiguationTest("java.util.List<?>[] p",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("java.util.List<?>[][] p",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("a<b<c>>[] d",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("java.util.List<?>[] p when true",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("java.util.List<?> @Ann [] p",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("a<b<c>> @Ann [] d",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("(java.util.List<?>[]) o",
+                                 ExpressionType.EXPRESSION);
+        test.disambiguationTest("String[].class",
+                                 ExpressionType.EXPRESSION);
+        test.disambiguationTest("new int[1][]",
+                                ExpressionType.EXPRESSION);
+        test.disambiguationTest("new java.util.List<?>[1][]",
+                                ExpressionType.EXPRESSION);
     }
 
     private final ParserFactory factory;


### PR DESCRIPTION
The parser was too strict when parsing `>` in the classification of a label on whether it is an expression or pattern. There are still occasions that after an `[` or an `@` an expression may follow. This PR addresses this issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374629](https://bugs.openjdk.org/browse/JDK-8374629): Type test pattern with array type in switch fails to parse (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30721/head:pull/30721` \
`$ git checkout pull/30721`

Update a local copy of the PR: \
`$ git checkout pull/30721` \
`$ git pull https://git.openjdk.org/jdk.git pull/30721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30721`

View PR using the GUI difftool: \
`$ git pr show -t 30721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30721.diff">https://git.openjdk.org/jdk/pull/30721.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30721#issuecomment-4244638255)
</details>
