### PR TITLE
8382419: Add missed @key randomness after JDK-8370489

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -96,6 +96,7 @@
 /*
  * @test id=sse4-v004-A
  * @bug 8298935 8308606 8310308 8312570 8310190
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")


### PR DESCRIPTION
Tiny issue I ran into backporting JDK-8370489.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382419](https://bugs.openjdk.org/browse/JDK-8382419): Add missed @<!---->key randomness after JDK-8370489 (**Enhancement** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [6fc80997](https://git.openjdk.org/jdk/pull/30790/files/6fc809975cd190a842ab2139c6632b6a99a72e77)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [6fc80997](https://git.openjdk.org/jdk/pull/30790/files/6fc809975cd190a842ab2139c6632b6a99a72e77)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30790/head:pull/30790` \
`$ git checkout pull/30790`

Update a local copy of the PR: \
`$ git checkout pull/30790` \
`$ git pull https://git.openjdk.org/jdk.git pull/30790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30790`

View PR using the GUI difftool: \
`$ git pr show -t 30790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30790.diff">https://git.openjdk.org/jdk/pull/30790.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30790#issuecomment-4267820008)
</details>
