### PR TITLE
8382327: Disable some SA tests for mixed jstack on musl C

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -54,6 +54,10 @@ import jtreg.SkippedException;
 public class ClhsdbPstack {
 
     public static void main(String[] args) throws Exception {
+        if (Platform.isMusl()) {
+            throw new SkippedException("This test does not work on musl libc.");
+        }
+
         boolean withCore = Boolean.parseBoolean(args[0]);
         System.out.println("Starting ClhsdbPstack test: withCore==" + withCore);
 

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
@@ -33,6 +33,8 @@ import jdk.test.lib.Utils;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
 
+import jtreg.SkippedException;
+
 /**
  * @test
  * @key randomness
@@ -174,6 +176,10 @@ public class TestJhsdbJstackMixed {
     }
 
     public static void main(String... args) throws Exception {
+        if (Platform.isMusl()) {
+            throw new SkippedException("This test does not work on musl libc.");
+        }
+
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
         LingeredApp app = null;
 

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixedWithXComp.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixedWithXComp.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025, NTT DATA
+ * Copyright (c) 2025, 2026, NTT DATA
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Platform;
 import jdk.test.lib.SA.SATestUtils;
 import jdk.test.lib.Utils;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
+
+import jtreg.SkippedException;
 
 /**
  * @test id=xcomp
@@ -111,6 +114,10 @@ public class TestJhsdbJstackMixedWithXComp {
     }
 
     public static void main(String... args) throws Exception {
+        if (Platform.isMusl()) {
+            throw new SkippedException("This test does not work on musl libc.");
+        }
+
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
         LingeredApp app = null;
 

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
@@ -22,6 +22,7 @@
  */
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Platform;
 import jdk.test.lib.SA.SATestUtils;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -43,6 +44,10 @@ public class TestJhsdbJstackPrintVMLocks {
 
     final static int MAX_ATTEMPTS = 5;
     public static void main(String[] args) throws Exception {
+        if (Platform.isMusl()) {
+            throw new SkippedException("This test does not work on musl libc.");
+        }
+
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
         LingeredApp theApp = null;


### PR DESCRIPTION
`serviceability/sa/ClhsdbPstack.java#core` test seems to be failed since [JDK-8377946](https://bugs.openjdk.org/browse/JDK-8377946). See [comments in the its ticket](https://bugs.openjdk.org/browse/JDK-8377946?focusedId=14870950&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14870950) for details.

We discussed mixed jstack tests on Alpine in [JDK-8376284](https://bugs.openjdk.org/browse/JDK-8376284), then SA tests which runs mixed jstack should be skipped on Alpine. However following tests still would run on it.

- TestJhsdbJstackMixed.java
- TestJhsdbJstackMixedWithXComp.java
- TestJhsdbJstackPrintVMLocks.java
- ClhsdbPstack.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382327](https://bugs.openjdk.org/browse/JDK-8382327): Disable some SA tests for mixed jstack on musl C (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30761/head:pull/30761` \
`$ git checkout pull/30761`

Update a local copy of the PR: \
`$ git checkout pull/30761` \
`$ git pull https://git.openjdk.org/jdk.git pull/30761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30761`

View PR using the GUI difftool: \
`$ git pr show -t 30761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30761.diff">https://git.openjdk.org/jdk/pull/30761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30761#issuecomment-4258809428)
</details>
