### PR TITLE
8382617: Test runtime/cds/appcds/aotCache/AOTCacheConsistency.java fails with "can't find HelloWorld in test directory or libraries"

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheConsistency.java
@@ -28,7 +28,7 @@
  * @summary AOTCacheConsistency This test checks that there is a CRC validation of the AOT Cache regions.
  * @bug 8382166
  * @requires vm.cds.supports.aot.class.linking
- * @library /test/lib
+ * @library /test/lib /test/setup_aot
  * @build jdk.test.whitebox.WhiteBox AOTCacheConsistency HelloWorld
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar HelloWorld


### PR DESCRIPTION
The test from https://github.com/openjdk/jdk/pull/30720 was missing a library and that made it fail. This fixes it.

Fixes: https://bugs.openjdk.org/browse/JDK-8382617

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382617](https://bugs.openjdk.org/browse/JDK-8382617): Test runtime/cds/appcds/aotCache/AOTCacheConsistency.java fails with "can't find HelloWorld in test directory or libraries" (**Bug** - P3)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30852/head:pull/30852` \
`$ git checkout pull/30852`

Update a local copy of the PR: \
`$ git checkout pull/30852` \
`$ git pull https://git.openjdk.org/jdk.git pull/30852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30852`

View PR using the GUI difftool: \
`$ git pr show -t 30852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30852.diff">https://git.openjdk.org/jdk/pull/30852.diff</a>

</details>
