### PR TITLE
8382423: G1: Remove unused G1GCPhaseTimes::_external_accounted_time_ms

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -181,7 +181,6 @@ void G1GCPhaseTimes::reset() {
   _cur_resize_heap_time_ms = 0.0;
   _cur_ref_proc_time_ms = 0.0;
   _root_region_scan_time_ms = 0.0;
-  _external_accounted_time_ms = 0.0;
   _recorded_prepare_heap_roots_time_ms = 0.0;
   _recorded_young_cset_choice_time_ms = 0.0;
   _recorded_non_young_cset_choice_time_ms = 0.0;

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -193,8 +193,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
   // Not included in _gc_pause_time_ms
   double _root_region_scan_time_ms;
 
-  double _external_accounted_time_ms;
-
   double _recorded_prepare_heap_roots_time_ms;
 
   double _recorded_young_cset_choice_time_ms;
@@ -371,10 +369,6 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   void record_verify_after_time_ms(double time_ms) {
     _cur_verify_after_time_ms = time_ms;
-  }
-
-  void inc_external_accounted_time_ms(double time_ms) {
-    _external_accounted_time_ms += time_ms;
   }
 
   void record_prepare_heap_roots_time_ms(double recorded_prepare_heap_roots_time_ms) {


### PR DESCRIPTION
Hi all,

  please review this removal of the dead `G1GCPhaseTimes::_external_accounted_time_ms` and associated methods.

Testing: local compilation, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382423](https://bugs.openjdk.org/browse/JDK-8382423): G1: Remove unused G1GCPhaseTimes::_external_accounted_time_ms (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30792/head:pull/30792` \
`$ git checkout pull/30792`

Update a local copy of the PR: \
`$ git checkout pull/30792` \
`$ git pull https://git.openjdk.org/jdk.git pull/30792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30792`

View PR using the GUI difftool: \
`$ git pr show -t 30792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30792.diff">https://git.openjdk.org/jdk/pull/30792.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30792#issuecomment-4267924467)
</details>
