### PR TITLE
8382436: Build failures after JDK-8326205

### DIFF
--- a/src/hotspot/share/runtime/hotCodeCollector.cpp
+++ b/src/hotspot/share/runtime/hotCodeCollector.cpp
@@ -29,6 +29,7 @@
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/method.inline.hpp"
 #include "runtime/hotCodeCollector.hpp"
 #include "runtime/hotCodeSampler.hpp"
 #include "runtime/java.hpp"


### PR DESCRIPTION
Looks like they uniquely reproduce with ARM32/S390X *release* builds, which is why GHA did not catch them. I only caught it in my CI which builds all JDK flavors.

Manifests like this:

```
Creating support/modules_libs/java.base/server/libjvm.so from 1018 file(s)
/home/shade/trunks/jdk/build/linux-arm-server-release/hotspot/variant-server/libjvm/objs/hotCodeCollector.o: In function `HotCodeCollector::do_relocation(void*, unsigned int)':
make/hotspot/src/hotspot/share/runtime/hotCodeCollector.cpp:157: undefined reference to `Method::code() const'
collect2: error: ld returned 1 exit status
gmake[3]: *** [lib/CompileJvm.gmk:183: /home/shade/trunks/jdk/build/linux-arm-server-release/support/modules_libs/java.base/server/libjvm.so] Error 1
gmake[2]: *** [make/Main.gmk:242: hotspot-server-libs] Error 2 
```

Additional testing:
 - [x] Linux ARM32 server release now builds fine
 - [x] Linux S390X server release now builds fine

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382436](https://bugs.openjdk.org/browse/JDK-8382436): Build failures after JDK-8326205 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30799/head:pull/30799` \
`$ git checkout pull/30799`

Update a local copy of the PR: \
`$ git checkout pull/30799` \
`$ git pull https://git.openjdk.org/jdk.git pull/30799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30799`

View PR using the GUI difftool: \
`$ git pr show -t 30799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30799.diff">https://git.openjdk.org/jdk/pull/30799.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30799#issuecomment-4270303153)
</details>
