### PR TITLE
8381933: Possible memory leak in src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -78,6 +78,7 @@ ShenandoahHeapRegionCounters::ShenandoahHeapRegionCounters() :
 
 ShenandoahHeapRegionCounters::~ShenandoahHeapRegionCounters() {
   if (_name_space != nullptr) FREE_C_HEAP_ARRAY(char, _name_space);
+  if (_regions_data != nullptr) FREE_C_HEAP_ARRAY(PerfVariable*, _regions_data);
 }
 
 void ShenandoahHeapRegionCounters::write_snapshot(PerfLongVariable** regions,


### PR DESCRIPTION
`_regions_data` is being dynamically allocated and not being freed in the destructor. Called `FREE_C_HEAP_ARRAY` and passed in `_regions_data` to free the dynamically allocated memory.

### Testing:
test/hotspot/jtreg/gc/shenandoah (all passed)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381933](https://bugs.openjdk.org/browse/JDK-8381933): Possible memory leak in src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp (**Bug** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30727/head:pull/30727` \
`$ git checkout pull/30727`

Update a local copy of the PR: \
`$ git checkout pull/30727` \
`$ git pull https://git.openjdk.org/jdk.git pull/30727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30727`

View PR using the GUI difftool: \
`$ git pr show -t 30727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30727.diff">https://git.openjdk.org/jdk/pull/30727.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30727#issuecomment-4247304765)
</details>
