### PR TITLE
8380060: C2: Wrong execution with COH and arraycopy

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -750,7 +750,6 @@ void BarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* si
     // per-instance slices (from escape analysis) pointing to the
     // pre-clone memory state via the Initialize's NarrowMemProj.
     kit->set_predefined_output_for_runtime_call(ac);
-    kit->set_all_memory_call(ac);
   } else {
     kit->set_all_memory(n);
   }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -742,9 +742,16 @@ void BarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* si
   }
   Node* n = kit->gvn().transform(ac);
   if (n == ac) {
-    const TypePtr* raw_adr_type = TypeRawPtr::BOTTOM;
     ac->set_adr_type(TypeRawPtr::BOTTOM);
-    kit->set_predefined_output_for_runtime_call(ac, ac->in(TypeFunc::Memory), raw_adr_type);
+    // The clone copies the entire object content. Set all memory slices
+    // to the clone's output so that subsequent typed loads see the
+    // clone's writes. Using set_predefined_output_for_runtime_call with
+    // TypeRawPtr::BOTTOM would only update the raw slice, leaving typed
+    // per-instance slices (from escape analysis) pointing to the
+    // pre-clone memory state via the Initialize's NarrowMemProj.
+    kit->set_control(kit->gvn().transform(new ProjNode(ac, TypeFunc::Control)));
+    Node* mem_proj = kit->gvn().transform(new ProjNode(ac, TypeFunc::Memory));
+    kit->set_all_memory(mem_proj);
   } else {
     kit->set_all_memory(n);
   }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -749,9 +749,8 @@ void BarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* si
     // TypeRawPtr::BOTTOM would only update the raw slice, leaving typed
     // per-instance slices (from escape analysis) pointing to the
     // pre-clone memory state via the Initialize's NarrowMemProj.
-    kit->set_control(kit->gvn().transform(new ProjNode(ac, TypeFunc::Control)));
-    Node* mem_proj = kit->gvn().transform(new ProjNode(ac, TypeFunc::Memory));
-    kit->set_all_memory(mem_proj);
+    kit->set_predefined_output_for_runtime_call(ac);
+    kit->set_all_memory_call(ac);
   } else {
     kit->set_all_memory(n);
   }

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -498,6 +498,7 @@ Node* ArrayCopyNode::array_copy_backward(PhaseGVN *phase,
   return phase->C->top();
 }
 
+// mem - the cumulative memory state of all stores of the decomposed clone
 bool ArrayCopyNode::finish_transform(PhaseGVN *phase, bool can_reshape,
                                      Node* ctl, Node *mem) {
   if (can_reshape) {
@@ -509,11 +510,15 @@ bool ArrayCopyNode::finish_transform(PhaseGVN *phase, bool can_reshape,
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       // Expected pattern: out_mem → MergeMem → MemBar, or
       // out_mem → MemBar (when MergeMem was folded away).
+      if (out_mem->outcnt() != 1) {
+        assert(bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, is_clone_inst(), BarrierSetC2::Optimization), "can only happen with card marking");
+        return false;
+      }
       Node* mem_use = out_mem->raw_out(0);
-      if (out_mem->outcnt() != 1 ||
-          (!mem_use->is_MemBar() &&
-           (!mem_use->is_MergeMem() ||
-            mem_use->outcnt() != 1 || !mem_use->raw_out(0)->is_MemBar()))) {
+      // Bail out unless mem_use is a MemBar, or it's a MergeMem with exactly one use that is a MemBar.
+      if (!(mem_use->is_MemBar() ||
+            (mem_use->is_MergeMem() &&
+             mem_use->outcnt() == 1 && mem_use->raw_out(0)->is_MemBar()))) {
         assert(bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, is_clone_inst(), BarrierSetC2::Optimization), "can only happen with card marking");
         return false;
       }

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -523,8 +523,8 @@ bool ArrayCopyNode::finish_transform(PhaseGVN *phase, bool can_reshape,
         return false;
       }
 
-      // Replace the MergeMem (or MemBar if MergeMem was folded) with
-      // the new memory from the decomposed clone.
+      // Replace the MergeMem (or the out_mem projection if MergeMem
+      // was folded) with the new memory from the decomposed clone.
       Node* replace_target = mem_use->is_MergeMem() ? mem_use : out_mem;
       igvn->replace_node(replace_target, mem);
 

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -507,13 +507,21 @@ bool ArrayCopyNode::finish_transform(PhaseGVN *phase, bool can_reshape,
       Node* out_mem = proj_out(TypeFunc::Memory);
 
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-      if (out_mem->outcnt() != 1 || !out_mem->raw_out(0)->is_MergeMem() ||
-          out_mem->raw_out(0)->outcnt() != 1 || !out_mem->raw_out(0)->raw_out(0)->is_MemBar()) {
+      // Expected pattern: out_mem → MergeMem → MemBar, or
+      // out_mem → MemBar (when MergeMem was folded away).
+      Node* mem_use = out_mem->raw_out(0);
+      if (out_mem->outcnt() != 1 ||
+          !(mem_use->is_MergeMem() || mem_use->is_MemBar()) ||
+          (mem_use->is_MergeMem() &&
+           (mem_use->outcnt() != 1 || !mem_use->raw_out(0)->is_MemBar()))) {
         assert(bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, is_clone_inst(), BarrierSetC2::Optimization), "can only happen with card marking");
         return false;
       }
 
-      igvn->replace_node(out_mem->raw_out(0), mem);
+      // Replace the MergeMem (or MemBar if MergeMem was folded) with
+      // the new memory from the decomposed clone.
+      Node* replace_target = mem_use->is_MergeMem() ? mem_use : out_mem;
+      igvn->replace_node(replace_target, mem);
 
       Node* out_ctl = proj_out(TypeFunc::Control);
       igvn->replace_node(out_ctl, ctl);

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -511,9 +511,9 @@ bool ArrayCopyNode::finish_transform(PhaseGVN *phase, bool can_reshape,
       // out_mem → MemBar (when MergeMem was folded away).
       Node* mem_use = out_mem->raw_out(0);
       if (out_mem->outcnt() != 1 ||
-          !(mem_use->is_MergeMem() || mem_use->is_MemBar()) ||
-          (mem_use->is_MergeMem() &&
-           (mem_use->outcnt() != 1 || !mem_use->raw_out(0)->is_MemBar()))) {
+          (!mem_use->is_MemBar() &&
+           (!mem_use->is_MergeMem() ||
+            mem_use->outcnt() != 1 || !mem_use->raw_out(0)->is_MemBar()))) {
         assert(bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, is_clone_inst(), BarrierSetC2::Optimization), "can only happen with card marking");
         return false;
       }

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1010,6 +1010,17 @@ bool PhaseMacroExpand::generate_block_arraycopy(Node** ctrl, MergeMemNode** mem,
     // This is a common case, since abase can be odd mod 8.
     if (((src_off | dest_off) & (BytesPerLong-1)) == BytesPerInt &&
         ((src_off ^ dest_off) & (BytesPerLong-1)) == 0) {
+      if (dest_uninitialized) {
+        // When the destination is an uninitialized tightly-coupled allocation,
+        // the typed load created here for the source can be incorrectly
+        // optimized to zero by the IGVN. This happens because the source
+        // array may have been initialized by an arraycopy (e.g. clone) that
+        // wrote to raw memory, while the typed memory slice still appears
+        // uninitialized. Bail out and let the arraycopy stub handle the
+        // unaligned copy. This is triggered by compact object headers where
+        // the array data offset (12) is not 8-byte aligned.
+        return false;
+      }
       Node* sptr = basic_plus_adr(src,  src_off);
       Node* dptr = basic_plus_adr(dest, dest_off, adr_type == TypeRawPtr::BOTTOM);
       const TypePtr* s_adr_type = _igvn.type(sptr)->is_ptr();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1010,17 +1010,6 @@ bool PhaseMacroExpand::generate_block_arraycopy(Node** ctrl, MergeMemNode** mem,
     // This is a common case, since abase can be odd mod 8.
     if (((src_off | dest_off) & (BytesPerLong-1)) == BytesPerInt &&
         ((src_off ^ dest_off) & (BytesPerLong-1)) == 0) {
-      if (dest_uninitialized) {
-        // When the destination is an uninitialized tightly-coupled allocation,
-        // the typed load created here for the source can be incorrectly
-        // optimized to zero by the IGVN. This happens because the source
-        // array may have been initialized by an arraycopy (e.g. clone) that
-        // wrote to raw memory, while the typed memory slice still appears
-        // uninitialized. Bail out and let the arraycopy stub handle the
-        // unaligned copy. This is triggered by compact object headers where
-        // the array data offset (12) is not 8-byte aligned.
-        return false;
-      }
       Node* sptr = basic_plus_adr(src,  src_off);
       Node* dptr = basic_plus_adr(dest, dest_off, adr_type == TypeRawPtr::BOTTOM);
       const TypePtr* s_adr_type = _igvn.type(sptr)->is_ptr();

--- a/test/hotspot/jtreg/compiler/arraycopy/TestBlockArrayCopyMisaligned.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestBlockArrayCopyMisaligned.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8380060
+ * @summary C2 block arraycopy initial-word pick-off folds load to zero
+ *
+ * @run main/othervm -Xbatch -XX:+UseCompactObjectHeaders
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestBlockArrayCopyMisaligned::test*
+ *                   compiler.arraycopy.TestBlockArrayCopyMisaligned
+ * @run main/othervm -Xbatch -XX:-UseCompactObjectHeaders
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestBlockArrayCopyMisaligned::test*
+ *                   compiler.arraycopy.TestBlockArrayCopyMisaligned
+ */
+
+package compiler.arraycopy;
+
+import java.util.Arrays;
+
+public class TestBlockArrayCopyMisaligned {
+
+    // Byte array with enough data to exercise the block arraycopy path.
+    // The clone + substring pattern triggers a tightly-coupled allocation
+    // where the source is initialized via a raw arraycopy (clone) and the
+    // destination is a nozero allocation filled by a block arraycopy.
+    static final byte[] BYTES = new byte[] {
+            108, 77, 120, 120, 100, 77, 105, 113,
+             83, 97,  71, 108, 116, 107,  90,  71,
+             72, 107,  73,  85,  54,  65,  61,  61
+    };
+
+    // Test via String(byte[],hibyte,off,count) + substring.
+    // The deprecated String constructor clones the byte array via
+    // Arrays.copyOfRange; substring then does another copyOfRange
+    // on the clone, triggering the block arraycopy optimization.
+    static String testStringSubstring() {
+        String s = new String(BYTES, 0, 0, 24);
+        return s.substring(0, 23);
+    }
+
+    // Test via explicit clone + Arrays.copyOfRange.
+    static byte[] testCloneCopyOfRange() {
+        byte[] clone = BYTES.clone();
+        return Arrays.copyOfRange(clone, 0, 23);
+    }
+
+    // Test via explicit clone + Arrays.copyOf.
+    static byte[] testCloneCopyOf() {
+        byte[] clone = BYTES.clone();
+        return Arrays.copyOf(clone, 20);
+    }
+
+    public static void main(String[] args) {
+        String golden = new String(BYTES, 0, 0, 23);
+
+        for (int i = 0; i < 10_000; i++) {
+            // Test 1: String path
+            String result1 = testStringSubstring();
+            if (!result1.equals(golden)) {
+                throw new RuntimeException("testStringSubstring: expected "
+                    + golden + ", got " + result1);
+            }
+
+            // Test 2: clone + copyOfRange
+            byte[] result2 = testCloneCopyOfRange();
+            for (int j = 0; j < 23; j++) {
+                if (result2[j] != BYTES[j]) {
+                    throw new RuntimeException("testCloneCopyOfRange: mismatch at index " + j
+                        + ", expected " + BYTES[j] + ", got " + result2[j]);
+                }
+            }
+
+            // Test 3: clone + copyOf
+            byte[] result3 = testCloneCopyOf();
+            for (int j = 0; j < 20; j++) {
+                if (result3[j] != BYTES[j]) {
+                    throw new RuntimeException("testCloneCopyOf: mismatch at index " + j
+                        + ", expected " + BYTES[j] + ", got " + result3[j]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
C2's generate_block_arraycopy miscompiles when compact object headers are enabled. With compact headers, arrayOopDesc::base_offset_in_bytes(T_BYTE) returns 12 instead of 16. Since 12 is not 8-byte aligned, the block arraycopy optimization picks off an initial 32-bit word via a typed LoadI/StoreI pair before switching to a long-word copy.

The LoadI reads from the source array using the typed memory slice. When the source array was initialized by a prior arraycopy (e.g. Arrays.copyOfRange optimized to a clone), that arraycopy wrote to raw memory. The typed memory slice does not reflect these raw writes. The IGVN folds the typed load to zero, corrupting the first 4 bytes of the copied array.

The initial-word pick-off path is only reached when the array data offset is not 8-byte aligned. Without compact headers the offset is 16 (aligned), so this path is never taken through standard library code. With compact headers it is always taken for byte/boolean/short/char/int/float arrays copied via tightly-coupled allocations.

The proposed fix is to make the clone AC update all memory slices, not just raw. This is already done for all other places where we create an ArrayCopyNode.

I also turned the Test.java test into a jtreg test (with some improvements to cover more scenarios).

Special thanks to Luca Ardueser, BSI Software AG who found and reported the issue, and helped with initial investigation and came up with a test-case.

Testing:
 - [x] the originally submitted test-case
 - [x] the new derived jtreg test
 - [x] tier1 (default)
 - [ ] tier1 (+UseCompactObjectHeaders)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380060](https://bugs.openjdk.org/browse/JDK-8380060): C2: Wrong execution with COH and arraycopy (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30775/head:pull/30775` \
`$ git checkout pull/30775`

Update a local copy of the PR: \
`$ git checkout pull/30775` \
`$ git pull https://git.openjdk.org/jdk.git pull/30775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30775`

View PR using the GUI difftool: \
`$ git pr show -t 30775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30775.diff">https://git.openjdk.org/jdk/pull/30775.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30775#issuecomment-4279204382)
</details>
