### PR TITLE
8382691: RISC-V: Clean up redundant restore_locals() in TemplateTable::invokeinterface

### DIFF
--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3389,7 +3389,6 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ bind(notVFinal);
 
   // Get receiver klass into x13
-  __ restore_locals();
   __ load_klass(x13, x12);
 
   Label no_such_method;


### PR DESCRIPTION
Hi, please consider removing the redundant restore_locals() call in TemplateTable::invokeinterface() on AArch64 and RISC-V architectures. On x86 architectures, this call is necessary because the implementation explicitly uses rlocals (r14) as a temporary register throughout the invokeinterface handler and modifies it prior to this point. However, on AArch64 and RISC-V architectures, the local registers (rlocals/xlocals) remain unchanged prior to this, so the restore_locals call is redundant.

### Testing
- [x] tier1 tests on SOPHON SG2042 (fastdebug)



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382691](https://bugs.openjdk.org/browse/JDK-8382691): RISC-V: Clean up redundant restore_locals() in TemplateTable::invokeinterface (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30865/head:pull/30865` \
`$ git checkout pull/30865`

Update a local copy of the PR: \
`$ git checkout pull/30865` \
`$ git pull https://git.openjdk.org/jdk.git pull/30865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30865`

View PR using the GUI difftool: \
`$ git pr show -t 30865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30865.diff">https://git.openjdk.org/jdk/pull/30865.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30865#issuecomment-4292774945)
</details>
