### PR TITLE
8382427: C2: compiler/vectorapi/TestVectorAddMulReduction.java segfaults in compiled code with COH and stress flags

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2993,17 +2993,17 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       // Find surviving projection
       assert(iff->is_If(), "");
       ProjNode* dp = ((IfNode*)iff)->proj_out(1-flip);
-      // Find loads off the surviving projection; remove their control edge
-      for (DUIterator_Fast imax, i = dp->fast_outs(imax); i < imax; i++) {
-        Node* cd = dp->fast_out(i); // Control-dependent node
-        if (cd->is_Load() && cd->depends_only_on_test()) {   // Loads can now float around in the loop
-          // Allow the load to float around in the loop, or before it
-          // but NOT before the pre-loop.
-          _igvn.replace_input_of(cd, 0, ctrl); // ctrl, not null
-          --i;
-          --imax;
-        }
-      }
+      // Note: we intentionally do NOT relax the control edges of loads
+      // off the surviving projection here. Previously, their control was
+      // set to the loop entry (above predicates) to allow them to float
+      // for better scheduling. However, after loop transformations like
+      // peeling and unrolling, this allows loads to be scheduled above
+      // predicate guards, causing out-of-bounds array accesses (see
+      // JDK-8382427). Instead, we leave the loads' control at the
+      // surviving projection. When IGVN later folds the constant-
+      // condition If, the loads will naturally get a control within the
+      // loop body, which still allows scheduling flexibility within the
+      // loop but prevents floating above guards.
     } // End of is IF
   }
   if (loop_entry != cl->skip_strip_mined()->in(LoopNode::EntryControl)) {


### PR DESCRIPTION
WIP



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382427](https://bugs.openjdk.org/browse/JDK-8382427): C2: compiler/vectorapi/TestVectorAddMulReduction.java segfaults in compiled code with COH and stress flags (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30845/head:pull/30845` \
`$ git checkout pull/30845`

Update a local copy of the PR: \
`$ git checkout pull/30845` \
`$ git pull https://git.openjdk.org/jdk.git pull/30845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30845`

View PR using the GUI difftool: \
`$ git pr show -t 30845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30845.diff">https://git.openjdk.org/jdk/pull/30845.diff</a>

</details>
