### PR TITLE
8382368: Warning that @Deprecated "has no effect" is suppressed by @Deprecated

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,13 @@ import java.util.stream.Stream;
 
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Names;
 import com.sun.tools.javac.util.Options;
+
+import static com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag.DEFAULT_ENABLED;
+import static com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag.DEPRECATION_SENSITIVE;
 
 /**
  * A class for handling -Xlint suboptions and @SuppressWarnings.
@@ -76,8 +80,9 @@ public class Lint {
      */
     public Lint augment(Symbol sym) {
         EnumSet<LintCategory> suppressions = suppressionsFrom(sym);
-        if (!suppressions.isEmpty()) {
-            Lint lint = new Lint(this);
+        boolean symWithinDeprecated = withinDeprecated || isDeprecatedDeclaration(sym);
+        if (!suppressions.isEmpty() || symWithinDeprecated != withinDeprecated) {
+            Lint lint = new Lint(this, symWithinDeprecated);
             lint.values.removeAll(suppressions);
             lint.suppressedValues.addAll(suppressions);
             return lint;
@@ -90,10 +95,14 @@ public class Lint {
      * @param lc one or more categories to be enabled
      */
     public Lint enable(LintCategory... lc) {
-        Lint l = new Lint(this);
+        Lint l = new Lint(this, withinDeprecated);
         l.values.addAll(Arrays.asList(lc));
         l.suppressedValues.removeAll(Arrays.asList(lc));
         return l;
+    }
+
+    public static boolean isDeprecatedDeclaration(Symbol sym) {
+        return sym.isDeprecated() && sym.isDeprecatableViaAnnotation();
     }
 
     /**
@@ -101,7 +110,7 @@ public class Lint {
      * @param lc one or more categories to be suppressed
      */
     public Lint suppress(LintCategory... lc) {
-        Lint l = new Lint(this);
+        Lint l = new Lint(this, withinDeprecated);
         l.values.removeAll(Arrays.asList(lc));
         l.suppressedValues.addAll(Arrays.asList(lc));
         return l;
@@ -118,6 +127,7 @@ public class Lint {
     // Invariant: it's never the case that a category is in both "values" and "suppressedValues"
     private EnumSet<LintCategory> values;
     private EnumSet<LintCategory> suppressedValues;
+    private final boolean withinDeprecated;
 
     private static final Map<String, LintCategory> map = new LinkedHashMap<>(40);
 
@@ -127,10 +137,11 @@ public class Lint {
         context.put(lintKey, this);
         options = Options.instance(context);
         log = Log.instance(context);
+        withinDeprecated = false;
     }
 
     // Instantiate a non-root ("symbol scoped") instance
-    protected Lint(Lint other) {
+    protected Lint(Lint other, boolean withinDeprecated) {
         other.initializeRootIfNeeded();
         this.context = other.context;
         this.options = other.options;
@@ -139,6 +150,7 @@ public class Lint {
         this.names = other.names;
         this.values = other.values.clone();
         this.suppressedValues = other.suppressedValues.clone();
+        this.withinDeprecated = withinDeprecated;
     }
 
     // Process command line options on demand to allow use of root Lint early during startup
@@ -444,6 +456,32 @@ public class Lint {
     }
 
     /**
+     * Determine if the given diagnostic should be emitted given the state of this instance.
+     */
+    public boolean shouldEmit(JCDiagnostic diag) {
+
+        // Check category
+        LintCategory category = diag.getLintCategory();
+        if (category == null)
+            return true;
+
+        // Certain warnings within @Deprecated declarations are automatically suppressed (JLS 9.6.4.6)
+        if (withinDeprecated && diag.isFlagSet(DEPRECATION_SENSITIVE))
+            return false;
+
+        // If the warning is not enabled by default, then emit only when its lint category is explicitly enabled
+        if (!diag.isFlagSet(DEFAULT_ENABLED))
+            return isEnabled(category);
+
+        // If the lint category doesn't support @SuppressWarnings, then we just check the -Xlint:category flag
+        if (!category.annotationSuppression)
+            return !options.isDisabled(Option.XLINT, category);
+
+        // Check whether the lint category is currently suppressed
+        return !isSuppressed(category);
+    }
+
+    /**
      * Checks if a warning category is enabled. A warning category may be enabled
      * on the command line, or by default, and can be temporarily disabled with
      * the SuppressWarnings annotation.
@@ -454,10 +492,7 @@ public class Lint {
     }
 
     /**
-     * Checks is a warning category has been specifically suppressed, by means
-     * of the SuppressWarnings annotation, or, in the case of the deprecated
-     * category, whether it has been implicitly suppressed by virtue of the
-     * current entity being itself deprecated.
+     * Check if a warning category has been specifically suppressed by means of @SuppressWarnings.
      */
     public boolean isSuppressed(LintCategory lc) {
         initializeRootIfNeeded();
@@ -468,17 +503,13 @@ public class Lint {
      * Obtain the set of recognized lint warning categories suppressed at the given symbol's declaration.
      *
      * <p>
-     * This set can be non-empty only if the symbol is annotated with either
-     * @SuppressWarnings or @Deprecated.
+     * This set can be non-empty only if the symbol is annotated with @SuppressWarnings.
      *
      * @param symbol symbol corresponding to a possibly-annotated declaration
      * @return new warning suppressions applied to sym
      */
     public EnumSet<LintCategory> suppressionsFrom(Symbol symbol) {
-        EnumSet<LintCategory> suppressions = suppressionsFrom(symbol.getDeclarationAttributes().stream());
-        if (symbol.isDeprecated() && symbol.isDeprecatableViaAnnotation())
-            suppressions.add(LintCategory.DEPRECATION);
-        return suppressions;
+        return suppressionsFrom(symbol.getDeclarationAttributes().stream());
     }
 
     // Find the @SuppressWarnings annotation in the given stream and extract the recognized suppressions

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -105,7 +105,9 @@ public class Lint {
     private Symtab syms;
     private Names names;
 
-    // Invariant: it's never the case that a category is in both "values" and "suppressedValues"
+    // Invariants:
+    //  - It's never the case that a category is in both "values" and "suppressedValues"
+    //  - All categories in "suppressedValues" have annotationSuppression = true
     private EnumSet<LintCategory> values;
     private EnumSet<LintCategory> suppressedValues;
     private boolean withinDeprecated;
@@ -475,6 +477,10 @@ public class Lint {
 
     /**
      * Check if a warning category has been specifically suppressed by means of @SuppressWarnings.
+     *
+     * <p>
+     * Always returns false for categories that are not suppressible by the annotation, even
+     * if they (uselessly) happen to appear in one.
      */
     public boolean isSuppressed(LintCategory lc) {
         initializeRootIfNeeded();
@@ -485,7 +491,8 @@ public class Lint {
      * Obtain the set of recognized lint warning categories suppressed at the given symbol's declaration.
      *
      * <p>
-     * This set can be non-empty only if the symbol is annotated with @SuppressWarnings.
+     * This set can be non-empty only if the symbol is annotated with @SuppressWarnings, and only categories
+     * for which {@code annotationSuppression} is true are included.
      *
      * @param symbol symbol corresponding to a possibly-annotated declaration
      * @return new warning suppressions applied to sym

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import com.sun.tools.javac.main.Option;
+import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.Log;
@@ -445,8 +446,10 @@ public class Lint {
             return true;
 
         // Certain warnings within @Deprecated declarations are automatically suppressed (JLS 9.6.4.6)
-        if (withinDeprecated && diag.isFlagSet(DEPRECATION_SENSITIVE))
+        if (withinDeprecated && diag.isFlagSet(DEPRECATION_SENSITIVE)) {
+            Assert.check(diag.isFlagSet(DEFAULT_ENABLED) && category.annotationSuppression);
             return false;
+        }
 
         // If the warning is not enabled by default, then emit only when its lint category is explicitly enabled
         if (!diag.isFlagSet(DEFAULT_ENABLED))

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -160,7 +160,7 @@ public class Lint {
     @Override
     public String toString() {
         initializeRootIfNeeded();
-        return "Lint:[enable" + values + ",suppress" + suppressedValues + "]";
+        return "Lint:[enable" + values + ",suppress" + suppressedValues + ",deprecated=" + withinDeprecated + "]";
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -82,12 +82,18 @@ public class Lint {
         EnumSet<LintCategory> suppressions = suppressionsFrom(sym);
         boolean symWithinDeprecated = withinDeprecated || isDeprecatedDeclaration(sym);
         if (!suppressions.isEmpty() || symWithinDeprecated != withinDeprecated) {
-            Lint lint = new Lint(this, symWithinDeprecated);
+            Lint lint = new Lint(this);
             lint.values.removeAll(suppressions);
             lint.suppressedValues.addAll(suppressions);
+            lint.withinDeprecated = symWithinDeprecated;
             return lint;
         }
         return this;
+    }
+
+    // Does sym's declaration have a (non-useless) @Deprecated annotation?
+    public static boolean isDeprecatedDeclaration(Symbol sym) {
+        return sym.isDeprecated() && sym.isDeprecatableViaAnnotation();
     }
 
     /**
@@ -95,14 +101,10 @@ public class Lint {
      * @param lc one or more categories to be enabled
      */
     public Lint enable(LintCategory... lc) {
-        Lint l = new Lint(this, withinDeprecated);
+        Lint l = new Lint(this);
         l.values.addAll(Arrays.asList(lc));
         l.suppressedValues.removeAll(Arrays.asList(lc));
         return l;
-    }
-
-    public static boolean isDeprecatedDeclaration(Symbol sym) {
-        return sym.isDeprecated() && sym.isDeprecatableViaAnnotation();
     }
 
     /**
@@ -110,7 +112,7 @@ public class Lint {
      * @param lc one or more categories to be suppressed
      */
     public Lint suppress(LintCategory... lc) {
-        Lint l = new Lint(this, withinDeprecated);
+        Lint l = new Lint(this);
         l.values.removeAll(Arrays.asList(lc));
         l.suppressedValues.addAll(Arrays.asList(lc));
         return l;
@@ -127,7 +129,7 @@ public class Lint {
     // Invariant: it's never the case that a category is in both "values" and "suppressedValues"
     private EnumSet<LintCategory> values;
     private EnumSet<LintCategory> suppressedValues;
-    private final boolean withinDeprecated;
+    private boolean withinDeprecated;
 
     private static final Map<String, LintCategory> map = new LinkedHashMap<>(40);
 
@@ -137,11 +139,10 @@ public class Lint {
         context.put(lintKey, this);
         options = Options.instance(context);
         log = Log.instance(context);
-        withinDeprecated = false;
     }
 
-    // Instantiate a non-root ("symbol scoped") instance
-    protected Lint(Lint other, boolean withinDeprecated) {
+    // Copy constructor - used to instantiate a non-root ("symbol scoped") instances
+    protected Lint(Lint other) {
         other.initializeRootIfNeeded();
         this.context = other.context;
         this.options = other.options;
@@ -150,7 +151,7 @@ public class Lint {
         this.names = other.names;
         this.values = other.values.clone();
         this.suppressedValues = other.suppressedValues.clone();
-        this.withinDeprecated = withinDeprecated;
+        this.withinDeprecated = other.withinDeprecated;
     }
 
     // Process command line options on demand to allow use of root Lint early during startup

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -96,28 +96,6 @@ public class Lint {
         return sym.isDeprecated() && sym.isDeprecatableViaAnnotation();
     }
 
-    /**
-     * Returns a new Lint that has the given LintCategorys enabled.
-     * @param lc one or more categories to be enabled
-     */
-    public Lint enable(LintCategory... lc) {
-        Lint l = new Lint(this);
-        l.values.addAll(Arrays.asList(lc));
-        l.suppressedValues.removeAll(Arrays.asList(lc));
-        return l;
-    }
-
-    /**
-     * Returns a new Lint that has the given LintCategorys suppressed.
-     * @param lc one or more categories to be suppressed
-     */
-    public Lint suppress(LintCategory... lc) {
-        Lint l = new Lint(this);
-        l.values.removeAll(Arrays.asList(lc));
-        l.suppressedValues.addAll(Arrays.asList(lc));
-        return l;
-    }
-
     private final Context context;
     private final Options options;
     private final Log log;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1960,7 +1960,7 @@ compiler.warn.incubating.modules=\
 
 # 0: symbol, 1: symbol
 # lint: deprecation
-# flags: aggregate, mandatory, default-enabled
+# flags: aggregate, mandatory, default-enabled, deprecation-sensitive
 compiler.warn.has.been.deprecated=\
     {0} in {1} has been deprecated
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -436,6 +436,10 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
          *  is not explicitly enabled, as long as it is not explicitly suppressed.
          */
         DEFAULT_ENABLED,
+        /** Flag for warnings that are automatically suppressed when they occur inside
+         *  a declaration that is itself annotated as @Deprecated. See JLS 9.6.4.6.
+         */
+        DEPRECATION_SENSITIVE,
         /** Flags mandatory warnings that should pass through a mandatory warning aggregator.
          */
         AGGREGATE,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,16 +174,8 @@ public class Log extends AbstractLog {
             }
 
             // Apply the lint configuration (if any) and discard the warning if it gets filtered out
-            if (lint != null) {
-                LintCategory category = diag.getLintCategory();
-                boolean emit = !diag.isFlagSet(DEFAULT_ENABLED) ?       // is the warning not enabled by default?
-                  lint.isEnabled(category) :                            // then emit if the category is enabled
-                  category.annotationSuppression ?                      // else emit if the category is not suppressed, where
-                    !lint.isSuppressed(category) :                      // ...suppression happens via @SuppressWarnings
-                    !options.isDisabled(Option.XLINT, category);        // ...suppression happens via -Xlint:-category
-                if (!emit)
-                    return;
-            }
+            if (lint != null && !lint.shouldEmit(diag))
+                return;
 
             // Proceed
             reportReady(diag);

--- a/test/langtools/tools/javac/warnings/DeprecatedNoEffect.java
+++ b/test/langtools/tools/javac/warnings/DeprecatedNoEffect.java
@@ -1,0 +1,14 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8382368
+ * @compile/ref=DeprecatedNoEffect.out -Xlint:deprecation -XDrawDiagnostics DeprecatedNoEffect.java
+ */
+public class DeprecatedNoEffect {
+  void m1() {
+    @Deprecated int i1;    // there should be a "has no effect" warning here
+  }
+  @Deprecated
+  void m2() {
+    @Deprecated int i2;    // there should be a "has no effect" warning here also
+  }
+}

--- a/test/langtools/tools/javac/warnings/DeprecatedNoEffect.out
+++ b/test/langtools/tools/javac/warnings/DeprecatedNoEffect.out
@@ -1,0 +1,3 @@
+DeprecatedNoEffect.java:8:21: compiler.warn.deprecated.annotation.has.no.effect: kindname.variable
+DeprecatedNoEffect.java:12:21: compiler.warn.deprecated.annotation.has.no.effect: kindname.variable
+2 warnings


### PR DESCRIPTION
JLS §9.6.4.6 says that warnings about references to deprecated symbols (where `forRemoval = false`) should be automatically suppressed by the compiler if those references appear within the scope of a declaration that is itself annotated with `@Deprecated`.

The compiler implements this by suppressing the entire `DEPRECATION` lint category. That almost works, except that lint category contains three warnings but only two of them are deprecation warnings. The other is the warning for a `@Deprecated` annotation that has no effect (`@Deprecated annotation has no effect on this ... declaration`).

As a result, the compiler also suppresses any "has no effect" warnings that appear within the scope of a `@Deprecated` declaration, which is incorrect.

This patch replaces the lint category strategy with one based on the `DiagnosticFlag` mechanism.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382368](https://bugs.openjdk.org/browse/JDK-8382368): Warning that @<!---->Deprecated "has no effect" is suppressed by @<!---->Deprecated (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30782/head:pull/30782` \
`$ git checkout pull/30782`

Update a local copy of the PR: \
`$ git checkout pull/30782` \
`$ git pull https://git.openjdk.org/jdk.git pull/30782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30782`

View PR using the GUI difftool: \
`$ git pr show -t 30782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30782.diff">https://git.openjdk.org/jdk/pull/30782.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30782#issuecomment-4264937787)
</details>
