### PR TITLE
8382815: C2: Reference intrinsics are broken by shadow "referent" field

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6933,7 +6933,7 @@ bool LibraryCallKit::inline_reference_get0() {
   DecoratorSet decorators = IN_HEAP | ON_WEAK_OOP_REF;
   Node* result = load_field_from_object(reference_obj, "referent", "Ljava/lang/Object;",
                                         decorators, /*is_static*/ false,
-                                        Compile::current()->env()->Reference_klass());
+                                        env()->Reference_klass());
   if (result == nullptr) return false;
 
   // Add memory barrier to prevent commoning reads from this field
@@ -6957,7 +6957,7 @@ bool LibraryCallKit::inline_reference_refersTo0(bool is_phantom) {
   decorators |= (is_phantom ? ON_PHANTOM_OOP_REF : ON_WEAK_OOP_REF);
   Node* referent = load_field_from_object(reference_obj, "referent", "Ljava/lang/Object;",
                                           decorators, /*is_static*/ false,
-                                          Compile::current()->env()->Reference_klass());
+                                          env()->Reference_klass());
   if (referent == nullptr) return false;
 
   // Add memory barrier to prevent commoning reads from this field

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6932,7 +6932,8 @@ bool LibraryCallKit::inline_reference_get0() {
 
   DecoratorSet decorators = IN_HEAP | ON_WEAK_OOP_REF;
   Node* result = load_field_from_object(reference_obj, "referent", "Ljava/lang/Object;",
-                                        decorators, /*is_static*/ false, nullptr);
+                                        decorators, /*is_static*/ false,
+                                        Compile::current()->env()->Reference_klass());
   if (result == nullptr) return false;
 
   // Add memory barrier to prevent commoning reads from this field
@@ -6955,7 +6956,8 @@ bool LibraryCallKit::inline_reference_refersTo0(bool is_phantom) {
   DecoratorSet decorators = IN_HEAP | AS_NO_KEEPALIVE;
   decorators |= (is_phantom ? ON_PHANTOM_OOP_REF : ON_WEAK_OOP_REF);
   Node* referent = load_field_from_object(reference_obj, "referent", "Ljava/lang/Object;",
-                                          decorators, /*is_static*/ false, nullptr);
+                                          decorators, /*is_static*/ false,
+                                          Compile::current()->env()->Reference_klass());
   if (referent == nullptr) return false;
 
   // Add memory barrier to prevent commoning reads from this field
@@ -7042,8 +7044,6 @@ Node* LibraryCallKit::load_field_from_object(Node* fromObj, const char* fieldNam
     assert(tinst != nullptr, "obj is null");
     assert(tinst->is_loaded(), "obj is not loaded");
     fromKls = tinst->instance_klass();
-  } else {
-    assert(is_static, "only for static field access");
   }
   ciField* field = fromKls->get_field_by_name(ciSymbol::make(fieldName),
                                               ciSymbol::make(fieldTypeString),

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGet.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGet.java
@@ -24,8 +24,10 @@
 /*
  * @test
  * @bug 8382815
- * @run main/othervm -XX:CompileCommand=dontinline,TestReferenceGet::test_* TestReferenceGet
+ * @run main/othervm -XX:CompileCommand=dontinline,${test.main.class}::test_* ${test.main.class}
  */
+
+package compiler.intrinsics;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGet.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGet.java
@@ -23,9 +23,8 @@
 
 /*
  * @test
- * @bug 8256377 8382815
- * @summary Based on test/jdk/java/lang/ref/ReferenceRefersTo.java.
- * @run main/othervm -XX:CompileCommand=dontinline,TestReferenceRefersTo::test_* TestReferenceRefersTo
+ * @bug 8382815
+ * @run main/othervm -XX:CompileCommand=dontinline,TestReferenceGet::test_* TestReferenceGet
  */
 
 import java.lang.ref.Reference;
@@ -34,56 +33,42 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 
-public class TestReferenceRefersTo {
+public class TestReferenceGet {
     private static final void fail(String msg) throws Exception {
         throw new RuntimeException(msg);
     }
 
-    // Test java.lang.ref.Reference::refersTo0 intrinsic.
     private static final void test0(Reference ref,
-                                   Object expectedValue,
-                                   Object unexpectedValue,
-                                   String kind) throws Exception {
-        if ((expectedValue != null) && ref.refersTo(null)) {
+                                    Object expectedValue,
+                                    Object unexpectedValue,
+                                    String kind) throws Exception {
+        if ((expectedValue != null) && ref.get() == null) {
             fail(kind + " refers to null");
         }
-        if (!ref.refersTo(expectedValue)) {
+        if (ref.get() != expectedValue) {
             fail(kind + " doesn't refer to expected value");
         }
-        if (ref.refersTo(unexpectedValue)) {
+        if (ref.get() == unexpectedValue) {
             fail(kind + " refers to unexpected value");
         }
     }
 
-    // Test java.lang.ref.PhantomReference::refersTo0 intrinsic.
     private static final void test_phantom0(PhantomReference ref,
-                                           Object expectedValue,
-                                           Object unexpectedValue,
-                                           String kind) throws Exception {
-        if ((expectedValue != null) && ref.refersTo(null)) {
-            fail(kind + " refers to null");
-        }
-        if (!ref.refersTo(expectedValue)) {
-            fail(kind + " doesn't refer to expected value");
-        }
-        if (ref.refersTo(unexpectedValue)) {
-            fail(kind + " refers to unexpected value");
+                                            String kind) throws Exception {
+        if (ref.get() != null) {
+            fail(kind + " does not refer to null");
         }
     }
 
     // Entry points to the test, important to push down type information to
     // individual test methods.
 
-    private static final void test_phantom(PhantomReference ref,
-                                           Object expectedValue,
-                                           Object unexpectedValue) throws Exception {
-        test_phantom0(ref, expectedValue, unexpectedValue, "phantom");
+    private static final void test_phantom(PhantomReference ref) throws Exception {
+        test_phantom0(ref, "phantom");
     }
 
-    private static final void test_phantom_shadow(ShadowPhantomReference ref,
-                                           Object expectedValue,
-                                           Object unexpectedValue) throws Exception {
-        test_phantom0(ref, expectedValue, unexpectedValue, "phantom shadow");
+    private static final void test_phantom_shadow(ShadowPhantomReference ref) throws Exception {
+        test_phantom0(ref, "phantom shadow");
     }
 
     private static final void test_weak(WeakReference ref,
@@ -134,10 +119,10 @@ public class TestReferenceRefersTo {
             var ssref = new ShadowSoftReference<>(obj5);
 
             System.out.println("After creation");
-            test_phantom(pref, obj0, unexpected);
+            test_phantom(pref);
             test_weak(wref, obj1, unexpected);
             test_soft(sref, obj2, unexpected);
-            test_phantom_shadow(psref, obj3, unexpected);
+            test_phantom_shadow(psref);
             test_weak_shadow(wsref, obj4, unexpected);
             test_soft_shadow(ssref, obj5, unexpected);
 
@@ -150,10 +135,10 @@ public class TestReferenceRefersTo {
             ssref.clear();
 
             System.out.println("Testing after cleaning");
-            test_phantom(pref, null, unexpected);
+            test_phantom(pref);
             test_weak(wref, null, unexpected);
             test_soft(sref, null, unexpected);
-            test_phantom_shadow(psref, null, unexpected);
+            test_phantom_shadow(psref);
             test_weak_shadow(wsref, null, unexpected);
             test_soft_shadow(ssref, null, unexpected);
         }

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
@@ -23,8 +23,9 @@
 
 /*
  * @test
- * @bug 8256377
+ * @bug 8256377 8382815
  * @summary Based on test/jdk/java/lang/ref/ReferenceRefersTo.java.
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=dontinline,TestReferenceRefersTo::test_* TestReferenceRefersTo
  */
 
 import java.lang.ref.Reference;
@@ -39,7 +40,7 @@ public class TestReferenceRefersTo {
     }
 
     // Test java.lang.ref.Reference::refersTo0 intrinsic.
-    private static final void test(Reference ref,
+    private static final void test0(Reference ref,
                                    Object expectedValue,
                                    Object unexpectedValue,
                                    String kind) throws Exception {
@@ -55,10 +56,10 @@ public class TestReferenceRefersTo {
     }
 
     // Test java.lang.ref.PhantomReference::refersTo0 intrinsic.
-    private static final void test_phantom(PhantomReference ref,
+    private static final void test_phantom0(PhantomReference ref,
                                            Object expectedValue,
-                                           Object unexpectedValue) throws Exception {
-        String kind = "phantom";
+                                           Object unexpectedValue,
+                                           String kind) throws Exception {
         if ((expectedValue != null) && ref.refersTo(null)) {
             fail(kind + " refers to null");
         }
@@ -68,53 +69,120 @@ public class TestReferenceRefersTo {
         if (ref.refersTo(unexpectedValue)) {
             fail(kind + " refers to unexpected value");
         }
+    }
 
+    // Entry points to the test, important to push down type information to
+    // individual test methods.
+
+    private static final void test_phantom(PhantomReference ref,
+                                           Object expectedValue,
+                                           Object unexpectedValue) throws Exception {
+        test_phantom0(ref, expectedValue, unexpectedValue, "phantom");
+    }
+
+    private static final void test_phantom_shadow(ShadowPhantomReference ref,
+                                           Object expectedValue,
+                                           Object unexpectedValue) throws Exception {
+        test_phantom0(ref, expectedValue, unexpectedValue, "phantom shadow");
     }
 
     private static final void test_weak(WeakReference ref,
                                         Object expectedValue,
                                         Object unexpectedValue) throws Exception {
-        test(ref, expectedValue, unexpectedValue, "weak");
+        test0(ref, expectedValue, unexpectedValue, "weak");
+    }
+
+    private static final void test_weak_shadow(ShadowWeakReference ref,
+                                        Object expectedValue,
+                                        Object unexpectedValue) throws Exception {
+        test0(ref, expectedValue, unexpectedValue, "weak shadow");
     }
 
     private static final void test_soft(SoftReference ref,
                                         Object expectedValue,
                                         Object unexpectedValue) throws Exception {
-        test(ref, expectedValue, unexpectedValue, "soft");
+        test0(ref, expectedValue, unexpectedValue, "soft");
+    }
+
+    private static final void test_soft_shadow(ShadowSoftReference ref,
+                                        Object expectedValue,
+                                        Object unexpectedValue) throws Exception {
+        test0(ref, expectedValue, unexpectedValue, "soft shadow");
     }
 
     public static void main(String[] args) throws Exception {
         var queue = new ReferenceQueue<Object>();
 
+        var unexpected = new Object();
+
         var obj0 = new Object();
         var obj1 = new Object();
         var obj2 = new Object();
         var obj3 = new Object();
+        var obj4 = new Object();
+        var obj5 = new Object();
 
-        var pref = new PhantomReference(obj0, queue);
-        var wref = new WeakReference(obj1);
-        var sref = new SoftReference(obj2);
+        // It is important to do all test methods in the loop, so that we
+        // exercise all paths in intrinsics.
+        for (int i = 0; i < 100000; i++) {
+            System.out.println("Create");
+            var pref = new PhantomReference(obj0, queue);
+            var wref = new WeakReference(obj1);
+            var sref = new SoftReference(obj2);
+            var psref = new ShadowPhantomReference<>(obj3, queue);
+            var wsref = new ShadowWeakReference<>(obj4);
+            var ssref = new ShadowSoftReference<>(obj5);
 
-        System.out.println("Warmup");
-        for (int i = 0; i < 10000; i++) {
-            test_phantom(pref, obj0, obj3);
-            test_weak(wref, obj1, obj3);
-            test_soft(sref, obj2, obj3);
+            System.out.println("Test starts");
+            test_phantom(pref, obj0, unexpected);
+            test_weak(wref, obj1, unexpected);
+            test_soft(sref, obj2, unexpected);
+            test_phantom_shadow(psref, obj3, unexpected);
+            test_weak_shadow(wsref, obj4, unexpected);
+            test_soft_shadow(ssref, obj5, unexpected);
+
+            System.out.println("Cleaning references");
+            pref.clear();
+            wref.clear();
+            sref.clear();
+            psref.clear();
+            wsref.clear();
+            ssref.clear();
+
+            System.out.println("Testing after cleaning");
+            test_phantom(pref, null, unexpected);
+            test_weak(wref, null, unexpected);
+            test_soft(sref, null, unexpected);
+            test_phantom_shadow(psref, null, unexpected);
+            test_weak_shadow(wsref, null, unexpected);
+            test_soft_shadow(ssref, null, unexpected);
         }
+    }
 
-        System.out.println("Testing starts");
-        test_phantom(pref, obj0, obj3);
-        test_weak(wref, obj1, obj3);
-        test_soft(sref, obj2, obj3);
+    // References that have their own "shadow" referent. Check that intrinsics
+    // hit the right referent.
 
-        System.out.println("Cleaning references");
-        pref.clear();
-        wref.clear();
-        sref.clear();
+    static class ShadowSoftReference<T> extends SoftReference<T> {
+        T referent;
+        public ShadowSoftReference(T ref) {
+            super(ref);
+            referent = ref;
+        }
+    }
 
-        System.out.println("Testing after cleaning");
-        test_phantom(pref, null, obj3);
-        test_weak(wref, null, obj3);
-        test_soft(sref, null, obj3);
+    static class ShadowWeakReference<T> extends WeakReference<T> {
+        T referent;
+        public ShadowWeakReference(T ref) {
+            super(ref);
+            referent = ref;
+        }
+    }
+
+    static class ShadowPhantomReference<T> extends PhantomReference<T> {
+        T referent;
+        public ShadowPhantomReference(T ref, ReferenceQueue<Object> q) {
+            super(ref, q);
+            referent = ref;
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8256377 8382815
  * @summary Based on test/jdk/java/lang/ref/ReferenceRefersTo.java.
- * @run main/othervm -XX:CompileCommand=dontinline,${test.main.class}::test_* TestReferenceRefersTo
+ * @run main/othervm -XX:CompileCommand=dontinline,${test.main.class}::test_* ${test.main.class}
  */
 
 package compiler.intrinsics;

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceRefersTo.java
@@ -25,8 +25,10 @@
  * @test
  * @bug 8256377 8382815
  * @summary Based on test/jdk/java/lang/ref/ReferenceRefersTo.java.
- * @run main/othervm -XX:CompileCommand=dontinline,TestReferenceRefersTo::test_* TestReferenceRefersTo
+ * @run main/othervm -XX:CompileCommand=dontinline,${test.main.class}::test_* TestReferenceRefersTo
  */
+
+package compiler.intrinsics;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;


### PR DESCRIPTION
See the bug for more details.

This is the surgical fix, because it likely deserves backports. We have not caught the failure in tests, because who would have thought to test a shadow field of the same name? Still, we have caught the verification failure in one of the Scala libraries when testing with Shenandoah LBE, so real code does it.

Since the whole issue is about discovering the fields in the `Reference` subclasses, while we are actually looking for a sole `Reference.referent`, it IMO stands to reason we just start (and end) looking up there. 

For testing, I started with amending the existing `ReferenceRefersTo` test. Unfortunately, in current test, when we need to test the reference after clearing, we end up stepping on an uncommon trap in the target method and recompiling. Thus we never fully test the intrinsic! The test is rewritten to warm up the intrinsic properly. New `ReferenceGet` test is a variant derived from `ReferenceRefersTo`. Both tests cover the changes in product code, and they are individually sensitive to individual fixes.

Additional testing:
 - [x] New regression tests fail without the fix, pass with it
 - [x] Linux x86_64 server fastdebug, `tier1`  
 - [x] Linux x86_64 server fastdebug, `all`  

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382815](https://bugs.openjdk.org/browse/JDK-8382815): C2: Reference intrinsics are broken by shadow "referent" field (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30882/head:pull/30882` \
`$ git checkout pull/30882`

Update a local copy of the PR: \
`$ git checkout pull/30882` \
`$ git pull https://git.openjdk.org/jdk.git pull/30882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30882`

View PR using the GUI difftool: \
`$ git pr show -t 30882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30882.diff">https://git.openjdk.org/jdk/pull/30882.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30882#issuecomment-4297124791)
</details>
