### PR TITLE
8382877: Heap pollution warning points to first parameter instead of last

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -898,7 +898,7 @@ public class Check {
         }
         else if (!hasTrustMeAnno && varargElemType != null &&
                 !types.isReifiable(varargElemType)) {
-            warnUnchecked(tree.params.head.pos(), LintWarnings.UncheckedVarargsNonReifiableType(varargElemType));
+            warnUnchecked(tree.params.last().pos(), LintWarnings.UncheckedVarargsNonReifiableType(varargElemType));
         }
     }
     //where

--- a/test/langtools/tools/javac/warnings/HeapPollutionParam.java
+++ b/test/langtools/tools/javac/warnings/HeapPollutionParam.java
@@ -1,0 +1,11 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8382877
+ * @compile/ref=HeapPollutionParam.out -Xlint:unchecked -XDrawDiagnostics HeapPollutionParam.java
+ */
+abstract class HeapPollutionParam<A> {
+    abstract <A> HeapPollutionParam<A> m1(A head, A... tail);
+    @SuppressWarnings("unchecked") abstract <A> HeapPollutionParam<A> m2(A head, A... tail);
+    abstract <A> HeapPollutionParam<A> m3(@SuppressWarnings("unchecked") A head, A... tail);
+    abstract <A> HeapPollutionParam<A> m4(A head, @SuppressWarnings("unchecked") A... tail);
+}

--- a/test/langtools/tools/javac/warnings/HeapPollutionParam.out
+++ b/test/langtools/tools/javac/warnings/HeapPollutionParam.out
@@ -1,0 +1,3 @@
+HeapPollutionParam.java:7:56: compiler.warn.unchecked.varargs.non.reifiable.type: A
+HeapPollutionParam.java:9:87: compiler.warn.unchecked.varargs.non.reifiable.type: A
+2 warnings


### PR DESCRIPTION
Given this input:
```java
import java.util.*;
public class HeapPollutionTest {
    public static <A> List<A> of(A head, A... tail) {
        return null;
    }
}
```
the compiler produces this warning:
```
HeapPollutionTest.java:3: warning: [unchecked] Possible heap pollution from parameterized vararg type A
    public static <A> List<A> of(A head, A... tail) {
                                   ^
  where A is a type-variable:
    A extends Object declared in method <A>of(A,A...)
1 warning
```
The warning is being incorrectly located at `head` instead of `tail` where it belongs.

This doesn't seem to matter that much until you start thinking about how `@SuppressWarnings` is handled. For example, suppressing `"unchecked"` warnings on the declaration of `head` should not cause the warning to go away, but it does. Conversely, suppressing `"unchecked"` warnings on the declaration of `tail` should suppress the warning, but it doesn't.

This PR fixes the source position of the warning so it points to the last parameter (i.e., the varargs one) instead of the first.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382877](https://bugs.openjdk.org/browse/JDK-8382877): Heap pollution warning points to first parameter instead of last (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30892/head:pull/30892` \
`$ git checkout pull/30892`

Update a local copy of the PR: \
`$ git checkout pull/30892` \
`$ git pull https://git.openjdk.org/jdk.git pull/30892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30892`

View PR using the GUI difftool: \
`$ git pr show -t 30892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30892.diff">https://git.openjdk.org/jdk/pull/30892.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30892#issuecomment-4301253243)
</details>
