### PR TITLE
8381872: C2: assert before block local scheduling failed with UseCompactObjectHeaders

### DIFF
--- a/src/hotspot/cpu/x86/peephole_x86_64.cpp
+++ b/src/hotspot/cpu/x86/peephole_x86_64.cpp
@@ -338,6 +338,29 @@ bool Peephole::lea_remove_redundant(Block* block, int block_index, PhaseCFG* cfg
   }
 
   // We now have verified that the decode is redundant and can be removed with a peephole.
+
+  // Before rewiring, check that the new base won't create a register conflict.
+  // The new base (lea_address) might share a register with a dependant_lea.
+  // If the dependant_lea overwrites that register and the base is still live
+  // (used in successor blocks), this creates a conflict detected by verify_good_schedule.
+  Node* new_base = lea_derived_oop->in(AddPNode::Address);
+  OptoReg::Name new_base_reg = ra_->get_reg_first(new_base);
+  if (OptoReg::is_valid(new_base_reg)) {
+    for (DUIterator_Fast imax, i = decode->fast_outs(imax); i < imax; i++) {
+      Node* dependant_lea = decode->fast_out(i);
+      if (dependant_lea->is_Mach() && dependant_lea->as_Mach()->ideal_Opcode() == Op_AddP) {
+        OptoReg::Name lea_reg = ra_->get_reg_first(dependant_lea);
+        OptoReg::Name lea_reg2 = ra_->get_reg_second(dependant_lea);
+        // If the new base register overlaps with any register slot of
+        // the dependant lea's output, the rewiring would create a conflict
+        // when the lea overwrites the base pointer's register.
+        if (new_base_reg == lea_reg || new_base_reg == lea_reg2) {
+          return false;
+        }
+      }
+    }
+  }
+
   // Remove the projection
   block->find_remove(proj);
   cfg_->map_node_to_block(proj, nullptr);
@@ -346,7 +369,7 @@ bool Peephole::lea_remove_redundant(Block* block, int block_index, PhaseCFG* cfg
   for (DUIterator_Fast imax, i = decode->fast_outs(imax); i < imax; i++) {
     Node* dependant_lea = decode->fast_out(i);
     if (dependant_lea->is_Mach() && dependant_lea->as_Mach()->ideal_Opcode() == Op_AddP) {
-      dependant_lea->set_req(AddPNode::Base, lea_derived_oop->in(AddPNode::Address));
+      dependant_lea->set_req(AddPNode::Base, new_base);
       // This deleted something in the out array, hence adjust i, imax.
       --i;
       --imax;

--- a/src/hotspot/cpu/x86/peephole_x86_64.cpp
+++ b/src/hotspot/cpu/x86/peephole_x86_64.cpp
@@ -25,6 +25,7 @@
 #ifdef COMPILER2
 
 #include "opto/addnode.hpp"
+#include "opto/compile.hpp"
 #include "peephole_x86_64.hpp"
 #include "adfiles/ad_x86.hpp"
 
@@ -339,33 +340,16 @@ bool Peephole::lea_remove_redundant(Block* block, int block_index, PhaseCFG* cfg
 
   // We now have verified that the decode is redundant and can be removed with a peephole.
 
-  // Before rewiring, check that the new base won't create a register conflict.
-  // The new base (lea_address) might share a register with a dependant_lea.
-  // If the dependant_lea overwrites that register and the base is still live
-  // (used in successor blocks), this creates a conflict detected by verify_good_schedule.
-  Node* new_base = lea_derived_oop->in(AddPNode::Address);
-  OptoReg::Name new_base_reg = ra_->get_reg_first(new_base);
-  if (OptoReg::is_valid(new_base_reg)) {
-    for (DUIterator_Fast imax, i = decode->fast_outs(imax); i < imax; i++) {
-      Node* dependant_lea = decode->fast_out(i);
-      if (dependant_lea->is_Mach() && dependant_lea->as_Mach()->ideal_Opcode() == Op_AddP) {
-        OptoReg::Name lea_reg = ra_->get_reg_first(dependant_lea);
-        OptoReg::Name lea_reg2 = ra_->get_reg_second(dependant_lea);
-        // If the new base register overlaps with any register slot of
-        // the dependant lea's output, the rewiring would create a conflict
-        // when the lea overwrites the base pointer's register.
-        if (new_base_reg == lea_reg || new_base_reg == lea_reg2) {
-          return false;
-        }
-      }
-    }
-  }
-
   // Remove the projection
   block->find_remove(proj);
   cfg_->map_node_to_block(proj, nullptr);
 
   // Rewire the base of all leas currently depending on the decode we are removing.
+  // Use top() rather than a real value: leaP* emission does not consult Base, and the
+  // unused MachProj of decode confirms the derived oops produced by these leaP*s are
+  // not consumed by any OopMap. Avoiding a real input here also avoids creating a
+  // register conflict that would later be flagged by verify_good_schedule.
+  Node* new_base = Compile::current()->top();
   for (DUIterator_Fast imax, i = decode->fast_outs(imax); i < imax; i++) {
     Node* dependant_lea = decode->fast_out(i);
     if (dependant_lea->is_Mach() && dependant_lea->as_Mach()->ideal_Opcode() == Op_AddP) {

--- a/src/hotspot/cpu/x86/peephole_x86_64.cpp
+++ b/src/hotspot/cpu/x86/peephole_x86_64.cpp
@@ -339,7 +339,6 @@ bool Peephole::lea_remove_redundant(Block* block, int block_index, PhaseCFG* cfg
   }
 
   // We now have verified that the decode is redundant and can be removed with a peephole.
-
   // Remove the projection
   block->find_remove(proj);
   cfg_->map_node_to_block(proj, nullptr);
@@ -349,11 +348,11 @@ bool Peephole::lea_remove_redundant(Block* block, int block_index, PhaseCFG* cfg
   // unused MachProj of decode confirms the derived oops produced by these leaP*s are
   // not consumed by any OopMap. Avoiding a real input here also avoids creating a
   // register conflict that would later be flagged by verify_good_schedule.
-  Node* new_base = Compile::current()->top();
+  Node* top = Compile::current()->top();
   for (DUIterator_Fast imax, i = decode->fast_outs(imax); i < imax; i++) {
     Node* dependant_lea = decode->fast_out(i);
     if (dependant_lea->is_Mach() && dependant_lea->as_Mach()->ideal_Opcode() == Op_AddP) {
-      dependant_lea->set_req(AddPNode::Base, new_base);
+      dependant_lea->set_req(AddPNode::Base, top);
       // This deleted something in the out array, hence adjust i, imax.
       --i;
       --imax;

--- a/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
@@ -298,8 +298,11 @@ class StoreNTest {
     @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    // Test that the peephole worked for leaPCompressedOopOffset
-    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
+    // Test that the peephole worked for leaPCompressedOopOffset.
+    // The peephole may bail out if the new base pointer's register
+    // would conflict with a dependent lea's output register, so we
+    // allow up to the non-peephole count.
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     // Test that the peephole removes a spill.
@@ -340,8 +343,9 @@ class StoreNTest {
     @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    // Test that the peephole worked for leaPCompressedOopOffset
-    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
+    // Test that the peephole worked for leaPCompressedOopOffset.
+    // The peephole may bail out due to register conflicts.
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     public void testNoAlloc() {
@@ -357,8 +361,9 @@ class StoreNTest {
     @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=1"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    // Test that the peephole worked for leaPCompressedOopOffset
-    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
+    // Test that the peephole worked for leaPCompressedOopOffset.
+    // The peephole may bail out due to register conflicts.
+    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=1"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     public void testNoAllocSameArray() {

--- a/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestRedundantLea.java
@@ -298,11 +298,8 @@ class StoreNTest {
     @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    // Test that the peephole worked for leaPCompressedOopOffset.
-    // The peephole may bail out if the new base pointer's register
-    // would conflict with a dependent lea's output register, so we
-    // allow up to the non-peephole count.
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=2"},
+    // Test that the peephole worked for leaPCompressedOopOffset
+    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     // Test that the peephole removes a spill.
@@ -343,9 +340,8 @@ class StoreNTest {
     @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=2"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    // Test that the peephole worked for leaPCompressedOopOffset.
-    // The peephole may bail out due to register conflicts.
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=2"},
+    // Test that the peephole worked for leaPCompressedOopOffset
+    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     public void testNoAlloc() {
@@ -361,9 +357,8 @@ class StoreNTest {
     @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "=1"},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "false"})
-    // Test that the peephole worked for leaPCompressedOopOffset.
-    // The peephole may bail out due to register conflicts.
-    @IR(counts = {IRNode.DECODE_HEAP_OOP_NOT_NULL, "<=1"},
+    // Test that the peephole worked for leaPCompressedOopOffset
+    @IR(failOn = {IRNode.DECODE_HEAP_OOP_NOT_NULL},
         phase = {CompilePhase.FINAL_CODE},
         applyIf = {"OptoPeephole", "true"})
     public void testNoAllocSameArray() {


### PR DESCRIPTION
This fixes a bug in Peephole::lea_remove_redundant() in peephole_x86_64.cpp, which can lead to miscompilations caused by two distinct values getting assigned to the same register.

Testing:
 - [x] 100x `compiler/compilercontrol/matcher/MethodMatcherTest.java TEST_VM_OPTS="-XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+OptoScheduling"`
 - [x] tier1 -UCOH
 - [x] tier1 +UCOH


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381872](https://bugs.openjdk.org/browse/JDK-8381872): C2: assert before block local scheduling failed with UseCompactObjectHeaders (**Bug** - P3)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Contributors
 * Manuel Hässig `<mhaessig@openjdk.org>`
 * Quan Anh Mai `<qamai@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30762/head:pull/30762` \
`$ git checkout pull/30762`

Update a local copy of the PR: \
`$ git checkout pull/30762` \
`$ git pull https://git.openjdk.org/jdk.git pull/30762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30762`

View PR using the GUI difftool: \
`$ git pr show -t 30762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30762.diff">https://git.openjdk.org/jdk/pull/30762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30762#issuecomment-4259876928)
</details>
