### PR TITLE
8382215: SectigoCSRootCAs.java fails when there is no internet connection

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/SectigoCSRootCAs.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/SectigoCSRootCAs.java
@@ -26,7 +26,7 @@
  * @bug 8359170
  * @summary Interoperability tests with Sectigo Public Code Signing Root CAs
  * @library /test/lib
- * @build jtreg.SkippedException ValidatePathWithParams
+ * @build ValidatePathWithParams
  * @run main/othervm/manual -Djava.security.debug=ocsp,certpath SectigoCSRootCAs OCSP
  * @run main/othervm/manual -Djava.security.debug=certpath SectigoCSRootCAs CRL
  */

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/SectigoCSRootCAs.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/SectigoCSRootCAs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,71 @@
  * @test
  * @bug 8359170
  * @summary Interoperability tests with Sectigo Public Code Signing Root CAs
- * @build ValidatePathWithParams
+ * @library /test/lib
+ * @build jtreg.SkippedException ValidatePathWithParams
  * @run main/othervm/manual -Djava.security.debug=ocsp,certpath SectigoCSRootCAs OCSP
  * @run main/othervm/manual -Djava.security.debug=certpath SectigoCSRootCAs CRL
  */
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import jtreg.SkippedException;
+
 public class SectigoCSRootCAs {
+
+    /**
+     * Live revocation checks need outbound HTTP to Sectigo. Skip when the
+     * environment has no route (or needs an HTTP proxy that is not configured).
+     */
+    private static void requireSectigoRevocationServicesReachable(boolean crlMode) {
+        final String probeUrl = crlMode
+                ? "http://crl.sectigo.com/SectigoPublicCodeSigningRootR46.crl"
+                : "http://ocsp.sectigo.com/";
+        final String modeLabel = crlMode ? "CRL" : "OCSP";
+
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(probeUrl).openConnection();
+            conn.setConnectTimeout(10_000);
+            conn.setReadTimeout(10_000);
+            conn.setInstanceFollowRedirects(true);
+            conn.connect();
+            int code = conn.getResponseCode();
+            InputStream in = (code >= HttpURLConnection.HTTP_BAD_REQUEST)
+                    ? conn.getErrorStream()
+                    : conn.getInputStream();
+            if (in != null) {
+                try {
+                    byte[] buf = new byte[512];
+                    in.read(buf);
+                } finally {
+                    in.close();
+                }
+            }
+        } catch (IOException e) {
+            throw new SkippedException(
+                    "Cannot reach Sectigo " + modeLabel + " endpoint (" + probeUrl + "). "
+                            + "This test needs outbound internet to Sectigo (or "
+                            + "http.proxyHost/http.proxyPort if HTTP access requires a proxy).",
+                    e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
 
     public static void main(String[] args) throws Exception {
 
+        boolean crlMode = args.length >= 1 && "CRL".equalsIgnoreCase(args[0]);
+        requireSectigoRevocationServicesReachable(crlMode);
+
         ValidatePathWithParams pathValidator = new ValidatePathWithParams(null);
 
-        if (args.length >= 1 && "CRL".equalsIgnoreCase(args[0])) {
+        if (crlMode) {
             pathValidator.enableCRLCheck();
         } else {
             // OCSP check by default


### PR DESCRIPTION
Hi all,

Test security/infra/java/security/cert/CertPathValidator/certification/SectigoCSRootCAs.java fails when there is no internet connection. This PR check the outbound network connection to http://crl.sectigo.com/SectigoPublicCodeSigningRootR46.crl or ocsp.sectigo.com before test executed. I think if there is no network connection, test should not report failure, because it's not jvm bug or test bug. It's enviroenmental issue, so maybe it's better to throw SkippedException.

Additional testing:

- [x] The environmental which need proxy, and the proxy is set correctly, test should be run passed
- [x] The environmental which need proxy, and the proxy is unset, test should report skip
- [x] The environmental do not need proxy, test should be run passed
- [x] The environmental do not network at all, test should report skip




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382215](https://bugs.openjdk.org/browse/JDK-8382215): SectigoCSRootCAs.java fails when there is no internet connection (**Bug** - P4)


### Reviewers
 * [Mikhail Yankelevich](https://openjdk.org/census#myankelevich) (@myankelev - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30740/head:pull/30740` \
`$ git checkout pull/30740`

Update a local copy of the PR: \
`$ git checkout pull/30740` \
`$ git pull https://git.openjdk.org/jdk.git pull/30740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30740`

View PR using the GUI difftool: \
`$ git pr show -t 30740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30740.diff">https://git.openjdk.org/jdk/pull/30740.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30740#issuecomment-4250564484)
</details>
