### PR TITLE
8382103: Shenandoah: Optimize ShenandoahLock size for release build

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -48,8 +48,8 @@ private:
   static void yield_or_sleep(int &yields);
 
 public:
-  ShenandoahLock() : _state(unlocked) { 
-    DEBUG_ONLY(_owner.store_relaxed(nullptr);) 
+  ShenandoahLock() : _state(unlocked) {
+    DEBUG_ONLY(_owner.store_relaxed(nullptr);)
   };
 
   void lock(bool allow_block_for_safepoint = false) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -38,15 +38,15 @@ private:
   shenandoah_padding(0);
   Atomic<LockState> _state;
   shenandoah_padding(1);
-  DEBUG_ONLY(Atomic<Thread*> _owner;)
-  DEBUG_ONLY(shenandoah_padding(2);)
+  DEBUG_ONLY(Atomic<Thread*> _owner;);
+  DEBUG_ONLY(shenandoah_padding(2););
 
   template<bool ALLOW_BLOCK>
   void contended_lock_internal(JavaThread* java_thread);
   static void yield_or_sleep(int &yields);
 
 public:
-  ShenandoahLock() : _state(unlocked), _owner(nullptr) {};
+  ShenandoahLock() : _state(unlocked) { DEBUG_ONLY(_owner = nullptr;) };
 
   void lock(bool allow_block_for_safepoint = false) {
     assert(_owner.load_relaxed() != Thread::current(), "reentrant locking attempt, would deadlock");

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -38,8 +38,8 @@ private:
   shenandoah_padding(0);
   Atomic<LockState> _state;
   shenandoah_padding(1);
-  Atomic<Thread*> _owner;
-  shenandoah_padding(2);
+  DEBUG_ONLY(Atomic<Thread*> _owner;)
+  DEBUG_ONLY(shenandoah_padding(2);)
 
   template<bool ALLOW_BLOCK>
   void contended_lock_internal(JavaThread* java_thread);

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -46,7 +46,7 @@ private:
   static void yield_or_sleep(int &yields);
 
 public:
-  ShenandoahLock() : _state(unlocked) { DEBUG_ONLY(_owner = nullptr;) };
+  ShenandoahLock() : _state(unlocked) { DEBUG_ONLY(_owner.store_relaxed(nullptr);) };
 
   void lock(bool allow_block_for_safepoint = false) {
     assert(_owner.load_relaxed() != Thread::current(), "reentrant locking attempt, would deadlock");

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -38,15 +38,19 @@ private:
   shenandoah_padding(0);
   Atomic<LockState> _state;
   shenandoah_padding(1);
-  DEBUG_ONLY(Atomic<Thread*> _owner;);
-  DEBUG_ONLY(shenandoah_padding(2););
+#ifdef ASSERT
+  Atomic<Thread*> _owner;
+  shenandoah_padding(2);
+#endif
 
   template<bool ALLOW_BLOCK>
   void contended_lock_internal(JavaThread* java_thread);
   static void yield_or_sleep(int &yields);
 
 public:
-  ShenandoahLock() : _state(unlocked) { DEBUG_ONLY(_owner.store_relaxed(nullptr);) };
+  ShenandoahLock() : _state(unlocked) { 
+    DEBUG_ONLY(_owner.store_relaxed(nullptr);) 
+  };
 
   void lock(bool allow_block_for_safepoint = false) {
     assert(_owner.load_relaxed() != Thread::current(), "reentrant locking attempt, would deadlock");


### PR DESCRIPTION
The ShenandoahLock class members: `_owner` and `shenandoah_padding(2)` are only used in debug builds, but they will appear in the release build. Used `ASSERT` and `DEBUG_ONLY` macro, so they no longer appear in the release build.

### Testing:
test/hotspot/jtreg/gc/shenandoah (all passed)  

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382103](https://bugs.openjdk.org/browse/JDK-8382103): Shenandoah: Optimize ShenandoahLock size for release build (**Enhancement** - P5)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30728/head:pull/30728` \
`$ git checkout pull/30728`

Update a local copy of the PR: \
`$ git checkout pull/30728` \
`$ git pull https://git.openjdk.org/jdk.git pull/30728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30728`

View PR using the GUI difftool: \
`$ git pr show -t 30728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30728.diff">https://git.openjdk.org/jdk/pull/30728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30728#issuecomment-4247301753)
</details>
