### PR TITLE
8345301: GenShen: TestShenandoahEvacuationInformationEvent.java intermittent fails

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestShenandoahEvacuationInformationEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestShenandoahEvacuationInformationEvent.java
@@ -41,7 +41,7 @@ import jdk.test.lib.jfr.GCHelper;
  * @requires vm.hasJFR & vm.gc.Shenandoah
  * @requires vm.flagless
  * @library /test/lib /test/jdk
- * @run main/othervm -Xmx64m -XX:+UnlockExperimentalVMOptions -XX:ShenandoahRegionSize=1m -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational jdk.jfr.event.gc.detailed.TestShenandoahEvacuationInformationEvent
+ * @run main/othervm -Xmx64m -XX:+UnlockExperimentalVMOptions -XX:ShenandoahRegionSize=1m -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:ShenandoahGenerationalMinPIPUsage=100 -XX:ShenandoahImmediateThreshold=100 jdk.jfr.event.gc.detailed.TestShenandoahEvacuationInformationEvent
  */
 
 public class TestShenandoahEvacuationInformationEvent {

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestShenandoahPromotionInformationEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestShenandoahPromotionInformationEvent.java
@@ -39,7 +39,7 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.gc.Shenandoah
  * @requires vm.flagless
  * @library /test/lib /test/jdk
- * @run main/othervm -Xmx64m -XX:+UnlockExperimentalVMOptions -XX:ShenandoahRegionSize=1m -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational jdk.jfr.event.gc.detailed.TestShenandoahPromotionInformationEvent
+ * @run main/othervm -Xmx64m -XX:+UnlockExperimentalVMOptions -XX:ShenandoahRegionSize=1m -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:ShenandoahGenerationalMinPIPUsage=100 -XX:ShenandoahImmediateThreshold=100 jdk.jfr.event.gc.detailed.TestShenandoahPromotionInformationEvent
  */
 
 public class TestShenandoahPromotionInformationEvent {


### PR DESCRIPTION
Though I could not reproduce this failure after running the tests 1000+ times, I do know that the generational mode may decide to promote regions in place and/or skip evacuations entirely when enough memory can be reclaimed from regions with no live objects. I have therefore added options to these tests to effectively disable these features to force Shenandoah to evacuate more often.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8345301](https://bugs.openjdk.org/browse/JDK-8345301): GenShen: TestShenandoahEvacuationInformationEvent.java intermittent fails (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30807/head:pull/30807` \
`$ git checkout pull/30807`

Update a local copy of the PR: \
`$ git checkout pull/30807` \
`$ git pull https://git.openjdk.org/jdk.git pull/30807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30807`

View PR using the GUI difftool: \
`$ git pr show -t 30807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30807.diff">https://git.openjdk.org/jdk/pull/30807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30807#issuecomment-4272061159)
</details>
