### PR TITLE
8382534: Some Compile methods should return bool instead of int

### DIFF
--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -776,8 +776,8 @@ class CFGEdge : public ResourceObj {
   // Private accessors
   int  from_pct() const { return _from_pct; }
   int  to_pct()   const { return _to_pct;   }
-  int  from_infrequent() const { return from_pct() < BlockLayoutMinDiamondPercentage; }
-  int  to_infrequent()   const { return to_pct()   < BlockLayoutMinDiamondPercentage; }
+  bool from_infrequent() const { return from_pct() < BlockLayoutMinDiamondPercentage; }
+  bool to_infrequent()   const { return to_pct()   < BlockLayoutMinDiamondPercentage; }
 
  public:
   enum {
@@ -795,7 +795,7 @@ class CFGEdge : public ResourceObj {
   double  freq() const { return _freq; }
   Block* from() const { return _from; }
   Block* to  () const { return _to;   }
-  int  infrequent() const { return _infrequent; }
+  bool   infrequent() const { return _infrequent; }
   int state() const { return _state; }
 
   void set_state(int state) { _state = state; }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -78,7 +78,7 @@ public:
 
   virtual bool      is_parse() const           { return true; }
   virtual JVMState* generate(JVMState* jvms);
-  int is_osr() { return _is_osr; }
+  bool              is_osr() const             { return _is_osr; }
 
 };
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -599,11 +599,11 @@ public:
   int               fixed_slots() const         { assert(_fixed_slots >= 0, "");         return _fixed_slots; }
   void          set_fixed_slots(int n)          { _fixed_slots = n; }
   void          set_inlining_progress(bool z)   { _inlining_progress = z; }
-  int               inlining_progress() const   { return _inlining_progress; }
+  bool              inlining_progress() const   { return _inlining_progress; }
   void          set_inlining_incrementally(bool z) { _inlining_incrementally = z; }
-  int               inlining_incrementally() const { return _inlining_incrementally; }
+  bool              inlining_incrementally() const { return _inlining_incrementally; }
   void          set_do_cleanup(bool z)          { _do_cleanup = z; }
-  int               do_cleanup() const          { return _do_cleanup; }
+  bool              do_cleanup() const          { return _do_cleanup; }
   bool              major_progress() const      { return _major_progress; }
   void          set_major_progress()            { _major_progress = true; }
   void          restore_major_progress(bool progress) { _major_progress = _major_progress || progress; }

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -908,7 +908,7 @@ public:
 #endif // ASSERT
 
   // Check for positive 32-bit value.
-  int is_positive_int() const { return _lo >= 0 && _hi <= (jlong)max_jint; }
+  bool is_positive_int() const { return _lo >= 0 && _hi <= (jlong)max_jint; }
 
   virtual bool        is_finite() const;  // Has a finite value
 


### PR DESCRIPTION


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8382534](https://bugs.openjdk.org/browse/JDK-8382534)

### Issue
 * [JDK-8382534](https://bugs.openjdk.org/browse/JDK-8382534): Some opto methods should return bool instead of int (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30870/head:pull/30870` \
`$ git checkout pull/30870`

Update a local copy of the PR: \
`$ git checkout pull/30870` \
`$ git pull https://git.openjdk.org/jdk.git pull/30870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30870`

View PR using the GUI difftool: \
`$ git pr show -t 30870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30870.diff">https://git.openjdk.org/jdk/pull/30870.diff</a>

</details>
