### PR TITLE
8382375: Remove obsolete options from CLDRConverter

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/BundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/BundleGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public interface BundleGenerator {
     };
 
     public void generateBundle(String packageName, String baseName, String localeID,
-            boolean useJava, Map<String, ?> map, BundleType type) throws IOException;
+            Map<String, ?> map, BundleType type) throws IOException;
 
     public void generateMetaInfo(Map<String, SortedSet<String>> metaInfo) throws IOException;
 }

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -183,7 +183,6 @@ public class CLDRConverter {
         }
     }
 
-    static boolean USE_UTF8 = false;
     private static boolean verbose;
 
     private CLDRConverter() {
@@ -230,10 +229,6 @@ public class CLDRConverter {
                     case "-o":
                         // output directory
                         DESTINATION_DIR = args[++i];
-                        break;
-
-                    case "-utf8":
-                        USE_UTF8 = true;
                         break;
 
                     case "-verbose":
@@ -336,7 +331,6 @@ public class CLDRConverter {
                 + "\t-year year     copyright year in output%n"
                 + "\t-zntempfile    template file for java.time.format.ZoneName.java%n"
                 + "\t-tzdatadir     tzdata directory for java.time.format.ZoneName.java%n"
-                + "\t-utf8          use UTF-8 rather than \\uxxxx (for debug)%n"
                 + "\t-jdk-header-template <file>%n"
                 + "\t\t       override default GPL header with contents of file%n");
     }
@@ -612,31 +606,31 @@ public class CLDRConverter {
             if (bundleTypes.contains(Bundle.Type.LOCALENAMES)) {
                 Map<String, Object> localeNamesMap = extractLocaleNames(targetMap, id);
                 if (!localeNamesMap.isEmpty() || bundle.isRoot()) {
-                    bundleGenerator.generateBundle("util", "LocaleNames", id, true, localeNamesMap, BundleType.OPEN);
+                    bundleGenerator.generateBundle("util", "LocaleNames", id, localeNamesMap, BundleType.OPEN);
                 }
             }
             if (bundleTypes.contains(Bundle.Type.CURRENCYNAMES)) {
                 Map<String, Object> currencyNamesMap = extractCurrencyNames(targetMap, id, bundle.getCurrencies());
                 if (!currencyNamesMap.isEmpty() || bundle.isRoot()) {
-                    bundleGenerator.generateBundle("util", "CurrencyNames", id, true, currencyNamesMap, BundleType.OPEN);
+                    bundleGenerator.generateBundle("util", "CurrencyNames", id, currencyNamesMap, BundleType.OPEN);
                 }
             }
             if (bundleTypes.contains(Bundle.Type.TIMEZONENAMES)) {
                 Map<String, Object> zoneNamesMap = extractZoneNames(targetMap, id);
                 if (!zoneNamesMap.isEmpty() || bundle.isRoot()) {
-                    bundleGenerator.generateBundle("util", "TimeZoneNames", id, true, zoneNamesMap, BundleType.TIMEZONE);
+                    bundleGenerator.generateBundle("util", "TimeZoneNames", id, zoneNamesMap, BundleType.TIMEZONE);
                 }
             }
             if (bundleTypes.contains(Bundle.Type.CALENDARDATA)) {
                 Map<String, Object> calendarDataMap = extractCalendarData(targetMap, id);
                 if (!calendarDataMap.isEmpty() || bundle.isRoot()) {
-                    bundleGenerator.generateBundle("util", "CalendarData", id, true, calendarDataMap, BundleType.PLAIN);
+                    bundleGenerator.generateBundle("util", "CalendarData", id, calendarDataMap, BundleType.PLAIN);
                 }
             }
             if (bundleTypes.contains(Bundle.Type.FORMATDATA)) {
                 Map<String, Object> formatDataMap = extractFormatData(targetMap, id);
                 if (!formatDataMap.isEmpty() || bundle.isRoot()) {
-                    bundleGenerator.generateBundle("text", "FormatData", id, true, formatDataMap, BundleType.PLAIN);
+                    bundleGenerator.generateBundle("text", "FormatData", id, formatDataMap, BundleType.PLAIN);
                 }
             }
 
@@ -1053,27 +1047,14 @@ public class CLDRConverter {
         }
     }
 
-    // --- code below here is adapted from java.util.Properties ---
-    private static final String specialSaveCharsJava = "\"";
-    private static final String specialSaveCharsProperties = "=: \t\r\n\f#!";
-
     /*
-     * Converts unicodes to encoded &#92;uxxxx
-     * and writes out any of the characters in specialSaveChars
-     * with a preceding slash
+     * Escapes control codes to ASCII escapes or encoded &#92;uxxxx
+     * and writes out double-quotes with a preceding slash
      */
-    static String saveConvert(String theString, boolean useJava) {
+    static String escape(String theString) {
         if (theString == null) {
             return "";
         }
-
-        String specialSaveChars;
-        if (useJava) {
-            specialSaveChars = specialSaveCharsJava;
-        } else {
-            specialSaveChars = specialSaveCharsProperties;
-        }
-        boolean escapeSpace = false;
 
         int len = theString.length();
         StringBuilder outBuffer = new StringBuilder(len * 2);
@@ -1083,7 +1064,7 @@ public class CLDRConverter {
             char aChar = theString.charAt(x);
             switch (aChar) {
             case ' ':
-                if (x == 0 || escapeSpace) {
+                if (x == 0) {
                     outBuffer.append('\\');
                 }
                 outBuffer.append(' ');
@@ -1109,10 +1090,10 @@ public class CLDRConverter {
                 outBuffer.append('f');
                 break;
             default:
-                if (aChar < 0x0020 || (!USE_UTF8 && aChar > 0x007e)) {
+                if (aChar < 0x0020) {
                     formatter.format("\\u%04x", (int)aChar);
                 } else {
-                    if (specialSaveChars.indexOf(aChar) != -1) {
+                    if (aChar == 0x0022) {
                         outBuffer.append('\\');
                     }
                     outBuffer.append(aChar);

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -1049,7 +1049,7 @@ public class CLDRConverter {
 
     /*
      * Escapes control codes to ASCII escapes or encoded &#92;uxxxx
-     * and writes out double-quotes with a preceding slash
+     * and writes out ASCII quotation marks with a preceding slash
      */
     static String escape(String theString) {
         if (theString == null) {
@@ -1094,6 +1094,7 @@ public class CLDRConverter {
                     formatter.format("\\u%04x", (int)aChar);
                 } else {
                     if (aChar == 0x0022) {
+                        // Escape ASCII quotation marks
                         outBuffer.append('\\');
                     }
                     outBuffer.append(aChar);

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -1069,9 +1069,9 @@ public class CLDRConverter {
                 }
                 outBuffer.append(' ');
                 break;
-            case '\\':
+            case '\\', '"':
                 outBuffer.append('\\');
-                outBuffer.append('\\');
+                outBuffer.append(aChar);
                 break;
             case '\t':
                 outBuffer.append('\\');
@@ -1093,10 +1093,6 @@ public class CLDRConverter {
                 if (aChar < 0x0020) {
                     formatter.format("\\u%04x", (int)aChar);
                 } else {
-                    if (aChar == 0x0022) {
-                        // Escape ASCII quotation marks
-                        outBuffer.append('\\');
-                    }
                     outBuffer.append(aChar);
                 }
             }

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -70,9 +70,8 @@ class ResourceBundleGenerator implements BundleGenerator {
     private static final String META_VALUE_PREFIX = "metaValue_";
 
     @Override
-    public void generateBundle(String packageName, String baseName, String localeID, boolean useJava,
+    public void generateBundle(String packageName, String baseName, String localeID,
                                Map<String, ?> map, BundleType type) throws IOException {
-        String suffix = useJava ? ".java" : ".properties";
         String dirName = CLDRConverter.DESTINATION_DIR + File.separator + "sun" + File.separator
                 + packageName + File.separator + "resources" + File.separator + "cldr";
         packageName = packageName + ".resources.cldr";
@@ -91,22 +90,11 @@ class ResourceBundleGenerator implements BundleGenerator {
         if (!dir.exists()) {
             dir.mkdirs();
         }
-        File file = new File(dir, baseName + ("root".equals(localeID) ? "" : "_" + localeID) + suffix);
+        File file = new File(dir, baseName + ("root".equals(localeID) ? "" : "_" + localeID) + ".java");
         if (!file.exists()) {
             file.createNewFile();
         }
         CLDRConverter.info("\tWriting file " + file);
-
-        String encoding;
-        if (useJava) {
-            if (CLDRConverter.USE_UTF8) {
-                encoding = "utf-8";
-            } else {
-                encoding = "us-ascii";
-            }
-        } else {
-            encoding = "iso-8859-1";
-        }
 
         Formatter fmt = null;
         if (type == BundleType.TIMEZONE) {
@@ -119,7 +107,7 @@ class ResourceBundleGenerator implements BundleGenerator {
                     value = (String[]) map.get(key);
                     fmt.format("        final String[] %s = new String[] {\n", meta);
                     for (String s : value) {
-                        fmt.format("               \"%s\",\n", CLDRConverter.saveConvert(s, useJava));
+                        fmt.format("               \"%s\",\n", CLDRConverter.escape(s));
                     }
                     fmt.format("            };\n");
                     metaKeys.add(key);
@@ -159,11 +147,11 @@ class ResourceBundleGenerator implements BundleGenerator {
                         if (val instanceof String[] values) {
                             fmt.format("        final String[] %s = new String[] {\n", metaVal);
                             for (String s : values) {
-                                fmt.format("            \"%s\",\n", CLDRConverter.saveConvert(s, useJava));
+                                fmt.format("            \"%s\",\n", CLDRConverter.escape(s));
                             }
                             fmt.format("        };\n");
                         } else {
-                            fmt.format("        final String %s = \"%s\";\n", metaVal, CLDRConverter.saveConvert((String)val, useJava));
+                            fmt.format("        final String %s = \"%s\";\n", metaVal, CLDRConverter.escape((String)val));
                         }
                         newMap.put(oldEntry.key, oldEntry.metaKey());
                     }
@@ -173,55 +161,47 @@ class ResourceBundleGenerator implements BundleGenerator {
             map = newMap;
         }
 
-        try (PrintWriter out = new PrintWriter(file, encoding)) {
+        try (PrintWriter out = new PrintWriter(file, "utf-8")) {
             // Output copyright headers
             out.println(getOpenJDKCopyright());
             out.println(CopyrightHeaders.getUnicodeCopyright());
 
-            if (useJava) {
-                out.println("package sun." + packageName + ";\n");
-                out.printf("import %s;\n\n", type.getPathName());
-                out.printf("public class %s%s extends %s {\n", baseName, "root".equals(localeID) ? "" : "_" + localeID, type.getClassName());
+            out.println("package sun." + packageName + ";\n");
+            out.printf("import %s;\n\n", type.getPathName());
+            out.printf("public class %s%s extends %s {\n", baseName, "root".equals(localeID) ? "" : "_" + localeID, type.getClassName());
 
-                out.println("    @Override\n" +
-                            "    protected final Object[][] getContents() {");
-                if (fmt != null) {
-                    out.print(fmt.toString());
-                }
-                out.println("        final Object[][] data = new Object[][] {");
+            out.println("    @Override\n" +
+                        "    protected final Object[][] getContents() {");
+            if (fmt != null) {
+                out.print(fmt.toString());
             }
+            out.println("        final Object[][] data = new Object[][] {");
             for (String key : map.keySet()) {
-                if (useJava) {
-                    Object value = map.get(key);
-                    if (value == null) {
-                        CLDRConverter.warning("null value for " + key);
-                    } else if (value instanceof String) {
-                        String valStr = (String)value;
-                        if (type == BundleType.TIMEZONE &&
-                            !(key.startsWith(CLDRConverter.EXEMPLAR_CITY_PREFIX) ||
-                              key.startsWith(CLDRConverter.METAZONE_DSTOFFSET_PREFIX)) ||
-                            valStr.startsWith(META_VALUE_PREFIX)) {
-                            out.printf("            { \"%s\", %s },\n", key, CLDRConverter.saveConvert(valStr, useJava));
-                        } else {
-                            out.printf("            { \"%s\", \"%s\" },\n", key, CLDRConverter.saveConvert(valStr, useJava));
-                        }
-                    } else if (value instanceof String[]) {
-                        String[] values = (String[]) value;
-                        out.println("            { \"" + key + "\",\n                new String[] {");
-                        for (String s : values) {
-                            out.println("                    \"" + CLDRConverter.saveConvert(s, useJava) + "\",");
-                        }
-                        out.println("                }\n            },");
+                Object value = map.get(key);
+                if (value == null) {
+                    CLDRConverter.warning("null value for " + key);
+                } else if (value instanceof String) {
+                    String valStr = (String)value;
+                    if (type == BundleType.TIMEZONE &&
+                        !(key.startsWith(CLDRConverter.EXEMPLAR_CITY_PREFIX) ||
+                          key.startsWith(CLDRConverter.METAZONE_DSTOFFSET_PREFIX)) ||
+                        valStr.startsWith(META_VALUE_PREFIX)) {
+                        out.printf("            { \"%s\", %s },\n", key, CLDRConverter.escape(valStr));
                     } else {
-                        throw new RuntimeException("unknown value type: " + value.getClass().getName());
+                        out.printf("            { \"%s\", \"%s\" },\n", key, CLDRConverter.escape(valStr));
                     }
+                } else if (value instanceof String[]) {
+                    String[] values = (String[]) value;
+                    out.println("            { \"" + key + "\",\n                new String[] {");
+                    for (String s : values) {
+                        out.println("                    \"" + CLDRConverter.escape(s) + "\",");
+                    }
+                    out.println("                }\n            },");
                 } else {
-                    out.println(key + "=" + CLDRConverter.saveConvert((String) map.get(key), useJava));
+                    throw new RuntimeException("unknown value type: " + value.getClass().getName());
                 }
             }
-            if (useJava) {
-                out.println("        };\n        return data;\n    }\n}");
-            }
+            out.println("        };\n        return data;\n    }\n}");
         }
     }
 

--- a/make/modules/java.base/Gensrc.gmk
+++ b/make/modules/java.base/Gensrc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,6 @@ CLDR_GEN_DONE := $(GENSRC_DIR)/_cldr-gensrc.marker
 TZ_DATA_DIR := $(MODULE_SRC)/share/data/tzdata
 ZONENAME_TEMPLATE := $(MODULE_SRC)/share/classes/java/time/format/ZoneName.java.template
 
-# The `-utf8` option is used even for US English, as some names
-# may contain non-ASCII characters, such as “Türkiye”.
 $(CLDR_GEN_DONE): $(wildcard $(CLDR_DATA_DIR)/dtd/*.dtd) \
     $(wildcard $(CLDR_DATA_DIR)/main/en*.xml) \
     $(wildcard $(CLDR_DATA_DIR)/supplemental/*.xml) \
@@ -64,8 +62,7 @@ $(CLDR_GEN_DONE): $(wildcard $(CLDR_DATA_DIR)/dtd/*.dtd) \
 	    -basemodule \
 	    -year $(COPYRIGHT_YEAR) \
 	    -zntempfile $(ZONENAME_TEMPLATE) \
-	    -tzdatadir $(TZ_DATA_DIR) \
-	    -utf8)
+	    -tzdatadir $(TZ_DATA_DIR))
 	$(TOUCH) $@
 
 TARGETS += $(CLDR_GEN_DONE)

--- a/make/modules/jdk.localedata/Gensrc.gmk
+++ b/make/modules/jdk.localedata/Gensrc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,7 @@ $(CLDR_GEN_DONE): $(wildcard $(CLDR_DATA_DIR)/dtd/*.dtd) \
 	    -baselocales "en-US" \
 	    -year $(COPYRIGHT_YEAR) \
 	    -o $(GENSRC_DIR) \
-	    -tzdatadir $(TZ_DATA_DIR) \
-	    -utf8)
+	    -tzdatadir $(TZ_DATA_DIR))
 	$(TOUCH) $@
 
 TARGETS += $(CLDR_GEN_DONE)


### PR DESCRIPTION
Removing obsolete options/code from CLDRConverter, which is now always emits Java code in UTF-8 encoding.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382375](https://bugs.openjdk.org/browse/JDK-8382375): Remove obsolete options from CLDRConverter (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [4756d60d](https://git.openjdk.org/jdk/pull/30797/files/4756d60d89aa8424e72d0c3cfd450095e63bc4eb)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30797/head:pull/30797` \
`$ git checkout pull/30797`

Update a local copy of the PR: \
`$ git checkout pull/30797` \
`$ git pull https://git.openjdk.org/jdk.git pull/30797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30797`

View PR using the GUI difftool: \
`$ git pr show -t 30797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30797.diff">https://git.openjdk.org/jdk/pull/30797.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30797#issuecomment-4269871523)
</details>
