### PR TITLE
8382428: libsyslookup.so is not needed for Linux

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -153,22 +153,22 @@ ifeq ($(call isTargetOsType, unix), true)
 endif
 
 ################################################################################
-## Build libsyslookup
+## Build libsyslookup (other than Linux)
 ## The LIBDL dependency on Linux is needed to dynamically access libdl symbols,
 ## which may be needed as part of resolving some standard symbols
 ################################################################################
 
-$(eval $(call SetupJdkLibrary, BUILD_LIBSYSLOOKUP, \
-    NAME := syslookup, \
-    EXTRA_HEADER_DIRS := java.base:libjava, \
-    LD_SET_ORIGIN := false, \
-    LDFLAGS_linux := -Wl$(COMMA)--no-as-needed, \
-    LDFLAGS_aix := -brtl -bexpfull, \
-    LIBS_linux := $(LIBDL) $(LIBM), \
-    LIBS_aix := -ldecNumber $(LIBM), \
-))
+ifeq ($(call isTargetOs, linux), false)
+  $(eval $(call SetupJdkLibrary, BUILD_LIBSYSLOOKUP, \
+      NAME := syslookup, \
+      EXTRA_HEADER_DIRS := java.base:libjava, \
+      LD_SET_ORIGIN := false, \
+      LDFLAGS_aix := -brtl -bexpfull, \
+      LIBS_aix := -ldecNumber $(LIBM), \
+  ))
 
-TARGETS += $(BUILD_LIBSYSLOOKUP)
+  TARGETS += $(BUILD_LIBSYSLOOKUP)
+endif
 
 ifeq ($(ENABLE_FALLBACK_LINKER), true)
   ##############################################################################

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,8 +132,14 @@ public final class SystemLookup implements SymbolLookup {
 
     @SuppressWarnings("restricted")
     private static SymbolLookup sysLookup() {
-        NativeLibraries libs = NativeLibraries.newInstance(null);
-        NativeLibrary lib = libs.loadLibrary(SymbolLookup.class, "syslookup");
+        NativeLibrary lib;
+        if (OperatingSystem.isLinux()) {
+            RawNativeLibraries libs = RawNativeLibraries.newInstance(MethodHandles.lookup());
+            lib = libs.defaultLibrary();
+        } else {
+            NativeLibraries libs = NativeLibraries.newInstance(null);
+            lib = libs.loadLibrary(SymbolLookup.class, "syslookup");
+        }
         return lookup(lib);
     }
 

--- a/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,14 @@ public final class RawNativeLibraries {
             return null;
         }
         return load(name);
+    }
+
+    /*
+     * Returns special NativeLibrary instance to be associated with RTLD_DEFAULT.
+     * Note the instance would be worked on Linux only.
+     */
+    public NativeLibrary defaultLibrary() {
+        return DefaultLibrary.getInstance();
     }
 
     /**
@@ -176,6 +184,31 @@ public final class RawNativeLibraries {
          */
         void close() {
             unload0(name, handle);
+        }
+    }
+
+    static class DefaultLibrary extends RawNativeLibraryImpl {
+        private static final long RTLD_DEFAULT = 0L; // from dlfcn.h
+
+        private static DefaultLibrary INSTANCE = new DefaultLibrary();
+
+        private DefaultLibrary() {
+            super("<default>");
+            this.handle = RTLD_DEFAULT;
+        }
+
+        static DefaultLibrary getInstance() {
+            return INSTANCE;
+        }
+
+        @Override
+        boolean open() {
+            throw new InternalError("This method should not be called");
+        }
+
+        @Override
+        void close() {
+            throw new InternalError("This method should not be called");
         }
     }
 


### PR DESCRIPTION
`SystemLookup` in FFM uses libsyslookup to find symbols from the system. But it is not needed because `RTLD_DEFAULT` can be used for this purpose on Linux.
Removing unneeded library improves security.

I've sent [email](https://mail.openjdk.org/archives/list/core-libs-dev@openjdk.org/thread/KHXIJCQZD2VCY4QXMPONAPS26IERMEGR/) to core-libs-dev, but I've not yet received any comments, so I created this PR.

syslookup.dll for Windows is needed because some functions might not be lookup'ed. OTOH on Linux, `dlsym` can lookup symbols from library dependencies. In `SystemLookup`, handle of libsyslookup would be passed to `dlsym` eventually, but it is better to pass `RTLD_DEFAULT` in this case.
It works when the handle of libsyslookup is passed, but `RTLD_DEFAULT` is better because Javadoc of `Linker::defaultLookup` says it returns a set of commonly used libraries.

In addition, I guess we can apply this change to all of POSIX platforms because `dlsym` is defined in POSIX, but I'm not sure we can do (especially AIX - it has own syslookup.c in JDK source tree).

This change passed all of jdk_foreign tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382428](https://bugs.openjdk.org/browse/JDK-8382428): libsyslookup.so is not needed for Linux (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30794/head:pull/30794` \
`$ git checkout pull/30794`

Update a local copy of the PR: \
`$ git checkout pull/30794` \
`$ git pull https://git.openjdk.org/jdk.git pull/30794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30794`

View PR using the GUI difftool: \
`$ git pr show -t 30794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30794.diff">https://git.openjdk.org/jdk/pull/30794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30794#issuecomment-4268799194)
</details>
