### PR TITLE
8382196: Clean up C++ iterator style in compactHashtable.hpp and trainingData.hpp

### DIFF
--- a/src/hotspot/share/classfile/compactHashtable.hpp
+++ b/src/hotspot/share/classfile/compactHashtable.hpp
@@ -307,14 +307,9 @@ public:
   template <class ITER>
   inline void iterate(ITER* iter) const { iterate([&](V v) { iter->do_value(v); }); }
 
-  template<typename Function>
-  inline void iterate(const Function& function) const { // lambda enabled API
-    iterate(const_cast<Function&>(function));
-  }
-
   // Iterate through the values in the table, stopping when the lambda returns false.
   template<typename Function>
-  inline void iterate(Function& function) const { // lambda enabled API
+  inline void iterate(Function function) const { // lambda enabled API
     for (u4 i = 0; i < _bucket_count; i++) {
       u4 bucket_info = _buckets[i];
       u4 bucket_offset = BUCKET_OFFSET(bucket_info);

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -217,11 +217,7 @@ public:
       return *prior;
     }
     template<typename Function>
-    void iterate(const Function& fn) const { // lambda enabled API
-      iterate(const_cast<Function&>(fn));
-    }
-    template<typename Function>
-    void iterate(Function& fn) const { // lambda enabled API
+    void iterate(Function fn) const { // lambda enabled API
       return _table.iterate_all([&](const TrainingData::Key* k, TrainingData* td) { fn(td); });
     }
     int size() const { return _table.number_of_entries(); }
@@ -304,10 +300,7 @@ private:
   }
 
   template<typename Function>
-  static void iterate(const Function& fn) { iterate(const_cast<Function&>(fn)); }
-
-  template<typename Function>
-  static void iterate(Function& fn) { // lambda enabled API
+  static void iterate(Function fn) { // lambda enabled API
     TrainingDataLocker l;
     if (have_data()) {
       archived_training_data_dictionary()->iterate_all(fn);


### PR DESCRIPTION
Problem: the use of references in APIs such as `iterate(Function& function)` leads to hacks with `static_cast<>`.

Fix: change the APIs to `iterate(Function function)` and remove the hacks.

Please see the JBS issue [JDK-8382196](https://bugs.openjdk.org/browse/JDK-8382196) for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382196](https://bugs.openjdk.org/browse/JDK-8382196): Clean up C++ iterator style in compactHashtable.hpp and trainingData.hpp (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30731/head:pull/30731` \
`$ git checkout pull/30731`

Update a local copy of the PR: \
`$ git checkout pull/30731` \
`$ git pull https://git.openjdk.org/jdk.git pull/30731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30731`

View PR using the GUI difftool: \
`$ git pr show -t 30731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30731.diff">https://git.openjdk.org/jdk/pull/30731.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30731#issuecomment-4248247936)
</details>
