### PR TITLE
8382275: Update  nsk/stress/jni to use ThreadWrapper

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/GarbageGenerator.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/GarbageGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,9 @@
  */
 
 package nsk.stress.jni;
+import jdk.test.lib.thread.ThreadWrapper;
 
-class GarbageGenerator extends Thread {
+class GarbageGenerator extends ThreadWrapper {
     class Garbage {
         Garbage() {
             this(1024);

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,8 +61,9 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 
-public class jnistress001 extends Thread {
+public class jnistress001 extends ThreadWrapper {
 
     /* Maximum number of iterations.    Ignored if <= 0L */
     static long numIteration = 0L;
@@ -256,8 +257,11 @@ public class jnistress001 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter001(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -372,7 +376,7 @@ public class jnistress001 extends Thread {
     final private static boolean DEBUG = false;
 }
 
-class JNIter001 extends Thread {
+class JNIter001 extends ThreadWrapper {
 
     // The native method for testing JNI UTF-8 calls
     public native String jnistress(String threadName, int nstr, int printPeriod);

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,12 +60,13 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 import jdk.test.lib.Utils;
 
 import java.lang.reflect.Field;
 import java.util.Random;
 
-public class jnistress002 extends Thread {
+public class jnistress002 extends ThreadWrapper {
 
     /* Maximum number of iterations.    Ignored if <= 0L */
     static long numIteration = 0L;
@@ -246,8 +247,11 @@ public class jnistress002 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter002(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -423,7 +427,7 @@ class objectsJNI {
     }
 }
 
-class JNIter002 extends Thread {
+class JNIter002 extends ThreadWrapper {
 
     // The native method for testing JNI Object's calls
     public native objectsJNI[] jniobjects(String s, int i, long l,

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,11 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 
 import java.lang.reflect.Array;
 
-public class jnistress003 extends Thread {
+public class jnistress003 extends ThreadWrapper {
 
     /* Maximum number of iterations.  Ignored if <= 0L */
     static long numIteration = 0L;
@@ -257,8 +258,11 @@ public class jnistress003 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter003(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -379,7 +383,7 @@ public class jnistress003 extends Thread {
     final private static boolean DEBUG = false;
 }
 
-class JNIter003 extends Thread {
+class JNIter003 extends ThreadWrapper {
 
     // The native methods for testing JNI Arrays calls
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,8 +60,9 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 
-public class jnistress004 extends Thread {
+public class jnistress004 extends ThreadWrapper {
 
     /* Maximum number of iterations.  Ignored if <= 0L */
     static long numIteration = 2L;
@@ -243,8 +244,11 @@ public class jnistress004 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter004(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -364,7 +368,7 @@ public class jnistress004 extends Thread {
     final private static boolean DEBUG = false;
 }
 
-class JNIter004 extends Thread {
+class JNIter004 extends ThreadWrapper {
 
     // The native methods for testing JNI critical calls
     public native char[] CheckSum(String str);

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,8 +61,9 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 
-public class jnistress005 extends Thread {
+public class jnistress005 extends ThreadWrapper {
 
     /* Maximum number of iterations.  Ignored if <= 0L */
     static long numIteration = 0L;
@@ -244,8 +245,11 @@ public class jnistress005 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter005(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -366,7 +370,7 @@ public class jnistress005 extends Thread {
     final private static boolean DEBUG = false;
 }
 
-class JNIter005 extends Thread {
+class JNIter005 extends ThreadWrapper {
 
     // The native methods for testing JNI exception calls
     public native void except(Throwable tobj);

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,8 +61,9 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 
-public class jnistress006 extends Thread {
+public class jnistress006 extends ThreadWrapper {
 
     /* Maximum number of iterations.  Ignored if <= 0L */
     static long numIteration = 0L;
@@ -245,8 +246,11 @@ public class jnistress006 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter006(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -366,7 +370,7 @@ public class jnistress006 extends Thread {
     final private static boolean DEBUG = false;
 }
 
-class JNIter006 extends Thread {
+class JNIter006 extends ThreadWrapper {
 
     // The native methods for testing JNI exception calls
     public native boolean refs(Object tobj, int jniStringAllocSize);

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,8 +61,9 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.thread.ThreadWrapper;
 
-public class jnistress007 extends Thread {
+public class jnistress007 extends ThreadWrapper {
 
     /* Maximum number of iterations.  Ignored if <= 0L */
     static long numIteration = 0L;
@@ -244,8 +245,11 @@ public class jnistress007 extends Thread {
         garb = new GarbageGenerator[nGarb];
         for (i = 0; i < nJNI; i++)
             jniter[i] = new JNIter007(sync);
+        Thread[] jniterThreads = new Thread[nJNI];
+        for (i = 0; i < nJNI; i++)
+            jniterThreads[i] = jniter[i].getThread();
         for (i = 0; i < nInter; i++) {
-            irupt[i] = new Interrupter(jniter, sync);
+            irupt[i] = new Interrupter(jniterThreads, sync);
             irupt[i].setInterval(iruptInterval);
         }
         for (i = 0; i < nGarb; i++) {
@@ -364,7 +368,7 @@ public class jnistress007 extends Thread {
     final private static boolean DEBUG = false;
 }
 
-class JNIter007 extends Thread {
+class JNIter007 extends ThreadWrapper {
 
     // The native methods for testing JNI monitors calls
     public native void incCount(String name);


### PR DESCRIPTION
Changed jnistress001-007, JNIter classes, and GarbageGenerator to extend ThreadWrapper instead of Thread. Interrupter left as platform thread since it only interrupts other threads and doesn't do test work.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382275](https://bugs.openjdk.org/browse/JDK-8382275): Update  nsk/stress/jni to use ThreadWrapper (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30795/head:pull/30795` \
`$ git checkout pull/30795`

Update a local copy of the PR: \
`$ git checkout pull/30795` \
`$ git pull https://git.openjdk.org/jdk.git pull/30795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30795`

View PR using the GUI difftool: \
`$ git pr show -t 30795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30795.diff">https://git.openjdk.org/jdk/pull/30795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30795#issuecomment-4269333711)
</details>
