### PR TITLE
8382146: jdk/jfr/event/compiler/TestCodeCacheFull.java fails when C2 is disabled

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
@@ -34,7 +34,7 @@ import jdk.test.whitebox.WhiteBox;
 import jdk.test.whitebox.code.BlobType;
 
 /**
- * @test TestCodeCacheFull
+ * @test id=Default
  * @requires vm.hasJFR
  * @requires vm.opt.UseCodeCacheFlushing == null | vm.opt.UseCodeCacheFlushing == true
  *
@@ -50,6 +50,20 @@ import jdk.test.whitebox.code.BlobType;
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache jdk.jfr.event.compiler.TestCodeCacheFull
+ */
+
+/**
+ * @test id=HotCode
+ * @requires vm.hasJFR
+ * @requires vm.opt.UseCodeCacheFlushing == null | vm.opt.UseCodeCacheFlushing == true
+ * @requires vm.compiler2.enabled
+ *
+ * @library /test/lib
+ * @modules jdk.jfr
+ *          jdk.management.jfr
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+TieredCompilation -XX:+UnlockExperimentalVMOptions -XX:+HotCodeHeap -XX:HotCodeHeapSize=8M jdk.jfr.event.compiler.TestCodeCacheFull


### PR DESCRIPTION
[JDK-8382146](https://bugs.openjdk.org/browse/JDK-8382146)

Updates `test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java` to require C2 when running with the HotCodeHeap.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382146](https://bugs.openjdk.org/browse/JDK-8382146): jdk/jfr/event/compiler/TestCodeCacheFull.java fails when C2 is disabled (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30725/head:pull/30725` \
`$ git checkout pull/30725`

Update a local copy of the PR: \
`$ git checkout pull/30725` \
`$ git pull https://git.openjdk.org/jdk.git pull/30725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30725`

View PR using the GUI difftool: \
`$ git pr show -t 30725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30725.diff">https://git.openjdk.org/jdk/pull/30725.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30725#issuecomment-4246052129)
</details>
