### PR TITLE
8378894: AOT training run crashes with jcmd VM.native_memory

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1464,14 +1464,14 @@ size_t FileMapInfo::read_bytes(void* buffer, size_t count) {
   return count;
 }
 
-// Get the total size in bytes of a read only region
+// Get the total size in bytes of all mapped read only region
 size_t FileMapInfo::readonly_total() {
   size_t total = 0;
-  if (current_info() != nullptr) {
+  if (current_info() != nullptr && current_info()->is_mapped()) {
     FileMapRegion* r = FileMapInfo::current_info()->region_at(AOTMetaspace::ro);
     if (r->read_only()) total += r->used();
   }
-  if (dynamic_info() != nullptr) {
+  if (dynamic_info() != nullptr && current_info()->is_mapped()) {
     FileMapRegion* r = FileMapInfo::dynamic_info()->region_at(AOTMetaspace::ro);
     if (r->read_only()) total += r->used();
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, Microsoft, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8378894
+ * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.cds.write.archived.java.heap
+ * @summary Test the use of jcmd on a JVM process that's running in AOT training mode.
+ * @library /test/lib
+ * @build JcmdOnTrainingProcess
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar LingeredApp.jar
+ *              jdk/test/lib/apps/LingeredApp
+ *              jdk/test/lib/apps/LingeredApp$1
+ *              jdk/test/lib/apps/LingeredApp$SteadyStateLock
+ *              jdk/test/lib/process/OutputBuffer
+ * @run driver JcmdOnTrainingProcess
+ */
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+import java.io.IOException;
+
+public class JcmdOnTrainingProcess {
+    public static void main(String[] args) throws Exception {
+        test_VM_native_memory();
+        // Add other test cases here if needed in the future.
+    }
+
+    static void test_VM_native_memory() throws Exception {
+        // In training run, we should not map any read-only regions.
+        OutputAnalyzer out = runJcmdOnTrainingProcess("VM.native_memory");
+        out.shouldMatch("Shared class space .* readonly=0KB");
+    }
+
+    static OutputAnalyzer runJcmdOnTrainingProcess(String... cmds) throws Exception {
+        LingeredApp theApp = null;
+        try {
+            theApp = new LingeredApp();
+            theApp.setUseDefaultClasspath(false);
+            LingeredApp.startApp(theApp,
+                                 "-cp", "LingeredApp.jar",
+                                 "-XX:AOTMode=record",
+                                 "-XX:AOTConfiguration=LingeredApp.aotconfig");
+            long pid = theApp.getPid();
+
+            JDKToolLauncher jcmd = JDKToolLauncher.createUsingTestJDK("jcmd");
+            jcmd.addToolArg(String.valueOf(pid));
+            for (String cmd : cmds) {
+                jcmd.addToolArg(cmd);
+            }
+
+            try {
+                OutputAnalyzer output = ProcessTools.executeProcess(jcmd.getCommand());
+                output.shouldHaveExitValue(0);
+                return output;
+            } catch (Exception e) {
+                throw new RuntimeException("Test failed: " + e);
+            }        }
+        catch (IOException e) {
+            throw new RuntimeException("Test failed: " + e);
+        }
+        finally {
+            LingeredApp.stopApp(theApp);
+        }
+    }
+}


### PR DESCRIPTION
Please review this simple fix.

In AOT training mode, `FileMapInfo::current_info()` is non-null but it doesn't contain any mapped regions, so we need to check for this condition before querying the `AOTMetaspace::ro` region.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378894](https://bugs.openjdk.org/browse/JDK-8378894): AOT training run crashes with jcmd VM.native_memory (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30858/head:pull/30858` \
`$ git checkout pull/30858`

Update a local copy of the PR: \
`$ git checkout pull/30858` \
`$ git pull https://git.openjdk.org/jdk.git pull/30858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30858`

View PR using the GUI difftool: \
`$ git pr show -t 30858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30858.diff">https://git.openjdk.org/jdk/pull/30858.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30858#issuecomment-4290991355)
</details>
