### PR TITLE
8382418: G1: Remove some stale comments about time accounting

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -416,8 +416,6 @@ double G1GCPhaseTimes::print_pre_evacuate_collection_set() const {
 
   info_time("Pre Evacuate Collection Set", sum_ms);
 
-  // Concurrent tasks of ResetMarkingState and NoteStartOfMark are triggered during
-  // young collection. However, their execution time are not included in _gc_pause_time_ms.
   if (_cur_prepare_concurrent_task_time_ms > 0.0) {
     debug_time("Prepare Concurrent Start", _cur_prepare_concurrent_task_time_ms);
     debug_phase(_gc_par_phases[ResetMarkingState], 1);
@@ -543,10 +541,9 @@ void G1GCPhaseTimes::print_other(double accounted_ms) const {
   info_time("Other", _gc_pause_time_ms - accounted_ms);
 }
 
-// Root-region-scan-wait, verify-before and verify-after are part of young GC,
+// Root region scan, verify before and verify after are part of young GC,
 // but these are not measured by G1Policy. i.e. these are not included in
 // G1Policy::record_young_collection_start() and record_young_collection_end().
-// In addition, these are not included in G1GCPhaseTimes::_gc_pause_time_ms.
 // See G1YoungCollector::collect().
 void G1GCPhaseTimes::print(bool evacuation_failed) {
   if (_root_region_scan_time_ms > 0.0) {

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -175,7 +175,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   double _cur_collection_nmethod_list_cleanup_time_ms;
 
   double _cur_merge_heap_roots_time_ms;
-  // Merge refinement table time. Note that this time is included in _cur_merge_heap_roots_time_ms.
   double _cur_merge_refinement_table_time_ms;
   double _cur_optional_merge_heap_roots_time_ms;
 
@@ -190,7 +189,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   double _cur_resize_heap_time_ms;
   double _cur_ref_proc_time_ms;
 
-  // Not included in _gc_pause_time_ms
   double _root_region_scan_time_ms;
 
   double _external_accounted_time_ms;
@@ -210,7 +208,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   double _cur_region_register_time;
 
-  // Not included in _gc_pause_time_ms
   double _cur_verify_before_time_ms;
   double _cur_verify_after_time_ms;
 


### PR DESCRIPTION
Hi all,

  while looking at JDK-8370063 I found that several comments about timinig scoping are wrong. This change fixes these, mostly just removing them.

Testing: local compilation (this is just comment removal)

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382418](https://bugs.openjdk.org/browse/JDK-8382418): G1: Remove some stale comments about time accounting (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30789/head:pull/30789` \
`$ git checkout pull/30789`

Update a local copy of the PR: \
`$ git checkout pull/30789` \
`$ git pull https://git.openjdk.org/jdk.git pull/30789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30789`

View PR using the GUI difftool: \
`$ git pr show -t 30789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30789.diff">https://git.openjdk.org/jdk/pull/30789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30789#issuecomment-4267640003)
</details>
