### PR TITLE
8382095: GenShen: Do not clamp young reserve unnecessarily

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -2679,8 +2679,11 @@ void ShenandoahFreeSet::reduce_young_reserve(size_t adjusted_young_reserve, size
  *  1. Memory currently available within old and young
  *  2. Trashed regions currently residing in young and old, which will become available momentarily
  *  3. The value of old_generation->get_region_balance() which represents the number of regions that we plan
- *     to transfer from old generation to young generation.  Prior to each invocation of compute_young_and_old_reserves(),
- *     this value should computed by ShenandoahGenerationalHeap::compute_old_generation_balance().
+ *     to transfer from old generation to young generation. At the end of each GC cycle, we reset region_balance
+ *     to zero. As we prepare to rebuild free set at the end of update-refs, we call
+ *     ShenandoahGenerationalHeap::compute_old_generation_balance() to compute a new value of region_balance.
+ *     This allows us to expand or shrink the size of the Old Collector reserves based on anticipated needs of
+ *     the next GC cycle.
  */
 void ShenandoahFreeSet::compute_young_and_old_reserves(size_t young_trashed_regions, size_t old_trashed_regions,
                                                        size_t& young_reserve_result, size_t& old_reserve_result) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -309,16 +309,9 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::final_rebuild_freeset :
                             ShenandoahPhaseTimings::degen_gc_final_rebuild_freeset);
     ShenandoahHeapLocker locker(heap->lock());
-
-    // We are preparing for evacuation.
+    // At start of evacation, we do NOT compute_old_generation_balance()
     size_t young_trashed_regions, old_trashed_regions, first_old, last_old, num_old;
     _free_set->prepare_to_rebuild(young_trashed_regions, old_trashed_regions, first_old, last_old, num_old);
-    if (heap->mode()->is_generational()) {
-      ShenandoahGenerationalHeap* gen_heap = ShenandoahGenerationalHeap::heap();
-      size_t allocation_runway =
-        gen_heap->young_generation()->heuristics()->bytes_of_allocation_runway_before_gc_trigger(young_trashed_regions);
-      gen_heap->compute_old_generation_balance(allocation_runway, old_trashed_regions, young_trashed_regions);
-    }
     _free_set->finish_rebuild(young_trashed_regions, old_trashed_regions, num_old);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -411,14 +411,13 @@ template oop ShenandoahGenerationalHeap::try_evacuate_object<YOUNG_GENERATION, O
 template oop ShenandoahGenerationalHeap::try_evacuate_object<OLD_GENERATION, OLD_GENERATION>(oop p, Thread* thread, uint from_region_age);
 
 // Call this function at the end of a GC cycle in order to establish proper sizes of young and old reserves,
-// setting the old-generation balance so that we can
+// setting the old-generation balance so that GC can perform the anticipated evacuations.
 //
 // Make sure old-generation is large enough, but no larger than is necessary, to hold mixed evacuations
 // and promotions, if we anticipate either. Any deficit is provided by the young generation, subject to
 // mutator_xfer_limit, and any surplus is transferred to the young generation.  mutator_xfer_limit is
-// the maximum we're able to transfer from young to old.  This is called at the end of GC, as we prepare
-// for the idle span that precedes the next GC.  The mutator_xfer_limit constrains the transfer of memory
-// from young to old.  It does not limit young reserves.
+// the maximum we're able to transfer from young to old. The mutator_xfer_limit constrains the transfer
+// of memory from young to old.  It does not limit young reserves.
 void ShenandoahGenerationalHeap::compute_old_generation_balance(size_t mutator_xfer_limit,
                                                                 size_t old_trashed_regions, size_t young_trashed_regions) {
   shenandoah_assert_heaplocked();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -410,11 +410,15 @@ template oop ShenandoahGenerationalHeap::try_evacuate_object<YOUNG_GENERATION, Y
 template oop ShenandoahGenerationalHeap::try_evacuate_object<YOUNG_GENERATION, OLD_GENERATION>(oop p, Thread* thread, uint from_region_age);
 template oop ShenandoahGenerationalHeap::try_evacuate_object<OLD_GENERATION, OLD_GENERATION>(oop p, Thread* thread, uint from_region_age);
 
+// Call this function at the end of a GC cycle in order to establish proper sizes of young and old reserves,
+// setting the old-generation balance so that we can
+//
 // Make sure old-generation is large enough, but no larger than is necessary, to hold mixed evacuations
 // and promotions, if we anticipate either. Any deficit is provided by the young generation, subject to
 // mutator_xfer_limit, and any surplus is transferred to the young generation.  mutator_xfer_limit is
 // the maximum we're able to transfer from young to old.  This is called at the end of GC, as we prepare
-// for the idle span that precedes the next GC.
+// for the idle span that precedes the next GC.  The mutator_xfer_limit constrains the transfer of memory
+// from young to old.  It does not limit young reserves.
 void ShenandoahGenerationalHeap::compute_old_generation_balance(size_t mutator_xfer_limit,
                                                                 size_t old_trashed_regions, size_t young_trashed_regions) {
   shenandoah_assert_heaplocked();
@@ -466,11 +470,17 @@ void ShenandoahGenerationalHeap::compute_old_generation_balance(size_t mutator_x
                                   bound_on_old_reserve));
   assert(mutator_xfer_limit <= young_available,
          "Cannot transfer (%zu) memory that is not available (%zu)", mutator_xfer_limit, young_available);
-  // Young reserves are to be taken out of the mutator_xfer_limit.
-  if (young_reserve > mutator_xfer_limit) {
-    young_reserve = mutator_xfer_limit;
+
+  if (young_reserve > young_available) {
+    young_reserve = young_available;
   }
-  mutator_xfer_limit -= young_reserve;
+  // We allow young_reserve to exceed mutator_xfer_limit. Essentially, this means the GC is already behind the pace
+  // of mutator allocations, and we'll need to trigger the next GC as soon as possible.
+  if (mutator_xfer_limit > young_reserve) {
+    mutator_xfer_limit -= young_reserve;
+  } else {
+    mutator_xfer_limit = 0;
+  }
 
   // Decide how much old space we should reserve for a mixed collection
   size_t proposed_reserve_for_mixed = 0;


### PR DESCRIPTION
Generational mode of Shenandoah takes precautions to avoid overcommitting memory to young reserves.  This behavior was too conservative, causing young reserve to be clamped to zero when GC is under duress.  This would result in GC cycles that get triggered, but can perform no useful work because there is no memory available to receive young evacuations.

This PR makes two changes to that behavior:

1. We allow the young reserve to be larger than the allocation runway (but still no larger than mutator available).  At the time we make this reserve, this means we may be already in arrears.  In other words, according to our "budgeting calculations", we should have triggered GC already because there is now insufficient allocation runway to complete GC before our free pool is exhausted.  In this situation, it is still better to make the reserves so that the next GC has enough work space to make meaningful progress.  The GC may still be able to avoid degeneration because our budgeting is conservative, and in the very near future, the GC will be able to surge workers in order to catch up when this situation is detected.

2. When we rebuild the free set at the start of evacuation, we had erroneously been checking the allocation runway and clamping reserves there.  At this rebuild, we no longer check the allocation runway.  In this situation, it is also necessary to keep the reserves available so that the GC can do its planned evacuations.

The negative effects of the previous behavior were most notable on specjbb measurements, which drives allocation rates very aggressively.  This PR shows significant reduction in degenerated GC times especially on that workload.

Testing: has passed Amazon CI pipeline tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382095](https://bugs.openjdk.org/browse/JDK-8382095): GenShen: Do not clamp young reserve unnecessarily (**Enhancement** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30743/head:pull/30743` \
`$ git checkout pull/30743`

Update a local copy of the PR: \
`$ git checkout pull/30743` \
`$ git pull https://git.openjdk.org/jdk.git pull/30743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30743`

View PR using the GUI difftool: \
`$ git pr show -t 30743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30743.diff">https://git.openjdk.org/jdk/pull/30743.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30743#issuecomment-4252647212)
</details>
