### PR TITLE
8373651: [TESTBUG] Test java/awt/Menu/SetShortCutTest.java fails because the instructions does not match with the context in menu

### DIFF
--- a/test/jdk/java/awt/Menu/SetShortCutTest.java
+++ b/test/jdk/java/awt/Menu/SetShortCutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Menu/SetShortCutTest.java
+++ b/test/jdk/java/awt/Menu/SetShortCutTest.java
@@ -45,7 +45,7 @@ import static java.awt.event.KeyEvent.VK_SHIFT;
 public class SetShortCutTest {
     public static void main(String[] args) throws Exception {
         boolean isMac = System.getProperty("os.name").startsWith("Mac");
-        String shortcut = "Ctrl+Shift+";
+        String shortcut = " Ctrl+Shift+";
         if (isMac) {
             shortcut = KeyEvent.getKeyText(VK_SHIFT) + "+" + KeyEvent.getKeyText(VK_META);
         }


### PR DESCRIPTION
Fixed the space issue that was confusing in the test instruction.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8373651`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8373651`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30888/head:pull/30888` \
`$ git checkout pull/30888`

Update a local copy of the PR: \
`$ git checkout pull/30888` \
`$ git pull https://git.openjdk.org/jdk.git pull/30888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30888`

View PR using the GUI difftool: \
`$ git pr show -t 30888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30888.diff">https://git.openjdk.org/jdk/pull/30888.diff</a>

</details>
