### PR TITLE
8380447: Fix linter warnings in compiler testlibrary

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/compile_framework/CompileFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/CompileFrameworkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/compile_framework/CompileFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/CompileFrameworkException.java
@@ -26,6 +26,7 @@ package compiler.lib.compile_framework;
 /**
  * Exception thrown in the Compilation Framework. Most likely, the user is responsible for the failure.
  */
+@SuppressWarnings("serial")
 public class CompileFrameworkException extends RuntimeException {
     public CompileFrameworkException(String message) {
         super("Exception in Compile Framework:" + System.lineSeparator() + message);

--- a/test/hotspot/jtreg/compiler/lib/compile_framework/InternalCompileFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/InternalCompileFrameworkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/compile_framework/InternalCompileFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/InternalCompileFrameworkException.java
@@ -26,6 +26,7 @@ package compiler.lib.compile_framework;
 /**
  * Internal exception thrown in Compilation Framework. Most likely, this is due to a bug in the CompileFramework.
  */
+@SuppressWarnings("serial")
 public class InternalCompileFrameworkException extends RuntimeException {
     public InternalCompileFrameworkException(String message) {
         super("Internal exception in Compile Framework, please file a bug:" + System.lineSeparator() + message);

--- a/test/hotspot/jtreg/compiler/lib/generators/EmptyGeneratorException.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/EmptyGeneratorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/generators/EmptyGeneratorException.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/EmptyGeneratorException.java
@@ -28,6 +28,7 @@ package compiler.lib.generators;
  * set of values. For example, bounds such as [1, 0] cause an EmptyGeneratorException. Another example would be
  * restricting a uniform integer generator over the range [0, 1] to [10, 11].
  */
+@SuppressWarnings("serial")
 public class EmptyGeneratorException extends RuntimeException {
     public EmptyGeneratorException() {}
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -258,6 +258,7 @@ public final class Generators {
      * An overload for restrictable generators exists.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public final <T> Generator<T> mixed(List<Integer> weights, Generator<T>... generators) {
         return new MixedGenerator<>(this, Arrays.asList(generators), weights);
     }
@@ -279,6 +280,7 @@ public final class Generators {
      * generator.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public final <T extends Comparable<T>> RestrictableGenerator<T> mixed(List<Integer> weights, RestrictableGenerator<T>... generators) {
         return new RestrictableMixedGenerator<>(this, Arrays.asList(generators), weights);
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -364,6 +364,7 @@ public class TestFramework {
      * @return the same framework instance.
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     final public TestFramework addCrossProductScenarios(Set<String>... flagSets) {
         TestFormat.checkAndReport(flagSets != null &&
                                   Arrays.stream(flagSets).noneMatch(Objects::isNull) &&

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/SuccessOnlyConstraintException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/SuccessOnlyConstraintException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/SuccessOnlyConstraintException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/SuccessOnlyConstraintException.java
@@ -28,6 +28,7 @@ import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
 /**
  * Exception used to signal that a {@link Constraint} should always succeed.
  */
+@SuppressWarnings("serial")
 public class SuccessOnlyConstraintException extends RuntimeException {
     public SuccessOnlyConstraintException(String message) {
         super("Unhandled SuccessOnlyConstraintException, should have created a Constraint that always succeeds:" + System.lineSeparator() + message);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMException.java
@@ -28,6 +28,7 @@ import compiler.lib.ir_framework.shared.TestFormatException;
 /**
  * Exception that is thrown if the Test VM has thrown any kind of exception (except for {@link TestFormatException}).
  */
+@SuppressWarnings("serial")
 public class TestVMException extends RuntimeException {
     private final String exceptionInfo;
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/IRViolationException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/IRViolationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/IRViolationException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/IRViolationException.java
@@ -34,6 +34,7 @@ import compiler.lib.ir_framework.Test;
  * @see IR
  * @see Test
  */
+@SuppressWarnings("serial")
 public class IRViolationException extends RuntimeException {
     private final String compilations;
     private String exceptionInfo;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/mapping/OverlappingPhaseRangesException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/mapping/OverlappingPhaseRangesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/mapping/OverlappingPhaseRangesException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/mapping/OverlappingPhaseRangesException.java
@@ -29,6 +29,7 @@ package compiler.lib.ir_framework.driver.irmatching.mapping;
  * @see PhaseInterval
  * @see MultiPhaseRangeEntry
  */
+@SuppressWarnings("serial")
 class OverlappingPhaseRangesException extends RuntimeException {
     public OverlappingPhaseRangesException(PhaseInterval entry, PhaseInterval entry2) {
         super("The following two PhaseRangeEntry objects overlap which is forbidden:" + System.lineSeparator() + "- "

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/CheckedTestFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/CheckedTestFrameworkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/CheckedTestFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/CheckedTestFrameworkException.java
@@ -26,6 +26,7 @@ package compiler.lib.ir_framework.shared;
 /**
  * Checked internal exceptions in the framework to propagate error handling.
  */
+@SuppressWarnings("serial")
 public class CheckedTestFrameworkException extends Exception {
     public CheckedTestFrameworkException(String msg) {
         super(msg);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/EmptyConstraintException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/EmptyConstraintException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/EmptyConstraintException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/EmptyConstraintException.java
@@ -26,5 +26,6 @@ package compiler.lib.ir_framework.shared;
 /**
  * Exception thrown when {@link ComparisonConstraintParser} cannot find a constraint.
  */
+@SuppressWarnings("serial")
 class EmptyConstraintException extends Exception {
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidComparatorException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidComparatorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidComparatorException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidComparatorException.java
@@ -26,6 +26,7 @@ package compiler.lib.ir_framework.shared;
 /**
  * Exception threw when {@link ComparisonConstraintParser} parses an invalid comparator.
  */
+@SuppressWarnings("serial")
 public class InvalidComparatorException extends Exception {
     private final String comparator;
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidConstraintValueException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidConstraintValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidConstraintValueException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/InvalidConstraintValueException.java
@@ -26,6 +26,7 @@ package compiler.lib.ir_framework.shared;
 /**
  * Exception thrown when {@link ComparisonConstraintParser} parses an invalid value.
  */
+@SuppressWarnings("serial")
 class InvalidConstraintValueException extends Exception {
     private final String invalidValue;
     private final String comparator;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/MissingConstraintValueException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/MissingConstraintValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/MissingConstraintValueException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/MissingConstraintValueException.java
@@ -26,6 +26,7 @@ package compiler.lib.ir_framework.shared;
 /**
  * Exception thrown when {@link ComparisonConstraintParser} cannot find a value in a constraint after a comparator.
  */
+@SuppressWarnings("serial")
 class MissingConstraintValueException extends Exception {
     private final String comparator;
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/NoTestsRunException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/NoTestsRunException.java
@@ -27,6 +27,7 @@ package compiler.lib.ir_framework.shared;
  * Exception that is thrown by the Test VM if no tests are run as a result of specifying {@code -DTest} and/or
  * {@code -DExclude} defining an empty set with the used Test VM flags.
  */
+@SuppressWarnings("serial")
 public class NoTestsRunException extends RuntimeException {
     /**
      * Default constructor used by Test VM

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormatException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormatException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFormatException.java
@@ -26,6 +26,7 @@ package compiler.lib.ir_framework.shared;
 /**
  * Exception that is thrown if a JTreg test violates the supported format by the test framework.
  */
+@SuppressWarnings("serial")
 public class TestFormatException extends RuntimeException {
     public TestFormatException(String message) {
         super(message);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkException.java
@@ -27,6 +27,7 @@ package compiler.lib.ir_framework.shared;
  * Exception that is thrown if there is an internal error in the framework. This is most likely an indicator of a bug
  * in the framework.
  */
+@SuppressWarnings("serial")
 public class TestFrameworkException extends RuntimeException {
     public TestFrameworkException(String message) {
         super("Internal Test Framework exception - please file a bug:" + System.lineSeparator() + message);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestRunException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestRunException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestRunException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestRunException.java
@@ -27,6 +27,7 @@ package compiler.lib.ir_framework.shared;
  * Exception that is thrown if the JTreg test throws an exception during the execution of individual tests of the
  * test class.
  */
+@SuppressWarnings("serial")
 public class TestRunException extends RuntimeException {
     public TestRunException(String message) {
         super(message);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/AbstractTest.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/AbstractTest.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Modifier;
 /**
  * Abstract super class for base, checked and custom run tests.
  */
+@SuppressWarnings("serial")
 abstract class AbstractTest {
     protected static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
     protected static final int TEST_COMPILATION_TIMEOUT_MS = Integer.parseInt(System.getProperty("TestCompilationTimeout", "10")) * 1000;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ArgumentsProvider.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ArgumentsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ArgumentsProvider.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ArgumentsProvider.java
@@ -23,17 +23,6 @@
 
 package compiler.lib.ir_framework.test;
 
-import compiler.lib.ir_framework.shared.TestFormat;
-import compiler.lib.ir_framework.shared.TestRunException;
-import compiler.lib.ir_framework.Argument;
-import compiler.lib.ir_framework.Arguments;
-import compiler.lib.ir_framework.SetupInfo;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Arrays;
-
 /**
  * This interface provides arguments (and can set fields) for a test method. Different implementations are chosen
  * based on the @Arguments annotation for the @Test method.
@@ -51,90 +40,3 @@ interface ArgumentsProvider {
     Object[] getArguments(Object invocationTarget, int invocationCounter);
 
 }
-
-/**
- * For a test method, determine what ArgumentsProvider is to be constructed, given its @Arguments annotation,
- * and the available setup methods.
- */
-class ArgumentsProviderBuilder {
-   public static ArgumentsProvider build(Method method,
-                                         HashMap<String, Method> setupMethodMap) {
-        Arguments argumentsAnnotation = method.getAnnotation(Arguments.class);
-        if (argumentsAnnotation == null) {
-            return new DefaultArgumentsProvider();
-        }
-
-        Argument[] values = argumentsAnnotation.values();
-        String setupMethodName = argumentsAnnotation.setup();
-
-        if (!setupMethodName.isEmpty()) {
-            TestFormat.check(values.length == 0,
-                             "@Arguments: Can only specify \"setup\" or \"values\" but not both in " + method);
-            TestFormat.check(setupMethodMap.containsKey(setupMethodName),
-                             "@Arguments setup: did not find " + setupMethodName +
-                             " for " + method);
-            Method setupMethod = setupMethodMap.get(setupMethodName);
-            return new SetupArgumentsProvider(setupMethod);
-        } else {
-            TestFormat.check(values.length > 0,
-                             "@Arguments: Empty annotation not allowed. Either specify \"values\" or \"setup\" in " + method);
-            ArgumentValue[] argumentValues = ArgumentValue.getArgumentValues(method, values);
-            return new ValueArgumentsProvider(argumentValues);
-        }
-    }
-}
-
-/**
- * Default: when no @Arguments annotation is provided (including for custom run tests).
- */
-final class DefaultArgumentsProvider implements ArgumentsProvider {
-    @Override
-    public Object[] getArguments(Object invocationTarget, int invocationCounter) {
-        return new Object[]{};
-    }
-}
-
-/**
- * Used for @Arguments(values = {...}) to specify individual arguments directly.
- */
-final class ValueArgumentsProvider implements ArgumentsProvider {
-    ArgumentValue[] argumentValues;
-
-    ValueArgumentsProvider(ArgumentValue[] argumentValues) {
-        this.argumentValues = argumentValues;
-    }
-
-    @Override
-    public Object[] getArguments(Object invocationTarget, int invocationCounter) {
-        return Arrays.stream(argumentValues).map(v -> v.getValue()).toArray();
-    }
-}
-
-/**
- * Used for @Arguments(setup = "setupMethodName") to specify a setup method to provide arguments
- * and possibly set fields.
- */
-final class SetupArgumentsProvider implements ArgumentsProvider {
-    Method setupMethod;
-
-    SetupArgumentsProvider(Method setupMethod) {
-        this.setupMethod = setupMethod;
-    }
-
-    @Override
-    public Object[] getArguments(Object invocationTarget, int invocationCounter) {
-        Object target = Modifier.isStatic(setupMethod.getModifiers()) ? null
-                                                                      : invocationTarget;
-        try {
-            if (setupMethod.getParameterCount() == 1) {
-                return (Object[]) setupMethod.invoke(target, new SetupInfo(invocationCounter));
-            } else {
-                return (Object[]) setupMethod.invoke(target);
-            }
-        } catch (Exception e) {
-            throw new TestRunException("There was an error while invoking setup method " +
-                                       setupMethod + " on " + target, e);
-        }
-    }
-}
-

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ArgumentsProviderBuilder.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ArgumentsProviderBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.test;
+
+import compiler.lib.ir_framework.Argument;
+import compiler.lib.ir_framework.Arguments;
+import compiler.lib.ir_framework.shared.TestFormat;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+/**
+ * For a test method, determine what ArgumentsProvider is to be constructed, given its @Arguments annotation,
+ * and the available setup methods.
+ */
+class ArgumentsProviderBuilder {
+    public static ArgumentsProvider build(Method method,
+                                          HashMap<String, Method> setupMethodMap) {
+        Arguments argumentsAnnotation = method.getAnnotation(Arguments.class);
+        if (argumentsAnnotation == null) {
+            return new DefaultArgumentsProvider();
+        }
+
+        Argument[] values = argumentsAnnotation.values();
+        String setupMethodName = argumentsAnnotation.setup();
+
+        if (!setupMethodName.isEmpty()) {
+            TestFormat.check(values.length == 0,
+                    "@Arguments: Can only specify \"setup\" or \"values\" but not both in " + method);
+            TestFormat.check(setupMethodMap.containsKey(setupMethodName),
+                    "@Arguments setup: did not find " + setupMethodName +
+                            " for " + method);
+            Method setupMethod = setupMethodMap.get(setupMethodName);
+            return new SetupArgumentsProvider(setupMethod);
+        } else {
+            TestFormat.check(values.length > 0,
+                    "@Arguments: Empty annotation not allowed. Either specify \"values\" or \"setup\" in " + method);
+            ArgumentValue[] argumentValues = ArgumentValue.getArgumentValues(method, values);
+            return new ValueArgumentsProvider(argumentValues);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/DefaultArgumentsProvider.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/DefaultArgumentsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,22 +21,14 @@
  * questions.
  */
 
-package compiler.lib.template_framework;
-
-import java.util.function.Function;
+package compiler.lib.ir_framework.test;
 
 /**
- * Represents the for-each execution of the provided function and (optional) hashtag replacement
- * keys for name and type of each name.
+ * Default: when no @Arguments annotation is provided (including for custom run tests).
  */
-record NameForEachToken<N extends Name>(
-        Class<N> clazz,
-        NameSet.Predicate predicate,
-        String name,
-        String type,
-        Function<N, ScopeToken> function) implements Token {
-
-    ScopeToken getScopeToken(Name n) {
-        return function().apply(clazz.cast(n));
+final class DefaultArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Object[] getArguments(Object invocationTarget, int invocationCounter) {
+        return new Object[]{};
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/SetupArgumentsProvider.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/SetupArgumentsProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.test;
+
+import compiler.lib.ir_framework.SetupInfo;
+import compiler.lib.ir_framework.shared.TestRunException;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * Used for @Arguments(setup = "setupMethodName") to specify a setup method to provide arguments
+ * and possibly set fields.
+ */
+final class SetupArgumentsProvider implements ArgumentsProvider {
+    Method setupMethod;
+
+    SetupArgumentsProvider(Method setupMethod) {
+        this.setupMethod = setupMethod;
+    }
+
+    @Override
+    public Object[] getArguments(Object invocationTarget, int invocationCounter) {
+        Object target = Modifier.isStatic(setupMethod.getModifiers()) ? null
+                : invocationTarget;
+        try {
+            if (setupMethod.getParameterCount() == 1) {
+                return (Object[]) setupMethod.invoke(target, new SetupInfo(invocationCounter));
+            } else {
+                return (Object[]) setupMethod.invoke(target);
+            }
+        } catch (Exception e) {
+            throw new TestRunException("There was an error while invoking setup method " +
+                    setupMethod + " on " + target, e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ValueArgumentsProvider.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ValueArgumentsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,22 +21,22 @@
  * questions.
  */
 
-package compiler.lib.template_framework;
+package compiler.lib.ir_framework.test;
 
-import java.util.function.Function;
+import java.util.Arrays;
 
 /**
- * Represents the for-each execution of the provided function and (optional) hashtag replacement
- * keys for name and type of each name.
+ * Used for @Arguments(values = {...}) to specify individual arguments directly.
  */
-record NameForEachToken<N extends Name>(
-        Class<N> clazz,
-        NameSet.Predicate predicate,
-        String name,
-        String type,
-        Function<N, ScopeToken> function) implements Token {
+final class ValueArgumentsProvider implements ArgumentsProvider {
+    ArgumentValue[] argumentValues;
 
-    ScopeToken getScopeToken(Name n) {
-        return function().apply(clazz.cast(n));
+    ValueArgumentsProvider(ArgumentValue[] argumentValues) {
+        this.argumentValues = argumentValues;
+    }
+
+    @Override
+    public Object[] getArguments(Object invocationTarget, int invocationCounter) {
+        return Arrays.stream(argumentValues).map(v -> v.getValue()).toArray();
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/template_framework/DataName.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/DataName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/DataName.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/DataName.java
@@ -202,7 +202,7 @@ public record DataName(String name, DataName.Type type, boolean mutable, int wei
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sample(Function<DataName, ScopeToken> function) {
-            return new NameSampleToken<>(predicate(), null, null, function);
+            return new NameSampleToken<>(DataName.class, predicate(), null, null, function);
         }
 
         /**
@@ -244,7 +244,7 @@ public record DataName(String name, DataName.Type type, boolean mutable, int wei
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sampleAndLetAs(String name, String type) {
-            return new NameSampleToken<DataName>(predicate(), name, type, n -> Template.transparentScope());
+            return new NameSampleToken<>(DataName.class, predicate(), name, type, n -> Template.transparentScope());
         }
 
         /**
@@ -284,7 +284,7 @@ public record DataName(String name, DataName.Type type, boolean mutable, int wei
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sampleAndLetAs(String name) {
-            return new NameSampleToken<DataName>(predicate(), name, null, n -> Template.transparentScope());
+            return new NameSampleToken<>(DataName.class, predicate(), name, null, n -> Template.transparentScope());
         }
 
         /**
@@ -326,7 +326,7 @@ public record DataName(String name, DataName.Type type, boolean mutable, int wei
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token toList(Function<List<DataName>, ScopeToken> function) {
-            return new NamesToListToken<>(predicate(), function);
+            return new NamesToListToken<>(DataName.class, predicate(), function);
         }
 
         /**
@@ -340,7 +340,7 @@ public record DataName(String name, DataName.Type type, boolean mutable, int wei
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token forEach(Function<DataName, ScopeToken> function) {
-            return new NameForEachToken<>(predicate(), null, null, function);
+            return new NameForEachToken<>(DataName.class, predicate(), null, null, function);
         }
 
         /**
@@ -364,7 +364,7 @@ public record DataName(String name, DataName.Type type, boolean mutable, int wei
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token forEach(String name, String type, Function<DataName, ScopeToken> function) {
-            return new NameForEachToken<>(predicate(), name, type, function);
+            return new NameForEachToken<>(DataName.class, predicate(), name, type, function);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/template_framework/NameForEachToken.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/NameForEachToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/NameSampleToken.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/NameSampleToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/NameSampleToken.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/NameSampleToken.java
@@ -31,13 +31,14 @@ import java.util.function.Function;
  * name and type of the sampled name, which are then available in the inner scope
  * created by the provided function.
  */
-record NameSampleToken<N>(
+record NameSampleToken<N extends Name>(
+        Class<N> clazz,
         NameSet.Predicate predicate,
         String name,
         String type,
         Function<N, ScopeToken> function) implements Token {
 
     ScopeToken getScopeToken(Name n) {
-        return function().apply((N)n);
+        return function().apply(clazz.cast(n));
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/template_framework/NamesToListToken.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/NamesToListToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/NamesToListToken.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/NamesToListToken.java
@@ -30,12 +30,13 @@ import java.util.List;
  * Represents the {@code toList} on a filtered name set, including the collection of the
  * names and the creation of the inner scope with the function.
  */
-record NamesToListToken<N>(
+record NamesToListToken<N extends Name>(
+        Class<N> type,
         NameSet.Predicate predicate,
         Function<List<N>, ScopeToken> function) implements Token {
 
     ScopeToken getScopeToken(List<Name> names) {
-        List<N> castNames = names.stream().map(n -> (N)n).toList();
+        List<N> castNames = names.stream().map(type::cast).toList();
         return function().apply(castNames);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/template_framework/Renderer.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/Renderer.java
@@ -346,7 +346,7 @@ final class Renderer {
             case ScopeToken scopeToken -> {
                 renderScopeToken(scopeToken);
             }
-            case NameSampleToken nameScopeToken -> {
+            case NameSampleToken<?> nameScopeToken -> {
                 Name name = currentCodeFrame.sampleName(nameScopeToken.predicate());
                 if (name == null) {
                     throw new RendererException("No Name found for " + nameScopeToken.predicate().toString());
@@ -361,9 +361,9 @@ final class Renderer {
                     }
                 });
             }
-            case NameForEachToken nameForEachToken -> {
+            case NameForEachToken<?> nameForEachToken -> {
                 List<Name> list = currentCodeFrame.listNames(nameForEachToken.predicate());
-                list.stream().forEach(name -> {
+                list.forEach(name -> {
                     ScopeToken scopeToken = nameForEachToken.getScopeToken(name);
                     renderScopeToken(scopeToken, () -> {
                         if (nameForEachToken.name() != null) {
@@ -375,7 +375,7 @@ final class Renderer {
                     });
                 });
             }
-            case NamesToListToken nameToListToken -> {
+            case NamesToListToken<?> nameToListToken -> {
                 List<Name> list = currentCodeFrame.listNames(nameToListToken.predicate());
                 renderScopeToken(nameToListToken.getScopeToken(list));
             }
@@ -390,7 +390,7 @@ final class Renderer {
             case SetFuelCostToken(float fuelCost) -> {
                 currentTemplateFrame.setFuelCost(fuelCost);
             }
-            case LetToken letToken -> {
+            case LetToken<?> letToken -> {
                 ScopeToken scopeToken = letToken.getScopeToken();
                 renderScopeToken(scopeToken, () -> {
                     addHashtagReplacement(letToken.key(), letToken.value());

--- a/test/hotspot/jtreg/compiler/lib/template_framework/RendererException.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/RendererException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/RendererException.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/RendererException.java
@@ -28,6 +28,7 @@ package compiler.lib.template_framework;
  * rendering, or in the use of any of its static methods.
  * It most likely indicates a wrong use of the Templates.
  */
+@SuppressWarnings("serial")
 public class RendererException extends RuntimeException {
     RendererException(String message) {
         super(message);

--- a/test/hotspot/jtreg/compiler/lib/template_framework/StructuralName.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/StructuralName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/StructuralName.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/StructuralName.java
@@ -190,7 +190,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sampleAndLetAs(String name, String type) {
-            return new NameSampleToken<StructuralName>(StructuralName.class, predicate(), name, type, n -> Template.transparentScope());
+            return new NameSampleToken<>(StructuralName.class, predicate(), name, type, n -> Template.transparentScope());
         }
 
         /**

--- a/test/hotspot/jtreg/compiler/lib/template_framework/StructuralName.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/StructuralName.java
@@ -175,7 +175,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sample(Function<StructuralName, ScopeToken> function) {
-            return new NameSampleToken<>(predicate(), null, null, function);
+            return new NameSampleToken<>(StructuralName.class, predicate(), null, null, function);
         }
 
         /**
@@ -190,7 +190,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sampleAndLetAs(String name, String type) {
-            return new NameSampleToken<StructuralName>(predicate(), name, type, n -> Template.transparentScope());
+            return new NameSampleToken<StructuralName>(StructuralName.class, predicate(), name, type, n -> Template.transparentScope());
         }
 
         /**
@@ -204,7 +204,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token sampleAndLetAs(String name) {
-            return new NameSampleToken<StructuralName>(predicate(), name, null, n -> Template.transparentScope());
+            return new NameSampleToken<>(StructuralName.class, predicate(), name, null, n -> Template.transparentScope());
         }
 
         /**
@@ -245,7 +245,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token toList(Function<List<StructuralName>, ScopeToken> function) {
-            return new NamesToListToken<>(predicate(), function);
+            return new NamesToListToken<>(StructuralName.class, predicate(), function);
         }
 
         /**
@@ -259,7 +259,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token forEach(Function<StructuralName, ScopeToken> function) {
-            return new NameForEachToken<>(predicate(), null, null, function);
+            return new NameForEachToken<>(StructuralName.class, predicate(), null, null, function);
         }
 
         /**
@@ -283,7 +283,7 @@ public record StructuralName(String name, StructuralName.Type type, int weight) 
          *                                       {@link #subtypeOf}, {@link #supertypeOf} or {@link #exactOf}.
          */
         public Token forEach(String name, String type, Function<StructuralName, ScopeToken> function) {
-            return new NameForEachToken<>(predicate(), name, type, function);
+            return new NameForEachToken<>(StructuralName.class, predicate(), name, type, function);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
@@ -873,7 +873,7 @@ public sealed interface Template permits Template.ZeroArgs,
      * @return A token that represents the hashtag replacement definition.
      */
     static Token let(String key, Object value) {
-        return new LetToken(key, value, v -> transparentScope());
+        return new LetToken<>(key, value, v -> transparentScope());
     }
 
     /**
@@ -902,7 +902,7 @@ public sealed interface Template permits Template.ZeroArgs,
      * @return A {@link Token} representing the hashtag replacement definition and inner scope.
      */
     static <T> Token let(String key, T value, Function<T, ScopeToken> function) {
-        return new LetToken(key, value, function);
+        return new LetToken<>(key, value, function);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/template_framework/library/Operations.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/library/Operations.java
@@ -638,35 +638,28 @@ public final class Operations {
                 var vopInfo = vop.isDeterministic ? new Expression.Info() : WITH_NONDETERMINISTIC_RESULT;
                 if (vop.elementTypes().contains(type.elementType)) {
                     switch(vop.type()) {
-                    case VOPType.UNARY:
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.maskType, ")", vopInfo));
-                        break;
-                    case VOPType.ASSOCIATIVE:
-                    case VOPType.INTEGRAL_ASSOCIATIVE:
-                        if (vop.type() == VOPType.ASSOCIATIVE || !type.elementType.isFloating()) {
-                            ops.add(Expression.make(type.elementType, "", type, ".reduceLanes(VectorOperators." + vop.name() + ")", vopInfo));
-                            ops.add(Expression.make(type.elementType, "", type, ".reduceLanes(VectorOperators." + vop.name() + ", ", type.maskType, ")", vopInfo));
+                        case VOPType.UNARY -> {
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.maskType, ")", vopInfo));
                         }
-                        // fall-through
-                    case VOPType.BINARY:
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", LONGS, ")", vopInfo.combineWith(WITH_ILLEGAL_ARGUMENT_EXCEPTION)));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", LONGS, ", ", type.maskType, ")", vopInfo.combineWith(WITH_ILLEGAL_ARGUMENT_EXCEPTION)));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.maskType, ")", vopInfo));
-                        break;
-                    case VOPType.TERNARY:
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ", ", type.maskType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ")", vopInfo));
-                        ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ", ", type.maskType, ")", vopInfo));
-                        break;
+                        case VOPType.ASSOCIATIVE, VOPType.INTEGRAL_ASSOCIATIVE -> {
+                            if (vop.type() == VOPType.ASSOCIATIVE || !type.elementType.isFloating()) {
+                                ops.add(Expression.make(type.elementType, "", type, ".reduceLanes(VectorOperators." + vop.name() + ")", vopInfo));
+                                ops.add(Expression.make(type.elementType, "", type, ".reduceLanes(VectorOperators." + vop.name() + ", ", type.maskType, ")", vopInfo));
+                            }
+                            ops.addAll(binaryOps(vop, type, vopInfo));
+                        }
+                        case VOPType.BINARY -> ops.addAll(binaryOps(vop, type, vopInfo));
+                        case VOPType.TERNARY -> {
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ", ", type.maskType, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ")", vopInfo));
+                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ", ", type.maskType, ")", vopInfo));
+                        }
                     }
                 }
             }
@@ -811,6 +804,17 @@ public final class Operations {
 
         // Make sure the list is not modifiable.
         return List.copyOf(ops);
+    }
+
+    private static List<Expression> binaryOps(Operations.VOP vop, VectorType.Vector type, Expression.Info vopInfo) {
+        return List.of(
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.maskType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", LONGS, ")", vopInfo.combineWith(WITH_ILLEGAL_ARGUMENT_EXCEPTION)),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", LONGS, ", ", type.maskType, ")", vopInfo.combineWith(WITH_ILLEGAL_ARGUMENT_EXCEPTION)),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.maskType, ")", vopInfo)
+        );
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/template_framework/library/Operations.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/library/Operations.java
@@ -650,16 +650,7 @@ public final class Operations {
                             ops.addAll(binaryOps(vop, type, vopInfo));
                         }
                         case VOPType.BINARY -> ops.addAll(binaryOps(vop, type, vopInfo));
-                        case VOPType.TERNARY -> {
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ", ", type.maskType, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ", ", type.maskType, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ")", vopInfo));
-                            ops.add(Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ", ", type.maskType, ")", vopInfo));
-                        }
+                        case VOPType.TERNARY -> ops.addAll(ternaryOps(vop, type, vopInfo));
                     }
                 }
             }
@@ -817,8 +808,21 @@ public final class Operations {
         );
     }
 
+    private static List<Expression> ternaryOps(Operations.VOP vop, VectorType.Vector type, Expression.Info vopInfo) {
+        return List.of(
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type.elementType, ", ", type.maskType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type.elementType, ", ", type, ", ", type.maskType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type.elementType, ", ", type.maskType, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ")", vopInfo),
+                Expression.make(type, "", type, ".lanewise(VectorOperators." + vop.name() + ", ", type, ", ", type, ", ", type.maskType, ")", vopInfo)
+        );
+    }
+
     /**
-     * Provides a lits of operations on {@link PrimitiveType}s, such as arithmetic, logical,
+     * Provides a list of operations on {@link PrimitiveType}s, such as arithmetic, logical,
      * and cast operations.
      */
     public static final List<Expression> PRIMITIVE_OPERATIONS = generatePrimitiveOperations();

--- a/test/hotspot/jtreg/compiler/lib/template_framework/library/Utils.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/library/Utils.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
  */
 final class Utils {
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> List<T> concat(List<? extends T>... lists) {
         return Arrays.stream(lists)
                      .flatMap(List::stream)

--- a/test/hotspot/jtreg/compiler/lib/verify/VerifyException.java
+++ b/test/hotspot/jtreg/compiler/lib/verify/VerifyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/verify/VerifyException.java
+++ b/test/hotspot/jtreg/compiler/lib/verify/VerifyException.java
@@ -26,6 +26,7 @@ package compiler.lib.verify;
 /**
  * Exception thrown in verification.
  */
+@SuppressWarnings("serial")
 public class VerifyException extends RuntimeException {
 
     /**


### PR DESCRIPTION
Fix linter warnings in test/hotspot/jtreg/compiler/lib.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380447](https://bugs.openjdk.org/browse/JDK-8380447): Fix linter warnings in compiler testlibrary (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30745/head:pull/30745` \
`$ git checkout pull/30745`

Update a local copy of the PR: \
`$ git checkout pull/30745` \
`$ git pull https://git.openjdk.org/jdk.git pull/30745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30745`

View PR using the GUI difftool: \
`$ git pr show -t 30745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30745.diff">https://git.openjdk.org/jdk/pull/30745.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30745#issuecomment-4298762280)
</details>
