### PR TITLE
8381739: Comma-separated declaration with type-use annotations causes compiler crash

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1342,9 +1342,9 @@ public class Attr extends JCTree.Visitor {
 
     private void doQueueScanTreeAndTypeAnnotateForVarInit(JCVariableDecl tree, Env<AttrContext> env) {
         if (tree.init != null &&
-            (tree.mods.flags & Flags.FIELD_INIT_TYPE_ANNOTATIONS_QUEUED) == 0 &&
+            (tree.sym.flags_field & Flags.FIELD_INIT_TYPE_ANNOTATIONS_QUEUED) == 0 &&
             env.info.scope.owner.kind != MTH && env.info.scope.owner.kind != VAR) {
-            tree.mods.flags |= Flags.FIELD_INIT_TYPE_ANNOTATIONS_QUEUED;
+            tree.sym.flags_field |= Flags.FIELD_INIT_TYPE_ANNOTATIONS_QUEUED;
             // Field initializer expression need to be entered.
             annotate.queueScanTreeAndTypeAnnotate(tree.init, env, tree.sym);
             annotate.flush();

--- a/test/langtools/tools/javac/annotations/typeAnnotations/TypeAnnotatedCastsInFieldGroup.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/TypeAnnotatedCastsInFieldGroup.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8381739
+ * @summary Verify comma-separated field declarations with type-annotated casts
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+
+public class TypeAnnotatedCastsInFieldGroup {
+
+    private Path base;
+    private ToolBox tb = new ToolBox();
+
+    @Test
+    public void testCompactDiags() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics", "-Xdiags:compact")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         class Test {
+                             int x = (@A int) 0, y = (@A int) 1;
+                         }
+
+                         @Target({ElementType.TYPE_USE})
+                         @interface A {}
+                         """)
+                .run()
+                .writeAll();
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Consider having a class with two fields declared in a single `FieldDeclaration` with type annotations used in their initializers:
```
import java.lang.annotation.ElementType;
import java.lang.annotation.Target;

class Test {
    int x = (@A int) 0, y = (@A int) 1;
}

@Target({ElementType.TYPE_USE})
@interface A {}
```
Compiling the source code, `AssertionError` is thrown from `Check.validateTypeAnnotation(...)`

The problem is that `Attr.doQueueScanTreeAndTypeAnnotateForVarInit(...)` uses `Flags.FIELD_INIT_TYPE_ANNOTATIONS_QUEUED` added to the `tree.mods.flags` as an “already queued” marker. However, if a single `FieldDeclaration` contains more `VariableDeclarators` the `FieldModifiers` apply to all the declarators in the declaration (the single `mods` instance is shared between all the declarators). So while processing the first declarator, the marker is set and later declarators skip the type-annotation attribution for their initializers.

The proposal here is to add the marker `Flags.FIELD_INIT_TYPE_ANNOTATIONS_QUEUED` to the variable symbol flags (`tree.sym.flags_field`) instead of shared `tree.mods.flags`.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381739](https://bugs.openjdk.org/browse/JDK-8381739): Comma-separated declaration with type-use annotations causes compiler crash (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30821/head:pull/30821` \
`$ git checkout pull/30821`

Update a local copy of the PR: \
`$ git checkout pull/30821` \
`$ git pull https://git.openjdk.org/jdk.git pull/30821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30821`

View PR using the GUI difftool: \
`$ git pr show -t 30821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30821.diff">https://git.openjdk.org/jdk/pull/30821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30821#issuecomment-4279501646)
</details>
