### PR TITLE
8382202: New file VectorMinMaxTransforms.java has a copyright format error

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMinMaxTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMinMaxTransforms.java
@@ -12,9 +12,9 @@
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
- * You should have received a copy of the GNU General Public License
- * version 2 along with this work; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any


### PR DESCRIPTION
Line breaks were wrong in the FSF address paragraph.

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382202](https://bugs.openjdk.org/browse/JDK-8382202): New file VectorMinMaxTransforms.java has a copyright format error (**Bug** - P3)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30736/head:pull/30736` \
`$ git checkout pull/30736`

Update a local copy of the PR: \
`$ git checkout pull/30736` \
`$ git pull https://git.openjdk.org/jdk.git pull/30736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30736`

View PR using the GUI difftool: \
`$ git pr show -t 30736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30736.diff">https://git.openjdk.org/jdk/pull/30736.diff</a>

</details>
