### PR TITLE
 8382295: Shenandoah: wrong denominator in full gc summary 

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -257,10 +257,10 @@ void ShenandoahCollectorPolicy::print_gc_stats(outputStream* out) const {
 
   out->print_cr("%5zu Full GCs (%.2f%%)", _success_full_gcs, percent_of(_success_full_gcs, completed_gcs));
   if (!ExplicitGCInvokesConcurrent) {
-    out->print_cr("  %5zu invoked explicitly (%.2f%%)", explicit_requests, percent_of(explicit_requests, _success_concurrent_gcs));
+    out->print_cr("  %5zu invoked explicitly (%.2f%%)", explicit_requests, percent_of(explicit_requests, _success_full_gcs));
   }
   if (!ShenandoahImplicitGCInvokesConcurrent) {
-    out->print_cr("  %5zu invoked implicitly (%.2f%%)", implicit_requests, percent_of(implicit_requests, _success_concurrent_gcs));
+    out->print_cr("  %5zu invoked implicitly (%.2f%%)", implicit_requests, percent_of(implicit_requests, _success_full_gcs));
   }
   out->print_cr("  %5zu caused by allocation failure (%.2f%%)", _alloc_failure_full, percent_of(_alloc_failure_full, _success_full_gcs));
   out->print_cr("  %5zu upgraded from Degenerated GC (%.2f%%)", _alloc_failure_degenerated_upgrade_to_full, percent_of(_alloc_failure_degenerated_upgrade_to_full, _success_full_gcs));


### PR DESCRIPTION
When printing full gc summary, it prints out the percentage of explicit (`System,gc()`) and implicit GCs. 

In the full GC section, its dominator is currently set to be [concurrent GC count](https://github.com/rgithubli/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp#L259-L264), which is wrong. The denominator should be the full gc count. 

GHA passed.

Local testing: Run a simple app with two `System.gc()` calls. Before the change:

```
[6.077s][info][gc,stats       ]    15 Completed GCs
[6.077s][info][gc,stats       ]       2 caused by System.gc() (13.33%)
[6.077s][info][gc,stats       ]      13 caused by Concurrent GC (86.67%)
[6.077s][info][gc,stats       ] 
[6.077s][info][gc,stats       ]    13 Successful Concurrent GCs (86.67%)
[6.077s][info][gc,stats       ]      11 abbreviated (84.62%)
[6.077s][info][gc,stats       ] 
[6.077s][info][gc,stats       ]     0 Degenerated GCs (0.00%)
[6.077s][info][gc,stats       ]       0 upgraded to Full GC (0.00%)
[6.077s][info][gc,stats       ]       0 caused by allocation failure (0.00%)
[6.077s][info][gc,stats       ]       0 abbreviated (0.00%)
[6.077s][info][gc,stats       ] 
[6.077s][info][gc,stats       ]     2 Full GCs (13.33%)
[6.077s][info][gc,stats       ]       2 invoked explicitly (15.38%)
[6.077s][info][gc,stats       ]       0 invoked implicitly (0.00%)
[6.077s][info][gc,stats       ]       0 caused by allocation failure (0.00%)
[6.077s][info][gc,stats       ]       0 upgraded from Degenerated GC (0.00%)
[6.077s][info][gc,stats       ] 
```

After change:
```
[6.809s][info][gc,stats       ]    16 Completed GCs
[6.809s][info][gc,stats       ]       2 caused by System.gc() (12.50%)
[6.809s][info][gc,stats       ]      14 caused by Concurrent GC (87.50%)
[6.809s][info][gc,stats       ] 
[6.809s][info][gc,stats       ]    14 Successful Concurrent GCs (87.50%)
[6.809s][info][gc,stats       ]      12 abbreviated (85.71%)
[6.809s][info][gc,stats       ] 
[6.809s][info][gc,stats       ]     0 Degenerated GCs (0.00%)
[6.809s][info][gc,stats       ]       0 upgraded to Full GC (0.00%)
[6.809s][info][gc,stats       ]       0 caused by allocation failure (0.00%)
[6.809s][info][gc,stats       ]       0 abbreviated (0.00%)
[6.809s][info][gc,stats       ] 
[6.809s][info][gc,stats       ]     2 Full GCs (12.50%)
[6.809s][info][gc,stats       ]       2 invoked explicitly (100.00%)
[6.809s][info][gc,stats       ]       0 invoked implicitly (0.00%)
[6.809s][info][gc,stats       ]       0 caused by allocation failure (0.00%)
[6.809s][info][gc,stats       ]       0 upgraded from Degenerated GC (0.00%)
[6.809s][info][gc,stats       ] 



```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382295](https://bugs.openjdk.org/browse/JDK-8382295): Shenandoah: wrong denominator in full gc summary (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30755/head:pull/30755` \
`$ git checkout pull/30755`

Update a local copy of the PR: \
`$ git checkout pull/30755` \
`$ git pull https://git.openjdk.org/jdk.git pull/30755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30755`

View PR using the GUI difftool: \
`$ git pr show -t 30755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30755.diff">https://git.openjdk.org/jdk/pull/30755.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30755#issuecomment-4255145815)
</details>
