### PR TITLE
8382481: GenShen: Compilation failure using GCC 14

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -800,13 +800,13 @@ private:
   template<class T>
   void update_references_in_remembered_set(uint worker_id, T &cl, const ShenandoahMarkingContext* ctx, bool is_mixed) {
 
-    struct ShenandoahRegionChunk assignment;
+    ShenandoahRegionChunk assignment;
     ShenandoahScanRemembered* scanner = _heap->old_generation()->card_scan();
 
     while (!_heap->check_cancelled_gc_and_yield(CONCURRENT) && _work_chunks->next(&assignment)) {
       // Keep grabbing next work chunk to process until finished, or asked to yield
       ShenandoahHeapRegion* r = assignment._r;
-      if (r->is_active() && !r->is_cset() && r->is_old()) {
+      if (r != nullptr && r->is_active() && !r->is_cset() && r->is_old()) {
         HeapWord* start_of_range = r->bottom() + assignment._chunk_offset;
         HeapWord* end_of_range = r->get_update_watermark();
         if (end_of_range > start_of_range + assignment._chunk_size) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -383,7 +383,7 @@ inline bool ShenandoahRegionChunkIterator::has_next() const {
   return _index.load_relaxed() < _total_chunks;
 }
 
-inline bool ShenandoahRegionChunkIterator::next(struct ShenandoahRegionChunk *assignment) {
+inline bool ShenandoahRegionChunkIterator::next(ShenandoahRegionChunk* assignment) {
   if (_index.load_relaxed() >= _total_chunks) {
     return false;
   }


### PR DESCRIPTION
GCC 14's deeper inlining optimizations interact badly with `stringop-overflow` here. It falsely detects that the region pointer could be null. Simplest fix is to just add a `nullptr` check for it. Alternatively, should we consider disabling this warning? The Linux kernel has: https://www.phoronix.com/news/Linux-Drop-GCC--Wstringop-of.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382481](https://bugs.openjdk.org/browse/JDK-8382481): GenShen: Compilation failure using GCC 14 (**Bug** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30805/head:pull/30805` \
`$ git checkout pull/30805`

Update a local copy of the PR: \
`$ git checkout pull/30805` \
`$ git pull https://git.openjdk.org/jdk.git pull/30805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30805`

View PR using the GUI difftool: \
`$ git pr show -t 30805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30805.diff">https://git.openjdk.org/jdk/pull/30805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30805#issuecomment-4272058540)
</details>
