### PR TITLE
8379919: C2: Merge bit flag for node hash check after Ideal into -XX:VerifyIterativeGVN=1

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -722,13 +722,11 @@
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
           "Verify Iterative Global Value Numbering =FEDCBA, with:"          \
-          "  F: verify Node::Ideal does not return nullptr if the node"     \
-                "hash has changed"                                          \
           "  E: verify node specific invariants"                            \
           "  D: verify Node::Identity did not miss opportunities"           \
           "  C: verify Node::Ideal did not miss opportunities"              \
           "  B: verify that type(n) == n->Value() after IGVN"               \
-          "  A: verify Def-Use modifications during IGVN"                   \
+          "  A: verify various invariants per IGVN iteration"               \
           "Each can be 0=off or 1=on")                                      \
           constraint(VerifyIterativeGVNConstraintFunc, AtParse)             \
                                                                             \

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -744,7 +744,7 @@ bool Node::is_dead() const {
 }
 
 bool Node::is_not_dead(const Node* n) {
-  return n == nullptr || !PhaseIterGVN::is_verify_def_use() || !(n->is_dead());
+  return n == nullptr || !PhaseIterGVN::is_verify_per_iteration() || !(n->is_dead());
 }
 
 bool Node::is_reachable_from_root() const {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -877,7 +877,7 @@ void PhaseIterGVN::shuffle_worklist() {
 
 #ifndef PRODUCT
 void PhaseIterGVN::verify_step(Node* n) {
-  if (is_verify_def_use()) {
+  if (is_verify_per_iteration()) {
     ResourceMark rm;
     VectorSet visited;
     Node_List worklist;
@@ -991,7 +991,7 @@ void PhaseIterGVN::verify_PhaseIterGVN(bool deep_revisit_converged) {
 #endif
 
   C->verify_graph_edges();
-  if (is_verify_def_use() && PrintOpto) {
+  if (is_verify_per_iteration() && PrintOpto) {
     if (_verify_counter == _verify_full_passes) {
       tty->print_cr("VerifyIterativeGVN: %d transforms and verify passes",
                     (int) _verify_full_passes);
@@ -2202,7 +2202,7 @@ Node *PhaseIterGVN::transform_old(Node* n) {
   // Remove 'n' from hash table in case it gets modified
   _table.hash_delete(n);
 #ifdef ASSERT
-  if (is_verify_def_use()) {
+  if (is_verify_per_iteration()) {
     assert(!_table.find_index(n->_idx), "found duplicate entry in table");
   }
 #endif
@@ -2218,12 +2218,12 @@ Node *PhaseIterGVN::transform_old(Node* n) {
   DEBUG_ONLY(bool is_new = (k->outcnt() == 0);)
   C->remove_modified_node(k);
 #ifndef PRODUCT
-  uint hash_before = is_verify_Ideal_return() ? k->hash() : 0;
+  uint hash_before = is_verify_per_iteration() ? k->hash() : 0;
 #endif
   Node* i = apply_ideal(k, /*can_reshape=*/true);
   assert(i != k || is_new || i->outcnt() > 0, "don't return dead nodes");
 #ifndef PRODUCT
-  if (is_verify_Ideal_return()) {
+  if (is_verify_per_iteration()) {
     assert(k->outcnt() == 0 || i != nullptr || hash_before == k->hash(), "hash changed after Ideal returned nullptr for %s", k->Name());
   }
   verify_step(k);
@@ -2253,12 +2253,12 @@ Node *PhaseIterGVN::transform_old(Node* n) {
     DEBUG_ONLY(is_new = (k->outcnt() == 0);)
     C->remove_modified_node(k);
 #ifndef PRODUCT
-    uint hash_before = is_verify_Ideal_return() ? k->hash() : 0;
+    uint hash_before = is_verify_per_iteration() ? k->hash() : 0;
 #endif
     i = apply_ideal(k, /*can_reshape=*/true);
     assert(i != k || is_new || (i->outcnt() > 0), "don't return dead nodes");
 #ifndef PRODUCT
-    if (is_verify_Ideal_return()) {
+    if (is_verify_per_iteration()) {
       assert(k->outcnt() == 0 || i != nullptr || hash_before == k->hash(), "hash changed after Ideal returned nullptr for %s", k->Name());
     }
     verify_step(k);
@@ -2466,7 +2466,7 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
     _worklist.push(nn);
   }
 #ifndef PRODUCT
-  if (is_verify_def_use()) {
+  if (is_verify_per_iteration()) {
     for ( int i = 0; i < _verify_window_size; i++ ) {
       if ( _verify_window[i] == old )
         _verify_window[i] = nn;

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -656,7 +656,7 @@ public:
   bool is_dominator(Node *d, Node *n) { return is_dominator_helper(d, n, false); }
 
 #ifndef PRODUCT
-  static bool is_verify_def_use() {
+  static bool is_verify_per_iteration() {
     // '-XX:VerifyIterativeGVN=1'
     return (VerifyIterativeGVN % 10) == 1;
   }
@@ -675,10 +675,6 @@ public:
   static bool is_verify_invariants() {
     // '-XX:VerifyIterativeGVN=10000'
     return ((VerifyIterativeGVN % 100000) / 10000) == 1;
-  }
-  static bool is_verify_Ideal_return() {
-    // '-XX:VerifyIterativeGVN=100000'
-    return ((VerifyIterativeGVN % 1000000) / 100000) == 1;
   }
 protected:
   // Sub-quadratic implementation of '-XX:VerifyIterativeGVN=1' (Use-Def verification).

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1043,6 +1043,7 @@ Node* VectorNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   // Sort inputs of commutative non-predicated vector operations to help value numbering.
   if (should_swap_inputs_to_help_global_value_numbering()) {
     swap_edges(1, 2);
+    return this;
   }
   return nullptr;
 }

--- a/test/hotspot/jtreg/compiler/c2/TestVerifyIterativeGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestVerifyIterativeGVN.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8238756 8351889
  * @requires vm.debug == true & vm.flavor == "server"
- * @summary Run with -Xcomp to test -XX:VerifyIterativeGVN=111111 in debug builds.
+ * @summary Run with -Xcomp to test -XX:VerifyIterativeGVN=11111 in debug builds.
  *
- * @run main/othervm/timeout=300 -Xcomp -XX:VerifyIterativeGVN=111111 compiler.c2.TestVerifyIterativeGVN
+ * @run main/othervm/timeout=300 -Xcomp -XX:VerifyIterativeGVN=11111 compiler.c2.TestVerifyIterativeGVN
  */
 package compiler.c2;
 

--- a/test/hotspot/jtreg/compiler/c2/igvn/TestIdealReturnReplaceShiftAmount.java
+++ b/test/hotspot/jtreg/compiler/c2/igvn/TestIdealReturnReplaceShiftAmount.java
@@ -28,12 +28,12 @@ package compiler.c2.igvn;
  * @bug 8373251
  * @summary In Ideal of shift nodes, we call mask_and_replace_shift_amount to reduce the
  *          shift amount. We need to make sure that Ideal returns something if this is
- *          the only modification taking place. Use -XX:VerifyIterativeGVN=100000 to
+ *          the only modification taking place. Use -XX:VerifyIterativeGVN=1 to
  *          verify the return value of Ideal if the hash has changed.
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -Xcomp -XX:-TieredCompilation
  *      -XX:CompileCommand=compileonly,${test.main.class}::test*
- *      -XX:VerifyIterativeGVN=100000
+ *      -XX:VerifyIterativeGVN=1
  *      ${test.main.class}
  * @run main ${test.main.class}
  *


### PR DESCRIPTION
Waiting for test results to see if there's more to do

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8379919](https://bugs.openjdk.org/browse/JDK-8379919): C2: Merge bit flag for node hash check after Ideal into -XX:VerifyIterativeGVN=1 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30881/head:pull/30881` \
`$ git checkout pull/30881`

Update a local copy of the PR: \
`$ git checkout pull/30881` \
`$ git pull https://git.openjdk.org/jdk.git pull/30881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30881`

View PR using the GUI difftool: \
`$ git pr show -t 30881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30881.diff">https://git.openjdk.org/jdk/pull/30881.diff</a>

</details>
