### PR TITLE
8382890: JcmdOnTrainingProcess.java fails Native memory tracking is not enabled

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2026, Microsoft, Inc. All rights reserved.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2026, Microsoft, Inc. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +39,12 @@
  * @run driver JcmdOnTrainingProcess
  */
 
+import java.io.IOException;
+
 import jdk.test.lib.JDKToolLauncher;
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
-import java.io.IOException;
+import jdk.test.lib.process.ProcessTools;
 
 public class JcmdOnTrainingProcess {
     public static void main(String[] args) throws Exception {
@@ -64,7 +66,8 @@ public class JcmdOnTrainingProcess {
             LingeredApp.startApp(theApp,
                                  "-cp", "LingeredApp.jar",
                                  "-XX:AOTMode=record",
-                                 "-XX:AOTConfiguration=LingeredApp.aotconfig");
+                                 "-XX:AOTConfiguration=LingeredApp.aotconfig",
+                                 "-XX:NativeMemoryTracking=summary");
             long pid = theApp.getPid();
 
             JDKToolLauncher jcmd = JDKToolLauncher.createUsingTestJDK("jcmd");
@@ -79,8 +82,8 @@ public class JcmdOnTrainingProcess {
                 return output;
             } catch (Exception e) {
                 throw new RuntimeException("Test failed: " + e);
-            }        }
-        catch (IOException e) {
+            }
+        } catch (IOException e) {
             throw new RuntimeException("Test failed: " + e);
         }
         finally {


### PR DESCRIPTION
Hi all,

Test runtime/cds/appcds/aotCache/JcmdOnTrainingProcess.java fails "Native memory tracking is not enabled" when run with release build. This is becasue the default option value of NativeMemoryTracking is 'summary' when the build target is fastbug, but  the default option value of NativeMemoryTracking is 'off' when the build target is release.

This PR pass -XX:NativeMemoryTracking=summary parameter to tested jdk, to make this test run pass both with fastdebug build and release build.

Test-fix only, no risk.


```bash
yansendao@napoleon:[jdk-ysd]> ./build/linux-x86_64-server-release/images/jdk/bin/java -XX:+PrintFlagsFinal -version 2>&1 | grep NativeMemoryTracking
    ccstr NativeMemoryTracking                     = off                                       {product} {default}
yansendao@napoleon:[jdk-ysd]> ./build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:+PrintFlagsFinal -version 2>&1 | grep NativeMemoryTracking
    ccstr NativeMemoryTracking                     = summary                                   {product} {default}
```



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382890](https://bugs.openjdk.org/browse/JDK-8382890): JcmdOnTrainingProcess.java fails Native memory tracking is not enabled (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30894/head:pull/30894` \
`$ git checkout pull/30894`

Update a local copy of the PR: \
`$ git checkout pull/30894` \
`$ git pull https://git.openjdk.org/jdk.git pull/30894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30894`

View PR using the GUI difftool: \
`$ git pr show -t 30894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30894.diff">https://git.openjdk.org/jdk/pull/30894.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30894#issuecomment-4303030196)
</details>
