### PR TITLE
8382359: Align 32-bit data in AOT Code Cache to sizeof(uint)

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -163,7 +163,7 @@
                                                                             \
   product(uint, AOTCodeMaxSize, 10*M, DIAGNOSTIC,                           \
           "Buffer size in bytes for AOT code caching")                      \
-          range(1*M, max_jint)                                              \
+          range(1*M, CODE_CACHE_SIZE_LIMIT)                                 \
                                                                             \
   product(bool, AbortVMOnAOTCodeFailure, false, DIAGNOSTIC,                 \
           "Abort VM on the first occurrence of AOT code load or store "     \

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -652,6 +652,10 @@ void AOTCodeReader::set_read_position(uint pos) {
   _read_position = pos;
 }
 
+uint AOTCodeReader::align_read_int() {
+  return align_up(_read_position, sizeof(int));
+}
+
 bool AOTCodeCache::set_write_position(uint pos) {
   if (pos == _write_position) {
     return true;
@@ -666,19 +670,27 @@ bool AOTCodeCache::set_write_position(uint pos) {
 
 static char align_buffer[256] = { 0 };
 
-bool AOTCodeCache::align_write() {
-  // We are not executing code from cache - we copy it by bytes first.
-  // No need for big alignment (or at all).
-  uint padding = DATA_ALIGNMENT - (_write_position & (DATA_ALIGNMENT - 1));
-  if (padding == DATA_ALIGNMENT) {
+bool AOTCodeCache::align_write_bytes(uint alignment) {
+  uint padding = alignment - (_write_position & (alignment - 1));
+  if (padding == alignment) {
     return true;
   }
   uint n = write_bytes((const void*)&align_buffer, padding);
   if (n != padding) {
     return false;
   }
-  log_trace(aot, codecache)("Adjust write alignment in AOT Code Cache");
+  log_trace(aot, codecache)("Adjust write alignment to %d bytes in AOT Code Cache", alignment);
   return true;
+}
+
+bool AOTCodeCache::align_write() {
+  // We are not executing code from cache - we copy it by bytes first.
+  // No need for big alignment (or at all).
+  return align_write_bytes(DATA_ALIGNMENT);
+}
+
+bool AOTCodeCache::align_write_int() {
+  return align_write_bytes(sizeof(int));
 }
 
 // Check to see if AOT code cache has required space to store "nbytes" of data
@@ -1012,19 +1024,8 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   }
   uint entry_position = cache->_write_position;
 
-  // Write name
-  uint name_offset = cache->_write_position - entry_position;
-  uint name_size = (uint)strlen(name) + 1; // Includes '/0'
-  uint n = cache->write_bytes(name, name_size);
-  if (n != name_size) {
-    return false;
-  }
-
-  // Write CodeBlob
-  if (!cache->align_write()) {
-    return false;
-  }
   uint blob_offset = cache->_write_position - entry_position;
+  // Code blob's size is aligned to oopSize
   address archive_buffer = cache->reserve_bytes(blob.size());
   if (archive_buffer == nullptr) {
     return false;
@@ -1056,7 +1057,7 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
     reloc_count = blob.relocation_size() / sizeof(relocInfo);
     reloc_data = (address)blob.relocation_begin();
   }
-  n = cache->write_bytes(&reloc_count, sizeof(int));
+  uint n = cache->write_bytes(&reloc_count, sizeof(int));
   if (n != sizeof(int)) {
     return false;
   }
@@ -1123,6 +1124,14 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   }
 #endif /* PRODUCT */
 
+  // Write name after code comments
+  uint name_offset = cache->_write_position - entry_position;
+  uint name_size = (uint)strlen(name) + 1; // Includes '/0'
+  n = cache->write_bytes(name, name_size);
+  if (n != name_size) {
+    return false;
+  }
+
   uint entry_size = cache->_write_position - entry_position;
 
   AOTCodeEntry* entry = new(cache) AOTCodeEntry(entry_kind, encode_id(entry_kind, id),
@@ -1151,6 +1160,9 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
 }
 
 bool AOTCodeCache::write_stub_data(CodeBlob &blob, AOTStubData *stub_data) {
+  if (!align_write_int()) {
+    return false;
+  }
   BlobId blob_id = stub_data->blob_id();
   StubId stub_id = StubInfo::stub_base(blob_id);
   address blob_base = blob.code_begin();
@@ -1320,7 +1332,8 @@ CodeBlob* AOTCodeReader::compile_code_blob(const char* name, AOTCodeEntry::Kind 
   CodeBlob* archived_blob = (CodeBlob*)addr(offset);
   offset += archived_blob->size();
 
-  _reloc_count = *(int*)addr(offset); offset += sizeof(int);
+  _reloc_count = *(int*)addr(offset);
+  offset += sizeof(int);
   if (AOTCodeEntry::is_multi_stub_blob(entry_kind)) {
     // position of relocs will have been aligned to heap word size so
     // we can install them into a code buffer
@@ -1443,7 +1456,7 @@ void AOTCodeReader::read_stub_data(CodeBlob* code_blob, AOTStubData* stub_data) 
 
   address blob_base = code_blob->code_begin();
   uint blob_size = (uint)(code_blob->code_end() - blob_base);
-  int offset = read_position();
+  uint offset = align_read_int();
   LogStreamHandle(Trace, aot, codecache, stubs) log;
   if (log.is_enabled()) {
     log.print_cr("======== Stub data starts at offset %d", offset);
@@ -1571,6 +1584,9 @@ void AOTCodeCache::publish_stub_addresses(CodeBlob &code_blob, BlobId blob_id, A
 #define BAD_ADDRESS_ID -2
 
 bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter) {
+  if (!align_write_int()) {
+    return false;
+  }
   GrowableArray<uint> reloc_data;
   LogStreamHandle(Trace, aot, codecache, reloc) log;
   while (iter.next()) {
@@ -1653,7 +1669,7 @@ bool AOTCodeCache::write_relocations(CodeBlob& code_blob, RelocIterator& iter) {
 }
 
 void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter) {
-  uint offset = read_position();
+  uint offset = align_read_int();
   int reloc_count = *(int*)addr(offset);
   offset += sizeof(int);
   uint* reloc_data = (uint*)addr(offset);
@@ -1726,6 +1742,9 @@ void AOTCodeReader::fix_relocations(CodeBlob *code_blob, RelocIterator& iter) {
 }
 
 bool AOTCodeCache::write_oop_map_set(CodeBlob& cb) {
+  if (!align_write_int()) {
+    return false;
+  }
   ImmutableOopMapSet* oopmaps = cb.oop_maps();
   int oopmaps_size = oopmaps->nr_of_bytes();
   if (!write_bytes(&oopmaps_size, sizeof(int))) {
@@ -1739,7 +1758,7 @@ bool AOTCodeCache::write_oop_map_set(CodeBlob& cb) {
 }
 
 ImmutableOopMapSet* AOTCodeReader::read_oop_map_set() {
-  uint offset = read_position();
+  uint offset = align_read_int();
   int size = *(int *)addr(offset);
   offset += sizeof(int);
   ImmutableOopMapSet* oopmaps = (ImmutableOopMapSet *)addr(offset);
@@ -1750,6 +1769,9 @@ ImmutableOopMapSet* AOTCodeReader::read_oop_map_set() {
 
 #ifndef PRODUCT
 bool AOTCodeCache::write_asm_remarks(CodeBlob& cb) {
+  if (!align_write_int()) {
+    return false;
+  }
   // Write asm remarks
   uint* count_ptr = (uint *)reserve_bytes(sizeof(uint));
   if (count_ptr == nullptr) {
@@ -1778,7 +1800,7 @@ bool AOTCodeCache::write_asm_remarks(CodeBlob& cb) {
 
 void AOTCodeReader::read_asm_remarks(AsmRemarks& asm_remarks) {
   // Read asm remarks
-  uint offset = read_position();
+  uint offset = align_read_int();
   uint count = *(uint *)addr(offset);
   offset += sizeof(uint);
   for (uint i = 0; i < count; i++) {
@@ -1793,6 +1815,9 @@ void AOTCodeReader::read_asm_remarks(AsmRemarks& asm_remarks) {
 }
 
 bool AOTCodeCache::write_dbg_strings(CodeBlob& cb) {
+  if (!align_write_int()) {
+    return false;
+  }
   // Write dbg strings
   uint* count_ptr = (uint *)reserve_bytes(sizeof(uint));
   if (count_ptr == nullptr) {
@@ -1817,7 +1842,7 @@ bool AOTCodeCache::write_dbg_strings(CodeBlob& cb) {
 
 void AOTCodeReader::read_dbg_strings(DbgStrings& dbg_strings) {
   // Read dbg strings
-  uint offset = read_position();
+  uint offset = align_read_int();
   uint count = *(uint *)addr(offset);
   offset += sizeof(uint);
   for (uint i = 0; i < count; i++) {

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -478,6 +478,8 @@ private:
 
   bool set_write_position(uint pos);
   bool align_write();
+  bool align_write_int();
+  bool align_write_bytes(uint alignment);
   address reserve_bytes(uint nbytes);
   uint write_bytes(const void* buffer, uint nbytes);
   const char* addr(uint offset) const { return _load_buffer + offset; }
@@ -643,6 +645,7 @@ private:
   uint  _read_position;              // Position in _load_buffer
   uint  read_position() const { return _read_position; }
   void  set_read_position(uint pos);
+  uint  align_read_int();
   const char* addr(uint offset) const { return _load_buffer + offset; }
 
   bool _lookup_failed;       // Failed to lookup for info (skip only this code load)


### PR DESCRIPTION
During initial AOT code caching development all values were stored and loaded by byte to not worry about alignment.

Later in development we start referenced data directly in AOT cache:
```
  int reloc_count = *(int*)addr(offset);
  offset += sizeof(int);
  uint* reloc_data = (uint*)addr(offset);
```
where `reloc_data` is array of `uint` values.

Most modern CPUs, for which we support AOT code caching, allow loading unaligned 32bit values. But it may not have optimal performance. Some future CPU may need such alignment when we add AOT code caching support.

I also noticed that max value for `AOTCodeMaxSize` flag is `max_jint`. I changed it to CODE_CACHE_SIZE_LIMIT which is the same (2Gb) but clear shows the meaning of the limit.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382359](https://bugs.openjdk.org/browse/JDK-8382359): Align 32-bit data in AOT Code Cache to sizeof(uint) (**Enhancement** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30779/head:pull/30779` \
`$ git checkout pull/30779`

Update a local copy of the PR: \
`$ git checkout pull/30779` \
`$ git pull https://git.openjdk.org/jdk.git pull/30779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30779`

View PR using the GUI difftool: \
`$ git pr show -t 30779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30779.diff">https://git.openjdk.org/jdk/pull/30779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30779#issuecomment-4264444678)
</details>
