### PR TITLE
8382174: Clarify the meaning of address cast in ADD() macro

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -12807,7 +12807,7 @@ class StubGenerator: public StubCodeGenerator {
 #if INCLUDE_CDS
   static void init_AOTAddressTable(GrowableArray<address>& external_addresses) {
     // external data defined in this file
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
     ADD(_sha256_round_consts);
     ADD(_sha512_round_consts);
     ADD(_sha3_round_consts);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -431,10 +431,8 @@ void StubRoutines::init_AOTAddressTable() {
   AOTCodeCache::publish_external_addresses(external_addresses);
 }
 
-
-#define ADD(addr) external_addresses.append((address)addr);
-
 void StubRoutines::aarch64::init_AOTAddressTable(GrowableArray<address>& external_addresses) {
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(_kyberConsts);
   ADD(_dilithiumConsts);
   // this is added in generic code
@@ -445,7 +443,6 @@ void StubRoutines::aarch64::init_AOTAddressTable(GrowableArray<address>& externa
   ADD(_dcos_coef);
   ADD(_two_over_pi);
   ADD(_pio2);
-}
-
 #undef ADD
+}
 #endif // INCLUDE_CDS

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -74,7 +74,7 @@ static jlong *double_signflip_pool = double_quadword(&fp_signmask_pool[4*2], (jl
 #if INCLUDE_CDS
 // publish external addresses defined in this file
 void LIR_Assembler::init_AOTAddressTable(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(float_signmask_pool);
   ADD(double_signmask_pool);
   ADD(float_signflip_pool);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_constants.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_constants.cpp
@@ -247,7 +247,7 @@ void StubGenerator::init_AOTAddressTable_constants(GrowableArray<address>& exter
   ADD(_SC_2);
   ADD(_SC_3);
   ADD(_SC_4);
-  // address StubGenerator::PI_4;
+  // Use value which was already cast to (address): StubGenerator::PI_4;
   ADD(PI_4);
   ADD(PI_4 + 8);
   ADD(_PI32INV);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_constants.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_constants.cpp
@@ -247,8 +247,9 @@ void StubGenerator::init_AOTAddressTable_constants(GrowableArray<address>& exter
   ADD(_SC_2);
   ADD(_SC_3);
   ADD(_SC_4);
-  ADD(_PI_4);
-  ADD(((address)_PI_4+8));
+  // address StubGenerator::PI_4;
+  ADD(PI_4);
+  ADD(PI_4 + 8);
   ADD(_PI32INV);
   ADD(_NEG_ZERO);
   ADD(_P_1);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_exp.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_exp.cpp
@@ -397,13 +397,14 @@ address StubGenerator::generate_libmExp() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_exp(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
-  ADD(_cv);
-  ADD(((address)_cv+16));
-  ADD(((address)_cv+32));
-  ADD(((address)_cv+48));
-  ADD(((address)_cv+64));
-  ADD(((address)_cv+80));
+#define ADD(addr) external_addresses.append((address)(addr));
+  address cv = (address)_cv;
+  ADD(cv);
+  ADD(cv + 16);
+  ADD(cv + 32);
+  ADD(cv + 48);
+  ADD(cv + 64);
+  ADD(cv + 80);
   ADD(_mmask);
   ADD(_bias);
   ADD(_Tbl_addr);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_fmod.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_fmod.cpp
@@ -537,7 +537,7 @@ address StubGenerator::generate_libmFmod() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_fmod(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(CONST_NaN);
   ADD(CONST_1p260);
   ADD(CONST_MAX);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_ghash.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_ghash.cpp
@@ -558,7 +558,7 @@ void StubGenerator::generateHtbl_eight_blocks(Register htbl) {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_ghash(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(GHASH_SHUFFLE_MASK);
   ADD(GHASH_LONG_SWAP_MASK);
   ADD(GHASH_BYTE_SWAP_MASK);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_log.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_log.cpp
@@ -736,7 +736,6 @@ void StubGenerator::init_AOTAddressTable_log(GrowableArray<address>& external_ad
   address log2_log10  = (address)_log2_log10;
   address coeff_log10 = (address)_coeff_log10;
 
-
   ADD(_L_tbl);
   ADD(log2);
   ADD(log2 + 8);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_log.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_log.cpp
@@ -729,22 +729,29 @@ address StubGenerator::generate_libmLog10() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_log(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
+  address log2  = (address)_log2;
+  address coeff = (address)_coeff;
+  address LOG10_E     = (address)_LOG10_E;
+  address log2_log10  = (address)_log2_log10;
+  address coeff_log10 = (address)_coeff_log10;
+
+
   ADD(_L_tbl);
-  ADD(_log2);
-  ADD(((address)_log2+8));
-  ADD(_coeff);
-  ADD(((address)_coeff+16));
-  ADD(((address)_coeff+32));
+  ADD(log2);
+  ADD(log2 + 8);
+  ADD(coeff);
+  ADD(coeff + 16);
+  ADD(coeff + 32);
   ADD(_HIGHSIGMASK_log10);
-  ADD(_LOG10_E);
-  ADD(((address)_LOG10_E+8));
+  ADD(LOG10_E);
+  ADD(LOG10_E + 8);
   ADD(_L_tbl_log10);
-  ADD(_log2_log10);
-  ADD(((address)_log2_log10+8));
-  ADD(_coeff_log10);
-  ADD(((address)_coeff_log10+16));
-  ADD(((address)_coeff_log10+32));
+  ADD(log2_log10);
+  ADD(log2_log10 + 8);
+  ADD(coeff_log10);
+  ADD(coeff_log10 + 16);
+  ADD(coeff_log10 + 32);
 #undef ADD
 }
 #endif // INCLUDE_CDS

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly1305.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly1305.cpp
@@ -1709,7 +1709,7 @@ void StubGenerator::poly1305_msg_mul_reduce_vec4_avx2(
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_poly1305(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(POLY1305_PAD_MSG);
   ADD(POLY1305_MASK42);
   ADD(POLY1305_MASK44);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
@@ -788,7 +788,7 @@ address StubGenerator::generate_intpoly_assign() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_poly_mont(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   // use accessors to retrieve all correct addresses
   ADD(shift_1L());
   ADD(shift_1R());

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_pow.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_pow.cpp
@@ -1875,25 +1875,30 @@ address StubGenerator::generate_libmPow() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_pow(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
+  address HIGHMASK_Y = (address)_HIGHMASK_Y;
+  address e_coeff    = (address)_e_coeff;
+  address coeff_h    = (address)_coeff_h;
+  address coeff_pow  = (address)_coeff_pow;
+
   ADD(_HIGHSIGMASK);
   ADD(_LOG2_E);
-  ADD(_HIGHMASK_Y);
-  ADD((address)_HIGHMASK_Y+8);
+  ADD(HIGHMASK_Y);
+  ADD(HIGHMASK_Y + 8);
   ADD(_T_exp);
-  ADD(_e_coeff);
-  ADD((address)_e_coeff+16);
-  ADD((address)_e_coeff+32);
-  ADD(_coeff_h);
-  ADD((address)_coeff_h+8);
+  ADD(e_coeff);
+  ADD(e_coeff + 16);
+  ADD(e_coeff + 32);
+  ADD(coeff_h);
+  ADD(coeff_h + 8);
   ADD(_HIGHMASK_LOG_X);
   ADD(_HALFMASK);
-  ADD(_coeff_pow);
-  ADD((address)_coeff_pow+16);
-  ADD((address)_coeff_pow+32);
-  ADD((address)_coeff_pow+48);
-  ADD((address)_coeff_pow+64);
-  ADD((address)_coeff_pow+80);
+  ADD(coeff_pow);
+  ADD(coeff_pow + 16);
+  ADD(coeff_pow + 32);
+  ADD(coeff_pow + 48);
+  ADD(coeff_pow + 64);
+  ADD(coeff_pow + 80);
   ADD(_L_tbl_pow);
   ADD(_log2_pow);
   ADD(_DOUBLE2);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_sha3.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_sha3.cpp
@@ -530,7 +530,7 @@ void StubGenerator::generate_sha3_stubs() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_sha3(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(round_constsAddr());
   ADD(permsAndRotsAddr());
 #undef ADD

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_sin.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_sin.cpp
@@ -661,7 +661,7 @@ address StubGenerator::generate_libmSin() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_sin(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(_ALL_ONES);
 #undef ADD
 }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_sinh.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_sinh.cpp
@@ -535,21 +535,25 @@ address StubGenerator::generate_libmSinh() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_sinh(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
-  ADD(_L2E);
-  ADD(_L2E + 8);
+#define ADD(addr) external_addresses.append((address)(addr));
+  address L2E = (address)_L2E;
+  address cv  = (address)_cv;
+  address pv  = (address)_pv;
+
+  ADD(L2E);
+  ADD(L2E + 8);
   ADD(_HALFMASK);
   ADD(_Shifter);
-  ADD(_cv);
-  ADD(_cv + 16);
-  ADD(_cv + 32);
-  ADD(_cv + 48);
-  ADD(_cv + 64);
+  ADD(cv);
+  ADD(cv + 16);
+  ADD(cv + 32);
+  ADD(cv + 48);
+  ADD(cv + 64);
   ADD(_T2f);
   ADD(_T2_neg_f);
-  ADD(_pv);
-  ADD(_pv + 16);
-  ADD(_pv + 32);
+  ADD(pv);
+  ADD(pv + 16);
+  ADD(pv + 32);
   ADD(_MASK3);
 #undef ADD
 }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_tan.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_tan.cpp
@@ -1041,7 +1041,7 @@ address StubGenerator::generate_libmTan() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_tan(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(_MUL16);
   ADD(_sign_mask_tan);
   ADD(_PI32INV_tan);
@@ -1055,8 +1055,9 @@ void StubGenerator::init_AOTAddressTable_tan(GrowableArray<address>& external_ad
   ADD(_Q_7_tan);
   ADD(_Q_5_tan);
   ADD(_Q_3_tan);
-  ADD(_PI_4_tan);
-  ADD(((address)_PI_4_tan+8));
+  address PI_4_tan = (address)_PI_4_tan;
+  ADD(PI_4_tan);
+  ADD(PI_4_tan + 8);
   ADD(_QQ_2_tan);
 #undef ADD
 }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_tan.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_tan.cpp
@@ -1042,6 +1042,8 @@ address StubGenerator::generate_libmTan() {
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_tan(GrowableArray<address>& external_addresses) {
 #define ADD(addr) external_addresses.append((address)(addr));
+  address PI_4_tan = (address)_PI_4_tan;
+
   ADD(_MUL16);
   ADD(_sign_mask_tan);
   ADD(_PI32INV_tan);
@@ -1055,7 +1057,6 @@ void StubGenerator::init_AOTAddressTable_tan(GrowableArray<address>& external_ad
   ADD(_Q_7_tan);
   ADD(_Q_5_tan);
   ADD(_Q_3_tan);
-  address PI_4_tan = (address)_PI_4_tan;
   ADD(PI_4_tan);
   ADD(PI_4_tan + 8);
   ADD(_QQ_2_tan);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
@@ -511,20 +511,24 @@ address StubGenerator::generate_libmTanh() {
 
 #if INCLUDE_CDS
 void StubGenerator::init_AOTAddressTable_tanh(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
-  ADD(_L2E);
-  ADD(_L2E + 8);
+#define ADD(addr) external_addresses.append((address)(addr));
+  address L2E = (address)_L2E;
+  address cv  = (address)_cv;
+  address pv  = (address)_pv;
+
+  ADD(L2E);
+  ADD(L2E + 8);
   ADD(_HALFMASK);
   ADD(_ONEMASK);
   ADD(_TWOMASK);
   ADD(_Shifter);
-  ADD(_cv);
-  ADD(_cv + 16);
-  ADD(_cv + 32);
+  ADD(cv);
+  ADD(cv + 16);
+  ADD(cv + 32);
   ADD(_T2_neg_f);
-  ADD(_pv);
-  ADD(_pv + 16);
-  ADD(_pv + 32);
+  ADD(pv);
+  ADD(pv + 16);
+  ADD(pv + 32);
   ADD(_MASK3);
   ADD(_RMASK);
 #undef ADD

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -435,7 +435,7 @@ void StubRoutines::init_AOTAddressTable() {
 // publish addresses of external data defined in this file which may
 // be referenced from stub or code
 void StubRoutines::x86::init_AOTAddressTable(GrowableArray<address>& external_addresses) {
-#define ADD(addr) external_addresses.append((address)addr);
+#define ADD(addr) external_addresses.append((address)(addr));
   ADD(&_mxcsr_std);
   ADD(&_mxcsr_rz);
   ADD(crc_by128_masks_addr());


### PR DESCRIPTION
In few x86 stubs/intrinsics code the macro `#define ADD(addr) external_addresses.append((address)addr);` is used like this: "ADD(_L2E + 8);" where `_L2E` is `juint[]` array.

It is not clear from that if (address) is cast on whole expression "(address)(_L2E + 8)" or on first only "((address)_L2E + 8)".
Actually it is cast only on _L2E because there are no parentheses around addr: "((address)(addr))". This confuse some parsing tools and will hard to maintain because it is not clear is the code correct or not.

On other hand, there is good example in [StubGenerator::init_AOTAddressTable_cbrt](https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/stubGenerator_x86_64_cbrt.cpp#L364) which shows how to handle such cases.

I followed that example to update other places where `ADD(addr)` is used for expressions.  It seems such issue is present only in x86 code and not in aarch64.

Tested: tier1-3,hs-comp-stress

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382174](https://bugs.openjdk.org/browse/JDK-8382174): Clarify the meaning of address cast in ADD() macro (**Bug** - P3)


### Reviewers
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer) Review applies to [412b5940](https://git.openjdk.org/jdk/pull/30735/files/412b5940ae318f123ddb881cfa7e49bf6498ee78)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30735/head:pull/30735` \
`$ git checkout pull/30735`

Update a local copy of the PR: \
`$ git checkout pull/30735` \
`$ git pull https://git.openjdk.org/jdk.git pull/30735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30735`

View PR using the GUI difftool: \
`$ git pr show -t 30735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30735.diff">https://git.openjdk.org/jdk/pull/30735.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30735#issuecomment-4248953684)
</details>
