### PR TITLE
8356223: ProblemList-AotJdk.txt should be added automatically if AOT mode is tested

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1020,6 +1020,9 @@ define SetupRunJtregTestBody
         VM_OPTIONS := $$(JTREG_ALL_OPTIONS) ))
     $$(call LogWarn, AOT_JDK_CACHE=$$($1_AOT_JDK_CACHE))
     $1_JTREG_BASIC_OPTIONS += -vmoption:-XX:AOTCache="$$($1_AOT_JDK_CACHE)"
+    $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \
+        $$(addprefix $$($1_TEST_ROOT)/, ProblemList-AotJdk.txt) \
+    ))
   endif
 
 


### PR DESCRIPTION
The ProblemList-AotJdk.txt  is automatically added when AOT_JDK is set.
The same away as it is done for other modes, vm flags and problemlists.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356223](https://bugs.openjdk.org/browse/JDK-8356223): ProblemList-AotJdk.txt should be added automatically if AOT mode is tested (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Ekaterina Pavlova](https://openjdk.org/census#epavlova) (@katyapav - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30751/head:pull/30751` \
`$ git checkout pull/30751`

Update a local copy of the PR: \
`$ git checkout pull/30751` \
`$ git pull https://git.openjdk.org/jdk.git pull/30751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30751`

View PR using the GUI difftool: \
`$ git pr show -t 30751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30751.diff">https://git.openjdk.org/jdk/pull/30751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30751#issuecomment-4254818836)
</details>
