### PR TITLE
8382257: Shenandoah: Clean up stack watermark barrier support

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahPassiveMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahPassiveMode.cpp
@@ -50,7 +50,6 @@ void ShenandoahPassiveMode::initialize_flags() const {
   SHENANDOAH_ERGO_DISABLE_FLAG(ShenandoahSATBBarrier);
   SHENANDOAH_ERGO_DISABLE_FLAG(ShenandoahCASBarrier);
   SHENANDOAH_ERGO_DISABLE_FLAG(ShenandoahCloneBarrier);
-  SHENANDOAH_ERGO_DISABLE_FLAG(ShenandoahStackWatermarkBarrier);
   SHENANDOAH_ERGO_DISABLE_FLAG(ShenandoahCardBarrier);
 }
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahSATBMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahSATBMode.cpp
@@ -42,6 +42,5 @@ void ShenandoahSATBMode::initialize_flags() const {
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahSATBBarrier);
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahCASBarrier);
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahCloneBarrier);
-  SHENANDOAH_CHECK_FLAG_SET(ShenandoahStackWatermarkBarrier);
   SHENANDOAH_CHECK_FLAG_UNSET(ShenandoahCardBarrier);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -149,11 +149,9 @@ void ShenandoahBarrierSet::on_thread_attach(Thread *thread) {
     BarrierSetNMethod* bs_nm = barrier_set_nmethod();
     thread->set_nmethod_disarmed_guard_value(bs_nm->disarmed_guard_value());
 
-    if (ShenandoahStackWatermarkBarrier) {
-      JavaThread* const jt = JavaThread::cast(thread);
-      StackWatermark* const watermark = new ShenandoahStackWatermark(jt);
-      StackWatermarkSet::add_watermark(jt, watermark);
-    }
+    JavaThread* const jt = JavaThread::cast(thread);
+    StackWatermark* const watermark = new ShenandoahStackWatermark(jt);
+    StackWatermarkSet::add_watermark(jt, watermark);
   }
 }
 
@@ -172,14 +170,12 @@ void ShenandoahBarrierSet::on_thread_detach(Thread *thread) {
     }
 
     // SATB protocol requires to keep alive reachable oops from roots at the beginning of GC
-    if (ShenandoahStackWatermarkBarrier) {
-      if (_heap->is_concurrent_mark_in_progress()) {
-        ShenandoahKeepAliveClosure oops;
-        StackWatermarkSet::finish_processing(JavaThread::cast(thread), &oops, StackWatermarkKind::gc);
-      } else if (_heap->is_concurrent_weak_root_in_progress() && _heap->is_evacuation_in_progress()) {
-        ShenandoahContextEvacuateUpdateRootsClosure oops;
-        StackWatermarkSet::finish_processing(JavaThread::cast(thread), &oops, StackWatermarkKind::gc);
-      }
+    if (_heap->is_concurrent_mark_in_progress()) {
+      ShenandoahKeepAliveClosure oops;
+      StackWatermarkSet::finish_processing(JavaThread::cast(thread), &oops, StackWatermarkKind::gc);
+    } else if (_heap->is_concurrent_weak_root_in_progress() && _heap->is_evacuation_in_progress()) {
+      ShenandoahContextEvacuateUpdateRootsClosure oops;
+      StackWatermarkSet::finish_processing(JavaThread::cast(thread), &oops, StackWatermarkKind::gc);
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -560,9 +560,6 @@
   product(bool, ShenandoahLoadRefBarrier, true, DIAGNOSTIC,                 \
           "Turn on/off load-reference barriers in Shenandoah")              \
                                                                             \
-  product(bool, ShenandoahStackWatermarkBarrier, true, DIAGNOSTIC,          \
-          "Turn on/off stack watermark barriers in Shenandoah")             \
-                                                                            \
   develop(bool, ShenandoahVerifyOptoBarriers, trueInDebug,                  \
           "Verify no missing barriers in C2.")                              \
                                                                             \

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestSelectiveBarrierFlags.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestSelectiveBarrierFlags.java
@@ -52,8 +52,7 @@ public class TestSelectiveBarrierFlags {
                 new String[] { "ShenandoahLoadRefBarrier" },
                 new String[] { "ShenandoahSATBBarrier" },
                 new String[] { "ShenandoahCASBarrier" },
-                new String[] { "ShenandoahCloneBarrier" },
-                new String[] { "ShenandoahStackWatermarkBarrier" }
+                new String[] { "ShenandoahCloneBarrier" }
         };
 
         int size = 1;

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierDisable.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierDisable.java
@@ -41,8 +41,7 @@ public class TestWrongBarrierDisable {
                 "ShenandoahLoadRefBarrier",
                 "ShenandoahSATBBarrier",
                 "ShenandoahCASBarrier",
-                "ShenandoahCloneBarrier",
-                "ShenandoahStackWatermarkBarrier",
+                "ShenandoahCloneBarrier"
         };
 
         String[] generational = {

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierEnable.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierEnable.java
@@ -41,8 +41,7 @@ public class TestWrongBarrierEnable {
                 "ShenandoahLoadRefBarrier",
                 "ShenandoahSATBBarrier",
                 "ShenandoahCASBarrier",
-                "ShenandoahCloneBarrier",
-                "ShenandoahStackWatermarkBarrier",
+                "ShenandoahCloneBarrier"
         };
         String[] generational = { "ShenandoahCardBarrier" };
         String[] all = {
@@ -50,7 +49,6 @@ public class TestWrongBarrierEnable {
                 "ShenandoahSATBBarrier",
                 "ShenandoahCASBarrier",
                 "ShenandoahCloneBarrier",
-                "ShenandoahStackWatermarkBarrier",
                 "ShenandoahCardBarrier"
         };
 


### PR DESCRIPTION
Similar to [JDK-8382150](https://bugs.openjdk.org/browse/JDK-8382150), stack watermark machinery is nearly always on now. In fact, stack watermark machinery calls nmethod entry barriers to fix up nmethods, so it stands to reason that it should have the same support level as nmethod entry barriers.

This barrier is also different from the "normal" mutator barriers that are inserted near the heap accesses. Stack watermark barrier only fires when leaving the safepoint / unwinding the stack.

Therefore, it does not pay off to guard the machinery under the separate feature flag.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382257](https://bugs.openjdk.org/browse/JDK-8382257): Shenandoah: Clean up stack watermark barrier support (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30744/head:pull/30744` \
`$ git checkout pull/30744`

Update a local copy of the PR: \
`$ git checkout pull/30744` \
`$ git pull https://git.openjdk.org/jdk.git pull/30744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30744`

View PR using the GUI difftool: \
`$ git pr show -t 30744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30744.diff">https://git.openjdk.org/jdk/pull/30744.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30744#issuecomment-4252713585)
</details>
