### PR TITLE
8382389: Test java/lang/LazyConstant/LazyConstantSafePublicationTest.java failed

### DIFF
--- a/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
+++ b/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
+++ b/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
@@ -151,9 +151,9 @@ final class LazyConstantSafePublicationTest {
     static void join(final LazyConstant<Holder>[] constants, List<Consumer> consumers, Thread... threads) {
         try {
             for (Thread t:threads) {
-                long deadline = System.nanoTime() + TimeUnit.MINUTES.toNanos(1);
+                long deadline = System.nanoTime() + TimeUnit.MINUTES.toNanos(4);
                 while (t.isAlive()) {
-                    t.join(TimeUnit.SECONDS.toMillis(10));
+                    t.join(TimeUnit.SECONDS.toMillis(20));
                     if (t.isAlive()) {
                         String stack = Arrays.stream(t.getStackTrace())
                                 .map(Objects::toString)

--- a/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
+++ b/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
@@ -25,10 +25,12 @@
  * @summary Basic tests for making sure ComputedConstant publishes values safely
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.lang
+ * @library /test/lib
  * @enablePreview
  * @run junit LazyConstantSafePublicationTest
  */
 
+import jdk.test.lib.Utils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -151,7 +153,7 @@ final class LazyConstantSafePublicationTest {
     static void join(final LazyConstant<Holder>[] constants, List<Consumer> consumers, Thread... threads) {
         try {
             for (Thread t:threads) {
-                long deadline = System.nanoTime() + TimeUnit.MINUTES.toNanos(4);
+                long deadline = System.nanoTime() + Utils.adjustTimeout(TimeUnit.MINUTES.toNanos(4));
                 while (t.isAlive()) {
                     t.join(TimeUnit.SECONDS.toMillis(20));
                     if (t.isAlive()) {

--- a/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
+++ b/test/jdk/java/lang/LazyConstant/LazyConstantSafePublicationTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.*;
 final class LazyConstantSafePublicationTest {
 
     private static final int SIZE = 100_000;
-    private static final int THREADS = Runtime.getRuntime().availableProcessors();
+    private static final int THREADS = Math.max(8, Runtime.getRuntime().availableProcessors());
 
     static final class Holder {
         // These are non-final fields but should be seen
@@ -104,7 +104,7 @@ final class LazyConstantSafePublicationTest {
             for (int i = 0; i < SIZE; i++) {
                 s = constants[i];
                 s.get();
-                deadlineNs += 1000;
+                deadlineNs += Utils.adjustTimeout(1000L);
                 while (System.nanoTime() < deadlineNs) {
                     Thread.onSpinWait();
                 }


### PR DESCRIPTION
This PR proposes to increase the timeout for `LazyConstantSafePublicationTest`. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382389](https://bugs.openjdk.org/browse/JDK-8382389): Test java/lang/LazyConstant/LazyConstantSafePublicationTest.java failed (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30832/head:pull/30832` \
`$ git checkout pull/30832`

Update a local copy of the PR: \
`$ git checkout pull/30832` \
`$ git pull https://git.openjdk.org/jdk.git pull/30832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30832`

View PR using the GUI difftool: \
`$ git pr show -t 30832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30832.diff">https://git.openjdk.org/jdk/pull/30832.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30832#issuecomment-4286600830)
</details>
