### PR TITLE
8359665: JFR: Specification should use long and boolean, not Long and Boolean

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Period.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Period.java
@@ -54,7 +54,7 @@ public @interface Period {
     /**
      * Returns the default setting value for a periodic setting.
      * <p>
-     * String representation of a positive {@code Long} value followed by an empty
+     * String representation of a positive {@code long} value followed by an empty
      * space and one of the following units:<br>
      * <br>
      * {@code "ns"} (nanoseconds)<br>

--- a/src/jdk.jfr/share/classes/jdk/jfr/Threshold.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Threshold.java
@@ -50,7 +50,7 @@ public @interface Threshold {
     /**
      * The threshold (for example, {@code "20 ms"}).
      * <p>
-     * A {@code String} representation of a positive {@code Long} value followed by an
+     * A {@code String} representation of a positive {@code long} value followed by an
      * empty space and one of the following units:<br>
      * <br>
      * {@code "ns"} (nanoseconds)<br>

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Cutoff.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Cutoff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public @interface Cutoff {
     /**
      * Cutoff, for example {@code "20 ms"}.
      * <p>
-     * String representation of a positive {@code Long} value followed by an empty
+     * String representation of a positive {@code long} value followed by an empty
      * space and one of the following units<br>
      * <br>
      * {@code "ns"} (nanoseconds)<br>

--- a/src/jdk.jfr/share/classes/jdk/jfr/package-info.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/package-info.java
@@ -119,7 +119,7 @@
  * <th scope="row">{@code enabled}</th>
  * <td>Specifies whether the event is recorded</td>
  * <td>{@code "true"}</td>
- * <td>String representation of a {@code Boolean} ({@code "true"} or
+ * <td>String representation of a {@code boolean} ({@code "true"} or
  * {@code "false"})</td>
  * <td>{@code "true"}<br>
  * {@code "false"}</td>
@@ -129,7 +129,7 @@
  * <td>Specifies the duration below which an event is not recorded</td>
  * <td>{@code "0"} (no limit)</td>
  * <td>{@code "0"} if no threshold is used, otherwise a string representation of
- * a positive {@code Long} followed by a space and one of the following units:
+ * a positive {@code long} followed by a space and one of the following units:
  * <ul style="list-style-type:none">
  * <li>{@code "ns"} (nanoseconds)
  * <li>{@code "us"} (microseconds)
@@ -149,7 +149,7 @@
  * periodic</td>
  * <td>{@code "everyChunk"}</td>
  * <td>{@code "everyChunk"}, if a periodic event should be emitted with every
- * file rotation, otherwise a string representation of a positive {@code Long}
+ * file rotation, otherwise a string representation of a positive {@code long}
  * value followed by an empty space and one of the following units:
  * <ul style="list-style-type:none">
  * <li>{@code "ns"} (nanoseconds)
@@ -171,7 +171,7 @@
  * <td>Specifies whether the stack trace from the {@link Event#commit()} method
  * is recorded</td>
  * <td>{@code "true"}</td>
- * <td>String representation of a {@code Boolean} ({@code "true"} or
+ * <td>String representation of a {@code boolean} ({@code "true"} or
  * {@code "false"})</td>
  * <td>{@code "true"},<br>
  * {@code "false"}</td>
@@ -181,7 +181,7 @@
  *   <td>Specifies the maximum rate of events per time unit.</td>
  *   <td>{@code "off"} (no throttling)</td>
  *   <td>
- *     "off", if events should not be throttled, otherwise a string representation of a positive {@code Long} value followed by forward slash ("/") and one of the following units:
+ *     "off", if events should not be throttled, otherwise a string representation of a positive {@code long} value followed by forward slash ("/") and one of the following units:
  *     <ul style="list-style-type:none">
  *       <li>{@code "ns"} (nanoseconds)
  *       <li>{@code "us"} (microseconds)

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBean.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/FlightRecorderMXBean.java
@@ -90,7 +90,7 @@ import jdk.jfr.Recording;
  * this parameter is ignored.</td>
  * <td>{@code "0"} (no limit)</td>
  * <td>{@code "0"} if no limit is imposed, otherwise a string
- * representation of a positive {@code Long} value followed by an empty space
+ * representation of a positive {@code long} value followed by an empty space
  * and one of the following units,<br>
  * <br>
  * {@code "ns"} (nanoseconds)<br>
@@ -112,7 +112,7 @@ import jdk.jfr.Recording;
  * repository. Only works if
  * {@code disk=true}, otherwise this parameter is ignored.</td>
  * <td>{@code "0"} (no limit)</td>
- * <td>String representation of a {@code Long} value, must be positive</td>
+ * <td>String representation of a {@code long} value, must be positive</td>
  * <td>{@code "0"}, <br>
  * {@code "1000000000"}</td>
  * </tr>
@@ -120,7 +120,7 @@ import jdk.jfr.Recording;
  * <th scope="row">{@code dumpOnExit}</th>
  * <td>Dumps recording data to disk on Java Virtual Machine (JVM) exit</td>
  * <td>{@code "false"}</td>
- * <td>String representation of a {@code Boolean} value, {@code "true"} or
+ * <td>String representation of a {@code boolean} value, {@code "true"} or
  * {@code "false"}</td>
  * <td>{@code "true"},<br>
  * {@code "false"}</td>
@@ -140,7 +140,7 @@ import jdk.jfr.Recording;
  * <th scope="row">{@code disk}</th>
  * <td>Stores recorded data as it is recorded</td>
  * <td><code>"false"</code></td>
- * <td>String representation of a {@code Boolean} value, {@code "true"} or
+ * <td>String representation of a {@code boolean} value, {@code "true"} or
  * {@code "false"}</td>
  * <td>{@code "true"},<br>
  * {@code "false"}</td>
@@ -149,7 +149,7 @@ import jdk.jfr.Recording;
  * <td>Specifies the duration of the recording.</td>
  * <td>{@code "0"} (no limit, continuous)</td>
  * <td>{@code "0"} if no limit should be imposed, otherwise a string
- * representation of a positive {@code Long} followed by an empty space and one
+ * representation of a positive {@code long} followed by an empty space and one
  * of the following units:<br>
  * <br>
  * {@code "ns"} (nanoseconds)<br>


### PR DESCRIPTION
Could I have a review of a PR that updates the specification to use primitives when describing event settings. Null is not an allowed value.

Testing: test/jdk/jdk/jfr + tier1

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8359673](https://bugs.openjdk.org/browse/JDK-8359673) to be approved

### Issues
 * [JDK-8359665](https://bugs.openjdk.org/browse/JDK-8359665): JFR: Specification should use long and boolean, not Long and Boolean (**Bug** - P3)
 * [JDK-8359673](https://bugs.openjdk.org/browse/JDK-8359673): JFR: Specification should use long and boolean, not Long and Boolean (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30831/head:pull/30831` \
`$ git checkout pull/30831`

Update a local copy of the PR: \
`$ git checkout pull/30831` \
`$ git pull https://git.openjdk.org/jdk.git pull/30831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30831`

View PR using the GUI difftool: \
`$ git pr show -t 30831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30831.diff">https://git.openjdk.org/jdk/pull/30831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30831#issuecomment-4286290957)
</details>
