### PR TITLE
8345631: TestRegionSamplingLogging.java#generational-rotation intermittent fails

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestRegionSamplingLogging.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRegionSamplingLogging.java
@@ -61,6 +61,8 @@ public class TestRegionSamplingLogging {
         File directory = new File(".");
         File[] files = directory.listFiles((dir, name) -> name.startsWith("region-snapshots"));
         System.out.println(Arrays.toString(files));
+
+        // Expect one or more log files when region logging is enabled
         if (files == null || files.length == 0) {
             throw new IllegalStateException("Did not find expected snapshot log file.");
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestRegionSamplingLogging.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRegionSamplingLogging.java
@@ -59,7 +59,7 @@ public class TestRegionSamplingLogging {
         }
 
         File directory = new File(".");
-        File[] files = directory.listFiles((dir, name) -> name.startsWith("region-snapshots") && name.endsWith(".log"));
+        File[] files = directory.listFiles((dir, name) -> name.startsWith("region-snapshots"));
         System.out.println(Arrays.toString(files));
         if (files == null || files.length == 0) {
             throw new IllegalStateException("Did not find expected snapshot log file.");

--- a/test/hotspot/jtreg/gc/shenandoah/TestShenandoahRegionLogging.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestShenandoahRegionLogging.java
@@ -33,6 +33,7 @@
  *      TestShenandoahRegionLogging
  */
 import java.io.File;
+import java.util.Arrays;
 
 public class TestShenandoahRegionLogging {
     public static void main(String[] args) throws Exception {
@@ -40,9 +41,10 @@ public class TestShenandoahRegionLogging {
 
         File directory = new File(".");
         File[] files = directory.listFiles((dir, name) -> name.startsWith("region-snapshots"));
+        System.out.println(Arrays.toString(files));
 
         // Expect one or more log files when region logging is enabled
-        if (files.length == 0) {
+        if (files == null || files.length == 0) {
             throw new Error("Expected at least one log file for region sampling data.");
         }
     }


### PR DESCRIPTION
Hi all,

Test gc/shenandoah/TestRegionSamplingLogging.java#generational-rotation was observed intermittent fails. This test is intent to verify the gc log ratote, and check there is at least one '*.log' files by `name.endsWith(".log")`. But, according the implemention of `LogFileOutput::rotate()` in src/hotspot/share/logging/logFileOutput.cpp, there is a very very short moment there is no region-snapshots-%p.log file, but it's have `region-snapshots-%p.log.*` files, because `LogFileOutput::rotate()` will `rename region-snapshots-%p.log region-snapshots-%p.log.*` first, then create a new region-snapshots-%p.log after rename finish. Rename finish by `LogFileOutput::archive()`.

So I think this is a test bug cause test intermittent failure. This PR remove the `name.endsWith(".log")` limitation when search the gc log files, which same to test/hotspot/jtreg/gc/shenandoah/TestShenandoahRegionLogging.java. And in this PR I also add the null check for files by the way, this will make test more strict.

Before this PR, gc/shenandoah/TestRegionSamplingLogging.java#generational-rotation failure probability about 1/10k. I run test after this PR 50k times and all passed.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8345631](https://bugs.openjdk.org/browse/JDK-8345631): TestRegionSamplingLogging.java#generational-rotation intermittent fails (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30734/head:pull/30734` \
`$ git checkout pull/30734`

Update a local copy of the PR: \
`$ git checkout pull/30734` \
`$ git pull https://git.openjdk.org/jdk.git pull/30734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30734`

View PR using the GUI difftool: \
`$ git pr show -t 30734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30734.diff">https://git.openjdk.org/jdk/pull/30734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30734#issuecomment-4248778083)
</details>
