### PR TITLE
8377727: Ghost caret and focus appear in non‑editable text fields on JDK 8u451+

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.swing.text;
 
+import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.HeadlessException;
 import java.awt.Point;
@@ -690,7 +691,18 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                     // semantics of damage we can't really get around this.
                     damage(r);
                 }
-                g.setColor(component.getCaretColor());
+                if (component.isEditable()) {
+                    g.setColor(component.getCaretColor());
+                } else {
+                    Color caretColor = component.getCaretColor();
+                    Color bg = component.getBackground();
+                    int red = (caretColor.getRed() + bg.getRed()) / 2;
+                    int green = (caretColor.getGreen() + bg.getGreen()) / 2;
+                    int blue = (caretColor.getBlue() + bg.getBlue()) / 2;
+                    int alpha = 127;
+                    Color newCaretColor = new Color(red, green, blue, alpha);
+                    g.setColor(newCaretColor);
+                }
                 int paintWidth = getCaretWidth(r.height);
                 r.x -= paintWidth  >> 1;
                 g.fillRect(r.x, r.y, paintWidth, r.height);


### PR DESCRIPTION
Make caret color closer to the background color so it does appear as disabled caret.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8377727`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8377727`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30756/head:pull/30756` \
`$ git checkout pull/30756`

Update a local copy of the PR: \
`$ git checkout pull/30756` \
`$ git pull https://git.openjdk.org/jdk.git pull/30756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30756`

View PR using the GUI difftool: \
`$ git pr show -t 30756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30756.diff">https://git.openjdk.org/jdk/pull/30756.diff</a>

</details>
