### PR TITLE
8380753: C2: RegMask::find_first_set() incorrectly returns partially contained sets for scalable vector registers

### DIFF
--- a/src/hotspot/share/opto/regmask.cpp
+++ b/src/hotspot/share/opto/regmask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,8 +248,15 @@ OptoReg::Name RegMask::find_first_set(LRG &lrg, const int size) const {
   for (unsigned i = _lwm; i <= _hwm; i++) {
     if (rm_word(i) != 0) {                // Found some bits
       // Convert to bit number, return hi bit in pair
-      return OptoReg::Name(offset_bits() + (i << LogBitsPerWord) +
-                           find_lowest_bit(rm_word(i)) + (size - 1));
+      OptoReg::Name hi_bit = OptoReg::Name(offset_bits() +
+        (i << LogBitsPerWord) + find_lowest_bit(rm_word(i)) + (size - 1));
+      if (!can_represent(hi_bit)) {
+        // For scalable vector registers, whose actual length exceeds
+        // SlotsPerVecA bits, the mask may not contain the highest register
+        // number in the set (hi_bit).
+        return OptoReg::Bad;
+      }
+      return hi_bit;
     }
   }
   return OptoReg::Bad;

--- a/test/hotspot/gtest/opto/test_regmask.cpp
+++ b/test/hotspot/gtest/opto/test_regmask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,6 +251,32 @@ TEST_VM(RegMask, find_first_set) {
   rm.insert(OptoReg::Name(18));
   rm.insert(OptoReg::Name(19));
   ASSERT_EQ(rm.find_first_set(lrg, 4), OptoReg::Name(19));
+}
+
+TEST_VM(RegMask, find_first_set_scalable_vector) {
+  RegMask rm;
+  LRG lrg{}; // Zero initialize
+  lrg._is_scalable = 1;
+  lrg._is_vector = 1;
+  lrg.set_num_regs(RegMask::SlotsPerVecA);
+  // This test only runs on hardware with scalable vector support (e.g.,
+  // AArch64, RISC-V). This condition ensures the expected execution path in
+  // RegMask::find_first_set().
+  if (lrg.is_scalable()) {
+    rm.insert(OptoReg::Name(rm.rm_size_in_bits() - 4));
+    rm.insert(OptoReg::Name(rm.rm_size_in_bits() - 3));
+    rm.insert(OptoReg::Name(rm.rm_size_in_bits() - 2));
+    rm.insert(OptoReg::Name(rm.rm_size_in_bits() - 1));
+    // Case-1: The physical length of scalable vector registers equals to
+    // RegMask::SlotsPerVecA, e.g., AArch64 Neoverse-V2.
+    uint scalable_reg_slots = RegMask::SlotsPerVecA;
+    ASSERT_EQ(rm.find_first_set(lrg, scalable_reg_slots),
+      OptoReg::Name(rm.rm_size_in_bits() - 1));
+    // Case-2: The physical length of scalable vector registers is bigger than
+    // RegMask::SlotsPerVecA, e.g., AArch64 Neoverse-V1.
+    scalable_reg_slots = RegMask::SlotsPerVecA * 2;
+    ASSERT_EQ(rm.find_first_set(lrg, scalable_reg_slots), OptoReg::Bad);
+  }
 }
 
 TEST_VM(RegMask, alignment) {


### PR DESCRIPTION
Issue: compiler/loopopts/superword/TestAlignVectorFuzzer.java fails intermittently only on Neoverse-V1 machine (256-bit SVE) after JDK-8325467 with:

```
  Internal Error (/tmp/jdk-src/src/hotspot/share/opto/chaitin.cpp:1451), pid=101028, tid=101050
  assert(mask.can_represent(assigned)) failed: sanity
```

Root cause: On Neoverse-V1, the physical size of a scalable vector register exceeds RegMask::SlotsPerVecA (i.e. 2x larger). When querying a stack slot, RegMask::find_first_set() returns a register that is partially covered by the mask, violating can_represent().

Note-1: The failure is intermittent. I didn't check the jtreg code in details. I suppose the randomized and stress tests hit this corner case.

Note-2: JDK-8325467 converted a previously handled can_represent() check into an assertion. I suppose the bug is independent of other parts of JDK-8325467.

In this patch, we further validate the query result in RegMask::find_first_set().

Test-1: Run TestAlignVectorFuzzer.java case 100 times on Neoverse-V1 and all passes.

Test-2: Run tier1, tier2 and tier3 on Linux AArch64 and x86_64. No new failure.

Test-3: Add one unit test in gtest:RegMask. It fails on AArch64 if the change to regmask.cpp (that is done in this patch) is removed.

Co-contributed-by: Daniel Lunden <daniel.lunden@oracle.com>




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380753](https://bugs.openjdk.org/browse/JDK-8380753): C2: RegMask::find_first_set() incorrectly returns partially contained sets for scalable vector registers (**Bug** - P4)


### Reviewers
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Author)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Contributors
 * Daniel Lundén `<dlunden@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30890/head:pull/30890` \
`$ git checkout pull/30890`

Update a local copy of the PR: \
`$ git checkout pull/30890` \
`$ git pull https://git.openjdk.org/jdk.git pull/30890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30890`

View PR using the GUI difftool: \
`$ git pr show -t 30890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30890.diff">https://git.openjdk.org/jdk/pull/30890.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30890#issuecomment-4301074785)
</details>
