### PR TITLE
8335355: Shenandoah: Fix race condition in gc/shenandoah/mxbeans/TestPauseNotifications.java

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -109,6 +109,8 @@ public class TestPauseNotifications {
 
     static final long HEAP_MB = 128;                           // adjust for test configuration above
     static final long TARGET_MB = Long.getLong("target", 2_000); // 2 Gb allocation
+    static final long STEP_MS = 1000;
+    static final int  SIZE = 100_000;
 
     static volatile Object sink;
 
@@ -160,24 +162,21 @@ public class TestPauseNotifications {
             ((NotificationEmitter) bean).addNotificationListener(listener, null, null);
         }
 
-        final int size = 100_000;
-        long count = TARGET_MB * 1024 * 1024 / (16 + 4 * size);
-
+        final long count = TARGET_MB * 1024 * 1024 / (16 + 4 * SIZE);
         for (int c = 0; c < count; c++) {
-            sink = new int[size];
+            sink = new int[SIZE];
         }
 
         // Look at test timeout to figure out how long we can wait without breaking into timeout.
         // Default to 1/4 of the remaining time in 1s steps.
-        final long STEP_MS = 1000;
-        long spentTimeNanos = System.nanoTime() - startTimeNanos;
-        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - (spentTimeNanos / 1_000_000L)) / STEP_MS / 4;
+        final long spentTimeNanos = System.nanoTime() - startTimeNanos;
+        final long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - (spentTimeNanos / 1_000_000L)) / STEP_MS / 4;
 
         long actualPauses = 0;
         long actualCycles = 0;
 
         // Wait until enough notifications are accrued to match minimum boundary.
-        long minExpected = 10;
+        final long minExpected = 10;
 
         long tries = 0;
         while (tries++ < maxTries) {
@@ -186,12 +185,19 @@ public class TestPauseNotifications {
             if (minExpected <= actualPauses && minExpected <= actualCycles) {
                 // Wait a little bit to catch the lingering notifications.
                 Thread.sleep(5000);
-                actualPauses = pausesCount.get();
-                actualCycles = cyclesCount.get();
                 break;
             }
             Thread.sleep(STEP_MS);
         }
+
+        for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            ((NotificationEmitter) bean).removeNotificationListener(listener);
+        }
+
+        actualPauses = pausesCount.get();
+        actualCycles = cyclesCount.get();
+        long actualPauseDuration = pausesDuration.get();
+        long actualCycleDuration = cyclesDuration.get();
 
         {
             String msg = "Pauses expected = [" + minExpected + "; +inf], actual = " + actualPauses;
@@ -212,11 +218,7 @@ public class TestPauseNotifications {
         }
 
         {
-            long actualPauseDuration = pausesDuration.get();
-            long actualCycleDuration = cyclesDuration.get();
-
             String msg = "Pauses duration (" + actualPauseDuration + ") is expected to be not larger than cycles duration (" + actualCycleDuration + ")";
-
             if (actualPauseDuration <= actualCycleDuration) {
                 System.out.println(msg);
             } else {


### PR DESCRIPTION
This test was making assertions about variables that could be modified concurrently by the gc notification listener thread. Pause notifications are emitted before cycle notifications, so the test could observe an increase in pause duration without the commensurate increase in cycle duration.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8335355](https://bugs.openjdk.org/browse/JDK-8335355): Shenandoah: Fix race condition in gc/shenandoah/mxbeans/TestPauseNotifications.java (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30774/head:pull/30774` \
`$ git checkout pull/30774`

Update a local copy of the PR: \
`$ git checkout pull/30774` \
`$ git pull https://git.openjdk.org/jdk.git pull/30774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30774`

View PR using the GUI difftool: \
`$ git pr show -t 30774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30774.diff">https://git.openjdk.org/jdk/pull/30774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30774#issuecomment-4262415519)
</details>
