### PR TITLE
8382338: Various serviceability agent tests fail on Linux x86_64 with LTO enabled

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -179,10 +179,6 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   ifneq ($(call isCompiler, microsoft), true)
     JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM)
   endif
-  # avoid elimination of Metadata vtable when using LTO (important for serviceability agent)
-  #ifeq ($(call isCompiler, gcc), true)
-  #  JVM_LDFLAGS_FEATURES += -Wl,--undefined=_ZTV8Metadata
-  #endif
 else
   JVM_LTO := false
   ifeq ($(call isCompiler, gcc), true)

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -179,6 +179,10 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   ifneq ($(call isCompiler, microsoft), true)
     JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM)
   endif
+  # avoid elimination of Metadata vtable when using LTO (important for serviceability agent)
+  #ifeq ($(call isCompiler, gcc), true)
+  #  JVM_LDFLAGS_FEATURES += -Wl,--undefined=_ZTV8Metadata
+  #endif
 else
   JVM_LTO := false
   ifeq ($(call isCompiler, gcc), true)

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -179,6 +179,10 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   ifneq ($(call isCompiler, microsoft), true)
     JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM)
   endif
+  # avoid elimination of Metadata vtable when using LTO (important for serviceability agent)
+  ifeq ($(call isCompiler, gcc), true)
+    JVM_LDFLAGS_FEATURES += -Wl,--undefined=_ZTV8Metadata
+  endif
 else
   JVM_LTO := false
   ifeq ($(call isCompiler, gcc), true)

--- a/src/hotspot/share/oops/metadata.cpp
+++ b/src/hotspot/share/oops/metadata.cpp
@@ -31,6 +31,11 @@ void Metadata::set_on_stack(const bool value) {
   // Can't inline because this materializes the vtable on some C++ compilers.
 }
 
+// Keep the vtable alive under LTGC dead-section removal / LTO
+Metadata::Metadata() {
+  NOT_PRODUCT(_valid = 0;)
+}
+
 void Metadata::print_on(outputStream* st) const {
   ResourceMark rm;
   // print title

--- a/src/hotspot/share/oops/metadata.cpp
+++ b/src/hotspot/share/oops/metadata.cpp
@@ -31,11 +31,6 @@ void Metadata::set_on_stack(const bool value) {
   // Can't inline because this materializes the vtable on some C++ compilers.
 }
 
-// Keep the vtable alive under LTGC dead-section removal / LTO
-Metadata::Metadata() {
-  NOT_PRODUCT(_valid = 0;)
-}
-
 void Metadata::print_on(outputStream* st) const {
   ResourceMark rm;
   // print title

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -34,7 +34,9 @@ class Metadata : public MetaspaceObj {
   // Debugging hook to check that the metadata has not been deleted.
   NOT_PRODUCT(int _valid;)
  public:
-  NOT_PRODUCT(Metadata() : _valid(0) {})
+  // Keep the vtable alive under LTGC dead-section removal / LTO
+  NOINLINE Metadata();
+
   NOT_PRODUCT(bool is_valid() const { return _valid == 0; })
 
   int identity_hash()                { return (int)(uintptr_t)this; }

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -35,6 +35,9 @@ class Metadata : public MetaspaceObj {
   NOT_PRODUCT(int _valid;)
  public:
   // Keep the vtable alive under LTGC dead-section removal / LTO
+#if defined(__GNUC__) || defined(__clang__)
+  [[gnu::retain]]
+#endif
   NOINLINE Metadata();
 
   NOT_PRODUCT(bool is_valid() const { return _valid == 0; })

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -35,9 +35,6 @@ class Metadata : public MetaspaceObj {
   NOT_PRODUCT(int _valid;)
  public:
   // Keep the vtable alive under LTGC dead-section removal / LTO
-#if defined(__GNUC__) || defined(__clang__)
-  [[gnu::retain]]
-#endif
   NOINLINE Metadata();
 
   NOT_PRODUCT(bool is_valid() const { return _valid == 0; })

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -34,6 +34,8 @@ class Metadata : public MetaspaceObj {
   // Debugging hook to check that the metadata has not been deleted.
   NOT_PRODUCT(int _valid;)
  public:
+  NOT_PRODUCT(Metadata() : _valid(0) {})
+
   // We have to keep the vtable alive under LTGC dead-section removal/LTO
   // for serviceability tests to work.
   // This can be done by linker settings or modifications to the Metadata class.

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,9 @@ class Metadata : public MetaspaceObj {
   // Debugging hook to check that the metadata has not been deleted.
   NOT_PRODUCT(int _valid;)
  public:
-  // Keep the vtable alive under LTGC dead-section removal / LTO
-  NOINLINE Metadata();
+  // We have to keep the vtable alive under LTGC dead-section removal/LTO
+  // for serviceability tests to work.
+  // This can be done by linker settings or modifications to the Metadata class.
 
   NOT_PRODUCT(bool is_valid() const { return _valid == 0; })
 


### PR DESCRIPTION
When building hotspot on linuxx86_64/gcc with LTO enabled (--enable-jvm-feature-link-time-opt), we get various test errors in the serviceability/sa area.
Example serviceability/sa/CDSJMapClstats.java

```
finding class loader instances ..java.lang.InternalError: Metadata does not appear to be polymorphic
at jdk.hotspot.agent/sun.jvm.hotspot.types.basic.BasicTypeDataBase.findDynamicTypeForAddress(BasicTypeDataBase.java:223)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.VirtualBaseConstructor.instantiateWrapperFor(VirtualBaseConstructor.java:104)
at jdk.hotspot.agent/sun.jvm.hotspot.oops.Metadata.instantiateWrapperFor(Metadata.java:77)
at jdk.hotspot.agent/sun.jvm.hotspot.memory.SystemDictionary.getClassLoaderKlass(SystemDictionary.java:102)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.ClassLoaderStats.printClassLoaderStatistics(ClassLoaderStats.java:93)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.ClassLoaderStats.run(ClassLoaderStats.java:78)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.run(JMap.java:121)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.startInternal(Tool.java:278)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.start(Tool.java:241)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.execute(Tool.java:134)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.main(JMap.java:202)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runJMAP(SALauncher.java:344)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:507)

```
Seems we have to avoid elimination of the Metadata vtable ; this can be achieved by linker flags or by modifying class Metadata.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382338](https://bugs.openjdk.org/browse/JDK-8382338): Various serviceability agent tests fail on Linux x86_64 with LTO enabled (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30771/head:pull/30771` \
`$ git checkout pull/30771`

Update a local copy of the PR: \
`$ git checkout pull/30771` \
`$ git pull https://git.openjdk.org/jdk.git pull/30771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30771`

View PR using the GUI difftool: \
`$ git pr show -t 30771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30771.diff">https://git.openjdk.org/jdk/pull/30771.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30771#issuecomment-4261093461)
</details>
