### PR TITLE
8382396: RepaintManager throws NPE when painting detached JPanel without volatile buffering

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/RepaintManager.java
+++ b/src/java.desktop/share/classes/javax/swing/RepaintManager.java
@@ -1026,7 +1026,7 @@ public class RepaintManager
 
         // If the window is non-opaque, it's double-buffered at peer's level
         Window w = (c instanceof Window) ? (Window)c : SwingUtilities.getWindowAncestor(c);
-        if (!w.isOpaque()) {
+        if (w != null && !w.isOpaque()) {
             Toolkit tk = Toolkit.getDefaultToolkit();
             if ((tk instanceof SunToolkit) && (((SunToolkit)tk).needUpdateWindow())) {
                 return null;

--- a/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
+++ b/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,12 @@
  */
 
 /* @test
- * @bug 8170794
+ * @bug 8170794 8382396
  * @key headful
  * @summary Verifies iconifying internalframe after setting DesktopManager
  *          does not return NPE
- *  @run main TestDesktopManagerNPE
+ * @run main -Dswing.volatileImageBufferEnabled=false TestDesktopManagerNPE
+ * @run main -Dswing.volatileImageBufferEnabled=true TestDesktopManagerNPE
  */
 
 import java.awt.Dimension;

--- a/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
+++ b/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
+++ b/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
@@ -37,11 +37,6 @@ import javax.swing.DefaultDesktopManager;
 import javax.swing.JInternalFrame;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JMenuBar;
-import javax.swing.KeyStroke;
-import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 public class TestDesktopManagerNPE {

--- a/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
+++ b/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
@@ -26,8 +26,8 @@
  * @key headful
  * @summary Verifies iconifying internalframe after setting DesktopManager
  *          does not return NPE
- * @run main -Dswing.volatileImageBufferEnabled=false TestDesktopManagerNPE
- * @run main -Dswing.volatileImageBufferEnabled=true TestDesktopManagerNPE
+ * @run main TestDesktopManagerNPE
+ * @run main/othervm -Dswing.volatileImageBufferEnabled=false TestDesktopManagerNPE
  */
 
 import java.awt.Dimension;

--- a/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
+++ b/test/jdk/javax/swing/JDesktopPane/TestDesktopManagerNPE.java
@@ -41,6 +41,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JMenuBar;
 import javax.swing.KeyStroke;
+import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 public class TestDesktopManagerNPE {


### PR DESCRIPTION
This adds a null check in case SwingUtilities.getWindowAncestor is null.

Although I developed a jtreg test in the original ticket write-up for 8382396, I later realized I can just ask the preexisting test for JDK-8170794 to run with different VM options to help test this issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382396](https://bugs.openjdk.org/browse/JDK-8382396): RepaintManager throws NPE when painting detached JPanel without volatile buffering (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30783/head:pull/30783` \
`$ git checkout pull/30783`

Update a local copy of the PR: \
`$ git checkout pull/30783` \
`$ git pull https://git.openjdk.org/jdk.git pull/30783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30783`

View PR using the GUI difftool: \
`$ git pr show -t 30783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30783.diff">https://git.openjdk.org/jdk/pull/30783.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30783#issuecomment-4265090872)
</details>
