### PR TITLE
8316466: 8 com/sun/jdi tests ignore VM flags

### DIFF
--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,7 +202,8 @@ public class ClassUnloadEventTest {
         LaunchingConnector launchingConnector = Bootstrap.virtualMachineManager().defaultConnector();
         Map<String, Connector.Argument> arguments = launchingConnector.defaultArguments();
         arguments.get("main").setValue(ClassUnloadEventTest.class.getName());
-        arguments.get("options").setValue("-Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=info -Xlog:gc");
+        String testOpts = System.getProperty("test.vm.opts", "") + " " + System.getProperty("test.java.opts", "");
+        arguments.get("options").setValue(testOpts + " -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xlog:class+unload=info -Xlog:gc");
         return launchingConnector.launch(arguments);
     }
 }

--- a/test/jdk/com/sun/jdi/JdbOptions.java
+++ b/test/jdk/com/sun/jdi/JdbOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8234808
  *
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/othervm JdbOptions
  */

--- a/test/jdk/com/sun/jdi/OomDebugTest.java
+++ b/test/jdk/com/sun/jdi/OomDebugTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Red Hat Inc.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -30,6 +31,7 @@
  *  @author Severin Gehwolf <sgehwolf@redhat.com>
  *
  *  @requires vm.gc != "Z"
+ *  @requires vm.flagless
  *  @library ..
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g OomDebugTest.java

--- a/test/jdk/com/sun/jdi/SunBootClassPathEmptyTest.java
+++ b/test/jdk/com/sun/jdi/SunBootClassPathEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,12 @@ public class SunBootClassPathEmptyTest {
         }
 
         PathSearchingVirtualMachine launchVm(String cmdLine, String options) throws Exception {
+            String testOpts = System.getProperty("test.vm.opts", "") + " " + System.getProperty("test.java.opts", "");
+            if (options != null) {
+                options = testOpts + " " + options;
+            } else {
+                options = testOpts;
+            }
             Map<String, Connector.Argument> vmArgs = lc.defaultArguments();
             vmArgs.get("main").setValue(cmdLine);
             if (options != null) {

--- a/test/jdk/com/sun/jdi/connect/spi/DebugUsingCustomConnector.java
+++ b/test/jdk/com/sun/jdi/connect/spi/DebugUsingCustomConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  *
  * This tests launches a debuggee using a custom LaunchingConnector.
  *
+ * @requires vm.flagless
  * @modules jdk.jdi/com.sun.tools.jdi
  * @build DebugUsingCustomConnector SimpleLaunchingConnector Foo NullTransportService
  * @run main/othervm DebugUsingCustomConnector


### PR DESCRIPTION
Marked JdbOptions, OomDebugTest, and DebugUsingCustomConnector as vm.flagless since they deliberately set their own options.
Fixed ClassUnloadEventTest and SunBootClassPathEmptyTest to include test.vm.opts/test.java.opts. 
3 CDS tests already pass VM flags through CDSJDITest so no changes needed for those

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316466](https://bugs.openjdk.org/browse/JDK-8316466): 8 com/sun/jdi tests ignore VM flags (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30868/head:pull/30868` \
`$ git checkout pull/30868`

Update a local copy of the PR: \
`$ git checkout pull/30868` \
`$ git pull https://git.openjdk.org/jdk.git pull/30868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30868`

View PR using the GUI difftool: \
`$ git pr show -t 30868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30868.diff">https://git.openjdk.org/jdk/pull/30868.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30868#issuecomment-4293189857)
</details>
