### PR TITLE
8381988: Fix inconsistency in clearing cpu feature bits

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -305,9 +305,9 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  CHECK_CPU_FEATURE(supports_crc32, CRC32);
-  CHECK_CPU_FEATURE(supports_lse, LSE);
-  CHECK_CPU_FEATURE(supports_aes, AES);
+  CHECK_CPU_FEATURE(UseCRC32, CRC32, supports_crc32(), MULTI_INST_WARNING_MSG);
+  CHECK_CPU_FEATURE(UseLSE, LSE, supports_lse(), MULTI_INST_WARNING_MSG);
+  CHECK_CPU_FEATURE(UseAES, AES, supports_aes(), MULTI_INST_WARNING_MSG);
 
   if (_cpu == CPU_ARM &&
       model_is_in({ CPU_MODEL_ARM_NEOVERSE_V1, CPU_MODEL_ARM_NEOVERSE_V2,

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1664,14 +1664,14 @@ void Assembler::eandl(Register dst, Register src1, Register src2, bool no_flags)
 }
 
 void Assembler::andnl(Register dst, Register src1, Register src2) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(dst->encoding(), src1->encoding(), src2->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF2, (0xC0 | encode));
 }
 
 void Assembler::andnl(Register dst, Register src1, Address src2) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_32bit);
@@ -1696,14 +1696,14 @@ void Assembler::bswapl(Register reg) { // bswap
 }
 
 void Assembler::blsil(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(rbx->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF3, (0xC0 | encode));
 }
 
 void Assembler::blsil(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_32bit);
@@ -1713,7 +1713,7 @@ void Assembler::blsil(Register dst, Address src) {
 }
 
 void Assembler::blsmskl(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(rdx->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF3,
@@ -1721,7 +1721,7 @@ void Assembler::blsmskl(Register dst, Register src) {
 }
 
 void Assembler::blsmskl(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_32bit);
@@ -1731,14 +1731,14 @@ void Assembler::blsmskl(Register dst, Address src) {
 }
 
 void Assembler::blsrl(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(rcx->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF3, (0xC0 | encode));
 }
 
 void Assembler::blsrl(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_32bit);
@@ -7275,21 +7275,21 @@ void Assembler::testl(Register dst, Address src) {
 }
 
 void Assembler::tzcntl(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   emit_int8((unsigned char)0xF3);
   int encode = prefix_and_encode(dst->encoding(), src->encoding(), true /* is_map1 */);
   emit_opcode_prefix_and_encoding((unsigned char)0xBC, 0xC0, encode);
 }
 
 void Assembler::etzcntl(Register dst, Register src, bool no_flags) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = eevex_prefix_and_encode_nf(dst->encoding(), 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_3C /* MAP4 */, &attributes, no_flags);
   emit_int16((unsigned char)0xF4, (0xC0 | encode));
 }
 
 void Assembler::tzcntl(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   InstructionMark im(this);
   emit_int8((unsigned char)0xF3);
   prefix(src, dst, false, true /* is_map1 */);
@@ -7298,7 +7298,7 @@ void Assembler::tzcntl(Register dst, Address src) {
 }
 
 void Assembler::etzcntl(Register dst, Address src, bool no_flags) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_32bit);
@@ -7308,21 +7308,21 @@ void Assembler::etzcntl(Register dst, Address src, bool no_flags) {
 }
 
 void Assembler::tzcntq(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   emit_int8((unsigned char)0xF3);
   int encode = prefixq_and_encode(dst->encoding(), src->encoding(), true /* is_map1 */);
   emit_opcode_prefix_and_encoding((unsigned char)0xBC, 0xC0, encode);
 }
 
 void Assembler::etzcntq(Register dst, Register src, bool no_flags) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = eevex_prefix_and_encode_nf(dst->encoding(), 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_3C /* MAP4 */, &attributes, no_flags);
   emit_int16((unsigned char)0xF4, (0xC0 | encode));
 }
 
 void Assembler::tzcntq(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   InstructionMark im(this);
   emit_int8((unsigned char)0xF3);
   prefixq(src, dst, true /* is_map1 */);
@@ -7331,7 +7331,7 @@ void Assembler::tzcntq(Register dst, Address src) {
 }
 
 void Assembler::etzcntq(Register dst, Address src, bool no_flags) {
-  assert(VM_Version::supports_bmi1(), "tzcnt instruction not supported");
+  assert(UseCountTrailingZerosInstruction, "tzcnt instruction not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_64bit);
@@ -15000,14 +15000,14 @@ void Assembler::eandq(Register dst, Address src1, Register src2, bool no_flags) 
 }
 
 void Assembler::andnq(Register dst, Register src1, Register src2) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(dst->encoding(), src1->encoding(), src2->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF2, (0xC0 | encode));
 }
 
 void Assembler::andnq(Register dst, Register src1, Address src2) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_64bit);
@@ -15032,14 +15032,14 @@ void Assembler::bswapq(Register reg) {
 }
 
 void Assembler::blsiq(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(rbx->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF3, (0xC0 | encode));
 }
 
 void Assembler::blsiq(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_64bit);
@@ -15049,14 +15049,14 @@ void Assembler::blsiq(Register dst, Address src) {
 }
 
 void Assembler::blsmskq(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(rdx->encoding(),  dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF3, (0xC0 | encode));
 }
 
 void Assembler::blsmskq(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_64bit);
@@ -15066,14 +15066,14 @@ void Assembler::blsmskq(Register dst, Address src) {
 }
 
 void Assembler::blsrq(Register dst, Register src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(rcx->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F_38, &attributes, true);
   emit_int16((unsigned char)0xF3, (0xC0 | encode));
 }
 
 void Assembler::blsrq(Register dst, Address src) {
-  assert(VM_Version::supports_bmi1(), "bit manipulation instructions not supported");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "bit manipulation instructions not supported");
   InstructionMark im(this);
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_address_attributes(/* tuple_type */ EVEX_NOSCALE, /* input_size_in_bits */ EVEX_64bit);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -5562,7 +5562,7 @@ void C2_MacroAssembler::vector_mask_operation_helper(int opc, Register dst, Regi
       }
       break;
     case Op_VectorMaskFirstTrue:
-      if (VM_Version::supports_bmi1()) {
+      if (UseCountTrailingZerosInstruction) {
         if (masklen < 32) {
           orl(tmp, 1 << masklen);
           tzcntl(dst, tmp);
@@ -6354,7 +6354,7 @@ void C2_MacroAssembler::udivI(Register rax, Register divisor, Register rdx) {
   // See Hacker's Delight (2nd ed), section 9.3 which is implemented in java.lang.Long.divideUnsigned()
   movl(rdx, rax);
   subl(rdx, divisor);
-  if (VM_Version::supports_bmi1()) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx()) {
     andnl(rax, rdx, rax);
   } else {
     notl(rdx);
@@ -6378,7 +6378,7 @@ void C2_MacroAssembler::umodI(Register rax, Register divisor, Register rdx) {
   // See Hacker's Delight (2nd ed), section 9.3 which is implemented in java.lang.Long.remainderUnsigned()
   movl(rdx, rax);
   subl(rax, divisor);
-  if (VM_Version::supports_bmi1()) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx()) {
     andnl(rax, rax, rdx);
   } else {
     notl(rax);
@@ -6407,7 +6407,7 @@ void C2_MacroAssembler::udivmodI(Register rax, Register divisor, Register rdx, R
   // java.lang.Long.divideUnsigned() and java.lang.Long.remainderUnsigned()
   movl(rdx, rax);
   subl(rax, divisor);
-  if (VM_Version::supports_bmi1()) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx()) {
     andnl(rax, rax, rdx);
   } else {
     notl(rax);
@@ -6519,7 +6519,7 @@ void C2_MacroAssembler::udivL(Register rax, Register divisor, Register rdx) {
   // See Hacker's Delight (2nd ed), section 9.3 which is implemented in java.lang.Long.divideUnsigned()
   movq(rdx, rax);
   subq(rdx, divisor);
-  if (VM_Version::supports_bmi1()) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx()) {
     andnq(rax, rdx, rax);
   } else {
     notq(rdx);
@@ -6543,7 +6543,7 @@ void C2_MacroAssembler::umodL(Register rax, Register divisor, Register rdx) {
   // See Hacker's Delight (2nd ed), section 9.3 which is implemented in java.lang.Long.remainderUnsigned()
   movq(rdx, rax);
   subq(rax, divisor);
-  if (VM_Version::supports_bmi1()) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx()) {
     andnq(rax, rax, rdx);
   } else {
     notq(rax);
@@ -6571,7 +6571,7 @@ void C2_MacroAssembler::udivmodL(Register rax, Register divisor, Register rdx, R
   // java.lang.Long.divideUnsigned() and java.lang.Long.remainderUnsigned()
   movq(rdx, rax);
   subq(rax, divisor);
-  if (VM_Version::supports_bmi1()) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx()) {
     andnq(rax, rax, rdx);
   } else {
     notq(rax);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6955,7 +6955,7 @@ void MacroAssembler::vectorized_mismatch(Register obja, Register objb, Register 
   xorq(result, result);
 
   if ((AVX3Threshold == 0) && (UseAVX > 2) &&
-      VM_Version::supports_avx512vlbw()) {
+      VM_Version::supports_avx512vlbw() && UseCountTrailingZerosInstruction) {
     Label VECTOR64_LOOP, VECTOR64_NOT_EQUAL, VECTOR32_TAIL;
 
     cmpq(length, 64);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4873,7 +4873,7 @@ void StubGenerator::generate_compiler_stubs() {
   StubRoutines::_data_cache_writeback_sync = generate_data_cache_writeback_sync();
 
 #ifdef COMPILER2
-  if ((UseAVX == 2) && EnableX86ECoreOpts) {
+  if ((UseAVX == 2) && EnableX86ECoreOpts && UseCountTrailingZerosInstruction) {
     generate_string_indexof(StubRoutines::_string_indexof_array);
   }
 #endif

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1097,34 +1097,51 @@ void VM_Version::get_processor_features() {
   // Currently APX support is only enabled for targets supporting AVX512VL feature.
   if (supports_apx_f() && os_supports_apx_egprs() && supports_avx512vl()) {
     if (FLAG_IS_DEFAULT(UseAPX)) {
-      UseAPX = false; // by default UseAPX is false
+      FLAG_SET_DEFAULT(UseAPX, false); // by default UseAPX is false
       _features.clear_feature(CPU_APX_F);
     } else if (!UseAPX) {
       _features.clear_feature(CPU_APX_F);
     }
-  } else if (UseAPX) {
-    if (!FLAG_IS_DEFAULT(UseAPX)) {
-      warning("APX is not supported on this CPU, setting it to false)");
+  } else {
+    if (!os_supports_apx_egprs() || !supports_avx512vl()) {
+      _features.clear_feature(CPU_APX_F);
     }
-    FLAG_SET_DEFAULT(UseAPX, false);
+    if (UseAPX) {
+      if (!FLAG_IS_DEFAULT(UseAPX)) {
+        warning("APX is not supported on this CPU, setting it to false)");
+      }
+      FLAG_SET_DEFAULT(UseAPX, false);
+    }
   }
 
-  CHECK_CPU_FEATURE(supports_clmul, CLMUL);
-  CHECK_CPU_FEATURE(supports_aes, AES);
-  CHECK_CPU_FEATURE(supports_fma, FMA);
+  CHECK_CPU_FEATURE(UseCLMUL, CLMUL, supports_clmul(), MULTI_INST_WARNING_MSG);
+  CHECK_CPU_FEATURE(UseAES, AES, supports_aes(), MULTI_INST_WARNING_MSG);
+  CHECK_CPU_FEATURE(UseFMA, FMA, supports_fma(), MULTI_INST_WARNING_MSG);
+  CHECK_CPU_FEATURE(UseCountLeadingZerosInstruction, LZCNT, supports_lzcnt(), SINGLE_INST_WARNING_MSG);
+  // BMI instructions (except tzcnt) use an encoding with VEX prefix.
+  // VEX prefix is generated only when AVX > 0.
+  CHECK_CPU_FEATURE(UseBMI1Instructions, BMI1, supports_bmi1(), MULTI_INST_WARNING_MSG);
 
-  if (supports_sha() || (supports_avx2() && supports_bmi2())) {
-    if (FLAG_IS_DEFAULT(UseSHA)) {
-      UseSHA = true;
-    } else if (!UseSHA) {
-      _features.clear_feature(CPU_SHA);
+  if (supports_bmi2() && supports_avx()) {
+    if (FLAG_IS_DEFAULT(UseBMI2Instructions)) {
+      FLAG_SET_DEFAULT(UseBMI2Instructions, true);
+    } else if (!UseBMI2Instructions) {
+      clear_feature(CPU_BMI2);
     }
-  } else if (UseSHA) {
-    if (!FLAG_IS_DEFAULT(UseSHA)) {
-      warning("SHA instructions are not available on this CPU");
+  } else {
+    if (!supports_avx()) {
+      clear_feature(CPU_BMI2);
     }
-    FLAG_SET_DEFAULT(UseSHA, false);
+    if (UseBMI2Instructions) {
+      if (!FLAG_IS_DEFAULT(UseBMI2Instructions)) {
+        warning("BMI2 instructions are not available on this CPU (AVX is also required)");
+      }
+      FLAG_SET_DEFAULT(UseBMI2Instructions, false);
+    }
   }
+
+  CHECK_CPU_FEATURE(UsePopCountInstruction, POPCNT, supports_popcnt(), SINGLE_INST_WARNING_MSG);
+  CHECK_CPU_FEATURE(UseSHA, SHA, supports_sha() || (supports_avx2() && supports_bmi2()), MULTI_INST_WARNING_MSG);
 
   if (FLAG_IS_DEFAULT(IntelJccErratumMitigation)) {
     _has_intel_jcc_erratum = compute_has_intel_jcc_erratum();
@@ -1720,70 +1737,17 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseVectorizedHashCodeIntrinsic, false);
   }
 
-  // Use count leading zeros count instruction if available.
-  if (supports_lzcnt()) {
-    if (FLAG_IS_DEFAULT(UseCountLeadingZerosInstruction)) {
-      UseCountLeadingZerosInstruction = true;
-    }
-   } else if (UseCountLeadingZerosInstruction) {
-    if (!FLAG_IS_DEFAULT(UseCountLeadingZerosInstruction)) {
-      warning("lzcnt instruction is not available on this CPU");
-    }
-    FLAG_SET_DEFAULT(UseCountLeadingZerosInstruction, false);
-  }
-
   // Use count trailing zeros instruction if available
   if (supports_bmi1()) {
     // tzcnt does not require VEX prefix
     if (FLAG_IS_DEFAULT(UseCountTrailingZerosInstruction)) {
-      if (!UseBMI1Instructions && !FLAG_IS_DEFAULT(UseBMI1Instructions)) {
-        // Don't use tzcnt if BMI1 is switched off on command line.
-        UseCountTrailingZerosInstruction = false;
-      } else {
-        UseCountTrailingZerosInstruction = true;
-      }
+      UseCountTrailingZerosInstruction = true;
     }
   } else if (UseCountTrailingZerosInstruction) {
     if (!FLAG_IS_DEFAULT(UseCountTrailingZerosInstruction)) {
       warning("tzcnt instruction is not available on this CPU");
     }
     FLAG_SET_DEFAULT(UseCountTrailingZerosInstruction, false);
-  }
-
-  // BMI instructions (except tzcnt) use an encoding with VEX prefix.
-  // VEX prefix is generated only when AVX > 0.
-  if (supports_bmi1() && supports_avx()) {
-    if (FLAG_IS_DEFAULT(UseBMI1Instructions)) {
-      UseBMI1Instructions = true;
-    }
-  } else if (UseBMI1Instructions) {
-    if (!FLAG_IS_DEFAULT(UseBMI1Instructions)) {
-      warning("BMI1 instructions are not available on this CPU (AVX is also required)");
-    }
-    FLAG_SET_DEFAULT(UseBMI1Instructions, false);
-  }
-
-  if (supports_bmi2() && supports_avx()) {
-    if (FLAG_IS_DEFAULT(UseBMI2Instructions)) {
-      UseBMI2Instructions = true;
-    }
-  } else if (UseBMI2Instructions) {
-    if (!FLAG_IS_DEFAULT(UseBMI2Instructions)) {
-      warning("BMI2 instructions are not available on this CPU (AVX is also required)");
-    }
-    FLAG_SET_DEFAULT(UseBMI2Instructions, false);
-  }
-
-  // Use population count instruction if available.
-  if (supports_popcnt()) {
-    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
-      UsePopCountInstruction = true;
-    }
-  } else if (UsePopCountInstruction) {
-    if (!FLAG_IS_DEFAULT(UsePopCountInstruction)) {
-      warning("POPCNT instruction is not available on this CPU");
-    }
-    FLAG_SET_DEFAULT(UsePopCountInstruction, false);
   }
 
   // Use fast-string operations if available.

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -942,21 +942,21 @@ void VM_Version::get_processor_features() {
   }
 
   if (UseSSE < 4) {
-    _features.clear_feature(CPU_SSE4_1);
-    _features.clear_feature(CPU_SSE4_2);
+    clear_feature(CPU_SSE4_1);
+    clear_feature(CPU_SSE4_2);
   }
 
   if (UseSSE < 3) {
-    _features.clear_feature(CPU_SSE3);
-    _features.clear_feature(CPU_SSSE3);
-    _features.clear_feature(CPU_SSE4A);
+    clear_feature(CPU_SSE3);
+    clear_feature(CPU_SSSE3);
+    clear_feature(CPU_SSE4A);
   }
 
   if (UseSSE < 2)
-    _features.clear_feature(CPU_SSE2);
+    clear_feature(CPU_SSE2);
 
   if (UseSSE < 1)
-    _features.clear_feature(CPU_SSE);
+    clear_feature(CPU_SSE);
 
   // ZX cpus specific settings
   if (is_zx() && FLAG_IS_DEFAULT(UseAVX)) {
@@ -1030,67 +1030,67 @@ void VM_Version::get_processor_features() {
   }
 
   if (UseAVX < 3) {
-    _features.clear_feature(CPU_AVX512F);
-    _features.clear_feature(CPU_AVX512DQ);
-    _features.clear_feature(CPU_AVX512CD);
-    _features.clear_feature(CPU_AVX512BW);
-    _features.clear_feature(CPU_AVX512ER);
-    _features.clear_feature(CPU_AVX512PF);
-    _features.clear_feature(CPU_AVX512VL);
-    _features.clear_feature(CPU_AVX512_VPOPCNTDQ);
-    _features.clear_feature(CPU_AVX512_VPCLMULQDQ);
-    _features.clear_feature(CPU_AVX512_VAES);
-    _features.clear_feature(CPU_AVX512_VNNI);
-    _features.clear_feature(CPU_AVX512_VBMI);
-    _features.clear_feature(CPU_AVX512_VBMI2);
-    _features.clear_feature(CPU_AVX512_BITALG);
-    _features.clear_feature(CPU_AVX512_IFMA);
-    _features.clear_feature(CPU_APX_F);
-    _features.clear_feature(CPU_AVX512_FP16);
-    _features.clear_feature(CPU_AVX10_1);
-    _features.clear_feature(CPU_AVX10_2);
+    clear_feature(CPU_AVX512F);
+    clear_feature(CPU_AVX512DQ);
+    clear_feature(CPU_AVX512CD);
+    clear_feature(CPU_AVX512BW);
+    clear_feature(CPU_AVX512ER);
+    clear_feature(CPU_AVX512PF);
+    clear_feature(CPU_AVX512VL);
+    clear_feature(CPU_AVX512_VPOPCNTDQ);
+    clear_feature(CPU_AVX512_VPCLMULQDQ);
+    clear_feature(CPU_AVX512_VAES);
+    clear_feature(CPU_AVX512_VNNI);
+    clear_feature(CPU_AVX512_VBMI);
+    clear_feature(CPU_AVX512_VBMI2);
+    clear_feature(CPU_AVX512_BITALG);
+    clear_feature(CPU_AVX512_IFMA);
+    clear_feature(CPU_APX_F);
+    clear_feature(CPU_AVX512_FP16);
+    clear_feature(CPU_AVX10_1);
+    clear_feature(CPU_AVX10_2);
   }
 
 
   if (UseAVX < 2) {
-    _features.clear_feature(CPU_AVX2);
-    _features.clear_feature(CPU_AVX_IFMA);
+    clear_feature(CPU_AVX2);
+    clear_feature(CPU_AVX_IFMA);
   }
 
   if (UseAVX < 1) {
-    _features.clear_feature(CPU_AVX);
-    _features.clear_feature(CPU_VZEROUPPER);
-    _features.clear_feature(CPU_F16C);
-    _features.clear_feature(CPU_SHA512);
+    clear_feature(CPU_AVX);
+    clear_feature(CPU_VZEROUPPER);
+    clear_feature(CPU_F16C);
+    clear_feature(CPU_SHA512);
   }
 
   if (logical_processors_per_package() == 1) {
     // HT processor could be installed on a system which doesn't support HT.
-    _features.clear_feature(CPU_HT);
+    clear_feature(CPU_HT);
   }
 
   if (is_intel()) { // Intel cpus specific settings
     if (is_knights_family()) {
-      _features.clear_feature(CPU_VZEROUPPER);
-      _features.clear_feature(CPU_AVX512BW);
-      _features.clear_feature(CPU_AVX512VL);
-      _features.clear_feature(CPU_APX_F);
-      _features.clear_feature(CPU_AVX512DQ);
-      _features.clear_feature(CPU_AVX512_VNNI);
-      _features.clear_feature(CPU_AVX512_VAES);
-      _features.clear_feature(CPU_AVX512_VPOPCNTDQ);
-      _features.clear_feature(CPU_AVX512_VPCLMULQDQ);
-      _features.clear_feature(CPU_AVX512_VBMI);
-      _features.clear_feature(CPU_AVX512_VBMI2);
-      _features.clear_feature(CPU_CLWB);
-      _features.clear_feature(CPU_FLUSHOPT);
-      _features.clear_feature(CPU_GFNI);
-      _features.clear_feature(CPU_AVX512_BITALG);
-      _features.clear_feature(CPU_AVX512_IFMA);
-      _features.clear_feature(CPU_AVX_IFMA);
-      _features.clear_feature(CPU_AVX512_FP16);
-      _features.clear_feature(CPU_AVX10_1);
-      _features.clear_feature(CPU_AVX10_2);
+      clear_feature(CPU_VZEROUPPER);
+      clear_feature(CPU_AVX512BW);
+      clear_feature(CPU_AVX512VL);
+      clear_feature(CPU_APX_F);
+      clear_feature(CPU_AVX512DQ);
+      clear_feature(CPU_AVX512_VNNI);
+      clear_feature(CPU_AVX512_VAES);
+      clear_feature(CPU_AVX512_VPOPCNTDQ);
+      clear_feature(CPU_AVX512_VPCLMULQDQ);
+      clear_feature(CPU_AVX512_VBMI);
+      clear_feature(CPU_AVX512_VBMI2);
+      clear_feature(CPU_CLWB);
+      clear_feature(CPU_FLUSHOPT);
+      clear_feature(CPU_GFNI);
+      clear_feature(CPU_AVX512_BITALG);
+      clear_feature(CPU_AVX512_IFMA);
+      clear_feature(CPU_AVX_IFMA);
+      clear_feature(CPU_AVX512_FP16);
+      clear_feature(CPU_AVX10_1);
+      clear_feature(CPU_AVX10_2);
     }
   }
 
@@ -1098,13 +1098,13 @@ void VM_Version::get_processor_features() {
   if (supports_apx_f() && os_supports_apx_egprs() && supports_avx512vl()) {
     if (FLAG_IS_DEFAULT(UseAPX)) {
       FLAG_SET_DEFAULT(UseAPX, false); // by default UseAPX is false
-      _features.clear_feature(CPU_APX_F);
+      clear_feature(CPU_APX_F);
     } else if (!UseAPX) {
-      _features.clear_feature(CPU_APX_F);
+      clear_feature(CPU_APX_F);
     }
   } else {
     if (!os_supports_apx_egprs() || !supports_avx512vl()) {
-      _features.clear_feature(CPU_APX_F);
+      clear_feature(CPU_APX_F);
     }
     if (UseAPX) {
       if (!FLAG_IS_DEFAULT(UseAPX)) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -4048,7 +4048,7 @@ class FusedPatternMatcher {
 };
 
 static bool is_bmi_pattern(Node* n, Node* m) {
-  assert(UseBMI1Instructions, "sanity");
+  assert(VM_Version::supports_bmi1() && VM_Version::supports_avx(), "sanity");
   if (n != nullptr && m != nullptr) {
     if (m->Opcode() == Op_LoadI) {
       FusedPatternMatcher<TypeInt> bmii(n, m, Op_ConI);
@@ -4068,7 +4068,7 @@ static bool is_bmi_pattern(Node* n, Node* m) {
 // Should the matcher clone input 'm' of node 'n'?
 bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
   // If 'n' and 'm' are part of a graph for BMI instruction, clone the input 'm'.
-  if (UseBMI1Instructions && is_bmi_pattern(n, m)) {
+  if (VM_Version::supports_bmi1() && VM_Version::supports_avx() && is_bmi_pattern(n, m)) {
     mstack.push(m, Visit);
     return true;
   }
@@ -13161,7 +13161,7 @@ instruct andI_mem_imm(memory dst, immI src, rFlagsReg cr)
 // BMI1 instructions
 instruct andnI_rReg_rReg_mem(rRegI dst, rRegI src1, memory src2, immI_M1 minus_1, rFlagsReg cr) %{
   match(Set dst (AndI (XorI src1 minus_1) (LoadI src2)));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
@@ -13176,7 +13176,7 @@ instruct andnI_rReg_rReg_mem(rRegI dst, rRegI src1, memory src2, immI_M1 minus_1
 
 instruct andnI_rReg_rReg_rReg(rRegI dst, rRegI src1, rRegI src2, immI_M1 minus_1, rFlagsReg cr) %{
   match(Set dst (AndI (XorI src1 minus_1) src2));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
@@ -13190,7 +13190,7 @@ instruct andnI_rReg_rReg_rReg(rRegI dst, rRegI src1, rRegI src2, immI_M1 minus_1
 
 instruct blsiI_rReg_rReg(rRegI dst, rRegI src, immI_0 imm_zero, rFlagsReg cr) %{
   match(Set dst (AndI (SubI imm_zero src) src));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13204,7 +13204,7 @@ instruct blsiI_rReg_rReg(rRegI dst, rRegI src, immI_0 imm_zero, rFlagsReg cr) %{
 
 instruct blsiI_rReg_mem(rRegI dst, memory src, immI_0 imm_zero, rFlagsReg cr) %{
   match(Set dst (AndI (SubI imm_zero (LoadI src) ) (LoadI src) ));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13220,7 +13220,7 @@ instruct blsiI_rReg_mem(rRegI dst, memory src, immI_0 imm_zero, rFlagsReg cr) %{
 instruct blsmskI_rReg_mem(rRegI dst, memory src, immI_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (XorI (AddI (LoadI src) minus_1) (LoadI src) ) );
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_clears_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13236,7 +13236,7 @@ instruct blsmskI_rReg_mem(rRegI dst, memory src, immI_M1 minus_1, rFlagsReg cr)
 instruct blsmskI_rReg_rReg(rRegI dst, rRegI src, immI_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (XorI (AddI src minus_1) src));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_clears_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13252,7 +13252,7 @@ instruct blsmskI_rReg_rReg(rRegI dst, rRegI src, immI_M1 minus_1, rFlagsReg cr)
 instruct blsrI_rReg_rReg(rRegI dst, rRegI src, immI_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (AndI (AddI src minus_1) src) );
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13268,7 +13268,7 @@ instruct blsrI_rReg_rReg(rRegI dst, rRegI src, immI_M1 minus_1, rFlagsReg cr)
 instruct blsrI_rReg_mem(rRegI dst, memory src, immI_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (AndI (AddI (LoadI src) minus_1) (LoadI src) ) );
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13809,7 +13809,7 @@ instruct btrL_mem_imm(memory dst, immL_NotPow2 con, rFlagsReg cr)
 // BMI1 instructions
 instruct andnL_rReg_rReg_mem(rRegL dst, rRegL src1, memory src2, immL_M1 minus_1, rFlagsReg cr) %{
   match(Set dst (AndL (XorL src1 minus_1) (LoadL src2)));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
@@ -13824,7 +13824,7 @@ instruct andnL_rReg_rReg_mem(rRegL dst, rRegL src1, memory src2, immL_M1 minus_1
 
 instruct andnL_rReg_rReg_rReg(rRegL dst, rRegL src1, rRegL src2, immL_M1 minus_1, rFlagsReg cr) %{
   match(Set dst (AndL (XorL src1 minus_1) src2));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
@@ -13838,7 +13838,7 @@ instruct andnL_rReg_rReg_rReg(rRegL dst, rRegL src1, rRegL src2, immL_M1 minus_1
 
 instruct blsiL_rReg_rReg(rRegL dst, rRegL src, immL0 imm_zero, rFlagsReg cr) %{
   match(Set dst (AndL (SubL imm_zero src) src));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13852,7 +13852,7 @@ instruct blsiL_rReg_rReg(rRegL dst, rRegL src, immL0 imm_zero, rFlagsReg cr) %{
 
 instruct blsiL_rReg_mem(rRegL dst, memory src, immL0 imm_zero, rFlagsReg cr) %{
   match(Set dst (AndL (SubL imm_zero (LoadL src) ) (LoadL src) ));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13868,7 +13868,7 @@ instruct blsiL_rReg_mem(rRegL dst, memory src, immL0 imm_zero, rFlagsReg cr) %{
 instruct blsmskL_rReg_mem(rRegL dst, memory src, immL_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (XorL (AddL (LoadL src) minus_1) (LoadL src) ) );
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_clears_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13884,7 +13884,7 @@ instruct blsmskL_rReg_mem(rRegL dst, memory src, immL_M1 minus_1, rFlagsReg cr)
 instruct blsmskL_rReg_rReg(rRegL dst, rRegL src, immL_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (XorL (AddL src minus_1) src));
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_clears_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13900,7 +13900,7 @@ instruct blsmskL_rReg_rReg(rRegL dst, rRegL src, immL_M1 minus_1, rFlagsReg cr)
 instruct blsrL_rReg_rReg(rRegL dst, rRegL src, immL_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (AndL (AddL src minus_1) src) );
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 
@@ -13916,7 +13916,7 @@ instruct blsrL_rReg_rReg(rRegL dst, rRegL src, immL_M1 minus_1, rFlagsReg cr)
 instruct blsrL_rReg_mem(rRegL dst, memory src, immL_M1 minus_1, rFlagsReg cr)
 %{
   match(Set dst (AndL (AddL (LoadL src) minus_1) (LoadL src)) );
-  predicate(UseBMI1Instructions);
+  predicate(VM_Version::supports_bmi1() && VM_Version::supports_avx());
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_clears_overflow_flag);
 

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -45,19 +45,22 @@ class outputStream;
 class stringStream;
 enum class vmIntrinsicID;
 
+#define SINGLE_INST_WARNING_MSG " instruction is not available on this CPU"
+#define MULTI_INST_WARNING_MSG " instructions are not available on this CPU"
+
 // Helper macro to test and set VM flag and corresponding cpu feature
-#define CHECK_CPU_FEATURE(feature_test_fn, feature) \
-  if (feature_test_fn()) { \
-    if (FLAG_IS_DEFAULT(Use##feature)) { \
-      FLAG_SET_DEFAULT(Use##feature, true); \
-    } else if (!Use##feature) { \
-      clear_feature(CPU_##feature); \
+#define CHECK_CPU_FEATURE(vmflag, feature_id, predicate, warning_msg) \
+  if (predicate) { \
+    if (FLAG_IS_DEFAULT(vmflag)) { \
+      FLAG_SET_DEFAULT(vmflag, true); \
+    } else if (!vmflag) { \
+      clear_feature(CPU_##feature_id); \
     } \
-  } else if (Use##feature) { \
-    if (!FLAG_IS_DEFAULT(Use##feature)) { \
-      warning(#feature " instructions are not available on this CPU"); \
+  } else if (vmflag) { \
+    if (!FLAG_IS_DEFAULT(vmflag)) { \
+      warning(#feature_id warning_msg); \
     } \
-    FLAG_SET_DEFAULT(Use##feature, false); \
+    FLAG_SET_DEFAULT(vmflag, false); \
   }
 
 // Abstract_VM_Version provides information about the VM.

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
@@ -67,7 +67,7 @@ public class TestUseCountTrailingZerosInstructionOnSupportedCPU
                 TestUseCountTrailingZerosInstructionOnSupportedCPU.DISABLE_BMI);
 
         /*
-          Verify that option cannot be turned on when BMI1 instructions 
+          Verify that option cannot be turned on when BMI1 instructions
           are explicitly turned off. VM will be launched with following
           options: -XX:-UseBMI1Instructions
           -XX:+UseCountTrailingZerosInstruction -version

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
@@ -67,14 +67,14 @@ public class TestUseCountTrailingZerosInstructionOnSupportedCPU
                 TestUseCountTrailingZerosInstructionOnSupportedCPU.DISABLE_BMI);
 
         /*
-          Verify that option could be turned on even if other BMI1
-          instructions were turned off. VM will be launched with following
+          Verify that option cannot be turned on when BMI1 instructions 
+          are explicitly turned off. VM will be launched with following
           options: -XX:-UseBMI1Instructions
           -XX:+UseCountTrailingZerosInstruction -version
         */
-        CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "true",
-                "Option 'UseCountTrailingZerosInstruction' should be able to "
-                    + "be turned on even if all BMI1 instructions are "
+        CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
+                "Option 'UseCountTrailingZerosInstruction' should have "
+                    + "'false' value if all BMI1 instructions are "
                     + "disabled (-XX:-UseBMI1Instructions flag used)",
                 TestUseCountTrailingZerosInstructionOnSupportedCPU.DISABLE_BMI,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));

--- a/test/hotspot/jtreg/compiler/cpuflags/CPUFeaturesClearTest.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/CPUFeaturesClearTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8364584 8381988
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -38,6 +39,7 @@
 package compiler.cpuflags;
 
 import java.util.List;
+import java.util.Map;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
@@ -62,15 +64,23 @@ public class CPUFeaturesClearTest {
     }
 
     public void testX86Flags() throws Throwable {
+        Map<String, String> vmFlagToCpuFeatureMap = Map.of("UseCLMUL", "clmul",
+                                                           "UseAES", "aes",
+                                                           "UseFMA", "fma",
+                                                           "UseCountLeadingZerosInstruction", "lzcnt",
+                                                           "UseBMI1Instructions", "bmi1",
+                                                           "UseBMI2Instructions", "bmi2",
+                                                           "UsePopCountInstruction", "popcnt",
+                                                           "UseSHA", "sha");
+        vmFlagToCpuFeatureMap.forEach((vmFlag, cpuFeature) -> {
+            try {
+                OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareBooleanFlag(vmFlag, false)));
+                outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* " + cpuFeature + ".*");
+            } catch (Exception e) {
+                throw new RuntimeException (e);
+            }
+        });
         OutputAnalyzer outputAnalyzer;
-        String vmFlagsToTest[] = {"UseCLMUL", "UseAES", "UseFMA", "UseSHA"};
-        String cpuFeatures[] =   {"clmul",    "aes",    "fma",    "sha"};
-        for (int i = 0; i < vmFlagsToTest.length; i++) {
-            String vmFlag = vmFlagsToTest[i];
-            String cpuFeature = cpuFeatures[i];
-            outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareBooleanFlag(vmFlag, false)));
-            outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* " + cpuFeatures[i] + ".*");
-        }
         if (isCpuFeatureSupported("sse4")) {
             outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareNumericFlag("UseSSE", 3)));
             outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* sse4.*");
@@ -103,18 +113,20 @@ public class CPUFeaturesClearTest {
     }
 
     public void testAArch64Flags() throws Throwable {
-        OutputAnalyzer outputAnalyzer;
-        String vmFlagsToTest[] = {"UseCRC32", "UseLSE", "UseAES"};
-        String cpuFeatures[] =   {"crc32",    "lse",    "aes"};
-        for (int i = 0; i < vmFlagsToTest.length; i++) {
-            String vmFlag = vmFlagsToTest[i];
-            String cpuFeature = cpuFeatures[i];
-            outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareBooleanFlag(vmFlag, false)));
-            outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* " + cpuFeatures[i] + ".*");
-        }
+        Map<String, String> vmFlagToCpuFeatureMap = Map.of("UseCRC32", "crc32",
+                                                           "UseLSE", "lse",
+                                                           "UseAES", "aes");
+        vmFlagToCpuFeatureMap.forEach((vmFlag, cpuFeature) -> {
+            try {
+                OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareBooleanFlag(vmFlag, false)));
+                outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* " + cpuFeature + ".*");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
 
         // Disabling UseSHA should clear all shaXXX cpu features
-        outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareBooleanFlag("UseSHA", false)));
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(generateArgs(prepareBooleanFlag("UseSHA", false)));
         outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* sha1.*");
         outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* sha256.*");
         outputAnalyzer.shouldNotMatch("[os,cpu] CPU: .* sha3.*");

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
@@ -41,7 +41,6 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestAndnI;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 public class AndnTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -71,12 +70,6 @@ public class AndnTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF2};
-    }
-
-    @Override
-    protected List<String> getCpuFlag() {
-        // blsi instruction requires avx in addition to bmi1 flag
-        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestI.java
@@ -41,6 +41,7 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestAndnI;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 public class AndnTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -70,6 +71,12 @@ public class AndnTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0x00,
                 (byte) 0xF2};
+    }
+
+    @Override
+    protected List<String> getCpuFlag() {
+        // blsi instruction requires avx in addition to bmi1 flag
+        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/AndnTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -41,7 +41,6 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestBlsiI;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -77,12 +76,6 @@ public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_1000}; // bits 543 == 011 (3)
-    }
-
-    @Override
-    protected List<String> getCpuFlag() {
-        // blsi instruction requires avx in addition to bmi1 flag
-        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestI.java
@@ -41,6 +41,7 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestBlsiI;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -76,6 +77,12 @@ public class BlsiTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_1000}; // bits 543 == 011 (3)
+    }
+
+    @Override
+    protected List<String> getCpuFlag() {
+        // blsi instruction requires avx in addition to bmi1 flag
+        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsiTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -40,7 +40,6 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestBlsmskI;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -76,12 +75,6 @@ public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_0000}; // bits 543 == 010 (2)
-    }
-
-    @Override
-    protected List<String> getCpuFlag() {
-        // blsi instruction requires avx in addition to bmi1 flag
-        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestI.java
@@ -40,6 +40,7 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestBlsmskI;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -75,6 +76,12 @@ public class BlsmskTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0x00,
                 (byte) 0xF3,
                 (byte) 0b0001_0000}; // bits 543 == 010 (2)
+    }
+
+    @Override
+    protected List<String> getCpuFlag() {
+        // blsi instruction requires avx in addition to bmi1 flag
+        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsmskTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
@@ -41,6 +41,7 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestBlsrI;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -77,6 +78,12 @@ public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0xF3,
                 (byte) 0b0000_1000}; // bits 543 == 001 (1)
 
+    }
+
+    @Override
+    protected List<String> getCpuFlag() {
+        // blsr instruction requires avx in addition to bmi1 flag
+        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestI.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -41,7 +41,6 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestBlsrI;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
 
@@ -78,12 +77,6 @@ public class BlsrTestI extends BmiIntrinsicBase.BmiTestCase {
                 (byte) 0xF3,
                 (byte) 0b0000_1000}; // bits 543 == 001 (1)
 
-    }
-
-    @Override
-    protected List<String> getCpuFlag() {
-        // blsr instruction requires avx in addition to bmi1 flag
-        return List.of(cpuFlag, "avx");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BlsrTestL.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8031321
- * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.flavor == "server" & !vm.graal.enabled & vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
+import java.util.List;
 
 public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
 
@@ -71,9 +72,11 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
             throw new Error("TESTBUG: test can not be run in interpreter");
         }
 
-        if (!CPUInfo.hasFeature(bmiTestCase.getCpuFlag())) {
-            System.out.println("Unsupported hardware, no required CPU flag " + bmiTestCase.getCpuFlag() + " , test SKIPPED");
-            return;
+        for (String cpuFlag: bmiTestCase.getCpuFlag()) {
+            if (!CPUInfo.hasFeature(cpuFlag)) {
+                System.out.println("Unsupported hardware, no required CPU flag " + cpuFlag + " , test SKIPPED");
+                return;
+            }
         }
 
         if (!Boolean.valueOf(getVMOption(bmiTestCase.getVMFlag()))) {
@@ -204,8 +207,8 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
             }
         }
 
-        protected String getCpuFlag() {
-            return cpuFlag;
+        protected List<String> getCpuFlag() {
+            return List.of(cpuFlag);
         }
 
         protected String getVMFlag() {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BmiIntrinsicBase.java
@@ -72,11 +72,9 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
             throw new Error("TESTBUG: test can not be run in interpreter");
         }
 
-        for (String cpuFlag: bmiTestCase.getCpuFlag()) {
-            if (!CPUInfo.hasFeature(cpuFlag)) {
-                System.out.println("Unsupported hardware, no required CPU flag " + cpuFlag + " , test SKIPPED");
-                return;
-            }
+        if (!CPUInfo.hasFeature(bmiTestCase.getCpuFlag())) {
+            System.out.println("Unsupported hardware, no required CPU flag " + bmiTestCase.getCpuFlag() + " , test SKIPPED");
+            return;
         }
 
         if (!Boolean.valueOf(getVMOption(bmiTestCase.getVMFlag()))) {
@@ -207,8 +205,8 @@ public class BmiIntrinsicBase extends CompilerWhiteBoxTest {
             }
         }
 
-        protected List<String> getCpuFlag() {
-            return List.of(cpuFlag);
+        protected String getCpuFlag() {
+            return cpuFlag;
         }
 
         protected String getVMFlag() {

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -41,6 +41,7 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestLzcntI;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
 
@@ -71,7 +72,7 @@ public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
     }
 
     @Override
-    protected String getCpuFlag() {
-        return "lzcnt";
+    protected List<String> getCpuFlag() {
+        return List.of("lzcnt");
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/LZcntTestI.java
@@ -41,7 +41,6 @@ package compiler.intrinsics.bmi.verifycode;
 import compiler.intrinsics.bmi.TestLzcntI;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
 
@@ -72,7 +71,7 @@ public class LZcntTestI extends BmiIntrinsicBase.BmiTestCase_x64 {
     }
 
     @Override
-    protected List<String> getCpuFlag() {
-        return List.of("lzcnt");
+    protected String getCpuFlag() {
+        return "lzcnt";
     }
 }


### PR DESCRIPTION
For some x86-specific VM flags the existing code was not clearing the corresponding cpu feature bit when the flag was explicitly disabled by the user. This patch fixes the code to be consistent in clearing the cpu feature bit.

The  changes to the case of `UseBMI1Instructions` needs more explanation.
All BMI1 instructions except `tzcnt` use VEX encoding, which means they depend on AVX feature as well. So the existing code checked for `supports_bmi1()` and `supports_avx()` before enabling `UseBMI1Instructions`. 

```
  if (supports_bmi1() && supports_avx()) {
    if (FLAG_IS_DEFAULT(UseBMI1Instructions)) {
      UseBMI1Instructions = true;
    }
  }
```

However, if the user specifies `UseAVX=0` on a system with bmi1 support, we would end up with in situation where `supports_bmi1()` is true but `UseBMI1Instructions` is false (its default value). Moreover, in this case it would be incorrect to clear the bmi1 feature flag (to be consistent with `UseBMI1Instructions`) because that would disable use of `tzcnt` instruction, even though VM can use it:
```
  // Use count trailing zeros instruction if available
  if (supports_bmi1()) {
    // tzcnt does not require VEX prefix
    if (FLAG_IS_DEFAULT(UseCountTrailingZerosInstruction)) {
```

So I decided to remove the check for `supports_avx` for enabling `UseBMI1Instructions`, and added the asserts and checks for `supports_avx()` to the backend that emits the bmi1 instructions (see the assembler and x86.ad file). This change allows  `UseBMI1Instructions`  to be in sync with `supports_bmi()` value. 
Another implication of this change is earlier `-XX:-UseBMI1Instructions -XX:+UseCountTrailingZerosInstruction` allowed `tzcnt` to be available to the VM, but now it is not the case. This is reflected in the change to the testcase `TestUseCountTrailingZerosInstructionOnSupportedCPU.java`,

I also noticed use of `tzcnt` was guarded by `bmi1_support()` instead of `UseCountTrailingZerosInstruction`. This has been fixed as well. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381988](https://bugs.openjdk.org/browse/JDK-8381988): Fix inconsistency in clearing cpu feature bits (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30752/head:pull/30752` \
`$ git checkout pull/30752`

Update a local copy of the PR: \
`$ git checkout pull/30752` \
`$ git pull https://git.openjdk.org/jdk.git pull/30752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30752`

View PR using the GUI difftool: \
`$ git pr show -t 30752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30752.diff">https://git.openjdk.org/jdk/pull/30752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30752#issuecomment-4254607077)
</details>
