### PR TITLE
8381007: MultiPixelPackedSampleModel can throw ArithmeticException

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -345,22 +345,12 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * subset of the bands of this
      * {@code MultiPixelPackedSampleModel}.  Since a
      * {@code MultiPixelPackedSampleModel} only has one band, the
-     * bands argument must have a length of one and indicate the zeroth
-     * band.
-     * @param bands the specified bands
+     * bands argument is ignored.
+     * @param bands the specified bands (ignored)
      * @return a new {@code SampleModel} with a subset of bands of
      * this {@code MultiPixelPackedSampleModel}.
-     * @throws RasterFormatException if the number of bands requested
-     * is not one.
-     * @throws IllegalArgumentException if {@code w} or
-     *         {@code h} is not greater than 0
      */
     public SampleModel createSubsetSampleModel(int[] bands) {
-        if (bands != null) {
-           if (bands.length != 1)
-            throw new RasterFormatException("MultiPixelPackedSampleModel has "
-                                            + "only one band.");
-        }
         SampleModel sm = createCompatibleSampleModel(width, height);
         return sm;
     }

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -111,8 +111,8 @@ public class MultiPixelPackedSampleModel extends SampleModel
                                        int numberOfBits) {
         this(dataType,w,h,
              numberOfBits,
-            (w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
-                DataBuffer.getDataTypeSize(dataType),
+            (int)(((long)w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
+                DataBuffer.getDataTypeSize(dataType)),
              0);
         if (dataType != DataBuffer.TYPE_BYTE &&
             dataType != DataBuffer.TYPE_USHORT &&
@@ -144,7 +144,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @throws IllegalArgumentException if {@code scanlineStride}
      *         is less than or equal to 0
      * @throws RasterFormatException if
-     *         {@code ((numberOfBits * w) + DataBuffer.getDataTypeSize(dataType) - 1)
+     *         {@code ((numberOfBits * (long)w) + DataBuffer.getDataTypeSize(dataType) - 1)
      *         / DataBuffer.getDataTypeSize(dataType)}
      *         is greater than {@code scanlineStride}
      * @throws RasterFormatException if the number of bits per pixel

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -141,8 +141,11 @@ public class MultiPixelPackedSampleModel extends SampleModel
      *         {@code DataBuffer.TYPE_INT}
      * @throws IllegalArgumentException if either {@code w} or {@code h}
      *         is less than or equal to 0
+     * @throws IllegalArgumentException if {@code scanlineStride}
+     *         is less than or equal to 0
      * @throws RasterFormatException if
-     *         {@code (numberOfBits * w) / DataBuffer.getDataTypeSize(dataType)}
+     *         {@code ((numberOfBits * w) + DataBuffer.getDataTypeSize(dataType) - 1)
+     *         / DataBuffer.getDataTypeSize(dataType)}
      *         is greater than {@code scanlineStride}
      * @throws RasterFormatException if the number of bits per pixel
      *                  is not a power of 2 or if a power of 2 number of
@@ -161,7 +164,6 @@ public class MultiPixelPackedSampleModel extends SampleModel
             throw new IllegalArgumentException("Unsupported data type "+
                                                dataType);
         }
-        this.dataType = dataType;
         if ((numberOfBits <= 0) || ((numberOfBits & (numberOfBits - 1)) != 0)) {
             throw new RasterFormatException("numberOfBits per pixel must be a power of 2");
         }
@@ -178,6 +180,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
         if ((dataBitOffset % numberOfBits) != 0) {
             throw new IllegalArgumentException("dataBitOffset must be a multiple of bits per pixel");
         }
+        this.dataType = dataType;
         this.pixelBitStride = numberOfBits;
         this.scanlineStride = scanlineStride;
         this.dataBitOffset = dataBitOffset;
@@ -348,7 +351,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * {@code MultiPixelPackedSampleModel} only has one band, the
      * bands argument is ignored.
      * @param bands the specified bands (ignored)
-     * @return a new {@code SampleModel} with a subset of bands of
+     * @return a new {@code SampleModel} with the same bands of
      * this {@code MultiPixelPackedSampleModel}.
      */
     public SampleModel createSubsetSampleModel(int[] bands) {

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -147,6 +147,8 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @throws RasterFormatException if the number of bits per pixel
      *                  is not a power of 2 or if a power of 2 number of
      *                  pixels do not fit in one data element.
+     * @throws IllegalArgumentException if {@code dataBitOffset} is less than zero,
+     *         or not a multiple of {@code numberOfBits}.
      */
     public MultiPixelPackedSampleModel(int dataType, int w, int h,
                                        int numberOfBits,

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -351,7 +351,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * {@code MultiPixelPackedSampleModel} only has one band, the
      * bands argument is ignored.
      * @param bands the specified bands (ignored)
-     * @return a new {@code SampleModel} with the same bands of
+     * @return a new {@code SampleModel} with the same bands as
      * this {@code MultiPixelPackedSampleModel}.
      */
     public SampleModel createSubsetSampleModel(int[] bands) {

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -126,12 +126,12 @@ public class MultiPixelPackedSampleModel extends SampleModel
             throw new IllegalArgumentException("Unsupported dataType: "+
                                                dataType);
         }
-        int sls = (int)(((long)w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
-                        DataBuffer.getDataTypeSize(dataType));
-        if (sls < 0) {
+        long sls = ((long)w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
+                        DataBuffer.getDataTypeSize(dataType);
+        if (sls > Integer.MAX_VALUE) {
             throw new RasterFormatException("Pixels do not fit");
         }
-        this(dataType, w, h, numberOfBits, sls, 0);
+        this(dataType, w, h, numberOfBits, (int)sls, 0);
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -168,7 +168,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
         if (scanlineStride <= 0) {
             throw new IllegalArgumentException("scanlineStride must be > 0");
         }
-        if (((numberOfBits * w) / DataBuffer.getDataTypeSize(dataType)) > scanlineStride) {
+        if (((numberOfBits * (long)w) / DataBuffer.getDataTypeSize(dataType)) > scanlineStride) {
             throw new RasterFormatException("scanlineStride is too small for width");
         }
         if (dataBitOffset < 0) {

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -168,7 +168,8 @@ public class MultiPixelPackedSampleModel extends SampleModel
         if (scanlineStride <= 0) {
             throw new IllegalArgumentException("scanlineStride must be > 0");
         }
-        if (((numberOfBits * (long)w) / DataBuffer.getDataTypeSize(dataType)) > scanlineStride) {
+        int dataTypeSize = DataBuffer.getDataTypeSize(dataType);
+        if ((((numberOfBits * (long)w) + dataTypeSize - 1) / dataTypeSize) > scanlineStride) {
             throw new RasterFormatException("scanlineStride is too small for width");
         }
         if (dataBitOffset < 0) {
@@ -180,7 +181,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
         this.pixelBitStride = numberOfBits;
         this.scanlineStride = scanlineStride;
         this.dataBitOffset = dataBitOffset;
-        this.dataElementSize = DataBuffer.getDataTypeSize(dataType);
+        this.dataElementSize = dataTypeSize;
         this.pixelsPerDataElement = dataElementSize/numberOfBits;
         if (pixelsPerDataElement*numberOfBits != dataElementSize) {
            throw new RasterFormatException("MultiPixelPackedSampleModel " +

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -119,9 +119,9 @@ public class MultiPixelPackedSampleModel extends SampleModel
                                                " height="+h+") are too large");
         }
 
-        if (dataType < DataBuffer.TYPE_BYTE ||
-            (dataType > DataBuffer.TYPE_DOUBLE &&
-             dataType != DataBuffer.TYPE_UNDEFINED))
+        if (dataType != DataBuffer.TYPE_BYTE &&
+            dataType != DataBuffer.TYPE_USHORT &&
+            dataType != DataBuffer.TYPE_INT)
         {
             throw new IllegalArgumentException("Unsupported dataType: "+
                                                dataType);
@@ -130,14 +130,8 @@ public class MultiPixelPackedSampleModel extends SampleModel
                         DataBuffer.getDataTypeSize(dataType));
         if (sls < 0) {
             throw new RasterFormatException("Pixels do not fit");
-        };
-        this(dataType, w, h, numberOfBits, sls, 0);
-        if (dataType != DataBuffer.TYPE_BYTE &&
-            dataType != DataBuffer.TYPE_USHORT &&
-            dataType != DataBuffer.TYPE_INT) {
-            throw new IllegalArgumentException("Unsupported data type "+
-                                               dataType);
         }
+        this(dataType, w, h, numberOfBits, sls, 0);
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -109,6 +109,23 @@ public class MultiPixelPackedSampleModel extends SampleModel
                                        int w,
                                        int h,
                                        int numberOfBits) {
+        long size = (long)w * h;
+        if (w <= 0 || h <= 0) {
+            throw new IllegalArgumentException("Width ("+w+") and height ("+
+                                               h+") must be > 0");
+        }
+        if (size > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Dimensions (width="+w+
+                                               " height="+h+") are too large");
+        }
+
+        if (dataType < DataBuffer.TYPE_BYTE ||
+            (dataType > DataBuffer.TYPE_DOUBLE &&
+             dataType != DataBuffer.TYPE_UNDEFINED))
+        {
+            throw new IllegalArgumentException("Unsupported dataType: "+
+                                               dataType);
+        }
         int sls = (int)(((long)w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
                         DataBuffer.getDataTypeSize(dataType));
         if (sls < 0) {

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -99,6 +99,11 @@ public class MultiPixelPackedSampleModel extends SampleModel
      *         either {@code DataBuffer.TYPE_BYTE},
      *         {@code DataBuffer.TYPE_USHORT}, or
      *         {@code DataBuffer.TYPE_INT}
+     * @throws IllegalArgumentException if either {@code w} or {@code h}
+     *         is less than or equal to 0
+     * @throws RasterFormatException if the number of bits per pixel
+     *                  is not a power of 2 or if a power of 2 number of
+     *                  pixels do not fit in one data element.
      */
     public MultiPixelPackedSampleModel(int dataType,
                                        int w,
@@ -130,15 +135,18 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @param scanlineStride the line stride of the image data
      * @param dataBitOffset the data bit offset for the region of image
      *                  data described
-     * @throws RasterFormatException if the number of bits per pixel
-     *                  is not a power of 2 or if a power of 2 number of
-     *                  pixels do not fit in one data element.
-     * @throws IllegalArgumentException if {@code w} or
-     *         {@code h} is not greater than 0
      * @throws IllegalArgumentException if {@code dataType} is not
      *         either {@code DataBuffer.TYPE_BYTE},
      *         {@code DataBuffer.TYPE_USHORT}, or
      *         {@code DataBuffer.TYPE_INT}
+     * @throws IllegalArgumentException if either {@code w} or {@code h}
+     *         is less than or equal to 0
+     * @throws RasterFormatException if
+     *         {@code (numberOfBits * w) / DataBuffer.getDataTypeSize(dataType)}
+     *         is greater than {@code scanlineStride}
+     * @throws RasterFormatException if the number of bits per pixel
+     *                  is not a power of 2 or if a power of 2 number of
+     *                  pixels do not fit in one data element.
      */
     public MultiPixelPackedSampleModel(int dataType, int w, int h,
                                        int numberOfBits,
@@ -152,6 +160,21 @@ public class MultiPixelPackedSampleModel extends SampleModel
                                                dataType);
         }
         this.dataType = dataType;
+        if ((numberOfBits <= 0) || ((numberOfBits & (numberOfBits - 1)) != 0)) {
+            throw new RasterFormatException("numberOfBits per pixel must be a power of 2");
+        }
+        if (scanlineStride <= 0) {
+            throw new IllegalArgumentException("scanlineStride must be > 0");
+        }
+        if (((numberOfBits * w) / DataBuffer.getDataTypeSize(dataType)) > scanlineStride) {
+            throw new RasterFormatException("scanlineStride is too small for width");
+        }
+        if (dataBitOffset < 0) {
+            throw new IllegalArgumentException("dataBitOffset must be >= 0");
+        }
+        if ((dataBitOffset % numberOfBits) != 0) {
+            throw new IllegalArgumentException("dataBitOffset must be a multiple of bits per pixel");
+        }
         this.pixelBitStride = numberOfBits;
         this.scanlineStride = scanlineStride;
         this.dataBitOffset = dataBitOffset;

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -109,11 +109,12 @@ public class MultiPixelPackedSampleModel extends SampleModel
                                        int w,
                                        int h,
                                        int numberOfBits) {
-        this(dataType,w,h,
-             numberOfBits,
-            (int)(((long)w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
-                DataBuffer.getDataTypeSize(dataType)),
-             0);
+        int sls = (int)(((long)w*numberOfBits+DataBuffer.getDataTypeSize(dataType)-1)/
+                        DataBuffer.getDataTypeSize(dataType));
+        if (sls < 0) {
+            throw new RasterFormatException("Pixels do not fit");
+        };
+        this(dataType, w, h, numberOfBits, sls, 0);
         if (dataType != DataBuffer.TYPE_BYTE &&
             dataType != DataBuffer.TYPE_USHORT &&
             dataType != DataBuffer.TYPE_INT) {

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -44,6 +44,12 @@ public class MultiPixelPackedSampleModelConstructor {
         for (Args6 a : args6) {
             test6(a);
         }
+
+       // Also verify createSubsetSampleModel ignores bands.
+       MultiPixelPackedSampleModel m =
+            new MultiPixelPackedSampleModel(TYPE_BYTE, 1, 1, 1);
+       int[] bands = new int[5];
+       m.createSubsetSampleModel(bands);
     }
 
     static record Args4(int dType, int w, int h, int bits, Class eType) { }

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -21,7 +21,11 @@
  * questions.
  */
 
-import static java.awt.image.DataBuffer.*;
+import static java.awt.image.DataBuffer.TYPE_BYTE;
+import static java.awt.image.DataBuffer.TYPE_INT;
+import static java.awt.image.DataBuffer.TYPE_SHORT;
+import static java.awt.image.DataBuffer.TYPE_USHORT;
+
 import java.awt.image.MultiPixelPackedSampleModel;
 import java.awt.image.RasterFormatException;
 
@@ -77,6 +81,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args6(TYPE_BYTE, 4, 1, 4, 1, 0, RasterFormatException.class),
         new Args6(TYPE_BYTE, 1, 1, 2, 1, 1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 2, 1, -1, IllegalArgumentException.class),
+        new Args6(TYPE_BYTE, 1, 1, 1, -1, 1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 1, 1, 1, null),
         new Args6(TYPE_INT, 77777777, 2, 32, 1, 0, RasterFormatException.class),
     };

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static java.awt.image.DataBuffer.*;
+import java.awt.image.MultiPixelPackedSampleModel;
+import java.awt.image.RasterFormatException;
+
+/*
+ * @test
+ * @bug 8381007
+ * @summary test MultiPixelPackedSampleModel Constructors
+ */
+
+public class MultiPixelPackedSampleModelConstructor {
+
+    public static void main(String[] args) {
+        for (Args4 a : args4) {
+            test4(a);
+        }
+        for (Args6 a : args6) {
+            test6(a);
+        }
+    }
+
+    static record Args4(int dType, int w, int h, int bits, Class eType) { }
+
+    static final Args4[] args4 = {
+        new Args4(TYPE_BYTE, 1, 1, -1, RasterFormatException.class),
+        new Args4(TYPE_BYTE, 1, 1, 0, RasterFormatException.class),
+        new Args4(TYPE_BYTE, 1, 1, 1, null),
+        new Args4(TYPE_BYTE, 1, 1, 3, RasterFormatException.class),
+        new Args4(TYPE_BYTE, 1, 1, 4, null),
+        new Args4(TYPE_BYTE, 1, 1, 16, RasterFormatException.class),
+        new Args4(TYPE_SHORT, 1, 1, 16, IllegalArgumentException.class),
+        new Args4(TYPE_USHORT, 1, 1, 16, null),
+        new Args4(TYPE_INT, 1, 1, 16, null),
+        new Args4(TYPE_BYTE, 1, 30, 0, RasterFormatException.class),
+        new Args4(TYPE_BYTE, 0, 1, 4, IllegalArgumentException.class),
+    };
+
+    static record Args6(int dType, int w, int h, int bits, int stride, int bitOffset, Class eType) { }
+
+    static final Args6[] args6 = {
+        new Args6(TYPE_BYTE, 1, 1, -1, 1, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 1, 1, 0, 1, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 1, 1, 1, 1, 0, null),
+        new Args6(TYPE_BYTE, 1, 1, 3, 1, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 1, 1, 4, 1, 0, null),
+        new Args6(TYPE_BYTE, 1, 1, 16, 2, 0, RasterFormatException.class),
+        new Args6(TYPE_SHORT, 1, 1, 16, 2, 0, IllegalArgumentException.class),
+        new Args6(TYPE_USHORT, 1, 1, 16, 2, 0, null),
+        new Args6(TYPE_INT, 1, 1, 16, 1, 0, null),
+        new Args6(TYPE_BYTE, 1, 30, 0, 4, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 0, 1, 4, 1, 0, IllegalArgumentException.class),
+        new Args6(TYPE_BYTE, 1, 1, 2, 1, 0, null),
+        new Args6(TYPE_BYTE, 4, 1, 4, 1, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 1, 1, 2, 1, 1, IllegalArgumentException.class),
+        new Args6(TYPE_BYTE, 1, 1, 2, 1, -1, IllegalArgumentException.class),
+        new Args6(TYPE_BYTE, 1, 1, 1, 1, 1, null),
+    };
+
+    static void test4(Args4 a) {
+        try {
+             new MultiPixelPackedSampleModel(a.dType, a.w, a.h, a.bits);
+        } catch (Exception e) {
+             if (a.eType == null || !(a.eType.isInstance(e))) {
+               throw new RuntimeException("failed for " + a + " got " + e);
+           } else {
+               return;
+           }
+        }
+        if (a.eType != null) {
+            throw new RuntimeException("No exception for " + a);
+        }
+    }
+
+
+    static void test6(Args6 a) {
+        try {
+             new MultiPixelPackedSampleModel(a.dType, a.w, a.h, a.bits, a.stride, a.bitOffset);
+        } catch (Exception e) {
+             if (a.eType == null || !(a.eType.isInstance(e))) {
+               throw new RuntimeException("failed for " + a + " got " + e);
+           } else {
+               return;
+           }
+        }
+        if (a.eType != null) {
+            throw new RuntimeException("No exception for " + a);
+        }
+    }
+}

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -67,6 +67,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args6(TYPE_BYTE, 1, 1, 3, 1, 0, RasterFormatException.class),
         new Args6(TYPE_BYTE, 1, 1, 4, 1, 0, null),
         new Args6(TYPE_BYTE, 1, 1, 16, 2, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 9, 1, 1, 1, 0, RasterFormatException.class),
         new Args6(TYPE_SHORT, 1, 1, 16, 2, 0, IllegalArgumentException.class),
         new Args6(TYPE_USHORT, 1, 1, 16, 2, 0, null),
         new Args6(TYPE_INT, 1, 1, 16, 1, 0, null),

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -77,6 +77,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args6(TYPE_BYTE, 1, 1, 2, 1, 1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 2, 1, -1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 1, 1, 1, null),
+        new Args6(TYPE_INT, 77777777, 2, 32, 1, 0, RasterFormatException.class),
     };
 
     static void test4(Args4 a) {

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -66,6 +66,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args4(TYPE_INT, 1, 1, 16, null),
         new Args4(TYPE_BYTE, 1, 30, 0, RasterFormatException.class),
         new Args4(TYPE_BYTE, 0, 1, 4, IllegalArgumentException.class),
+        new Args4(TYPE_BYTE, 1<<29, 1, 4, null),
     };
 
     static record Args6(int dType, int w, int h, int bits, int stride, int bitOffset, Class eType) { }
@@ -90,6 +91,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args6(TYPE_BYTE, 1, 1, 1, -1, 1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 1, 1, 1, null),
         new Args6(TYPE_INT, 77777777, 2, 32, 1, 0, RasterFormatException.class),
+        new Args6(TYPE_BYTE, 1<<29, 1, 4, 1<<28, 0, null),
     };
 
     static void test4(Args4 a) {

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -67,6 +67,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args4(TYPE_BYTE, 1, 30, 0, RasterFormatException.class),
         new Args4(TYPE_BYTE, 0, 1, 4, IllegalArgumentException.class),
         new Args4(TYPE_BYTE, 1<<29, 1, 4, null),
+        new Args4(TYPE_BYTE, 1<<30, 1, 16, RasterFormatException.class),
     };
 
     static record Args6(int dType, int w, int h, int bits, int stride, int bitOffset, Class eType) { }

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -70,6 +70,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args4(TYPE_BYTE, 0, 1, 4, IllegalArgumentException.class),
         new Args4(TYPE_BYTE, 1<<29, 1, 4, null),
         new Args4(TYPE_BYTE, 1<<30, 1, 16, RasterFormatException.class),
+        new Args4(TYPE_BYTE, 32, 1, 1<<30, RasterFormatException.class),
         new Args4(99, 8, 1, 1, IllegalArgumentException.class),
     };
 

--- a/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
+++ b/test/jdk/java/awt/image/MultiPixelPackedSampleModelConstructor.java
@@ -61,6 +61,8 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args4(TYPE_BYTE, 1, 1, 3, RasterFormatException.class),
         new Args4(TYPE_BYTE, 1, 1, 4, null),
         new Args4(TYPE_BYTE, 1, 1, 16, RasterFormatException.class),
+        new Args4(TYPE_BYTE, -1, 1, 1, IllegalArgumentException.class),
+        new Args4(TYPE_SHORT, -1, 1, 1, IllegalArgumentException.class),
         new Args4(TYPE_SHORT, 1, 1, 16, IllegalArgumentException.class),
         new Args4(TYPE_USHORT, 1, 1, 16, null),
         new Args4(TYPE_INT, 1, 1, 16, null),
@@ -68,6 +70,7 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args4(TYPE_BYTE, 0, 1, 4, IllegalArgumentException.class),
         new Args4(TYPE_BYTE, 1<<29, 1, 4, null),
         new Args4(TYPE_BYTE, 1<<30, 1, 16, RasterFormatException.class),
+        new Args4(99, 8, 1, 1, IllegalArgumentException.class),
     };
 
     static record Args6(int dType, int w, int h, int bits, int stride, int bitOffset, Class eType) { }
@@ -90,9 +93,11 @@ public class MultiPixelPackedSampleModelConstructor {
         new Args6(TYPE_BYTE, 1, 1, 2, 1, 1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 2, 1, -1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 1, -1, 1, IllegalArgumentException.class),
+        new Args6(TYPE_BYTE, -1, 1, 1, 1, 1, IllegalArgumentException.class),
         new Args6(TYPE_BYTE, 1, 1, 1, 1, 1, null),
         new Args6(TYPE_INT, 77777777, 2, 32, 1, 0, RasterFormatException.class),
         new Args6(TYPE_BYTE, 1<<29, 1, 4, 1<<28, 0, null),
+        new Args6(99, 8, 1, 1, 1, 0, IllegalArgumentException.class),
     };
 
     static void test4(Args4 a) {


### PR DESCRIPTION
The bug was filed to note that the constructor for MultiPixelPackedSampleModel could throw an odd exception if numberOfBits is zero.
Per the spec this should throw RasterFormatException.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change requires CSR request [JDK-8382542](https://bugs.openjdk.org/browse/JDK-8382542) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8381007](https://bugs.openjdk.org/browse/JDK-8381007): MultiPixelPackedSampleModel can throw ArithmeticException (**Bug** - P4)
 * [JDK-8382542](https://bugs.openjdk.org/browse/JDK-8382542): MultiPixelPackedSampleModel can throw ArithmeticException (**CSR**)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [d66a4a93](https://git.openjdk.org/jdk/pull/30826/files/d66a4a93f9805ff28fbc58f772f992f23103d0d7)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30826/head:pull/30826` \
`$ git checkout pull/30826`

Update a local copy of the PR: \
`$ git checkout pull/30826` \
`$ git pull https://git.openjdk.org/jdk.git pull/30826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30826`

View PR using the GUI difftool: \
`$ git pr show -t 30826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30826.diff">https://git.openjdk.org/jdk/pull/30826.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30826#issuecomment-4282532321)
</details>
