### PR TITLE
8382267: VectorMathLibrary uses locale-sensitive String.format to construct native symbol names

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMathLibrary.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMathLibrary.java
@@ -31,6 +31,7 @@ import jdk.internal.vm.vector.VectorSupport;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
+import java.util.Locale;
 import java.util.function.IntFunction;
 
 import static jdk.incubator.vector.Util.requires;
@@ -141,7 +142,7 @@ import static jdk.internal.vm.vector.Utils.debug;
             String elemType = (vspecies.elementType() == float.class ? "f" : "");
             boolean isFloatVector64 = (vspecies.elementType() == float.class) && (vspecies.length() == 2); // FloatVector64 or FloatVectorMax
             int vlen = (isFloatVector64 ? 4 : vspecies.length()); // reuse 128-bit variant for 64-bit float vectors
-            return String.format("__jsvml_%s%s%d_ha_%s", op.operatorName(), elemType, vlen, suffix);
+            return String.format(Locale.ROOT, "__jsvml_%s%s%d_ha_%s", op.operatorName(), elemType, vlen, suffix);
         }
 
         @Override
@@ -214,7 +215,7 @@ import static jdk.internal.vm.vector.Utils.debug;
             boolean isFloatVector64 = (vspecies.elementType() == float.class) && (vspecies.length() == 2); // FloatVector64 or FloatVectorMax
             int vlen = (isFloatVector64 ? 4 : vspecies.length()); // reuse 128-bit variant for 64-bit float vectors
             boolean isShapeAgnostic = isRISCV64() || (isAARCH64() && vspecies.vectorBitSize() > 128);
-            return String.format("%s%s%s_%s%s", op.operatorName(),
+            return String.format(Locale.ROOT, "%s%s%s_%s%s", op.operatorName(),
                                  (vspecies.elementType() == float.class ? "f" : "d"),
                                  (isShapeAgnostic ? "x" : Integer.toString(vlen)),
                                  precisionLevel(op),

--- a/test/jdk/jdk/incubator/vector/VectorMathLibraryLocaleTest.java
+++ b/test/jdk/jdk/incubator/vector/VectorMathLibraryLocaleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8382267
+ * @summary VectorMathLibrary symbol names must not use locale-sensitive formatting
+ * @modules jdk.incubator.vector
+ * @run main/othervm -Duser.language=ar -Duser.country=SA VectorMathLibraryLocaleTest
+ */
+
+import java.util.Locale;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+public class VectorMathLibraryLocaleTest {
+    public static void main(String[] args) {
+        Locale locale = Locale.getDefault();
+        System.out.println("Locale: " + locale);
+        System.out.println("String.format(\"%d\", 16) = " + String.format("%d", 16));
+
+        VectorSpecies<Float> species = FloatVector.SPECIES_PREFERRED;
+        FloatVector v = FloatVector.broadcast(species, 1.0f);
+
+        // EXP is SVML-supported at all vector sizes on x86,
+        // so it exercises the symbol name construction path.
+        FloatVector result = v.lanewise(VectorOperators.EXP);
+        System.out.println("exp(1.0) = " + result);
+    }
+}

--- a/test/jdk/jdk/incubator/vector/VectorMathLibraryLocaleTest.java
+++ b/test/jdk/jdk/incubator/vector/VectorMathLibraryLocaleTest.java
@@ -42,9 +42,12 @@ public class VectorMathLibraryLocaleTest {
         VectorSpecies<Float> species = FloatVector.SPECIES_PREFERRED;
         FloatVector v = FloatVector.broadcast(species, 1.0f);
 
-        // EXP is SVML-supported at all vector sizes on x86,
-        // so it exercises the symbol name construction path.
+        // Without the fix, this throws InternalError due to locale-mangled symbol name.
+        // The assertion below is just a sanity check on the result.
         FloatVector result = v.lanewise(VectorOperators.EXP);
-        System.out.println("exp(1.0) = " + result);
+        float expected = (float) Math.E;
+        for (int i = 0; i < species.length(); i++) {
+            assert result.lane(i) == expected : "lane " + i + ": expected " + expected + ", got " + result.lane(i);
+        }
     }
 }

--- a/test/jdk/jdk/incubator/vector/VectorMathLibraryLocaleTest.java
+++ b/test/jdk/jdk/incubator/vector/VectorMathLibraryLocaleTest.java
@@ -21,24 +21,23 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8382267
  * @summary VectorMathLibrary symbol names must not use locale-sensitive formatting
  * @modules jdk.incubator.vector
- * @run main/othervm -Duser.language=ar -Duser.country=SA VectorMathLibraryLocaleTest
+ * @run main/othervm -ea -Duser.language=ar -Duser.country=SA VectorMathLibraryLocaleTest
  */
 
 import java.util.Locale;
+
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
 public class VectorMathLibraryLocaleTest {
     public static void main(String[] args) {
-        Locale locale = Locale.getDefault();
-        System.out.println("Locale: " + locale);
-        System.out.println("String.format(\"%d\", 16) = " + String.format("%d", 16));
+        assert !String.format("%d", 16).equals("16") : "expected non-ASCII digits for locale " + Locale.getDefault();
 
         VectorSpecies<Float> species = FloatVector.SPECIES_PREFERRED;
         FloatVector v = FloatVector.broadcast(species, 1.0f);


### PR DESCRIPTION
`VectorMathLibrary.SVML.symbolName()` uses `String.format("%d", vlen)` without specifying `Locale.ROOT` to construct native symbol names for libjsvml.so lookup. Under locales that use non-ASCII digit systems (e.g. `ar-SA` Arabic-Indic, `hi-IN` Devanagari), the `%d` format specifier produces locale-specific digits, causing the FFI SymbolLookup to fail with `NoSuchElementException`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382267](https://bugs.openjdk.org/browse/JDK-8382267): VectorMathLibrary uses locale-sensitive String.format to construct native symbol names (**Bug** - P2)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) Review applies to [847f8ccb](https://git.openjdk.org/jdk/pull/30748/files/847f8ccb5a4b62f5bd0210a72e41a0674869efd0)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30748/head:pull/30748` \
`$ git checkout pull/30748`

Update a local copy of the PR: \
`$ git checkout pull/30748` \
`$ git pull https://git.openjdk.org/jdk.git pull/30748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30748`

View PR using the GUI difftool: \
`$ git pr show -t 30748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30748.diff">https://git.openjdk.org/jdk/pull/30748.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30748#issuecomment-4253584257)
</details>
