### PR TITLE
8381843: FileDialog:setFile() specification needs to be enhanced w.r.to file selection

### DIFF
--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -511,15 +511,15 @@ public class FileDialog extends Dialog {
      * When the dialog is shown, the specified file may be pre-selected.
      * The visible manifestation of this selection, if any, depends on factors
      * such as the file existence, the dialog mode, and the native platform.
-     * E.g., the file could be highlighted in the file list, or a
+     * For example, the file could be highlighted in the file list, or a
      * file name editbox could be populated with the file name.
      * <p>
      * This method accepts either a full file path, or a file name with an
      * extension if used together with the {@code setDirectory} method.
-     * It is platform specific how a full file path interacts with {@code setDirectory}.
+     * It is platform-specific how a full file path interacts with {@code setDirectory}.
      * It may be that the directory is always used instead of the file path, or
-     * the file path over-rides the directory, or even that the full file path
-     * is interpreted as a base file name. Therefore it is strongly recommended to
+     * the file path overrides the directory, or even that the full file path
+     * is interpreted as a base file name. Therefore, it is strongly recommended to
      * use {@code setDirectory} to set the folder and {@code setFile} to
      * set a base file name.
      * <p>

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -454,7 +454,7 @@ public class FileDialog extends Dialog {
      * "accept" the result of a {@code setFile} value or to edit in the name
      * of some other file to load/open even if it is not present.
      * Applications should therefore verify the file represented by the
-     * {@code String} exists.
+     * returned {@code String} exists.
      * The value is usually the basename, not a full path name.
      *
      * @return    the currently selected file of this file dialog window,
@@ -529,7 +529,7 @@ public class FileDialog extends Dialog {
      * <p>
      * It is also platform-specific as to what happens for {@code LOAD} mode of a non-existent file.
      * For example, it may be possible for the user to "accept" the {@code setFile} value or
-     * to edit in the name some other file to load/open even if it is not present.
+     * to edit in the name of some other file to load/open even if it is not present.
      * <p>
      * Specifying "" as the file is exactly equivalent to specifying
      * {@code null} as the file.
@@ -549,7 +549,7 @@ public class FileDialog extends Dialog {
     /**
      * Enables or disables multiple file selection for the file dialog.
      * <p>
-     * Multiple mode may be ignored in some cases, for example commonly
+     * Multiple mode may be ignored in some cases, for example, commonly
      * {@code SAVE} mode dialogs do not support it.
      *
      * @param enable    if {@code true}, multiple file selection is enabled;

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import sun.awt.AWTAccessor;
  * its {@code show} method to display the dialog,
  * it blocks the rest of the application until the user has
  * chosen a file.
+ * This means that {@link Dialog#setModalityType(ModalityType)} may be ignored.
  *
  * @see Window#show
  *
@@ -447,6 +448,12 @@ public class FileDialog extends Dialog {
     /**
      * Gets the selected file of this file dialog.  If the user
      * selected {@code CANCEL}, the returned file is {@code null}.
+     * <p>
+     * It is platform-specific as to what happens for {@code LOAD} mode of a non-existent file.
+     * For example, it may be possible for the user to "accept" the result of a {@code setFile} value or
+     * to edit in the name some other file to load/open even if it is not present.
+     * Applications should therefore verify the file represented by the {@code String} exists.
+     * The value is usually the basename, not a full path name.
      *
      * @return    the currently selected file of this file dialog window,
      *                or {@code null} if none is selected
@@ -501,13 +508,26 @@ public class FileDialog extends Dialog {
      * specified file. This file becomes the default file if it is set
      * before the file dialog window is first shown.
      * <p>
-     * When the dialog is shown, the specified file is selected. The kind of
-     * selection depends on the file existence, the dialog type, and the native
-     * platform. E.g., the file could be highlighted in the file list, or a
+     * When the dialog is shown, the specified file may be pre-selected.
+     * The visible manifestation of this selection, if any, depends on factors
+     * such as the file existence, the dialog mode, and the native platform.
+     * E.g., the file could be highlighted in the file list, or a
      * file name editbox could be populated with the file name.
      * <p>
      * This method accepts either a full file path, or a file name with an
      * extension if used together with the {@code setDirectory} method.
+     * It is platform specific how a full file path interacts with {@code setDirectory}.
+     * It may be that the directory is always used instead of the file path, or
+     * the file path over-rides the directory, or even that the full file path
+     * is interpreted as a base file name. Therefore it is strongly recommended to
+     * use {@code setDirectory} to set the folder and {@code setFile} to
+     * set a base file name.
+     * <p>
+     * Appearance and behaviours may also differ between {@code LOAD} and {@code SAVE} modes.
+     * <p>
+     * It is also platform-specific as to what happens for {@code LOAD} mode of a non-existent file.
+     * For example, it may be possible for the user to "accept" the {@code setFile} value or
+     * to edit in the name some other file to load/open even if it is not present.
      * <p>
      * Specifying "" as the file is exactly equivalent to specifying
      * {@code null} as the file.
@@ -526,6 +546,9 @@ public class FileDialog extends Dialog {
 
     /**
      * Enables or disables multiple file selection for the file dialog.
+     * <p>
+     * Multiple mode may be ignored in some cases, for example commonly
+     * {@code SAVE} mode dialogs do not support it.
      *
      * @param enable    if {@code true}, multiple file selection is enabled;
      *                  {@code false} - disabled.

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -450,8 +450,8 @@ public class FileDialog extends Dialog {
      * selected {@code CANCEL}, the returned file is {@code null}.
      * <p>
      * It is platform-specific as to what happens for {@code LOAD} mode of a non-existent file.
-     * For example, it may be possible for the user to "accept" the result of a {@code setFile} value or
-     * to edit in the name some other file to load/open even if it is not present.
+     * For example, it may be possible for the user to "accept" the result of a {@code setFile}
+     * value or to edit in the name some other file to load/open even if it is not present.
      * Applications should therefore verify the file represented by the {@code String} exists.
      * The value is usually the basename, not a full path name.
      *

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -449,10 +449,12 @@ public class FileDialog extends Dialog {
      * Gets the selected file of this file dialog.  If the user
      * selected {@code CANCEL}, the returned file is {@code null}.
      * <p>
-     * It is platform-specific as to what happens for {@code LOAD} mode of a non-existent file.
-     * For example, it may be possible for the user to "accept" the result of a {@code setFile}
-     * value or to edit in the name some other file to load/open even if it is not present.
-     * Applications should therefore verify the file represented by the {@code String} exists.
+     * It is platform-specific as to what happens for {@code LOAD} mode of a
+     * non-existent file. For example, it may be possible for the user to
+     * "accept" the result of a {@code setFile} value or to edit in the name
+     * of some other file to load/open even if it is not present.
+     * Applications should therefore verify the file represented by the
+     * {@code String} exists.
      * The value is usually the basename, not a full path name.
      *
      * @return    the currently selected file of this file dialog window,


### PR DESCRIPTION
It has been noted that the java.awt.FileDialog specification could be clearer that the UI showing a file as selected to load/open is not just variable in how it is done, the platform might not do it at all, and since FileDialog is (usually) a completely native component, we can only reinforce the platform is what decides if this is possible.

The CSR is ready for review.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))
- [x] Change requires CSR request [JDK-8382492](https://bugs.openjdk.org/browse/JDK-8382492) to be approved

### Issues
 * [JDK-8381843](https://bugs.openjdk.org/browse/JDK-8381843): FileDialog:setFile() specification needs to be enhanced w.r.to file selection (**Bug** - P3)
 * [JDK-8382492](https://bugs.openjdk.org/browse/JDK-8382492): FileDialog:setFile() specification needs to be enhanced w.r.to file selection (**CSR**)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [cc49a714](https://git.openjdk.org/jdk/pull/30777/files/cc49a714f49f6743cb66a4a0d52a66722c32a7e7)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30777/head:pull/30777` \
`$ git checkout pull/30777`

Update a local copy of the PR: \
`$ git checkout pull/30777` \
`$ git pull https://git.openjdk.org/jdk.git pull/30777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30777`

View PR using the GUI difftool: \
`$ git pr show -t 30777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30777.diff">https://git.openjdk.org/jdk/pull/30777.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30777#issuecomment-4263816766)
</details>
