### PR TITLE
8307537: Print blobs/nmethods/adapters stats per code heap in CodeCache::print_summary

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1888,7 +1888,7 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
       st->print_cr(" size=" JULONG_FORMAT "Kb, used=" JULONG_FORMAT
                    "Kb, max_used=" JULONG_FORMAT "Kb, free=" JULONG_FORMAT "Kb",
                    total_size, total_used, total_max_used, total_free);
-      st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
+      st->print_cr(" total blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
                    ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
                    total_blob_count, total_nmethod_count, total_adapter_count, full_count);
     }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1838,11 +1838,15 @@ void CodeCache::print() {
 }
 
 void CodeCache::print_summary(outputStream* st, bool detailed) {
+  int total_blob_count = 0;
+  int total_nmethod_count = 0;
+  int total_adapter_count = 0;
   int full_count = 0;
   julong total_used = 0;
   julong total_max_used = 0;
   julong total_free = 0;
   julong total_size = 0;
+
   FOR_ALL_HEAPS(heap_iterator) {
     CodeHeap* heap = (*heap_iterator);
     size_t total = (heap->high_boundary() - heap->low_boundary());
@@ -1868,8 +1872,13 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
                    p2i(heap->low_boundary()),
                    p2i(heap->high()),
                    p2i(heap->high_boundary()));
-
-      full_count += get_codemem_full_count(heap->code_blob_type());
+      st->print_cr(" blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
+                   ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
+                   heap->blob_count(), heap->nmethod_count(), heap->adapter_count(), heap->full_count());
+      total_blob_count += heap->blob_count();
+      total_nmethod_count += heap->nmethod_count();
+      total_adapter_count += heap->adapter_count();
+      full_count += heap->full_count();
     }
   }
 
@@ -1879,10 +1888,10 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
       st->print_cr(" size=" JULONG_FORMAT "Kb, used=" JULONG_FORMAT
                    "Kb, max_used=" JULONG_FORMAT "Kb, free=" JULONG_FORMAT "Kb",
                    total_size, total_used, total_max_used, total_free);
+      st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
+                   ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
+                   total_blob_count, total_nmethod_count, total_adapter_count, full_count);
     }
-    st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
-                 ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
-                 blob_count(), nmethod_count(), adapter_count(), full_count);
     st->print_cr("Compilation: %s, stopped_count=%d, restarted_count=%d",
                  CompileBroker::should_compile_new_jobs() ?
                  "enabled" : Arguments::mode() == Arguments::_int ?

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
@@ -72,7 +72,7 @@ public class CodeCacheTest {
      *  bounds [0x00007f20934d9000, 0x00007f2093949000, 0x00007f2093d3a000]
      *  blobs=478, nmethods=0, adapters=387, full_count=0
      * CodeCache: size=245764Kb, used=6965Kb, max_used=7010Kb, free=238796Kb
-     *  total_blobs=1966, nmethods=1488, adapters=387, full_count=0
+     *  total blobs=1966, nmethods=1488, adapters=387, full_count=0
      * Compilation: enabled, stopped_count=0, restarted_count=0
      */
 

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
@@ -79,7 +79,7 @@ public class CodeCacheTest {
     static Pattern line1 = Pattern.compile("(CodeCache|CodeHeap.*): size=(\\p{Digit}*)Kb used=(\\p{Digit}*)Kb max_used=(\\p{Digit}*)Kb free=(\\p{Digit}*)Kb");
     static Pattern line2 = Pattern.compile(" bounds \\[0x(\\p{XDigit}*), 0x(\\p{XDigit}*), 0x(\\p{XDigit}*)\\]");
     static Pattern line3 = Pattern.compile(" blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
-    static Pattern line4 = Pattern.compile(" total_blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
+    static Pattern line4 = Pattern.compile(" total blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
     static Pattern line5 = Pattern.compile("Compilation: (.*?), stopped_count=(\\p{Digit}*), restarted_count=(\\p{Digit}*)");
 
     private static boolean getFlagBool(String flag, String where) {

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test CodeCacheTest
- * @bug 8054889
+ * @bug 8054889 8307537
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler
@@ -57,26 +57,30 @@ public class CodeCacheTest {
      *
      * CodeCache: size=245760Kb used=1366Kb max_used=1935Kb free=244393Kb
      *  bounds [0x00007ff4d89f2000, 0x00007ff4d8c62000, 0x00007ff4e79f2000]
-     *  total_blobs=474, nmethods=87, adapters=293, full_count=0
+     *  blobs=474, nmethods=87, adapters=293, full_count=0
      * Compilation: enabled, stopped_count=0, restarted_count=0
      *
      * Expected output with code cache segmentation (number of segments may change):
      *
-     * CodeHeap 'non-profiled nmethods': size=118592Kb used=29Kb max_used=29Kb free=118562Kb
-     *  bounds [0x00007f09f8622000, 0x00007f09f8892000, 0x00007f09ff9f2000]
-     * CodeHeap 'profiled nmethods': size=118588Kb used=80Kb max_used=80Kb free=118507Kb
-     *  bounds [0x00007f09f09f2000, 0x00007f09f0c62000, 0x00007f09f7dc1000]
-     * CodeHeap 'non-nmethods': size=8580Kb used=1257Kb max_used=1833Kb free=7323Kb
-     *  bounds [0x00007f09f7dc1000, 0x00007f09f8031000, 0x00007f09f8622000]
-     * CodeCache: size=245760Kb, used=1366Kb, max_used=1942Kb, free=244392Kb
-     *  total_blobs=474, nmethods=87, adapters=293, full_count=0
+     * CodeHeap 'non-profiled nmethods': size=118592Kb used=370Kb max_used=370Kb free=118221Kb
+     *  bounds [0x00007f2093d3a000, 0x00007f2093faa000, 0x00007f209b10a000]
+     *  blobs=397, nmethods=397, adapters=0, full_count=0
+     * CodeHeap 'profiled nmethods': size=118592Kb used=2134Kb max_used=2134Kb free=116457Kb
+     *  bounds [0x00007f208c109000, 0x00007f208c379000, 0x00007f20934d9000]
+     *  blobs=1091, nmethods=1091, adapters=0, full_count=0
+     * CodeHeap 'non-nmethods': size=8580Kb used=4461Kb max_used=4506Kb free=4118Kb
+     *  bounds [0x00007f20934d9000, 0x00007f2093949000, 0x00007f2093d3a000]
+     *  blobs=478, nmethods=0, adapters=387, full_count=0
+     * CodeCache: size=245764Kb, used=6965Kb, max_used=7010Kb, free=238796Kb
+     *  total_blobs=1966, nmethods=1488, adapters=387, full_count=0
      * Compilation: enabled, stopped_count=0, restarted_count=0
      */
 
     static Pattern line1 = Pattern.compile("(CodeCache|CodeHeap.*): size=(\\p{Digit}*)Kb used=(\\p{Digit}*)Kb max_used=(\\p{Digit}*)Kb free=(\\p{Digit}*)Kb");
     static Pattern line2 = Pattern.compile(" bounds \\[0x(\\p{XDigit}*), 0x(\\p{XDigit}*), 0x(\\p{XDigit}*)\\]");
-    static Pattern line3 = Pattern.compile(" total_blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
-    static Pattern line4 = Pattern.compile("Compilation: (.*?), stopped_count=(\\p{Digit}*), restarted_count=(\\p{Digit}*)");
+    static Pattern line3 = Pattern.compile(" blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
+    static Pattern line4 = Pattern.compile(" total_blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
+    static Pattern line5 = Pattern.compile("Compilation: (.*?), stopped_count=(\\p{Digit}*), restarted_count=(\\p{Digit}*)");
 
     private static boolean getFlagBool(String flag, String where) {
       Matcher m = Pattern.compile(flag + "\\s+:?= (true|false)").matcher(where);
@@ -118,6 +122,9 @@ public class CodeCacheTest {
         String line;
         Matcher m;
         int matchedCount = 0;
+        int totalBlobs = 0;
+        int totalNmethods = 0;
+        int totalAdapters = 0;
         while (true) {
           // Validate first line
           line = lines.next();
@@ -151,6 +158,33 @@ public class CodeCacheTest {
           } else {
               Assert.fail("Regexp 2 failed to match line: " + line);
           }
+
+          // Validate third line
+          line = lines.next();
+          m = line3.matcher(line);
+          if (m.matches()) {
+              int blobs = Integer.parseInt(m.group(1));
+              if (blobs < 0) {
+                  Assert.fail("Failed parsing dcmd codecache output");
+              }
+              totalBlobs += blobs;
+              int nmethods = Integer.parseInt(m.group(2));
+              if (nmethods < 0) {
+                  Assert.fail("Failed parsing dcmd codecache output");
+              }
+              totalNmethods += nmethods;
+              int adapters = Integer.parseInt(m.group(3));
+              if (adapters < 0) {
+                  Assert.fail("Failed parsing dcmd codecache output");
+              }
+              totalAdapters += adapters;
+              if (blobs < (nmethods + adapters)) {
+                  Assert.fail("Failed parsing dcmd codecache output");
+              }
+          } else {
+              Assert.fail("Regexp 3 failed to match line: " + line);
+          }
+
           ++matchedCount;
         }
         // Because of CodeCacheExtensions, we could match more than expected
@@ -161,32 +195,33 @@ public class CodeCacheTest {
         if (segmentsCount != 1) {
             // Skip this line CodeCache: size=245760Kb, used=5698Kb, max_used=5735Kb, free=240059Kb
             line = lines.next();
-        }
-        // Validate third line
-        m = line3.matcher(line);
-        if (m.matches()) {
-            int blobs = Integer.parseInt(m.group(1));
-            if (blobs <= 0) {
-                Assert.fail("Failed parsing dcmd codecache output");
+
+            // Validate fourth line
+            m = line4.matcher(line);
+            if (m.matches()) {
+                int blobs = Integer.parseInt(m.group(1));
+                if (blobs != totalBlobs) {
+                    Assert.fail("Failed parsing dcmd codecache output");
+                }
+                int nmethods = Integer.parseInt(m.group(2));
+                if (nmethods != totalNmethods) {
+                    Assert.fail("Failed parsing dcmd codecache output");
+                }
+                int adapters = Integer.parseInt(m.group(3));
+                if (adapters != totalAdapters) {
+                    Assert.fail("Failed parsing dcmd codecache output");
+                }
+                if (blobs < (nmethods + adapters)) {
+                    Assert.fail("Failed parsing dcmd codecache output");
+                }
+            } else {
+                Assert.fail("Regexp 4 failed to match line: " + line);
             }
-            int nmethods = Integer.parseInt(m.group(2));
-            if (nmethods < 0) {
-                Assert.fail("Failed parsing dcmd codecache output");
-            }
-            int adapters = Integer.parseInt(m.group(3));
-            if (adapters <= 0) {
-                Assert.fail("Failed parsing dcmd codecache output");
-            }
-            if (blobs < (nmethods + adapters)) {
-                Assert.fail("Failed parsing dcmd codecache output");
-            }
-        } else {
-            Assert.fail("Regexp 3 failed to match line: " + line);
+            line = lines.next();
         }
 
-        // Validate fourth line
-        line = lines.next();
-        m = line4.matcher(line);
+        // Validate last line
+        m = line5.matcher(line);
         if (m.matches()) {
             if (!m.group(1).contains("enabled") && !m.group(1).contains("disabled")) {
                 Assert.fail("Failed parsing dcmd codecache output");
@@ -200,7 +235,7 @@ public class CodeCacheTest {
                 Assert.fail("Failed parsing dcmd codecache output");
             }
         } else {
-            Assert.fail("Regexp 4 failed to match line: " + line);
+            Assert.fail("Regexp 5 failed to match line: " + line);
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,15 +56,16 @@ public class Test {
     static {
         String p1 = " size=\\d+Kb used=\\d+Kb max_used=\\d+Kb free=\\d+Kb\\n";
         String p2 = " bounds \\[0x[0-9a-f]+, 0x[0-9a-f]+, 0x[0-9a-f]+\\]\\n";
-        String p3 = "CodeCache:.*\\n";
-        String p4 = " total_blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
-        String p5 = "Compilation: enabled.*\\n";
+        String p3 = " blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
+        String p4 = "CodeCache:.*\\n";
+        String p5 = " total_blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
+        String p6 = "Compilation: enabled.*\\n";
 
-        String segPrefix = "^(CodeHeap '[^']+':" + p1 + p2 + ")+";
-        String nosegPrefix = "^CodeCache:" + p1 + p2;
+        String segPrefix = "^(CodeHeap '[^']+':" + p1 + p2 + p3 + ")+";
+        String nosegPrefix = "^CodeCache:" + p1 + p2 + p3;
 
-        SEG_REGEXP = segPrefix + p3 + p4 + p5;
-        NOSEG_REGEXP = nosegPrefix + p4 + p5;
+        SEG_REGEXP = segPrefix + p4 + p5 + p6;
+        NOSEG_REGEXP = nosegPrefix + p6;
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
@@ -58,7 +58,7 @@ public class Test {
         String p2 = " bounds \\[0x[0-9a-f]+, 0x[0-9a-f]+, 0x[0-9a-f]+\\]\\n";
         String p3 = " blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
         String p4 = "CodeCache:.*\\n";
-        String p5 = " total_blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
+        String p5 = " total blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
         String p6 = "Compilation: enabled.*\\n";
 
         String segPrefix = "^(CodeHeap '[^']+':" + p1 + p2 + p3 + ")+";


### PR DESCRIPTION
This PR adds blobs/nmethods/adapters stats per code heap in CodeCahe::print_summary:
```
CodeHeap 'non-profiled nmethods': size=118592Kb used=370Kb max_used=370Kb free=118221Kb
 bounds [0x00007f2093d3a000, 0x00007f2093faa000, 0x00007f209b10a000]
 blobs=397, nmethods=397, adapters=0, full_count=0
CodeHeap 'profiled nmethods': size=118592Kb used=2134Kb max_used=2134Kb free=116457Kb
 bounds [0x00007f208c109000, 0x00007f208c379000, 0x00007f20934d9000]
 blobs=1091, nmethods=1091, adapters=0, full_count=0
CodeHeap 'non-nmethods': size=8580Kb used=4461Kb max_used=4506Kb free=4118Kb
 bounds [0x00007f20934d9000, 0x00007f2093949000, 0x00007f2093d3a000]
 blobs=478, nmethods=0, adapters=387, full_count=0
CodeCache: size=245764Kb, used=6965Kb, max_used=7010Kb, free=238796Kb
 total_blobs=1966, nmethods=1488, adapters=387, full_count=0
Compilation: enabled, stopped_count=0, restarted_count=0
```

This information is useful for debugging CodeCache.

Testing: fastdebug, tier1-tier2 passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8307537](https://bugs.openjdk.org/browse/JDK-8307537): Print blobs/nmethods/adapters stats per code heap in CodeCache::print_summary (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30803/head:pull/30803` \
`$ git checkout pull/30803`

Update a local copy of the PR: \
`$ git checkout pull/30803` \
`$ git pull https://git.openjdk.org/jdk.git pull/30803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30803`

View PR using the GUI difftool: \
`$ git pr show -t 30803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30803.diff">https://git.openjdk.org/jdk/pull/30803.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30803#issuecomment-4271164443)
</details>
