### PR TITLE
8381145: Missing ResourceMark in Mutex::print_on()

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -350,9 +350,7 @@ void Mutex::print_rank_name(outputStream* st) const {
 
 // Requires caller to have ResourceMark.
 const char* Mutex::rank_name() const {
-  stringStream st;
-  print_rank_name_internal(&st, _rank);
-  return st.as_string();
+  rank_name_internal(_rank);
 }
 
 

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -348,7 +348,7 @@ const char* Mutex::rank_name() const {
   return rank_name_internal(_rank);
 }
 
-// Does not require caller to have ResourceMark, unless the outputStream already has one.
+// Does not require caller to have ResourceMark.
 void Mutex::print_rank_name(outputStream* st) const {
   print_rank_name_internal(st, _rank);
 }

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ Mutex::Mutex(Rank rank, const char * name, bool allow_vm_block) : _owner(nullptr
   _rank            = rank;
   _skip_rank_check = false;
 
-  assert(_rank >= static_cast<Rank>(0) && _rank <= safepoint, "Bad lock rank %s: %s", rank_name(), name);
+  assert(_rank >= static_cast<Rank>(0) && _rank <= safepoint, "Bad lock rank %d > %d: %s", (int)rank, (int)safepoint, name);
 
   // The allow_vm_block also includes allowing other non-Java threads to block or
   // allowing Java threads to block in native.
@@ -324,23 +324,34 @@ static const char* _rank_names[] = { "event", "service", "stackwatermark", "tty"
 
 static const int _num_ranks = 7;
 
-static const char* rank_name_internal(Mutex::Rank r) {
+static void rank_name_internal(outputStream* st, Mutex::Rank r) {
   // Find closest rank and print out the name
-  stringStream st;
   for (int i = 0; i < _num_ranks; i++) {
     if (r == _ranks[i]) {
-      return _rank_names[i];
+      st->print("%s", _rank_names[i]);
     } else if (r  > _ranks[i] && (i < _num_ranks-1 && r < _ranks[i+1])) {
       int delta = static_cast<int>(_ranks[i+1]) - static_cast<int>(r);
-      st.print("%s-%d", _rank_names[i+1], delta);
-      return st.as_string();
+      st->print("%s-%d", _rank_names[i+1], delta);
     }
   }
-  return "fail";
 }
 
+static const char* rank_name_internal(Mutex::Rank r) {
+  stringStream st;
+  rank_name_internal(&st, r);
+  return st.as_string();
+}
+
+// Does not require caller to have ResourceMark, unless the outputStream already has one.
+void Mutex::print_rank_name(outputStream* st) const {
+  rank_name_internal(st, _rank);
+}
+
+// Requires caller to have ResourceMark.
 const char* Mutex::rank_name() const {
-  return rank_name_internal(_rank);
+  stringStream st;
+  rank_name_internal(&st, _rank);
+  return st.as_string();
 }
 
 
@@ -350,9 +361,12 @@ void Mutex::assert_no_overlap(Rank orig, Rank adjusted, int adjust) {
   // underflow is caught in constructor
   if (i != 0 && adjusted > event && adjusted <= _ranks[i-1]) {
     ResourceMark rm;
+    const char* orig_name = rank_name_internal(orig);
+    const char* adjusted_name = rank_name_internal(adjusted);
+    log_info(vmmutex, bot)("Rank %s-%d compares with %s", orig_name, adjust, adjusted_name);
+
     assert(adjusted > _ranks[i-1],
-           "Rank %s-%d overlaps with %s",
-           rank_name_internal(orig), adjust, rank_name_internal(adjusted));
+           "Rank %s-%d overlaps with %s", orig_name, adjust, adjusted_name);
   }
 }
 #endif // ASSERT
@@ -362,9 +376,9 @@ void Mutex::print_on(outputStream* st) const {
   st->print("Mutex: [" PTR_FORMAT "] %s - owner: " PTR_FORMAT,
             p2i(this), _name, p2i(owner()));
   if (_allow_vm_block) {
-    st->print("%s", " allow_vm_block");
+    st->print("%s", " allow_vm_block ");
   }
-  DEBUG_ONLY(st->print(" %s", rank_name()));
+  DEBUG_ONLY(print_rank_name(st));
   st->cr();
 }
 

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -293,7 +293,8 @@ Mutex::Mutex(Rank rank, const char * name, bool allow_vm_block) : _owner(nullptr
   _rank            = rank;
   _skip_rank_check = false;
 
-  assert(_rank >= static_cast<Rank>(0) && _rank <= safepoint, "Bad lock rank %d > %d: %s", (int)rank, (int)safepoint, name);
+  assert(_rank >= static_cast<Rank>(0) && _rank <= safepoint, "Bad lock rank %d outside [0, %d]: %s",
+         static_cast<int>(rank), static_cast<int>(safepoint), name);
 
   // The allow_vm_block also includes allowing other non-Java threads to block or
   // allowing Java threads to block in native.
@@ -376,8 +377,9 @@ void Mutex::print_on(outputStream* st) const {
   st->print("Mutex: [" PTR_FORMAT "] %s - owner: " PTR_FORMAT,
             p2i(this), _name, p2i(owner()));
   if (_allow_vm_block) {
-    st->print("%s", " allow_vm_block ");
+    st->print("%s", " allow_vm_block");
   }
+  st->print(" ");
   DEBUG_ONLY(print_rank_name(st));
   st->cr();
 }

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -325,7 +325,7 @@ static const char* _rank_names[] = { "event", "service", "stackwatermark", "tty"
 
 static const int _num_ranks = 7;
 
-static void rank_name_internal(outputStream* st, Mutex::Rank r) {
+static void print_rank_name_internal(outputStream* st, Mutex::Rank r) {
   // Find closest rank and print out the name
   for (int i = 0; i < _num_ranks; i++) {
     if (r == _ranks[i]) {
@@ -339,19 +339,19 @@ static void rank_name_internal(outputStream* st, Mutex::Rank r) {
 
 static const char* rank_name_internal(Mutex::Rank r) {
   stringStream st;
-  rank_name_internal(&st, r);
+  print_rank_name_internal(&st, r);
   return st.as_string();
 }
 
 // Does not require caller to have ResourceMark, unless the outputStream already has one.
 void Mutex::print_rank_name(outputStream* st) const {
-  rank_name_internal(st, _rank);
+  print_rank_name_internal(st, _rank);
 }
 
 // Requires caller to have ResourceMark.
 const char* Mutex::rank_name() const {
   stringStream st;
-  rank_name_internal(&st, _rank);
+  print_rank_name_internal(&st, _rank);
   return st.as_string();
 }
 
@@ -362,12 +362,9 @@ void Mutex::assert_no_overlap(Rank orig, Rank adjusted, int adjust) {
   // underflow is caught in constructor
   if (i != 0 && adjusted > event && adjusted <= _ranks[i-1]) {
     ResourceMark rm;
-    const char* orig_name = rank_name_internal(orig);
-    const char* adjusted_name = rank_name_internal(adjusted);
-    log_info(vmmutex, bot)("Rank %s-%d compares with %s", orig_name, adjust, adjusted_name);
-
     assert(adjusted > _ranks[i-1],
-           "Rank %s-%d overlaps with %s", orig_name, adjust, adjusted_name);
+           "Rank %s-%d overlaps with %s",
+           rank_name_internal(orig), adjust, rank_name_internal(adjusted));
   }
 }
 #endif // ASSERT

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -337,22 +337,21 @@ static void print_rank_name_internal(outputStream* st, Mutex::Rank r) {
   }
 }
 
+// Requires caller to have ResourceMark.
 static const char* rank_name_internal(Mutex::Rank r) {
   stringStream st;
   print_rank_name_internal(&st, r);
   return st.as_string();
 }
 
+const char* Mutex::rank_name() const {
+  return rank_name_internal(_rank);
+}
+
 // Does not require caller to have ResourceMark, unless the outputStream already has one.
 void Mutex::print_rank_name(outputStream* st) const {
   print_rank_name_internal(st, _rank);
 }
-
-// Requires caller to have ResourceMark.
-const char* Mutex::rank_name() const {
-  rank_name_internal(_rank);
-}
-
 
 void Mutex::assert_no_overlap(Rank orig, Rank adjusted, int adjust) {
   int i = 0;

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -130,7 +130,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
     return _skip_rank_check;
   }
 
-  const char*  rank_name() const;
+  const char* rank_name() const;
   void print_rank_name(outputStream* st) const;
 
  public:

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,9 +130,11 @@ class Mutex : public CHeapObj<mtSynchronizer> {
     return _skip_rank_check;
   }
 
+  const char*  rank_name() const;
+  void print_rank_name(outputStream* st) const;
+
  public:
   Rank   rank() const          { return _rank; }
-  const char*  rank_name() const;
   Mutex* next()  const         { return _next; }
 #endif // ASSERT
 

--- a/test/hotspot/gtest/runtime/test_mutex.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -325,9 +325,12 @@ TEST_VM_ASSERT_MSG(MutexSafepoint, possible_safepoint_lock,
   ThreadInVMfromNative in_native(thread);
   MutexLocker ml(new Mutex(Mutex::nosafepoint, "SpecialTest_lock"),
                    Mutex::_no_safepoint_check_flag);
+  MutexLocker m2(new Mutex(Mutex::nosafepoint-1, "SpecialTest2_lock"),
+                   Mutex::_no_safepoint_check_flag);
   thread->print_thread_state_on(tty);
   // If the lock above succeeds, try to safepoint to test the NSV implied with this nosafepoint lock.
   ThreadBlockInVM tbivm(thread);
   thread->print_thread_state_on(tty);
 }
+
 #endif // ASSERT

--- a/test/hotspot/gtest/runtime/test_mutex.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex.cpp
@@ -323,9 +323,7 @@ TEST_VM_ASSERT_MSG(MutexSafepoint, possible_safepoint_lock,
     ".* Possible safepoint reached by thread that does not allow it") {
   JavaThread* thread = JavaThread::current();
   ThreadInVMfromNative in_native(thread);
-  MutexLocker ml(new Mutex(Mutex::nosafepoint, "SpecialTest_lock"),
-                   Mutex::_no_safepoint_check_flag);
-  MutexLocker m2(new Mutex(Mutex::nosafepoint-1, "SpecialTest2_lock"),
+  MutexLocker ml(new Mutex(Mutex::nosafepoint-2, "SpecialTest_lock"),
                    Mutex::_no_safepoint_check_flag);
   thread->print_thread_state_on(tty);
   // If the lock above succeeds, try to safepoint to test the NSV implied with this nosafepoint lock.


### PR DESCRIPTION

This change creates a new print_mutex_name() to be called so there's no ResourceMark needed in the Mutex::print_on() path.  Since the rank_name() that returns a const char* is nice in the formatted error messages, I left that but it's internal to mutex making it easier to see that there's a ResourceMark in the code path.  The case in the Mutex constructor was wrong.  It can't print the name if it's out of range.

Tested with tier1-3.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381145](https://bugs.openjdk.org/browse/JDK-8381145): Missing ResourceMark in Mutex::print_on() (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) Review applies to [ad504bb7](https://git.openjdk.org/jdk/pull/30742/files/ad504bb71a04c064a19a4d94ebf78f9b9de58532)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [ad504bb7](https://git.openjdk.org/jdk/pull/30742/files/ad504bb71a04c064a19a4d94ebf78f9b9de58532)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30742/head:pull/30742` \
`$ git checkout pull/30742`

Update a local copy of the PR: \
`$ git checkout pull/30742` \
`$ git pull https://git.openjdk.org/jdk.git pull/30742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30742`

View PR using the GUI difftool: \
`$ git pr show -t 30742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30742.diff">https://git.openjdk.org/jdk/pull/30742.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30742#issuecomment-4252428650)
</details>
