### PR TITLE
8377655: C1: in x86, avoid 0x00s leftover after PatchingStub

### DIFF
--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,18 +341,31 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(patch_info_pc - end_of_patch == bytes_to_skip, "incorrect patch info");
 
   address entry = __ pc();
-  // 8377655: replace the leftover 0x00 by nops to be disassembler-friendly
+  // NativeGeneralJump::insert_unconditional will be writing a jmp rel32 at _pc_start over the existing instructions.
+  // There are 2 cases:
+  // - the existing instruction is a mov r64 imm64 from LIR_Assembler::klass2reg_with_patching
+  // - or there are nops there (from higher in this function).
+  // In the first case, since a jmp rel32 is 5-byte long, but a mov r64 imm64 is 10-byte long, so we are left with
+  // the last 5 bytes of the immediate operand (which are all 0x00). When debugging, this confuses the disassembler
+  // because it tries to recognize an instruction starting immediately after the jmp rel32, leading to wrong instructions,
+  // and possibly failure to disassemble further the whole function.
+  //
+  // To be disassembler-friendly, let's replace the leftover 0x00 with nops.
+  // To recognize a mov r64 imm64, we look for the 2-byte sequence
   // REX prefix | MOV r64
+  // then, we know the 8 bytes after are the immediate operand.
   if ((*_pc_start & Assembler::REX) == Assembler::REX && (*(_pc_start + 1) & 0xb8) == 0xb8) {
     assert(*(long long int*)(_pc_start+2) == 0, "imm64 must be 0 in mov r64, imm64");
+    // We don't need to replace the NativeGeneralJump::instruction_size first bytes, since insert_unconditional
+    // will overwrite.
     for (int i = NativeGeneralJump::instruction_size; i < 10; ++i) {
       *(_pc_start + i) = NativeInstruction::nop_instruction_code;
     }
   }
 #ifdef ASSERT
-  else {  // make sure we are patching all that is patchable
+  else {  // and we make sure otherwise, we indeed have just nops.
     for (int i = 0; i < NativeGeneralJump::instruction_size; ++i) {
-      assert(*(_pc_start + i) == NativeInstruction::nop_instruction_code, "");
+      assert(*(_pc_start + i) == NativeInstruction::nop_instruction_code, "patching over an unexpected instruction");
     }
   }
 #endif

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -341,14 +341,16 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(patch_info_pc - end_of_patch == bytes_to_skip, "incorrect patch info");
 
   address entry = __ pc();
-  if (0x40 <= *_pc_start && *_pc_start <= 0x4f && 0xb8 <= *(_pc_start + 1) && *(_pc_start + 1) <= 0xbf) {
+  // 8377655: replace the leftover 0x00 by nops to be disassembler-friendly
+  // REX prefix | MOV r64
+  if ((*_pc_start & Assembler::REX) == Assembler::REX && (*(_pc_start + 1) & 0xb8) == 0xb8) {
     assert(*(long long int*)(_pc_start+2) == 0, "imm64 must be 0 in mov r64, imm64");
     for (int i = NativeGeneralJump::instruction_size; i < 10; ++i) {
       *(_pc_start + i) = NativeInstruction::nop_instruction_code;
     }
   }
 #ifdef ASSERT
-  else {
+  else {  // make sure we are patching all that is patchable
     for (int i = 0; i < NativeGeneralJump::instruction_size; ++i) {
       assert(*(_pc_start + i) == NativeInstruction::nop_instruction_code, "");
     }

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -247,7 +247,6 @@ void PatchingStub::align_patch_site(MacroAssembler* masm) {
 
 void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(NativeCall::instruction_size <= _bytes_to_copy && _bytes_to_copy <= 0xFF, "not enough room for call");
-
   Label call_patch;
 
   // static field accesses have special semantics while the class
@@ -342,7 +341,22 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(patch_info_pc - end_of_patch == bytes_to_skip, "incorrect patch info");
 
   address entry = __ pc();
+  bool seen_the_thing = false;
+  if (*_pc_start == 0x48 && *(_pc_start + 1) == 0xba && UseNewCode) {
+    tty->print_cr("B %p: %02x %02x%02x%02x%02x%02x%02x%02x%02x%02x", _pc_start, *(_pc_start), *(_pc_start+1), *(_pc_start+2), *(_pc_start+3), *(_pc_start+4), *(_pc_start+5), *(_pc_start+6), *(_pc_start+7), *(_pc_start+8), *(_pc_start+9));
+    seen_the_thing = true;
+  }
+  if (*_pc_start == 0x48 && *(_pc_start + 1) == 0xba) {
+    assert(*(long long int*)(_pc_start+2) == 0, "");
+    for (int i = 0; i < 8; ++i) {
+      *(_pc_start + i + 2) = NativeInstruction::nop_instruction_code;
+    }
+  }
   NativeGeneralJump::insert_unconditional((address)_pc_start, entry);
+  if (seen_the_thing) {
+    tty->print_cr("C %p: %02x %02x%02x%02x%02x%02x%02x%02x%02x%02x", _pc_start, *(_pc_start), *(_pc_start+1), *(_pc_start+2), *(_pc_start+3), *(_pc_start+4), *(_pc_start+5), *(_pc_start+6), *(_pc_start+7), *(_pc_start+8), *(_pc_start+9));
+    tty->print_cr("");
+  }
   address target = nullptr;
   relocInfo::relocType reloc_type = relocInfo::none;
   switch (_id) {

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -247,6 +247,7 @@ void PatchingStub::align_patch_site(MacroAssembler* masm) {
 
 void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(NativeCall::instruction_size <= _bytes_to_copy && _bytes_to_copy <= 0xFF, "not enough room for call");
+
   Label call_patch;
 
   // static field accesses have special semantics while the class

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -292,7 +292,7 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
       address ptr = (address)(_pc_start + i);
       int a_byte = (*ptr) & 0xFF;
       __ emit_int8(a_byte);
-      *ptr = 0x90; // make the site look like a nop
+      *ptr = NativeInstruction::nop_instruction_code; // make the site look like a nop
     }
   }
 
@@ -341,22 +341,13 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(patch_info_pc - end_of_patch == bytes_to_skip, "incorrect patch info");
 
   address entry = __ pc();
-  bool seen_the_thing = false;
-  if (*_pc_start == 0x48 && *(_pc_start + 1) == 0xba && UseNewCode) {
-    tty->print_cr("B %p: %02x %02x%02x%02x%02x%02x%02x%02x%02x%02x", _pc_start, *(_pc_start), *(_pc_start+1), *(_pc_start+2), *(_pc_start+3), *(_pc_start+4), *(_pc_start+5), *(_pc_start+6), *(_pc_start+7), *(_pc_start+8), *(_pc_start+9));
-    seen_the_thing = true;
-  }
-  if (*_pc_start == 0x48 && *(_pc_start + 1) == 0xba) {
-    assert(*(long long int*)(_pc_start+2) == 0, "");
+  if (*_pc_start == 0x48 && 0xb8 <= *(_pc_start + 1) && *(_pc_start + 1) <= 0xbf) {
+    assert(*(long long int*)(_pc_start+2) == 0, "imm64 must be 0 in mov r64, imm64");
     for (int i = 0; i < 8; ++i) {
       *(_pc_start + i + 2) = NativeInstruction::nop_instruction_code;
     }
   }
   NativeGeneralJump::insert_unconditional((address)_pc_start, entry);
-  if (seen_the_thing) {
-    tty->print_cr("C %p: %02x %02x%02x%02x%02x%02x%02x%02x%02x%02x", _pc_start, *(_pc_start), *(_pc_start+1), *(_pc_start+2), *(_pc_start+3), *(_pc_start+4), *(_pc_start+5), *(_pc_start+6), *(_pc_start+7), *(_pc_start+8), *(_pc_start+9));
-    tty->print_cr("");
-  }
   address target = nullptr;
   relocInfo::relocType reloc_type = relocInfo::none;
   switch (_id) {

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -363,13 +363,13 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
     // We don't need to replace the NativeGeneralJump::instruction_size first bytes, since insert_unconditional
     // will overwrite.
     for (int i = NativeGeneralJump::instruction_size; i < length_before_immediate + BytesPerLong; ++i) {
-      *(_pc_start + i) = NativeInstruction::nop_instruction_code;
+      _pc_start[i] = NativeInstruction::nop_instruction_code;
     }
   }
 #ifdef ASSERT
   else {  // and we make sure otherwise, we indeed have just nops.
     for (int i = 0; i < NativeGeneralJump::instruction_size; ++i) {
-      assert(*(_pc_start + i) == NativeInstruction::nop_instruction_code, "patching over an unexpected instruction");
+      assert(_pc_start[i] == NativeInstruction::nop_instruction_code, "patching over an unexpected instruction");
     }
   }
 #endif

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -341,12 +341,20 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
   assert(patch_info_pc - end_of_patch == bytes_to_skip, "incorrect patch info");
 
   address entry = __ pc();
-  if (*_pc_start == 0x48 && 0xb8 <= *(_pc_start + 1) && *(_pc_start + 1) <= 0xbf) {
+  if (0x40 <= *_pc_start && *_pc_start <= 0x4f && 0xb8 <= *(_pc_start + 1) && *(_pc_start + 1) <= 0xbf) {
     assert(*(long long int*)(_pc_start+2) == 0, "imm64 must be 0 in mov r64, imm64");
-    for (int i = 0; i < 8; ++i) {
-      *(_pc_start + i + 2) = NativeInstruction::nop_instruction_code;
+    for (int i = NativeGeneralJump::instruction_size; i < 10; ++i) {
+      *(_pc_start + i) = NativeInstruction::nop_instruction_code;
     }
   }
+#ifdef ASSERT
+  else {
+    for (int i = 0; i < NativeGeneralJump::instruction_size; ++i) {
+      assert(*(_pc_start + i) == NativeInstruction::nop_instruction_code, "");
+    }
+  }
+#endif
+
   NativeGeneralJump::insert_unconditional((address)_pc_start, entry);
   address target = nullptr;
   relocInfo::relocType reloc_type = relocInfo::none;

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -346,20 +346,23 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
   // There are 2 cases:
   // - the existing instruction is a mov r64 imm64 from LIR_Assembler::klass2reg_with_patching
   // - or there are nops there (from higher in this function).
-  // In the first case, since a jmp rel32 is 5-byte long, but a mov r64 imm64 is 10-byte long, so we are left with
-  // the last 5 bytes of the immediate operand (which are all 0x00). When debugging, this confuses the disassembler
-  // because it tries to recognize an instruction starting immediately after the jmp rel32, leading to wrong instructions,
-  // and possibly failure to disassemble further the whole function.
+  // In the first case, since a jmp rel32 is 5-byte long, but a mov r64 imm64 is 10-byte long
+  // (resp. 11 if using a REX2 prefix), so we are left with the last 5 (resp. 6) bytes of the
+  // immediate operand (which are all 0x00). When debugging, this confuses the disassembler
+  // because it tries to recognize an instruction starting immediately after the jmp rel32,
+  // leading to wrong instructions, and possibly failure to disassemble further the whole function.
   //
   // To be disassembler-friendly, let's replace the leftover 0x00 with nops.
-  // To recognize a mov r64 imm64, we look for the 2-byte sequence
-  // REX prefix | MOV r64
+  // There are 2 shapes:
+  // - without REX2 prefix: REX prefix | MOV r64
+  // - with REX2 prefix: REX2 prefix | REX prefix | MOV r64
   // then, we know the 8 bytes after are the immediate operand.
-  if ((*_pc_start & Assembler::REX) == Assembler::REX && (*(_pc_start + 1) & 0xb8) == 0xb8) {
-    assert(*(long long int*)(_pc_start+2) == 0, "imm64 must be 0 in mov r64, imm64");
+  if (NativeInstruction* ni = nativeInstruction_at(_pc_start); ni->is_mov_literal64()) {
+    int length_before_immediate = ni->has_rex2_prefix() ? 3 : 2;
+    assert(*(long long int*)(_pc_start + length_before_immediate) == 0, "imm64 must be 0 in mov r64, imm64");
     // We don't need to replace the NativeGeneralJump::instruction_size first bytes, since insert_unconditional
     // will overwrite.
-    for (int i = NativeGeneralJump::instruction_size; i < 10; ++i) {
+    for (int i = NativeGeneralJump::instruction_size; i < length_before_immediate + BytesPerLong; ++i) {
       *(_pc_start + i) = NativeInstruction::nop_instruction_code;
     }
   }

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -97,11 +97,7 @@ class NativeInstruction {
 };
 
 inline NativeInstruction* nativeInstruction_at(address address) {
-  NativeInstruction* inst = (NativeInstruction*)address;
-#ifdef ASSERT
-  //inst->verify();
-#endif
-  return inst;
+  return (NativeInstruction*)address;
 }
 
 class NativeCall;


### PR DESCRIPTION
In `LIR_Assembler::klass2reg_with_patching`

https://github.com/openjdk/jdk/blob/3dcf2a3bac491ba4344bde9701628c41b8b46749/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp#L327-L332

we emit
```
48ba 0000 | 0000 0000 | 0000
^--------------------------^
        movabs rdx, 0
```
then, let's say we add a jump after:
```
48ba 0000 | 0000 0000 | 0000 e983 | 0400 00
^--------------------------^ ^------------^
        movabs rdx, 0           rel32 jmp
```

Later, in `PatchingStub::emit_code`
https://github.com/openjdk/jdk/blob/3dcf2a3bac491ba4344bde9701628c41b8b46749/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp#L345
and
https://github.com/openjdk/jdk/blob/32e8aa45828a7dbaf5ed558efd5870c9c5a149de/src/hotspot/cpu/x86/nativeInst_x86.cpp#L351-L358
we overwrite the movabs with a jump, and now, the binary looks like:
```
e983 0400 | 0000 0000 | 0000 e983 | 0400 00
^------------^^------------^ ^------------^
  rel32 jmp   imm64 leftover    rel32 jmp
```

And later, the disassembler get confused:
```nasm
jmp 0x00007f84d9000c38        ; the jump, correct
add BYTE PTR [rax],al         ; 0000 trash
add BYTE PTR [rax],al         ; 0000 trash
add cl,ch                     ; 00e9 trash, and shifted
add DWORD PTR [rax+rax*1],0x0 ; 8304 0000 misinterpreted rel32 part of the jmp rel32
```

It may sync again, or lead to an invalid opcode.

But it's purely a debugging problem: since this trash 0s are after an unconditional jump (that used to be the middle of an instruction), nobody is going to execute them.

Using nop (0x90) payload could avoid that but writing directly 8 nops as the immediate in `LIR_Assembler::klass2reg_with_patching` causes a crash in `CodeBuffer::finalize_oop_references`
In
https://github.com/openjdk/jdk/blob/32e8aa45828a7dbaf5ed558efd5870c9c5a149de/src/hotspot/share/asm/codeBuffer.cpp#L535-L537

`is_real` seems true because `m` is not null and not `non_oop_word`

https://github.com/openjdk/jdk/blob/32e8aa45828a7dbaf5ed558efd5870c9c5a149de/src/hotspot/share/code/oopRecorder.inline.hpp#L32-L43

`is_real` is shared code, platform-agnostic. Fixing `is_real` seems like a huge hack. If I understand well, the relocation logic remember only where the immediate was written by `mov_metadata`, not its value, so we can't write nops, and pretend it was a null pointer.

I think the most pragmatic solution is to fix at editing time. Since we write a jump, that means we know we are at the start of an instruction, we can thus read the previous instruction that was there. If we find it was a `mov r64, imm64`, we know it's 10-byte long, and so we can write nops instead of the payload, before overwriting it.
I couldn't manage to make use of the convenient
https://github.com/openjdk/jdk/blob/32e8aa45828a7dbaf5ed558efd5870c9c5a149de/src/hotspot/cpu/x86/assembler_x86.cpp#L4280
because there is no way to tell where to write: it will just emit at `end()` and increment it. I think this is harmless because these nops are never executed. The branch prediction should have no problem figuring out that after an unconditional jump, we never execute the next instruction.

We shouldn't unconditionally add nops, because if we come from this branch
https://github.com/openjdk/jdk/blob/32e8aa45828a7dbaf5ed558efd5870c9c5a149de/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp#L290-L298
we already have nops there.


Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8377655](https://bugs.openjdk.org/browse/JDK-8377655): C1: in x86, avoid 0x00s leftover after PatchingStub (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30817/head:pull/30817` \
`$ git checkout pull/30817`

Update a local copy of the PR: \
`$ git checkout pull/30817` \
`$ git pull https://git.openjdk.org/jdk.git pull/30817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30817`

View PR using the GUI difftool: \
`$ git pr show -t 30817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30817.diff">https://git.openjdk.org/jdk/pull/30817.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30817#issuecomment-4279006604)
</details>
