### PR TITLE
8382397: Make lint category property declaration more straightforward

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -25,14 +25,14 @@
 
 package com.sun.tools.javac.code;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -119,8 +119,6 @@ public class Lint {
     private EnumSet<LintCategory> values;
     private EnumSet<LintCategory> suppressedValues;
 
-    private static final Map<String, LintCategory> map = new LinkedHashMap<>(40);
-
     @SuppressWarnings("this-escape")
     protected Lint(Context context) {
         this.context = context;
@@ -202,7 +200,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        CLASSFILE("classfile", false, false),
+        CLASSFILE("classfile", Property.NO_ANNOTATION_SUPPRESSION),
 
         /**
          * Warn about "dangling" documentation comments,
@@ -219,7 +217,7 @@ public class Lint {
          * Warn about items which are documented with an {@code @deprecated} JavaDoc
          * comment, but which do not have {@code @Deprecated} annotation.
          */
-        DEP_ANN("dep-ann", true, true),
+        DEP_ANN("dep-ann", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about division by constant integer 0.
@@ -249,7 +247,7 @@ public class Lint {
         /**
          * Warn about uses of @ValueBased classes where an identity class is expected.
          */
-        IDENTITY("identity", true, true, "synchronization"),
+        IDENTITY(List.of("identity", "synchronization"), Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about use of incubating modules.
@@ -257,7 +255,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        INCUBATING("incubating", false, true),
+        INCUBATING("incubating", Property.NO_ANNOTATION_SUPPRESSION, Property.ENABLED_BY_DEFAULT),
 
         /**
           * Warn about compiler possible lossy conversions.
@@ -272,12 +270,12 @@ public class Lint {
         /**
          * Warn about module system related issues.
          */
-        MODULE("module", true, true),
+        MODULE("module", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about issues regarding module opens.
          */
-        OPENS("opens", true, true),
+        OPENS("opens", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about issues relating to use of command line options.
@@ -285,7 +283,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        OPTIONS("options", false, false),
+        OPTIONS("options", Property.NO_ANNOTATION_SUPPRESSION),
 
         /**
          * Warn when any output file is written to more than once.
@@ -293,7 +291,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        OUTPUT_FILE_CLASH("output-file-clash", false, false),
+        OUTPUT_FILE_CLASH("output-file-clash", Property.NO_ANNOTATION_SUPPRESSION),
 
         /**
          * Warn about issues regarding method overloads.
@@ -311,7 +309,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        PATH("path", false, false),
+        PATH("path", Property.NO_ANNOTATION_SUPPRESSION),
 
         /**
          * Warn about issues regarding annotation processing.
@@ -319,7 +317,7 @@ public class Lint {
          * <p>
          * This category is not supported by {@code @SuppressWarnings}.
          */
-        PROCESSING("processing", false, false),
+        PROCESSING("processing", Property.NO_ANNOTATION_SUPPRESSION),
 
         /**
          * Warn about unchecked operations on raw types.
@@ -329,7 +327,7 @@ public class Lint {
         /**
          * Warn about use of deprecated-for-removal items.
          */
-        REMOVAL("removal", true, true),
+        REMOVAL("removal", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about use of automatic modules in the requires clauses.
@@ -339,7 +337,7 @@ public class Lint {
         /**
          * Warn about automatic modules in requires transitive.
          */
-        REQUIRES_TRANSITIVE_AUTOMATIC("requires-transitive-automatic", true, true),
+        REQUIRES_TRANSITIVE_AUTOMATIC("requires-transitive-automatic", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about Serializable classes that do not provide a serial version ID.
@@ -354,7 +352,7 @@ public class Lint {
         /**
          * Warn about unnecessary uses of the strictfp modifier
          */
-        STRICTFP("strictfp", true, true),
+        STRICTFP("strictfp", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about issues relating to use of text blocks
@@ -384,27 +382,37 @@ public class Lint {
         /**
          * Warn about use of preview features.
          */
-        PREVIEW("preview", true, true),
+        PREVIEW("preview", Property.ENABLED_BY_DEFAULT),
 
         /**
          * Warn about use of restricted methods.
          */
         RESTRICTED("restricted");
 
-        LintCategory(String option) {
-            this(option, true, false);
+        enum Property { NO_ANNOTATION_SUPPRESSION, ENABLED_BY_DEFAULT }
+
+        LintCategory(String option, Property... properties) {
+            this(List.of(option), properties);
         }
 
-        LintCategory(String option, boolean annotationSuppression, boolean enabledByDefault, String... aliases) {
-            this.option = option;
-            this.annotationSuppression = annotationSuppression;
-            this.enabledByDefault = enabledByDefault;
-            ArrayList<String> optionList = new ArrayList<>(1 + aliases.length);
-            optionList.add(option);
-            Collections.addAll(optionList, aliases);
-            this.optionList = Collections.unmodifiableList(optionList);
-            this.optionList.forEach(ident -> map.put(ident, this));
+        LintCategory(List<String> options, Property... properties) {
+            this.option = options.getFirst();
+            this.optionList = options;
+            Set<Property> propertySet = properties.length == 0 ? Set.of() : EnumSet.copyOf(Arrays.asList(properties));
+            this.annotationSuppression = !propertySet.contains(Property.NO_ANNOTATION_SUPPRESSION);
+            this.enabledByDefault = propertySet.contains(Property.ENABLED_BY_DEFAULT);
         }
+
+        private static final SequencedMap<String, LintCategory> lookup = createLookup();
+
+        private static SequencedMap<String, LintCategory> createLookup() {
+            var map = new LinkedHashMap<String, LintCategory>();
+            for (var category : values()) {
+                category.optionList.forEach(id -> map.put(id, category));
+            }
+            return Collections.unmodifiableSequencedMap(map);
+        }
+
 
         /**
          * Get the {@link LintCategory} having the given command line option.
@@ -413,14 +421,14 @@ public class Lint {
          * @return corresponding {@link LintCategory}, or empty if none exists
          */
         public static Optional<LintCategory> get(String option) {
-            return Optional.ofNullable(map.get(option));
+            return Optional.ofNullable(lookup.get(option));
         }
 
         /**
          * Get all lint category option strings and aliases.
          */
-        public static Set<String> options() {
-            return Collections.unmodifiableSet(map.keySet());
+        public static SequencedSet<String> options() {
+            return lookup.sequencedKeySet();
         }
 
         public static EnumSet<LintCategory> newEmptySet() {


### PR DESCRIPTION
Lint category properties are now declared with confusing boolean variables. We can convert them to be enums to make these declarations more straightforward and easier to check in general.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382397](https://bugs.openjdk.org/browse/JDK-8382397): Make lint category property declaration more straightforward (**Enhancement** - P5)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30776/head:pull/30776` \
`$ git checkout pull/30776`

Update a local copy of the PR: \
`$ git checkout pull/30776` \
`$ git pull https://git.openjdk.org/jdk.git pull/30776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30776`

View PR using the GUI difftool: \
`$ git pr show -t 30776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30776.diff">https://git.openjdk.org/jdk/pull/30776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30776#issuecomment-4265260093)
</details>
