### PR TITLE
8382705: Improve calculation of num in CallArrangers

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -23,6 +23,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package jdk.internal.foreign.abi.aarch64;
 
 import jdk.internal.foreign.Utils;
@@ -262,8 +263,13 @@ public abstract class CallArranger {
         Windows, VF     | CW in regs       | CW split between regs and stack | CW on the stack
          */
         StructStorage[] structStorages(GroupLayout layout, boolean forHFA) {
-            int numChunks = (int)Utils.alignUp(layout.byteSize(), MAX_COPY_SIZE) / MAX_COPY_SIZE;
-
+            // Allocate enough gp slots (regs and stack) such that the struct fits in them.
+            final int numChunks;
+            try {
+                numChunks = Math.toIntExact(Utils.alignUp(layout.byteSize(), MAX_COPY_SIZE) / MAX_COPY_SIZE);
+            } catch (ArithmeticException ae) {
+                throw new IllegalArgumentException("Layout too large: " + layout, ae);
+            }
             int regType = StorageType.INTEGER;
             List<MemoryLayout> scalarLayouts = null;
             int requiredStorages = numChunks;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Institute of Software, Chinese Academy of Sciences.
  * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -189,7 +189,12 @@ public class LinuxRISCV64CallArranger {
         }
 
         VMStorage[] getStorages(MemoryLayout layout, boolean isVariadicArg) {
-            int regCnt = (int) SharedUtils.alignUp(layout.byteSize(), 8) / 8;
+            int regCnt;
+            try {
+                regCnt = Math.toIntExact(SharedUtils.alignUp(layout.byteSize(), 8) / 8);
+            } catch (ArithmeticException ae) {
+                throw new IllegalArgumentException("Layout too large: " + layout, ae);
+            }
             if (isVariadicArg && layout.byteAlignment() == 16 && layout.byteSize() <= 16) {
                 alignStorage();
                 // Two registers or stack slots will be allocated, even layout.byteSize <= 8B.


### PR DESCRIPTION
This PR proposes to improve the calculation of `num` values in two call arrangers. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382705](https://bugs.openjdk.org/browse/JDK-8382705): Improve calculation of num in CallArrangers (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30871/head:pull/30871` \
`$ git checkout pull/30871`

Update a local copy of the PR: \
`$ git checkout pull/30871` \
`$ git pull https://git.openjdk.org/jdk.git pull/30871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30871`

View PR using the GUI difftool: \
`$ git pr show -t 30871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30871.diff">https://git.openjdk.org/jdk/pull/30871.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30871#issuecomment-4294594504)
</details>
