### PR TITLE
8382529: Tests com/sun/jdi/RedefineCrossEvent.java and com/sun/jdi/ClassesByName2Test.java fail when running frequent GC

### DIFF
--- a/test/jdk/com/sun/jdi/ClassesByName2Test.java
+++ b/test/jdk/com/sun/jdi/ClassesByName2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/ClassesByName2Test.java
+++ b/test/jdk/com/sun/jdi/ClassesByName2Test.java
@@ -173,7 +173,7 @@ public class ClassesByName2Test extends TestScaffold {
 
                 List found = vm().classesByName(name);
                 if (found.contains(cls)) {
-                    System.out.println("Found class: " + name);
+                    //System.out.println("Found class: " + name);
                 } else {
                     System.out.println("CLASS NOT FOUND: " + name);
                     throw new Exception("CLASS NOT FOUND (by classesByName): " +

--- a/test/jdk/com/sun/jdi/ClassesByName2Test.java
+++ b/test/jdk/com/sun/jdi/ClassesByName2Test.java
@@ -166,9 +166,9 @@ public class ClassesByName2Test extends TestScaffold {
                 String name = cls.name();
 
                 if (isHiddenClass(name)) {
-                  // Hidden classes may have been unloaded by the time classesByName
-                  // is called so we skip those
-                  continue;
+                    // Hidden classes may have been unloaded by the time classesByName
+                    // is called so we skip those
+                    continue;
                 }
 
                 List found = vm().classesByName(name);

--- a/test/jdk/com/sun/jdi/ClassesByName2Test.java
+++ b/test/jdk/com/sun/jdi/ClassesByName2Test.java
@@ -138,7 +138,7 @@ public class ClassesByName2Test extends TestScaffold {
     }
 
     private static boolean isHiddenClass(String className) {
-      return className.contains("/");
+        return className.contains("/");
     }
 
     protected void runTests() throws Exception {

--- a/test/jdk/com/sun/jdi/ClassesByName2Test.java
+++ b/test/jdk/com/sun/jdi/ClassesByName2Test.java
@@ -137,6 +137,10 @@ public class ClassesByName2Test extends TestScaffold {
         }
     }
 
+    private static boolean isHiddenClass(String className) {
+      return className.contains("/");
+    }
+
     protected void runTests() throws Exception {
         BreakpointEvent bpe = startToMain("ClassesByName2Targ");
 
@@ -160,9 +164,16 @@ public class ClassesByName2Test extends TestScaffold {
             for (Iterator it = all.iterator(); it.hasNext(); ) {
                 ReferenceType cls = (ReferenceType)it.next();
                 String name = cls.name();
+
+                if (isHiddenClass(name)) {
+                  // Hidden classes may have been unloaded by the time classesByName
+                  // is called so we skip those
+                  continue;
+                }
+
                 List found = vm().classesByName(name);
                 if (found.contains(cls)) {
-                    //System.out.println("Found class: " + name);
+                    System.out.println("Found class: " + name);
                 } else {
                     System.out.println("CLASS NOT FOUND: " + name);
                     throw new Exception("CLASS NOT FOUND (by classesByName): " +


### PR DESCRIPTION
Hello,

In the development of Automatic Heap Sizing (AHS) for ZGC we run into intermittent failures in the ClassesByName2Test.java test, and also RedefineCrossEvent.java which runs ClassesByName2Test.java.

In AHS we are running GCs more frequently, which affects how often classes are unloaded for example. In the tests mentioned above, we see that LambdaForm classes are unloaded before we call `vm().classesByName(name)`, which fails the test. 

LambdaForm classes are hidden, so they can be unloaded independently of their class loader. I suggest we make this test more robust by skipping verification of hidden classes, which include the LambdaForm classes we've observed so far. Checking for a slash `/` should be enough to determine if a class is hidden or not. A "valid"/"normal" Java class should not have a slash in their name, as specified by "normal" classes having a "binary name", which can't include a slash. See [https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/lang/Class.html#getName()](https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/lang/Class.html#getName()) for details on the class name returned by `getName()`.

Another way to get a similar failure to this in mainline is to run with the following JVM flags, which also runs frequent GCs:
```
-XX:+UseZGC -XX:+ZCollectionIntervalOnly -XX:ZCollectionIntervalMajor=0.001
```

I've also removed the commented-out print, which was very useful in debugging this.

Testing:
* We've not been able to see failures for this test after this fix.
* Oracle's tier1, tier2 and tier6 (where we've observed failures so far)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382529](https://bugs.openjdk.org/browse/JDK-8382529): Tests com/sun/jdi/RedefineCrossEvent.java and com/sun/jdi/ClassesByName2Test.java fail when running frequent GC (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [202a534b](https://git.openjdk.org/jdk/pull/30825/files/202a534bf8ad0772e125f09b1571d0f34841ccd3)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30825/head:pull/30825` \
`$ git checkout pull/30825`

Update a local copy of the PR: \
`$ git checkout pull/30825` \
`$ git pull https://git.openjdk.org/jdk.git pull/30825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30825`

View PR using the GUI difftool: \
`$ git pr show -t 30825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30825.diff">https://git.openjdk.org/jdk/pull/30825.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30825#issuecomment-4280884963)
</details>
