### PR TITLE
8382505: Use union for bitmaps in InterpreterOopMap

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -155,8 +155,8 @@ InterpreterOopMap::InterpreterOopMap() {
 
 InterpreterOopMap::~InterpreterOopMap() {
   if (has_valid_mask() && mask_size() > small_mask_limit) {
-    assert(_bit_mask[0] != 0, "should have pointer to C heap");
-    FREE_C_HEAP_ARRAY((uintptr_t*)_bit_mask[0]);
+    assert(_external_bit_mask != nullptr, "should have pointer to C heap");
+    FREE_C_HEAP_ARRAY(_external_bit_mask);
   }
 }
 
@@ -164,7 +164,7 @@ bool InterpreterOopMap::is_empty() const {
   bool result = _method == nullptr;
   assert(_method != nullptr || (_bci == 0 &&
     (_mask_size == 0 || _mask_size == USHRT_MAX) &&
-    _bit_mask[0] == 0), "Should be completely empty");
+    _external_bit_mask == nullptr), "Should be completely empty");
   return result;
 }
 
@@ -278,18 +278,17 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
 
 void OopMapCacheEntry::allocate_bit_mask() {
   if (mask_size() > small_mask_limit) {
-    assert(_bit_mask[0] == 0, "bit mask should be new or just flushed");
-    _bit_mask[0] = (intptr_t)
-      NEW_C_HEAP_ARRAY(uintptr_t, mask_word_size(), mtClass);
+    assert(_external_bit_mask == nullptr, "bit mask should be new or just flushed");
+    _external_bit_mask = NEW_C_HEAP_ARRAY(uintptr_t, mask_word_size(), mtClass);
   }
 }
 
 void OopMapCacheEntry::deallocate_bit_mask() {
-  if (mask_size() > small_mask_limit && _bit_mask[0] != 0) {
-    assert(!Thread::current()->resource_area()->contains((void*)_bit_mask[0]),
+  if (mask_size() > small_mask_limit && _external_bit_mask != nullptr) {
+    assert(!Thread::current()->resource_area()->contains(_external_bit_mask),
       "This bit mask should not be in the resource area");
-    FREE_C_HEAP_ARRAY((uintptr_t*)_bit_mask[0]);
-    DEBUG_ONLY(_bit_mask[0] = 0;)
+    FREE_C_HEAP_ARRAY(_external_bit_mask);
+    DEBUG_ONLY(_external_bit_mask = nullptr;)
   }
 }
 
@@ -402,8 +401,8 @@ void InterpreterOopMap::copy_from(const OopMapCacheEntry* src) {
   if (src->mask_size() <= small_mask_limit) {
     memcpy(_bit_mask, src->_bit_mask, mask_word_size() * BytesPerWord);
   } else {
-    _bit_mask[0] = (uintptr_t) NEW_C_HEAP_ARRAY(uintptr_t, mask_word_size(), mtClass);
-    memcpy((void*) _bit_mask[0], (void*) src->_bit_mask[0], mask_word_size() * BytesPerWord);
+    _external_bit_mask = NEW_C_HEAP_ARRAY(uintptr_t, mask_word_size(), mtClass);
+    memcpy(_external_bit_mask, src->_external_bit_mask, mask_word_size() * BytesPerWord);
   }
 }
 

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -90,12 +90,15 @@ class InterpreterOopMap: ResourceObj {
 
  protected:
   int            _num_oops;
-  intptr_t       _bit_mask[N];    // the bit mask if
+  union {
+    uintptr_t    _bit_mask[N];    // the bit mask if
                                   // mask_size <= small_mask_limit,
                                   // ptr to bit mask otherwise
                                   // "protected" so that sub classes can
                                   // access it without using trickery in
                                   // method bit_mask().
+    uintptr_t*   _external_bit_mask;
+  };
 
   // access methods
   Method*        method() const                  { return _method; }
@@ -106,7 +109,9 @@ class InterpreterOopMap: ResourceObj {
   void           set_mask_size(int v)            { _mask_size = v; }
   // Test bit mask size and return either the in-line bit mask or allocated
   // bit mask.
-  uintptr_t*  bit_mask() const                   { return (uintptr_t*)(mask_size() <= small_mask_limit ? (intptr_t)_bit_mask : _bit_mask[0]); }
+  uintptr_t*     bit_mask() const                { return mask_size() <= small_mask_limit
+                                                       ? const_cast<uintptr_t*>(_bit_mask)
+                                                       : _external_bit_mask; }
 
   // return the word size of_bit_mask.  mask_size() <= 4 * MAX_USHORT
   size_t mask_word_size() const {
@@ -128,10 +133,9 @@ class InterpreterOopMap: ResourceObj {
   InterpreterOopMap();
   ~InterpreterOopMap();
 
-  // Copy the OopMapCacheEntry in parameter "src" into this
-  // InterpreterOopMap.  If the _bit_mask[0] in "src" points to
-  // allocated space (i.e., the bit mask was too large to hold
-  // in-line), allocate the space from the C heap.
+  // Copy the OopMapCacheEntry in parameter "src" into this InterpreterOopMap.
+  // If the _external_bit_mask in "src" points to allocated space (i.e., the bit
+  // mask was too large to hold in-line), allocate the space from the C heap.
   void copy_from(const OopMapCacheEntry* src);
 
   void iterate_oop(OffsetClosure* oop_closure) const;


### PR DESCRIPTION
While working on [JDK-8382401](https://bugs.openjdk.org/browse/JDK-8382401), I realized that there were some "interesting" type punning going on in the InterpreterOopMap bitmaps. I propose that we make this clearer and more explicit by using an union instead.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382505](https://bugs.openjdk.org/browse/JDK-8382505): Use union for bitmaps in InterpreterOopMap (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30820/head:pull/30820` \
`$ git checkout pull/30820`

Update a local copy of the PR: \
`$ git checkout pull/30820` \
`$ git pull https://git.openjdk.org/jdk.git pull/30820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30820`

View PR using the GUI difftool: \
`$ git pr show -t 30820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30820.diff">https://git.openjdk.org/jdk/pull/30820.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30820#issuecomment-4279386364)
</details>
