### PR TITLE
8382620: G1: Remove unused G1RefineRegionClosure::_num_collections_at_start

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.cpp
@@ -35,8 +35,6 @@ class G1RefineRegionClosure : public G1HeapRegionClosure {
 
   uint _worker_id;
 
-  size_t _num_collections_at_start;
-
   bool has_work(G1HeapRegion* r) {
     return _scan_state->has_unclaimed_cards(r->hrm_index());
   }


### PR DESCRIPTION
Trivial removing dead code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382620](https://bugs.openjdk.org/browse/JDK-8382620): G1: Remove unused G1RefineRegionClosure::_num_collections_at_start (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30846/head:pull/30846` \
`$ git checkout pull/30846`

Update a local copy of the PR: \
`$ git checkout pull/30846` \
`$ git pull https://git.openjdk.org/jdk.git pull/30846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30846`

View PR using the GUI difftool: \
`$ git pr show -t 30846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30846.diff">https://git.openjdk.org/jdk/pull/30846.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30846#issuecomment-4288555108)
</details>
