### PR TITLE
8382391: Cleanup unnecessary storestore() in stringStream::as_string

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -425,11 +425,6 @@ char* stringStream::as_string(bool c_heap) const {
     NEW_C_HEAP_ARRAY(char, _written + 1, mtInternal) : NEW_RESOURCE_ARRAY(char, _written + 1);
   ::memcpy(copy, _buffer, _written);
   copy[_written] = '\0';  // terminating null
-  if (c_heap) {
-    // Need to ensure our content is written to memory before we return
-    // the pointer to it.
-    OrderAccess::storestore();
-  }
   return copy;
 }
 


### PR DESCRIPTION
Very simple cleanup that removes an unnecessary `storestore` that should have been removed years ago. See JBS for details.

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382391](https://bugs.openjdk.org/browse/JDK-8382391): Cleanup unnecessary storestore() in stringStream::as_string (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30781/head:pull/30781` \
`$ git checkout pull/30781`

Update a local copy of the PR: \
`$ git checkout pull/30781` \
`$ git pull https://git.openjdk.org/jdk.git pull/30781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30781`

View PR using the GUI difftool: \
`$ git pr show -t 30781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30781.diff">https://git.openjdk.org/jdk/pull/30781.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30781#issuecomment-4264729699)
</details>
