### PR TITLE
8382315: RISC-V: TestMultiplyReductionByte.java fails with guarantee(is_uimm5(imm)) failed: uimm is invalid

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3069,12 +3069,12 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
     //    If the operation is MUL, then the identity value is one.
     vmv_v_i(vtmp1, 1);
     vmerge_vvm(vtmp2, vtmp1, src2); // vm == v0
-    vslidedown_vi(vtmp1, vtmp2, vector_length);
+    slidedown_v(vtmp1, vtmp2, vector_length);
 
     vsetvli_helper(bt, vector_length);
     vmul_vv(vtmp1, vtmp1, vtmp2);
   } else {
-    vslidedown_vi(vtmp1, src2, vector_length);
+    slidedown_v(vtmp1, src2, vector_length);
 
     vsetvli_helper(bt, vector_length);
     vmul_vv(vtmp1, vtmp1, src2);
@@ -3082,7 +3082,7 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
 
   while (vector_length > 1) {
     vector_length /= 2;
-    vslidedown_vi(vtmp2, vtmp1, vector_length);
+    slidedown_v(vtmp2, vtmp1, vector_length);
     vsetvli_helper(bt, vector_length);
     vmul_vv(vtmp1, vtmp1, vtmp2);
   }
@@ -3281,40 +3281,44 @@ VFCVT_SAFE(vfcvt_rtz_x_f_v);
 
 // Extract a scalar element from an vector at position 'idx'.
 // The input elements in src are expected to be of integral type.
-void C2_MacroAssembler::extract_v(Register dst, VectorRegister src, BasicType bt,
-                                  int idx, VectorRegister tmp) {
+void C2_MacroAssembler::extract_v(Register dst, VectorRegister src,
+                                  BasicType bt, int idx, VectorRegister tmp) {
   assert(is_integral_type(bt), "unsupported element type");
   assert(idx >= 0, "idx cannot be negative");
   // Only need the first element after vector slidedown
   vsetvli_helper(bt, 1);
   if (idx == 0) {
     vmv_x_s(dst, src);
-  } else if (idx <= 31) {
-    vslidedown_vi(tmp, src, idx);
-    vmv_x_s(dst, tmp);
   } else {
-    mv(t0, idx);
-    vslidedown_vx(tmp, src, t0);
+    slidedown_v(tmp, src, idx);
     vmv_x_s(dst, tmp);
   }
 }
 
 // Extract a scalar element from an vector at position 'idx'.
 // The input elements in src are expected to be of floating point type.
-void C2_MacroAssembler::extract_fp_v(FloatRegister dst, VectorRegister src, BasicType bt,
-                                     int idx, VectorRegister tmp) {
+void C2_MacroAssembler::extract_fp_v(FloatRegister dst, VectorRegister src,
+                                     BasicType bt, int idx, VectorRegister tmp) {
   assert(is_floating_point_type(bt), "unsupported element type");
   assert(idx >= 0, "idx cannot be negative");
   // Only need the first element after vector slidedown
   vsetvli_helper(bt, 1);
   if (idx == 0) {
     vfmv_f_s(dst, src);
-  } else if (idx <= 31) {
-    vslidedown_vi(tmp, src, idx);
-    vfmv_f_s(dst, tmp);
   } else {
-    mv(t0, idx);
-    vslidedown_vx(tmp, src, t0);
+    slidedown_v(tmp, src, idx);
     vfmv_f_s(dst, tmp);
+  }
+}
+
+// Move elements down a vector register group.
+// Offset is the start index (offset) for the source.
+void C2_MacroAssembler::slidedown_v(VectorRegister dst, VectorRegister src,
+                                    uint32_t offset, Register tmp) {
+  if (is_uimm5(offset)) {
+    vslidedown_vi(dst, src, offset);
+  } else {
+    mv(tmp, offset);
+    vslidedown_vx(dst, src, tmp);
   }
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3282,7 +3282,7 @@ VFCVT_SAFE(vfcvt_rtz_x_f_v);
 // Extract a scalar element from an vector at position 'idx'.
 // The input elements in src are expected to be of integral type.
 void C2_MacroAssembler::extract_v(Register dst, VectorRegister src,
-                                  BasicType bt, int idx, VectorRegister tmp) {
+                                  BasicType bt, int idx, VectorRegister vtmp) {
   assert(is_integral_type(bt), "unsupported element type");
   assert(idx >= 0, "idx cannot be negative");
   // Only need the first element after vector slidedown
@@ -3290,15 +3290,15 @@ void C2_MacroAssembler::extract_v(Register dst, VectorRegister src,
   if (idx == 0) {
     vmv_x_s(dst, src);
   } else {
-    slidedown_v(tmp, src, idx);
-    vmv_x_s(dst, tmp);
+    slidedown_v(vtmp, src, idx);
+    vmv_x_s(dst, vtmp);
   }
 }
 
 // Extract a scalar element from an vector at position 'idx'.
 // The input elements in src are expected to be of floating point type.
 void C2_MacroAssembler::extract_fp_v(FloatRegister dst, VectorRegister src,
-                                     BasicType bt, int idx, VectorRegister tmp) {
+                                     BasicType bt, int idx, VectorRegister vtmp) {
   assert(is_floating_point_type(bt), "unsupported element type");
   assert(idx >= 0, "idx cannot be negative");
   // Only need the first element after vector slidedown
@@ -3306,8 +3306,8 @@ void C2_MacroAssembler::extract_fp_v(FloatRegister dst, VectorRegister src,
   if (idx == 0) {
     vfmv_f_s(dst, src);
   } else {
-    slidedown_v(tmp, src, idx);
-    vfmv_f_s(dst, tmp);
+    slidedown_v(vtmp, src, idx);
+    vfmv_f_s(dst, vtmp);
   }
 }
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -296,7 +296,13 @@
 
   void vfcvt_rtz_x_f_v_safe(VectorRegister dst, VectorRegister src);
 
-  void extract_v(Register dst, VectorRegister src, BasicType bt, int idx, VectorRegister tmp);
-  void extract_fp_v(FloatRegister dst, VectorRegister src, BasicType bt, int idx, VectorRegister tmp);
+  void extract_v(Register dst, VectorRegister src,
+                 BasicType bt, int idx, VectorRegister tmp);
+
+  void extract_fp_v(FloatRegister dst, VectorRegister src,
+                    BasicType bt, int idx, VectorRegister tmp);
+
+  void slidedown_v(VectorRegister dst, VectorRegister src,
+                   uint32_t offset, Register tmp = t0);
 
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -297,10 +297,10 @@
   void vfcvt_rtz_x_f_v_safe(VectorRegister dst, VectorRegister src);
 
   void extract_v(Register dst, VectorRegister src,
-                 BasicType bt, int idx, VectorRegister tmp);
+                 BasicType bt, int idx, VectorRegister vtmp);
 
   void extract_fp_v(FloatRegister dst, VectorRegister src,
-                    BasicType bt, int idx, VectorRegister tmp);
+                    BasicType bt, int idx, VectorRegister vtmp);
 
   void slidedown_v(VectorRegister dst, VectorRegister src,
                    uint32_t offset, Register tmp = t0);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMultiplyReductionByte.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMultiplyReductionByte.java
@@ -57,7 +57,7 @@ public class TestMultiplyReductionByte {
 
     @Test
     @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=8"})
     static byte testMulReduce64() {
         return ByteVector.fromArray(ByteVector.SPECIES_64, input, 0)
@@ -75,7 +75,7 @@ public class TestMultiplyReductionByte {
 
     @Test
     @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=16"})
     static byte testMulReduce128() {
         return ByteVector.fromArray(ByteVector.SPECIES_128, input, 0)
@@ -93,7 +93,7 @@ public class TestMultiplyReductionByte {
 
     @Test
     @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=32"})
     static byte testMulReduce256() {
         return ByteVector.fromArray(ByteVector.SPECIES_256, input, 0)
@@ -111,7 +111,7 @@ public class TestMultiplyReductionByte {
 
     @Test
     @IR(counts = {IRNode.MUL_REDUCTION_VI, ">=1"},
-        applyIfCPUFeatureOr = {"avx512f", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"avx512f", "true", "asimd", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=64"})
     static byte testMulReduce512() {
         return ByteVector.fromArray(ByteVector.SPECIES_512, input, 0)


### PR DESCRIPTION
Hi, please review.

The vector slide down instruction `vslidedown_vi` can only encode a 5-bit zero-extended offset.
But that is not handled properly in `C2_MacroAssembler::reduce_mul_integral_v` which uses this instruction.
The contraint won't be satisfied when running `compiler.vectorapi.TestMultiplyReductionByte::testMulReduce512`
with a much larger MaxVectorSize (>= 64 bytes).
This fixes the issue by introducing a new macro-assembler routine `slidedown_v` which would do the check
and delegates work to either `vslidedown_vi` or `vslidedown_vx` accordingly.

Testing:
  Same test using fastdebug build on linux-riscv64 qemu (MaxVectorSize = 64).
  `hs:tier1` - `hs:tier3` using fastdebug build on linux-riscv64 qemu (MaxVectorSize = 16).



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382315](https://bugs.openjdk.org/browse/JDK-8382315): RISC-V: TestMultiplyReductionByte.java fails with guarantee(is_uimm5(imm)) failed: uimm is invalid (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30759/head:pull/30759` \
`$ git checkout pull/30759`

Update a local copy of the PR: \
`$ git checkout pull/30759` \
`$ git pull https://git.openjdk.org/jdk.git pull/30759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30759`

View PR using the GUI difftool: \
`$ git pr show -t 30759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30759.diff">https://git.openjdk.org/jdk/pull/30759.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30759#issuecomment-4257797722)
</details>
