### PR TITLE
8382167: Warning message should be displayed only when UseAESCTRIntrinsics is explicitly enabled by the user

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1187,7 +1187,7 @@ void VM_Version::get_processor_features() {
     }
     if (!UseAESIntrinsics) {
       if (UseAESCTRIntrinsics) {
-        if (FLAG_IS_DEFAULT(UseAESCTRIntrinsics)) {
+        if (!FLAG_IS_DEFAULT(UseAESCTRIntrinsics)) {
           warning("AES-CTR intrinsics require UseAESIntrinsics flag to be enabled. Intrinsics will be disabled.");
         }
         FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);


### PR DESCRIPTION
Trivial change to fix the warning message.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382167](https://bugs.openjdk.org/browse/JDK-8382167): Warning message should be displayed only when UseAESCTRIntrinsics is explicitly enabled by the user (**Enhancement** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30722/head:pull/30722` \
`$ git checkout pull/30722`

Update a local copy of the PR: \
`$ git checkout pull/30722` \
`$ git pull https://git.openjdk.org/jdk.git pull/30722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30722`

View PR using the GUI difftool: \
`$ git pr show -t 30722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30722.diff">https://git.openjdk.org/jdk/pull/30722.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30722#issuecomment-4244892284)
</details>
