### PR TITLE
8316465: 10 nsk debugger tests ignore VM flags while starting debugee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@
  *     - debuggee wrapper is used to handle VMStartEvent
  * ================================================
  *
+ * @requires vm.flagless
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdi.Argument.value.value003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Argument/value/value004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@
  *     4778296 TEST_BUG: debuggee VM intemittently hangs after resuming
  *     - debuggee wrapper is used to handle VMStartEvent
  *
+ * @requires vm.flagless
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdi.Argument.value.value004

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn010/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  *      -waittime=5
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
- *      -debugee.vmkeys="-XX:+Inline"
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts} -XX:+Inline"
  *      -inlineType INLINE_METHOD_RETURNING_CONST
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn011/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  *      -waittime=5
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
- *      -debugee.vmkeys="-XX:+Inline"
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts} -XX:+Inline"
  *      -inlineType INLINE_METHOD_ACCESSIN_INTERNAL_FIELDS
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn012/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@
  *      -waittime=5
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
- *      -debugee.vmkeys="-XX:+Inline"
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts} -XX:+Inline"
  *      -inlineType INLINE_HOT_METHOD
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitorsAndFrames/ownedMonitorsAndFrames008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitorsAndFrames/ownedMonitorsAndFrames008/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@
  *      -waittime=5
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
- *      -debugee.vmkeys="-Xmixed
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts} -Xmixed
  *      -XX:CompileThreshold=2"
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jdi/breakpoint/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jdi/breakpoint/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  *      -transport.address=dynamic
  *      -debugger.debuggeeClass vm.mlvm.share.jdi.IndyDebuggee
  */

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jdi/breakpointOtherStratum/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jdi/breakpointOtherStratum/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java
- *      -debugee.vmkeys="-cp ./bin/classes${path.separator}${test.class.path}"
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts} -cp ./bin/classes${path.separator}${test.class.path}"
  *      -transport.address=dynamic
  *      -debugger.debuggeeClass vm.mlvm.share.jdi.IndyDebuggee
  */

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/jdi/breakpoint/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/jdi/breakpoint/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  *      -transport.address=dynamic
  *      -debugger.debuggeeClass vm.mlvm.share.jdi.MHDebuggee
  */

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/jdi/breakpointOtherStratum/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/jdi/breakpointOtherStratum/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java
- *      -debugee.vmkeys="-cp ./bin/classes${path.separator}${test.class.path}"
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts} -cp ./bin/classes${path.separator}${test.class.path}"
  *      -transport.address=dynamic
  *      -debugger.debuggeeClass vm.mlvm.share.jdi.MHDebuggee
  */


### PR DESCRIPTION
Marked value003 and value004 as vm.flagless since they test the Argument.value() API. Added test.vm.opts/test.java.opts to debugee vmkeys for the remaining 8 tests

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316465](https://bugs.openjdk.org/browse/JDK-8316465): 10 nsk debugger tests ignore VM flags while starting debugee (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30866/head:pull/30866` \
`$ git checkout pull/30866`

Update a local copy of the PR: \
`$ git checkout pull/30866` \
`$ git pull https://git.openjdk.org/jdk.git pull/30866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30866`

View PR using the GUI difftool: \
`$ git pr show -t 30866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30866.diff">https://git.openjdk.org/jdk/pull/30866.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30866#issuecomment-4293140804)
</details>
