### PR TITLE
8382401: Remove return type parameters from FREE_ and REALLOC_ macros

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2527,7 +2527,7 @@ const char* VM_Version::cpu_brand_string(void) {
     }
     int ret_val = cpu_extended_brand_string(_cpu_brand_string, CPU_EBS_MAX_LENGTH);
     if (ret_val != OS_OK) {
-      FREE_C_HEAP_ARRAY(char, _cpu_brand_string);
+      FREE_C_HEAP_ARRAY(_cpu_brand_string);
       _cpu_brand_string = nullptr;
     }
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -578,13 +578,13 @@ void os::init_system_properties_values() {
   char *ld_library_path = NEW_C_HEAP_ARRAY(char, pathsize, mtInternal);
   os::snprintf_checked(ld_library_path, pathsize, "%s%s" DEFAULT_LIBPATH, v, v_colon);
   Arguments::set_library_path(ld_library_path);
-  FREE_C_HEAP_ARRAY(char, ld_library_path);
+  FREE_C_HEAP_ARRAY(ld_library_path);
 
   // Extensions directories.
   os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
 
 #undef DEFAULT_LIBPATH
 #undef EXTENSIONS_DIR

--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -258,10 +258,10 @@ bool CPUPerformanceInterface::CPUPerformance::initialize() {
 
 CPUPerformanceInterface::CPUPerformance::~CPUPerformance() {
   if (_lcpu_names) {
-    FREE_C_HEAP_ARRAY(perfstat_id_t, _lcpu_names);
+    FREE_C_HEAP_ARRAY(_lcpu_names);
   }
   if (_prev_ticks) {
-    FREE_C_HEAP_ARRAY(cpu_tick_store_t, _prev_ticks);
+    FREE_C_HEAP_ARRAY(_prev_ticks);
   }
 }
 
@@ -511,12 +511,12 @@ CPUInformationInterface::~CPUInformationInterface() {
   if (_cpu_info != nullptr) {
     if (_cpu_info->cpu_name() != nullptr) {
       const char* cpu_name = _cpu_info->cpu_name();
-      FREE_C_HEAP_ARRAY(char, cpu_name);
+      FREE_C_HEAP_ARRAY(cpu_name);
       _cpu_info->set_cpu_name(nullptr);
     }
     if (_cpu_info->cpu_description() != nullptr) {
        const char* cpu_desc = _cpu_info->cpu_description();
-       FREE_C_HEAP_ARRAY(char, cpu_desc);
+       FREE_C_HEAP_ARRAY(cpu_desc);
       _cpu_info->set_cpu_description(nullptr);
     }
     delete _cpu_info;
@@ -576,7 +576,7 @@ int NetworkPerformanceInterface::NetworkPerformance::network_utilization(Network
 
   // check for error
   if (n_records < 0) {
-    FREE_C_HEAP_ARRAY(perfstat_netinterface_t, net_stats);
+    FREE_C_HEAP_ARRAY(net_stats);
     return OS_ERR;
   }
 
@@ -593,7 +593,7 @@ int NetworkPerformanceInterface::NetworkPerformance::network_utilization(Network
     *network_interfaces = new_interface;
   }
 
-  FREE_C_HEAP_ARRAY(perfstat_netinterface_t, net_stats);
+  FREE_C_HEAP_ARRAY(net_stats);
   return OS_OK;
 }
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -444,14 +444,14 @@ void os::init_system_properties_values() {
     char *ld_library_path = NEW_C_HEAP_ARRAY(char, ld_library_path_size, mtInternal);
     os::snprintf_checked(ld_library_path, ld_library_path_size, "%s%s" SYS_EXT_DIR "/lib/%s:" DEFAULT_LIBPATH, v, v_colon, cpu_arch);
     Arguments::set_library_path(ld_library_path);
-    FREE_C_HEAP_ARRAY(char, ld_library_path);
+    FREE_C_HEAP_ARRAY(ld_library_path);
   }
 
   // Extensions directories.
   os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
 
 #else // __APPLE__
 
@@ -538,7 +538,7 @@ void os::init_system_properties_values() {
     os::snprintf_checked(ld_library_path, ld_library_path_size, "%s%s%s%s%s" SYS_EXTENSIONS_DIR ":" SYS_EXTENSIONS_DIRS ":.",
             v, v_colon, l, l_colon, user_home_dir);
     Arguments::set_library_path(ld_library_path);
-    FREE_C_HEAP_ARRAY(char, ld_library_path);
+    FREE_C_HEAP_ARRAY(ld_library_path);
   }
 
   // Extensions directories.
@@ -550,7 +550,7 @@ void os::init_system_properties_values() {
                        user_home_dir, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
 
 #undef SYS_EXTENSIONS_DIR
 #undef SYS_EXTENSIONS_DIRS

--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -301,7 +301,7 @@ int SystemProcessInterface::SystemProcesses::system_processes(SystemProcess** sy
     pids_bytes = proc_listpids(PROC_ALL_PIDS, 0, pids, pids_bytes);
     if (pids_bytes <= 0) {
        // couldn't fit buffer, retry.
-      FREE_RESOURCE_ARRAY(pid_t, pids, pid_count);
+      FREE_RESOURCE_ARRAY(pids, pid_count);
       pids = nullptr;
       try_count++;
       if (try_count > 3) {
@@ -381,12 +381,12 @@ CPUInformationInterface::~CPUInformationInterface() {
   if (_cpu_info != nullptr) {
     if (_cpu_info->cpu_name() != nullptr) {
       const char* cpu_name = _cpu_info->cpu_name();
-      FREE_C_HEAP_ARRAY(char, cpu_name);
+      FREE_C_HEAP_ARRAY(cpu_name);
       _cpu_info->set_cpu_name(nullptr);
     }
     if (_cpu_info->cpu_description() != nullptr) {
       const char* cpu_desc = _cpu_info->cpu_description();
-      FREE_C_HEAP_ARRAY(char, cpu_desc);
+      FREE_C_HEAP_ARRAY(cpu_desc);
       _cpu_info->set_cpu_description(nullptr);
     }
     delete _cpu_info;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -710,14 +710,14 @@ void os::init_system_properties_values() {
     char *ld_library_path = NEW_C_HEAP_ARRAY(char, pathsize, mtInternal);
     os::snprintf_checked(ld_library_path, pathsize, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
     Arguments::set_library_path(ld_library_path);
-    FREE_C_HEAP_ARRAY(char, ld_library_path);
+    FREE_C_HEAP_ARRAY(ld_library_path);
   }
 
   // Extensions directories.
   os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
 
 #undef DEFAULT_LIBPATH
 #undef SYS_EXT_DIR
@@ -3435,7 +3435,7 @@ void os::Linux::rebuild_cpu_to_node_map() {
       }
     }
   }
-  FREE_C_HEAP_ARRAY(unsigned long, cpu_map);
+  FREE_C_HEAP_ARRAY(cpu_map);
 }
 
 int os::Linux::numa_node_to_cpus(int node, unsigned long *buffer, int bufferlen) {

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -545,7 +545,7 @@ bool CPUPerformanceInterface::CPUPerformance::initialize() {
 
 CPUPerformanceInterface::CPUPerformance::~CPUPerformance() {
   if (_counters.cpus != nullptr) {
-    FREE_C_HEAP_ARRAY(char, _counters.cpus);
+    FREE_C_HEAP_ARRAY(_counters.cpus);
   }
 }
 
@@ -811,7 +811,7 @@ int SystemProcessInterface::SystemProcesses::ProcessIterator::current(SystemProc
   cmdline = get_cmdline();
   if (cmdline != nullptr) {
     process_info->set_command_line(allocate_string(cmdline));
-    FREE_C_HEAP_ARRAY(char, cmdline);
+    FREE_C_HEAP_ARRAY(cmdline);
   }
 
   return OS_OK;
@@ -937,12 +937,12 @@ CPUInformationInterface::~CPUInformationInterface() {
   if (_cpu_info != nullptr) {
     if (_cpu_info->cpu_name() != nullptr) {
       const char* cpu_name = _cpu_info->cpu_name();
-      FREE_C_HEAP_ARRAY(char, cpu_name);
+      FREE_C_HEAP_ARRAY(cpu_name);
       _cpu_info->set_cpu_name(nullptr);
     }
     if (_cpu_info->cpu_description() != nullptr) {
        const char* cpu_desc = _cpu_info->cpu_description();
-       FREE_C_HEAP_ARRAY(char, cpu_desc);
+       FREE_C_HEAP_ARRAY(cpu_desc);
       _cpu_info->set_cpu_description(nullptr);
     }
     delete _cpu_info;

--- a/src/hotspot/os/linux/procMapsParser.cpp
+++ b/src/hotspot/os/linux/procMapsParser.cpp
@@ -45,7 +45,7 @@ ProcSmapsParser::ProcSmapsParser(FILE* f) :
 }
 
 ProcSmapsParser::~ProcSmapsParser() {
-  FREE_C_HEAP_ARRAY(char, _line);
+  FREE_C_HEAP_ARRAY(_line);
 }
 
 bool ProcSmapsParser::read_line() {

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -118,7 +118,7 @@ static void save_memory_to_file(char* addr, size_t size) {
       }
     }
   }
-  FREE_C_HEAP_ARRAY(char, destfile);
+  FREE_C_HEAP_ARRAY(destfile);
 }
 
 
@@ -483,14 +483,14 @@ static char* get_user_name(uid_t uid) {
                      p->pw_name == nullptr ? "pw_name = null" : "pw_name zero length");
       }
     }
-    FREE_C_HEAP_ARRAY(char, pwbuf);
+    FREE_C_HEAP_ARRAY(pwbuf);
     return nullptr;
   }
 
   char* user_name = NEW_C_HEAP_ARRAY(char, strlen(p->pw_name) + 1, mtInternal);
   strcpy(user_name, p->pw_name);
 
-  FREE_C_HEAP_ARRAY(char, pwbuf);
+  FREE_C_HEAP_ARRAY(pwbuf);
   return user_name;
 }
 
@@ -572,7 +572,7 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
     DIR* subdirp = open_directory_secure(usrdir_name);
 
     if (subdirp == nullptr) {
-      FREE_C_HEAP_ARRAY(char, usrdir_name);
+      FREE_C_HEAP_ARRAY(usrdir_name);
       continue;
     }
 
@@ -583,7 +583,7 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
     // symlink can be exploited.
     //
     if (!is_directory_secure(usrdir_name)) {
-      FREE_C_HEAP_ARRAY(char, usrdir_name);
+      FREE_C_HEAP_ARRAY(usrdir_name);
       os::closedir(subdirp);
       continue;
     }
@@ -607,13 +607,13 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
         // don't follow symbolic links for the file
         RESTARTABLE(::lstat(filename, &statbuf), result);
         if (result == OS_ERR) {
-           FREE_C_HEAP_ARRAY(char, filename);
+           FREE_C_HEAP_ARRAY(filename);
            continue;
         }
 
         // skip over files that are not regular files.
         if (!S_ISREG(statbuf.st_mode)) {
-          FREE_C_HEAP_ARRAY(char, filename);
+          FREE_C_HEAP_ARRAY(filename);
           continue;
         }
 
@@ -623,7 +623,7 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
           if (statbuf.st_ctime > oldest_ctime) {
             char* user = strchr(dentry->d_name, '_') + 1;
 
-            FREE_C_HEAP_ARRAY(char, oldest_user);
+            FREE_C_HEAP_ARRAY(oldest_user);
             oldest_user = NEW_C_HEAP_ARRAY(char, strlen(user)+1, mtInternal);
 
             strcpy(oldest_user, user);
@@ -631,11 +631,11 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
           }
         }
 
-        FREE_C_HEAP_ARRAY(char, filename);
+        FREE_C_HEAP_ARRAY(filename);
       }
     }
     os::closedir(subdirp);
-    FREE_C_HEAP_ARRAY(char, usrdir_name);
+    FREE_C_HEAP_ARRAY(usrdir_name);
   }
   os::closedir(tmpdirp);
 
@@ -1105,11 +1105,11 @@ static char* mmap_create_shared(size_t size) {
   log_info(perf, memops)("Trying to open %s/%s", dirname, short_filename);
   fd = create_sharedmem_file(dirname, short_filename, size);
 
-  FREE_C_HEAP_ARRAY(char, user_name);
-  FREE_C_HEAP_ARRAY(char, dirname);
+  FREE_C_HEAP_ARRAY(user_name);
+  FREE_C_HEAP_ARRAY(dirname);
 
   if (fd == -1) {
-    FREE_C_HEAP_ARRAY(char, filename);
+    FREE_C_HEAP_ARRAY(filename);
     return nullptr;
   }
 
@@ -1121,7 +1121,7 @@ static char* mmap_create_shared(size_t size) {
   if (mapAddress == MAP_FAILED) {
     log_debug(perf)("mmap failed - %s", os::strerror(errno));
     remove_file(filename);
-    FREE_C_HEAP_ARRAY(char, filename);
+    FREE_C_HEAP_ARRAY(filename);
     return nullptr;
   }
 
@@ -1171,7 +1171,7 @@ static void delete_shared_memory(char* addr, size_t size) {
     remove_file(backing_store_file_name);
     // Don't.. Free heap memory could deadlock os::abort() if it is called
     // from signal handler. OS will reclaim the heap memory.
-    // FREE_C_HEAP_ARRAY(char, backing_store_file_name);
+    // FREE_C_HEAP_ARRAY(backing_store_file_name);
     backing_store_file_name = nullptr;
   }
 }
@@ -1223,8 +1223,8 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   // store file, we don't follow them when attaching either.
   //
   if (!is_directory_secure(dirname)) {
-    FREE_C_HEAP_ARRAY(char, dirname);
-    FREE_C_HEAP_ARRAY(char, luser);
+    FREE_C_HEAP_ARRAY(dirname);
+    FREE_C_HEAP_ARRAY(luser);
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "Process not found");
   }
@@ -1236,9 +1236,9 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   int fd = open_sharedmem_file(filename, file_flags, THREAD);
 
   // free the c heap resources that are no longer needed
-  FREE_C_HEAP_ARRAY(char, luser);
-  FREE_C_HEAP_ARRAY(char, dirname);
-  FREE_C_HEAP_ARRAY(char, filename);
+  FREE_C_HEAP_ARRAY(luser);
+  FREE_C_HEAP_ARRAY(dirname);
+  FREE_C_HEAP_ARRAY(filename);
 
   if (HAS_PENDING_EXCEPTION) {
     assert(fd == OS_ERR, "open_sharedmem_file always return OS_ERR on exceptions");

--- a/src/hotspot/os/windows/os_perf_windows.cpp
+++ b/src/hotspot/os/windows/os_perf_windows.cpp
@@ -178,9 +178,9 @@ static void destroy(MultiCounterQueryP query) {
     for (int i = 0; i < query->noOfCounters; ++i) {
       close_query(nullptr, &query->counters[i]);
     }
-    FREE_C_HEAP_ARRAY(char, query->counters);
+    FREE_C_HEAP_ARRAY(query->counters);
     close_query(&query->query.pdh_query_handle, nullptr);
-    FREE_C_HEAP_ARRAY(MultiCounterQueryS, query);
+    FREE_C_HEAP_ARRAY(query);
   }
 }
 
@@ -189,15 +189,15 @@ static void destroy_query_set(MultiCounterQuerySetP query_set) {
     for (int j = 0; j < query_set->queries[i].noOfCounters; ++j) {
       close_query(nullptr, &query_set->queries[i].counters[j]);
     }
-    FREE_C_HEAP_ARRAY(char, query_set->queries[i].counters);
+    FREE_C_HEAP_ARRAY(query_set->queries[i].counters);
     close_query(&query_set->queries[i].query.pdh_query_handle, nullptr);
   }
-  FREE_C_HEAP_ARRAY(MultiCounterQueryS, query_set->queries);
+  FREE_C_HEAP_ARRAY(query_set->queries);
 }
 
 static void destroy(MultiCounterQuerySetP query) {
   destroy_query_set(query);
-  FREE_C_HEAP_ARRAY(MultiCounterQuerySetS, query);
+  FREE_C_HEAP_ARRAY(query);
 }
 
 static void destroy(ProcessQueryP query) {
@@ -229,7 +229,7 @@ static void allocate_counters(ProcessQueryP query, size_t nofCounters) {
 }
 
 static void deallocate_counters(MultiCounterQueryP query) {
-  FREE_C_HEAP_ARRAY(char, query->counters);
+  FREE_C_HEAP_ARRAY(query->counters);
   query->counters = nullptr;
   query->noOfCounters = 0;
 }
@@ -710,11 +710,11 @@ static const char* pdh_process_image_name() {
 }
 
 static void deallocate_pdh_constants() {
-  FREE_C_HEAP_ARRAY(char, process_image_name);
+  FREE_C_HEAP_ARRAY(process_image_name);
   process_image_name = nullptr;
-  FREE_C_HEAP_ARRAY(char, pdh_process_instance_IDProcess_counter_fmt);
+  FREE_C_HEAP_ARRAY(pdh_process_instance_IDProcess_counter_fmt);
   pdh_process_instance_IDProcess_counter_fmt = nullptr;
-  FREE_C_HEAP_ARRAY(char, pdh_process_instance_wildcard_IDProcess_counter);
+  FREE_C_HEAP_ARRAY(pdh_process_instance_wildcard_IDProcess_counter);
   pdh_process_instance_wildcard_IDProcess_counter = nullptr;
 }
 
@@ -1445,9 +1445,9 @@ bool CPUInformationInterface::initialize() {
 
 CPUInformationInterface::~CPUInformationInterface() {
   if (_cpu_info != nullptr) {
-    FREE_C_HEAP_ARRAY(char, _cpu_info->cpu_name());
+    FREE_C_HEAP_ARRAY(_cpu_info->cpu_name());
     _cpu_info->set_cpu_name(nullptr);
-    FREE_C_HEAP_ARRAY(char, _cpu_info->cpu_description());
+    FREE_C_HEAP_ARRAY(_cpu_info->cpu_description());
     _cpu_info->set_cpu_description(nullptr);
     delete _cpu_info;
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -334,14 +334,14 @@ void os::init_system_properties_values() {
     home_path = NEW_C_HEAP_ARRAY(char, strlen(home_dir) + 1, mtInternal);
     strcpy(home_path, home_dir);
     Arguments::set_java_home(home_path);
-    FREE_C_HEAP_ARRAY(char, home_path);
+    FREE_C_HEAP_ARRAY(home_path);
 
     dll_path = NEW_C_HEAP_ARRAY(char, strlen(home_dir) + strlen(bin) + 1,
                                 mtInternal);
     strcpy(dll_path, home_dir);
     strcat(dll_path, bin);
     Arguments::set_dll_dir(dll_path);
-    FREE_C_HEAP_ARRAY(char, dll_path);
+    FREE_C_HEAP_ARRAY(dll_path);
 
     if (!set_boot_path('\\', ';')) {
       vm_exit_during_initialization("Failed setting boot class path.", nullptr);
@@ -396,7 +396,7 @@ void os::init_system_properties_values() {
     strcat(library_path, ";.");
 
     Arguments::set_library_path(library_path);
-    FREE_C_HEAP_ARRAY(char, library_path);
+    FREE_C_HEAP_ARRAY(library_path);
   }
 
   // Default extensions directory
@@ -1079,7 +1079,7 @@ void os::set_native_thread_name(const char *name) {
       HRESULT hr = _SetThreadDescription(current, unicode_name);
       if (FAILED(hr)) {
         log_debug(os, thread)("set_native_thread_name: SetThreadDescription failed - falling back to debugger method");
-        FREE_C_HEAP_ARRAY(WCHAR, unicode_name);
+        FREE_C_HEAP_ARRAY(unicode_name);
       } else {
         log_trace(os, thread)("set_native_thread_name: SetThreadDescription succeeded - new name: %s", name);
 
@@ -1102,7 +1102,7 @@ void os::set_native_thread_name(const char *name) {
           LocalFree(thread_name);
         }
 #endif
-        FREE_C_HEAP_ARRAY(WCHAR, unicode_name);
+        FREE_C_HEAP_ARRAY(unicode_name);
         return;
       }
     } else {
@@ -2897,7 +2897,7 @@ class NUMANodeListHolder {
   int _numa_used_node_count;
 
   void free_node_list() {
-    FREE_C_HEAP_ARRAY(int, _numa_used_node_list);
+    FREE_C_HEAP_ARRAY(_numa_used_node_list);
   }
 
  public:
@@ -4744,7 +4744,7 @@ static wchar_t* wide_abs_unc_path(char const* path, errno_t & err, int additiona
 
   LPWSTR unicode_path = nullptr;
   err = convert_to_unicode(buf, &unicode_path);
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
   if (err != ERROR_SUCCESS) {
     return nullptr;
   }
@@ -4772,9 +4772,9 @@ static wchar_t* wide_abs_unc_path(char const* path, errno_t & err, int additiona
   }
 
   if (converted_path != unicode_path) {
-    FREE_C_HEAP_ARRAY(WCHAR, converted_path);
+    FREE_C_HEAP_ARRAY(converted_path);
   }
-  FREE_C_HEAP_ARRAY(WCHAR, unicode_path);
+  FREE_C_HEAP_ARRAY(unicode_path);
 
   return static_cast<wchar_t*>(result); // LPWSTR and wchat_t* are the same type on Windows.
 }
@@ -5827,7 +5827,7 @@ int os::fork_and_exec(const char* cmd) {
     exit_code = -1;
   }
 
-  FREE_C_HEAP_ARRAY(char, cmd_string);
+  FREE_C_HEAP_ARRAY(cmd_string);
   return (int)exit_code;
 }
 

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -113,7 +113,7 @@ static void save_memory_to_file(char* addr, size_t size) {
     }
   }
 
-  FREE_C_HEAP_ARRAY(char, destfile);
+  FREE_C_HEAP_ARRAY(destfile);
 }
 
 // Shared Memory Implementation Details
@@ -319,7 +319,7 @@ static char* get_user_name_slow(int vmid) {
     DIR* subdirp = os::opendir(usrdir_name);
 
     if (subdirp == nullptr) {
-      FREE_C_HEAP_ARRAY(char, usrdir_name);
+      FREE_C_HEAP_ARRAY(usrdir_name);
       continue;
     }
 
@@ -330,7 +330,7 @@ static char* get_user_name_slow(int vmid) {
     // symlink can be exploited.
     //
     if (!is_directory_secure(usrdir_name)) {
-      FREE_C_HEAP_ARRAY(char, usrdir_name);
+      FREE_C_HEAP_ARRAY(usrdir_name);
       os::closedir(subdirp);
       continue;
     }
@@ -350,13 +350,13 @@ static char* get_user_name_slow(int vmid) {
         strcat(filename, udentry->d_name);
 
         if (::stat(filename, &statbuf) == OS_ERR) {
-           FREE_C_HEAP_ARRAY(char, filename);
+           FREE_C_HEAP_ARRAY(filename);
            continue;
         }
 
         // skip over files that are not regular files.
         if ((statbuf.st_mode & S_IFMT) != S_IFREG) {
-          FREE_C_HEAP_ARRAY(char, filename);
+          FREE_C_HEAP_ARRAY(filename);
           continue;
         }
 
@@ -378,18 +378,18 @@ static char* get_user_name_slow(int vmid) {
         if (statbuf.st_ctime > latest_ctime) {
           char* user = strchr(dentry->d_name, '_') + 1;
 
-          FREE_C_HEAP_ARRAY(char, latest_user);
+          FREE_C_HEAP_ARRAY(latest_user);
           latest_user = NEW_C_HEAP_ARRAY(char, strlen(user)+1, mtInternal);
 
           strcpy(latest_user, user);
           latest_ctime = statbuf.st_ctime;
         }
 
-        FREE_C_HEAP_ARRAY(char, filename);
+        FREE_C_HEAP_ARRAY(filename);
       }
     }
     os::closedir(subdirp);
-    FREE_C_HEAP_ARRAY(char, usrdir_name);
+    FREE_C_HEAP_ARRAY(usrdir_name);
   }
   os::closedir(tmpdirp);
 
@@ -481,7 +481,7 @@ static void remove_file(const char* dirname, const char* filename) {
     }
   }
 
-  FREE_C_HEAP_ARRAY(char, path);
+  FREE_C_HEAP_ARRAY(path);
 }
 
 // returns true if the process represented by pid is alive, otherwise
@@ -708,11 +708,11 @@ static void free_security_desc(PSECURITY_DESCRIPTOR pSD) {
     // be an ACL we enlisted. free the resources.
     //
     if (success && exists && pACL != nullptr && !isdefault) {
-      FREE_C_HEAP_ARRAY(char, pACL);
+      FREE_C_HEAP_ARRAY(pACL);
     }
 
     // free the security descriptor
-    FREE_C_HEAP_ARRAY(char, pSD);
+    FREE_C_HEAP_ARRAY(pSD);
   }
 }
 
@@ -768,7 +768,7 @@ static PSID get_user_sid(HANDLE hProcess) {
   if (!GetTokenInformation(hAccessToken, TokenUser, token_buf, rsize, &rsize)) {
     log_debug(perf)("GetTokenInformation failure: lasterror = %d, rsize = %d",
                     GetLastError(), rsize);
-    FREE_C_HEAP_ARRAY(char, token_buf);
+    FREE_C_HEAP_ARRAY(token_buf);
     CloseHandle(hAccessToken);
     return nullptr;
   }
@@ -779,15 +779,15 @@ static PSID get_user_sid(HANDLE hProcess) {
   if (!CopySid(nbytes, pSID, token_buf->User.Sid)) {
     log_debug(perf)("GetTokenInformation failure: lasterror = %d, rsize = %d",
                     GetLastError(), rsize);
-    FREE_C_HEAP_ARRAY(char, token_buf);
-    FREE_C_HEAP_ARRAY(char, pSID);
+    FREE_C_HEAP_ARRAY(token_buf);
+    FREE_C_HEAP_ARRAY(pSID);
     CloseHandle(hAccessToken);
     return nullptr;
   }
 
   // close the access token.
   CloseHandle(hAccessToken);
-  FREE_C_HEAP_ARRAY(char, token_buf);
+  FREE_C_HEAP_ARRAY(token_buf);
 
   return pSID;
 }
@@ -865,7 +865,7 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
 
   if (!InitializeAcl(newACL, newACLsize, ACL_REVISION)) {
     log_debug(perf)("InitializeAcl failure: lasterror = %d", GetLastError());
-    FREE_C_HEAP_ARRAY(char, newACL);
+    FREE_C_HEAP_ARRAY(newACL);
     return false;
   }
 
@@ -876,7 +876,7 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
       LPVOID ace;
       if (!GetAce(oldACL, ace_index, &ace)) {
         log_debug(perf)("InitializeAcl failure: lasterror = %d", GetLastError());
-        FREE_C_HEAP_ARRAY(char, newACL);
+        FREE_C_HEAP_ARRAY(newACL);
         return false;
       }
       if (((ACCESS_ALLOWED_ACE *)ace)->Header.AceFlags && INHERITED_ACE) {
@@ -901,7 +901,7 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
         if (!AddAce(newACL, ACL_REVISION, MAXDWORD, ace,
                     ((PACE_HEADER)ace)->AceSize)) {
           log_debug(perf)("AddAce failure: lasterror = %d", GetLastError());
-          FREE_C_HEAP_ARRAY(char, newACL);
+          FREE_C_HEAP_ARRAY(newACL);
           return false;
         }
       }
@@ -915,7 +915,7 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
                              aces[i].mask, aces[i].pSid)) {
       log_debug(perf)("AddAccessAllowedAce failure: lasterror = %d",
                       GetLastError());
-      FREE_C_HEAP_ARRAY(char, newACL);
+      FREE_C_HEAP_ARRAY(newACL);
       return false;
     }
   }
@@ -928,13 +928,13 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
       LPVOID ace;
       if (!GetAce(oldACL, ace_index, &ace)) {
         log_debug(perf)("InitializeAcl failure: lasterror = %d", GetLastError());
-        FREE_C_HEAP_ARRAY(char, newACL);
+        FREE_C_HEAP_ARRAY(newACL);
         return false;
       }
       if (!AddAce(newACL, ACL_REVISION, MAXDWORD, ace,
                   ((PACE_HEADER)ace)->AceSize)) {
         log_debug(perf)("AddAce failure: lasterror = %d", GetLastError());
-        FREE_C_HEAP_ARRAY(char, newACL);
+        FREE_C_HEAP_ARRAY(newACL);
         return false;
       }
       ace_index++;
@@ -944,7 +944,7 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
   // add the new ACL to the security descriptor.
   if (!SetSecurityDescriptorDacl(pSD, TRUE, newACL, FALSE)) {
     log_debug(perf)("SetSecurityDescriptorDacl failure: lasterror = %d", GetLastError());
-    FREE_C_HEAP_ARRAY(char, newACL);
+    FREE_C_HEAP_ARRAY(newACL);
     return false;
   }
 
@@ -952,7 +952,7 @@ static bool add_allow_aces(PSECURITY_DESCRIPTOR pSD,
   // protected prevents that.
   if (!SetSecurityDescriptorControl(pSD, SE_DACL_PROTECTED, SE_DACL_PROTECTED)) {
     log_debug(perf)("SetSecurityDescriptorControl failure: lasterror = %d", GetLastError());
-    FREE_C_HEAP_ARRAY(char, newACL);
+    FREE_C_HEAP_ARRAY(newACL);
     return false;
   }
 
@@ -1057,7 +1057,7 @@ static LPSECURITY_ATTRIBUTES make_user_everybody_admin_security_attr(
   // create a security attributes structure with access control
   // entries as initialized above.
   LPSECURITY_ATTRIBUTES lpSA = make_security_attr(aces, 3);
-  FREE_C_HEAP_ARRAY(char, aces[0].pSid);
+  FREE_C_HEAP_ARRAY(aces[0].pSid);
   FreeSid(everybodySid);
   FreeSid(administratorsSid);
   return(lpSA);
@@ -1341,8 +1341,8 @@ static char* mapping_create_shared(size_t size) {
 
   // check that the file system is secure - i.e. it supports ACLs.
   if (!is_filesystem_secure(dirname)) {
-    FREE_C_HEAP_ARRAY(char, dirname);
-    FREE_C_HEAP_ARRAY(char, user);
+    FREE_C_HEAP_ARRAY(dirname);
+    FREE_C_HEAP_ARRAY(user);
     return nullptr;
   }
 
@@ -1358,15 +1358,15 @@ static char* mapping_create_shared(size_t size) {
   assert(((size != 0) && (size % os::vm_page_size() == 0)),
          "unexpected PerfMemry region size");
 
-  FREE_C_HEAP_ARRAY(char, user);
+  FREE_C_HEAP_ARRAY(user);
 
   // create the shared memory resources
   sharedmem_fileMapHandle =
                create_sharedmem_resources(dirname, filename, objectname, size);
 
-  FREE_C_HEAP_ARRAY(char, filename);
-  FREE_C_HEAP_ARRAY(char, objectname);
-  FREE_C_HEAP_ARRAY(char, dirname);
+  FREE_C_HEAP_ARRAY(filename);
+  FREE_C_HEAP_ARRAY(objectname);
+  FREE_C_HEAP_ARRAY(dirname);
 
   if (sharedmem_fileMapHandle == nullptr) {
     return nullptr;
@@ -1480,8 +1480,8 @@ static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
   // store file, we also don't following them when attaching
   //
   if (!is_directory_secure(dirname)) {
-    FREE_C_HEAP_ARRAY(char, dirname);
-    FREE_C_HEAP_ARRAY(char, luser);
+    FREE_C_HEAP_ARRAY(dirname);
+    FREE_C_HEAP_ARRAY(luser);
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               "Process not found");
   }
@@ -1498,10 +1498,10 @@ static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
   char* robjectname = ResourceArea::strdup(THREAD, objectname);
 
   // free the c heap resources that are no longer needed
-  FREE_C_HEAP_ARRAY(char, luser);
-  FREE_C_HEAP_ARRAY(char, dirname);
-  FREE_C_HEAP_ARRAY(char, filename);
-  FREE_C_HEAP_ARRAY(char, objectname);
+  FREE_C_HEAP_ARRAY(luser);
+  FREE_C_HEAP_ARRAY(dirname);
+  FREE_C_HEAP_ARRAY(filename);
+  FREE_C_HEAP_ARRAY(objectname);
 
   size_t size;
   if (*sizep == 0) {

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -417,7 +417,7 @@ void CodeSection::expand_locs(int new_capacity) {
       new_capacity = old_capacity * 2;
     relocInfo* locs_start;
     if (_locs_own) {
-      locs_start = REALLOC_RESOURCE_ARRAY(relocInfo, _locs_start, old_capacity, new_capacity);
+      locs_start = REALLOC_RESOURCE_ARRAY(_locs_start, old_capacity, new_capacity);
     } else {
       locs_start = NEW_RESOURCE_ARRAY(relocInfo, new_capacity);
       Copy::conjoint_jbytes(_locs_start, locs_start, old_capacity * sizeof(relocInfo));

--- a/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
@@ -797,7 +797,7 @@ void AOTStreamedHeapLoader::cleanup() {
     Universe::vm_global()->release(&handles[num_null_handles], num_handles - num_null_handles);
   }
 
-  FREE_C_HEAP_ARRAY(void*, _object_index_to_heap_object_table);
+  FREE_C_HEAP_ARRAY(_object_index_to_heap_object_table);
 
   // Unmap regions
   FileMapInfo::current_info()->unmap_region(AOTMetaspace::hp);

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1171,7 +1171,7 @@ void ArchiveBuilder::write_archive(FileMapInfo* mapinfo, AOTMappedHeapInfo* mapp
     AOTMapLogger::dumptime_log(this, mapinfo, mapped_heap_info, streamed_heap_info, bitmap, bitmap_size_in_bytes);
   }
   CDS_JAVA_HEAP_ONLY(HeapShared::destroy_archived_object_cache());
-  FREE_C_HEAP_ARRAY(char, bitmap);
+  FREE_C_HEAP_ARRAY(bitmap);
 }
 
 void ArchiveBuilder::write_region(FileMapInfo* mapinfo, int region_idx, DumpRegion* dump_region, bool read_only,  bool allow_exec) {

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -520,7 +520,7 @@ static void substitute_aot_filename(JVMFlagsEnum flag_enum) {
     JVMFlag::Error err = JVMFlagAccess::set_ccstr(flag, &new_filename, JVMFlagOrigin::ERGONOMIC);
     assert(err == JVMFlag::SUCCESS, "must never fail");
   }
-  FREE_C_HEAP_ARRAY(char, new_filename);
+  FREE_C_HEAP_ARRAY(new_filename);
 }
 
 void CDSConfig::check_aotmode_record() {

--- a/src/hotspot/share/cds/classListWriter.cpp
+++ b/src/hotspot/share/cds/classListWriter.cpp
@@ -49,7 +49,7 @@ void ClassListWriter::init() {
     _classlist_file->print_cr("# This file is generated via the -XX:DumpLoadedClassList=<class_list_file> option");
     _classlist_file->print_cr("# and is used at CDS archive dump time (see -Xshare:dump).");
     _classlist_file->print_cr("#");
-    FREE_C_HEAP_ARRAY(char, list_name);
+    FREE_C_HEAP_ARRAY(list_name);
   }
 }
 

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -402,7 +402,7 @@ public:
 
   ~FileHeaderHelper() {
     if (_header != nullptr) {
-      FREE_C_HEAP_ARRAY(char, _header);
+      FREE_C_HEAP_ARRAY(_header);
     }
     if (_fd != -1) {
       ::close(_fd);

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -600,7 +600,7 @@ class CompileReplay : public StackObj {
         _nesting.check(); // Check if a reallocation in the resource arena is safe
         int new_length = _buffer_length * 2;
         // Next call will throw error in case of OOM.
-        _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
+        _buffer = REALLOC_RESOURCE_ARRAY(_buffer, _buffer_length, new_length);
         _buffer_length = new_length;
       }
       if (c == '\n') {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2363,8 +2363,8 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
           }
           if (lvt_cnt == max_lvt_cnt) {
             max_lvt_cnt <<= 1;
-            localvariable_table_length = REALLOC_RESOURCE_ARRAY(u2, localvariable_table_length, lvt_cnt, max_lvt_cnt);
-            localvariable_table_start  = REALLOC_RESOURCE_ARRAY(const unsafe_u2*, localvariable_table_start, lvt_cnt, max_lvt_cnt);
+            localvariable_table_length = REALLOC_RESOURCE_ARRAY(localvariable_table_length, lvt_cnt, max_lvt_cnt);
+            localvariable_table_start  = REALLOC_RESOURCE_ARRAY(localvariable_table_start, lvt_cnt, max_lvt_cnt);
           }
           localvariable_table_start[lvt_cnt] =
             parse_localvariable_table(cfs,
@@ -2393,8 +2393,8 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
           // Parse local variable type table
           if (lvtt_cnt == max_lvtt_cnt) {
             max_lvtt_cnt <<= 1;
-            localvariable_type_table_length = REALLOC_RESOURCE_ARRAY(u2, localvariable_type_table_length, lvtt_cnt, max_lvtt_cnt);
-            localvariable_type_table_start  = REALLOC_RESOURCE_ARRAY(const unsafe_u2*, localvariable_type_table_start, lvtt_cnt, max_lvtt_cnt);
+            localvariable_type_table_length = REALLOC_RESOURCE_ARRAY(localvariable_type_table_length, lvtt_cnt, max_lvtt_cnt);
+            localvariable_type_table_start  = REALLOC_RESOURCE_ARRAY(localvariable_type_table_start, lvtt_cnt, max_lvtt_cnt);
           }
           localvariable_type_table_start[lvtt_cnt] =
             parse_localvariable_table(cfs,

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -251,7 +251,7 @@ const char* ClassPathEntry::copy_path(const char* path) {
 }
 
 ClassPathDirEntry::~ClassPathDirEntry() {
-  FREE_C_HEAP_ARRAY(char, _dir);
+  FREE_C_HEAP_ARRAY(_dir);
 }
 
 ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char* name) {
@@ -280,7 +280,7 @@ ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char*
 #ifdef ASSERT
         // Freeing path is a no-op here as buffer prevents it from being reclaimed. But we keep it for
         // debug builds so that we guard against use-after-free bugs.
-        FREE_RESOURCE_ARRAY_IN_THREAD(current, char, path, path_len);
+        FREE_RESOURCE_ARRAY_IN_THREAD(current, path, path_len);
 #endif
         // We don't verify the length of the classfile stream fits in an int, but this is the
         // bootloader so we have control of this.
@@ -291,7 +291,7 @@ ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char*
       }
     }
   }
-  FREE_RESOURCE_ARRAY_IN_THREAD(current, char, path, path_len);
+  FREE_RESOURCE_ARRAY_IN_THREAD(current, path, path_len);
   return nullptr;
 }
 
@@ -302,7 +302,7 @@ ClassPathZipEntry::ClassPathZipEntry(jzfile* zip, const char* zip_name) : ClassP
 
 ClassPathZipEntry::~ClassPathZipEntry() {
   ZipLibrary::close(_zip);
-  FREE_C_HEAP_ARRAY(char, _zip_name);
+  FREE_C_HEAP_ARRAY(_zip_name);
 }
 
 bool ClassPathZipEntry::has_entry(JavaThread* current, const char* name) {
@@ -1438,7 +1438,7 @@ bool ClassLoader::is_module_observable(const char* module_name) {
     struct stat st;
     const char *path = get_exploded_module_path(module_name, true);
     bool res = os::stat(path, &st) == 0;
-    FREE_C_HEAP_ARRAY(char, path);
+    FREE_C_HEAP_ARRAY(path);
     return res;
   }
   jlong size;

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -69,7 +69,7 @@ CompactHashtableWriter::~CompactHashtableWriter() {
     delete bucket;
   }
 
-  FREE_C_HEAP_ARRAY(GrowableArray<Entry>*, _buckets);
+  FREE_C_HEAP_ARRAY(_buckets);
 }
 
 // Add an entry to the temporary hash table

--- a/src/hotspot/share/classfile/resolutionErrors.cpp
+++ b/src/hotspot/share/classfile/resolutionErrors.cpp
@@ -114,15 +114,15 @@ ResolutionErrorEntry::~ResolutionErrorEntry() {
   Symbol::maybe_decrement_refcount(_cause);
 
   if (_message != nullptr) {
-    FREE_C_HEAP_ARRAY(char, _message);
+    FREE_C_HEAP_ARRAY(_message);
   }
 
   if (_cause_msg != nullptr) {
-    FREE_C_HEAP_ARRAY(char, _cause_msg);
+    FREE_C_HEAP_ARRAY(_cause_msg);
   }
 
   if (nest_host_error() != nullptr) {
-    FREE_C_HEAP_ARRAY(char, nest_host_error());
+    FREE_C_HEAP_ARRAY(nest_host_error());
   }
 }
 

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -876,7 +876,7 @@ bool AOTCodeCache::finish_write() {
       current += size;
       uint n = write_bytes(&(entries_address[i]), sizeof(AOTCodeEntry));
       if (n != sizeof(AOTCodeEntry)) {
-        FREE_C_HEAP_ARRAY(uint, search);
+        FREE_C_HEAP_ARRAY(search);
         return false;
       }
       search[entries_count*2 + 0] = entries_address[i].id();
@@ -897,7 +897,7 @@ bool AOTCodeCache::finish_write() {
     }
     if (entries_count == 0) {
       log_info(aot, codecache, exit)("AOT Code Cache was not created: no entires");
-      FREE_C_HEAP_ARRAY(uint, search);
+      FREE_C_HEAP_ARRAY(search);
       return true; // Nothing to write
     }
     assert(entries_count <= store_count, "%d > %d", entries_count, store_count);
@@ -913,7 +913,7 @@ bool AOTCodeCache::finish_write() {
     qsort(search, entries_count, 2*sizeof(uint), uint_cmp);
     search_size = 2 * entries_count * sizeof(uint);
     copy_bytes((const char*)search, (address)current, search_size);
-    FREE_C_HEAP_ARRAY(uint, search);
+    FREE_C_HEAP_ARRAY(search);
     current += search_size;
 
     // Write entries

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -252,7 +252,7 @@ private:
 public:
   AOTStubData(BlobId blob_id) NOT_CDS({});
 
-  ~AOTStubData()    CDS_ONLY({FREE_C_HEAP_ARRAY(StubAddrRange, _ranges);}) NOT_CDS({})
+  ~AOTStubData()    CDS_ONLY({FREE_C_HEAP_ARRAY(_ranges);}) NOT_CDS({})
 
   bool is_open()    CDS_ONLY({ return (_flags & OPEN) != 0; }) NOT_CDS_RETURN_(false);
   bool is_using()   CDS_ONLY({ return (_flags & USING) != 0; }) NOT_CDS_RETURN_(false);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1715,7 +1715,7 @@ void CodeCache::print_internals() {
     }
   }
 
-  FREE_C_HEAP_ARRAY(int, buckets);
+  FREE_C_HEAP_ARRAY(buckets);
   print_memory_overhead();
 }
 

--- a/src/hotspot/share/code/exceptionHandlerTable.cpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.cpp
@@ -32,7 +32,7 @@ void ExceptionHandlerTable::add_entry(HandlerTableEntry entry) {
     // not enough space => grow the table (amortized growth, double its size)
     guarantee(_size > 0, "no space allocated => cannot grow the table since it is part of nmethod");
     int new_size = _size * 2;
-    _table = REALLOC_RESOURCE_ARRAY(HandlerTableEntry, _table, _size, new_size);
+    _table = REALLOC_RESOURCE_ARRAY(_table, _size, new_size);
     _size = new_size;
   }
   assert(_length < _size, "sanity check");
@@ -178,7 +178,7 @@ void ImplicitExceptionTable::append( uint exec_off, uint cont_off ) {
     if (_size == 0) _size = 4;
     _size *= 2;
     uint new_size_in_elements = _size*2;
-    _data = REALLOC_RESOURCE_ARRAY(uint, _data, old_size_in_elements, new_size_in_elements);
+    _data = REALLOC_RESOURCE_ARRAY(_data, old_size_in_elements, new_size_in_elements);
   }
   *(adr(l)  ) = exec_off;
   *(adr(l)+1) = cont_off;

--- a/src/hotspot/share/compiler/cHeapStringHolder.cpp
+++ b/src/hotspot/share/compiler/cHeapStringHolder.cpp
@@ -36,7 +36,7 @@ void CHeapStringHolder::set(const char* string) {
 
 void CHeapStringHolder::clear() {
   if (_string != nullptr) {
-    FREE_C_HEAP_ARRAY(char, _string);
+    FREE_C_HEAP_ARRAY(_string);
     _string = nullptr;
   }
 }

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -487,7 +487,7 @@ public:
 
   void clean_details() {
     if (_detail_stats != nullptr) {
-      FREE_C_HEAP_ARRAY(Details, _detail_stats);
+      FREE_C_HEAP_ARRAY(_detail_stats);
       _detail_stats = nullptr;
     }
   }

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -64,8 +64,8 @@ CompileLog::~CompileLog() {
   _out = nullptr;
   // Remove partial file after merging in CompileLog::finish_log_on_error
   unlink(_file);
-  FREE_C_HEAP_ARRAY(char, _identities);
-  FREE_C_HEAP_ARRAY(char, _file);
+  FREE_C_HEAP_ARRAY(_identities);
+  FREE_C_HEAP_ARRAY(_file);
 }
 
 
@@ -96,7 +96,7 @@ int CompileLog::identify(ciBaseObject* obj) {
   if (id >= _identities_capacity) {
     int new_cap = _identities_capacity * 2;
     if (new_cap <= id)  new_cap = id + 100;
-    _identities = REALLOC_C_HEAP_ARRAY(char, _identities, new_cap, mtCompiler);
+    _identities = REALLOC_C_HEAP_ARRAY(_identities, new_cap, mtCompiler);
     _identities_capacity = new_cap;
   }
   while (id >= _identities_limit) {

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -256,7 +256,7 @@ ControlIntrinsicIter::ControlIntrinsicIter(ccstrlist option_value, bool disable_
 }
 
 ControlIntrinsicIter::~ControlIntrinsicIter() {
-  FREE_C_HEAP_ARRAY(char, _list);
+  FREE_C_HEAP_ARRAY(_list);
 }
 
 // pre-increment

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -283,7 +283,7 @@ class ControlIntrinsicValidator {
 
   ~ControlIntrinsicValidator() {
     if (_bad != nullptr) {
-      FREE_C_HEAP_ARRAY(char, _bad);
+      FREE_C_HEAP_ARRAY(_bad);
     }
   }
 

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -198,7 +198,7 @@ bool DirectivesParser::push_key(const char* str, size_t len) {
     strncpy(s, str, len);
     s[len] = '\0';
     error(KEY_ERROR, "No such key: '%s'.", s);
-    FREE_C_HEAP_ARRAY(char, s);
+    FREE_C_HEAP_ARRAY(s);
     return false;
   }
 
@@ -370,7 +370,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
 #endif
 
         if (!valid) {
-          FREE_C_HEAP_ARRAY(char, s);
+          FREE_C_HEAP_ARRAY(s);
           return false;
         }
         (set->*test)((void *)&s);  // Takes ownership.
@@ -440,7 +440,7 @@ bool DirectivesParser::set_option(JSON_TYPE t, JSON_VAL* v) {
         assert (error_msg != nullptr, "Must have valid error message");
         error(VALUE_ERROR, "Method pattern error: %s", error_msg);
       }
-      FREE_C_HEAP_ARRAY(char, s);
+      FREE_C_HEAP_ARRAY(s);
     }
     break;
 
@@ -472,7 +472,7 @@ bool DirectivesParser::set_option(JSON_TYPE t, JSON_VAL* v) {
           error(VALUE_ERROR, "Method pattern error: %s", error_msg);
         }
       }
-      FREE_C_HEAP_ARRAY(char, s);
+      FREE_C_HEAP_ARRAY(s);
     }
     break;
 
@@ -622,4 +622,3 @@ bool DirectivesParser::callback(JSON_TYPE t, JSON_VAL* v, uint rlimit) {
     }
   }
 }
-

--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -869,7 +869,7 @@ ImmutableOopMapSet* ImmutableOopMapSet::clone() const {
 }
 
 void ImmutableOopMapSet::operator delete(void* p) {
-  FREE_C_HEAP_ARRAY(unsigned char, p);
+  FREE_C_HEAP_ARRAY(p);
 }
 
 //------------------------------DerivedPointerTable---------------------------

--- a/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
@@ -70,7 +70,7 @@ public:
   }
 
   ~EpsilonSpaceCounters() {
-    FREE_C_HEAP_ARRAY(char, _name_space);
+    FREE_C_HEAP_ARRAY(_name_space);
   }
 
   inline void update_all(size_t capacity, size_t used) {

--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -63,8 +63,8 @@ G1Allocator::~G1Allocator() {
     _mutator_alloc_regions[i].~MutatorAllocRegion();
     _survivor_gc_alloc_regions[i].~SurvivorGCAllocRegion();
   }
-  FREE_C_HEAP_ARRAY(MutatorAllocRegion, _mutator_alloc_regions);
-  FREE_C_HEAP_ARRAY(SurvivorGCAllocRegion, _survivor_gc_alloc_regions);
+  FREE_C_HEAP_ARRAY(_mutator_alloc_regions);
+  FREE_C_HEAP_ARRAY(_survivor_gc_alloc_regions);
 }
 
 #ifdef ASSERT
@@ -315,7 +315,7 @@ G1PLABAllocator::PLABData::~PLABData() {
   for (uint node_index = 0; node_index < _num_alloc_buffers; node_index++) {
     delete _alloc_buffer[node_index];
   }
-  FREE_C_HEAP_ARRAY(PLAB*, _alloc_buffer);
+  FREE_C_HEAP_ARRAY(_alloc_buffer);
 }
 
 void G1PLABAllocator::PLABData::initialize(uint num_alloc_buffers, size_t desired_plab_size, size_t tolerated_refills) {

--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -98,7 +98,7 @@ void G1Arguments::initialize_verification_types() {
       parse_verification_type(token);
       token = strtok_r(nullptr, delimiter, &save_ptr);
     }
-    FREE_C_HEAP_ARRAY(char, type_list);
+    FREE_C_HEAP_ARRAY(type_list);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -145,7 +145,7 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint inline_ptr_bits_per_card,
 }
 
 G1CardSetConfiguration::~G1CardSetConfiguration() {
-  FREE_C_HEAP_ARRAY(size_t, _card_set_alloc_options);
+  FREE_C_HEAP_ARRAY(_card_set_alloc_options);
 }
 
 void G1CardSetConfiguration::init_card_set_alloc_options() {

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -90,7 +90,7 @@ G1CardSetMemoryManager::~G1CardSetMemoryManager() {
   for (uint i = 0; i < num_mem_object_types(); i++) {
     _allocators[i].~G1CardSetAllocator();
   }
-  FREE_C_HEAP_ARRAY(G1CardSetAllocator, _allocators);
+  FREE_C_HEAP_ARRAY(_allocators);
 }
 
 void G1CardSetMemoryManager::free(uint type, void* value) {

--- a/src/hotspot/share/gc/g1/g1CardTableClaimTable.cpp
+++ b/src/hotspot/share/gc/g1/g1CardTableClaimTable.cpp
@@ -39,7 +39,7 @@ G1CardTableClaimTable::G1CardTableClaimTable(uint chunks_per_region) :
 }
 
 G1CardTableClaimTable::~G1CardTableClaimTable() {
-  FREE_C_HEAP_ARRAY(uint, _card_claims);
+  FREE_C_HEAP_ARRAY(_card_claims);
 }
 
 void G1CardTableClaimTable::initialize(uint max_reserved_regions) {

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -72,7 +72,7 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
 }
 
 G1CollectionSet::~G1CollectionSet() {
-  FREE_C_HEAP_ARRAY(uint, _regions);
+  FREE_C_HEAP_ARRAY(_regions);
   abandon_all_candidates();
 }
 
@@ -766,7 +766,7 @@ public:
     }
   }
   ~G1VerifyYoungCSetIndicesClosure() {
-    FREE_C_HEAP_ARRAY(int, _heap_region_indices);
+    FREE_C_HEAP_ARRAY(_heap_region_indices);
   }
 
   virtual bool do_heap_region(G1HeapRegion* r) {

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -214,7 +214,7 @@ G1CollectionSetCandidates::G1CollectionSetCandidates() :
 { }
 
 G1CollectionSetCandidates::~G1CollectionSetCandidates() {
-  FREE_C_HEAP_ARRAY(CandidateOrigin, _contains_map);
+  FREE_C_HEAP_ARRAY(_contains_map);
   _from_marking_groups.clear();
   _retained_groups.clear();
 }
@@ -413,7 +413,7 @@ void G1CollectionSetCandidates::verify() {
            static_cast<std::underlying_type<CandidateOrigin>::type>(verify_map[i]));
   }
 
-  FREE_C_HEAP_ARRAY(CandidateOrigin, verify_map);
+  FREE_C_HEAP_ARRAY(verify_map);
 }
 #endif
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -249,7 +249,7 @@ G1CMMarkStack::ChunkAllocator::~ChunkAllocator() {
     }
   }
 
-  FREE_C_HEAP_ARRAY(TaskQueueEntryChunk*, _buckets);
+  FREE_C_HEAP_ARRAY(_buckets);
 }
 
 bool G1CMMarkStack::ChunkAllocator::reserve(size_t new_capacity) {
@@ -676,9 +676,9 @@ void G1ConcurrentMark::reset_at_marking_complete() {
 }
 
 G1ConcurrentMark::~G1ConcurrentMark() {
-  FREE_C_HEAP_ARRAY(Atomic<HeapWord*>, _top_at_mark_starts);
-  FREE_C_HEAP_ARRAY(Atomic<HeapWord*>, _top_at_rebuild_starts);
-  FREE_C_HEAP_ARRAY(G1RegionMarkStats, _region_mark_stats);
+  FREE_C_HEAP_ARRAY(_top_at_mark_starts);
+  FREE_C_HEAP_ARRAY(_top_at_rebuild_starts);
+  FREE_C_HEAP_ARRAY(_region_mark_stats);
   // The G1ConcurrentMark instance is never freed.
   ShouldNotReachHere();
 }

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
@@ -55,7 +55,7 @@ void G1EvacFailureRegions::post_collection() {
   _regions_pinned.resize(0);
   _regions_alloc_failed.resize(0);
 
-  FREE_C_HEAP_ARRAY(uint, _evac_failed_regions);
+  FREE_C_HEAP_ARRAY(_evac_failed_regions);
   _evac_failed_regions = nullptr;
 }
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -167,10 +167,10 @@ G1FullCollector::~G1FullCollector() {
 
   delete _partial_array_state_manager;
 
-  FREE_C_HEAP_ARRAY(G1FullGCMarker*, _markers);
-  FREE_C_HEAP_ARRAY(G1FullGCCompactionPoint*, _compaction_points);
-  FREE_C_HEAP_ARRAY(Atomic<HeapWord*>, _compaction_tops);
-  FREE_C_HEAP_ARRAY(G1RegionMarkStats, _live_stats);
+  FREE_C_HEAP_ARRAY(_markers);
+  FREE_C_HEAP_ARRAY(_compaction_points);
+  FREE_C_HEAP_ARRAY(_compaction_tops);
+  FREE_C_HEAP_ARRAY(_live_stats);
 }
 
 class PrepareRegionsClosure : public G1HeapRegionClosure {

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -718,7 +718,7 @@ G1HeapRegionClaimer::G1HeapRegionClaimer(uint n_workers) :
 }
 
 G1HeapRegionClaimer::~G1HeapRegionClaimer() {
-  FREE_C_HEAP_ARRAY(uint, _claims);
+  FREE_C_HEAP_ARRAY(_claims);
 }
 
 uint G1HeapRegionClaimer::offset_for_worker(uint worker_id) const {
@@ -759,7 +759,7 @@ public:
     for (uint worker = 0; worker < _num_workers; worker++) {
       _worker_freelists[worker].~G1FreeRegionList();
     }
-    FREE_C_HEAP_ARRAY(G1FreeRegionList, _worker_freelists);
+    FREE_C_HEAP_ARRAY(_worker_freelists);
   }
 
   G1FreeRegionList* worker_freelist(uint worker) {

--- a/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
@@ -384,7 +384,7 @@ G1FreeRegionList::NodeInfo::NodeInfo() : _numa(G1NUMA::numa()), _length_of_node(
 }
 
 G1FreeRegionList::NodeInfo::~NodeInfo() {
-  FREE_C_HEAP_ARRAY(uint, _length_of_node);
+  FREE_C_HEAP_ARRAY(_length_of_node);
 }
 
 void G1FreeRegionList::NodeInfo::clear() {

--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -55,8 +55,8 @@ G1HeapTransition::Data::Data(G1CollectedHeap* g1_heap) :
 }
 
 G1HeapTransition::Data::~Data() {
-  FREE_C_HEAP_ARRAY(uint, _eden_length_per_node);
-  FREE_C_HEAP_ARRAY(uint, _survivor_length_per_node);
+  FREE_C_HEAP_ARRAY(_eden_length_per_node);
+  FREE_C_HEAP_ARRAY(_survivor_length_per_node);
 }
 
 G1HeapTransition::G1HeapTransition(G1CollectedHeap* g1_heap) : _g1_heap(g1_heap), _before(g1_heap) { }

--- a/src/hotspot/share/gc/g1/g1MonotonicArena.cpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArena.cpp
@@ -52,7 +52,7 @@ void G1MonotonicArena::Segment::delete_segment(Segment* segment) {
     GlobalCounter::write_synchronize();
   }
   segment->~Segment();
-  FREE_C_HEAP_ARRAY(_mem_tag, segment);
+  FREE_C_HEAP_ARRAY(segment);
 }
 
 void G1MonotonicArena::SegmentFreeList::bulk_add(Segment& first,

--- a/src/hotspot/share/gc/g1/g1MonotonicArenaFreePool.cpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArenaFreePool.cpp
@@ -159,7 +159,7 @@ G1MonotonicArenaFreePool::~G1MonotonicArenaFreePool() {
   for (uint i = 0; i < _num_free_lists; i++) {
     _free_lists[i].~SegmentFreeList();
   }
-  FREE_C_HEAP_ARRAY(mtGC, _free_lists);
+  FREE_C_HEAP_ARRAY(_free_lists);
 }
 
 G1MonotonicArenaMemoryStats G1MonotonicArenaFreePool::memory_sizes() const {

--- a/src/hotspot/share/gc/g1/g1NUMA.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.cpp
@@ -123,8 +123,8 @@ void G1NUMA::initialize(bool use_numa) {
 
 G1NUMA::~G1NUMA() {
   delete _stats;
-  FREE_C_HEAP_ARRAY(uint, _node_id_to_index_map);
-  FREE_C_HEAP_ARRAY(uint, _node_ids);
+  FREE_C_HEAP_ARRAY(_node_id_to_index_map);
+  FREE_C_HEAP_ARRAY(_node_ids);
 }
 
 void G1NUMA::set_region_info(size_t region_size, size_t page_size) {
@@ -280,9 +280,9 @@ G1NodeIndexCheckClosure::~G1NodeIndexCheckClosure() {
     _ls->print("%u: %u/%u/%u ", numa_ids[i], _matched[i], _mismatched[i], _total[i]);
   }
 
-  FREE_C_HEAP_ARRAY(uint, _matched);
-  FREE_C_HEAP_ARRAY(uint, _mismatched);
-  FREE_C_HEAP_ARRAY(uint, _total);
+  FREE_C_HEAP_ARRAY(_matched);
+  FREE_C_HEAP_ARRAY(_mismatched);
+  FREE_C_HEAP_ARRAY(_total);
 }
 
 bool G1NodeIndexCheckClosure::do_heap_region(G1HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1NUMAStats.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMAStats.cpp
@@ -45,9 +45,9 @@ G1NUMAStats::NodeDataArray::NodeDataArray(uint num_nodes) {
 
 G1NUMAStats::NodeDataArray::~NodeDataArray() {
   for (uint row = 0; row < _num_row; row++) {
-    FREE_C_HEAP_ARRAY(size_t, _data[row]);
+    FREE_C_HEAP_ARRAY(_data[row]);
   }
-  FREE_C_HEAP_ARRAY(size_t*, _data);
+  FREE_C_HEAP_ARRAY(_data);
 }
 
 void G1NUMAStats::NodeDataArray::create_hit_rate(Stat* result) const {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -131,9 +131,9 @@ size_t G1ParScanThreadState::flush_stats(size_t* surviving_young_words, uint num
 G1ParScanThreadState::~G1ParScanThreadState() {
   delete _plab_allocator;
   delete _closures;
-  FREE_C_HEAP_ARRAY(size_t, _surviving_young_words_base);
+  FREE_C_HEAP_ARRAY(_surviving_young_words_base);
   delete[] _oops_into_optional_regions;
-  FREE_C_HEAP_ARRAY(size_t, _obj_alloc_stat);
+  FREE_C_HEAP_ARRAY(_obj_alloc_stat);
 }
 
 size_t G1ParScanThreadState::lab_waste_words() const {
@@ -730,8 +730,8 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
 
 G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {
   assert(_flushed, "thread local state from the per thread states should have been flushed");
-  FREE_C_HEAP_ARRAY(G1ParScanThreadState*, _states);
-  FREE_C_HEAP_ARRAY(size_t, _surviving_young_words_total);
+  FREE_C_HEAP_ARRAY(_states);
+  FREE_C_HEAP_ARRAY(_surviving_young_words_total);
 }
 
 #if TASKQUEUE_STATS

--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
@@ -38,7 +38,7 @@ G1RegionMarkStatsCache::G1RegionMarkStatsCache(G1RegionMarkStats* target, uint n
 }
 
 G1RegionMarkStatsCache::~G1RegionMarkStatsCache() {
-  FREE_C_HEAP_ARRAY(G1RegionMarkStatsCacheEntry, _cache);
+  FREE_C_HEAP_ARRAY(_cache);
 }
 
 void G1RegionMarkStatsCache::add_live_words(oop obj) {

--- a/src/hotspot/share/gc/g1/g1RegionsOnNodes.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionsOnNodes.cpp
@@ -32,7 +32,7 @@ G1RegionsOnNodes::G1RegionsOnNodes() : _count_per_node(nullptr), _numa(G1NUMA::n
 }
 
 G1RegionsOnNodes::~G1RegionsOnNodes() {
-  FREE_C_HEAP_ARRAY(uint, _count_per_node);
+  FREE_C_HEAP_ARRAY(_count_per_node);
 }
 
 void G1RegionsOnNodes::add(G1HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -124,8 +124,8 @@ class G1RemSetScanState : public CHeapObj<mtGC> {
     }
 
     ~G1DirtyRegions() {
-      FREE_C_HEAP_ARRAY(uint, _buffer);
-      FREE_C_HEAP_ARRAY(Atomic<bool>, _contains);
+      FREE_C_HEAP_ARRAY(_buffer);
+      FREE_C_HEAP_ARRAY(_contains);
     }
 
     void reset() {
@@ -245,7 +245,7 @@ public:
     _scan_top(nullptr) { }
 
   ~G1RemSetScanState() {
-    FREE_C_HEAP_ARRAY(HeapWord*, _scan_top);
+    FREE_C_HEAP_ARRAY(_scan_top);
   }
 
   void initialize(uint max_reserved_regions) {

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -98,7 +98,7 @@ G1RemSetSummary::G1RemSetSummary(bool should_update) :
 }
 
 G1RemSetSummary::~G1RemSetSummary() {
-  FREE_C_HEAP_ARRAY(jlong, _worker_threads_cpu_times);
+  FREE_C_HEAP_ARRAY(_worker_threads_cpu_times);
 }
 
 void G1RemSetSummary::set(G1RemSetSummary* other) {

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -65,8 +65,8 @@ void G1SurvRateGroup::start_adding_regions() {
 
 void G1SurvRateGroup::stop_adding_regions() {
   if (_num_added_regions > _stats_arrays_length) {
-    _accum_surv_rate_pred = REALLOC_C_HEAP_ARRAY(double, _accum_surv_rate_pred, _num_added_regions, mtGC);
-    _surv_rate_predictors = REALLOC_C_HEAP_ARRAY(TruncatedSeq*, _surv_rate_predictors, _num_added_regions, mtGC);
+    _accum_surv_rate_pred = REALLOC_C_HEAP_ARRAY(_accum_surv_rate_pred, _num_added_regions, mtGC);
+    _surv_rate_predictors = REALLOC_C_HEAP_ARRAY(_surv_rate_predictors, _num_added_regions, mtGC);
 
     for (uint i = _stats_arrays_length; i < _num_added_regions; ++i) {
       // Initialize predictors and accumulated survivor rate predictions.

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -802,7 +802,7 @@ public:
     for (uint worker = 0; worker < _active_workers; worker++) {
       _worker_stats[worker].~FreeCSetStats();
     }
-    FREE_C_HEAP_ARRAY(FreeCSetStats, _worker_stats);
+    FREE_C_HEAP_ARRAY(_worker_stats);
 
     _g1h->clear_collection_set();
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPreEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPreEvacuateTasks.cpp
@@ -73,7 +73,7 @@ public:
 
   ~JavaThreadRetireTLABs() {
     static_assert(std::is_trivially_destructible<ThreadLocalAllocStats>::value, "must be");
-    FREE_C_HEAP_ARRAY(ThreadLocalAllocStats, _local_tlab_stats);
+    FREE_C_HEAP_ARRAY(_local_tlab_stats);
   }
 
   void do_work(uint worker_id) override {

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -55,7 +55,7 @@ MutableNUMASpace::MutableNUMASpace(size_t page_size) : MutableSpace(page_size) {
     lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], page_size));
   }
 
-  FREE_C_HEAP_ARRAY(uint, lgrp_ids);
+  FREE_C_HEAP_ARRAY(lgrp_ids);
 }
 
 MutableNUMASpace::~MutableNUMASpace() {

--- a/src/hotspot/share/gc/shared/bufferNode.cpp
+++ b/src/hotspot/share/gc/shared/bufferNode.cpp
@@ -41,7 +41,7 @@ void* BufferNode::AllocatorConfig::allocate() {
 
 void BufferNode::AllocatorConfig::deallocate(void* node) {
   assert(node != nullptr, "precondition");
-  FREE_C_HEAP_ARRAY(char, node);
+  FREE_C_HEAP_ARRAY(node);
 }
 
 BufferNode::Allocator::Allocator(const char* name, size_t buffer_capacity) :

--- a/src/hotspot/share/gc/shared/classUnloadingContext.cpp
+++ b/src/hotspot/share/gc/shared/classUnloadingContext.cpp
@@ -54,7 +54,7 @@ ClassUnloadingContext::~ClassUnloadingContext() {
   for (uint i = 0; i < _num_nmethod_unlink_workers; ++i) {
     delete _unlinked_nmethods[i];
   }
-  FREE_C_HEAP_ARRAY(NMethodSet*, _unlinked_nmethods);
+  FREE_C_HEAP_ARRAY(_unlinked_nmethods);
 
   assert(_context == this, "context not set correctly");
   _context = nullptr;

--- a/src/hotspot/share/gc/shared/collectorCounters.cpp
+++ b/src/hotspot/share/gc/shared/collectorCounters.cpp
@@ -62,7 +62,7 @@ CollectorCounters::CollectorCounters(const char* name, int ordinal) {
 }
 
 CollectorCounters::~CollectorCounters() {
-  FREE_C_HEAP_ARRAY(char, _name_space);
+  FREE_C_HEAP_ARRAY(_name_space);
 }
 
 TraceCollectorStats::TraceCollectorStats(CollectorCounters* c) :

--- a/src/hotspot/share/gc/shared/generationCounters.cpp
+++ b/src/hotspot/share/gc/shared/generationCounters.cpp
@@ -64,7 +64,7 @@ GenerationCounters::GenerationCounters(const char* name,
 }
 
 GenerationCounters::~GenerationCounters() {
-  FREE_C_HEAP_ARRAY(char, _name_space);
+  FREE_C_HEAP_ARRAY(_name_space);
 }
 
 void GenerationCounters::update_capacity(size_t curr_capacity) {

--- a/src/hotspot/share/gc/shared/hSpaceCounters.cpp
+++ b/src/hotspot/share/gc/shared/hSpaceCounters.cpp
@@ -66,7 +66,7 @@ HSpaceCounters::HSpaceCounters(const char* name_space,
 }
 
 HSpaceCounters::~HSpaceCounters() {
-  FREE_C_HEAP_ARRAY(char, _name_space);
+  FREE_C_HEAP_ARRAY(_name_space);
 }
 
 void HSpaceCounters::update_capacity(size_t v) {

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -136,7 +136,7 @@ OopStorage::ActiveArray* OopStorage::ActiveArray::create(size_t size,
 
 void OopStorage::ActiveArray::destroy(ActiveArray* ba) {
   ba->~ActiveArray();
-  FREE_C_HEAP_ARRAY(char, ba);
+  FREE_C_HEAP_ARRAY(ba);
 }
 
 size_t OopStorage::ActiveArray::size() const {
@@ -362,7 +362,7 @@ OopStorage::Block* OopStorage::Block::new_block(const OopStorage* owner) {
 void OopStorage::Block::delete_block(const Block& block) {
   void* memory = block._memory;
   block.Block::~Block();
-  FREE_C_HEAP_ARRAY(char, memory);
+  FREE_C_HEAP_ARRAY(memory);
 }
 
 // This can return a false positive if ptr is not contained by some

--- a/src/hotspot/share/gc/shared/partialArrayState.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayState.cpp
@@ -114,7 +114,7 @@ PartialArrayStateManager::PartialArrayStateManager(uint max_allocators)
 
 PartialArrayStateManager::~PartialArrayStateManager() {
   reset();
-  FREE_C_HEAP_ARRAY(Arena, _arenas);
+  FREE_C_HEAP_ARRAY(_arenas);
 }
 
 Arena* PartialArrayStateManager::register_allocator() {

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -148,7 +148,7 @@ void PreservedMarksSet::reclaim() {
   }
 
   if (_in_c_heap) {
-    FREE_C_HEAP_ARRAY(Padded<PreservedMarks>, _stacks);
+    FREE_C_HEAP_ARRAY(_stacks);
   } else {
     // the array was resource-allocated, so nothing to do
   }

--- a/src/hotspot/share/gc/shared/stringdedup/stringDedup.cpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedup.cpp
@@ -182,7 +182,7 @@ void StringDedup::Requests::flush() {
       assert(_storage_for_requests != nullptr, "invariant");
       _storage_for_requests->storage()->release(_buffer, _index);
     }
-    FREE_C_HEAP_ARRAY(oop*, _buffer);
+    FREE_C_HEAP_ARRAY(_buffer);
     _buffer = nullptr;
   }
   if (_storage_for_requests != nullptr) {

--- a/src/hotspot/share/gc/shared/stringdedup/stringDedupTable.cpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedupTable.cpp
@@ -455,7 +455,7 @@ void StringDedup::Table::free_buckets(Bucket* buckets, size_t number_of_buckets)
   while (number_of_buckets > 0) {
     buckets[--number_of_buckets].~Bucket();
   }
-  FREE_C_HEAP_ARRAY(Bucket, buckets);
+  FREE_C_HEAP_ARRAY(buckets);
 }
 
 // Compute the hash code for obj using halfsiphash_32.  As this is a high

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -48,7 +48,7 @@ inline GenericTaskQueueSet<T, MT>::GenericTaskQueueSet(uint n) : _n(n) {
 
 template <class T, MemTag MT>
 inline GenericTaskQueueSet<T, MT>::~GenericTaskQueueSet() {
-  FREE_C_HEAP_ARRAY(T*, _queues);
+  FREE_C_HEAP_ARRAY(_queues);
 }
 
 #if TASKQUEUE_STATS

--- a/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
@@ -72,7 +72,7 @@ WorkerDataArray<T>::~WorkerDataArray() {
   for (uint i = 0; i < MaxThreadWorkItems; i++) {
     delete _thread_work_items[i];
   }
-  FREE_C_HEAP_ARRAY(T, _data);
+  FREE_C_HEAP_ARRAY(_data);
 }
 
 template <typename T>

--- a/src/hotspot/share/gc/shared/workerUtils.cpp
+++ b/src/hotspot/share/gc/shared/workerUtils.cpp
@@ -122,7 +122,7 @@ bool SubTasksDone::try_claim_task(uint t) {
 
 SubTasksDone::~SubTasksDone() {
   assert(_verification_done.load_relaxed(), "all_tasks_claimed must have been called.");
-  FREE_C_HEAP_ARRAY(Atomic<bool>, _tasks);
+  FREE_C_HEAP_ARRAY(_tasks);
 }
 
 // *** SequentialSubTasksDone

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -111,12 +111,12 @@ ShenandoahAdaptiveHeuristics::ShenandoahAdaptiveHeuristics(ShenandoahSpaceInfo* 
   }
 
 ShenandoahAdaptiveHeuristics::~ShenandoahAdaptiveHeuristics() {
-  FREE_C_HEAP_ARRAY(double, _spike_acceleration_rate_samples);
-  FREE_C_HEAP_ARRAY(double, _spike_acceleration_rate_timestamps);
-  FREE_C_HEAP_ARRAY(double, _gc_time_timestamps);
-  FREE_C_HEAP_ARRAY(double, _gc_time_samples);
-  FREE_C_HEAP_ARRAY(double, _gc_time_xy);
-  FREE_C_HEAP_ARRAY(double, _gc_time_xx);
+  FREE_C_HEAP_ARRAY(_spike_acceleration_rate_samples);
+  FREE_C_HEAP_ARRAY(_spike_acceleration_rate_timestamps);
+  FREE_C_HEAP_ARRAY(_gc_time_timestamps);
+  FREE_C_HEAP_ARRAY(_gc_time_samples);
+  FREE_C_HEAP_ARRAY(_gc_time_xy);
+  FREE_C_HEAP_ARRAY(_gc_time_xx);
 }
 
 void ShenandoahAdaptiveHeuristics::initialize() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -73,7 +73,7 @@ ShenandoahHeuristics::ShenandoahHeuristics(ShenandoahSpaceInfo* space_info) :
 }
 
 ShenandoahHeuristics::~ShenandoahHeuristics() {
-  FREE_C_HEAP_ARRAY(RegionGarbage, _region_data);
+  FREE_C_HEAP_ARRAY(_region_data);
 }
 
 void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.cpp
@@ -70,15 +70,15 @@ ShenandoahAgeCensus::~ShenandoahAgeCensus() {
   for (uint i = 0; i < MAX_SNAPSHOTS; i++) {
     delete _global_age_tables[i];
   }
-  FREE_C_HEAP_ARRAY(AgeTable*, _global_age_tables);
-  FREE_C_HEAP_ARRAY(uint, _tenuring_threshold);
-  CENSUS_NOISE(FREE_C_HEAP_ARRAY(ShenandoahNoiseStats, _global_noise));
+  FREE_C_HEAP_ARRAY(_global_age_tables);
+  FREE_C_HEAP_ARRAY(_tenuring_threshold);
+  CENSUS_NOISE(FREE_C_HEAP_ARRAY(_global_noise));
   if (_local_age_tables) {
     for (uint i = 0; i < _max_workers; i++) {
       delete _local_age_tables[i];
     }
-    FREE_C_HEAP_ARRAY(AgeTable*, _local_age_tables);
-    CENSUS_NOISE(FREE_C_HEAP_ARRAY(ShenandoahNoiseStats, _local_noise));
+    FREE_C_HEAP_ARRAY(_local_age_tables);
+    CENSUS_NOISE(FREE_C_HEAP_ARRAY(_local_noise));
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -261,7 +261,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   for (uint i = 0; i < heap->max_workers(); i++) {
     delete worker_slices[i];
   }
-  FREE_C_HEAP_ARRAY(ShenandoahHeapRegionSet*, worker_slices);
+  FREE_C_HEAP_ARRAY(worker_slices);
 
   heap->set_full_gc_move_in_progress(false);
   heap->set_full_gc_in_progress(false);
@@ -688,7 +688,7 @@ void ShenandoahFullGC::distribute_slices(ShenandoahHeapRegionSet** worker_slices
     }
   }
 
-  FREE_C_HEAP_ARRAY(size_t, live);
+  FREE_C_HEAP_ARRAY(live);
 
 #ifdef ASSERT
   ResourceBitMap map(n_regions);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -77,8 +77,8 @@ ShenandoahHeapRegionCounters::ShenandoahHeapRegionCounters() :
 }
 
 ShenandoahHeapRegionCounters::~ShenandoahHeapRegionCounters() {
-  if (_name_space != nullptr) FREE_C_HEAP_ARRAY(char, _name_space);
-  if (_regions_data != nullptr) FREE_C_HEAP_ARRAY(PerfVariable*, _regions_data);
+  if (_name_space != nullptr) FREE_C_HEAP_ARRAY(_name_space);
+  if (_regions_data != nullptr) FREE_C_HEAP_ARRAY(_regions_data);
 }
 
 void ShenandoahHeapRegionCounters::write_snapshot(PerfLongVariable** regions,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionSet.cpp
@@ -47,7 +47,7 @@ ShenandoahHeapRegionSet::ShenandoahHeapRegionSet() :
 }
 
 ShenandoahHeapRegionSet::~ShenandoahHeapRegionSet() {
-  FREE_C_HEAP_ARRAY(jbyte, _set_map);
+  FREE_C_HEAP_ARRAY(_set_map);
 }
 
 void ShenandoahHeapRegionSet::add_region(ShenandoahHeapRegion* r) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
@@ -48,7 +48,7 @@ ShenandoahNMethod::ShenandoahNMethod(nmethod* nm, GrowableArray<oop*>& oops, boo
 
 ShenandoahNMethod::~ShenandoahNMethod() {
   if (_oops != nullptr) {
-    FREE_C_HEAP_ARRAY(oop*, _oops);
+    FREE_C_HEAP_ARRAY(_oops);
   }
 }
 
@@ -60,7 +60,7 @@ void ShenandoahNMethod::update() {
   detect_reloc_oops(nm(), oops, non_immediate_oops);
   if (oops.length() != _oops_count) {
     if (_oops != nullptr) {
-      FREE_C_HEAP_ARRAY(oop*, _oops);
+      FREE_C_HEAP_ARRAY(_oops);
       _oops = nullptr;
     }
 
@@ -394,7 +394,7 @@ ShenandoahNMethodList::ShenandoahNMethodList(int size) :
 ShenandoahNMethodList::~ShenandoahNMethodList() {
   assert(_list != nullptr, "Sanity");
   assert(_ref_count == 0, "Must be");
-  FREE_C_HEAP_ARRAY(ShenandoahNMethod*, _list);
+  FREE_C_HEAP_ARRAY(_list);
 }
 
 void ShenandoahNMethodList::transfer(ShenandoahNMethodList* const list, int limit) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -39,10 +39,10 @@ HdrSeq::~HdrSeq() {
   for (int c = 0; c < MagBuckets; c++) {
     int* sub = _hdr[c];
     if (sub != nullptr) {
-      FREE_C_HEAP_ARRAY(int, sub);
+      FREE_C_HEAP_ARRAY(sub);
     }
   }
-  FREE_C_HEAP_ARRAY(int*, _hdr);
+  FREE_C_HEAP_ARRAY(_hdr);
 }
 
 void HdrSeq::add(double val) {
@@ -191,7 +191,7 @@ BinaryMagnitudeSeq::BinaryMagnitudeSeq() {
 }
 
 BinaryMagnitudeSeq::~BinaryMagnitudeSeq() {
-  FREE_C_HEAP_ARRAY(size_t, _mags);
+  FREE_C_HEAP_ARRAY(_mags);
 }
 
 void BinaryMagnitudeSeq::clear() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -413,7 +413,7 @@ public:
   }
 
   ~ShenandoahCardCluster() {
-    FREE_C_HEAP_ARRAY(crossing_info, _object_starts);
+    FREE_C_HEAP_ARRAY(_object_starts);
     _object_starts = nullptr;
   }
 
@@ -751,7 +751,7 @@ public:
       for (uint i = 0; i < ParallelGCThreads; i++) {
         delete _card_stats[i];
       }
-      FREE_C_HEAP_ARRAY(HdrSeq*, _card_stats);
+      FREE_C_HEAP_ARRAY(_card_stats);
       _card_stats = nullptr;
     }
     assert(_card_stats == nullptr, "Error");

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.cpp
@@ -35,7 +35,7 @@ ShenandoahSimpleBitMap::ShenandoahSimpleBitMap(idx_t num_bits) :
 
 ShenandoahSimpleBitMap::~ShenandoahSimpleBitMap() {
   if (_bitmap != nullptr) {
-    FREE_C_HEAP_ARRAY(uintx, _bitmap);
+    FREE_C_HEAP_ARRAY(_bitmap);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -1073,7 +1073,7 @@ void ShenandoahVerifier::verify_at_safepoint(ShenandoahGeneration* generation,
   log_info(gc)("Verify %s, Level %zd (%zu reachable, %zu marked)",
                label, ShenandoahVerifyLevel, count_reachable, count_marked);
 
-  FREE_C_HEAP_ARRAY(ShenandoahLivenessData, ld);
+  FREE_C_HEAP_ARRAY(ld);
 }
 
 void ShenandoahVerifier::verify_generic(ShenandoahGeneration* generation, VerifyOption vo) {

--- a/src/hotspot/share/gc/z/zForwardingAllocator.cpp
+++ b/src/hotspot/share/gc/z/zForwardingAllocator.cpp
@@ -30,11 +30,11 @@ ZForwardingAllocator::ZForwardingAllocator()
     _top(nullptr) {}
 
 ZForwardingAllocator::~ZForwardingAllocator() {
-  FREE_C_HEAP_ARRAY(char, _start);
+  FREE_C_HEAP_ARRAY(_start);
 }
 
 void ZForwardingAllocator::reset(size_t size) {
-  _start = REALLOC_C_HEAP_ARRAY(char, _start, size, mtGC);
+  _start = REALLOC_C_HEAP_ARRAY(_start, size, mtGC);
   _top.store_relaxed(_start);
   _end = _start + size;
 }

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -154,7 +154,7 @@ InterpreterOopMap::InterpreterOopMap() {
 InterpreterOopMap::~InterpreterOopMap() {
   if (has_valid_mask() && mask_size() > small_mask_limit) {
     assert(_bit_mask[0] != 0, "should have pointer to C heap");
-    FREE_C_HEAP_ARRAY(uintptr_t, _bit_mask[0]);
+    FREE_C_HEAP_ARRAY((uintptr_t*)_bit_mask[0]);
   }
 }
 
@@ -286,7 +286,7 @@ void OopMapCacheEntry::deallocate_bit_mask() {
   if (mask_size() > small_mask_limit && _bit_mask[0] != 0) {
     assert(!Thread::current()->resource_area()->contains((void*)_bit_mask[0]),
       "This bit mask should not be in the resource area");
-    FREE_C_HEAP_ARRAY(uintptr_t, _bit_mask[0]);
+    FREE_C_HEAP_ARRAY((uintptr_t*)_bit_mask[0]);
     DEBUG_ONLY(_bit_mask[0] = 0;)
   }
 }

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -528,7 +528,7 @@ const char* JfrJavaSupport::c_str(jstring string, Thread* thread, bool c_heap /*
 
 void JfrJavaSupport::free_c_str(const char* str, bool c_heap) {
   if (c_heap) {
-    FREE_C_HEAP_ARRAY(char, str);
+    FREE_C_HEAP_ARRAY(str);
   }
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/sampling/samplePriorityQueue.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/samplePriorityQueue.cpp
@@ -36,7 +36,7 @@ SamplePriorityQueue::SamplePriorityQueue(size_t size) :
 }
 
 SamplePriorityQueue::~SamplePriorityQueue() {
-  FREE_C_HEAP_ARRAY(ObjectSample*, _items);
+  FREE_C_HEAP_ARRAY(_items);
   _items = nullptr;
 }
 

--- a/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
@@ -46,7 +46,7 @@ static GrowableArray<InterfaceEntry>* _interfaces = nullptr;
 void JfrNetworkUtilization::destroy() {
   if (_interfaces != nullptr) {
     for (int i = 0; i < _interfaces->length(); ++i) {
-      FREE_C_HEAP_ARRAY(char, _interfaces->at(i).name);
+      FREE_C_HEAP_ARRAY(_interfaces->at(i).name);
     }
     delete _interfaces;
     _interfaces = nullptr;

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -799,7 +799,7 @@ void JfrOptionSet::release_start_flight_recording_options() {
   if (start_flight_recording_options_array != nullptr) {
     const int length = start_flight_recording_options_array->length();
     for (int i = 0; i < length; ++i) {
-      FREE_C_HEAP_ARRAY(char, start_flight_recording_options_array->at(i));
+      FREE_C_HEAP_ARRAY(start_flight_recording_options_array->at(i));
     }
     delete start_flight_recording_options_array;
     start_flight_recording_options_array = nullptr;

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackFilter.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackFilter.cpp
@@ -55,6 +55,6 @@ JfrStackFilter::~JfrStackFilter() {
     Symbol::maybe_decrement_refcount(_method_names[i]);
     Symbol::maybe_decrement_refcount(_class_names[i]);
   }
-  FREE_C_HEAP_ARRAY(Symbol*, _method_names);
-  FREE_C_HEAP_ARRAY(Symbol*, _class_names);
+  FREE_C_HEAP_ARRAY(_method_names);
+  FREE_C_HEAP_ARRAY(_class_names);
 }

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackFilterRegistry.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackFilterRegistry.cpp
@@ -43,8 +43,8 @@ int64_t JfrStackFilterRegistry::add(jobjectArray classes, jobjectArray methods, 
   Symbol** method_names = JfrJavaSupport::symbol_array(methods, jt, &m_size, true);
   assert(method_names != nullptr, "invariant");
   if (c_size != m_size) {
-    FREE_C_HEAP_ARRAY(Symbol*, class_names);
-    FREE_C_HEAP_ARRAY(Symbol*, method_names);
+    FREE_C_HEAP_ARRAY(class_names);
+    FREE_C_HEAP_ARRAY(method_names);
     JfrJavaSupport::throw_internal_error("Method array size doesn't match class array size", jt);
     return STACK_FILTER_ERROR_CODE;
   }

--- a/src/hotspot/share/jfr/support/methodtracer/jfrFilter.cpp
+++ b/src/hotspot/share/jfr/support/methodtracer/jfrFilter.cpp
@@ -51,10 +51,10 @@ JfrFilter::~JfrFilter() {
     Symbol::maybe_decrement_refcount(_method_names[i]);
     Symbol::maybe_decrement_refcount(_annotation_names[i]);
   }
-  FREE_C_HEAP_ARRAY(Symbol*, _class_names);
-  FREE_C_HEAP_ARRAY(Symbol*, _method_names);
-  FREE_C_HEAP_ARRAY(Symbol*, _annotation_names);
-  FREE_C_HEAP_ARRAY(int, _modifications);
+  FREE_C_HEAP_ARRAY(_class_names);
+  FREE_C_HEAP_ARRAY(_method_names);
+  FREE_C_HEAP_ARRAY(_annotation_names);
+  FREE_C_HEAP_ARRAY(_modifications);
 }
 
 bool JfrFilter::can_instrument_module(const ModuleEntry* module) const {

--- a/src/hotspot/share/jfr/support/methodtracer/jfrFilterManager.cpp
+++ b/src/hotspot/share/jfr/support/methodtracer/jfrFilterManager.cpp
@@ -130,10 +130,10 @@ bool JfrFilterManager::install(jobjectArray classes, jobjectArray methods, jobje
     modifications[i] = modification_tah->int_at(i);
   }
   if (class_size != method_size || class_size != annotation_size || class_size != modification_size) {
-    FREE_C_HEAP_ARRAY(Symbol*, class_names);
-    FREE_C_HEAP_ARRAY(Symbol*, method_names);
-    FREE_C_HEAP_ARRAY(Symbol*, annotation_names);
-    FREE_C_HEAP_ARRAY(int, modifications);
+    FREE_C_HEAP_ARRAY(class_names);
+    FREE_C_HEAP_ARRAY(method_names);
+    FREE_C_HEAP_ARRAY(annotation_names);
+    FREE_C_HEAP_ARRAY(modifications);
     JfrJavaSupport::throw_internal_error("Method array sizes don't match", jt);
     return false;
   }

--- a/src/hotspot/share/jfr/utilities/jfrConcurrentHashtable.inline.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrConcurrentHashtable.inline.hpp
@@ -59,7 +59,7 @@ inline JfrConcurrentHashtable<T, IdType, TableEntry>::JfrConcurrentHashtable(uns
 
 template <typename T, typename IdType, template <typename, typename> class TableEntry>
 inline JfrConcurrentHashtable<T, IdType, TableEntry>::~JfrConcurrentHashtable() {
-  FREE_C_HEAP_ARRAY(Bucket, _buckets);
+  FREE_C_HEAP_ARRAY(_buckets);
 }
 
 template <typename T, typename IdType, template <typename, typename> class TableEntry>

--- a/src/hotspot/share/jfr/utilities/jfrHashtable.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrHashtable.hpp
@@ -93,7 +93,7 @@ class JfrBasicHashtable : public CHeapObj<mtTracing> {
     --_number_of_entries;
   }
   void free_buckets() {
-    FREE_C_HEAP_ARRAY(Bucket, _buckets);
+    FREE_C_HEAP_ARRAY(_buckets);
   }
   TableEntry* bucket(size_t i) { return _buckets[i].get_entry();}
   TableEntry** bucket_addr(size_t i) { return _buckets[i].entry_addr(); }

--- a/src/hotspot/share/jfr/utilities/jfrSet.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrSet.hpp
@@ -82,7 +82,7 @@ class JfrSetStorage : public AnyObj {
 
   ~JfrSetStorage() {
     if (CONFIG::alloc_type() == C_HEAP) {
-      FREE_C_HEAP_ARRAY(K, _table);
+      FREE_C_HEAP_ARRAY(_table);
     }
   }
 
@@ -160,7 +160,7 @@ class JfrSet : public JfrSetStorage<CONFIG> {
       }
     }
     if (CONFIG::alloc_type() == AnyObj::C_HEAP) {
-      FREE_C_HEAP_ARRAY(K, old_table);
+      FREE_C_HEAP_ARRAY(old_table);
     }
     assert(_table_mask + 1 == this->_table_size, "invariant");
     assert(_resize_threshold << 1 == this->_table_size, "invariant");

--- a/src/hotspot/share/libadt/vectset.cpp
+++ b/src/hotspot/share/libadt/vectset.cpp
@@ -51,7 +51,7 @@ void VectorSet::grow(uint new_word_capacity) {
   assert(new_word_capacity < (1U << 30), "");
   uint x = next_power_of_2(new_word_capacity);
   if (x > _data_size) {
-    _data = REALLOC_ARENA_ARRAY(_set_arena, uint32_t, _data, _size, x);
+    _data = REALLOC_ARENA_ARRAY(_set_arena, _data, _size, x);
     _data_size = x;
   }
   Copy::zero_to_bytes(_data + _size, (x - _size) * sizeof(uint32_t));

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -124,7 +124,7 @@ class AsyncLogWriter : public NonJavaThread {
     }
 
     ~Buffer() {
-      FREE_C_HEAP_ARRAY(char, _buf);
+      FREE_C_HEAP_ARRAY(_buf);
     }
 
     void push_flush_token();

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -123,7 +123,7 @@ void LogConfiguration::initialize(jlong vm_start_time) {
 
 void LogConfiguration::finalize() {
   disable_outputs();
-  FREE_C_HEAP_ARRAY(LogOutput*, _outputs);
+  FREE_C_HEAP_ARRAY(_outputs);
 }
 
 // Normalizes the given LogOutput name to type=name form.
@@ -206,7 +206,7 @@ LogOutput* LogConfiguration::new_output(const char* name,
 
 size_t LogConfiguration::add_output(LogOutput* output) {
   size_t idx = _n_outputs++;
-  _outputs = REALLOC_C_HEAP_ARRAY(LogOutput*, _outputs, _n_outputs, mtLogging);
+  _outputs = REALLOC_C_HEAP_ARRAY(_outputs, _n_outputs, mtLogging);
   _outputs[idx] = output;
   return idx;
 }
@@ -218,7 +218,7 @@ void LogConfiguration::delete_output(size_t idx) {
   LogOutput* output = _outputs[idx];
   // Swap places with the last output and shrink the array
   _outputs[idx] = _outputs[--_n_outputs];
-  _outputs = REALLOC_C_HEAP_ARRAY(LogOutput*, _outputs, _n_outputs, mtLogging);
+  _outputs = REALLOC_C_HEAP_ARRAY(_outputs, _n_outputs, mtLogging);
   delete output;
 }
 
@@ -546,7 +546,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       }
     }
 
-    FREE_C_HEAP_ARRAY(char, normalized);
+    FREE_C_HEAP_ARRAY(normalized);
     if (idx == SIZE_MAX) {
       return false;
     }
@@ -724,8 +724,7 @@ void LogConfiguration::register_update_listener(UpdateListenerFunction cb) {
   assert(cb != nullptr, "Should not register nullptr as listener");
   ConfigurationLock cl;
   size_t idx = _n_listener_callbacks++;
-  _listener_callbacks = REALLOC_C_HEAP_ARRAY(UpdateListenerFunction,
-                                             _listener_callbacks,
+  _listener_callbacks = REALLOC_C_HEAP_ARRAY(_listener_callbacks,
                                              _n_listener_callbacks,
                                              mtLogging);
   _listener_callbacks[idx] = cb;

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -160,8 +160,8 @@ static uint next_file_number(const char* filename,
     }
   }
 
-  FREE_C_HEAP_ARRAY(char, oldest_name);
-  FREE_C_HEAP_ARRAY(char, archive_name);
+  FREE_C_HEAP_ARRAY(oldest_name);
+  FREE_C_HEAP_ARRAY(archive_name);
   return next_num;
 }
 

--- a/src/hotspot/share/logging/logMessageBuffer.cpp
+++ b/src/hotspot/share/logging/logMessageBuffer.cpp
@@ -31,7 +31,7 @@ static void grow(T*& buffer, size_t& capacity, size_t minimum_length = 0) {
   if (new_size < minimum_length) {
     new_size = minimum_length;
   }
-  buffer = REALLOC_C_HEAP_ARRAY(T, buffer, new_size, mtLogging);
+  buffer = REALLOC_C_HEAP_ARRAY(buffer, new_size, mtLogging);
   capacity = new_size;
 }
 
@@ -48,8 +48,8 @@ LogMessageBuffer::LogMessageBuffer() : _message_buffer_size(0),
 
 LogMessageBuffer::~LogMessageBuffer() {
   if (_allocated) {
-    FREE_C_HEAP_ARRAY(char, _message_buffer);
-    FREE_C_HEAP_ARRAY(LogLine, _lines);
+    FREE_C_HEAP_ARRAY(_message_buffer);
+    FREE_C_HEAP_ARRAY(_lines);
   }
 }
 

--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -181,7 +181,7 @@ static void add_selections(LogSelection** selections,
     // Ensure there's enough room for both wildcard_match and exact_match
     if (*n_selections + 2 > *selections_cap) {
       *selections_cap *= 2;
-      *selections = REALLOC_C_HEAP_ARRAY(LogSelection, *selections, *selections_cap, mtLogging);
+      *selections = REALLOC_C_HEAP_ARRAY(*selections, *selections_cap, mtLogging);
     }
 
     // Add found matching selections to the result array
@@ -317,8 +317,8 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
       break;
     }
   }
-  FREE_C_HEAP_ARRAY(LogTagSet*, deviates);
-  FREE_C_HEAP_ARRAY(Selection, selections);
+  FREE_C_HEAP_ARRAY(deviates);
+  FREE_C_HEAP_ARRAY(selections);
 }
 
 bool LogOutput::parse_options(const char* options, outputStream* errstream) {

--- a/src/hotspot/share/logging/logTagSet.cpp
+++ b/src/hotspot/share/logging/logTagSet.cpp
@@ -215,5 +215,5 @@ void LogTagSet::list_all_tagsets(outputStream* out) {
     os::free(tagset_labels[idx]);
   }
   out->cr();
-  FREE_C_HEAP_ARRAY(char*, tagset_labels);
+  FREE_C_HEAP_ARRAY(tagset_labels);
 }

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -550,7 +550,7 @@ protected:
 #define NEW_C_HEAP_OBJ_RETURN_NULL(type, mem_tag)\
   NEW_C_HEAP_ARRAY_RETURN_NULL(type, 1, mem_tag)
 
-// deallocate obj of type in heap without calling dtor
+// deallocate obj in heap without calling dtor
 #define FREE_C_HEAP_OBJ(obj)\
   FREE_C_HEAP_ARRAY(obj)
 

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -510,9 +510,6 @@ protected:
 #define FREE_RESOURCE_ARRAY_IN_THREAD(thread, obj, size)\
   resource_free_bytes(thread, (char*)(obj), (size) * sizeof(*obj))
 
-#define FREE_FAST(obj)\
-    /* nop */
-
 #define NEW_RESOURCE_OBJ(type)\
   NEW_RESOURCE_ARRAY(type, 1)
 

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -479,6 +479,8 @@ protected:
 #endif // PRODUCT
 };
 
+#define REALLOC_RETURN_TYPE(old) typename std::remove_reference<decltype(old)>::type
+
 // One of the following macros must be used when allocating an array
 // or object to determine whether it should reside in the C heap on in
 // the resource area.
@@ -495,18 +497,18 @@ protected:
 #define NEW_RESOURCE_ARRAY_IN_THREAD_RETURN_NULL(thread, type, size)\
   (type*) resource_allocate_bytes(thread, (size) * sizeof(type), AllocFailStrategy::RETURN_NULL)
 
-#define REALLOC_RESOURCE_ARRAY(type, old, old_size, new_size)\
-  (type*) resource_reallocate_bytes((char*)(old), (old_size) * sizeof(type), (new_size) * sizeof(type))
+#define REALLOC_RESOURCE_ARRAY(old, old_size, new_size)\
+  (REALLOC_RETURN_TYPE(old)) resource_reallocate_bytes((char*)(old), (old_size) * sizeof(*old), (new_size) * sizeof(*old))
 
-#define REALLOC_RESOURCE_ARRAY_RETURN_NULL(type, old, old_size, new_size)\
-  (type*) resource_reallocate_bytes((char*)(old), (old_size) * sizeof(type),\
-                                    (new_size) * sizeof(type), AllocFailStrategy::RETURN_NULL)
+#define REALLOC_RESOURCE_ARRAY_RETURN_NULL(old, old_size, new_size)\
+  (REALLOC_RETURN_TYPE(old)) resource_reallocate_bytes((char*)(old), (old_size) * sizeof(*old), \
+                                                       (new_size) * sizeof(*old), AllocFailStrategy::RETURN_NULL)
 
-#define FREE_RESOURCE_ARRAY(type, old, size)\
-  resource_free_bytes(Thread::current(), (char*)(old), (size) * sizeof(type))
+#define FREE_RESOURCE_ARRAY(old, size)\
+  resource_free_bytes(Thread::current(), (char*)(old), (size) * sizeof(*old))
 
-#define FREE_RESOURCE_ARRAY_IN_THREAD(thread, type, old, size)\
-  resource_free_bytes(thread, (char*)(old), (size) * sizeof(type))
+#define FREE_RESOURCE_ARRAY_IN_THREAD(thread, old, size)\
+  resource_free_bytes(thread, (char*)(old), (size) * sizeof(*old))
 
 #define FREE_FAST(old)\
     /* nop */
@@ -532,14 +534,14 @@ protected:
 #define NEW_C_HEAP_ARRAY_RETURN_NULL(type, size, mem_tag)\
   NEW_C_HEAP_ARRAY2(type, (size), mem_tag, AllocFailStrategy::RETURN_NULL)
 
-#define REALLOC_C_HEAP_ARRAY(type, old, size, mem_tag)\
-  (type*) (ReallocateHeap((char*)(old), (size) * sizeof(type), mem_tag))
+#define REALLOC_C_HEAP_ARRAY(old, size, mem_tag)\
+  (REALLOC_RETURN_TYPE(old)) ReallocateHeap((char*)(old), (size) * sizeof(*old), mem_tag)
 
-#define REALLOC_C_HEAP_ARRAY_RETURN_NULL(type, old, size, mem_tag)\
-  (type*) (ReallocateHeap((char*)(old), (size) * sizeof(type), mem_tag, AllocFailStrategy::RETURN_NULL))
+#define REALLOC_C_HEAP_ARRAY_RETURN_NULL(old, size, mem_tag)\
+  (REALLOC_RETURN_TYPE(old)) ReallocateHeap((char*)(old), (size) * sizeof(*old), mem_tag, AllocFailStrategy::RETURN_NULL)
 
-#define FREE_C_HEAP_ARRAY(type, old) \
-  FreeHeap((char*)(old))
+#define FREE_C_HEAP_ARRAY(obj) \
+  FreeHeap((void*)(obj))
 
 // allocate type in heap without calling ctor
 #define NEW_C_HEAP_OBJ(type, mem_tag)\
@@ -549,8 +551,8 @@ protected:
   NEW_C_HEAP_ARRAY_RETURN_NULL(type, 1, mem_tag)
 
 // deallocate obj of type in heap without calling dtor
-#define FREE_C_HEAP_OBJ(objname)\
-  FreeHeap((char*)objname);
+#define FREE_C_HEAP_OBJ(obj)\
+  FREE_C_HEAP_ARRAY(obj)
 
 
 //------------------------------ReallocMark---------------------------------

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -95,7 +95,7 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
 //
 // char* AllocateHeap(size_t size, MemTag mem_tag, const NativeCallStack& stack, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 // char* AllocateHeap(size_t size, MemTag mem_tag, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
-// char* ReallocateHeap(char *old, size_t size, MemTag mem_tag, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+// char* ReallocateHeap(char* old, size_t size, MemTag mem_tag, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 // void FreeHeap(void* p);
 //
 
@@ -112,7 +112,7 @@ char* AllocateHeap(size_t size,
                    MemTag mem_tag,
                    AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 
-char* ReallocateHeap(char *old,
+char* ReallocateHeap(char* old,
                      size_t size,
                      MemTag mem_tag,
                      AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
@@ -374,9 +374,9 @@ extern char* resource_allocate_bytes(size_t size,
     AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 extern char* resource_allocate_bytes(Thread* thread, size_t size,
     AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
-extern char* resource_reallocate_bytes( char *old, size_t old_size, size_t new_size,
+extern char* resource_reallocate_bytes(char* old, size_t old_size, size_t new_size,
     AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
-extern void resource_free_bytes( Thread* thread, char *old, size_t size );
+extern void resource_free_bytes(Thread* thread, char* obj, size_t size);
 
 //----------------------------------------------------------------------
 // Base class for objects allocated in the resource area.
@@ -504,13 +504,13 @@ protected:
   (REALLOC_RETURN_TYPE(old)) resource_reallocate_bytes((char*)(old), (old_size) * sizeof(*old), \
                                                        (new_size) * sizeof(*old), AllocFailStrategy::RETURN_NULL)
 
-#define FREE_RESOURCE_ARRAY(old, size)\
-  resource_free_bytes(Thread::current(), (char*)(old), (size) * sizeof(*old))
+#define FREE_RESOURCE_ARRAY(obj, size)\
+  resource_free_bytes(Thread::current(), (char*)(obj), (size) * sizeof(*obj))
 
-#define FREE_RESOURCE_ARRAY_IN_THREAD(thread, old, size)\
-  resource_free_bytes(thread, (char*)(old), (size) * sizeof(*old))
+#define FREE_RESOURCE_ARRAY_IN_THREAD(thread, obj, size)\
+  resource_free_bytes(thread, (char*)(obj), (size) * sizeof(*obj))
 
-#define FREE_FAST(old)\
+#define FREE_FAST(obj)\
     /* nop */
 
 #define NEW_RESOURCE_OBJ(type)\

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -244,8 +244,8 @@ private:
   (decltype(old)) (arena)->Arealloc((char*)(old), (old_size) * sizeof(*old), \
                                   (new_size) * sizeof(*old) )
 
-#define FREE_ARENA_ARRAY(arena, old, size) \
-  (arena)->Afree((char*)(old), (size) * sizeof(*old))
+#define FREE_ARENA_ARRAY(arena, obj, size) \
+  (arena)->Afree((char*)(obj), (size) * sizeof(*obj))
 
 #define NEW_ARENA_OBJ(arena, type) \
   NEW_ARENA_ARRAY(arena, type, 1)

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -241,8 +241,8 @@ private:
   (type*) (arena)->Amalloc((size) * sizeof(type))
 
 #define REALLOC_ARENA_ARRAY(arena, old, old_size, new_size)    \
-  (decltype(old)) (arena)->Arealloc((char*)(old), (old_size) * sizeof(*old), \
-                                  (new_size) * sizeof(*old) )
+  (REALLOC_RETURN_TYPE(old)) (arena)->Arealloc((char*)(old), (old_size) * sizeof(*old), \
+                                               (new_size) * sizeof(*old) )
 
 #define FREE_ARENA_ARRAY(arena, obj, size) \
   (arena)->Afree((char*)(obj), (size) * sizeof(*obj))

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -240,12 +240,12 @@ private:
 #define NEW_ARENA_ARRAY(arena, type, size) \
   (type*) (arena)->Amalloc((size) * sizeof(type))
 
-#define REALLOC_ARENA_ARRAY(arena, type, old, old_size, new_size)    \
-  (type*) (arena)->Arealloc((char*)(old), (old_size) * sizeof(type), \
-                            (new_size) * sizeof(type) )
+#define REALLOC_ARENA_ARRAY(arena, old, old_size, new_size)    \
+  (decltype(old)) (arena)->Arealloc((char*)(old), (old_size) * sizeof(*old), \
+                                  (new_size) * sizeof(*old) )
 
-#define FREE_ARENA_ARRAY(arena, type, old, size) \
-  (arena)->Afree((char*)(old), (size) * sizeof(type))
+#define FREE_ARENA_ARRAY(arena, old, size) \
+  (arena)->Afree((char*)(old), (size) * sizeof(*old))
 
 #define NEW_ARENA_OBJ(arena, type) \
   NEW_ARENA_ARRAY(arena, type, 1)

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -189,7 +189,7 @@ KlassInfoTable::~KlassInfoTable() {
     for (int index = 0; index < _num_buckets; index++) {
       _buckets[index].empty();
     }
-    FREE_C_HEAP_ARRAY(KlassInfoBucket, _buckets);
+    FREE_C_HEAP_ARRAY(_buckets);
     _buckets = nullptr;
   }
 }

--- a/src/hotspot/share/memory/memRegion.cpp
+++ b/src/hotspot/share/memory/memRegion.cpp
@@ -115,5 +115,5 @@ void MemRegion::destroy_array(MemRegion* array, size_t length) {
   for (size_t i = 0; i < length; i++) {
     array[i].~MemRegion();
   }
-  FREE_C_HEAP_ARRAY(MemRegion, array);
+  FREE_C_HEAP_ARRAY(array);
 }

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
@@ -473,7 +473,7 @@ RootChunkAreaLUT::~RootChunkAreaLUT() {
   for (int i = 0; i < _num; i++) {
     _arr[i].~RootChunkArea();
   }
-  FREE_C_HEAP_ARRAY(RootChunkArea, _arr);
+  FREE_C_HEAP_ARRAY(_arr);
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/memory/resourceArea.cpp
+++ b/src/hotspot/share/memory/resourceArea.cpp
@@ -70,10 +70,10 @@ extern char* resource_allocate_bytes(Thread* thread, size_t size, AllocFailType 
   return thread->resource_area()->allocate_bytes(size, alloc_failmode);
 }
 
-extern char* resource_reallocate_bytes( char *old, size_t old_size, size_t new_size, AllocFailType alloc_failmode){
+extern char* resource_reallocate_bytes(char* old, size_t old_size, size_t new_size, AllocFailType alloc_failmode){
   return (char*)Thread::current()->resource_area()->Arealloc(old, old_size, new_size, alloc_failmode);
 }
 
-extern void resource_free_bytes( Thread* thread, char *old, size_t size ) {
-  thread->resource_area()->Afree(old, size);
+extern void resource_free_bytes(Thread* thread, char* obj, size_t size) {
+  thread->resource_area()->Afree(obj, size);
 }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1256,7 +1256,7 @@ void Universe::initialize_verify_flags() {
     }
     token = strtok_r(nullptr, delimiter, &save_ptr);
   }
-  FREE_C_HEAP_ARRAY(char, subset_list);
+  FREE_C_HEAP_ARRAY(subset_list);
 }
 
 bool Universe::should_verify_subset(uint subset) {

--- a/src/hotspot/share/nmt/nmtNativeCallStackStorage.cpp
+++ b/src/hotspot/share/nmt/nmtNativeCallStackStorage.cpp
@@ -55,7 +55,7 @@ NativeCallStackStorage::NativeCallStackStorage(bool is_detailed_mode, int table_
   }
 }
 NativeCallStackStorage::~NativeCallStackStorage() {
-  FREE_C_HEAP_ARRAY(LinkPtr, _table);
+  FREE_C_HEAP_ARRAY(_table);
 }
 
 NativeCallStackStorage::NativeCallStackStorage(const NativeCallStackStorage& other)

--- a/src/hotspot/share/nmt/vmatree.cpp
+++ b/src/hotspot/share/nmt/vmatree.cpp
@@ -807,7 +807,7 @@ void VMATree::SummaryDiff::grow_and_rehash() {
 
   // Clear previous -- if applicable
   if (_members != _small) {
-    FREE_C_HEAP_ARRAY(KVEntry, _members);
+    FREE_C_HEAP_ARRAY(_members);
   }
 
   _members = NEW_C_HEAP_ARRAY(KVEntry, new_len, mtNMT);
@@ -847,7 +847,7 @@ void VMATree::SummaryDiff::add(const SummaryDiff& other) {
 
 void VMATree::SummaryDiff::clear() {
   if (_members != _small) {
-    FREE_C_HEAP_ARRAY(KVEntry, _members);
+    FREE_C_HEAP_ARRAY(_members);
   }
   memset(_small, 0, sizeof(_small));
 }

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -264,7 +264,7 @@ public:
     }
     ~SummaryDiff() {
       if (_members != _small) {
-        FREE_C_HEAP_ARRAY(KVEntry, _members);
+        FREE_C_HEAP_ARRAY(_members);
       }
     }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2542,7 +2542,7 @@ void InstanceKlass::update_methods_jmethod_cache() {
         new_cache[i] = cache[i];
       }
       _methods_jmethod_ids = new_cache;
-      FREE_C_HEAP_ARRAY(jmethodID, cache);
+      FREE_C_HEAP_ARRAY(cache);
     }
   }
 }
@@ -3016,7 +3016,7 @@ void InstanceKlass::release_C_heap_structures(bool release_sub_metadata) {
   }
 #endif
 
-  FREE_C_HEAP_ARRAY(char, _source_debug_extension);
+  FREE_C_HEAP_ARRAY(_source_debug_extension);
 
   if (release_sub_metadata) {
     constants()->release_C_heap_structures();

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1430,7 +1430,7 @@ void UnionFind::extend( uint from_idx, uint to_idx ) {
   if( from_idx >= _max ) {
     uint size = 16;
     while( size <= from_idx ) size <<=1;
-    _indices = REALLOC_RESOURCE_ARRAY( uint, _indices, _max, size );
+    _indices = REALLOC_RESOURCE_ARRAY( _indices, _max, size );
     _max = size;
   }
   while( _cnt <= from_idx ) _indices[_cnt++] = 0;

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -265,7 +265,7 @@ PhaseChaitin::PhaseChaitin(uint unique, PhaseCFG &cfg, Matcher &matcher, bool sc
   assert((&buckets[0][0] + nr_blocks) == offset, "should be");
 
   // Free the now unused memory
-  FREE_RESOURCE_ARRAY(Block*, buckets[1], (NUMBUCKS-1)*nr_blocks);
+  FREE_RESOURCE_ARRAY(buckets[1], (NUMBUCKS-1)*nr_blocks);
   // Finally, point the _blks to our memory
   _blks = buckets[0];
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1618,7 +1618,7 @@ void Compile::grow_alias_types() {
   const int new_ats  = old_ats;          // how many more?
   const int grow_ats = old_ats+new_ats;  // how many now?
   _max_alias_types = grow_ats;
-  _alias_types =  REALLOC_ARENA_ARRAY(comp_arena(), AliasType*, _alias_types, old_ats, grow_ats);
+  _alias_types =  REALLOC_ARENA_ARRAY(comp_arena(), _alias_types, old_ats, grow_ats);
   AliasType* ats =    NEW_ARENA_ARRAY(comp_arena(), AliasType, new_ats);
   Copy::zero_to_bytes(ats, sizeof(AliasType)*new_ats);
   for (int i = 0; i < new_ats; i++)  _alias_types[old_ats+i] = &ats[i];

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5938,8 +5938,8 @@ void PhaseIdealLoop::set_idom(Node* d, Node* n, uint dom_depth) {
   uint idx = d->_idx;
   if (idx >= _idom_size) {
     uint newsize = next_power_of_2(idx);
-    _idom      = REALLOC_ARENA_ARRAY(&_arena, Node*,     _idom,_idom_size,newsize);
-    _dom_depth = REALLOC_ARENA_ARRAY(&_arena,  uint, _dom_depth,_idom_size,newsize);
+    _idom      = REALLOC_ARENA_ARRAY(&_arena, _idom, _idom_size, newsize);
+    _dom_depth = REALLOC_ARENA_ARRAY(&_arena, _dom_depth, _idom_size, newsize);
     memset( _dom_depth + _idom_size, 0, (newsize - _idom_size) * sizeof(uint) );
     _idom_size = newsize;
   }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -914,7 +914,7 @@ class PhaseIdealLoop : public PhaseTransform {
   void reallocate_preorders() {
     _nesting.check(); // Check if a potential re-allocation in the resource arena is safe
     if ( _max_preorder < C->unique() ) {
-      _preorders = REALLOC_RESOURCE_ARRAY(uint, _preorders, _max_preorder, C->unique());
+      _preorders = REALLOC_RESOURCE_ARRAY(_preorders, _max_preorder, C->unique());
       _max_preorder = C->unique();
     }
     memset(_preorders, 0, sizeof(uint) * _max_preorder);
@@ -926,7 +926,7 @@ class PhaseIdealLoop : public PhaseTransform {
     _nesting.check(); // Check if a potential re-allocation in the resource arena is safe
     if ( _max_preorder < C->unique() ) {
       uint newsize = _max_preorder<<1;  // double size of array
-      _preorders = REALLOC_RESOURCE_ARRAY(uint, _preorders, _max_preorder, newsize);
+      _preorders = REALLOC_RESOURCE_ARRAY(_preorders, _max_preorder, newsize);
       memset(&_preorders[_max_preorder],0,sizeof(uint)*(newsize-_max_preorder));
       _max_preorder = newsize;
     }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -3095,7 +3095,7 @@ void Node_Stack::grow() {
   size_t old_top = pointer_delta(_inode_top,_inodes,sizeof(INode)); // save _top
   size_t old_max = pointer_delta(_inode_max,_inodes,sizeof(INode));
   size_t max = old_max << 1;             // max * 2
-  _inodes = REALLOC_ARENA_ARRAY(_a, INode, _inodes, old_max, max);
+  _inodes = REALLOC_ARENA_ARRAY(_a, _inodes, old_max, max);
   _inode_max = _inodes + max;
   _inode_top = _inodes + old_top;        // restore _top
 }
@@ -3213,4 +3213,3 @@ Node* TypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
   return Node::Ideal(phase, can_reshape);
 }
-

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -204,7 +204,7 @@ class PhaseNameValidator {
 
   ~PhaseNameValidator() {
     if (_bad != nullptr) {
-      FREE_C_HEAP_ARRAY(char, _bad);
+      FREE_C_HEAP_ARRAY(_bad);
     }
   }
 

--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -285,8 +285,9 @@ class RegMask {
         _rm_word_ext = NEW_ARENA_ARRAY(_arena, uintptr_t, new_ext_size);
       } else {
         assert(_original_ext_address == &_rm_word_ext, "clone sanity check");
-        _rm_word_ext = REALLOC_ARENA_ARRAY(_arena, uintptr_t, _rm_word_ext,
+        _rm_word_ext = REALLOC_ARENA_ARRAY(_arena, _rm_word_ext,
                                            old_ext_size, new_ext_size);
+
       }
       if (initialize_by_infinite_stack) {
         int fill = 0;

--- a/src/hotspot/share/opto/traceAutoVectorizationTag.hpp
+++ b/src/hotspot/share/opto/traceAutoVectorizationTag.hpp
@@ -142,7 +142,7 @@ class TraceAutoVectorizationTagValidator {
 
   ~TraceAutoVectorizationTagValidator() {
     if (_bad != nullptr) {
-      FREE_C_HEAP_ARRAY(char, _bad);
+      FREE_C_HEAP_ARRAY(_bad);
     }
   }
 

--- a/src/hotspot/share/opto/traceMergeStoresTag.hpp
+++ b/src/hotspot/share/opto/traceMergeStoresTag.hpp
@@ -111,7 +111,7 @@ namespace TraceMergeStores {
 
     ~TagValidator() {
       if (_bad != nullptr) {
-        FREE_C_HEAP_ARRAY(char, _bad);
+        FREE_C_HEAP_ARRAY(_bad);
       }
     }
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2895,7 +2895,7 @@ JNI_ENTRY(void, jni_ReleaseStringCritical(JNIEnv *env, jstring str, const jchar 
   if (is_latin1) {
     // For latin1 string, free jchar array allocated by earlier call to GetStringCritical.
     // This assumes that ReleaseStringCritical bookends GetStringCritical.
-    FREE_C_HEAP_ARRAY(jchar, chars);
+    FREE_C_HEAP_ARRAY(chars);
   } else {
     // StringDedup can have replaced the value array, so don't fetch the array from 's'.
     // Instead, we calculate the address based on the jchar array exposed with GetStringCritical.

--- a/src/hotspot/share/prims/jvmtiAgent.cpp
+++ b/src/hotspot/share/prims/jvmtiAgent.cpp
@@ -247,7 +247,7 @@ static void vm_exit(const JvmtiAgent* agent, const char* sub_msg1, const char* s
     jio_snprintf(buf, len, "%s%s%s%s", not_found_error_msg, agent->name(), sub_msg1, &ebuf[0]);
   }
   vm_exit_during_initialization(buf, nullptr);
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -955,7 +955,7 @@ address JvmtiClassFileReconstituter::writeable_address(size_t size) {
                                                          * initial_buffer_size;
 
     // VM goes belly-up if the memory isn't available, so cannot do OOM processing
-    _buffer = REALLOC_RESOURCE_ARRAY(u1, _buffer, _buffer_size, new_buffer_size);
+    _buffer = REALLOC_RESOURCE_ARRAY(_buffer, _buffer_size, new_buffer_size);
     _buffer_size = new_buffer_size;
     _buffer_ptr = _buffer + used_size;
   }

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1160,7 +1160,7 @@ class JvmtiCompiledMethodLoadEventMark : public JvmtiMethodEventMark {
     JvmtiCodeBlobEvents::build_jvmti_addr_location_map(nm, &_map, &_map_length);
   }
   ~JvmtiCompiledMethodLoadEventMark() {
-     FREE_C_HEAP_ARRAY(jvmtiAddrLocationMap, _map);
+     FREE_C_HEAP_ARRAY(_map);
   }
 
   jint code_size() { return _code_size; }

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -716,7 +716,7 @@ static jint invoke_string_value_callback(jvmtiStringPrimitiveValueCallback cb,
                    user_data);
 
   if (is_latin1 && s_len > 0) {
-    FREE_C_HEAP_ARRAY(jchar, value);
+    FREE_C_HEAP_ARRAY(value);
   }
   return res;
 }

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -702,11 +702,11 @@ static jclass Unsafe_DefineClass_impl(JNIEnv *env, jstring name, jbyteArray data
   result = JVM_DefineClass(env, utfName, loader, body, length, pd);
 
   if (utfName && utfName != buf) {
-    FREE_C_HEAP_ARRAY(char, utfName);
+    FREE_C_HEAP_ARRAY(utfName);
   }
 
  free_body:
-  FREE_C_HEAP_ARRAY(jbyte, body);
+  FREE_C_HEAP_ARRAY(body);
   return result;
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -851,7 +851,7 @@ static bool set_string_flag(JVMFlag* flag, const char* value, JVMFlagOrigin orig
   }
   if (JVMFlagAccess::set_ccstr(flag, &value, origin) != JVMFlag::SUCCESS) return false;
   // Contract:  JVMFlag always returns a pointer that needs freeing.
-  FREE_C_HEAP_ARRAY(char, value);
+  FREE_C_HEAP_ARRAY(value);
   return true;
 }
 
@@ -876,9 +876,9 @@ static bool append_to_string_flag(JVMFlag* flag, const char* new_value, JVMFlagO
   }
   (void) JVMFlagAccess::set_ccstr(flag, &value, origin);
   // JVMFlag always returns a pointer that needs freeing.
-  FREE_C_HEAP_ARRAY(char, value);
+  FREE_C_HEAP_ARRAY(value);
   // JVMFlag made its own copy, so I must delete my own temp. buffer.
-  FREE_C_HEAP_ARRAY(char, free_this_too);
+  FREE_C_HEAP_ARRAY(free_this_too);
   return true;
 }
 
@@ -1013,7 +1013,7 @@ void Arguments::add_string(char*** bldarray, int* count, const char* arg) {
   if (*bldarray == nullptr) {
     *bldarray = NEW_C_HEAP_ARRAY(char*, new_count, mtArguments);
   } else {
-    *bldarray = REALLOC_C_HEAP_ARRAY(char*, *bldarray, new_count, mtArguments);
+    *bldarray = REALLOC_C_HEAP_ARRAY(*bldarray, new_count, mtArguments);
   }
   (*bldarray)[*count] = os::strdup_check_oom(arg);
   *count = new_count;
@@ -2050,7 +2050,7 @@ int Arguments::process_patch_mod_option(const char* patch_mod_tail) {
       *(module_name + module_len) = '\0';
       // The path piece begins one past the module_equal sign
       add_patch_mod_prefix(module_name, module_equal + 1);
-      FREE_C_HEAP_ARRAY(char, module_name);
+      FREE_C_HEAP_ARRAY(module_name);
       if (!create_numbered_module_property("jdk.module.patch", patch_mod_tail, patch_mod_count++)) {
         return JNI_ENOMEM;
       }
@@ -2201,8 +2201,8 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         }
 #endif // !INCLUDE_JVMTI
         JvmtiAgentList::add_xrun(name, options, false);
-        FREE_C_HEAP_ARRAY(char, name);
-        FREE_C_HEAP_ARRAY(char, options);
+        FREE_C_HEAP_ARRAY(name);
+        FREE_C_HEAP_ARRAY(options);
       }
     } else if (match_option(option, "--add-reads=", &tail)) {
       if (!create_numbered_module_property("jdk.module.addreads", tail, addreads_count++)) {
@@ -2331,7 +2331,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
         char *options = NEW_C_HEAP_ARRAY(char, length, mtArguments);
         jio_snprintf(options, length, "%s", tail);
         JvmtiAgentList::add("instrument", options, false);
-        FREE_C_HEAP_ARRAY(char, options);
+        FREE_C_HEAP_ARRAY(options);
 
         // java agents need module java.instrument
         if (!create_numbered_module_property("jdk.module.addmods", "java.instrument", _addmods_count++)) {
@@ -3066,7 +3066,7 @@ class ScopedVMInitArgs : public StackObj {
     for (int i = 0; i < _args.nOptions; i++) {
       os::free(_args.options[i].optionString);
     }
-    FREE_C_HEAP_ARRAY(JavaVMOption, _args.options);
+    FREE_C_HEAP_ARRAY(_args.options);
   }
 
   // Insert options into this option list, to replace option at
@@ -3215,7 +3215,7 @@ jint Arguments::parse_vm_options_file(const char* file_name, ScopedVMInitArgs* v
   ssize_t bytes_read = ::read(fd, (void *)buf, (unsigned)bytes_alloc);
   ::close(fd);
   if (bytes_read < 0) {
-    FREE_C_HEAP_ARRAY(char, buf);
+    FREE_C_HEAP_ARRAY(buf);
     jio_fprintf(defaultStream::error_stream(),
                 "Could not read options file '%s'\n", file_name);
     return JNI_ERR;
@@ -3223,13 +3223,13 @@ jint Arguments::parse_vm_options_file(const char* file_name, ScopedVMInitArgs* v
 
   if (bytes_read == 0) {
     // tell caller there is no option data and that is ok
-    FREE_C_HEAP_ARRAY(char, buf);
+    FREE_C_HEAP_ARRAY(buf);
     return JNI_OK;
   }
 
   retcode = parse_options_buffer(file_name, buf, bytes_read, vm_args);
 
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
   return retcode;
 }
 
@@ -3562,7 +3562,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   char *vmoptions = ClassLoader::lookup_vm_options();
   if (vmoptions != nullptr) {
     code = parse_options_buffer("vm options resource", vmoptions, strlen(vmoptions), &initial_vm_options_args);
-    FREE_C_HEAP_ARRAY(char, vmoptions);
+    FREE_C_HEAP_ARRAY(vmoptions);
     if (code != JNI_OK) {
       return code;
     }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -249,9 +249,9 @@ Deoptimization::UnrollBlock::UnrollBlock(int  size_of_deoptimized_frame,
 }
 
 Deoptimization::UnrollBlock::~UnrollBlock() {
-  FREE_C_HEAP_ARRAY(intptr_t, _frame_sizes);
-  FREE_C_HEAP_ARRAY(intptr_t, _frame_pcs);
-  FREE_C_HEAP_ARRAY(intptr_t, _register_block);
+  FREE_C_HEAP_ARRAY(_frame_sizes);
+  FREE_C_HEAP_ARRAY(_frame_pcs);
+  FREE_C_HEAP_ARRAY(_register_block);
 }
 
 int Deoptimization::UnrollBlock::size_of_frames() const {

--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -648,7 +648,7 @@ void JVMFlag::printSetFlags(outputStream* out) {
     }
   }
   out->cr();
-  FREE_C_HEAP_ARRAY(JVMFlag*, array);
+  FREE_C_HEAP_ARRAY(array);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -329,7 +329,7 @@ JVMFlag::Error JVMFlagAccess::set_ccstr(JVMFlag* flag, ccstr* value, JVMFlagOrig
   flag->set_ccstr(new_value);
   if (!flag->is_default() && old_value != nullptr) {
     // Old value is heap allocated so free it.
-    FREE_C_HEAP_ARRAY(char, old_value);
+    FREE_C_HEAP_ARRAY(old_value);
   }
   // Unlike the other APIs, the old value is NOT returned, so the caller won't need to free it.
   // The callers typically don't care what the old value is.

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -308,7 +308,7 @@ static jlong* resize_counters_array(jlong* old_counters, int current_size, int n
     if (new_size > current_size) {
       memset(new_counters + current_size, 0, sizeof(jlong) * (new_size - current_size));
     }
-    FREE_C_HEAP_ARRAY(jlong, old_counters);
+    FREE_C_HEAP_ARRAY(old_counters);
   }
   return new_counters;
 }
@@ -700,7 +700,7 @@ JavaThread::~JavaThread() {
 
 #if INCLUDE_JVMCI
   if (JVMCICounterSize > 0) {
-    FREE_C_HEAP_ARRAY(jlong, _jvmci_counters);
+    FREE_C_HEAP_ARRAY(_jvmci_counters);
   }
 #endif // INCLUDE_JVMCI
 }
@@ -1884,7 +1884,7 @@ WordSize JavaThread::popframe_preserved_args_size_in_words() {
 
 void JavaThread::popframe_free_preserved_args() {
   assert(_popframe_preserved_args != nullptr, "should not free PopFrame preserved arguments twice");
-  FREE_C_HEAP_ARRAY(char, (char*)_popframe_preserved_args);
+  FREE_C_HEAP_ARRAY((char*)_popframe_preserved_args);
   _popframe_preserved_args = nullptr;
   _popframe_preserved_args_size = 0;
 }

--- a/src/hotspot/share/runtime/nonJavaThread.cpp
+++ b/src/hotspot/share/runtime/nonJavaThread.cpp
@@ -133,7 +133,7 @@ NamedThread::NamedThread() :
 {}
 
 NamedThread::~NamedThread() {
-  FREE_C_HEAP_ARRAY(char, _name);
+  FREE_C_HEAP_ARRAY(_name);
 }
 
 void NamedThread::set_name(const char* format, ...) {

--- a/src/hotspot/share/runtime/objectMonitorTable.cpp
+++ b/src/hotspot/share/runtime/objectMonitorTable.cpp
@@ -192,7 +192,7 @@ public:
   }
 
   ~Table() {
-    FREE_C_HEAP_ARRAY(Atomic<Entry>, _buckets);
+    FREE_C_HEAP_ARRAY(_buckets);
   }
 
   Table* prev() {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -303,10 +303,10 @@ static void free_array_of_char_arrays(char** a, size_t n) {
       while (n > 0) {
           n--;
           if (a[n] != nullptr) {
-            FREE_C_HEAP_ARRAY(char, a[n]);
+            FREE_C_HEAP_ARRAY(a[n]);
           }
       }
-      FREE_C_HEAP_ARRAY(char*, a);
+      FREE_C_HEAP_ARRAY(a);
 }
 
 bool os::dll_locate_lib(char *buffer, size_t buflen,
@@ -353,7 +353,7 @@ bool os::dll_locate_lib(char *buffer, size_t buflen,
     }
   }
 
-  FREE_C_HEAP_ARRAY(char*, fullfname);
+  FREE_C_HEAP_ARRAY(fullfname);
   return retval;
 }
 
@@ -562,7 +562,7 @@ void* os::find_agent_function(JvmtiAgent *agent_lib, bool check_lib, const char 
   char* agent_function_name = build_agent_function_name(sym, lib_name, agent_lib->is_absolute_path());
   if (agent_function_name != nullptr) {
     entryName = dll_lookup(handle, agent_function_name);
-    FREE_C_HEAP_ARRAY(char, agent_function_name);
+    FREE_C_HEAP_ARRAY(agent_function_name);
   }
   return entryName;
 }
@@ -1510,20 +1510,20 @@ bool os::set_boot_path(char fileSep, char pathSep) {
   bool has_jimage = (os::stat(jimage, &st) == 0);
   if (has_jimage) {
     Arguments::set_boot_class_path(jimage, true);
-    FREE_C_HEAP_ARRAY(char, jimage);
+    FREE_C_HEAP_ARRAY(jimage);
     return true;
   }
-  FREE_C_HEAP_ARRAY(char, jimage);
+  FREE_C_HEAP_ARRAY(jimage);
 
   // check if developer build with exploded modules
   char* base_classes = format_boot_path("%/modules/" JAVA_BASE_NAME, home, home_len, fileSep, pathSep);
   if (base_classes == nullptr) return false;
   if (os::stat(base_classes, &st) == 0) {
     Arguments::set_boot_class_path(base_classes, false);
-    FREE_C_HEAP_ARRAY(char, base_classes);
+    FREE_C_HEAP_ARRAY(base_classes);
     return true;
   }
-  FREE_C_HEAP_ARRAY(char, base_classes);
+  FREE_C_HEAP_ARRAY(base_classes);
 
   return false;
 }
@@ -1653,7 +1653,7 @@ char** os::split_path(const char* path, size_t* elements, size_t file_name_lengt
     opath[i] = s;
     p += len + 1;
   }
-  FREE_C_HEAP_ARRAY(char, inpath);
+  FREE_C_HEAP_ARRAY(inpath);
   *elements = count;
   return opath;
 }

--- a/src/hotspot/share/runtime/os_perf.hpp
+++ b/src/hotspot/share/runtime/os_perf.hpp
@@ -152,9 +152,9 @@ class SystemProcess : public CHeapObj<mtInternal> {
   }
 
   virtual ~SystemProcess(void) {
-    FREE_C_HEAP_ARRAY(char, _name);
-    FREE_C_HEAP_ARRAY(char, _path);
-    FREE_C_HEAP_ARRAY(char, _command_line);
+    FREE_C_HEAP_ARRAY(_name);
+    FREE_C_HEAP_ARRAY(_path);
+    FREE_C_HEAP_ARRAY(_command_line);
   }
 };
 

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -118,9 +118,9 @@ PerfData::PerfData(CounterNS ns, const char* name, Units u, Variability v)
 }
 
 PerfData::~PerfData() {
-  FREE_C_HEAP_ARRAY(char, _name);
+  FREE_C_HEAP_ARRAY(_name);
   if (is_on_c_heap()) {
-    FREE_C_HEAP_ARRAY(PerfDataEntry, _pdep);
+    FREE_C_HEAP_ARRAY(_pdep);
   }
 }
 

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -247,7 +247,7 @@ char* PerfMemory::get_perfdata_file_path() {
     dest_file = NEW_C_HEAP_ARRAY(char, JVM_MAXPATHLEN, mtInternal);
     if(!Arguments::copy_expand_pid(PerfDataSaveFile, strlen(PerfDataSaveFile),
                                    dest_file, JVM_MAXPATHLEN)) {
-      FREE_C_HEAP_ARRAY(char, dest_file);
+      FREE_C_HEAP_ARRAY(dest_file);
       log_debug(perf)("invalid performance data file path name specified, fall back to a default name");
     } else {
       return dest_file;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3085,7 +3085,7 @@ AdapterHandlerEntry::~AdapterHandlerEntry() {
     _fingerprint = nullptr;
   }
 #ifdef ASSERT
-  FREE_C_HEAP_ARRAY(unsigned char, _saved_code);
+  FREE_C_HEAP_ARRAY(_saved_code);
 #endif
   FreeHeap(this);
 }
@@ -3376,7 +3376,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
 JRT_END
 
 JRT_LEAF(void, SharedRuntime::OSR_migration_end( intptr_t* buf) )
-  FREE_C_HEAP_ARRAY(intptr_t, buf);
+  FREE_C_HEAP_ARRAY(buf);
 JRT_END
 
 const char* AdapterHandlerLibrary::name(AdapterHandlerEntry* handler) {

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -667,7 +667,7 @@ ThreadsList::ThreadsList(int entries) :
 
 ThreadsList::~ThreadsList() {
   if (_threads != empty_threads_list_data) {
-    FREE_C_HEAP_ARRAY(JavaThread*, _threads);
+    FREE_C_HEAP_ARRAY(_threads);
   }
   _magic = 0xDEADBEEF;
 }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1062,7 +1062,7 @@ void Threads::destroy_vm() {
 
 #if INCLUDE_JVMCI
   if (JVMCICounterSize > 0) {
-    FREE_C_HEAP_ARRAY(jlong, JavaThread::_jvmci_old_thread_counters);
+    FREE_C_HEAP_ARRAY(JavaThread::_jvmci_old_thread_counters);
   }
 #endif
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2086,10 +2086,10 @@ static int recursiveFindType(VMTypeEntry* origtypes, const char* typeName, bool 
     s[len-1] = '\0';
     // tty->print_cr("checking \"%s\" for \"%s\"", s, typeName);
     if (recursiveFindType(origtypes, s, true) == 1) {
-      FREE_C_HEAP_ARRAY(char, s);
+      FREE_C_HEAP_ARRAY(s);
       return 1;
     }
-    FREE_C_HEAP_ARRAY(char, s);
+    FREE_C_HEAP_ARRAY(s);
   }
   const char* start = nullptr;
   if (strstr(typeName, "GrowableArray<") == typeName) {
@@ -2105,10 +2105,10 @@ static int recursiveFindType(VMTypeEntry* origtypes, const char* typeName, bool 
     s[len-1] = '\0';
     // tty->print_cr("checking \"%s\" for \"%s\"", s, typeName);
     if (recursiveFindType(origtypes, s, true) == 1) {
-      FREE_C_HEAP_ARRAY(char, s);
+      FREE_C_HEAP_ARRAY(s);
       return 1;
     }
-    FREE_C_HEAP_ARRAY(char, s);
+    FREE_C_HEAP_ARRAY(s);
   }
   if (strstr(typeName, "const ") == typeName) {
     const char * s = typeName + strlen("const ");

--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -36,7 +36,7 @@ StringArrayArgument::StringArrayArgument() {
 
 StringArrayArgument::~StringArrayArgument() {
   for (int i=0; i<_array->length(); i++) {
-    FREE_C_HEAP_ARRAY(char, _array->at(i));
+    FREE_C_HEAP_ARRAY(_array->at(i));
   }
   delete _array;
 }
@@ -183,7 +183,7 @@ template <> void DCmdArgument<bool>::init_value(TRAPS) {
 template <> void DCmdArgument<bool>::destroy_value() { }
 
 template <> void DCmdArgument<char*>::destroy_value() {
-  FREE_C_HEAP_ARRAY(char, _value);
+  FREE_C_HEAP_ARRAY(_value);
   set_value(nullptr);
 }
 
@@ -194,14 +194,14 @@ template <> void DCmdArgument<char*>::parse_value(const char* str,
   } else {
     // Use realloc as we may have a default set.
     if (strcmp(type(), "FILE") == 0) {
-      _value = REALLOC_C_HEAP_ARRAY(char, _value, JVM_MAXPATHLEN, mtInternal);
+      _value = REALLOC_C_HEAP_ARRAY(_value, JVM_MAXPATHLEN, mtInternal);
       if (!Arguments::copy_expand_pid(str, len, _value, JVM_MAXPATHLEN)) {
         stringStream error_msg;
         error_msg.print("File path invalid or too long: %s", str);
         THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), error_msg.base());
       }
     } else {
-      _value = REALLOC_C_HEAP_ARRAY(char, _value, len + 1, mtInternal);
+      _value = REALLOC_C_HEAP_ARRAY(_value, len + 1, mtInternal);
       int n = os::snprintf(_value, len + 1, "%.*s", (int)len, str);
       assert((size_t)n <= len, "Unexpected number of characters in string");
     }

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -93,7 +93,7 @@ FinalizerEntry::FinalizerEntry(const InstanceKlass* ik) :
     _total_finalizers_run(0) {}
 
 FinalizerEntry::~FinalizerEntry() {
-  FREE_C_HEAP_ARRAY(char, _codesource);
+  FREE_C_HEAP_ARRAY(_codesource);
 }
 
 const InstanceKlass* FinalizerEntry::klass() const {

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2308,7 +2308,7 @@ class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public Unmounte
       for (int i = 0; i < _thread_dumpers_count; i++) {
         delete _thread_dumpers[i];
       }
-      FREE_C_HEAP_ARRAY(ThreadDumper*, _thread_dumpers);
+      FREE_C_HEAP_ARRAY(_thread_dumpers);
     }
 
     if (_dumper_controller != nullptr) {

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1715,7 +1715,7 @@ ThreadTimesClosure::~ThreadTimesClosure() {
   for (int i = 0; i < _count; i++) {
     os::free(_names_chars[i]);
   }
-  FREE_C_HEAP_ARRAY(char *, _names_chars);
+  FREE_C_HEAP_ARRAY(_names_chars);
 }
 
 // Fills names with VM internal thread names and times with the corresponding

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -163,8 +163,8 @@ GCStatInfo::GCStatInfo(int num_pools) {
 }
 
 GCStatInfo::~GCStatInfo() {
-  FREE_C_HEAP_ARRAY(MemoryUsage*, _before_gc_usage_array);
-  FREE_C_HEAP_ARRAY(MemoryUsage*, _after_gc_usage_array);
+  FREE_C_HEAP_ARRAY(_before_gc_usage_array);
+  FREE_C_HEAP_ARRAY(_after_gc_usage_array);
 }
 
 void GCStatInfo::set_gc_usage(int pool_index, MemoryUsage usage, bool before_gc) {

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -217,7 +217,7 @@ template <typename CONFIG, MemTag MT>
 inline ConcurrentHashTable<CONFIG, MT>::
   InternalTable::~InternalTable()
 {
-  FREE_C_HEAP_ARRAY(Bucket, _buckets);
+  FREE_C_HEAP_ARRAY(_buckets);
 }
 
 // ScopedCS

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -942,7 +942,7 @@ bool DwarfFile::ArangesCache::add_entry(const AddressDescriptor& descriptor, uin
 
 bool DwarfFile::ArangesCache::grow() {
   size_t new_capacity = _capacity == 0 ? 128 : _capacity * 1.5;
-  ArangesEntry* new_entries = REALLOC_C_HEAP_ARRAY_RETURN_NULL(ArangesEntry, _entries, new_capacity, mtInternal);
+  ArangesEntry* new_entries = REALLOC_C_HEAP_ARRAY_RETURN_NULL(_entries, new_capacity, mtInternal);
   if (new_entries == nullptr) {
     return false;
   }

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -487,7 +487,7 @@ class DwarfFile : public ElfFile {
     bool grow();
     void free() {
       if (_entries != nullptr) {
-        FREE_C_HEAP_ARRAY(ArangesEntry, _entries);
+        FREE_C_HEAP_ARRAY(_entries);
         _entries = nullptr;
       }
     }

--- a/src/hotspot/share/utilities/istream.cpp
+++ b/src/hotspot/share/utilities/istream.cpp
@@ -265,7 +265,7 @@ bool inputStream::expand_buffer(size_t new_length) {
   } else {
     // realloc
     COV(EXB_R);
-    new_buf = REALLOC_C_HEAP_ARRAY(char, _buffer, new_length, mtInternal);
+    new_buf = REALLOC_C_HEAP_ARRAY(_buffer, new_length, mtInternal);
     assert(new_buf != nullptr, "would have exited VM if OOM");
   }
 

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -144,7 +144,7 @@ TruncatedSeq::TruncatedSeq(int length, double alpha):
 }
 
 TruncatedSeq::~TruncatedSeq() {
-  FREE_C_HEAP_ARRAY(double, _sequence);
+  FREE_C_HEAP_ARRAY(_sequence);
 }
 
 void TruncatedSeq::add(double val) {

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -369,7 +369,7 @@ void stringStream::grow(size_t new_capacity) {
     }
     zero_terminate();
   } else {
-    _buffer = REALLOC_C_HEAP_ARRAY(char, _buffer, new_capacity, mtInternal);
+    _buffer = REALLOC_C_HEAP_ARRAY(_buffer, new_capacity, mtInternal);
     _capacity = new_capacity;
   }
 }
@@ -442,7 +442,7 @@ char* stringStream::as_string(Arena* arena) const {
 
 stringStream::~stringStream() {
   if (!_is_fixed && _buffer != _small_buffer) {
-    FREE_C_HEAP_ARRAY(char, _buffer);
+    FREE_C_HEAP_ARRAY(_buffer);
   }
 }
 
@@ -681,7 +681,7 @@ fileStream* defaultStream::open_file(const char* log_name) {
   }
 
   fileStream* file = new (mtInternal) fileStream(try_name);
-  FREE_C_HEAP_ARRAY(char, try_name);
+  FREE_C_HEAP_ARRAY(try_name);
   if (file->is_open()) {
     return file;
   }
@@ -699,7 +699,7 @@ fileStream* defaultStream::open_file(const char* log_name) {
   jio_printf("Warning:  Forcing option -XX:LogFile=%s\n", try_name);
 
   file = new (mtInternal) fileStream(try_name);
-  FREE_C_HEAP_ARRAY(char, try_name);
+  FREE_C_HEAP_ARRAY(try_name);
   if (file->is_open()) {
     return file;
   }
@@ -1056,7 +1056,7 @@ void bufferedStream::write(const char* s, size_t len) {
       }
     }
     if (buffer_length < end) {
-      buffer = REALLOC_C_HEAP_ARRAY(char, buffer, end, mtInternal);
+      buffer = REALLOC_C_HEAP_ARRAY(buffer, end, mtInternal);
       buffer_length = end;
     }
   }
@@ -1075,7 +1075,7 @@ char* bufferedStream::as_string() {
 }
 
 bufferedStream::~bufferedStream() {
-  FREE_C_HEAP_ARRAY(char, buffer);
+  FREE_C_HEAP_ARRAY(buffer);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/utilities/resizableHashTable.hpp
+++ b/src/hotspot/share/utilities/resizableHashTable.hpp
@@ -45,7 +45,7 @@ protected:
 
   ~ResizeableHashTableStorage() {
     if (ALLOC_TYPE == C_HEAP) {
-      FREE_C_HEAP_ARRAY(Node*, _table);
+      FREE_C_HEAP_ARRAY(_table);
     }
   }
 
@@ -151,7 +151,7 @@ public:
     }
 
     if (ALLOC_TYPE == AnyObj::C_HEAP) {
-      FREE_C_HEAP_ARRAY(Node*, old_table);
+      FREE_C_HEAP_ARRAY(old_table);
     }
     BASE::_table = new_table;
     BASE::_table_size = new_size;

--- a/src/hotspot/share/utilities/stack.inline.hpp
+++ b/src/hotspot/share/utilities/stack.inline.hpp
@@ -145,7 +145,7 @@ E* Stack<E, MT>::alloc(size_t bytes)
 template <class E, MemTag MT>
 void Stack<E, MT>::free(E* addr, size_t bytes)
 {
-  FREE_C_HEAP_ARRAY(char, (char*) addr);
+  FREE_C_HEAP_ARRAY((char*) addr);
 }
 
 // Stack is used by the GC code and in some hot paths a lot of the Stack

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -125,7 +125,7 @@ bool StringUtils::is_star_match(const char* star_pattern, const char* str) {
 }
 
 StringUtils::CommaSeparatedStringIterator::~CommaSeparatedStringIterator() {
-  FREE_C_HEAP_ARRAY(char, _list);
+  FREE_C_HEAP_ARRAY(_list);
 }
 
 ccstrlist StringUtils::CommaSeparatedStringIterator::canonicalize(ccstrlist option_value) {

--- a/src/hotspot/share/utilities/xmlstream.cpp
+++ b/src/hotspot/share/utilities/xmlstream.cpp
@@ -65,7 +65,7 @@ void xmlStream::initialize(outputStream* out) {
 
 #ifdef ASSERT
 xmlStream::~xmlStream() {
-  FREE_C_HEAP_ARRAY(char, _element_close_stack_low);
+  FREE_C_HEAP_ARRAY(_element_close_stack_low);
 }
 #endif
 
@@ -169,7 +169,7 @@ void xmlStream::see_tag(const char* tag, bool push) {
     _element_close_stack_high = new_high;
     _element_close_stack_low  = new_low;
     _element_close_stack_ptr  = new_ptr;
-    FREE_C_HEAP_ARRAY(char, old_low);
+    FREE_C_HEAP_ARRAY(old_low);
     push_ptr = new_ptr - (tag_len+1);
   }
   assert(push_ptr >= _element_close_stack_low, "in range");

--- a/test/hotspot/gtest/concurrentTestRunner.inline.hpp
+++ b/test/hotspot/gtest/concurrentTestRunner.inline.hpp
@@ -86,7 +86,7 @@ public:
       done.wait();
     }
 
-    FREE_C_HEAP_ARRAY(UnitTestThread**, t);
+    FREE_C_HEAP_ARRAY(t);
   }
 
 private:

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -91,5 +91,5 @@ TEST_OTHER_VM(G1FreeRegionList, length) {
   bot_storage->uncommit_regions(0, num_regions_in_test);
   delete bot_storage;
   os::release_memory(addr, sz);
-  FREE_C_HEAP_ARRAY(HeapWord, bot_data);
+  FREE_C_HEAP_ARRAY(bot_data);
 }

--- a/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
@@ -87,7 +87,7 @@ public:
 
   ~G1TestSubTask() {
     check_and_inc_phase(3);
-    FREE_C_HEAP_ARRAY(Atomic<bool>, _do_work_called_by);
+    FREE_C_HEAP_ARRAY(_do_work_called_by);
   }
 
   double worker_cost() const override {

--- a/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
@@ -69,7 +69,7 @@ public:
   }
 
   ~G1FindCardsInRange() {
-    FREE_C_HEAP_ARRAY(mtGC, _cards_found);
+    FREE_C_HEAP_ARRAY(_cards_found);
   }
   void operator()(uint card) {
     ASSERT_TRUE((card - _range_min) < _num_cards);
@@ -185,7 +185,7 @@ void G1CardSetContainersTest::cardset_array_test(uint cards_per_array) {
     found.verify_all_found();
   }
 
-  FREE_C_HEAP_ARRAY(mtGC, cardset_data);
+  FREE_C_HEAP_ARRAY(cardset_data);
 }
 
 void G1CardSetContainersTest::cardset_bitmap_test(uint threshold, uint size_in_bits) {
@@ -232,7 +232,7 @@ void G1CardSetContainersTest::cardset_bitmap_test(uint threshold, uint size_in_b
     found.verify_part_found(threshold);
   }
 
-  FREE_C_HEAP_ARRAY(mtGC, cardset_data);
+  FREE_C_HEAP_ARRAY(cardset_data);
 }
 
 TEST_VM_F(G1CardSetContainersTest, basic_cardset_inptr_test) {

--- a/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
@@ -486,7 +486,7 @@ public:
 
     EXPECT_EQ(storage().block_count(), empty_block_count(storage()));
 
-    FREE_C_HEAP_ARRAY(oop*, to_release);
+    FREE_C_HEAP_ARRAY(to_release);
   }
 
   struct PointerCompare {
@@ -534,7 +534,7 @@ TEST_VM_F(OopStorageTest, invalid_malloc_pointer) {
   oop* ptr = reinterpret_cast<oop*>(align_down(mem + 250, sizeof(oop)));
   // Predicate returns false for some malloc'ed block.
   EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(ptr));
-  FREE_C_HEAP_ARRAY(char, mem);
+  FREE_C_HEAP_ARRAY(mem);
 }
 
 TEST_VM_F(OopStorageTest, invalid_random_pointer) {

--- a/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
@@ -137,7 +137,7 @@ public:
   }
 
   ~Task() {
-    FREE_C_HEAP_ARRAY(Tickspan, _worker_times);
+    FREE_C_HEAP_ARRAY(_worker_times);
   }
 
   virtual void work(uint worker_id) {

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahMarkBitMap.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahMarkBitMap.cpp
@@ -555,7 +555,7 @@ public:
                       is_weakly_marked_object_after_2nd_clear, is_strongly_marked_object_after_2nd_clear,
                       all_marked_objects_after_2nd_clear, my_heap_memory, end_of_my_heap);
 
-    FREE_C_HEAP_ARRAY(HeapWord, my_bitmap_memory);
+    FREE_C_HEAP_ARRAY(my_bitmap_memory);
     _success = true;
     return true;
   }

--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -116,7 +116,7 @@ void LogTestFixture::clear_snapshot() {
   for (size_t i = 0; i < _n_snapshots; i++) {
     os::free(_configuration_snapshot[i]);
   }
-  FREE_C_HEAP_ARRAY(char*, _configuration_snapshot);
+  FREE_C_HEAP_ARRAY(_configuration_snapshot);
   _configuration_snapshot = nullptr;
   _n_snapshots = 0;
 }

--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -126,7 +126,7 @@ static inline char* read_line(FILE* fp) {
   char* ret = fgets(buf, buflen, fp);
   while (ret != nullptr && buf[strlen(buf) - 1] != '\n' && !feof(fp)) {
     // retry with a larger buffer
-    buf = REALLOC_RESOURCE_ARRAY(char, buf, buflen, buflen * 2);
+    buf = REALLOC_RESOURCE_ARRAY(buf, buflen, buflen * 2);
     buflen *= 2;
     // rewind to beginning of line
     fseek(fp, pos, SEEK_SET);

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -234,7 +234,7 @@ TEST_VM_F(AsyncLogTest, logBuffer) {
   EXPECT_FALSE(buffer->iterator().hasNext());
 
   delete output; // close file
-  FREE_C_HEAP_ARRAY(char, name);
+  FREE_C_HEAP_ARRAY(name);
 
   const char* strs[4];
   strs[0] = "a log line";

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -158,7 +158,7 @@ TEST_VM_F(LogMessageTest, long_message) {
   const char* expected[] = { start_marker, "0123456789", end_marker, nullptr };
   EXPECT_TRUE(file_contains_substrings_in_order(_level_filename[LogLevel::Trace], expected))
     << "unable to print long line";
-  FREE_C_HEAP_ARRAY(char, data);
+  FREE_C_HEAP_ARRAY(data);
 }
 
 TEST_VM_F(LogMessageTest, message_with_many_lines) {

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -306,9 +306,9 @@ TEST_VM(Arena, random_allocs) {
   }
 
   // Free temp data
-  FREE_C_HEAP_ARRAY(char*, ptrs);
-  FREE_C_HEAP_ARRAY(size_t, sizes);
-  FREE_C_HEAP_ARRAY(size_t, alignments);
+  FREE_C_HEAP_ARRAY(ptrs);
+  FREE_C_HEAP_ARRAY(sizes);
+  FREE_C_HEAP_ARRAY(alignments);
 }
 
 #ifndef LP64

--- a/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
@@ -42,7 +42,7 @@ public:
     _arr = NEW_C_HEAP_ARRAY(char, len, mtInternal);
     memset(_arr, 0, _len);
   }
-  ~TestMap() { FREE_C_HEAP_ARRAY(char, _arr); }
+  ~TestMap() { FREE_C_HEAP_ARRAY(_arr); }
 
   int get_num_set(size_t from, size_t to) const {
     int result = 0;
@@ -193,7 +193,7 @@ public:
   }
 
   ~FeederBuffer() {
-    FREE_C_HEAP_ARRAY(MetaWord, _buf);
+    FREE_C_HEAP_ARRAY(_buf);
   }
 
   MetaWord* get(size_t word_size) {

--- a/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
@@ -100,7 +100,7 @@ public:
   }
 
   ~SparseArray() {
-    FREE_C_HEAP_ARRAY(T, _slots);
+    FREE_C_HEAP_ARRAY(_slots);
   }
 
   T at(int i)              { return _slots[i]; }
@@ -165,4 +165,3 @@ public:
 };
 
 #endif // GTEST_METASPACE_METASPACEGTESTSPARSEARRAY_HPP
-

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -63,7 +63,7 @@ static void test_for_live_c_heap_block(size_t sz, ssize_t offset) {
     // NMT disabled: we should see nothing.
     test_pointer(c + offset, false, "");
   }
-  FREE_C_HEAP_ARRAY(char, c);
+  FREE_C_HEAP_ARRAY(c);
 }
 
 #ifdef LINUX
@@ -90,7 +90,7 @@ static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
   test_pointer(c + offset, true, expected_string);
 
   hdr->revive();
-  FREE_C_HEAP_ARRAY(char, c);
+  FREE_C_HEAP_ARRAY(c);
 }
 #endif
 

--- a/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
@@ -110,7 +110,7 @@ TEST_VM(NMTPreInit, stress_test_map) {
 
   print_and_check_table(table, 0);
 
-  FREE_C_HEAP_ARRAY(NMTPreInitAllocation*, allocations);
+  FREE_C_HEAP_ARRAY(allocations);
 }
 
 #ifdef ASSERT

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -746,7 +746,7 @@ static void test_show_mappings(address start, size_t size) {
 #endif
   // buf[buflen - 1] = '\0';
   // tty->print_raw(buf);
-  FREE_C_HEAP_ARRAY(char, buf);
+  FREE_C_HEAP_ARRAY(buf);
 }
 
 TEST_VM(os, show_mappings_small_range) {

--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -169,7 +169,7 @@ public:
     }
   }
   ~TestThreadGroup() {
-    FREE_C_HEAP_ARRAY(BasicTestThread<F>*, _threads);
+    FREE_C_HEAP_ARRAY(_threads);
   }
 
   void doit() {

--- a/test/hotspot/gtest/utilities/test_bitMap_popcnt.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_popcnt.cpp
@@ -42,7 +42,7 @@ public:
   }
 
   ~SimpleFakeBitmap() {
-    FREE_C_HEAP_ARRAY(char, _buffer);
+    FREE_C_HEAP_ARRAY(_buffer);
   }
 
   // Set or clear the specified bit.

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -609,7 +609,7 @@ class ValueSaver {
     _vals[_it++] = *val;
     if (_it == _size) {
       _size *= 2;
-      _vals = REALLOC_RESOURCE_ARRAY(uintptr_t, _vals, _size/2, _size);
+      _vals = REALLOC_RESOURCE_ARRAY(_vals, _size/2, _size);
     }
     return true;
   }

--- a/test/hotspot/gtest/utilities/test_lockFreeStack.cpp
+++ b/test/hotspot/gtest/utilities/test_lockFreeStack.cpp
@@ -300,5 +300,5 @@ TEST_VM(LockFreeStackTest, stress) {
   ASSERT_EQ(nelements, final_stack.length());
   while (final_stack.pop() != nullptr) {}
 
-  FREE_C_HEAP_ARRAY(Element, elements);
+  FREE_C_HEAP_ARRAY(elements);
 }

--- a/test/hotspot/gtest/utilities/test_quicksort.cpp
+++ b/test/hotspot/gtest/utilities/test_quicksort.cpp
@@ -129,7 +129,7 @@ TEST(QuickSort, random) {
     // Compare sorting to stdlib::qsort()
     qsort(expected_array, length, sizeof(int), test_stdlib_comparator);
     EXPECT_TRUE(sort_and_compare(test_array, expected_array, length, test_comparator));
-    FREE_C_HEAP_ARRAY(int, test_array);
-    FREE_C_HEAP_ARRAY(int, expected_array);
+    FREE_C_HEAP_ARRAY(test_array);
+    FREE_C_HEAP_ARRAY(expected_array);
   }
 }


### PR DESCRIPTION
In JDK-8381934 "Wrong type passed to FREE_C_HEAP_ARRAY deallocating G1CardSetMemoryManager" we saw how the wrong type was being passed to the FREE_C_HEAP_ARRAY macro. That bug is benign, because the type parameter is not used. I see that we have similar issues in some of our gtests. I propose that we get rid of the type parameter to remove this confusion and lower the line noise on these lines.

I also propose that we get rid of it from the REALLOC_ macros. These macros however are using the type parameter, but we can infer the type from the other parameters, so I propose that we do that instead.

Tested with tier1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382401](https://bugs.openjdk.org/browse/JDK-8382401): Remove return type parameters from FREE_ and REALLOC_ macros (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30786/head:pull/30786` \
`$ git checkout pull/30786`

Update a local copy of the PR: \
`$ git checkout pull/30786` \
`$ git pull https://git.openjdk.org/jdk.git pull/30786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30786`

View PR using the GUI difftool: \
`$ git pr show -t 30786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30786.diff">https://git.openjdk.org/jdk/pull/30786.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30786#issuecomment-4266323190)
</details>
