### PR TITLE
8343606: Test FinalizerTest.java intermittent fails Debuggee heap OOM

### DIFF
--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -79,28 +79,27 @@ class FinalizerTarg {
         System.gc();
         System.runFinalization();
         try {
-            // finalize() run in another lower priority Finalizer thread,
-            // wait for it to finish
+            // finalize() is run in another lower priority Finalizer thread.
+            // Wait for it to finish.
             finalizerDone.await(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
 
         // If System.gc() and System.runFinalization() did not trigger the
-        // finalizer, then finalizerDone.await() will timed out and the code
-        // below will be needed as second attempt to trigger finalization.
+        // finalizer, then finalizerDone.await() will time out and the code
+        // below will be needed as a second attempt to trigger finalization.
         List holdAlot = new ArrayList();
         for (int chunk=10000000; chunk > 10000; chunk = chunk / 2) {
             if (finalizerDone.getCount() == 0) {
                 return;
             }
             try {
-                while(finalizerDone.getCount() > 0) {
+                while (finalizerDone.getCount() > 0) {
                     holdAlot.add(new byte[chunk]);
                     System.err.println("Allocated " + chunk);
                 }
-            }
-            catch ( Throwable thrown ) {  // OutOfMemoryError
+} catch ( Throwable thrown ) {  // OutOfMemoryError
             } finally {
                 holdAlot.clear();
                 System.gc();

--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -96,17 +96,16 @@ class FinalizerTarg {
                 return;
             }
             try {
-                while(true) {
+                while(!finalizerRun) {
                     holdAlot.add(new byte[chunk]);
                     System.err.println("Allocated " + chunk);
                 }
             }
             catch ( Throwable thrown ) {  // OutOfMemoryError
+            } finally {
                 holdAlot.clear();
                 System.gc();
             }
-            holdAlot.clear();
-            System.gc();
             System.runFinalization();
         }
         return;  // not reached

--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -99,7 +99,7 @@ class FinalizerTarg {
                     holdAlot.add(new byte[chunk]);
                     System.err.println("Allocated " + chunk);
                 }
-} catch ( Throwable thrown ) {  // OutOfMemoryError
+            } catch ( Throwable thrown ) {  // OutOfMemoryError
             } finally {
                 holdAlot.clear();
                 System.gc();

--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -106,6 +106,7 @@ class FinalizerTarg {
             }
             System.runFinalization();
         }
+        System.out.println("The Debuggee should not reach here in theory!");
         return;
     }
 

--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,17 @@
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g FinalizerTest.java
  *
- * @run driver FinalizerTest
+ * @run driver FinalizerTest -Xmx256M
  */
-import com.sun.jdi.*;
-import com.sun.jdi.event.*;
-import com.sun.jdi.request.*;
-
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.jdi.StackFrame;
+import com.sun.jdi.event.BreakpointEvent;
+import com.sun.jdi.event.StepEvent;
 
 
 /*
@@ -48,8 +50,8 @@ import java.util.Iterator;
  * @author Gordon Hirsch  (modified for HotSpot by tbell & rfield)
  */
 class FinalizerTarg {
-    static String lockit = "lock";
-    static boolean finalizerRun = false;
+    static volatile boolean finalizerRun = false;
+    static final CountDownLatch FINALIZER_DONE = new CountDownLatch(1);
     static class BigObject {
         String name;
         byte[] foo = new byte[300000];
@@ -68,6 +70,7 @@ class FinalizerTarg {
             super.finalize();
             //Thread.dumpStack();
             finalizerRun = true;
+            FINALIZER_DONE.countDown();
         }
     }
 
@@ -77,9 +80,13 @@ class FinalizerTarg {
         b = null; // Drop the object, creating garbage...
         System.gc();
         System.runFinalization();
-
+        try {
+            FINALIZER_DONE.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         // Now, we have to make sure the finalizer
-        // gets run.  We will keep allocating more
+        // gets run. We will keep allocating more
         // and more memory with the idea that eventually,
         // the memory occupied by the BigObject will get reclaimed
         // and the finalizer will be run.
@@ -95,8 +102,11 @@ class FinalizerTarg {
                 }
             }
             catch ( Throwable thrown ) {  // OutOfMemoryError
+                holdAlot.clear();
                 System.gc();
             }
+            holdAlot.clear();
+            System.gc();
             System.runFinalization();
         }
         return;  // not reached

--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -50,8 +50,7 @@ import com.sun.jdi.event.StepEvent;
  * @author Gordon Hirsch  (modified for HotSpot by tbell & rfield)
  */
 class FinalizerTarg {
-    static volatile boolean finalizerRun = false;
-    static final CountDownLatch FINALIZER_DONE = new CountDownLatch(1);
+    static final CountDownLatch finalizerDone = new CountDownLatch(1);
     static class BigObject {
         String name;
         byte[] foo = new byte[300000];
@@ -69,8 +68,7 @@ class FinalizerTarg {
              */
             super.finalize();
             //Thread.dumpStack();
-            finalizerRun = true;
-            FINALIZER_DONE.countDown();
+            finalizerDone.countDown();
         }
     }
 
@@ -81,22 +79,23 @@ class FinalizerTarg {
         System.gc();
         System.runFinalization();
         try {
-            FINALIZER_DONE.await(5, TimeUnit.SECONDS);
+            // finalize() run in another lower priority Finalizer thread,
+            // wait for it to finish
+            finalizerDone.await(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        // Now, we have to make sure the finalizer
-        // gets run. We will keep allocating more
-        // and more memory with the idea that eventually,
-        // the memory occupied by the BigObject will get reclaimed
-        // and the finalizer will be run.
+
+        // If System.gc() and System.runFinalization() did not trigger the
+        // finalizer, then finalizerDone.await() will timed out and the code
+        // below will be needed as second attempt to trigger finalization.
         List holdAlot = new ArrayList();
         for (int chunk=10000000; chunk > 10000; chunk = chunk / 2) {
-            if (finalizerRun) {
+            if (finalizerDone.getCount() == 0) {
                 return;
             }
             try {
-                while(!finalizerRun) {
+                while(finalizerDone.getCount() > 0) {
                     holdAlot.add(new byte[chunk]);
                     System.err.println("Allocated " + chunk);
                 }
@@ -108,7 +107,7 @@ class FinalizerTarg {
             }
             System.runFinalization();
         }
-        return;  // not reached
+        return;
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Hi all,

Test com/sun/jdi/FinalizerTest.java intermittent fails. This is because arraylist holdAlot do not clear or set as null before recliam heap memory by invoke System.gc. This PR add arraylist.clear() before call System.gc() to avoid OOME in the senond System.runFinalization().

The first System.runFinalization() has a synchronize bug. System.runFinalization() run in another low priority Finalizer thread. In the main thread maybe read variable finalizerRun before Finalizer thread change it. So waitForAFinalizer will run into whille(true) allocation loop sometimes. This PR add a countdownlatch synchronize to make sure main thread read the finalizerRun value after Finalizer thread write it.

This PR also remove the unused variable and optimize the imports, and add -Xmx256M to debuggee jvm process, this will make debuggee throw OOME steady in large physical memory machine.

Before this PR, test failure probability about 1/30. After this PR test run 3k times and all passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343606](https://bugs.openjdk.org/browse/JDK-8343606): Test FinalizerTest.java intermittent fails Debuggee heap OOM (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30829/head:pull/30829` \
`$ git checkout pull/30829`

Update a local copy of the PR: \
`$ git checkout pull/30829` \
`$ git pull https://git.openjdk.org/jdk.git pull/30829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30829`

View PR using the GUI difftool: \
`$ git pr show -t 30829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30829.diff">https://git.openjdk.org/jdk/pull/30829.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30829#issuecomment-4285860234)
</details>
