### PR TITLE
8370656: Re-examine use of InterruptedIOException in sun.security.ssl code

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1677,37 +1677,25 @@ public final class SSLSocketImpl
             SSLLogger.warning("handling exception", cause);
         }
 
-        // Don't close the Socket in case of timeouts or interrupts.
-        if (cause instanceof SocketTimeoutException) {
-            throw (IOException)cause;
-        }
-
-        // need to perform error shutdown
-        boolean isSSLException = (cause instanceof SSLException);
         Alert alert;
-        if (isSSLException) {
-            if (cause instanceof SSLHandshakeException) {
-                alert = Alert.HANDSHAKE_FAILURE;
-            } else {
-                alert = Alert.UNEXPECTED_MESSAGE;
-            }
-        } else {
-            if (cause instanceof IOException) {
-                alert = Alert.UNEXPECTED_MESSAGE;
-            } else {
-                // RuntimeException
-                alert = Alert.INTERNAL_ERROR;
-            }
+
+        switch (cause) {
+            // Don't close the Socket in case of timeouts.
+            case SocketTimeoutException ste -> throw ste;
+            // Set alert type based on exception type.
+            case SSLHandshakeException _ -> alert = Alert.HANDSHAKE_FAILURE;
+            case IOException _ -> alert = Alert.UNEXPECTED_MESSAGE;
+            default -> alert = Alert.INTERNAL_ERROR;
         }
 
-        if (cause instanceof SocketException) {
+        if (cause instanceof SocketException se) {
             try {
-                throw conContext.fatal(alert, cause);
+                throw conContext.fatal(alert, se);
             } catch (Exception e) {
                 // Just delivering the fatal alert, re-throw the socket exception instead.
             }
 
-            throw (SocketException)cause;
+            throw se;
         }
 
         throw conContext.fatal(alert, cause);

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,10 +77,10 @@ public final class SSLSocketImpl
     /**
      * ERROR HANDLING GUIDELINES
      * (which exceptions to throw and catch and which not to throw and catch)
-     *
+     * <p>
      * - if there is an IOException (SocketException) when accessing the
      *   underlying Socket, pass it through
-     *
+     * <p>
      * - do not throw IOExceptions, throw SSLExceptions (or a subclass)
      */
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1677,25 +1677,20 @@ public final class SSLSocketImpl
             SSLLogger.warning("handling exception", cause);
         }
 
-        Alert alert = switch (cause) {
+        throw switch (cause) {
             // Don't close the Socket in case of timeouts.
-            case SocketTimeoutException ste -> throw ste;
-            case SSLHandshakeException _ -> Alert.HANDSHAKE_FAILURE;
-            case IOException _ -> Alert.UNEXPECTED_MESSAGE;
-            default -> Alert.INTERNAL_ERROR;
-        };
-
-        if (cause instanceof SocketException se) {
-            try {
-                throw conContext.fatal(alert, se);
-            } catch (Exception e) {
-                // Just delivering the fatal alert, re-throw the socket exception instead.
+            case SocketTimeoutException ste -> ste;
+            // Send TLS alert with "fatal", then throw the socket exception.
+            case SocketException se -> {
+                conContext.fatal(Alert.UNEXPECTED_MESSAGE, se);
+                yield se;
             }
-
-            throw se;
-        }
-
-        throw conContext.fatal(alert, cause);
+            case SSLHandshakeException sslhe ->
+                    conContext.fatal(Alert.HANDSHAKE_FAILURE, sslhe);
+            case IOException ioe ->
+                    conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
+            default -> conContext.fatal(Alert.INTERNAL_ERROR, cause);
+        };
     }
 
     private Plaintext handleEOF(EOFException eofe) throws IOException {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1682,7 +1682,10 @@ public final class SSLSocketImpl
             case SocketTimeoutException ste -> ste;
             // Send TLS alert with "fatal", then throw the socket exception.
             case SocketException se -> {
-                conContext.fatal(Alert.UNEXPECTED_MESSAGE, se);
+                try {
+                    throw conContext.fatal(Alert.UNEXPECTED_MESSAGE, se);
+                } catch (Exception _) {
+                }
                 yield se;
             }
             case SSLHandshakeException sslhe ->

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -28,13 +28,13 @@ package sun.security.ssl;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -454,12 +454,12 @@ public final class SSLSocketImpl
                 if (!conContext.isNegotiated) {
                     readHandshakeRecord();
                 }
-            } catch (InterruptedIOException iioe) {
+            } catch (SocketTimeoutException e) {
                 if(resumable){
-                    handleException(iioe);
+                    handleException(e);
                 } else{
                     throw conContext.fatal(Alert.HANDSHAKE_FAILURE,
-                            "Couldn't kickstart handshaking", iioe);
+                            "Couldn't kickstart handshaking", e);
                 }
             } catch (SocketException se) {
                 handleException(se);
@@ -1427,7 +1427,7 @@ public final class SSLSocketImpl
                     return 0;
                 }
             } catch (SSLException |
-                    InterruptedIOException | SocketException se) {
+                     SocketTimeoutException | SocketException se) {
                 // Don't change exception in case of timeouts or interrupts
                 // or SocketException.
                 throw se;
@@ -1486,7 +1486,7 @@ public final class SSLSocketImpl
                     return buffer;
                 }
             } catch (SSLException |
-                    InterruptedIOException | SocketException se) {
+                     SocketTimeoutException | SocketException se) {
                 // Don't change exception in case of timeouts or interrupts
                 // or SocketException.
                 throw se;
@@ -1678,7 +1678,7 @@ public final class SSLSocketImpl
         }
 
         // Don't close the Socket in case of timeouts or interrupts.
-        if (cause instanceof InterruptedIOException) {
+        if (cause instanceof SocketTimeoutException) {
             throw (IOException)cause;
         }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1677,16 +1677,13 @@ public final class SSLSocketImpl
             SSLLogger.warning("handling exception", cause);
         }
 
-        Alert alert;
-
-        switch (cause) {
+        Alert alert = switch (cause) {
             // Don't close the Socket in case of timeouts.
             case SocketTimeoutException ste -> throw ste;
-            // Set alert type based on exception type.
-            case SSLHandshakeException _ -> alert = Alert.HANDSHAKE_FAILURE;
-            case IOException _ -> alert = Alert.UNEXPECTED_MESSAGE;
-            default -> alert = Alert.INTERNAL_ERROR;
-        }
+            case SSLHandshakeException _ -> Alert.HANDSHAKE_FAILURE;
+            case IOException _ -> Alert.UNEXPECTED_MESSAGE;
+            default -> Alert.INTERNAL_ERROR;
+        };
 
         if (cause instanceof SocketException se) {
             try {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -27,10 +27,10 @@
 package sun.security.ssl;
 
 import java.io.EOFException;
-import java.io.InterruptedIOException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
@@ -180,7 +180,7 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
             if (plaintext == null) {
                 plaintext = decodeInputRecord();
             }
-        } catch(InterruptedIOException e) {
+        } catch (SocketTimeoutException e) {
             // do not clean header and recordBody in case of Socket Timeout
             cleanInBuffer = false;
             throw e;

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -27,8 +27,8 @@ package sun.security.ssl;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
@@ -138,7 +138,7 @@ interface SSLTransport {
         } catch (EOFException eofe) {
             // rethrow EOFException, the call will handle it if needed.
             throw eofe;
-        } catch (InterruptedIOException | SocketException se) {
+        } catch (SocketTimeoutException | SocketException se) {
             // don't close the Socket in case of timeouts or interrupts or SocketException.
             throw se;
         } catch (IOException ioe) {

--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,10 @@
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.security.Security;
 import java.util.Arrays;
 
@@ -88,7 +88,7 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
             // log it for debugging
             System.out.println("Server SSLHandshakeException:");
             se.printStackTrace(System.out);
-        } catch (InterruptedIOException ioe) {
+        } catch (SocketTimeoutException _) {
             // must have been interrupted, no harm
         } catch (SSLException | SocketException se) {
             // The client side may have closed the socket.

--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -88,9 +88,7 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
             // log it for debugging
             System.out.println("Server SSLHandshakeException:");
             se.printStackTrace(System.out);
-        } catch (SocketTimeoutException _) {
-            // must have been interrupted, no harm
-        } catch (SSLException | SocketException se) {
+        } catch (SocketTimeoutException | SSLException | SocketException se) {
             // The client side may have closed the socket.
             System.out.println("Server SSLException:");
             se.printStackTrace(System.out);

--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -90,7 +90,7 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
             se.printStackTrace(System.out);
         } catch (SocketTimeoutException | SSLException | SocketException se) {
             // The client side may have closed the socket.
-            System.out.println("Server SSLException:");
+            System.out.println("Server exception:");
             se.printStackTrace(System.out);
         } catch (Exception e) {
             System.out.println("Server exception:");

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ClientTimeout.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ClientTimeout.java
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 4836493 8239798
+ * @bug 4836493 8239798 8370656
  * @summary Socket timeouts for SSLSockets causes data corruption.
  * @run main/othervm ClientTimeout
  */

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ClientTimeout.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ClientTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 4836493 8239798 8370656
+ * @bug 4836493 8239798
  * @summary Socket timeouts for SSLSockets causes data corruption.
  * @run main/othervm ClientTimeout
  */

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ClientTimeout.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ClientTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
`InterruptedIOException` is being deprecated, replace it with `SocketTimeoutException` in SSL code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8370656](https://bugs.openjdk.org/browse/JDK-8370656): Re-examine use of InterruptedIOException in sun.security.ssl code (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [91f334b4](https://git.openjdk.org/jdk/pull/30753/files/91f334b41293cc9322ec9ac9626644b8d5212fda)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30753/head:pull/30753` \
`$ git checkout pull/30753`

Update a local copy of the PR: \
`$ git checkout pull/30753` \
`$ git pull https://git.openjdk.org/jdk.git pull/30753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30753`

View PR using the GUI difftool: \
`$ git pr show -t 30753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30753.diff">https://git.openjdk.org/jdk/pull/30753.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30753#issuecomment-4254613444)
</details>
