### PR TITLE
8382637: GenShen: ubsan error, divide by zero during TestThreadFailure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -428,9 +428,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   double predicted_future_gc_time = 0;
   double future_planned_gc_time = 0;
   bool future_planned_gc_time_is_average = false;
-  double avg_time_to_deplete_available = 0.0;
   bool is_spiking = false;
-  double spike_time_to_deplete_available = 0.0;
 
   log_debug(gc, ergo)("should_start_gc calculation: available: " PROPERFMT ", soft_max_capacity: "  PROPERFMT ", "
                 "allocated_since_gc_start: "  PROPERFMT,
@@ -650,9 +648,8 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
                 _space_info->name(), avg_cycle_time * 1000, predicted_future_gc_time * 1000,
                 byte_size_in_proper_unit(avg_alloc_rate), proper_unit_for_byte_size(avg_alloc_rate));
   size_t allocatable_bytes = allocatable_words * HeapWordSize;
-  avg_time_to_deplete_available = allocatable_bytes / avg_alloc_rate;
 
-  if (future_planned_gc_time > avg_time_to_deplete_available) {
+  if (future_planned_gc_time * avg_alloc_rate > allocatable_bytes) {
     log_trigger("%s GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s)"
                 " to deplete free headroom (%zu%s) (margin of error = %.2f)",
                 future_planned_gc_time_is_average? "Average": "Linear prediction of", future_planned_gc_time * 1000,
@@ -675,8 +672,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   }
 
   is_spiking = _allocation_rate.is_spiking(rate, _spike_threshold_sd);
-  spike_time_to_deplete_available = (rate == 0)? 0: allocatable_bytes / rate;
-  if (is_spiking && (rate != 0) && (future_planned_gc_time > spike_time_to_deplete_available)) {
+  if (is_spiking && (rate != 0) && (future_planned_gc_time * rate > allocatable_bytes)) {
     log_trigger("%s GC time (%.2f ms) is above the time for instantaneous allocation rate (%.0f %sB/s)"
                 " to deplete free headroom (%zu%s) (spike threshold = %.2f)",
                 future_planned_gc_time_is_average? "Average": "Linear prediction of", future_planned_gc_time * 1000,

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -672,7 +672,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   }
 
   is_spiking = _allocation_rate.is_spiking(rate, _spike_threshold_sd);
-  if (is_spiking && (rate != 0) && (future_planned_gc_time * rate > allocatable_bytes)) {
+  if (is_spiking && (future_planned_gc_time * rate > allocatable_bytes)) {
     log_trigger("%s GC time (%.2f ms) is above the time for instantaneous allocation rate (%.0f %sB/s)"
                 " to deplete free headroom (%zu%s) (spike threshold = %.2f)",
                 future_planned_gc_time_is_average? "Average": "Linear prediction of", future_planned_gc_time * 1000,

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -95,7 +95,6 @@ gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
 gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
-gc/shenandoah/oom/TestThreadFailure.java 8382637 generic-all
 gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
 gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#generational 8382335 generic-all
 gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#default 8382335 generic-all


### PR DESCRIPTION
Narrowed down the root cause of the bug to [this commit](https://github.com/pengxiaolong/jdk/commit/0b183bf2d608bedf118607b1471fbf1e68813a08), which changed they way how the alloc rate is used, before it division on allocation rate was not used, the code was like:

```
if (avg_cycle_time * avg_alloc_rate > allocation_headroom) {
   ...some logs
   return true;
}
```

after the change, allocation rate is used ase below:

```
  size_t allocatable_bytes = allocatable_words * HeapWordSize;
  avg_time_to_deplete_available = allocatable_bytes / avg_alloc_rate;
```

Since there is chance that allocation rate is 0, we have chance to run into divide by zero error.

Additional:
 - [x] hotspot_gc_shenandoah test suite
 - [x] 1000 times of TestThreadFailure test with ubsan enabled(used to fail after few iterations) 


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382637](https://bugs.openjdk.org/browse/JDK-8382637): GenShen: ubsan error, divide by zero during TestThreadFailure (**Bug** - P3)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30869/head:pull/30869` \
`$ git checkout pull/30869`

Update a local copy of the PR: \
`$ git checkout pull/30869` \
`$ git pull https://git.openjdk.org/jdk.git pull/30869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30869`

View PR using the GUI difftool: \
`$ git pr show -t 30869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30869.diff">https://git.openjdk.org/jdk/pull/30869.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30869#issuecomment-4293574036)
</details>
