### PR TITLE
8382441: Problemlist TestStressAllocationGCEventsWithShenandoah and TestStressBigAllocationGCEventsWithShenandoah

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -96,8 +96,10 @@ gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
 gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
 gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
-gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java 8382335 generic-all
-gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java 8382335 generic-all
+gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#generational 8382335 generic-all
+gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#default 8382335 generic-all
+gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#generational 8382335 generic-all
+gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#default 8382335 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -96,6 +96,8 @@ gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
 gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
 gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
+gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java 8382335 generic-all
+gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java 8382335 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
 Problemlist these two tests before coming up with a stable fix. Original test failure report: https://bugs.openjdk.org/browse/JDK-8382335


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This pull request must be associated with at least one component. Please use the [/label](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/label) pull request command.

### Issue
 * [JDK-8382441](https://bugs.openjdk.org/browse/JDK-8382441): Problemlist TestStressAllocationGCEventsWithShenandoah and TestStressBigAllocationGCEventsWithShenandoah (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30800/head:pull/30800` \
`$ git checkout pull/30800`

Update a local copy of the PR: \
`$ git checkout pull/30800` \
`$ git pull https://git.openjdk.org/jdk.git pull/30800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30800`

View PR using the GUI difftool: \
`$ git pr show -t 30800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30800.diff">https://git.openjdk.org/jdk/pull/30800.diff</a>

</details>
