### PR TITLE
8382522: Disable stringop-overflow in safepointMechanism.cpp

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -209,6 +209,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_macroAssembler_ppc_sha.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
+    DISABLED_WARNINGS_gcc_safepointMechanism.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_stubGenerator_s390.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \


### PR DESCRIPTION
Hi, please consider.

I have been witnessing this build issue with GCC 14 for quite some time on linux-riscv64.
Seems that GCC 14's deeper inlining optimizations interact badly with stringop-overflow here.
And I always need to pass `--disable-warnings-as-errors` to work around it.
Similar to [JDK-8382395](https://bugs.openjdk.org/browse/JDK-8382395), this disables this warning for the affected file as well.

configure command:
```
sh configure --with-debug-level=fastdebug --with-jvm-variants=server --enable-unlimited-crypto --with-native-debug-symbols=internal --with-boot-jdk=/home/openeuler/tools/boot-jdk --with-jtreg=/home/openeuler/tools/jtreg --with-gtest=/home/openeuler/tools/googletest
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382522](https://bugs.openjdk.org/browse/JDK-8382522): Disable stringop-overflow in safepointMechanism.cpp (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [7df0b7bf](https://git.openjdk.org/jdk/pull/30823/files/7df0b7bf3112d2ad872c927b5099ca37ab16a83d)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30823/head:pull/30823` \
`$ git checkout pull/30823`

Update a local copy of the PR: \
`$ git checkout pull/30823` \
`$ git pull https://git.openjdk.org/jdk.git pull/30823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30823`

View PR using the GUI difftool: \
`$ git pr show -t 30823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30823.diff">https://git.openjdk.org/jdk/pull/30823.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30823#issuecomment-4279777962)
</details>
