### PR TITLE
8382489: aarch64: Clean up redundant restore_locals() in TemplateTable::invokeinterface

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3479,7 +3479,6 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ bind(notVFinal);
 
   // Get receiver klass into r3
-  __ restore_locals();
   __ load_klass(r3, r2);
 
   Label no_such_method;


### PR DESCRIPTION
## Summary

Remove redundant `restore_locals()` calls in `TemplateTable::invokeinterface()` on AArch64 and RISC-V architectures. On x86, this call is necessary because the implementation explicitly uses `rlocals` (r14) as a temporary register throughout the invokeinterface handler, modifying it in multiple code paths. However, on AArch64 and RISC-V,  the locals register (`rlocals`/`xlocals`) remains untouched throughout the entire invokeinterface execution, making the restore call redundant.

## Problem

In `templateTable_aarch64.cpp`, the `invokeinterface()` bytecode handler contains a `restore_locals()` 
call at the `notVFinal` label that is never needed because no preceding code path modifies the locals register.

### Code Flow Analysis

```cpp
void TemplateTable::invokeinterface(int byte_no) {
  load_resolved_method_entry_interface(...);  // May call call_VM → already restores locals
  prepare_invoke(...);                         // Does NOT use rlocals

  // Forced virtual path
  Label notObjectMethod;
  __ tbz(r3, ...is_forced_virtual_shift, notObjectMethod);
  invokevirtual_helper(rmethod, r2, r3);       // Uses r0, r3, r4 - NOT rlocals
  __ bind(notObjectMethod);

  Label no_such_interface;

  // vfinal path
  Label notVFinal;
  __ tbz(r3, ...is_vfinal_shift, notVFinal);
  __ load_klass(r3, r2);                       // Uses r3, NOT rlocals
  __ check_klass_subtype(r3, r0, r4, subtype); // Uses r3, r4 - NOT rlocals
  __ jump_from_interpreted(...);               // Jumps away, never returns to notVFinal

  // notVFinal path (only reached if NOT vfinal)
  __ bind(notVFinal);
  __ restore_locals();  // ← REDUNDANT: rlocals was never modified!
  __ load_klass(r3, r2);
  ...
}
```
## Testing

- [x] tier1, tier2 tests on linux-aarch64(fastdebug)

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382489](https://bugs.openjdk.org/browse/JDK-8382489): aarch64: Clean up redundant restore_locals() in TemplateTable::invokeinterface (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30813/head:pull/30813` \
`$ git checkout pull/30813`

Update a local copy of the PR: \
`$ git checkout pull/30813` \
`$ git pull https://git.openjdk.org/jdk.git pull/30813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30813`

View PR using the GUI difftool: \
`$ git pr show -t 30813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30813.diff">https://git.openjdk.org/jdk/pull/30813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30813#issuecomment-4275531143)
</details>
