### PR TITLE
8376626: Shenandoah: Remove command line options for setting min and max region sizes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -207,6 +207,7 @@ void ShenandoahArguments::initialize() {
 }
 
 size_t ShenandoahArguments::conservative_max_heap_alignment() {
+  static_assert(is_power_of_2(ShenandoahHeapRegion::MAX_REGION_SIZE), "Max region size must be a power of 2.");
   size_t align = next_power_of_2(ShenandoahHeapRegion::MAX_REGION_SIZE);
   if (UseLargePages) {
     align = MAX2(align, os::large_page_size());

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -207,7 +207,7 @@ void ShenandoahArguments::initialize() {
 }
 
 size_t ShenandoahArguments::conservative_max_heap_alignment() {
-  size_t align = next_power_of_2(ShenandoahMaxRegionSize);
+  size_t align = next_power_of_2(ShenandoahHeapRegion::MAX_REGION_SIZE);
   if (UseLargePages) {
     align = MAX2(align, os::large_page_size());
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -208,7 +208,7 @@ void ShenandoahArguments::initialize() {
 
 size_t ShenandoahArguments::conservative_max_heap_alignment() {
   static_assert(is_power_of_2(ShenandoahHeapRegion::MAX_REGION_SIZE), "Max region size must be a power of 2.");
-  size_t align = next_power_of_2(ShenandoahHeapRegion::MAX_REGION_SIZE);
+  size_t align = ShenandoahHeapRegion::MAX_REGION_SIZE;
   if (UseLargePages) {
     align = MAX2(align, os::large_page_size());
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -671,10 +671,6 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
   // Absolute minimums we should not ever break.
   static const size_t MIN_REGION_SIZE = 256*K;
 
-  if (FLAG_IS_DEFAULT(ShenandoahMinRegionSize)) {
-    FLAG_SET_DEFAULT(ShenandoahMinRegionSize, MIN_REGION_SIZE);
-  }
-
   // Generational Shenandoah needs this alignment for card tables.
   if (strcmp(ShenandoahGCMode, "generational") == 0) {
     max_heap_size = align_up(max_heap_size , CardTable::ct_max_alignment_constraint());
@@ -682,47 +678,13 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
 
   size_t region_size;
   if (FLAG_IS_DEFAULT(ShenandoahRegionSize)) {
-    if (ShenandoahMinRegionSize > max_heap_size / MIN_NUM_REGIONS) {
-      err_msg message("Max heap size (%zu%s) is too low to afford the minimum number "
-                      "of regions (%zu) of minimum region size (%zu%s).",
-                      byte_size_in_proper_unit(max_heap_size), proper_unit_for_byte_size(max_heap_size),
-                      MIN_NUM_REGIONS,
-                      byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize));
-      vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize option", message);
-    }
-    if (ShenandoahMinRegionSize < MIN_REGION_SIZE) {
-      err_msg message("%zu%s should not be lower than minimum region size (%zu%s).",
-                      byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize),
-                      byte_size_in_proper_unit(MIN_REGION_SIZE),         proper_unit_for_byte_size(MIN_REGION_SIZE));
-      vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize option", message);
-    }
-    if (ShenandoahMinRegionSize < MinTLABSize) {
-      err_msg message("%zu%s should not be lower than TLAB size size (%zu%s).",
-                      byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize),
-                      byte_size_in_proper_unit(MinTLABSize),             proper_unit_for_byte_size(MinTLABSize));
-      vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize option", message);
-    }
-    if (ShenandoahMaxRegionSize < MIN_REGION_SIZE) {
-      err_msg message("%zu%s should not be lower than min region size (%zu%s).",
-                      byte_size_in_proper_unit(ShenandoahMaxRegionSize), proper_unit_for_byte_size(ShenandoahMaxRegionSize),
-                      byte_size_in_proper_unit(MIN_REGION_SIZE),         proper_unit_for_byte_size(MIN_REGION_SIZE));
-      vm_exit_during_initialization("Invalid -XX:ShenandoahMaxRegionSize option", message);
-    }
-    if (ShenandoahMinRegionSize > ShenandoahMaxRegionSize) {
-      err_msg message("Minimum (%zu%s) should be larger than maximum (%zu%s).",
-                      byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize),
-                      byte_size_in_proper_unit(ShenandoahMaxRegionSize), proper_unit_for_byte_size(ShenandoahMaxRegionSize));
-      vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize or -XX:ShenandoahMaxRegionSize", message);
-    }
-
     // We rapidly expand to max_heap_size in most scenarios, so that is the measure
     // for usual heap sizes. Do not depend on initial_heap_size here.
     region_size = max_heap_size / ShenandoahTargetNumRegions;
 
     // Now make sure that we don't go over or under our limits.
-    region_size = MAX2(ShenandoahMinRegionSize, region_size);
-    region_size = MIN2(ShenandoahMaxRegionSize, region_size);
-
+    region_size = MAX2(MIN_REGION_SIZE, region_size);
+    region_size = MIN2(MAX_REGION_SIZE, region_size);
   } else {
     if (ShenandoahRegionSize > max_heap_size / MIN_NUM_REGIONS) {
       err_msg message("Max heap size (%zu%s) is too low to afford the minimum number "
@@ -732,16 +694,16 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
                       byte_size_in_proper_unit(ShenandoahRegionSize), proper_unit_for_byte_size(ShenandoahRegionSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahRegionSize option", message);
     }
-    if (ShenandoahRegionSize < ShenandoahMinRegionSize) {
+    if (ShenandoahRegionSize < MIN_REGION_SIZE) {
       err_msg message("Heap region size (%zu%s) should be larger than min region size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahRegionSize), proper_unit_for_byte_size(ShenandoahRegionSize),
-                      byte_size_in_proper_unit(ShenandoahMinRegionSize),  proper_unit_for_byte_size(ShenandoahMinRegionSize));
+                      byte_size_in_proper_unit(MIN_REGION_SIZE),  proper_unit_for_byte_size(MIN_REGION_SIZE));
       vm_exit_during_initialization("Invalid -XX:ShenandoahRegionSize option", message);
     }
-    if (ShenandoahRegionSize > ShenandoahMaxRegionSize) {
+    if (ShenandoahRegionSize > MAX_REGION_SIZE) {
       err_msg message("Heap region size (%zu%s) should be lower than max region size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahRegionSize), proper_unit_for_byte_size(ShenandoahRegionSize),
-                      byte_size_in_proper_unit(ShenandoahMaxRegionSize),  proper_unit_for_byte_size(ShenandoahMaxRegionSize));
+                      byte_size_in_proper_unit(MAX_REGION_SIZE),  proper_unit_for_byte_size(MAX_REGION_SIZE));
       vm_exit_during_initialization("Invalid -XX:ShenandoahRegionSize option", message);
     }
     region_size = ShenandoahRegionSize;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -668,9 +668,6 @@ size_t ShenandoahHeapRegion::block_size(const HeapWord* p) const {
 }
 
 size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
-  // Absolute minimums we should not ever break.
-  static const size_t MIN_REGION_SIZE = 256*K;
-
   // Generational Shenandoah needs this alignment for card tables.
   if (strcmp(ShenandoahGCMode, "generational") == 0) {
     max_heap_size = align_up(max_heap_size , CardTable::ct_max_alignment_constraint());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -276,7 +276,7 @@ private:
 
 public:
   ShenandoahHeapRegion(HeapWord* start, size_t index, bool committed);
-  
+
   // Absolute minimums and maximums we should not ever break.
   static const size_t MIN_NUM_REGIONS = 10;
   static const size_t MIN_REGION_SIZE = 256*K;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -278,6 +278,7 @@ public:
   ShenandoahHeapRegion(HeapWord* start, size_t index, bool committed);
 
   static const size_t MIN_NUM_REGIONS = 10;
+  static const size_t MAX_REGION_SIZE = 32*M;
 
   // Return adjusted max heap size
   static size_t setup_sizes(size_t max_heap_size);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -276,8 +276,9 @@ private:
 
 public:
   ShenandoahHeapRegion(HeapWord* start, size_t index, bool committed);
-
+  // Absolute minimums and maximums we should not ever break.
   static const size_t MIN_NUM_REGIONS = 10;
+  static const size_t MIN_REGION_SIZE = 256*K;
   static const size_t MAX_REGION_SIZE = 32*M;
 
   // Return adjusted max heap size

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -276,6 +276,7 @@ private:
 
 public:
   ShenandoahHeapRegion(HeapWord* start, size_t index, bool committed);
+  
   // Absolute minimums and maximums we should not ever break.
   static const size_t MIN_NUM_REGIONS = 10;
   static const size_t MIN_REGION_SIZE = 256*K;

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -196,14 +196,6 @@
           "of regions that would be used, within min/max region size "      \
           "limits.")                                                        \
                                                                             \
-  product(size_t, ShenandoahMinRegionSize, 256 * K, EXPERIMENTAL,           \
-          "With automatic region sizing, the regions would be at least "    \
-          "this large.")                                                    \
-                                                                            \
-  product(size_t, ShenandoahMaxRegionSize, 32 * M, EXPERIMENTAL,            \
-          "With automatic region sizing, the regions would be at most "     \
-          "this large.")                                                    \
-                                                                            \
   product(ccstr, ShenandoahGCMode, "satb",                                  \
           "GC mode to use.  Among other things, this defines which "        \
           "barriers are in in use. Possible values are:"                    \

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestRegionSizeArgs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestRegionSizeArgs.java
@@ -38,8 +38,6 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestRegionSizeArgs {
     public static void main(String[] args) throws Exception {
         testInvalidRegionSizes();
-        testMinRegionSize();
-        testMaxRegionSize();
     }
 
     private static void testInvalidRegionSizes() throws Exception {
@@ -143,90 +141,6 @@ public class TestRegionSizeArgs {
                     "-XX:ShenandoahRegionSize=128K",
                     "-version");
             output.shouldMatch("Invalid -XX:ShenandoahRegionSize option");
-            output.shouldHaveExitValue(1);
-        }
-    }
-
-    private static void testMinRegionSize() throws Exception {
-
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMinRegionSize=255K",
-                    "-version");
-            output.shouldMatch("Invalid -XX:ShenandoahMinRegionSize option");
-            output.shouldHaveExitValue(1);
-        }
-
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMinRegionSize=1M",
-                    "-XX:ShenandoahMaxRegionSize=260K",
-                    "-version");
-            output.shouldMatch("Invalid -XX:ShenandoahMinRegionSize or -XX:ShenandoahMaxRegionSize");
-            output.shouldHaveExitValue(1);
-        }
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMinRegionSize=200m",
-                    "-version");
-            output.shouldMatch("Invalid -XX:ShenandoahMinRegionSize option");
-            output.shouldHaveExitValue(1);
-        }
-
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMinRegionSize=9m",
-                    "-version");
-            output.shouldHaveExitValue(0);
-        }
-
-        // This used to assert that _conservative_max_heap_alignment is not a power-of-2.
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMaxRegionSize=33m",
-                    "-version");
-            output.shouldHaveExitValue(0);
-        }
-
-    }
-
-    private static void testMaxRegionSize() throws Exception {
-
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMaxRegionSize=255K",
-                    "-version");
-            output.shouldMatch("Invalid -XX:ShenandoahMaxRegionSize option");
-            output.shouldHaveExitValue(1);
-        }
-
-        {
-            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UnlockExperimentalVMOptions",
-                    "-XX:+UseShenandoahGC",
-                    "-Xms100m",
-                    "-Xmx1g",
-                    "-XX:ShenandoahMinRegionSize=1M",
-                    "-XX:ShenandoahMaxRegionSize=260K",
-                    "-version");
-            output.shouldMatch("Invalid -XX:ShenandoahMinRegionSize or -XX:ShenandoahMaxRegionSize");
             output.shouldHaveExitValue(1);
         }
     }


### PR DESCRIPTION
Removed `ShenandoahMinRegionSize` and `ShenandoahMaxRegionSize` command line options.

### Testing:
- GHA 
- hotspot/jtreg/gc/shenandoah tests using Linux x86_64 server release and fastdebug.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376626](https://bugs.openjdk.org/browse/JDK-8376626): Shenandoah: Remove command line options for setting min and max region sizes (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30860/head:pull/30860` \
`$ git checkout pull/30860`

Update a local copy of the PR: \
`$ git checkout pull/30860` \
`$ git pull https://git.openjdk.org/jdk.git pull/30860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30860`

View PR using the GUI difftool: \
`$ git pr show -t 30860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30860.diff">https://git.openjdk.org/jdk/pull/30860.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30860#issuecomment-4297629443)
</details>
