### PR TITLE
8382306: Remove JvmtiTagMap::check_hashmap

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -136,20 +136,6 @@ bool JvmtiTagMap::is_empty() {
   return hashmap()->is_empty();
 }
 
-// This checks for posting before operations that use
-// this tagmap table.
-void JvmtiTagMap::check_hashmap(GrowableArray<jlong>* objects) {
-  assert(is_locked(), "checking");
-
-  if (is_empty()) { return; }
-
-  if (_needs_cleaning &&
-      objects != nullptr &&
-      env()->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
-    remove_dead_entries_locked(objects);
-  }
-}
-
 // This checks for posting and is called from the heap walks.
 void JvmtiTagMap::check_hashmaps_for_heapwalk(GrowableArray<jlong>* objects) {
   assert(SafepointSynchronize::is_at_safepoint(), "called from safepoints");
@@ -162,7 +148,7 @@ void JvmtiTagMap::check_hashmaps_for_heapwalk(GrowableArray<jlong>* objects) {
     if (tag_map != nullptr) {
       // The ZDriver may be walking the hashmaps concurrently so this lock is needed.
       MutexLocker ml(tag_map->lock(), Mutex::_no_safepoint_check_flag);
-      tag_map->check_hashmap(objects);
+      tag_map->remove_dead_entries_locked(objects);
     }
   }
 }
@@ -329,11 +315,6 @@ class TwoOopCallbackWrapper : public CallbackWrapper {
 void JvmtiTagMap::set_tag(jobject object, jlong tag) {
   MutexLocker ml(lock(), Mutex::_no_safepoint_check_flag);
 
-  // SetTag should not post events because the JavaThread has to
-  // transition to native for the callback and this cannot stop for
-  // safepoints with the hashmap lock held.
-  check_hashmap(nullptr);  /* don't collect dead objects */
-
   // resolve the object
   oop o = JNIHandles::resolve_non_null(object);
 
@@ -353,11 +334,6 @@ void JvmtiTagMap::set_tag(jobject object, jlong tag) {
 // get the tag for an object
 jlong JvmtiTagMap::get_tag(jobject object) {
   MutexLocker ml(lock(), Mutex::_no_safepoint_check_flag);
-
-  // GetTag should not post events because the JavaThread has to
-  // transition to native for the callback and this cannot stop for
-  // safepoints with the hashmap lock held.
-  check_hashmap(nullptr); /* don't collect dead objects */
 
   // resolve the object
   oop o = JNIHandles::resolve_non_null(object);

--- a/src/hotspot/share/prims/jvmtiTagMap.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.hpp
@@ -51,8 +51,6 @@ class JvmtiTagMap :  public CHeapObj<mtServiceability> {
   // accessors
   inline JvmtiEnv* env() const              { return _env; }
 
-  void check_hashmap(GrowableArray<jlong>* objects);
-
   void entry_iterate(JvmtiTagMapKeyClosure* closure);
 
  public:


### PR DESCRIPTION
The check_hashmap(nullptr) doesn't do anything now.
It was used to rehash map but now just returns.

And the remaining usage can be replaced with direct call of remove_dead_entries_locked.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382306](https://bugs.openjdk.org/browse/JDK-8382306): Remove JvmtiTagMap::check_hashmap (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30757/head:pull/30757` \
`$ git checkout pull/30757`

Update a local copy of the PR: \
`$ git checkout pull/30757` \
`$ git pull https://git.openjdk.org/jdk.git pull/30757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30757`

View PR using the GUI difftool: \
`$ git pr show -t 30757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30757.diff">https://git.openjdk.org/jdk/pull/30757.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30757#issuecomment-4256326050)
</details>
