### PR TITLE
8382395: Disable stringop-overflow in shenandoahGenerationalHeap.cpp

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -209,6 +209,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_macroAssembler_ppc_sha.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
+    DISABLED_WARNINGS_gcc_shenandoahGenerationalHeap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_stubGenerator_s390.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \


### PR DESCRIPTION
After JDK-8381382, GCC 13.3.0 fails to compile
shenandoahGenerationalHeap.cpp on Ubuntu 24.04 + AArch64.

It's a weird GCC bug. See the previous discussion in [1].

Similar to JDK-8326717 and JDK-8320212, we disable this warning for the affected file as well.

[1] https://github.com/openjdk/jdk/pull/26067#issuecomment-3030839463




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382395](https://bugs.openjdk.org/browse/JDK-8382395): Disable stringop-overflow in shenandoahGenerationalHeap.cpp (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30784/head:pull/30784` \
`$ git checkout pull/30784`

Update a local copy of the PR: \
`$ git checkout pull/30784` \
`$ git pull https://git.openjdk.org/jdk.git pull/30784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30784`

View PR using the GUI difftool: \
`$ git pr show -t 30784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30784.diff">https://git.openjdk.org/jdk/pull/30784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30784#issuecomment-4265534530)
</details>
