### PR TITLE
8350971: C2: assert(idx == alias_idx) failed: Following Phi nodes should be on the same memory slice

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4855,6 +4855,8 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
     // push user on appropriate worklist
     for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
       Node *use = n->fast_out(i);
+      // Push user memory phis on the orig_phis worklist to update
+      // during Phase 4 if needed.
       if (use->is_Phi() && (((uint) _compile->get_alias_index(use->as_Phi()->adr_type()) < new_index_start))) {
           orig_phis.append_if_missing(use->as_Phi());
       }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4793,12 +4793,14 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
     if (visited.test_set(n->_idx)) {
       continue;
     }
-    if (n->is_Phi() || n->is_ClearArray()) {
-      // Push memory phis on the orig_phis worklist to update
-      // during Phase 4 if needed.
-      if (n->is_Phi() && (((uint) _compile->get_alias_index(n->as_Phi()->adr_type()) < new_index_start))) {
-          orig_phis.append_if_missing(n->as_Phi());
+    if (n->is_Phi()) {
+      if ((uint) _compile->get_alias_index(n->as_Phi()->adr_type()) < new_index_start) {
+        // Push memory phis on the orig_phis worklist to update
+        // during Phase 4 if needed.
+        orig_phis.append_if_missing(n->as_Phi());
       }
+    } else if (n->is_ClearArray()) {
+     // we don't need to do anything, but the users must be pushed
     } else if (n->is_MemBar()) { // MemBar nodes
       if (!n->is_Initialize()) { // memory projections for Initialize pushed below (so we get to all their uses)
         // we don't need to do anything, but the users must be pushed

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4855,10 +4855,10 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
     // push user on appropriate worklist
     for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
       Node *use = n->fast_out(i);
-      if (use->is_Phi() || use->is_ClearArray()) {
-        if (use->is_Phi() && (((uint) _compile->get_alias_index(use->as_Phi()->adr_type()) < new_index_start))) {
+      if (use->is_Phi() && (((uint) _compile->get_alias_index(use->as_Phi()->adr_type()) < new_index_start))) {
           orig_phis.append_if_missing(use->as_Phi());
-        }
+      }
+      if (use->is_Phi() || use->is_ClearArray()) {
         memnode_worklist.append_if_missing(use);
       } else if (use->is_Mem() && use->in(MemNode::Memory) == n) {
         memnode_worklist.append_if_missing(use);

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4794,7 +4794,11 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       continue;
     }
     if (n->is_Phi() || n->is_ClearArray()) {
-      // we don't need to do anything, but the users must be pushed
+      // Push memory phis on the orig_phis worklist to update
+      // during Phase 4 if needed.
+      if (n->is_Phi() && (((uint) _compile->get_alias_index(n->as_Phi()->adr_type()) < new_index_start))) {
+          orig_phis.append_if_missing(n->as_Phi());
+      }
     } else if (n->is_MemBar()) { // MemBar nodes
       if (!n->is_Initialize()) { // memory projections for Initialize pushed below (so we get to all their uses)
         // we don't need to do anything, but the users must be pushed
@@ -4855,11 +4859,6 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
     // push user on appropriate worklist
     for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
       Node *use = n->fast_out(i);
-      // Push user memory phis on the orig_phis worklist to update
-      // during Phase 4 if needed.
-      if (use->is_Phi() && (((uint) _compile->get_alias_index(use->as_Phi()->adr_type()) < new_index_start))) {
-          orig_phis.append_if_missing(use->as_Phi());
-      }
       if (use->is_Phi() || use->is_ClearArray()) {
         memnode_worklist.append_if_missing(use);
       } else if (use->is_Mem() && use->in(MemNode::Memory) == n) {

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4856,6 +4856,9 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
     for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
       Node *use = n->fast_out(i);
       if (use->is_Phi() || use->is_ClearArray()) {
+        if (use->is_Phi() && (((uint) _compile->get_alias_index(use->as_Phi()->adr_type()) < new_index_start))) {
+          orig_phis.append_if_missing(use->as_Phi());
+        }
         memnode_worklist.append_if_missing(use);
       } else if (use->is_Mem() && use->in(MemNode::Memory) == n) {
         memnode_worklist.append_if_missing(use);

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestMemoryPhiAlias.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestMemoryPhiAlias.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8350971
+ * @summary C2 compilation fails with assert(idx == alias_idx) failed: Following Phi nodes should be on the same memory slice
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch -XX:CompileCommand=compileonly,compiler.escapeAnalysis.TestMemoryPhiAlias::main
+ *                   compiler.escapeAnalysis.TestMemoryPhiAlias
+ */
+
+package compiler.escapeAnalysis;
+
+import java.util.function.*;
+
+public class TestMemoryPhiAlias {
+    static int[] iArrFld = new int[400];
+    static int counter = 0;
+    static int doWork() {
+        int[] more = {94};
+        java.util.function.Predicate<Integer> check = m -> m == 0;
+        java.util.function.IntConsumer decrement = x -> more[0]--;
+        java.util.function.BooleanSupplier innerLoop = () -> {
+            while (!check.test(more[0])) {
+                decrement.accept(0);
+            }
+            return true;
+        };
+        counter++;
+        if (counter == 10000000) {
+            throw new RuntimeException("excepted");
+        }
+        innerLoop.getAsBoolean();
+        java.util.function.BooleanSupplier process = () -> check.test(more[0]);
+        while (!process.getAsBoolean()) {
+        }
+        return 0;
+    }
+
+    public static void main(String[] strArr) {
+        int i14 = 1;
+        do {
+            iArrFld[i14] = 211;
+            for (int i15 = 1; i15 < 4; ++i15)
+                try {
+                    TestMemoryPhiAlias.doWork();
+                } catch (RuntimeException e) {
+                    return;
+                }
+        } while (i14 < 5);
+    }
+}


### PR DESCRIPTION
**Issue:**
The assert in `move_inst_mem` happens because a Phi node takes as input a Store while they belong to different memory slices. The issue here is that during `ConnectionGraph::split_unique_types`, this Phi should have been split into separate Phis such that each Phi only merges inputs from a single memory slice.

**Analysis**
The method `split_unique_types `converts the types of non-escaped objects to instance types. This transformation is performed in four phases, with memory Phis handled in phases 2 and 4. While processing memory nodes from `memnode_list` in phase 2, if a Phi is encountered, no transformation is performed but its uses are added to the `memnode_list`. For certain memory nodes, such as Store, `split_unique_types` calls `find_inst_mem`. The` find_inst_mem `method starts from a memory node and walks backward along the memory chain to compute a new address type. If it encounters a Phi, the Phi is either split to create a new version or added to the `orig_phis` list which is be handled later. Phase 4 of `split_unique_types` processes all Phis in `orig_phis` by calling `find_inst_mem`.

In this issue, `1833 Phi` and `963 StoreI` belong to different memory slices. However, `1833 Phi` takes `963 StoreI `as an input. `1833 Phi `has only one output, which is `1863 Phi`, and this `1863 Phi`, in turn, has only one output which is the original `1833 Phi`. The two Phis form a cycle and are not reached during the traversal in `split_unique_types `and `find_inst_mem `used to identify Phi nodes that require splitting.

**Solution**
@merykitty  suggested in the JBS that we aggressively eliminate the nodes in the self connected cycle. This solution will definitely work for this case. However, for the sake of completeness, my proposal in this PR is to add the Phi to the `orig_phis` list when it is encountered as a use of a memory node during Phase 2, and then let `find_inst_mem` handle the rest.


**Question to reviewers**
Please let me know if this fix is acceptable or if I should adopt @merykitty's initial proposal. Happy to revise the change accordingly.

Thank you @merykitty  for the initial analysis and solution.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8350971](https://bugs.openjdk.org/browse/JDK-8350971): C2: assert(idx == alias_idx) failed: Following Phi nodes should be on the same memory slice (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30849/head:pull/30849` \
`$ git checkout pull/30849`

Update a local copy of the PR: \
`$ git checkout pull/30849` \
`$ git pull https://git.openjdk.org/jdk.git pull/30849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30849`

View PR using the GUI difftool: \
`$ git pr show -t 30849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30849.diff">https://git.openjdk.org/jdk/pull/30849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30849#issuecomment-4294606338)
</details>
