### PR TITLE
8382192: Problem List "test/jdk/java/awt/Container/MouseEnteredTest.java" fails for MacOS 26.4 (aarch64)

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -245,7 +245,7 @@ java/awt/Clipboard/ClipboardSecurity.java 8054809 macosx-all
 java/awt/Clipboard/GetAltContentsTest/SystemClipboardTest.java 8234140 macosx-all
 java/awt/Clipboard/ImageTransferTest.java 8030710 generic-all
 java/awt/Clipboard/NoDataConversionFailureTest.java 8234140 macosx-all
-java/awt/Container/MouseEnteredTest.java 8382192 macosx-all
+java/awt/Container/MouseEnteredTest.java 8382191 macosx-all
 java/awt/Dialog/ModalExcludedTest.java 7125054 macosx-all
 java/awt/Frame/MiscUndecorated/RepaintTest.java 8266244 macosx-aarch64
 java/awt/Modal/FileDialog/FileDialogAppModal1Test.java 7186009 macosx-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -245,6 +245,7 @@ java/awt/Clipboard/ClipboardSecurity.java 8054809 macosx-all
 java/awt/Clipboard/GetAltContentsTest/SystemClipboardTest.java 8234140 macosx-all
 java/awt/Clipboard/ImageTransferTest.java 8030710 generic-all
 java/awt/Clipboard/NoDataConversionFailureTest.java 8234140 macosx-all
+java/awt/Container/MouseEnteredTest.java 8382192 macosx-all
 java/awt/Dialog/ModalExcludedTest.java 7125054 macosx-all
 java/awt/Frame/MiscUndecorated/RepaintTest.java 8266244 macosx-aarch64
 java/awt/Modal/FileDialog/FileDialogAppModal1Test.java 7186009 macosx-all


### PR DESCRIPTION
8382192: Problem List "test/jdk/java/awt/Container/MouseEnteredTest.java" fails for MacOS 26.04 (aarch64)

This PR adds "test/jdk/java/awt/Container/MouseEnteredTest.java" to the problem list.

Ran related tests on macos-aarch64:

make test TEST=test/jdk/java/awt/Container/MouseEnteredTest.java

Results:

Confirmed to be excluded

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/26755943/macos-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382192](https://bugs.openjdk.org/browse/JDK-8382192): Problem List "test/jdk/java/awt/Container/MouseEnteredTest.java" fails for MacOS 26.4 (aarch64) (**Task** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30749/head:pull/30749` \
`$ git checkout pull/30749`

Update a local copy of the PR: \
`$ git checkout pull/30749` \
`$ git pull https://git.openjdk.org/jdk.git pull/30749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30749`

View PR using the GUI difftool: \
`$ git pr show -t 30749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30749.diff">https://git.openjdk.org/jdk/pull/30749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30749#issuecomment-4253757230)
</details>
