### PR TITLE
8382316: Unused xtmp in long_to_maskLE8_avx

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -24923,7 +24923,7 @@ instruct mask_not_imm(kReg dst, kReg src, immI_M1 cnt) %{
 instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2) %{
   predicate(n->bottom_type()->isa_vectmask() == nullptr && Matcher::vector_length(n) <= 8);
   match(Set dst (VectorLongToMask src));
-  effect(TEMP dst, TEMP rtmp1, TEMP rtmp2, TEMP xtmp);
+  effect(TEMP dst, TEMP rtmp1, TEMP rtmp2);
   format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1, $rtmp2" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -24920,11 +24920,11 @@ instruct mask_not_imm(kReg dst, kReg src, immI_M1 cnt) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2, vec xtmp) %{
+instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2) %{
   predicate(n->bottom_type()->isa_vectmask() == nullptr && Matcher::vector_length(n) <= 8);
   match(Set dst (VectorLongToMask src));
   effect(TEMP dst, TEMP rtmp1, TEMP rtmp2, TEMP xtmp);
-  format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1, $rtmp2, $xtmp as TEMP" %}
+  format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1, $rtmp2" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);
     int vec_enc  = vector_length_encoding(mask_len);


### PR DESCRIPTION
Removed unused `vec xtmp` parameter in `long_to_maskLE8_avx`.

See JBS issue for details on how this parameter can be removed safely.

Additional testing:

- [X]  Linux x86_64 server fastdebug, `tier1-3`

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382316](https://bugs.openjdk.org/browse/JDK-8382316): Unused xtmp in long_to_maskLE8_avx (**Enhancement** - P4)


### Reviewers
 * [Jasmine Karthikeyan](https://openjdk.org/census#jkarthikeyan) (@jaskarth - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30836/head:pull/30836` \
`$ git checkout pull/30836`

Update a local copy of the PR: \
`$ git checkout pull/30836` \
`$ git pull https://git.openjdk.org/jdk.git pull/30836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30836`

View PR using the GUI difftool: \
`$ git pr show -t 30836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30836.diff">https://git.openjdk.org/jdk/pull/30836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30836#issuecomment-4287127887)
</details>
