### PR TITLE
8379620: G1: Typing error in jvmFlagConstraintsG1.cpp

### DIFF
--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -70,7 +70,7 @@ JVMFlag::Error G1RemSetHowlMaxNumBucketsConstraintFunc(uint value, bool verbose)
   }
   if (!is_power_of_2(G1RemSetHowlMaxNumBuckets)) {
     JVMFlag::printError(verbose,
-                        "G1RemSetMaxHowlNumBuckets (%u) must be a power of two.\n",
+                        "G1RemSetHowlMaxNumBuckets (%u) must be a power of two.\n",
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }


### PR DESCRIPTION
Hi all,

  please review this trivial fix of a typo in an error message.

Testing: local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8379620](https://bugs.openjdk.org/browse/JDK-8379620): G1: Typing error in jvmFlagConstraintsG1.cpp (**Bug** - P5)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30773/head:pull/30773` \
`$ git checkout pull/30773`

Update a local copy of the PR: \
`$ git checkout pull/30773` \
`$ git pull https://git.openjdk.org/jdk.git pull/30773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30773`

View PR using the GUI difftool: \
`$ git pr show -t 30773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30773.diff">https://git.openjdk.org/jdk/pull/30773.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30773#issuecomment-4261218177)
</details>
