### PR TITLE
8382393: Enable VectorStoreMaskIdentityTest.java IR tests for RISC-V

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorStoreMaskIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorStoreMaskIdentityTest.java
@@ -73,7 +73,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true" },
+        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", ">= 16" })
     public static void testVectorMaskStoreIdentityByte() {
         VectorMask<Byte> mask_byte_64 = VectorMask.fromArray(B64, mask_in, 0);
@@ -93,7 +93,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true" },
+        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", "> 16" })
     public static void testVectorMaskStoreIdentityByte256() {
         VectorMask<Byte> mask_byte_64 = VectorMask.fromArray(B64, mask_in, 0);
@@ -113,7 +113,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true" },
+        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", ">= 16" })
     public static void testVectorMaskStoreIdentityShort() {
         VectorMask<Short> mask_short_128 = VectorMask.fromArray(S128, mask_in, 0);
@@ -133,7 +133,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true" },
+        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", "> 16" })
     public static void testVectorMaskStoreIdentityShort256() {
         VectorMask<Short> mask_short_128 = VectorMask.fromArray(S128, mask_in, 0);
@@ -153,7 +153,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true" },
+        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", ">= 16" })
     public static void testVectorMaskStoreIdentityInt() {
         VectorMask<Integer> mask_int_128 = VectorMask.fromArray(I128, mask_in, 0);
@@ -173,7 +173,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true" },
+        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", "> 16" })
     public static void testVectorMaskStoreIdentityInt256() {
         VectorMask<Integer> mask_int_128 = VectorMask.fromArray(I128, mask_in, 0);
@@ -193,7 +193,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "asimd", "true" },
+        applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", ">= 16" })
     public static void testVectorMaskStoreIdentityLong() {
         VectorMask<Long> mask_long_128 = VectorMask.fromArray(L128, mask_in, 0);
@@ -213,7 +213,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true" },
+        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", "> 16" })
     public static void testVectorMaskStoreIdentityLong256() {
         VectorMask<Long> mask_long_256 = VectorMask.fromArray(L256, mask_in, 0);
@@ -233,7 +233,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true" },
+        applyIfCPUFeatureOr = { "asimd", "true", "avx", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", ">= 16" })
     public static void testVectorMaskStoreIdentityFloat() {
         VectorMask<Float> mask_float_128 = VectorMask.fromArray(F128, mask_in, 0);
@@ -253,7 +253,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true" },
+        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", "> 16" })
     public static void testVectorMaskStoreIdentityFloat256() {
         VectorMask<Float> mask_float_128 = VectorMask.fromArray(F128, mask_in, 0);
@@ -273,7 +273,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "asimd", "true" },
+        applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", ">= 16" })
     public static void testVectorMaskStoreIdentityDouble() {
         VectorMask<Double> mask_double_128 = VectorMask.fromArray(D128, mask_in, 0);
@@ -293,7 +293,7 @@ public class VectorStoreMaskIdentityTest {
                    IRNode.VECTOR_LOAD_MASK, "= 0",
                    IRNode.VECTOR_STORE_MASK, "= 0",
                    IRNode.VECTOR_MASK_CAST, "= 0" },
-        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true" },
+        applyIfCPUFeatureOr = { "sve", "true", "avx2", "true", "rvv", "true" },
         applyIf = { "MaxVectorSize", "> 16" })
     public static void testVectorMaskStoreIdentityDouble256() {
         VectorMask<Double> mask_double_256 = VectorMask.fromArray(D256, mask_in, 0);


### PR DESCRIPTION
Hi, please consider.

These IR tests was added by [JDK-8370863](https://bugs.openjdk.org/browse/JDK-8370863). It tests that vector mask cast chains preserve identity when stored to boolean arrays, and that redundant mask load/store/cast nodes are eliminated as expected. This enables it for the RISC-V platform.

Testing: run the same test using fastdebug build on linux-riscv64 (MaxVectorSize = 16 & MaxVectorSize = 32).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382393](https://bugs.openjdk.org/browse/JDK-8382393): Enable VectorStoreMaskIdentityTest.java IR tests for RISC-V (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30780/head:pull/30780` \
`$ git checkout pull/30780`

Update a local copy of the PR: \
`$ git checkout pull/30780` \
`$ git pull https://git.openjdk.org/jdk.git pull/30780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30780`

View PR using the GUI difftool: \
`$ git pr show -t 30780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30780.diff">https://git.openjdk.org/jdk/pull/30780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30780#issuecomment-4264659361)
</details>
