### PR TITLE
8382312: Cleanup instanceKlass dead code

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -330,9 +330,6 @@ class InstanceKlass: public Klass {
   bool defined_by_other_loaders() const    { return _misc_flags.defined_by_other_loaders(); }
   void set_class_loader_type()             { _misc_flags.set_class_loader_type(_class_loader_data); }
 
-  // Check if the class can be shared in CDS
-  bool is_shareable() const;
-
   bool shared_loading_failed() const { return _misc_flags.shared_loading_failed(); }
 
   void set_shared_loading_failed() { _misc_flags.set_shared_loading_failed(true); }
@@ -1136,8 +1133,6 @@ private:
   void link_previous_versions(InstanceKlass* pv) { _previous_versions = pv; }
   void mark_newly_obsolete_methods(Array<Method*>* old_methods, int emcp_method_count);
 #endif
-  // log class name to classlist
-  void log_to_classlist() const;
 public:
 
 #if INCLUDE_CDS


### PR DESCRIPTION
# changes
Cleanup unused `is_shareable` and `log_to_classlist` declarations from `InstanceKlass.hpp` 

## Test
- Verified that `make images` completes without errors.
- Confirmed that `Tier1` tests pass successfully.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382312](https://bugs.openjdk.org/browse/JDK-8382312): Cleanup instanceKlass dead code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30810/head:pull/30810` \
`$ git checkout pull/30810`

Update a local copy of the PR: \
`$ git checkout pull/30810` \
`$ git pull https://git.openjdk.org/jdk.git pull/30810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30810`

View PR using the GUI difftool: \
`$ git pr show -t 30810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30810.diff">https://git.openjdk.org/jdk/pull/30810.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30810#issuecomment-4274202997)
</details>
