### PR TITLE
8382499: G1: Let non young cset choice time also use Ticks API for measurements

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -373,7 +373,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 //   made to regular old regions without remembered sets after a few attempts to save computation costs
 //   of keeping them candidates for very long living pinned regions.
 void G1CollectionSet::finalize_old_part(double time_remaining_ms) {
-  double non_young_start_time_sec = os::elapsedTime();
+  Ticks start_time = Ticks::now();
 
   if (!candidates()->is_empty()) {
     candidates()->verify();
@@ -392,8 +392,7 @@ void G1CollectionSet::finalize_old_part(double time_remaining_ms) {
     log_debug(gc, ergo, cset)("No candidates to reclaim.");
   }
 
-  double non_young_end_time_sec = os::elapsedTime();
-  phase_times()->record_non_young_cset_choice_time_ms((non_young_end_time_sec - non_young_start_time_sec) * 1000.0);
+  phase_times()->record_non_young_cset_choice_time_ms((Ticks::now() - start_time).seconds() * MILLIUNITS);
 }
 
 static void print_finish_message(const char* reason, bool from_marking) {


### PR DESCRIPTION
Hi all,

  please review this small cleanup that lets G1 use the Ticks API for measuring non-young cset choice time like all other phases.

This is only a matter of code consistency, it does not change the clock used for comparisons that could explain issues like JDK-8370063.

Testing: local compilation, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382499](https://bugs.openjdk.org/browse/JDK-8382499): G1: Let non young cset choice time also use Ticks API for measurements (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30818/head:pull/30818` \
`$ git checkout pull/30818`

Update a local copy of the PR: \
`$ git checkout pull/30818` \
`$ git pull https://git.openjdk.org/jdk.git pull/30818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30818`

View PR using the GUI difftool: \
`$ git pr show -t 30818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30818.diff">https://git.openjdk.org/jdk/pull/30818.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30818#issuecomment-4279203660)
</details>
