### PR TITLE
8382490: RISC-V: Clean up redundant restore_locals() in TemplateTable::invokeinterface

### DIFF
--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3389,7 +3389,6 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ bind(notVFinal);
 
   // Get receiver klass into x13
-  __ restore_locals();
   __ load_klass(x13, x12);
 
   Label no_such_method;


### PR DESCRIPTION
## Summary

Remove redundant `restore_locals()` calls in `TemplateTable::invokeinterface()` on AArch64 and RISC-V architectures. On x86, this call is necessary because the implementation explicitly uses `rlocals` (r14) as a temporary register throughout the invokeinterface handler, modifying it in multiple code paths. However, on AArch64 and RISC-V, the locals register (`rlocals`/`xlocals`) remains untouched throughout the entire invokeinterface execution, making the restore call redundant.

## Problem

In `templateTable_riscv.cpp`, the `invokeinterface()` bytecode handler contains a `restore_locals()` 
call at the `notVFinal` label that is never needed because no preceding code path modifies the locals register.

### Code Flow Analysis

```cpp
void TemplateTable::invokeinterface(int byte_no) {
  load_resolved_method_entry_interface(...);  // May call call_VM → already restores locals
  prepare_invoke(...);                         // Does NOT use xlocals

  // Forced virtual path
  Label notObjectMethod;
  __ test_bit(t0, x13, ...is_forced_virtual_shift);
  __ beqz(t0, notObjectMethod);
  invokevirtual_helper(xmethod, x12, x13);     // Uses x10, x13, x14 - NOT xlocals
  __ bind(notObjectMethod);

  Label no_such_interface;

  // vfinal path
  Label notVFinal;
  __ test_bit(t0, x13, ...is_vfinal_shift);
  __ beqz(t0, notVFinal);
  __ load_klass(x13, x12);                     // Uses x13, NOT xlocals
  __ check_klass_subtype(x13, x10, x14, subtype); // Uses x13, x14 - NOT xlocals
  __ jump_from_interpreted(xmethod);           // Jumps away, never returns to notVFinal

  // notVFinal path (only reached if NOT vfinal)
  __ bind(notVFinal);
  __ restore_locals();  // ← REDUNDANT: xlocals was never modified!
  __ load_klass(x13, x12);
  ...
}
```
## Testing

- [x] tier1 tests on SOPHON SG2042 (fastdebug)

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382490](https://bugs.openjdk.org/browse/JDK-8382490): RISC-V: Clean up redundant restore_locals() in TemplateTable::invokeinterface (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30814/head:pull/30814` \
`$ git checkout pull/30814`

Update a local copy of the PR: \
`$ git checkout pull/30814` \
`$ git pull https://git.openjdk.org/jdk.git pull/30814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30814`

View PR using the GUI difftool: \
`$ git pr show -t 30814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30814.diff">https://git.openjdk.org/jdk/pull/30814.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30814#issuecomment-4285361161)
</details>
