### PR TITLE
8382170: Assert in AnyObj::operator delete due to race condition in in_aot_cache()

### DIFF
--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -107,7 +107,7 @@ public:
   //
   // Unlike MetaspaceObj::is_pointer_in_aot_cache(), this function should be called in contexts
   // where the AOT metaspace range is known to have been initialized (which happens very early
-  // in VM boostrap), so the caller doesn't need to explicity check for
+  // in VM bootstrap), so the caller doesn't need to explicitly check for
   // MetaspaceObj::aot_metaspace_range_initialized().
   static bool in_aot_cache(const void* p) {
     return MetaspaceObj::is_pointer_in_aot_cache(p);

--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -104,13 +104,10 @@ public:
 
   // Return true if given address is in the shared metaspace regions (i.e., excluding the
   // mapped heap region.)
-  //
-  // Unlike MetaspaceObj::is_pointer_in_aot_cache(), this function should be called in contexts
-  // where the AOT metaspace range is known to have been initialized (which happens very early
-  // in VM bootstrap), so the caller doesn't need to explicitly check for
-  // MetaspaceObj::aot_metaspace_range_initialized().
   static bool in_aot_cache(const void* p) {
-    return MetaspaceObj::is_pointer_in_aot_cache(p);
+    // This function is called only after the AOT metaspace is initialized, so
+    // we can skip init checks.
+    return MetaspaceObj::is_pointer_in_aot_cache_no_init_check(p);
   }
 
   static void set_aot_metaspace_range(void* base, void *static_top, void* top) NOT_CDS_RETURN;

--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -105,7 +105,9 @@ public:
   // Return true if given address is in the shared metaspace regions (i.e., excluding the
   // mapped heap region.)
   static bool in_aot_cache(const void* p) {
-    return MetaspaceObj::in_aot_cache((const MetaspaceObj*)p);
+    assert(MetaspaceObj::aot_metaspace_range_initialized(), "Do not call this function before"
+           " set_aot_metaspace_range() has been called");
+    return MetaspaceObj::is_pointer_in_aot_cache(p);
   }
 
   static void set_aot_metaspace_range(void* base, void *static_top, void* top) NOT_CDS_RETURN;

--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -110,8 +110,6 @@ public:
   // in VM boostrap), so the caller doesn't need to explicity check for
   // MetaspaceObj::aot_metaspace_range_initialized().
   static bool in_aot_cache(const void* p) {
-    assert(MetaspaceObj::aot_metaspace_range_initialized(), "Do not call this function before"
-           " set_aot_metaspace_range() has been called");
     return MetaspaceObj::is_pointer_in_aot_cache(p);
   }
 

--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -104,6 +104,11 @@ public:
 
   // Return true if given address is in the shared metaspace regions (i.e., excluding the
   // mapped heap region.)
+  //
+  // Unlike MetaspaceObj::is_pointer_in_aot_cache(), this function should be called in contexts
+  // where the AOT metaspace range is known to have been initialized (which happens very early
+  // in VM boostrap), so the caller doesn't need to explicity check for
+  // MetaspaceObj::aot_metaspace_range_initialized().
   static bool in_aot_cache(const void* p) {
     assert(MetaspaceObj::aot_metaspace_range_initialized(), "Do not call this function before"
            " set_aot_metaspace_range() has been called");

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1277,7 +1277,7 @@ unsigned int SystemDictionaryShared::hash_for_shared_dictionary(address ptr) {
     uintx offset = ArchiveBuilder::current()->any_to_offset(ptr);
     unsigned int hash = primitive_hash<uintx>(offset);
     DEBUG_ONLY({
-        if (MetaspaceObj::in_aot_cache((const MetaspaceObj*)ptr)) {
+        if (AOTMetaspace::in_aot_cache(ptr)) {
           assert(hash == SystemDictionaryShared::hash_for_shared_dictionary_quick(ptr), "must be");
         }
       });

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_CLASSFILE_SYSTEMDICTIONARYSHARED_HPP
 #define SHARE_CLASSFILE_SYSTEMDICTIONARYSHARED_HPP
 
+#include "cds/aotMetaspace.hpp"
 #include "cds/cds_globals.hpp"
 #include "cds/dumpTimeClassInfo.hpp"
 #include "cds/filemap.hpp"
@@ -312,7 +313,7 @@ public:
 
   template <typename T>
   static unsigned int hash_for_shared_dictionary_quick(T* ptr) {
-    assert(MetaspaceObj::in_aot_cache((const MetaspaceObj*)ptr), "must be");
+    assert(AOTMetaspace::in_aot_cache(ptr), "must be");
     assert(ptr > (T*)SharedBaseAddress, "must be");
     uintx offset = uintx(ptr) - uintx(SharedBaseAddress);
     return primitive_hash<uintx>(offset);

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -77,9 +77,11 @@ void MetaspaceObj::set_aot_metaspace_range(void* base, void* top) {
   AtomicAccess::release_store(&_aot_metaspace_range_initialized, true);
 }
 
+#if INCLUDE_CDS
 bool MetaspaceObj::aot_metaspace_range_initialized() {
   return AtomicAccess::load_acquire(&_aot_metaspace_range_initialized);
 }
+#endif
 
 void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
                                  size_t word_size,

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -182,7 +182,7 @@ void AnyObj::set_in_aot_cache() {
 }
 
 bool AnyObj::in_aot_cache() const {
-  if (MetaspaceObj::aot_metaspace_range_initialized() && MetaspaceObj::is_pointer_in_aot_cache(this)) {
+  if (MetaspaceObj::is_pointer_in_aot_cache(this)) {
     // "this" can be AOT space only if aot_metaspace_range_initialized()
     precond(_allocation_t[0] == 0);
     precond(_allocation_t[1] == 0);

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -180,7 +180,8 @@ void AnyObj::set_in_aot_cache() {
 }
 
 bool AnyObj::in_aot_cache() const {
-  if (MetaspaceObj::aot_metaspace_range_initialized() && AOTMetaspace::in_aot_cache(this)) {
+  if (MetaspaceObj::aot_metaspace_range_initialized() && MetaspaceObj::is_pointer_in_aot_cache(this)) {
+    // "this" can be AOT space only if aot_metaspace_range_initialized()
     precond(_allocation_t[0] == 0);
     precond(_allocation_t[1] == 0);
     return true;

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -67,6 +67,7 @@ void FreeHeap(void* p) {
   os::free(p);
 }
 
+#if INCLUDE_CDS
 void* MetaspaceObj::_aot_metaspace_base = nullptr;
 void* MetaspaceObj::_aot_metaspace_top  = nullptr;
 volatile bool MetaspaceObj::_aot_metaspace_range_initialized = false;
@@ -77,7 +78,6 @@ void MetaspaceObj::set_aot_metaspace_range(void* base, void* top) {
   AtomicAccess::release_store(&_aot_metaspace_range_initialized, true);
 }
 
-#if INCLUDE_CDS
 bool MetaspaceObj::aot_metaspace_range_initialized() {
   return AtomicAccess::load_acquire(&_aot_metaspace_range_initialized);
 }

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -28,6 +28,7 @@
 #include "memory/metaspace.hpp"
 #include "memory/resourceArea.hpp"
 #include "nmt/memTracker.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "runtime/os.hpp"
 #include "runtime/task.hpp"
 #include "utilities/ostream.hpp"
@@ -68,6 +69,17 @@ void FreeHeap(void* p) {
 
 void* MetaspaceObj::_aot_metaspace_base = nullptr;
 void* MetaspaceObj::_aot_metaspace_top  = nullptr;
+volatile bool MetaspaceObj::_aot_metaspace_range_initialized = false;
+
+void MetaspaceObj::set_aot_metaspace_range(void* base, void* top) {
+  _aot_metaspace_base = base;
+  _aot_metaspace_top = top;
+  AtomicAccess::release_store(&_aot_metaspace_range_initialized, true);
+}
+
+bool MetaspaceObj::aot_metaspace_range_initialized() {
+  return AtomicAccess::load_acquire(&_aot_metaspace_range_initialized);
+}
 
 void* MetaspaceObj::operator new(size_t size, ClassLoaderData* loader_data,
                                  size_t word_size,
@@ -168,7 +180,7 @@ void AnyObj::set_in_aot_cache() {
 }
 
 bool AnyObj::in_aot_cache() const {
-  if (AOTMetaspace::in_aot_cache(this)) {
+  if (MetaspaceObj::aot_metaspace_range_initialized() && AOTMetaspace::in_aot_cache(this)) {
     precond(_allocation_t[0] == 0);
     precond(_allocation_t[1] == 0);
     return true;

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -269,7 +269,7 @@ class MetaspaceObj {
 
 #if !INCLUDE_CDS
   static bool is_pointer_in_aot_cache(const void* p) { return false; }
-  static bool aot_metaspace_range_initialized() { return false; }
+  static bool is_pointer_in_aot_cache_no_init_check(const void* p) { return false; }
 #else
 private:
   // All metsapce objects in the AOT cache (CDS archive) are mapped
@@ -280,15 +280,16 @@ private:
   static void* _aot_metaspace_base;  // (inclusive) low address
   static void* _aot_metaspace_top;   // (exclusive) high address
   static volatile bool _aot_metaspace_range_initialized;
+  static bool aot_metaspace_range_initialized();
 
 public:
-  // Caller must check aot_metaspace_range_initialized() if it can call this
-  // function in very early VM bootstrap.
   inline static bool is_pointer_in_aot_cache(const void* p) {
-    // Don't assert with aot_metaspace_range_initialized(), as that has side effect
-    // of making the range visible to the current thread, even if the caller
-    // forgets to call aot_metaspace_range_initialized().
-    assert(_aot_metaspace_range_initialized, "range not initialized");
+    return aot_metaspace_range_initialized() && is_pointer_in_aot_cache_no_init_check(p);
+  }
+
+  // Call this ONLY if you know that the AOT metaspace has already been initialized.
+  inline static bool is_pointer_in_aot_cache_no_init_check(const void* p) {
+    precond(aot_metaspace_range_initialized());
 
     // If no shared metaspace regions are mapped, _aot_metaspace_{base,top} will
     // both be null and all values of p will be rejected quickly.
@@ -296,7 +297,6 @@ public:
             p >= _aot_metaspace_base);
   }
 
-  static bool aot_metaspace_range_initialized();
   static void set_aot_metaspace_range(void* base, void* top);
 
   static void* aot_metaspace_base() { return _aot_metaspace_base; }
@@ -304,7 +304,9 @@ public:
 #endif // INCLUDE_CDS
 
   bool in_aot_cache() const {
-    return is_pointer_in_aot_cache(this);
+    // MetaspaceObjects are only created or loaded from the AOT cache after
+    // the AOT metaspace has been initialized, so we can skip init checks.
+    return is_pointer_in_aot_cache_no_init_check(this);
   }
 
   void print_address_on(outputStream* st) const;  // nonvirtual address printing

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -276,15 +276,18 @@ class MetaspaceObj {
   static bool is_valid(const MetaspaceObj* p);
 
 #if INCLUDE_CDS
-  static bool in_aot_cache(const MetaspaceObj* p) {
-    // No threads in the JVM should see MetaspaceObjs from the AOT cache until
-    // set_aot_metaspace_range() has been called.
-    precond(aot_metaspace_range_initialized());
+  inline static bool in_aot_cache(const MetaspaceObj* p) {
+    assert(aot_metaspace_range_initialized(), "No threads in the JVM can see a MetaspaceObj until after"
+           " set_aot_metaspace_range() has been called");
+    return is_pointer_in_aot_cache((void*) p);
+  }
 
+  inline static bool is_pointer_in_aot_cache(const void* p) {
+    precond(aot_metaspace_range_initialized());
     // If no shared metaspace regions are mapped, _aot_metaspace_{base,top} will
     // both be null and all values of p will be rejected quickly.
-    return (((void*)p) < _aot_metaspace_top &&
-            ((void*)p) >= _aot_metaspace_base);
+    return (p < _aot_metaspace_top &&
+            p >= _aot_metaspace_base);
   }
   bool in_aot_cache() const { return MetaspaceObj::in_aot_cache(this); }
   static bool aot_metaspace_range_initialized();

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -295,7 +295,7 @@ class MetaspaceObj {
   }
   static bool aot_metaspace_range_initialized();
 #else
-  static bool in_aot_cache(const MetaspaceObj* p) { return false; }
+  static bool is_pointer_in_aot_cache(const void* p) { return false; }
   bool in_aot_cache() const { return false; }
   static bool aot_metaspace_range_initialized() { return false; }
 #endif

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -260,6 +260,18 @@ class MetaspaceObj {
   //   void deallocate_contents(ClassLoaderData* loader_data);
 
   friend class VMStructs;
+ public:
+
+  // Returns true if the pointer points to a valid MetaspaceObj. A valid
+  // MetaspaceObj is MetaWord-aligned and contained within either
+  // regular- or aot metaspace.
+  static bool is_valid(const MetaspaceObj* p);
+
+#if !INCLUDE_CDS
+  static bool is_pointer_in_aot_cache(const void* p) { return false; }
+  static bool aot_metaspace_range_initialized() { return false; }
+#else
+private:
   // All metsapce objects in the AOT cache (CDS archive) are mapped
   // into a single contiguous memory block, so we can use these
   // two pointers to quickly determine if a MetaspaceObj is in the
@@ -268,14 +280,8 @@ class MetaspaceObj {
   static void* _aot_metaspace_base;  // (inclusive) low address
   static void* _aot_metaspace_top;   // (exclusive) high address
   static volatile bool _aot_metaspace_range_initialized;
- public:
 
-  // Returns true if the pointer points to a valid MetaspaceObj. A valid
-  // MetaspaceObj is MetaWord-aligned and contained within either
-  // regular- or aot metaspace.
-  static bool is_valid(const MetaspaceObj* p);
-
-#if INCLUDE_CDS
+public:
   // Caller must check aot_metaspace_range_initialized() if it can call this
   // function in very early VM bootstrap.
   inline static bool is_pointer_in_aot_cache(const void* p) {
@@ -290,22 +296,19 @@ class MetaspaceObj {
             p >= _aot_metaspace_base);
   }
 
-  bool in_aot_cache() const {
-    return is_pointer_in_aot_cache(this);
-  }
   static bool aot_metaspace_range_initialized();
-#else
-  static bool is_pointer_in_aot_cache(const void* p) { return false; }
-  bool in_aot_cache() const { return false; }
-  static bool aot_metaspace_range_initialized() { return false; }
-#endif
-
-  void print_address_on(outputStream* st) const;  // nonvirtual address printing
-
   static void set_aot_metaspace_range(void* base, void* top);
 
   static void* aot_metaspace_base() { return _aot_metaspace_base; }
   static void* aot_metaspace_top()  { return _aot_metaspace_top;  }
+#endif // INCLUDE_CDS
+
+  bool in_aot_cache() const {
+    return is_pointer_in_aot_cache(this);
+  }
+
+  void print_address_on(outputStream* st) const;  // nonvirtual address printing
+
 
 #define METASPACE_OBJ_TYPES_DO(f) \
   f(Class) \

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -279,7 +279,11 @@ class MetaspaceObj {
   // Caller must check aot_metaspace_range_initialized() if it can call this
   // function in very early VM bootstrap.
   inline static bool is_pointer_in_aot_cache(const void* p) {
-    assert(aot_metaspace_range_initialized(), "range not initialized");
+    // Don't assert with aot_metaspace_range_initialized(), as that has side effect
+    // of making the range visible to the current thread, even if the caller
+    // forgets to call aot_metaspace_range_initialized().
+    assert(_aot_metaspace_range_initialized, "range not initialized");
+
     // If no shared metaspace regions are mapped, _aot_metaspace_{base,top} will
     // both be null and all values of p will be rejected quickly.
     return (p < _aot_metaspace_top &&
@@ -287,8 +291,6 @@ class MetaspaceObj {
   }
 
   bool in_aot_cache() const {
-    assert(aot_metaspace_range_initialized(), "No threads in the JVM can see a MetaspaceObj until after"
-           " set_aot_metaspace_range() has been called");
     return is_pointer_in_aot_cache(this);
   }
   static bool aot_metaspace_range_initialized();

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -267,7 +267,7 @@ class MetaspaceObj {
   // When AOT/CDS is not enabled, both pointers are set to null.
   static void* _aot_metaspace_base;  // (inclusive) low address
   static void* _aot_metaspace_top;   // (exclusive) high address
-
+  static volatile bool _aot_metaspace_range_initialized;
  public:
 
   // Returns true if the pointer points to a valid MetaspaceObj. A valid
@@ -277,23 +277,26 @@ class MetaspaceObj {
 
 #if INCLUDE_CDS
   static bool in_aot_cache(const MetaspaceObj* p) {
+    // No threads in the JVM should see MetaspaceObjs from the AOT cache until
+    // set_aot_metaspace_range() has been called.
+    precond(aot_metaspace_range_initialized());
+
     // If no shared metaspace regions are mapped, _aot_metaspace_{base,top} will
     // both be null and all values of p will be rejected quickly.
     return (((void*)p) < _aot_metaspace_top &&
             ((void*)p) >= _aot_metaspace_base);
   }
   bool in_aot_cache() const { return MetaspaceObj::in_aot_cache(this); }
+  static bool aot_metaspace_range_initialized();
 #else
   static bool in_aot_cache(const MetaspaceObj* p) { return false; }
   bool in_aot_cache() const { return false; }
+  static bool aot_metaspace_range_initialized() { return false; }
 #endif
 
   void print_address_on(outputStream* st) const;  // nonvirtual address printing
 
-  static void set_aot_metaspace_range(void* base, void* top) {
-    _aot_metaspace_base = base;
-    _aot_metaspace_top = top;
-  }
+  static void set_aot_metaspace_range(void* base, void* top);
 
   static void* aot_metaspace_base() { return _aot_metaspace_base; }
   static void* aot_metaspace_top()  { return _aot_metaspace_top;  }

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -276,20 +276,21 @@ class MetaspaceObj {
   static bool is_valid(const MetaspaceObj* p);
 
 #if INCLUDE_CDS
-  inline static bool in_aot_cache(const MetaspaceObj* p) {
-    assert(aot_metaspace_range_initialized(), "No threads in the JVM can see a MetaspaceObj until after"
-           " set_aot_metaspace_range() has been called");
-    return is_pointer_in_aot_cache((void*) p);
-  }
-
+  // Caller must check aot_metaspace_range_initialized() if it can call this
+  // function in very early VM bootstrap.
   inline static bool is_pointer_in_aot_cache(const void* p) {
-    precond(aot_metaspace_range_initialized());
+    assert(aot_metaspace_range_initialized(), "range not initialized");
     // If no shared metaspace regions are mapped, _aot_metaspace_{base,top} will
     // both be null and all values of p will be rejected quickly.
     return (p < _aot_metaspace_top &&
             p >= _aot_metaspace_base);
   }
-  bool in_aot_cache() const { return MetaspaceObj::in_aot_cache(this); }
+
+  bool in_aot_cache() const {
+    assert(aot_metaspace_range_initialized(), "No threads in the JVM can see a MetaspaceObj until after"
+           " set_aot_metaspace_range() has been called");
+    return is_pointer_in_aot_cache(this);
+  }
   static bool aot_metaspace_range_initialized();
 #else
   static bool in_aot_cache(const MetaspaceObj* p) { return false; }

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -739,6 +739,9 @@ void Metaspace::global_initialize() {
     AOTMetaspace::initialize_runtime_shared_and_meta_spaces();
     // If any of the archived space fails to map, UseSharedSpaces
     // is reset to false.
+  } else {
+    // Trivially set the range to empty to satisfy the precond in AOTMetaspace::in_aot_cache()
+    MetaspaceObj::set_aot_metaspace_range(nullptr, nullptr);
   }
 #endif // INCLUDE_CDS
 

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -740,7 +740,7 @@ void Metaspace::global_initialize() {
     // If any of the archived space fails to map, UseSharedSpaces
     // is reset to false.
   } else {
-    // Trivially set the range to empty to satisfy the precond in AOTMetaspace::in_aot_cache()
+    // Trivially set the range to empty to satisfy the assert in MetaspaceObj::is_pointer_in_aot_cache()
     MetaspaceObj::set_aot_metaspace_range(nullptr, nullptr);
   }
 #endif // INCLUDE_CDS

--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -727,7 +727,7 @@ void TrainingData::metaspace_pointers_do(MetaspaceClosure* iter) {
 }
 
 bool TrainingData::Key::can_compute_cds_hash(const Key* const& k) {
-  return k->meta() == nullptr || MetaspaceObj::in_aot_cache(k->meta());
+  return k->meta() == nullptr || k->meta()->in_aot_cache();
 }
 
 uint TrainingData::Key::cds_hash(const Key* const& k) {

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -57,7 +57,7 @@ void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag me
 }
 
 void GrowableArrayCHeapAllocator::deallocate(void* elements) {
-  if (!MetaspaceObj::aot_metaspace_range_initialized() || !MetaspaceObj::is_pointer_in_aot_cache(elements)) {
+  if (!(MetaspaceObj::aot_metaspace_range_initialized() && MetaspaceObj::is_pointer_in_aot_cache(elements))) {
     FreeHeap(elements);
   }
 }

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -57,7 +57,7 @@ void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag me
 }
 
 void GrowableArrayCHeapAllocator::deallocate(void* elements) {
-  if (!(MetaspaceObj::aot_metaspace_range_initialized() && MetaspaceObj::is_pointer_in_aot_cache(elements))) {
+  if (!MetaspaceObj::is_pointer_in_aot_cache(elements)) {
     FreeHeap(elements);
   }
 }

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -57,7 +57,7 @@ void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag me
 }
 
 void GrowableArrayCHeapAllocator::deallocate(void* elements) {
-  if (!MetaspaceObj::aot_metaspace_range_initialized() || !AOTMetaspace::in_aot_cache(elements)) {
+  if (!MetaspaceObj::aot_metaspace_range_initialized() || !MetaspaceObj::is_pointer_in_aot_cache(elements)) {
     FreeHeap(elements);
   }
 }

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -57,7 +57,7 @@ void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag me
 }
 
 void GrowableArrayCHeapAllocator::deallocate(void* elements) {
-  if (!AOTMetaspace::in_aot_cache(elements)) {
+  if (!MetaspaceObj::aot_metaspace_range_initialized() || !AOTMetaspace::in_aot_cache(elements)) {
     FreeHeap(elements);
   }
 }


### PR DESCRIPTION
The range `_aot_metaspace_base ... _aot_metaspace_top` is initialized in the main JVM thread during early bootstrap. In almost all cases when this range is consulted, the main thread has already published these two variables to all threads.

However, since [JDK-8374549](https://bugs.openjdk.org/browse/JDK-8374549), we could read this range during `GrowableArray` size adjustment or destruction, which can legally happen in an `ArchiveWorkerThread` before the range is properly initialized and published. The reader could get inconsistent values from these two variables and assert.

The fix is to require the `GrowableArray` use cases (in `GrowableArrayCHeapAllocator::deallocate()` and `AnyObj::in_aot_cache()`) to explicitly check for `_aot_metaspace_range_initialized` with `AtomicAccess::release_store/load_acquire`.

I also an assert to make sure in all other cases, `MetaspaceObj::is_pointer_in_aot_cache()` is called only after the range is initialized. This should catch similar bugs in the future.

**Performance:**

For performance reasons, I do not use `AtomicAccess` to load the range itself. In the product build, `AtomicAccess::load_acquire` is called only in `GrowableArrayCHeapAllocator::deallocate()`, which happens very infrequently.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382170](https://bugs.openjdk.org/browse/JDK-8382170): Assert in AnyObj::operator delete due to race condition in in_aot_cache() (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30726/head:pull/30726` \
`$ git checkout pull/30726`

Update a local copy of the PR: \
`$ git checkout pull/30726` \
`$ git pull https://git.openjdk.org/jdk.git pull/30726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30726`

View PR using the GUI difftool: \
`$ git pr show -t 30726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30726.diff">https://git.openjdk.org/jdk/pull/30726.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30726#issuecomment-4248174574)
</details>
