### PR TITLE
8382634: Remove redundant TLABRefillWasteFraction zero check

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -58,7 +58,11 @@ ThreadLocalAllocBuffer::ThreadLocalAllocBuffer() :
   // do nothing. TLABs must be inited by initialize() calls
 }
 
-size_t ThreadLocalAllocBuffer::initial_refill_waste_limit()     { return desired_size() / TLABRefillWasteFraction; }
+size_t ThreadLocalAllocBuffer::initial_refill_waste_limit() {
+  assert(TLABRefillWasteFraction != 0, "inv");
+  return desired_size() / TLABRefillWasteFraction;
+}
+
 size_t ThreadLocalAllocBuffer::min_size()                       { return align_object_size(MinTLABSize / HeapWordSize) + alignment_reserve(); }
 size_t ThreadLocalAllocBuffer::refill_waste_limit_increment()   { return TLABWasteIncrement; }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1810,14 +1810,6 @@ bool Arguments::check_vm_args_consistency() {
   // Note: Needs platform-dependent factoring.
   bool status = true;
 
-  if (TLABRefillWasteFraction == 0) {
-    jio_fprintf(defaultStream::error_stream(),
-                "TLABRefillWasteFraction should be a denominator, "
-                "not %zu\n",
-                TLABRefillWasteFraction);
-    status = false;
-  }
-
   status = CompilerConfig::check_args_consistency(status);
 #if INCLUDE_JVMCI
   if (status && EnableJVMCI) {


### PR DESCRIPTION
Remove redundant zero-checking of `TLABRefillWasteFraction` -- already covered by `range(1,...)` in its declaration.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382634](https://bugs.openjdk.org/browse/JDK-8382634): Remove redundant TLABRefillWasteFraction zero check (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30855/head:pull/30855` \
`$ git checkout pull/30855`

Update a local copy of the PR: \
`$ git checkout pull/30855` \
`$ git pull https://git.openjdk.org/jdk.git pull/30855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30855`

View PR using the GUI difftool: \
`$ git pr show -t 30855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30855.diff">https://git.openjdk.org/jdk/pull/30855.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30855#issuecomment-4290052722)
</details>
