### PR TITLE
8382422: G1: G1GCPhaseTimes::record_merge_heap_roots() uses += instead of direct assignment

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -298,7 +298,7 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   }
 
   void record_merge_heap_roots_time(double ms) {
-    _cur_merge_heap_roots_time_ms += ms;
+    _cur_merge_heap_roots_time_ms = ms;
   }
 
   void record_merge_refinement_table_time(double ms) {


### PR DESCRIPTION
Hi all,

  please review this change that changes storing the merge heap roots time for initial evacuation from an addition to a direct assignment. It is fairly trivially found only called once.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382422](https://bugs.openjdk.org/browse/JDK-8382422): G1: G1GCPhaseTimes::record_merge_heap_roots() uses += instead of direct assignment (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30791/head:pull/30791` \
`$ git checkout pull/30791`

Update a local copy of the PR: \
`$ git checkout pull/30791` \
`$ git pull https://git.openjdk.org/jdk.git pull/30791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30791`

View PR using the GUI difftool: \
`$ git pr show -t 30791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30791.diff">https://git.openjdk.org/jdk/pull/30791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30791#issuecomment-4267892038)
</details>
