### PR TITLE
8382442: Make SUN provider configurable so it support non-crypto services only

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -213,6 +213,9 @@ final class ProviderConfig {
                     }
                 }
             };
+            if (hasArgument()) {
+                p = p.configure(argument);
+            }
             provider = p;
         }
         return p;

--- a/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
@@ -235,18 +235,12 @@ final class ProviderConfig {
         }
         try {
             Provider p = ProviderLoader.INSTANCE.load(provName);
-            if (p != null) {
-                if (hasArgument()) {
-                    p = p.configure(argument);
-                }
-                if (debug != null) {
-                    debug.println("Loaded provider " + p.getName());
-                }
-            } else {
-                if (debug != null) {
-                    debug.println("Error loading provider " +
-                        ProviderConfig.this);
-                }
+            if (debug != null) {
+                debug.println(p != null ?
+                    "Loaded provider " + p.getName() :
+                    "Error loading provider " + ProviderConfig.this);
+            }
+            if (p == null) {
                 disableLoad();
             }
             return p;

--- a/src/java.base/share/classes/sun/security/provider/Sun.java
+++ b/src/java.base/share/classes/sun/security/provider/Sun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,26 @@ public final class Sun extends Provider {
     "PKIX CertPathBuilder; LDAP, Collection CertStores, JavaPolicy Policy; " +
     "JavaLoginConfig Configuration)";
 
+    private static String INFO_NO_CRYPTO = "SUN no_crypto " +
+    "(X.509 certificates; PKCS12, JKS & DKS keystores; " +
+    "PKIX CertPathValidator; " +
+    "PKIX CertPathBuilder; LDAP, Collection CertStores, JavaPolicy Policy; " +
+    "JavaLoginConfig Configuration)";
+
+    // Additional JCE crypto services, e.g. Cipher, KDF, are not included
+    // in this list since SUN provider does not support them
+    private static final Set<String> CRYPTO_SERVICE_TYPES = Set.of(
+            "AlgorithmParameterGenerator",
+            "AlgorithmParameters",
+            "KeyFactory",
+            "KeyPairGenerator",
+            "MessageDigest",
+            "SecureRandom",
+            "Signature"
+    );
+
+    private transient String info = INFO;
+
     public Sun() {
         /* We are the SUN provider */
         super("SUN", PROVIDER_VER, INFO);
@@ -57,5 +77,24 @@ public final class Sun extends Provider {
         while (serviceIter.hasNext()) {
             putService(serviceIter.next());
         }
+    }
+
+    @Override
+    public Provider configure(String option) {
+        if ("no_crypto".equalsIgnoreCase(option)) {
+            getServices().stream()
+                    .filter(s -> CRYPTO_SERVICE_TYPES.contains(s.getType()))
+                    .forEach(this::removeService);
+            info = INFO_NO_CRYPTO;
+        } else {
+            throw new ProviderException("Unsupported configuration option " +
+                    option);
+        }
+        return this;
+    }
+
+    @Override
+    public String getInfo() {
+        return info;
     }
 }

--- a/test/jdk/sun/security/provider/TestConfigure.java
+++ b/test/jdk/sun/security/provider/TestConfigure.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8382442
+ * @summary test the SUN provider no_crypto configuration option
+ * @library /test/lib
+ * @run main/othervm TestConfigure no_crypto
+ * @run main/othervm -Djava.security.properties==${test.src}/noCrypto.txt TestConfigure
+ */
+import jdk.test.lib.Asserts;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.ProviderException;
+import java.security.Security;
+import java.security.Signature;
+import java.security.cert.CertPathBuilder;
+import java.security.cert.CertPathValidator;
+
+public class TestConfigure {
+
+    private static Provider SUN_NO_CRYPTO;
+    private static String PROV_NAME = "SUN";
+
+    private static void test(String service, String algo)
+            throws Exception {
+        Object[] objs = {
+            PROV_NAME, Security.getProvider(PROV_NAME), SUN_NO_CRYPTO
+        };
+        for (Object o : objs) {
+            switch (service) {
+                case "CertPathBuilder"->{
+                    if (o instanceof String s) {
+                        CertPathBuilder.getInstance(algo, s);
+                    } else if (o instanceof Provider p) {
+                        System.out.println("provider info: " + p.getInfo());
+                        CertPathBuilder.getInstance(algo, p);
+                    } else {
+                        throw new RuntimeException
+                                ("Error: unsupported type "  + o);
+                    }
+                }
+                case "CertPathValidator"->{
+                    if (o instanceof String s) {
+                        CertPathValidator.getInstance(algo, s);
+                    } else if (o instanceof Provider p) {
+                        CertPathValidator.getInstance(algo, p);
+                    } else {
+                        throw new RuntimeException
+                                ("Error: unsupported type "  + o);
+                    }
+                }
+                case "MessageDigest"->{
+                    if (o instanceof String s) {
+                        Asserts.assertThrows(NoSuchAlgorithmException.class,
+                                () -> MessageDigest.getInstance(algo, s));
+                    } else if (o instanceof Provider p) {
+                        Asserts.assertThrows(NoSuchAlgorithmException.class,
+                                () -> MessageDigest.getInstance(algo, p));
+                    } else {
+                        throw new RuntimeException
+                                ("Error: unsupported type "  + o);
+                    }
+                }
+                case "Signature"->{
+                    if (o instanceof String s) {
+                        Asserts.assertThrows(NoSuchAlgorithmException.class,
+                                () -> Signature.getInstance(algo, s));
+                    } else if (o instanceof Provider p) {
+                        Asserts.assertThrows(NoSuchAlgorithmException.class,
+                                () -> Signature.getInstance(algo, p));
+                    } else {
+                        throw new RuntimeException
+                                ("Error: unsupported type "  + o);
+                    }
+                }
+                default->{
+                    throw new RuntimeException("Unsupported service: " +
+                            service);
+                }
+            }
+        }
+    }
+
+    public static void main(String[] argv) throws Exception {
+        if (argv.length > 0) {
+            System.out.println("Testing runtime configuration " + argv[0]);
+            // configure SUN provider w/ the supplied option
+            Provider orig = Security.getProvider("SUN");
+            Asserts.assertEQ(orig.getInfo().indexOf("no_crypto"), -1);
+            SUN_NO_CRYPTO = orig.configure(argv[0]);
+            Asserts.assertGTE(SUN_NO_CRYPTO.getInfo().indexOf("no_crypto"),
+                    PROV_NAME.length());
+            Asserts.assertThrows(ProviderException.class,
+                        () -> orig.configure("xyz"));
+        } else {
+            System.out.println("Testing static configuration w/ " +
+                     System.getProperty("java.security.properties"));
+            SUN_NO_CRYPTO = Security.getProvider("SUN");
+            Asserts.assertGTE(SUN_NO_CRYPTO.getInfo().indexOf("no_crypto"),
+                    PROV_NAME.length());
+        }
+
+        // crypto services should now throw NSAE
+        test("MessageDigest", "SHA-224");
+        test("Signature", "SHA224withDSA");
+        // make sure no change on non-crypto services
+        test("CertPathBuilder", "PKIX");
+        test("CertPathValidator", "PKIX");
+    }
+}

--- a/test/jdk/sun/security/provider/noCrypto.txt
+++ b/test/jdk/sun/security/provider/noCrypto.txt
@@ -1,0 +1,8 @@
+# This is the "test security properties file" for testing SUN no_crypto
+# config option
+
+#
+# List of providers and their preference orders
+#
+security.provider.1=SUN no_crypto
+security.provider.2=SunJCE


### PR DESCRIPTION
This PR adds a configuration option to SUN provider, named "no_crypto", so that SUN provider disables its support of crypto services such as MessageDigest, Signature, SecureRandom, etc.
 
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8383826](https://bugs.openjdk.org/browse/JDK-8383826) to be approved

### Issues
 * [JDK-8382442](https://bugs.openjdk.org/browse/JDK-8382442): Make SUN provider configurable so it support non-crypto services only (**Enhancement** - P4)
 * [JDK-8383826](https://bugs.openjdk.org/browse/JDK-8383826): Make SUN provider configurable so it support non-crypto services only (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30804/head:pull/30804` \
`$ git checkout pull/30804`

Update a local copy of the PR: \
`$ git checkout pull/30804` \
`$ git pull https://git.openjdk.org/jdk.git pull/30804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30804`

View PR using the GUI difftool: \
`$ git pr show -t 30804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30804.diff">https://git.openjdk.org/jdk/pull/30804.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30804#issuecomment-4356627243)
</details>
