### PR TITLE
8382875: javax/swing/JComboBox/JComboBoxActionEvent.java test instruction is not clear

### DIFF
--- a/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxActionEvent.java
@@ -35,18 +35,23 @@ import java.awt.FlowLayout;
 
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
-import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 public class JComboBoxActionEvent {
-    private static final String instructionsText = " Click the arrow to display the menu.\n" +
-         "While the menu is displayed, edit the text to create a new value.\n" +
-         "Type return.\n" +
-         "If a dialog appears with \"ActionCommand received\"\n" +
-         "press Pass, else Fail";
+    private static final String instructionsText = """
+                Please look at the 'Test Editable Combo Box' test frame.
+
+                1. Click the arrow button of the editable JComboBox to open its drop-down list.
+                2. While the drop-down list is visible, edit the text in the editable JComboBox and enter a new value.
+                3. Press Return.
+
+                Pass condition: a JOptionPane appears containing the message ActionCommand received.
+                Fail condition: the JOptionPane does not appear, or it does not contain the expected message.
+            """;
+
 
     private static JFrame frame;
 
@@ -82,7 +87,7 @@ public class JComboBoxActionEvent {
 
         UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
 
-        PassFailJFrame pfjFrame = new PassFailJFrame("JScrollPane "
+        PassFailJFrame pfjFrame = new PassFailJFrame("JComboBoxActionEvent "
                 + "Test Instructions", instructionsText, 5);
 
         createAndShowGUI();
@@ -90,3 +95,4 @@ public class JComboBoxActionEvent {
         pfjFrame.awaitAndCheck();
     }
 }
+


### PR DESCRIPTION
Fixed the test instructions.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8382875](https://bugs.openjdk.org/browse/JDK-8382875): javax/swing/JComboBox/JComboBoxActionEvent.java test instruction is not clear (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30887/head:pull/30887` \
`$ git checkout pull/30887`

Update a local copy of the PR: \
`$ git checkout pull/30887` \
`$ git pull https://git.openjdk.org/jdk.git pull/30887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30887`

View PR using the GUI difftool: \
`$ git pr show -t 30887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30887.diff">https://git.openjdk.org/jdk/pull/30887.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30887#issuecomment-4300262593)
</details>
