### PR TITLE
8367342: Doclet documentation is incomplete

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/package-info.java
@@ -190,7 +190,6 @@
  * and its members, supporting an option.
  *
  * {@snippet lang=java id="Example.java" :
- * // @replace region=imports replacement=" // Note: imports deleted for clarity"
  * import com.sun.source.doctree.DocCommentTree;
  * import com.sun.source.util.DocTrees;
  * import jdk.javadoc.doclet.Doclet;
@@ -207,12 +206,11 @@
  * import java.util.List;
  * import java.util.Locale;
  * import java.util.Set;
- * // @end
- *
  *
  * public class Example implements Doclet {
  *     private Reporter reporter;
  *     private PrintWriter stdout;
+ *     private String overviewFile;
  *
  *     @Override
  *     public void init(Locale locale, Reporter reporter) {
@@ -221,50 +219,10 @@
  *         stdout = reporter.getStandardWriter();
  *     }
  *
- *     public void printElement(DocTrees trees, Element e) {
- *         DocCommentTree docCommentTree = trees.getDocCommentTree(e);
- *         if (docCommentTree != null) {
- *             stdout.println("Element (" + e.getKind() + ": "
- *                     + e + ") has the following comments:");
- *             stdout.println("Entire body: " + docCommentTree.getFullBody());
- *             stdout.println("Block tags: " + docCommentTree.getBlockTags());
- *         }
- *     }
- *
- *     @Override
- *     public boolean run(DocletEnvironment docEnv) {
- *         reporter.print(Kind.NOTE, "overviewFile: " + overviewFile);
- *
- *         // get the DocTrees utility class to access document comments
- *         DocTrees docTrees = docEnv.getDocTrees();
- *
- *         // location of an element in the same directory as overview.html
- *         try {
- *             Element e = ElementFilter.typesIn(docEnv.getSpecifiedElements()).iterator().next();
- *             DocCommentTree docCommentTree
- *                     = docTrees.getDocCommentTree(e, overviewFile);
- *             if (docCommentTree != null) {
- *                 stdout.println("Overview html: " + docCommentTree.getFullBody());
- *             }
- *         } catch (IOException missing) {
- *             reporter.print(Kind.ERROR, "No overview.html found.");
- *         }
- *
- *         for (TypeElement t : ElementFilter.typesIn(docEnv.getIncludedElements())) {
- *             stdout.println(t.getKind() + ":" + t);
- *             for (Element e : t.getEnclosedElements()) {
- *                 printElement(docTrees, e);
- *             }
- *         }
- *         return true;
- *     }
- *
  *     @Override
  *     public String getName() {
  *         return "Example";
  *     }
- *
- *     private String overviewFile;
  *
  *     @Override
  *     public Set<? extends Option> getSupportedOptions() {
@@ -316,6 +274,44 @@
  *     public SourceVersion getSupportedSourceVersion() {
  *         // support the latest release
  *         return SourceVersion.latest();
+ *     }
+ *
+ *     @Override
+ *     public boolean run(DocletEnvironment docEnv) {
+ *         reporter.print(Kind.NOTE, "overviewFile: " + overviewFile);
+ *
+ *         // get the DocTrees utility class to access document comments
+ *         DocTrees docTrees = docEnv.getDocTrees();
+ *
+ *         // location of an element in the same directory as overview.html
+ *         try {
+ *             Element e = ElementFilter.typesIn(docEnv.getSpecifiedElements()).iterator().next();
+ *             DocCommentTree docCommentTree
+ *                     = docTrees.getDocCommentTree(e, overviewFile);
+ *             if (docCommentTree != null) {
+ *                 stdout.println("Overview html: " + docCommentTree.getFullBody());
+ *             }
+ *         } catch (IOException missing) {
+ *             reporter.print(Kind.ERROR, "No overview.html found.");
+ *         }
+ *
+ *         for (TypeElement t : ElementFilter.typesIn(docEnv.getIncludedElements())) {
+ *             stdout.println(t.getKind() + ":" + t);
+ *             for (Element e : t.getEnclosedElements()) {
+ *                 printElement(docTrees, e);
+ *             }
+ *         }
+ *         return true;
+ *     }
+ *
+ *     private void printElement(DocTrees trees, Element e) {
+ *         DocCommentTree docCommentTree = trees.getDocCommentTree(e);
+ *         if (docCommentTree != null) {
+ *             stdout.println("Element (" + e.getKind() + ": "
+ *                     + e + ") has the following comments:");
+ *             stdout.println("Entire body: " + docCommentTree.getFullBody());
+ *             stdout.println("Block tags: " + docCommentTree.getBlockTags());
+ *         }
  *     }
  * }
  * }


### PR DESCRIPTION
Please review a doc-only change to make the example doclet in `jdk.javadoc.doclet` package documentation compile and work out of the box by not hiding/replacing the imports. 

Additional changes are to reorder methods to match the more intuitive order in the `Doclet` interface, change access for the `printElement` method to private, and move the `overviewFile` field declaration to the top and the `printElement` method to the end of the class.

This is a `noreg-doc` change, to test the changes I copied the snippet contents via copy-to-clipboard button and compiled and ran the code using the command line provided in the documentation.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367342](https://bugs.openjdk.org/browse/JDK-8367342): Doclet documentation is incomplete (**Enhancement** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30788/head:pull/30788` \
`$ git checkout pull/30788`

Update a local copy of the PR: \
`$ git checkout pull/30788` \
`$ git pull https://git.openjdk.org/jdk.git pull/30788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30788`

View PR using the GUI difftool: \
`$ git pr show -t 30788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30788.diff">https://git.openjdk.org/jdk/pull/30788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30788#issuecomment-4266832109)
</details>
