### PR TITLE
8382635: G1: TAMSes overwritten by G1ConcurrentMark::fully_initialize() cause verification errors

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -524,7 +524,9 @@ void G1ConcurrentMark::fully_initialize() {
 
   uint max_num_regions = _g1h->max_num_regions();
   ::new (_region_mark_stats) G1RegionMarkStats[max_num_regions]{};
-  ::new (_top_at_mark_starts) Atomic<HeapWord*>[max_num_regions]{};
+  for (uint i = 0; i < max_num_regions; i++) {
+    ::new (&_top_at_mark_starts[i]) Atomic<HeapWord*>(_g1h->bottom_addr_for_region(i));
+  }
   ::new (_top_at_rebuild_starts) Atomic<HeapWord*>[max_num_regions]{};
 
   reset_at_marking_complete();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -527,6 +527,7 @@ void G1ConcurrentMark::fully_initialize() {
   for (uint i = 0; i < max_num_regions; i++) {
     ::new (&_top_at_mark_starts[i]) Atomic<HeapWord*>(_g1h->bottom_addr_for_region(i));
   }
+  // Contrary to TAMS, the default value of _top_at_rebuild_starts needs to be null.
   ::new (_top_at_rebuild_starts) Atomic<HeapWord*>[max_num_regions]{};
 
   reset_at_marking_complete();

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -316,7 +316,7 @@
   product(bool, G1VerifyHeapRegionCodeRoots, false, DIAGNOSTIC,             \
           "Verify the code root lists attached to each heap region.")       \
                                                                             \
-  develop(bool, G1VerifyBitmaps, false,                                     \
+  product(bool, G1VerifyBitmaps, false, DIAGNOSTIC,                         \
           "Verifies the consistency of the marking bitmaps")                \
                                                                             \
   product(uintx, G1PeriodicGCInterval, 0, MANAGEABLE,                       \

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -166,6 +166,7 @@ public class TestVerifyGCType {
                                        "-Xmx16m",
                                        "-XX:ParallelGCThreads=1",
                                        "-XX:G1HeapWastePercent=1",
+                                       "-XX:+G1VerifyBitmaps",
                                        "-XX:+VerifyBeforeGC",
                                        "-XX:+VerifyAfterGC",
                                        "-XX:+VerifyDuringGC"});

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -166,14 +166,10 @@ public class TestVerifyGCType {
                                        "-Xmx16m",
                                        "-XX:ParallelGCThreads=1",
                                        "-XX:G1HeapWastePercent=1",
+                                       "-XX:+G1VerifyBitmaps",
                                        "-XX:+VerifyBeforeGC",
                                        "-XX:+VerifyAfterGC",
                                        "-XX:+VerifyDuringGC"});
-
-        if (Platform.isDebugBuild()) {
-            // G1VerifyBitmaps is develop only.
-            Collections.addAll(basicOpts, "-XX:+G1VerifyBitmaps");
-        }
 
         for(String verifyType : types) {
             basicOpts.add("-XX:VerifyGCType="+verifyType);

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -166,10 +166,14 @@ public class TestVerifyGCType {
                                        "-Xmx16m",
                                        "-XX:ParallelGCThreads=1",
                                        "-XX:G1HeapWastePercent=1",
-                                       "-XX:+G1VerifyBitmaps",
                                        "-XX:+VerifyBeforeGC",
                                        "-XX:+VerifyAfterGC",
                                        "-XX:+VerifyDuringGC"});
+
+        if (Platform.isDebugBuild()) {
+            // G1VerifyBitmaps is develop only.
+            Collections.addAll(basicOpts, "-XX:+G1VerifyBitmaps");
+        }
 
         for(String verifyType : types) {
             basicOpts.add("-XX:VerifyGCType="+verifyType);


### PR DESCRIPTION
Hi all,

  please review this small fix that fixes a crash during bitmap verification. If there is no concurrent start gc, but another young gc before a full gc, `G1ConcurrentMark::fully_initialize()` overwrites TAMSes previously set by `G1HeapRegion::initialize/hr_clear()` to null.

Bitmap verification (enabled by `-XX:+G1VerifyBitmaps`) then tries to start verification from address 0x0, causing either verification failures or crashes.

Testing: amended test case now succeeds, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382635](https://bugs.openjdk.org/browse/JDK-8382635): G1: TAMSes overwritten by G1ConcurrentMark::fully_initialize() cause verification errors (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30872/head:pull/30872` \
`$ git checkout pull/30872`

Update a local copy of the PR: \
`$ git checkout pull/30872` \
`$ git pull https://git.openjdk.org/jdk.git pull/30872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30872`

View PR using the GUI difftool: \
`$ git pr show -t 30872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30872.diff">https://git.openjdk.org/jdk/pull/30872.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30872#issuecomment-4294673939)
</details>
