### PR TITLE
8359166: C2 asserts in Assembler::addr_nop_5 with -XX:-UseAddressNop

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -4568,7 +4568,7 @@ encode %{
     } else if (_method->intrinsic_id() == vmIntrinsicID::_ensureMaterializedForStackWalk) {
       // The NOP here is purely to ensure that eliding a call to
       // JVM_EnsureMaterializedForStackWalk doesn't change the code size.
-      __ addr_nop_5();
+      __ nop(5);
       __ block_comment("call JVM_EnsureMaterializedForStackWalk (elided)");
     } else {
       int method_index = resolved_method_index(masm);

--- a/test/hotspot/jtreg/runtime/8359166/Test.java
+++ b/test/hotspot/jtreg/runtime/8359166/Test.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8254790
+ * @bug 8359166
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @requires vm.debug
  *

--- a/test/hotspot/jtreg/runtime/8359166/Test.java
+++ b/test/hotspot/jtreg/runtime/8359166/Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8254790
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires vm.debug
+ *
+ * @run main/othervm
+ *        -XX:-UseAddressNop -Xcomp -Xbatch -XX:-TieredCompilation Test
+ */
+
+public class Test {
+    public static void main(String[] args) {
+
+    }
+}


### PR DESCRIPTION
`-XX:-UseAddressNop` is not honoured by HotSpot, and this might cause faults on old machines.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8359166](https://bugs.openjdk.org/browse/JDK-8359166): C2 asserts in Assembler::addr_nop_5 with -XX:-UseAddressNop (**Bug** - P3)


### Reviewers
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30798/head:pull/30798` \
`$ git checkout pull/30798`

Update a local copy of the PR: \
`$ git checkout pull/30798` \
`$ git pull https://git.openjdk.org/jdk.git pull/30798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30798`

View PR using the GUI difftool: \
`$ git pr show -t 30798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30798.diff">https://git.openjdk.org/jdk/pull/30798.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30798#issuecomment-4273958232)
</details>
