### PR TITLE
8382740: JFR: Disable jdk.OldObjectSample event for generational ZGC

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/leakProfiler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/leakProfiler.cpp
@@ -34,9 +34,15 @@
 #include "runtime/vmThread.hpp"
 
 bool LeakProfiler::is_supported() {
-  if (UseShenandoahGC) {
+  if (UseShenandoahGC || UseZGC) {
     // Leak Profiler uses mark words in the ways that might interfere
     // with concurrent GC uses of them. This affects Shenandoah.
+    //
+    // Generational ZGC only does weak reference processing in the old generation.
+    // All objects that would usually die, because we are sampling stuff
+    // that immediately becomes garbage, will be artificially kept alive
+    // until an old-generation collection. This incurs a significant
+    // performance hit by causing allocation stalls.
     return false;
   }
   return true;
@@ -58,7 +64,8 @@ bool LeakProfiler::start(int sample_count) {
 
   // Exit cleanly if not supported
   if (!is_supported()) {
-    log_trace(jfr, system)("Object sampling is not supported");
+    log_info(jfr, system)("jdk.OldObjectSample event is currently not supported for %s.",
+      UseShenandoahGC ? "ShenandoahGC" : "ZGC");
     return false;
   }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -731,6 +731,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8371630 generic-all
+jdk/jfr/event/oldobject/TestZ.java                              8375615 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Greetings,

JFR's memory leak profiler (underneath the event jdk.OldObjectSample) samples object allocations and wraps a sample in a weak handle.

Generational ZGC performs only weak-reference processing in the old generation. Therefore, all objects that would normally die, because we are sampling a lot of stuff that immediately becomes garbage, will be artificially kept alive until an old-generation collection occurs.

This incurs a significant performance hit by causing allocation stalls.

The underlying problem is tracked in [JDK-8375615](https://bugs.openjdk.org/browse/JDK-8375615).

Before [JDK-8375615](https://bugs.openjdk.org/browse/JDK-8375615) is fixed, the jdk.OldObjectSample event must be disabled when running with generational ZGC.

Testing: manual verification with reproducer attached to [JDK-8375615](https://bugs.openjdk.org/browse/JDK-8375615), jdk_jfr

Thanks
Markus

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382740](https://bugs.openjdk.org/browse/JDK-8382740): JFR: Disable jdk.OldObjectSample event for generational ZGC (**Bug** - P2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30880/head:pull/30880` \
`$ git checkout pull/30880`

Update a local copy of the PR: \
`$ git checkout pull/30880` \
`$ git pull https://git.openjdk.org/jdk.git pull/30880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30880`

View PR using the GUI difftool: \
`$ git pr show -t 30880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30880.diff">https://git.openjdk.org/jdk/pull/30880.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30880#issuecomment-4296554732)
</details>
