### PR TITLE
8382134: Replace assert with fatal check in AOTCodeCache::load_strings() to make sure we have valid value in product VM

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -2201,6 +2201,10 @@ void AOTCodeCache::load_strings() {
   if (strings_count == 0) {
     return;
   }
+  if (strings_count > MAX_STR_COUNT) {
+    fatal("Invalid strings_count loaded from AOT Code Cache: %d > MAX_STR_COUNT [%d]", strings_count, MAX_STR_COUNT);
+    return;
+  }
   uint strings_offset = _load_header->strings_offset();
   uint* string_lengths = (uint*)addr(strings_offset);
   strings_offset += (strings_count * sizeof(uint));
@@ -2211,7 +2215,6 @@ void AOTCodeCache::load_strings() {
   char* p = NEW_C_HEAP_ARRAY(char, strings_size+1, mtCode);
   memcpy(p, addr(strings_offset), strings_size);
   _C_strings_buf = p;
-  assert(strings_count <= MAX_STR_COUNT, "sanity");
   for (uint i = 0; i < strings_count; i++) {
     _C_strings[i] = p;
     uint len = string_lengths[i];


### PR DESCRIPTION
AOTCodeCache::load_strings() has next assert to catch situation if AOT cache is corrupted/damaged/different:
   assert(strings_count <= MAX_STR_COUNT, "sanity");

Replace assert() with fatal() to do this check in product VM too.  Note, strings_count is unsigned value.

Tested: GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382134](https://bugs.openjdk.org/browse/JDK-8382134): Replace assert with fatal check in AOTCodeCache::load_strings() to make sure we have valid value in product VM (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30730/head:pull/30730` \
`$ git checkout pull/30730`

Update a local copy of the PR: \
`$ git checkout pull/30730` \
`$ git pull https://git.openjdk.org/jdk.git pull/30730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30730`

View PR using the GUI difftool: \
`$ git pr show -t 30730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30730.diff">https://git.openjdk.org/jdk/pull/30730.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30730#issuecomment-4248005781)
</details>
