### PR TITLE
8378966: C2: PhaseIdealLoop::pin_nodes_dependent_on must not be called with nullptr

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1307,14 +1307,17 @@ Node* PhaseIdealLoop::place_outside_loop(Node* useblock, IdealLoopTree* loop) co
 
 
 bool PhaseIdealLoop::identical_backtoback_ifs(Node *n) {
-  if (!n->is_If() || n->is_BaseCountedLoopEnd()) {
-    return false;
-  }
-  if (!n->in(0)->is_Region()) {
+  if (!n->is_If()) {
     return false;
   }
   if (n->outcnt() != n->as_If()->required_outcnt()) {
     assert(false, "malformed IfNode with %d outputs", n->outcnt());
+    return false;
+  }
+  if (n->is_BaseCountedLoopEnd()) {
+    return false;
+  }
+  if (!n->in(0)->is_Region()) {
     return false;
   }
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1313,6 +1313,10 @@ bool PhaseIdealLoop::identical_backtoback_ifs(Node *n) {
   if (!n->in(0)->is_Region()) {
     return false;
   }
+  if (n->outcnt() != n->as_If()->required_outcnt()) {
+    assert(false, "malformed IfNode with %d outputs", n->outcnt());
+    return false; // Bail out in product
+  }
 
   Node* region = n->in(0);
   Node* dom = idom(region);
@@ -1433,7 +1437,10 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
 
     // Check some safety conditions
     if (iff->is_If()) {        // Classic split-if?
-      if (iff->in(0) != n_ctrl) {
+      if (iff->outcnt() != iff->as_If()->required_outcnt()) {
+        assert(false, "malformed IfNode with %d outputs", iff->outcnt());
+        return; // Bail out in product
+      } else if (iff->in(0) != n_ctrl) {
         return; // Compare must be in same blk as if
       }
     } else if (iff->is_CMove()) { // Trying to split-up a CMOVE

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1315,7 +1315,7 @@ bool PhaseIdealLoop::identical_backtoback_ifs(Node *n) {
   }
   if (n->outcnt() != n->as_If()->required_outcnt()) {
     assert(false, "malformed IfNode with %d outputs", n->outcnt());
-    return false; // Bail out in product
+    return false;
   }
 
   Node* region = n->in(0);
@@ -1439,7 +1439,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
     if (iff->is_If()) {        // Classic split-if?
       if (iff->outcnt() != iff->as_If()->required_outcnt()) {
         assert(false, "malformed IfNode with %d outputs", iff->outcnt());
-        return; // Bail out in product
+        return;
       } else if (iff->in(0) != n_ctrl) {
         return; // Compare must be in same blk as if
       }

--- a/src/hotspot/share/opto/split_if.cpp
+++ b/src/hotspot/share/opto/split_if.cpp
@@ -704,6 +704,9 @@ void PhaseIdealLoop::do_split_if(Node* iff, RegionNode** new_false_region, Regio
       new_true = ifpx;
     }
   }
+  assert(new_false != nullptr, "iff is malformed");
+  assert(new_true != nullptr, "iff is malformed");
+
   _igvn.remove_dead_node(new_iff, PhaseIterGVN::NodeOrigin::Speculative);
   // Lazy replace IDOM info with the region's dominator
   replace_node_and_forward_ctrl(iff, region_dom);


### PR DESCRIPTION
Hi,

Looking at the hs_err file, the SIGSEGV occurs because the parameter `ctrl` is `nullptr`. This happens because the `IfNode` that we want to push through the phi is malformed with only 1 output, so either `new_true` or `new_false` is `nullptr`. I have thought about adding verification after IGVN that an `IfNode` must have 2 outputs. However, there may be various transformations between the last IGVN invocation before the current loop opt pass and the place where we perform split if optimization, so I think for this particular issue, it is better to install a couple of verification during split if, and leaving general IGVN verification to [another issue](https://bugs.openjdk.org/browse/JDK-8382216).

The reason the SIGSEGV only occurs since [JDK-8347365](https://bugs.openjdk.org/browse/JDK-8347365) is that, previously, the corresponding method is only invoked if the `iff` is `RangeCheckNode`, which reduces the frequency in which this method is called. However, it is still incorrect and errorneous with either `new_true` or `new_false` being `nullptr`. As a result, while in debug, the verification crashes the VM, in product, I make it stop the split if only.

It is really hard to construct a regression test, I don't even know where to start.

Testing:

- [ ] tier1-4,hs-comp-stress

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378966](https://bugs.openjdk.org/browse/JDK-8378966): C2: PhaseIdealLoop::pin_nodes_dependent_on must not be called with nullptr (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30739/head:pull/30739` \
`$ git checkout pull/30739`

Update a local copy of the PR: \
`$ git checkout pull/30739` \
`$ git pull https://git.openjdk.org/jdk.git pull/30739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30739`

View PR using the GUI difftool: \
`$ git pr show -t 30739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30739.diff">https://git.openjdk.org/jdk/pull/30739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30739#issuecomment-4250412389)
</details>
