### PR TITLE
8382920: Shenandoah: Do fewer implicit narrowing conversions

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCardStats.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardStats.hpp
@@ -88,10 +88,10 @@ public:
       _local_card_stats[MAX_CLEAN_RUN].add(percent_of(_max_clean_run, _cards_in_cluster));
 
       // Update global stats for dirty obj scan counts
-      _local_card_stats[DIRTY_SCAN_OBJS].add(_dirty_scan_obj_cnt);
+      _local_card_stats[DIRTY_SCAN_OBJS].add(static_cast<double>(_dirty_scan_obj_cnt));
 
       // Update global stats for alternation counts
-      _local_card_stats[ALTERNATIONS].add(_alternation_cnt);
+      _local_card_stats[ALTERNATIONS].add(static_cast<double>(_alternation_cnt));
     }
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -455,7 +455,7 @@ inline bool ShenandoahHeap::in_collection_set_loc(void* p) const {
 }
 
 inline char ShenandoahHeap::gc_state() const {
-  return _gc_state.raw_value();
+  return integer_cast<char>(_gc_state.raw_value());
 }
 
 inline bool ShenandoahHeap::is_gc_state(GCState state) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -27,6 +27,7 @@
 
 #include "cppstdlib/cstddef.hpp"
 #include "gc/shenandoah/shenandoahAsserts.hpp"
+#include "utilities/integerCast.hpp"
 
 // TODO: Merge the enhanced capabilities of ShenandoahSimpleBitMap into src/hotspot/share/utilities/bitMap.hpp
 //       and deprecate ShenandoahSimpleBitMap.  The key enhanced capabilities to be integrated include:
@@ -110,7 +111,7 @@ public:
     assert((idx >= 0) && (idx < _num_bits), "precondition");
     size_t array_idx = idx >> LogBitsPerWord;
     uintx bit_number = idx & (BitsPerWord - 1);
-    uintx the_bit = nth_bit(bit_number);
+    uintx the_bit = nth_bit(integer_cast<int>(bit_number));
     _bitmap[array_idx] |= the_bit;
   }
 
@@ -118,7 +119,7 @@ public:
     assert((idx >= 0) && (idx < _num_bits), "precondition");
     size_t array_idx = idx >> LogBitsPerWord;
     uintx bit_number = idx & (BitsPerWord - 1);
-    uintx the_bit = nth_bit(bit_number);
+    uintx the_bit = nth_bit(integer_cast<int>(bit_number));
     _bitmap[array_idx] &= ~the_bit;
   }
 
@@ -126,7 +127,7 @@ public:
     assert((idx >= 0) && (idx < _num_bits), "precondition");
     size_t array_idx = idx >> LogBitsPerWord;
     uintx bit_number = idx & (BitsPerWord - 1);
-    uintx the_bit = nth_bit(bit_number);
+    uintx the_bit = nth_bit(integer_cast<int>(bit_number));
     return (_bitmap[array_idx] & the_bit) != 0;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -158,8 +158,8 @@ private:
   static const uintptr_t weak_extract_mask      = 1 << 1;
   static const uintptr_t chunk_pow_extract_mask = ~right_n_bits(oop_bits);
 
-  static const int chunk_range_mask = right_n_bits(chunk_bits);
-  static const int pow_range_mask   = right_n_bits(pow_bits);
+  static const int chunk_range_mask = right_n_bits<int>(chunk_bits);
+  static const int pow_range_mask   = right_n_bits<int>(pow_bits);
 
   inline oop decode_oop(uintptr_t val) const {
     STATIC_ASSERT(oop_shift == 0);
@@ -249,7 +249,7 @@ public:
   }
 
   static int chunk_size() {
-    return nth_bit(chunk_bits);
+    return nth_bit<int>(chunk_bits);
   }
 };
 #else

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -34,6 +34,7 @@
 #include "runtime/mutex.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/integerCast.hpp"
 
 class BytecodeStream;
 
@@ -206,7 +207,7 @@ public:
   }
 
   bool set_flag_at(u1 flag_number) {
-    const u1 bit = 1 << flag_number;
+    const u1 bit = integer_cast<u1>(1 << flag_number);
     u1 compare_value;
     do {
       compare_value = _header._struct._flags;
@@ -219,7 +220,7 @@ public:
   }
 
   bool clear_flag_at(u1 flag_number) {
-    const u1 bit = 1 << flag_number;
+    const u1 bit = integer_cast<u1>(1 << flag_number);
     u1 compare_value;
     u1 exchange_value;
     do {

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -355,7 +355,7 @@ class Deoptimization : AllStatic {
   }
   static int trap_request_debug_id(int trap_request) {
     if (trap_request < 0) {
-      return ((~(trap_request) >> _debug_id_shift) & right_n_bits(_debug_id_bits));
+      return (~(trap_request) >> _debug_id_shift) & right_n_bits<int>(_debug_id_bits);
     } else {
       // standard action for unloaded CP entry
       return 0;


### PR DESCRIPTION
I am trying to add stricter flags (initially to g1 files), but many header files are included even from Shenandoah (when enabled).

Thus I will remove a few implicit narrowing conversions in Shenandoah files that are included from g1.

I think this is a net win for Shenandoah as implicit narrowing conversions are dangerous. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382920](https://bugs.openjdk.org/browse/JDK-8382920): Shenandoah: Do fewer implicit narrowing conversions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30895/head:pull/30895` \
`$ git checkout pull/30895`

Update a local copy of the PR: \
`$ git checkout pull/30895` \
`$ git pull https://git.openjdk.org/jdk.git pull/30895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30895`

View PR using the GUI difftool: \
`$ git pr show -t 30895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30895.diff">https://git.openjdk.org/jdk/pull/30895.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30895#issuecomment-4305094116)
</details>
