### PR TITLE
8364148: Test java/foreign/StdLibTest.java timed out after passing on linux-x64-zero

### DIFF
--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run testng/othervm/timeout=480 --enable-native-access=ALL-UNNAMED StdLibTest
+ * @run junit/othervm/timeout=600 --enable-native-access=ALL-UNNAMED StdLibTest
  */
 
 import java.lang.invoke.MethodHandle;
@@ -41,73 +41,83 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import java.lang.foreign.*;
 
-import org.testng.annotations.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class StdLibTest extends NativeTestHelper {
+final class StdLibTest extends NativeTestHelper {
 
-    final static Linker abi = Linker.nativeLinker();
+    static final Linker ABI = Linker.nativeLinker();
 
-    private StdLibHelper stdLibHelper = new StdLibHelper();
+    static final StdLibHelper STD_LIB_HELPER = new StdLibHelper();
 
-    @Test(dataProvider = "stringPairs")
+    @ParameterizedTest
+    @MethodSource("stringPairs")
     void test_strcat(String s1, String s2) throws Throwable {
-        assertEquals(stdLibHelper.strcat(s1, s2), s1 + s2);
+        assertEquals(s1 + s2, STD_LIB_HELPER.strcat(s1, s2));
     }
 
-    @Test(dataProvider = "stringPairs")
+    @ParameterizedTest
+    @MethodSource("stringPairs")
     void test_strcmp(String s1, String s2) throws Throwable {
-        assertEquals(Math.signum(stdLibHelper.strcmp(s1, s2)), Math.signum(s1.compareTo(s2)));
+        assertEquals(Math.signum(s1.compareTo(s2)), Math.signum(STD_LIB_HELPER.strcmp(s1, s2)));
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     void test_puts(String s) throws Throwable {
-        assertTrue(stdLibHelper.puts(s) >= 0);
+        assertTrue(STD_LIB_HELPER.puts(s) >= 0);
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     void test_strlen(String s) throws Throwable {
-        assertEquals(stdLibHelper.strlen(s), s.length());
+        assertEquals(STD_LIB_HELPER.strlen(s), s.length());
     }
 
-    @Test(dataProvider = "instants")
+    @ParameterizedTest
+    @MethodSource("instants")
     void test_time(Instant instant) throws Throwable {
-        StdLibHelper.Tm tm = stdLibHelper.gmtime(instant.getEpochSecond());
+        StdLibHelper.Tm tm = STD_LIB_HELPER.gmtime(instant.getEpochSecond());
         LocalDateTime localTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-        assertEquals(tm.sec(), localTime.getSecond());
-        assertEquals(tm.min(), localTime.getMinute());
-        assertEquals(tm.hour(), localTime.getHour());
+        assertEquals(localTime.getSecond(), tm.sec());
+        assertEquals(localTime.getMinute(), tm.min());
+        assertEquals(localTime.getHour(), tm.hour());
         //day pf year in Java has 1-offset
-        assertEquals(tm.yday(), localTime.getDayOfYear() - 1);
-        assertEquals(tm.mday(), localTime.getDayOfMonth());
+        assertEquals(localTime.getDayOfYear() - 1, tm.yday());
+        assertEquals( localTime.getDayOfMonth(), tm.mday());
         //days of week starts from Sunday in C, but on Monday in Java, also account for 1-offset
-        assertEquals((tm.wday() + 6) % 7, localTime.getDayOfWeek().getValue() - 1);
+        assertEquals(localTime.getDayOfWeek().getValue() - 1,  (tm.wday() + 6) % 7);
         //month in Java has 1-offset
-        assertEquals(tm.mon(), localTime.getMonth().getValue() - 1);
-        assertEquals(tm.isdst(), ZoneOffset.UTC.getRules()
-                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)));
+        assertEquals(localTime.getMonth().getValue() - 1, tm.mon());
+        assertEquals(ZoneOffset.UTC.getRules()
+                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)), tm.isdst());
     }
 
-    @Test(dataProvider = "ints")
+    @ParameterizedTest
+    @MethodSource("ints")
     void test_qsort(List<Integer> ints) throws Throwable {
         if (ints.size() > 0) {
             int[] input = ints.stream().mapToInt(i -> i).toArray();
-            int[] sorted = stdLibHelper.qsort(input);
+            int[] sorted = STD_LIB_HELPER.qsort(input);
             Arrays.sort(input);
-            assertEquals(sorted, input);
+            assertArrayEquals(input, sorted);
         }
     }
 
     @Test
     void test_rand() throws Throwable {
-        int val = stdLibHelper.rand();
+        int val = STD_LIB_HELPER.rand();
         for (int i = 0 ; i < 100 ; i++) {
-            int newVal = stdLibHelper.rand();
+            int newVal = STD_LIB_HELPER.rand();
             if (newVal != val) {
                 return; //ok
             }
@@ -116,7 +126,8 @@ public class StdLibTest extends NativeTestHelper {
         fail("All values are the same! " + val);
     }
 
-    @Test(dataProvider = "printfArgs")
+    @ParameterizedTest
+    @MethodSource("printfArgs")
     void test_printf(List<PrintfArg> args) throws Throwable {
         String javaFormatArgs = args.stream()
                 .map(a -> a.javaFormat)
@@ -131,8 +142,8 @@ public class StdLibTest extends NativeTestHelper {
         String expected = String.format(javaFormatString, args.stream()
                 .map(a -> a.javaValue).toArray());
 
-        int found = stdLibHelper.printf(nativeFormatString, args);
-        assertEquals(found, expected.length());
+        int found = STD_LIB_HELPER.printf(nativeFormatString, args);
+        assertEquals(expected.length(), found);
     }
 
     @Test
@@ -140,25 +151,25 @@ public class StdLibTest extends NativeTestHelper {
         assertTrue(LINKER.defaultLookup().find("strlen\u0000foobar").isEmpty());
     }
 
-    static class StdLibHelper {
+    static final class StdLibHelper {
 
-        final static MethodHandle strcat = abi.downcallHandle(abi.defaultLookup().find("strcat").get(),
+        final static MethodHandle strcat = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strcat"),
                 FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
 
-        final static MethodHandle strcmp = abi.downcallHandle(abi.defaultLookup().find("strcmp").get(),
+        final static MethodHandle strcmp = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strcmp"),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MethodHandle puts = abi.downcallHandle(abi.defaultLookup().find("puts").get(),
+        final static MethodHandle puts = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("puts"),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle strlen = abi.downcallHandle(abi.defaultLookup().find("strlen").get(),
+        final static MethodHandle strlen = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strlen"),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle gmtime = abi.downcallHandle(abi.defaultLookup().find("gmtime").get(),
+        final static MethodHandle gmtime = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("gmtime"),
                 FunctionDescriptor.of(C_POINTER.withTargetLayout(Tm.LAYOUT), C_POINTER));
 
         // void qsort( void *ptr, size_t count, size_t size, int (*comp)(const void *, const void *) );
-        final static MethodHandle qsort = abi.downcallHandle(abi.defaultLookup().find("qsort").get(),
+        final static MethodHandle qsort = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("qsort"),
                 FunctionDescriptor.ofVoid(C_POINTER, C_SIZE_T, C_SIZE_T, C_POINTER));
 
         final static FunctionDescriptor qsortComparFunction = FunctionDescriptor.of(C_INT,
@@ -166,13 +177,13 @@ public class StdLibTest extends NativeTestHelper {
 
         final static MethodHandle qsortCompar;
 
-        final static MethodHandle rand = abi.downcallHandle(abi.defaultLookup().find("rand").get(),
+        final static MethodHandle rand = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("rand"),
                 FunctionDescriptor.of(C_INT));
 
-        final static MethodHandle vprintf = abi.downcallHandle(abi.defaultLookup().find("vprintf").get(),
+        final static MethodHandle vprintf = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("vprintf"),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MemorySegment printfAddr = abi.defaultLookup().find("printf").get();
+        final static MemorySegment printfAddr = ABI.defaultLookup().findOrThrow("printf");
 
         final static FunctionDescriptor printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
 
@@ -225,7 +236,7 @@ public class StdLibTest extends NativeTestHelper {
             }
         }
 
-        static class Tm {
+        static final class Tm {
 
             //Tm pointer should never be freed directly, as it points to shared memory
             private final MemorySegment base;
@@ -282,7 +293,7 @@ public class StdLibTest extends NativeTestHelper {
                 MemorySegment nativeArr = arena.allocateFrom(C_INT, arr);
 
                 //call qsort
-                MemorySegment qsortUpcallStub = abi.upcallStub(qsortCompar, qsortComparFunction, arena);
+                MemorySegment qsortUpcallStub = ABI.upcallStub(qsortCompar, qsortComparFunction, arena);
 
                 // both of these fit in an int
                 // automatically widen them to long on x64
@@ -297,7 +308,7 @@ public class StdLibTest extends NativeTestHelper {
 
         static int qsortCompare(MemorySegment addr1, MemorySegment addr2) {
             return addr1.get(C_INT, 0) -
-                   addr2.get(C_INT, 0);
+                    addr2.get(C_INT, 0);
         }
 
         int rand() throws Throwable {
@@ -322,7 +333,7 @@ public class StdLibTest extends NativeTestHelper {
                 variadicLayouts.add(arg.layout);
             }
             Linker.Option varargIndex = Linker.Option.firstVariadicArg(fd.argumentLayouts().size());
-            MethodHandle mh = abi.downcallHandle(printfAddr,
+            MethodHandle mh = ABI.downcallHandle(printfAddr,
                     fd.appendArgumentLayouts(variadicLayouts.toArray(new MemoryLayout[args.size()])),
                     varargIndex);
             return mh.asSpreader(1, Object[].class, args.size());
@@ -331,47 +342,36 @@ public class StdLibTest extends NativeTestHelper {
 
     /*** data providers ***/
 
-    @DataProvider
-    public static Object[][] ints() {
+    static Stream<Arguments> ints() {
         return perms(0, new Integer[] { 0, 1, 2, 3, 4 }).stream()
-                .map(l -> new Object[] { l })
-                .toArray(Object[][]::new);
+                .map(Arguments::of);
     }
 
-    @DataProvider
-    public static Object[][] strings() {
+    static Stream<Arguments> strings() {
+        return strings0()
+                .map(Arguments::of);
+    }
+
+    static Stream<Arguments> stringPairs() {
+        return strings0()
+                .flatMap(s -> strings0()
+                        .map(s2 -> Arguments.of(s, s2)));
+    }
+
+    static Stream<String> strings0() {
         return perms(0, new String[] { "a", "b", "c" }).stream()
-                .map(l -> new Object[] { String.join("", l) })
-                .toArray(Object[][]::new);
+                .map(l -> String.join("", l));
     }
 
-    @DataProvider
-    public static Object[][] stringPairs() {
-        Object[][] strings = strings();
-        Object[][] stringPairs = new Object[strings.length * strings.length][];
-        int pos = 0;
-        for (Object[] s1 : strings) {
-            for (Object[] s2 : strings) {
-                stringPairs[pos++] = new Object[] { s1[0], s2[0] };
-            }
-        }
-        return stringPairs;
-    }
-
-    @DataProvider
-    public static Object[][] instants() {
+    static Stream<Arguments> instants() {
         Instant start = ZonedDateTime.of(LocalDateTime.parse("2017-01-01T00:00:00"), ZoneOffset.UTC).toInstant();
         Instant end = ZonedDateTime.of(LocalDateTime.parse("2017-12-31T00:00:00"), ZoneOffset.UTC).toInstant();
-        Object[][] instants = new Object[100][];
-        for (int i = 0 ; i < instants.length ; i++) {
-            Instant instant = start.plusSeconds((long)(Math.random() * (end.getEpochSecond() - start.getEpochSecond())));
-            instants[i] = new Object[] { instant };
-        }
-        return instants;
+        return IntStream.range(0, 100)
+                .mapToObj(i -> start.plusSeconds((long)(Math.random() * (end.getEpochSecond() - start.getEpochSecond()))))
+                .map(Arguments::of);
     }
 
-    @DataProvider
-    public static Object[][] printfArgs() {
+    static Stream<Arguments> printfArgs() {
         ArrayList<List<PrintfArg>> res = new ArrayList<>();
         List<List<PrintfArg>> perms = new ArrayList<>(perms(0, PrintfArg.values()));
         for (int i = 0 ; i < 100 ; i++) {
@@ -379,8 +379,7 @@ public class StdLibTest extends NativeTestHelper {
             res.addAll(perms);
         }
         return res.stream()
-                .map(l -> new Object[] { l })
-                .toArray(Object[][]::new);
+                .map(Arguments::of);
     }
 
     enum PrintfArg {

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run junit/othervm/timeout=600 --enable-native-access=ALL-UNNAMED StdLibTest
+ * @run testng/othervm/timeout=480 --enable-native-access=ALL-UNNAMED StdLibTest
  */
 
 import java.lang.invoke.MethodHandle;
@@ -41,83 +41,73 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import java.lang.foreign.*;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.testng.annotations.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.testng.Assert.*;
 
-final class StdLibTest extends NativeTestHelper {
+public class StdLibTest extends NativeTestHelper {
 
-    static final Linker ABI = Linker.nativeLinker();
+    final static Linker abi = Linker.nativeLinker();
 
-    static final StdLibHelper STD_LIB_HELPER = new StdLibHelper();
+    private StdLibHelper stdLibHelper = new StdLibHelper();
 
-    @ParameterizedTest
-    @MethodSource("stringPairs")
+    @Test(dataProvider = "stringPairs")
     void test_strcat(String s1, String s2) throws Throwable {
-        assertEquals(s1 + s2, STD_LIB_HELPER.strcat(s1, s2));
+        assertEquals(stdLibHelper.strcat(s1, s2), s1 + s2);
     }
 
-    @ParameterizedTest
-    @MethodSource("stringPairs")
+    @Test(dataProvider = "stringPairs")
     void test_strcmp(String s1, String s2) throws Throwable {
-        assertEquals(Math.signum(s1.compareTo(s2)), Math.signum(STD_LIB_HELPER.strcmp(s1, s2)));
+        assertEquals(Math.signum(stdLibHelper.strcmp(s1, s2)), Math.signum(s1.compareTo(s2)));
     }
 
-    @ParameterizedTest
-    @MethodSource("strings")
+    @Test(dataProvider = "strings")
     void test_puts(String s) throws Throwable {
-        assertTrue(STD_LIB_HELPER.puts(s) >= 0);
+        assertTrue(stdLibHelper.puts(s) >= 0);
     }
 
-    @ParameterizedTest
-    @MethodSource("strings")
+    @Test(dataProvider = "strings")
     void test_strlen(String s) throws Throwable {
-        assertEquals(STD_LIB_HELPER.strlen(s), s.length());
+        assertEquals(stdLibHelper.strlen(s), s.length());
     }
 
-    @ParameterizedTest
-    @MethodSource("instants")
+    @Test(dataProvider = "instants")
     void test_time(Instant instant) throws Throwable {
-        StdLibHelper.Tm tm = STD_LIB_HELPER.gmtime(instant.getEpochSecond());
+        StdLibHelper.Tm tm = stdLibHelper.gmtime(instant.getEpochSecond());
         LocalDateTime localTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-        assertEquals(localTime.getSecond(), tm.sec());
-        assertEquals(localTime.getMinute(), tm.min());
-        assertEquals(localTime.getHour(), tm.hour());
+        assertEquals(tm.sec(), localTime.getSecond());
+        assertEquals(tm.min(), localTime.getMinute());
+        assertEquals(tm.hour(), localTime.getHour());
         //day pf year in Java has 1-offset
-        assertEquals(localTime.getDayOfYear() - 1, tm.yday());
-        assertEquals( localTime.getDayOfMonth(), tm.mday());
+        assertEquals(tm.yday(), localTime.getDayOfYear() - 1);
+        assertEquals(tm.mday(), localTime.getDayOfMonth());
         //days of week starts from Sunday in C, but on Monday in Java, also account for 1-offset
-        assertEquals(localTime.getDayOfWeek().getValue() - 1,  (tm.wday() + 6) % 7);
+        assertEquals((tm.wday() + 6) % 7, localTime.getDayOfWeek().getValue() - 1);
         //month in Java has 1-offset
-        assertEquals(localTime.getMonth().getValue() - 1, tm.mon());
-        assertEquals(ZoneOffset.UTC.getRules()
-                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)), tm.isdst());
+        assertEquals(tm.mon(), localTime.getMonth().getValue() - 1);
+        assertEquals(tm.isdst(), ZoneOffset.UTC.getRules()
+                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)));
     }
 
-    @ParameterizedTest
-    @MethodSource("ints")
+    @Test(dataProvider = "ints")
     void test_qsort(List<Integer> ints) throws Throwable {
         if (ints.size() > 0) {
             int[] input = ints.stream().mapToInt(i -> i).toArray();
-            int[] sorted = STD_LIB_HELPER.qsort(input);
+            int[] sorted = stdLibHelper.qsort(input);
             Arrays.sort(input);
-            assertArrayEquals(input, sorted);
+            assertEquals(sorted, input);
         }
     }
 
     @Test
     void test_rand() throws Throwable {
-        int val = STD_LIB_HELPER.rand();
+        int val = stdLibHelper.rand();
         for (int i = 0 ; i < 100 ; i++) {
-            int newVal = STD_LIB_HELPER.rand();
+            int newVal = stdLibHelper.rand();
             if (newVal != val) {
                 return; //ok
             }
@@ -126,8 +116,7 @@ final class StdLibTest extends NativeTestHelper {
         fail("All values are the same! " + val);
     }
 
-    @ParameterizedTest
-    @MethodSource("printfArgs")
+    @Test(dataProvider = "printfArgs")
     void test_printf(List<PrintfArg> args) throws Throwable {
         String javaFormatArgs = args.stream()
                 .map(a -> a.javaFormat)
@@ -142,8 +131,8 @@ final class StdLibTest extends NativeTestHelper {
         String expected = String.format(javaFormatString, args.stream()
                 .map(a -> a.javaValue).toArray());
 
-        int found = STD_LIB_HELPER.printf(nativeFormatString, args);
-        assertEquals(expected.length(), found);
+        int found = stdLibHelper.printf(nativeFormatString, args);
+        assertEquals(found, expected.length());
     }
 
     @Test
@@ -151,25 +140,25 @@ final class StdLibTest extends NativeTestHelper {
         assertTrue(LINKER.defaultLookup().find("strlen\u0000foobar").isEmpty());
     }
 
-    static final class StdLibHelper {
+    static class StdLibHelper {
 
-        final static MethodHandle strcat = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strcat"),
+        final static MethodHandle strcat = abi.downcallHandle(abi.defaultLookup().find("strcat").get(),
                 FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
 
-        final static MethodHandle strcmp = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strcmp"),
+        final static MethodHandle strcmp = abi.downcallHandle(abi.defaultLookup().find("strcmp").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MethodHandle puts = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("puts"),
+        final static MethodHandle puts = abi.downcallHandle(abi.defaultLookup().find("puts").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle strlen = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strlen"),
+        final static MethodHandle strlen = abi.downcallHandle(abi.defaultLookup().find("strlen").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle gmtime = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("gmtime"),
+        final static MethodHandle gmtime = abi.downcallHandle(abi.defaultLookup().find("gmtime").get(),
                 FunctionDescriptor.of(C_POINTER.withTargetLayout(Tm.LAYOUT), C_POINTER));
 
         // void qsort( void *ptr, size_t count, size_t size, int (*comp)(const void *, const void *) );
-        final static MethodHandle qsort = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("qsort"),
+        final static MethodHandle qsort = abi.downcallHandle(abi.defaultLookup().find("qsort").get(),
                 FunctionDescriptor.ofVoid(C_POINTER, C_SIZE_T, C_SIZE_T, C_POINTER));
 
         final static FunctionDescriptor qsortComparFunction = FunctionDescriptor.of(C_INT,
@@ -177,13 +166,13 @@ final class StdLibTest extends NativeTestHelper {
 
         final static MethodHandle qsortCompar;
 
-        final static MethodHandle rand = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("rand"),
+        final static MethodHandle rand = abi.downcallHandle(abi.defaultLookup().find("rand").get(),
                 FunctionDescriptor.of(C_INT));
 
-        final static MethodHandle vprintf = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("vprintf"),
+        final static MethodHandle vprintf = abi.downcallHandle(abi.defaultLookup().find("vprintf").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MemorySegment printfAddr = ABI.defaultLookup().findOrThrow("printf");
+        final static MemorySegment printfAddr = abi.defaultLookup().find("printf").get();
 
         final static FunctionDescriptor printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
 
@@ -236,7 +225,7 @@ final class StdLibTest extends NativeTestHelper {
             }
         }
 
-        static final class Tm {
+        static class Tm {
 
             //Tm pointer should never be freed directly, as it points to shared memory
             private final MemorySegment base;
@@ -293,7 +282,7 @@ final class StdLibTest extends NativeTestHelper {
                 MemorySegment nativeArr = arena.allocateFrom(C_INT, arr);
 
                 //call qsort
-                MemorySegment qsortUpcallStub = ABI.upcallStub(qsortCompar, qsortComparFunction, arena);
+                MemorySegment qsortUpcallStub = abi.upcallStub(qsortCompar, qsortComparFunction, arena);
 
                 // both of these fit in an int
                 // automatically widen them to long on x64
@@ -333,7 +322,7 @@ final class StdLibTest extends NativeTestHelper {
                 variadicLayouts.add(arg.layout);
             }
             Linker.Option varargIndex = Linker.Option.firstVariadicArg(fd.argumentLayouts().size());
-            MethodHandle mh = ABI.downcallHandle(printfAddr,
+            MethodHandle mh = abi.downcallHandle(printfAddr,
                     fd.appendArgumentLayouts(variadicLayouts.toArray(new MemoryLayout[args.size()])),
                     varargIndex);
             return mh.asSpreader(1, Object[].class, args.size());
@@ -342,36 +331,47 @@ final class StdLibTest extends NativeTestHelper {
 
     /*** data providers ***/
 
-    static Stream<Arguments> ints() {
+    @DataProvider
+    public static Object[][] ints() {
         return perms(0, new Integer[] { 0, 1, 2, 3, 4 }).stream()
-                .map(Arguments::of);
-   }
-
-    static Stream<Arguments> strings() {
-        return strings0()
-                .map(Arguments::of);
+                .map(l -> new Object[] { l })
+                .toArray(Object[][]::new);
     }
 
-    static Stream<Arguments> stringPairs() {
-        return strings0()
-                .flatMap(s -> strings0()
-                        .map(s2 -> Arguments.of(s, s2)));
-    }
-
-    static Stream<String> strings0() {
+    @DataProvider
+    public static Object[][] strings() {
         return perms(0, new String[] { "a", "b", "c" }).stream()
-                .map(l -> String.join("", l));
+                .map(l -> new Object[] { String.join("", l) })
+                .toArray(Object[][]::new);
     }
 
-    static Stream<Arguments> instants() {
+    @DataProvider
+    public static Object[][] stringPairs() {
+        Object[][] strings = strings();
+        Object[][] stringPairs = new Object[strings.length * strings.length][];
+        int pos = 0;
+        for (Object[] s1 : strings) {
+            for (Object[] s2 : strings) {
+                stringPairs[pos++] = new Object[] { s1[0], s2[0] };
+            }
+        }
+        return stringPairs;
+    }
+
+    @DataProvider
+    public static Object[][] instants() {
         Instant start = ZonedDateTime.of(LocalDateTime.parse("2017-01-01T00:00:00"), ZoneOffset.UTC).toInstant();
         Instant end = ZonedDateTime.of(LocalDateTime.parse("2017-12-31T00:00:00"), ZoneOffset.UTC).toInstant();
-        return IntStream.range(0, 100)
-                .mapToObj(i -> start.plusSeconds((long)(Math.random() * (end.getEpochSecond() - start.getEpochSecond()))))
-                .map(Arguments::of);
+        Object[][] instants = new Object[100][];
+        for (int i = 0 ; i < instants.length ; i++) {
+            Instant instant = start.plusSeconds((long)(Math.random() * (end.getEpochSecond() - start.getEpochSecond())));
+            instants[i] = new Object[] { instant };
+        }
+        return instants;
     }
 
-    static Stream<Arguments> printfArgs() {
+    @DataProvider
+    public static Object[][] printfArgs() {
         ArrayList<List<PrintfArg>> res = new ArrayList<>();
         List<List<PrintfArg>> perms = new ArrayList<>(perms(0, PrintfArg.values()));
         for (int i = 0 ; i < 100 ; i++) {
@@ -379,7 +379,8 @@ final class StdLibTest extends NativeTestHelper {
             res.addAll(perms);
         }
         return res.stream()
-                .map(Arguments::of);
+                .map(l -> new Object[] { l })
+                .toArray(Object[][]::new);
     }
 
     enum PrintfArg {

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run testng/othervm/timeout=480 --enable-native-access=ALL-UNNAMED StdLibTest
+ * @run junit/othervm/timeout=600 --enable-native-access=ALL-UNNAMED StdLibTest
  */
 
 import java.lang.invoke.MethodHandle;
@@ -41,73 +41,83 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import java.lang.foreign.*;
 
-import org.testng.annotations.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class StdLibTest extends NativeTestHelper {
+final class StdLibTest extends NativeTestHelper {
 
-    final static Linker abi = Linker.nativeLinker();
+    static final Linker ABI = Linker.nativeLinker();
 
-    private StdLibHelper stdLibHelper = new StdLibHelper();
+    static final StdLibHelper STD_LIB_HELPER = new StdLibHelper();
 
-    @Test(dataProvider = "stringPairs")
+    @ParameterizedTest
+    @MethodSource("stringPairs")
     void test_strcat(String s1, String s2) throws Throwable {
-        assertEquals(stdLibHelper.strcat(s1, s2), s1 + s2);
+        assertEquals(s1 + s2, STD_LIB_HELPER.strcat(s1, s2));
     }
 
-    @Test(dataProvider = "stringPairs")
+    @ParameterizedTest
+    @MethodSource("stringPairs")
     void test_strcmp(String s1, String s2) throws Throwable {
-        assertEquals(Math.signum(stdLibHelper.strcmp(s1, s2)), Math.signum(s1.compareTo(s2)));
+        assertEquals(Math.signum(s1.compareTo(s2)), Math.signum(STD_LIB_HELPER.strcmp(s1, s2)));
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     void test_puts(String s) throws Throwable {
-        assertTrue(stdLibHelper.puts(s) >= 0);
+        assertTrue(STD_LIB_HELPER.puts(s) >= 0);
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     void test_strlen(String s) throws Throwable {
-        assertEquals(stdLibHelper.strlen(s), s.length());
+        assertEquals(STD_LIB_HELPER.strlen(s), s.length());
     }
 
-    @Test(dataProvider = "instants")
+    @ParameterizedTest
+    @MethodSource("instants")
     void test_time(Instant instant) throws Throwable {
-        StdLibHelper.Tm tm = stdLibHelper.gmtime(instant.getEpochSecond());
+        StdLibHelper.Tm tm = STD_LIB_HELPER.gmtime(instant.getEpochSecond());
         LocalDateTime localTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-        assertEquals(tm.sec(), localTime.getSecond());
-        assertEquals(tm.min(), localTime.getMinute());
-        assertEquals(tm.hour(), localTime.getHour());
+        assertEquals(localTime.getSecond(), tm.sec());
+        assertEquals(localTime.getMinute(), tm.min());
+        assertEquals(localTime.getHour(), tm.hour());
         //day pf year in Java has 1-offset
-        assertEquals(tm.yday(), localTime.getDayOfYear() - 1);
-        assertEquals(tm.mday(), localTime.getDayOfMonth());
+        assertEquals(localTime.getDayOfYear() - 1, tm.yday());
+        assertEquals( localTime.getDayOfMonth(), tm.mday());
         //days of week starts from Sunday in C, but on Monday in Java, also account for 1-offset
-        assertEquals((tm.wday() + 6) % 7, localTime.getDayOfWeek().getValue() - 1);
+        assertEquals(localTime.getDayOfWeek().getValue() - 1,  (tm.wday() + 6) % 7);
         //month in Java has 1-offset
-        assertEquals(tm.mon(), localTime.getMonth().getValue() - 1);
-        assertEquals(tm.isdst(), ZoneOffset.UTC.getRules()
-                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)));
+        assertEquals(localTime.getMonth().getValue() - 1, tm.mon());
+        assertEquals(ZoneOffset.UTC.getRules()
+                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)), tm.isdst());
     }
 
-    @Test(dataProvider = "ints")
+    @ParameterizedTest
+    @MethodSource("ints")
     void test_qsort(List<Integer> ints) throws Throwable {
         if (ints.size() > 0) {
             int[] input = ints.stream().mapToInt(i -> i).toArray();
-            int[] sorted = stdLibHelper.qsort(input);
+            int[] sorted = STD_LIB_HELPER.qsort(input);
             Arrays.sort(input);
-            assertEquals(sorted, input);
+            assertArrayEquals(input, sorted);
         }
     }
 
     @Test
     void test_rand() throws Throwable {
-        int val = stdLibHelper.rand();
+        int val = STD_LIB_HELPER.rand();
         for (int i = 0 ; i < 100 ; i++) {
-            int newVal = stdLibHelper.rand();
+            int newVal = STD_LIB_HELPER.rand();
             if (newVal != val) {
                 return; //ok
             }
@@ -116,7 +126,8 @@ public class StdLibTest extends NativeTestHelper {
         fail("All values are the same! " + val);
     }
 
-    @Test(dataProvider = "printfArgs")
+    @ParameterizedTest
+    @MethodSource("printfArgs")
     void test_printf(List<PrintfArg> args) throws Throwable {
         String javaFormatArgs = args.stream()
                 .map(a -> a.javaFormat)
@@ -131,8 +142,8 @@ public class StdLibTest extends NativeTestHelper {
         String expected = String.format(javaFormatString, args.stream()
                 .map(a -> a.javaValue).toArray());
 
-        int found = stdLibHelper.printf(nativeFormatString, args);
-        assertEquals(found, expected.length());
+        int found = STD_LIB_HELPER.printf(nativeFormatString, args);
+        assertEquals(expected.length(), found);
     }
 
     @Test
@@ -140,25 +151,25 @@ public class StdLibTest extends NativeTestHelper {
         assertTrue(LINKER.defaultLookup().find("strlen\u0000foobar").isEmpty());
     }
 
-    static class StdLibHelper {
+    static final class StdLibHelper {
 
-        final static MethodHandle strcat = abi.downcallHandle(abi.defaultLookup().find("strcat").get(),
+        final static MethodHandle strcat = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strcat"),
                 FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
 
-        final static MethodHandle strcmp = abi.downcallHandle(abi.defaultLookup().find("strcmp").get(),
+        final static MethodHandle strcmp = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strcmp"),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MethodHandle puts = abi.downcallHandle(abi.defaultLookup().find("puts").get(),
+        final static MethodHandle puts = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("puts"),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle strlen = abi.downcallHandle(abi.defaultLookup().find("strlen").get(),
+        final static MethodHandle strlen = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("strlen"),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle gmtime = abi.downcallHandle(abi.defaultLookup().find("gmtime").get(),
+        final static MethodHandle gmtime = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("gmtime"),
                 FunctionDescriptor.of(C_POINTER.withTargetLayout(Tm.LAYOUT), C_POINTER));
 
         // void qsort( void *ptr, size_t count, size_t size, int (*comp)(const void *, const void *) );
-        final static MethodHandle qsort = abi.downcallHandle(abi.defaultLookup().find("qsort").get(),
+        final static MethodHandle qsort = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("qsort"),
                 FunctionDescriptor.ofVoid(C_POINTER, C_SIZE_T, C_SIZE_T, C_POINTER));
 
         final static FunctionDescriptor qsortComparFunction = FunctionDescriptor.of(C_INT,
@@ -166,13 +177,13 @@ public class StdLibTest extends NativeTestHelper {
 
         final static MethodHandle qsortCompar;
 
-        final static MethodHandle rand = abi.downcallHandle(abi.defaultLookup().find("rand").get(),
+        final static MethodHandle rand = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("rand"),
                 FunctionDescriptor.of(C_INT));
 
-        final static MethodHandle vprintf = abi.downcallHandle(abi.defaultLookup().find("vprintf").get(),
+        final static MethodHandle vprintf = ABI.downcallHandle(ABI.defaultLookup().findOrThrow("vprintf"),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MemorySegment printfAddr = abi.defaultLookup().find("printf").get();
+        final static MemorySegment printfAddr = ABI.defaultLookup().findOrThrow("printf");
 
         final static FunctionDescriptor printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
 
@@ -225,7 +236,7 @@ public class StdLibTest extends NativeTestHelper {
             }
         }
 
-        static class Tm {
+        static final class Tm {
 
             //Tm pointer should never be freed directly, as it points to shared memory
             private final MemorySegment base;
@@ -282,7 +293,7 @@ public class StdLibTest extends NativeTestHelper {
                 MemorySegment nativeArr = arena.allocateFrom(C_INT, arr);
 
                 //call qsort
-                MemorySegment qsortUpcallStub = abi.upcallStub(qsortCompar, qsortComparFunction, arena);
+                MemorySegment qsortUpcallStub = ABI.upcallStub(qsortCompar, qsortComparFunction, arena);
 
                 // both of these fit in an int
                 // automatically widen them to long on x64
@@ -322,7 +333,7 @@ public class StdLibTest extends NativeTestHelper {
                 variadicLayouts.add(arg.layout);
             }
             Linker.Option varargIndex = Linker.Option.firstVariadicArg(fd.argumentLayouts().size());
-            MethodHandle mh = abi.downcallHandle(printfAddr,
+            MethodHandle mh = ABI.downcallHandle(printfAddr,
                     fd.appendArgumentLayouts(variadicLayouts.toArray(new MemoryLayout[args.size()])),
                     varargIndex);
             return mh.asSpreader(1, Object[].class, args.size());
@@ -331,47 +342,36 @@ public class StdLibTest extends NativeTestHelper {
 
     /*** data providers ***/
 
-    @DataProvider
-    public static Object[][] ints() {
+    static Stream<Arguments> ints() {
         return perms(0, new Integer[] { 0, 1, 2, 3, 4 }).stream()
-                .map(l -> new Object[] { l })
-                .toArray(Object[][]::new);
+                .map(Arguments::of);
+   }
+
+    static Stream<Arguments> strings() {
+        return strings0()
+                .map(Arguments::of);
     }
 
-    @DataProvider
-    public static Object[][] strings() {
+    static Stream<Arguments> stringPairs() {
+        return strings0()
+                .flatMap(s -> strings0()
+                        .map(s2 -> Arguments.of(s, s2)));
+    }
+
+    static Stream<String> strings0() {
         return perms(0, new String[] { "a", "b", "c" }).stream()
-                .map(l -> new Object[] { String.join("", l) })
-                .toArray(Object[][]::new);
+                .map(l -> String.join("", l));
     }
 
-    @DataProvider
-    public static Object[][] stringPairs() {
-        Object[][] strings = strings();
-        Object[][] stringPairs = new Object[strings.length * strings.length][];
-        int pos = 0;
-        for (Object[] s1 : strings) {
-            for (Object[] s2 : strings) {
-                stringPairs[pos++] = new Object[] { s1[0], s2[0] };
-            }
-        }
-        return stringPairs;
-    }
-
-    @DataProvider
-    public static Object[][] instants() {
+    static Stream<Arguments> instants() {
         Instant start = ZonedDateTime.of(LocalDateTime.parse("2017-01-01T00:00:00"), ZoneOffset.UTC).toInstant();
         Instant end = ZonedDateTime.of(LocalDateTime.parse("2017-12-31T00:00:00"), ZoneOffset.UTC).toInstant();
-        Object[][] instants = new Object[100][];
-        for (int i = 0 ; i < instants.length ; i++) {
-            Instant instant = start.plusSeconds((long)(Math.random() * (end.getEpochSecond() - start.getEpochSecond())));
-            instants[i] = new Object[] { instant };
-        }
-        return instants;
+        return IntStream.range(0, 100)
+                .mapToObj(i -> start.plusSeconds((long)(Math.random() * (end.getEpochSecond() - start.getEpochSecond()))))
+                .map(Arguments::of);
     }
 
-    @DataProvider
-    public static Object[][] printfArgs() {
+    static Stream<Arguments> printfArgs() {
         ArrayList<List<PrintfArg>> res = new ArrayList<>();
         List<List<PrintfArg>> perms = new ArrayList<>(perms(0, PrintfArg.values()));
         for (int i = 0 ; i < 100 ; i++) {
@@ -379,8 +379,7 @@ public class StdLibTest extends NativeTestHelper {
             res.addAll(perms);
         }
         return res.stream()
-                .map(l -> new Object[] { l })
-                .toArray(Object[][]::new);
+                .map(Arguments::of);
     }
 
     enum PrintfArg {

--- a/test/jdk/java/foreign/TestSegmentOffset.java
+++ b/test/jdk/java/foreign/TestSegmentOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,30 +23,32 @@
 
 /*
  * @test
- * @run testng TestSegmentOffset
+ * @run junit TestSegmentOffset
  */
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
-import org.testng.SkipException;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.IntFunction;
+import java.util.stream.Stream;
+
 import static java.lang.System.out;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class TestSegmentOffset {
+final class TestSegmentOffset {
 
-    @Test(dataProvider = "slices")
-    public void testOffset(SegmentSlice s1, SegmentSlice s2) {
-        if (s1.kind != s2.kind) {
-            throw new SkipException("Slices of different segment kinds");
-        }
+    @ParameterizedTest
+    @MethodSource("slices")
+    void testOffset(SegmentSlice s1, SegmentSlice s2) {
         if (s1.contains(s2)) {
             // check that a segment and its overlapping segment point to same elements
             long offset = s1.offset(s2);
@@ -72,7 +74,7 @@ public class TestSegmentOffset {
         }
     }
 
-    static class SegmentSlice {
+    final static class SegmentSlice {
 
         enum Kind {
             NATIVE(i -> Arena.ofAuto().allocate(i, 1)),
@@ -94,7 +96,7 @@ public class TestSegmentOffset {
         final int last;
         final MemorySegment segment;
 
-        public SegmentSlice(Kind kind, int first, int last, MemorySegment segment) {
+        SegmentSlice(Kind kind, int first, int last, MemorySegment segment) {
             this.kind = kind;
             this.first = first;
             this.last = last;
@@ -116,8 +118,8 @@ public class TestSegmentOffset {
         }
     }
 
-    @DataProvider(name = "slices")
-    static Object[][] slices() {
+
+    static Stream<Arguments> slices() {
         int[] sizes = { 16, 8, 4, 2, 1 };
         List<SegmentSlice> slices = new ArrayList<>();
         for (SegmentSlice.Kind kind : SegmentSlice.Kind.values()) {
@@ -134,12 +136,15 @@ public class TestSegmentOffset {
                 }
             }
         }
-        Object[][] sliceArray = new Object[slices.size() * slices.size()][];
+        SegmentSlice[][] sliceArray = new SegmentSlice[slices.size() * slices.size()][];
         for (int i = 0 ; i < slices.size() ; i++) {
             for (int j = 0 ; j < slices.size() ; j++) {
-                sliceArray[i * slices.size() + j] = new Object[] { slices.get(i), slices.get(j) };
+                sliceArray[i * slices.size() + j] = new SegmentSlice[] { slices.get(i), slices.get(j) };
             }
         }
-        return sliceArray;
+        return Arrays.stream(sliceArray)
+                // Only consider segment slices of the same kind
+                .filter(a -> a[0].kind == a[1].kind)
+                .map(Arguments::of);
     }
 }

--- a/test/jdk/java/foreign/TestSegmentOffset.java
+++ b/test/jdk/java/foreign/TestSegmentOffset.java
@@ -56,7 +56,7 @@ final class TestSegmentOffset {
                 out.format("testOffset s1:%s, s2:%s, offset:%d, i:%s\n", s1, s2, offset, i);
                 byte expected = s2.segment.get(JAVA_BYTE, i);
                 byte found = s1.segment.get(JAVA_BYTE, i + offset);
-                assertEquals(found, expected);
+                assertEquals(expected, found);
             }
         } else if (!s2.contains(s1)) {
             // disjoint segments - check that offset is out of bounds


### PR DESCRIPTION
This PR proposes to increase the timeout for `StdLibTest` as it might be slow under certain conditions (e.g., using a zero linker). The PR also proposes to convert the test to junit.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
