### PR TITLE
8377727: Ghost caret and focus appear in non‑editable text fields

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -695,13 +695,20 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                     g.setColor(component.getCaretColor());
                 } else {
                     Color caretColor = component.getCaretColor();
+                    if (caretColor == null) {
+                        caretColor = g.getColor();
+                    }
                     Color bg = component.getBackground();
-                    int red = (caretColor.getRed() + bg.getRed()) / 2;
-                    int green = (caretColor.getGreen() + bg.getGreen()) / 2;
-                    int blue = (caretColor.getBlue() + bg.getBlue()) / 2;
-                    int alpha = 127;
-                    Color newCaretColor = new Color(red, green, blue, alpha);
-                    g.setColor(newCaretColor);
+                    if (bg == null) {
+                        g.setColor(caretColor);
+                    } else {
+                        int red = (caretColor.getRed() + bg.getRed()) / 2;
+                        int green = (caretColor.getGreen() + bg.getGreen()) / 2;
+                        int blue = (caretColor.getBlue() + bg.getBlue()) / 2;
+                        int alpha = 127;
+                        Color newCaretColor = new Color(red, green, blue, alpha);
+                        g.setColor(newCaretColor);
+                    }
                 }
                 int paintWidth = getCaretWidth(r.height);
                 r.x -= paintWidth  >> 1;

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.swing.text;
 
+import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.HeadlessException;
 import java.awt.Point;
@@ -690,7 +691,18 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                     // semantics of damage we can't really get around this.
                     damage(r);
                 }
-                g.setColor(component.getCaretColor());
+                if (component.isEditable()) {
+                    g.setColor(component.getCaretColor());
+                } else {
+                    Color caretColor = component.getCaretColor();
+                    Color bg = component.getBackground();
+                    int red = (caretColor.getRed() + bg.getRed()) / 2;
+                    int green = (caretColor.getGreen() + bg.getGreen()) / 2;
+                    int blue = (caretColor.getBlue() + bg.getBlue()) / 2;
+                    int alpha = 127;
+                    Color newCaretColor = new Color(red, green, blue, alpha);
+                    g.setColor(newCaretColor);
+                }
                 int paintWidth = getCaretWidth(r.height);
                 r.x -= paintWidth  >> 1;
                 g.fillRect(r.x, r.y, paintWidth, r.height);


### PR DESCRIPTION
Make caret color closer to the background color so it does appear as disabled caret.

Here is the comparison of default caret and the caret after the fix is applied:
Default white background: <img width="126" height="36" alt="white_editable" src="https://github.com/user-attachments/assets/35620f59-8ed6-40f4-8b52-00757acf3efc" />
After fix white background: <img width="124" height="38" alt="white_noneditable" src="https://github.com/user-attachments/assets/10a5bd08-ebc2-42e5-99e1-4a048a323666" />
Default red background: <img width="140" height="52" alt="red_editable" src="https://github.com/user-attachments/assets/f0c327a4-aee3-4802-98ed-915e314be36c" />
After fix with red background: <img width="130" height="36" alt="red_noneditable" src="https://github.com/user-attachments/assets/c3baaf41-6a67-4be2-98c0-d1e260fc53ae" />



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8377727](https://bugs.openjdk.org/browse/JDK-8377727): Ghost caret and focus appear in non‑editable text fields (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30758/head:pull/30758` \
`$ git checkout pull/30758`

Update a local copy of the PR: \
`$ git checkout pull/30758` \
`$ git pull https://git.openjdk.org/jdk.git pull/30758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30758`

View PR using the GUI difftool: \
`$ git pr show -t 30758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30758.diff">https://git.openjdk.org/jdk/pull/30758.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30758#issuecomment-4256371330)
</details>
