### PR TITLE
8372688: Test out-of-bounds indexing for List.ofLazy()::get

### DIFF
--- a/test/jdk/java/lang/LazyConstant/LazyListTest.java
+++ b/test/jdk/java/lang/LazyConstant/LazyListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,6 +151,15 @@ final class LazyListTest {
             assertEquals(i, lazy.lastIndexOf(i));
         }
         assertEquals(-1, lazy.lastIndexOf(SIZE + 1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("lazyLists")
+    void bounds(List list) {
+        IntStream.range(0, list.size())
+                .forEach(i -> assertEquals(IDENTITY.apply(i), list.get(i)));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> list.get(list.size()));
     }
 
     @Test
@@ -421,6 +430,11 @@ final class LazyListTest {
                 new Operation("listIter().add",    l -> l.listIterator().add(1)),
                 new Operation("listIter().set",    l -> l.listIterator().set(1))
         );
+    }
+
+    static Stream<List> lazyLists() {
+        return IntStream.rangeClosed(0, SIZE)
+                .mapToObj(i -> List.ofLazy(i, IDENTITY));
     }
 
     static List<Integer> newLazyList() {


### PR DESCRIPTION
This PR proposes to add range checking for lazy lists.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372688](https://bugs.openjdk.org/browse/JDK-8372688): Test out-of-bounds indexing for List.ofLazy()::get (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30839/head:pull/30839` \
`$ git checkout pull/30839`

Update a local copy of the PR: \
`$ git checkout pull/30839` \
`$ git pull https://git.openjdk.org/jdk.git pull/30839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30839`

View PR using the GUI difftool: \
`$ git pr show -t 30839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30839.diff">https://git.openjdk.org/jdk/pull/30839.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30839#issuecomment-4287356676)
</details>
