### PR TITLE
8382433: GenShen: Remembered set scan encountered invalid object

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -91,19 +91,6 @@ void ShenandoahGenerationalHeuristics::choose_collection_set_from_regiondata(She
     heap->shenandoah_policy()->record_mixed_cycle();
   }
 
-  if (_generation->is_global()) {
-    // We have just chosen a collection set for a global cycle. The mark bitmap covering old regions is complete, so
-    // the remembered set scan can use that to avoid walking into garbage. When the next old mark begins, we will
-    // use the mark bitmap to make the old regions parsable by coalescing and filling any unmarked objects. Thus,
-    // we prepare for old collections by remembering which regions are old at this time. Note that any objects
-    // promoted into old regions will be above TAMS, and so will be considered marked. However, free regions that
-    // become old after this point will not be covered correctly by the mark bitmap, so we must be careful not to
-    // coalesce those regions. Only the old regions which are not part of the collection set at this point are
-    // eligible for coalescing. As implemented now, this has the side effect of possibly initiating mixed-evacuations
-    // after a global cycle for old regions that were not included in this collection set.
-    heap->old_generation()->transition_old_generation_after_global_gc();
-  }
-
   ShenandoahTracer::report_promotion_info(collection_set,
                                           in_place_promotions.humongous_region_stats().count,
                                           in_place_promotions.humongous_region_stats().garbage,

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -294,8 +294,20 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
     ShenandoahHeapLocker locker(heap->lock());
     heap->assert_pinned_region_status(this);
     _heuristics->choose_collection_set(collection_set);
-  }
 
+    if (is_generational && is_global()) {
+      // We have finished marking the entire heap. The mark bitmap covering old regions is complete, so
+      // the remembered set scan can use that to avoid walking into garbage. When the next old mark begins, we will
+      // use the mark bitmap to make the old regions parsable by coalescing and filling any unmarked objects. Thus,
+      // we prepare for old collections by remembering which regions are old at this time. Note that any objects
+      // promoted into old regions will be above TAMS, and so will be considered marked. However, free regions that
+      // become old after this point will not be covered correctly by the mark bitmap, so we must be careful not to
+      // coalesce those regions. Only the old regions which are not part of the collection set at this point are
+      // eligible for coalescing. As implemented now, this has the side effect of possibly initiating mixed-evacuations
+      // after a global cycle for old regions that were not included in this collection set.
+      heap->old_generation()->transition_old_generation_after_global_gc();
+    }
+  }
 
   {
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::final_rebuild_freeset :

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2285,6 +2285,11 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
   }
   // Resize and verify metaspace
   MetaspaceGC::compute_new_size();
+
+  if (mode()->is_generational()) {
+    old_generation()->set_parsable(false);
+  }
+
   DEBUG_ONLY(MetaspaceUtils::verify();)
 }
 


### PR DESCRIPTION
This fix: https://github.com/openjdk/jdk/pull/30543 was unwittingly undone by this refactoring: https://github.com/openjdk/jdk/pull/30571. In this change, transitioning the old generation state machine is decoupled from choosing the collection set. Updating the old generation state is really done because final mark for the entire heap is completed.

While debugging this, I discovered a confounding factor in that when classes are unloaded during a safepoint it does not mark the old generation as unparsable (as it does for concurrent class unloading). This is not strictly necessary for a full GC, because rebuilding the remembered set at the end of the full gc makes the old generation parsable again. However, a global degenerated cycle did _not_ mark the old generation as unparsable, also resulting in the coalesce and fill step to be skipped. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382433](https://bugs.openjdk.org/browse/JDK-8382433): GenShen: Remembered set scan encountered invalid object (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30861/head:pull/30861` \
`$ git checkout pull/30861`

Update a local copy of the PR: \
`$ git checkout pull/30861` \
`$ git pull https://git.openjdk.org/jdk.git pull/30861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30861`

View PR using the GUI difftool: \
`$ git pr show -t 30861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30861.diff">https://git.openjdk.org/jdk/pull/30861.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30861#issuecomment-4291849886)
</details>
