### PR TITLE
8378603: libfontmanager FFM path needs to use FFM to locate both malloc and free

### DIFF
--- a/src/java.desktop/share/classes/sun/font/HBShaper.java
+++ b/src/java.desktop/share/classes/sun/font/HBShaper.java
@@ -174,6 +174,17 @@ public class HBShaper {
         MethodHandle tmp1 = LINKER.downcallHandle(malloc_symbol, mallocDescriptor);
         malloc_handle = tmp1;
 
+        MemorySegment free_symbol = SYM_LOOKUP.findOrThrow("free");
+        long free_address = free_symbol.address();
+        FunctionDescriptor setFreeFnDescriptor = FunctionDescriptor.ofVoid(JAVA_LONG);
+        MemorySegment set_free = SYM_LOOKUP.findOrThrow("HBSetFreeFn");
+        @SuppressWarnings("restricted")
+        MethodHandle set_free_handle = LINKER.downcallHandle(set_free, setFreeFnDescriptor);
+        try {
+            set_free_handle.invokeExact(free_address);
+        } catch (Throwable t) {
+        }
+
         FunctionDescriptor createFaceDescriptor =
             FunctionDescriptor.of(ADDRESS, ADDRESS);
         MemorySegment create_face_symbol = SYM_LOOKUP.findOrThrow("HBCreateFace");

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk-font-p.cc
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk-font-p.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,6 +174,22 @@ static void _do_nothing(void) {
 
 typedef int (*GetTableDataFn) (int tag, char **dataPtr);
 
+typedef void (*ffm_free_t) (void *ptr);
+
+static ffm_free_t ffm_free_fn = NULL;
+
+/* We pass the address of "free" which was obtained by FFM so that it matches
+ * the malloc found by FFM
+ */
+#include <stdio.h>
+static void ffmfree(void *ptr) {
+    if (ffm_free_fn != NULL) {
+        ffm_free_fn(ptr);
+    } else {
+        free(ptr);
+    }
+}
+
 static hb_blob_t *
 reference_table(hb_face_t *face HB_UNUSED, hb_tag_t tag, void *user_data) {
 
@@ -200,10 +216,14 @@ reference_table(hb_face_t *face HB_UNUSED, hb_tag_t tag, void *user_data) {
    */
   return hb_blob_create((const char *)tableData, length,
                          HB_MEMORY_MODE_WRITABLE,
-                         tableData, free);
+                         tableData, ffmfree);
 }
 
 extern "C" {
+
+JDKEXPORT void HBSetFreeFn(void *free_fn) {
+    ffm_free_fn = (ffm_free_t)free_fn;
+}
 
 JDKEXPORT hb_face_t* HBCreateFace(GetTableDataFn *get_data_upcall_fn) {
 


### PR DESCRIPTION
We need to use FFM to locate free() because we use malloc() as located by FFM.
If these two don't match, then it can cause problems and confusion.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8378603: libfontmanager FFM path needs to use FFM to locate both malloc and free`

### Issue
 * [JDK-8378603](https://bugs.openjdk.org/browse/JDK-8378603): libfontmanager FFM path needs to use FFM to locate both malloc and free (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30811/head:pull/30811` \
`$ git checkout pull/30811`

Update a local copy of the PR: \
`$ git checkout pull/30811` \
`$ git pull https://git.openjdk.org/jdk.git pull/30811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30811`

View PR using the GUI difftool: \
`$ git pr show -t 30811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30811.diff">https://git.openjdk.org/jdk/pull/30811.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30811#issuecomment-4274237853)
</details>
