### PR TITLE
8382090: Remove .rej and .orig from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,6 @@ NashornProfile.txt
 /.gdbinit
 /.lldbinit
 **/core.[0-9]*
-*.rej
-*.orig
 test/benchmarks/**/target
 /src/hotspot/CMakeLists.txt
 /src/hotspot/compile_commands.json


### PR DESCRIPTION
Keeping `.rej` and `.orig` files visible to the developer is important. It helps minimizing human error when moving or applying source code changes.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382090](https://bugs.openjdk.org/browse/JDK-8382090): Remove .rej and .orig from .gitignore (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30772/head:pull/30772` \
`$ git checkout pull/30772`

Update a local copy of the PR: \
`$ git checkout pull/30772` \
`$ git pull https://git.openjdk.org/jdk.git pull/30772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30772`

View PR using the GUI difftool: \
`$ git pr show -t 30772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30772.diff">https://git.openjdk.org/jdk/pull/30772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30772#issuecomment-4261167876)
</details>
