### PR TITLE
8382871: Completion failure during diagnostic formatting

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Printer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Printer.java
@@ -33,6 +33,8 @@ import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Pair;
 
 import static com.sun.tools.javac.code.BoundKind.*;
 import static com.sun.tools.javac.code.Flags.*;
@@ -151,13 +153,13 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
     @Override
     public String visitCapturedType(CapturedType t, Locale locale) {
         if (seenCaptured.contains(t))
-            return printAnnotations(t) +
+            return printAnnotations(t, locale) +
                 localize(locale, "compiler.misc.type.captureof.1",
                 capturedVarId(t, locale));
         else {
             try {
                 seenCaptured = seenCaptured.prepend(t);
-                return printAnnotations(t) +
+                return printAnnotations(t, locale) +
                     localize(locale, "compiler.misc.type.captureof",
                     capturedVarId(t, locale),
                     visit(t.wildcard, locale));
@@ -170,16 +172,16 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
 
     @Override
     public String visitForAll(ForAll t, Locale locale) {
-        return printAnnotations(t) + "<" + visitTypes(t.tvars, locale) +
+        return printAnnotations(t, locale) + "<" + visitTypes(t.tvars, locale) +
             ">" + visit(t.qtype, locale);
     }
 
     @Override
     public String visitUndetVar(UndetVar t, Locale locale) {
         if (t.getInst() != null) {
-            return printAnnotations(t) + visit(t.getInst(), locale);
+            return printAnnotations(t, locale) + visit(t.getInst(), locale);
         } else {
-            return printAnnotations(t) + visit(t.qtype, locale) + "?";
+            return printAnnotations(t, locale) + visit(t.qtype, locale) + "?";
         }
     }
 
@@ -191,11 +193,11 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
         return res.toString();
     }
 
-    private String printAnnotations(Type t) {
-        return printAnnotations(t, false);
+    private String printAnnotations(Type t, Locale locale) {
+        return printAnnotations(t, false, locale);
     }
 
-    private String printAnnotations(Type t, boolean prefix) {
+    private String printAnnotations(Type t, boolean prefix, Locale locale) {
         if (printingMethodArgs) {
             return "";
         }
@@ -204,9 +206,34 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
         if (!annos.isEmpty()) {
             if (prefix) sb.append(' ');
             for (Attribute.TypeCompound anno : annos) {
-                sb.append(anno);
+                sb.append(printAnnotation(anno, locale));
                 sb.append(' ');
             }
+        }
+        return sb.toString();
+    }
+
+    public String printAnnotation(Attribute.Compound a, Locale locale) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("@");
+        sb.append(visit(a.type, locale));
+        int len = a.values.length();
+        if (len > 0) {
+            sb.append('(');
+            boolean first = true;
+            for (Pair<MethodSymbol, Attribute> value : a.values) {
+                if (!first)
+                    sb.append(", ");
+                first = false;
+
+                Name name = value.fst.name;
+                if (len > 1 || name != name.table.names.value) {
+                    sb.append(name);
+                    sb.append('=');
+                }
+                sb.append(value.snd);
+            }
+            sb.append(')');
         }
         return sb.toString();
     }
@@ -222,7 +249,7 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
     private void printBrackets(Type t, StringBuilder sb, Locale locale) {
         Type arrel = t;
         while (arrel.hasTag(TypeTag.ARRAY)) {
-            sb.append(printAnnotations(arrel, true));
+            sb.append(printAnnotations(arrel, true, locale));
             sb.append("[]");
             arrel = ((ArrayType) arrel).elemtype;
         }
@@ -234,10 +261,10 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
         if (t.getEnclosingType().hasTag(CLASS) && t.tsym.owner.kind == TYP) {
             buf.append(visit(t.getEnclosingType(), locale));
             buf.append('.');
-            buf.append(printAnnotations(t));
+            buf.append(printAnnotations(t, locale));
             buf.append(className(t, false, locale));
         } else {
-            buf.append(printAnnotations(t));
+            buf.append(printAnnotations(t, locale));
             buf.append(className(t, true, locale));
         }
         if (t.getTypeArguments().nonEmpty()) {
@@ -264,7 +291,7 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
         StringBuilder s = new StringBuilder();
         s.append(t.kind);
         if (t.kind != UNBOUND) {
-            s.append(printAnnotations(t));
+            s.append(printAnnotations(t, locale));
             s.append(visit(t.type, locale));
         }
         return s.toString();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java
@@ -41,6 +41,7 @@ import com.sun.tools.javac.api.DiagnosticFormatter.Configuration.DiagnosticPart;
 import com.sun.tools.javac.api.DiagnosticFormatter.Configuration.MultilineLimit;
 import com.sun.tools.javac.api.DiagnosticFormatter.PositionKind;
 import com.sun.tools.javac.api.Formattable;
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Lint.LintCategory;
 import com.sun.tools.javac.code.Printer;
 import com.sun.tools.javac.code.Source;
@@ -229,6 +230,9 @@ public abstract class AbstractDiagnosticFormatter implements DiagnosticFormatter
         else if (arg instanceof Tag tag) {
             return messages.getLocalizedString(l, "compiler.misc.tree.tag." +
                                                   StringUtils.toLowerCase(tag.name()));
+        }
+        else if (arg instanceof Attribute.Compound compound) {
+            return printer.printAnnotation(compound, l);
         }
         else {
             return String.valueOf(arg);

--- a/test/langtools/tools/javac/annotations/typeAnnotations/DiagnosticFormatterCompletionFailureTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/DiagnosticFormatterCompletionFailureTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8382871
+ * @summary Completion Failure during diagnostic formatting
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main DiagnosticFormatterCompletionFailureTest
+ */
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class DiagnosticFormatterCompletionFailureTest extends TestRunner {
+    ToolBox tb;
+
+    public DiagnosticFormatterCompletionFailureTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new DiagnosticFormatterCompletionFailureTest()
+                .runTests(m -> new Object[] {Paths.get(m.getName())});
+    }
+
+    @Test
+    public void test(Path base) throws Exception {
+        Path libClasses = base.resolve("libclasses");
+        Files.createDirectories(libClasses);
+        new JavacTask(tb)
+                .outdir(libClasses)
+                .sources(
+                        """
+                        package lib;
+
+                        import java.lang.annotation.ElementType;
+                        import java.lang.annotation.Retention;
+                        import java.lang.annotation.RetentionPolicy;
+                        import java.lang.annotation.Target;
+
+                        @Retention(RetentionPolicy.RUNTIME)
+                        @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+                        @interface A {}
+                        """,
+                        """
+                        package lib;
+
+                        public class I {
+                          public final void g(@A Integer other) {}
+                        }
+                        """,
+                        """
+                        package lib;
+
+                        class NoSuch<T> {}
+                        """,
+                        """
+                        package lib;
+
+                        public class Lib {
+                          public static I f(@A Integer actual)   { return null; }
+                          public static I f(@A NoSuch<?> actual) { return null; }
+                        }
+                        """)
+                .run()
+                .writeAll();
+        Path lib = libClasses.resolve("lib");
+        Files.delete(lib.resolve("NoSuch.class"));
+        Files.delete(lib.resolve("A.class"));
+        String code =
+                """
+                import static lib.Lib.f;
+                class T {
+                  void f(L l) {
+                    f(2).g(2);
+                  }
+                }
+                """;
+        List<String> lines =
+                new JavacTask(tb)
+                        .classpath(libClasses)
+                        .sources(code)
+                        .run(Task.Expect.FAIL)
+                        .getOutputLines(Task.OutputKind.DIRECT);
+        String output = String.join("\n", lines);
+        if (!output.contains("Cannot attach type annotations @A to Lib.f")
+                && !output.contains("class file for lib.NoSuch not found")) {
+            throw new AssertionError(output);
+        }
+    }
+}


### PR DESCRIPTION
When javac formats annotations in diagnostic arguments, it calls `toString` on the annotation, which can cause symbol completion to occur. If the symbol completion fails during diagnostic formatting it can cause a crash, like the example in the bug.

The proposed fix adds logic to the diagnostic formatter to handle printing annotations, instead of relying on `Attribute.Compound#toString`, to avoid the potential completion failure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382871](https://bugs.openjdk.org/browse/JDK-8382871): Completion failure during diagnostic formatting (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30886/head:pull/30886` \
`$ git checkout pull/30886`

Update a local copy of the PR: \
`$ git checkout pull/30886` \
`$ git pull https://git.openjdk.org/jdk.git pull/30886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30886`

View PR using the GUI difftool: \
`$ git pr show -t 30886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30886.diff">https://git.openjdk.org/jdk/pull/30886.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30886#issuecomment-4299808133)
</details>
