### PR TITLE
8382330: G1: Enable stricter warning flags for g1ConcurrentMark.cpp

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -191,7 +191,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     arguments.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     whitebox.cpp_CXXFLAGS := $(CFLAGS_SHIP_DEBUGINFO), \
     $(call ExtendFlags, $(TOPDIR)/src/hotspot/share/gc/g1, \
-        g1Numa.cpp, _CXXFLAGS, $(CFLAGS_CONVERSION_WARNINGS)), \
+        g1ConcurrentMark.cpp, _CXXFLAGS, $(CFLAGS_CONVERSION_WARNINGS)), \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
     DISABLED_WARNINGS_gcc_bytecodeInterpreter.cpp := unused-label, \


### PR DESCRIPTION
After many changes, `g1ConcurrentMark.cpp` now compiles with more conversion warnings enabled.

Also replace `g1Numa.cpp` which I earlier added as en example for stricter flags. It was a mistake as it should really be `g1NUMA.cpp` which does still not compile with stricter flags. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8382330](https://bugs.openjdk.org/browse/JDK-8382330): G1: Enable stricter warning flags for g1ConcurrentMark.cpp (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30822/head:pull/30822` \
`$ git checkout pull/30822`

Update a local copy of the PR: \
`$ git checkout pull/30822` \
`$ git pull https://git.openjdk.org/jdk.git pull/30822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30822`

View PR using the GUI difftool: \
`$ git pr show -t 30822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30822.diff">https://git.openjdk.org/jdk/pull/30822.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30822#issuecomment-4279601611)
</details>
