### PR TITLE
8379722: C2: assert that result is used for CallLeafPureNode in final graph reshaping

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3235,6 +3235,12 @@ void Compile::final_graph_reshaping_impl(Node *n, Final_Reshape_Counts& frc, Uni
       assert(mb->trailing_membar()->leading_membar() == mb, "bad membar pair");
     }
   }
+  if (n->is_CallLeafPure()) {
+    // A pure call whose result projection is unused should have been
+    // eliminated by CallLeafPureNode::Ideal during IGVN.
+    assert(n->as_CallLeafPure()->proj_out_or_null(TypeFunc::Parms) != nullptr,
+           "unused CallLeafPureNode should have been removed before final graph reshaping");
+  }
 #endif
   // Count FPU ops and common calls, implements item (3)
   bool gc_handled = BarrierSet::barrier_set()->barrier_set_c2()->final_graph_reshaping(this, n, nop, dead_nodes);


### PR DESCRIPTION
As suggested in https://github.com/openjdk/jdk/pull/30026#issuecomment-4030899348, add a debug-only assert in `Compile::final_graph_reshaping_impl` that fires if a `CallLeafPureNode` reaches final graph reshaping with its result projection (`TypeFunc::Parms`) unused. Such a node should have been removed by `CallLeafPureNode::Ideal` during IGVN

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379722](https://bugs.openjdk.org/browse/JDK-8379722): C2: assert that result is used for CallLeafPureNode in final graph reshaping (**Enhancement** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30867/head:pull/30867` \
`$ git checkout pull/30867`

Update a local copy of the PR: \
`$ git checkout pull/30867` \
`$ git pull https://git.openjdk.org/jdk.git pull/30867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30867`

View PR using the GUI difftool: \
`$ git pr show -t 30867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30867.diff">https://git.openjdk.org/jdk/pull/30867.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30867#issuecomment-4293192141)
</details>
