### PR TITLE
8382878: RISC-V: Missing InlineSkippedInstructionsCounter in ZGC barriers stubs

### DIFF
--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -734,6 +734,7 @@ public:
 #define __ masm->
 
 void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, ZLoadBarrierStubC2* stub) const {
+  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZLoadBarrierStubC2");
 
   // Stub entry
@@ -753,6 +754,7 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
 }
 
 void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, ZStoreBarrierStubC2* stub) const {
+  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZStoreBarrierStubC2");
 
   // Stub entry

--- a/src/hotspot/cpu/riscv/gc/z/z_riscv.ad
+++ b/src/hotspot/cpu/riscv/gc/z/z_riscv.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
@@ -57,6 +57,7 @@ static void check_color(MacroAssembler* masm, Register ref, bool on_non_strong, 
 }
 
 static void z_load_barrier(MacroAssembler* masm, const MachNode* node, Address ref_addr, Register ref, Register tmp) {
+  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   const bool on_non_strong =
       ((node->barrier_data() & ZBarrierWeak) != 0) ||
       ((node->barrier_data() & ZBarrierPhantom) != 0);
@@ -78,6 +79,7 @@ static void z_load_barrier(MacroAssembler* masm, const MachNode* node, Address r
 }
 
 static void z_store_barrier(MacroAssembler* masm, const MachNode* node, Address ref_addr, Register rnew_zaddress, Register rnew_zpointer, Register tmp, bool is_atomic) {
+  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   if (node->barrier_data() == ZBarrierElided) {
     z_color(masm, node, rnew_zpointer, rnew_zaddress, tmp);
   } else {


### PR DESCRIPTION
Hi, Please review this small change.
I happened to find some InlineSkippedInstructionsCounters are missing in ZGC barriers stubs.
This may affect performance in certain cases [1]. So this adds them back just like other CPU platforms.
Testing: hs:tier1 - hs:tier3 using fastdebug build on linux-riscv64 platforms.

[1] https://bugs.openjdk.org/browse/JDK-8333226




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382878](https://bugs.openjdk.org/browse/JDK-8382878): RISC-V: Missing InlineSkippedInstructionsCounter in ZGC barriers stubs (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30893/head:pull/30893` \
`$ git checkout pull/30893`

Update a local copy of the PR: \
`$ git checkout pull/30893` \
`$ git pull https://git.openjdk.org/jdk.git pull/30893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30893`

View PR using the GUI difftool: \
`$ git pr show -t 30893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30893.diff">https://git.openjdk.org/jdk/pull/30893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30893#issuecomment-4301345187)
</details>
