### PR TITLE
8381881: Using TraceDwarfLevel triggers  assert(false) failed: Attempting to acquire lock tty_lock/tty out of order with lock SharedDecoder_lock/service-5 -- possible deadlock

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -136,6 +136,8 @@ Thread::Thread(MemTag mem_tag) {
   }
 
   MACOS_AARCH64_ONLY(DEBUG_ONLY(_wx_init = false));
+
+  DEBUG_ONLY(_dwarf_log_stream = nullptr;)
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -631,6 +631,17 @@ protected:
 
  private:
   VMErrorCallback* _vm_error_callbacks;
+
+#ifdef ASSERT
+ private:
+  // Optional per-thread stream used to buffer DWARF logging while
+  // SharedDecoder_lock is held, to avoid potential deadlock.
+  outputStream* _dwarf_log_stream;
+
+ public:
+  outputStream* dwarf_log_stream() const { return _dwarf_log_stream; }
+  void set_dwarf_log_stream(outputStream* st) { _dwarf_log_stream = st; }
+#endif
 };
 
 class ThreadInAsgct {

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -25,6 +25,8 @@
 
 #include "jvm.h"
 #include "memory/allocation.inline.hpp"
+#include "memory/resourceArea.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/vmError.hpp"
 

--- a/src/hotspot/share/utilities/decoder.cpp
+++ b/src/hotspot/share/utilities/decoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -116,6 +116,33 @@ bool Decoder::get_source_info(address pc, char* filename, size_t filename_len, i
   if (VMError::is_error_reported_in_current_thread()) {
     return get_error_handler_instance()->get_source_info(pc, filename, filename_len, line, is_pc_after_call);
   } else {
+#ifdef ASSERT
+    if (TraceDwarfLevel > 0) {
+      ResourceMark rm;
+      stringStream log_buf;
+      Thread* t = Thread::current_or_null();
+      outputStream* saved = nullptr;
+      if (t != nullptr) {
+        saved = t->dwarf_log_stream();
+        t->set_dwarf_log_stream(&log_buf);
+      }
+
+      bool result;
+      {
+        MutexLocker locker(shared_decoder_lock(), Mutex::_no_safepoint_check_flag);
+        result = get_shared_instance()->get_source_info(pc, filename, filename_len, line, is_pc_after_call);
+      }
+
+      if (t != nullptr) {
+        t->set_dwarf_log_stream(saved);
+      }
+
+      if (log_buf.size() > 0) {
+        tty->print_raw(log_buf.base());
+      }
+      return result;
+    }
+#endif
     MutexLocker locker(shared_decoder_lock(), Mutex::_no_safepoint_check_flag);
     return get_shared_instance()->get_source_info(pc, filename, filename_len, line, is_pc_after_call);
   }

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -70,6 +70,7 @@ typedef Elf32_Sym       Elf_Sym;
 #include "globalDefinitions.hpp"
 #include "jvm_md.h"
 #include "memory/allocation.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/quickSort.hpp"

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,11 +82,18 @@ typedef Elf32_Sym       Elf_Sym;
 #define DWARF_LOG_DEBUG(format, ...) DWARF_LOG_WITH_LEVEL(3, format, ##__VA_ARGS__)
 #define DWARF_LOG_TRACE(format, ...) DWARF_LOG_WITH_LEVEL(4, format, ##__VA_ARGS__)
 
-#define DWARF_LOG_WITH_LEVEL(level, format, ...) \
-    if (TraceDwarfLevel >= level) {         \
-      tty->print("[dwarf] ");               \
-      tty->print_cr(format, ##__VA_ARGS__); \
-    }
+#define DWARF_LOG_WITH_LEVEL(level, format, ...)                         \
+  do {                                                                   \
+    if (TraceDwarfLevel >= (level)) {                                    \
+      outputStream* log_stream = tty;                                    \
+      Thread* t = Thread::current_or_null();                             \
+      if (t != nullptr && t->dwarf_log_stream() != nullptr) {            \
+        log_stream = t->dwarf_log_stream();                              \
+      }                                                                  \
+      log_stream->print("[dwarf] ");                                     \
+      log_stream->print_cr(format, ##__VA_ARGS__);                       \
+    }                                                                    \
+  } while (0);
 #else
 #define DWARF_LOG_SUMMARY(format, ...)
 #define DWARF_LOG_ERROR(format, ...)

--- a/test/hotspot/jtreg/gtest/ElfDecoderTraceGtest.java
+++ b/test/hotspot/jtreg/gtest/ElfDecoderTraceGtest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8381881
+ * @summary Verify decoder does not hit deadlock when TraceDwarfLevel is enabled
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @requires vm.debug
+ * @requires vm.flagless
+ * @requires os.family != "windows"
+ * @run main/native GTestWrapper --gtest_filter=os_linux.decoder_get_source_info_valid_vm -XX:TraceDwarfLevel=4
+ */


### PR DESCRIPTION
**Description:**

When TraceDwarfLevel is enabled, DWARF logging may call into tty while SharedDecoder_lock is held in Decoder::get_source_info. Since printing to tty acquires tty_lock, this can violate the VM lock ordering and trigger a potential deadlock assertion.

**Solution:**

Buffer DWARF log output while SharedDecoder_lock is held and flush it to tty only after leaving the decoder critical section.

Please review this change, thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381881](https://bugs.openjdk.org/browse/JDK-8381881): Using TraceDwarfLevel triggers  assert(false) failed: Attempting to acquire lock tty_lock/tty out of order with lock SharedDecoder_lock/service-5 -- possible deadlock (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30733/head:pull/30733` \
`$ git checkout pull/30733`

Update a local copy of the PR: \
`$ git checkout pull/30733` \
`$ git pull https://git.openjdk.org/jdk.git pull/30733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30733`

View PR using the GUI difftool: \
`$ git pr show -t 30733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30733.diff">https://git.openjdk.org/jdk/pull/30733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30733#issuecomment-4248748753)
</details>
