### PR TITLE
8373298: Test java/foreign/TestBufferStackStress.java timed out then completed

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -744,8 +744,6 @@ jdk/jfr/jvm/TestWaste.java                                      8371630 generic-
 
 # jdk_foreign
 
-java/foreign/TestBufferStackStress.java                         8350455 macosx-all
-
 ############################################################################
 # Client manual tests
 

--- a/test/jdk/java/foreign/TestBufferStackStress.java
+++ b/test/jdk/java/foreign/TestBufferStackStress.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @modules java.base/jdk.internal.foreign
- * @build NativeTestHelper TestBufferStackStress
  * @run junit TestBufferStackStress
  */
 
@@ -41,16 +40,16 @@ import static java.lang.foreign.ValueLayout.*;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestBufferStackStress {
+final class TestBufferStackStress {
 
     @Test
-    public void stress() throws InterruptedException {
+    void stress() throws InterruptedException {
         BufferStack stack = BufferStack.of(256, 1);
-        Thread[] vThreads = IntStream.range(0, 1024).mapToObj(_ ->
+        Thread[] vThreads = IntStream.range(0, 512).mapToObj(_ ->
                 Thread.ofVirtual().start(() -> {
                     long threadId = Thread.currentThread().threadId();
                     while (!Thread.interrupted()) {
-                        for (int i = 0; i < 1_000_000; i++) {
+                        for (int i = 0; i < 500_000; i++) {
                             try (Arena arena = stack.pushFrame(JAVA_LONG.byteSize(), JAVA_LONG.byteAlignment())) {
                                 // Try to assert no two vThreads get allocated the same stack space.
                                 MemorySegment segment = arena.allocate(JAVA_LONG);

--- a/test/jdk/java/foreign/TestBufferStackStress.java
+++ b/test/jdk/java/foreign/TestBufferStackStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,19 @@ import java.util.stream.IntStream;
 import static java.lang.foreign.ValueLayout.*;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 final class TestBufferStackStress {
 
     @Test
     void stress() throws InterruptedException {
+        boolean isMac = System.getProperty("os.name").toLowerCase().startsWith("mac");
+        if (isMac) {
+            float osVersion = Float.parseFloat(System.getProperty("os.version"));
+            // 8350455 was only fixed in macOS versions 26 or higher
+            assumeFalse(osVersion < 26, "Unsupported OS version: " + osVersion);
+        }
+
         BufferStack stack = BufferStack.of(256, 1);
         Thread[] vThreads = IntStream.range(0, 512).mapToObj(_ ->
                 Thread.ofVirtual().start(() -> {

--- a/test/jdk/java/foreign/TestBufferStackStress.java
+++ b/test/jdk/java/foreign/TestBufferStackStress.java
@@ -24,10 +24,12 @@
 /*
  * @test
  * @modules java.base/jdk.internal.foreign
+ * @library /test/lib
  * @run junit TestBufferStackStress
  */
 
 import jdk.internal.foreign.BufferStack;
+import jdk.test.lib.Platform;
 import org.junit.jupiter.api.Test;
 
 import java.lang.foreign.Arena;
@@ -45,11 +47,9 @@ final class TestBufferStackStress {
 
     @Test
     void stress() throws InterruptedException {
-        boolean isMac = System.getProperty("os.name").toLowerCase().startsWith("mac");
-        if (isMac) {
-            float osVersion = Float.parseFloat(System.getProperty("os.version"));
+        if (Platform.isOSX()) {
             // 8350455 was only fixed in macOS versions 26 or higher
-            assumeFalse(osVersion < 26, "Unsupported OS version: " + osVersion);
+            assumeFalse(Platform.getOsVersionMajor() < 26, "Unsupported OS version: " + Platform.getOsVersionMajor());
         }
 
         BufferStack stack = BufferStack.of(256, 1);

--- a/test/jdk/java/foreign/TestBufferStackStress2.java
+++ b/test/jdk/java/foreign/TestBufferStackStress2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @bug 8356114 8356658
  * @modules java.base/jdk.internal.foreign
- * @build NativeTestHelper TestBufferStackStress2
  * @run junit/timeout=480 TestBufferStackStress2
  */
 


### PR DESCRIPTION
This PR proposes to improve the `TestBufferStackStress` and `TestBufferStackStress2` tests by removing an unnecessary `@build` tag and reducing the required work of  `TestBufferStackStress`.

The `TestBufferStackStress` is also proposed to be removed from the ProblemList as the underlying issue (https://bugs.openjdk.org/browse/JDK-8350455) has been fixed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373298](https://bugs.openjdk.org/browse/JDK-8373298): Test java/foreign/TestBufferStackStress.java timed out then completed (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) Review applies to [4a3fa436](https://git.openjdk.org/jdk/pull/30835/files/4a3fa436834f9d97f3f723712d965e6912d292b6)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30835/head:pull/30835` \
`$ git checkout pull/30835`

Update a local copy of the PR: \
`$ git checkout pull/30835` \
`$ git pull https://git.openjdk.org/jdk.git pull/30835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30835`

View PR using the GUI difftool: \
`$ git pr show -t 30835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30835.diff">https://git.openjdk.org/jdk/pull/30835.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30835#issuecomment-4287086539)
</details>
