### PR TITLE
8382931: Do fewer implicit narrowing conversions in deoptimization.hpp

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -355,7 +355,7 @@ class Deoptimization : AllStatic {
   }
   static int trap_request_debug_id(int trap_request) {
     if (trap_request < 0) {
-      return ((~(trap_request) >> _debug_id_shift) & right_n_bits(_debug_id_bits));
+      return (~(trap_request) >> _debug_id_shift) & right_n_bits<int>(_debug_id_bits);
     } else {
       // standard action for unloaded CP entry
       return 0;


### PR DESCRIPTION
Explicitly request `int` from `right_n_bits` instead of implicitly converting to `int` later. Also remove redundant brackets. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382931](https://bugs.openjdk.org/browse/JDK-8382931): Do fewer implicit narrowing conversions in deoptimization.hpp (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30898/head:pull/30898` \
`$ git checkout pull/30898`

Update a local copy of the PR: \
`$ git checkout pull/30898` \
`$ git pull https://git.openjdk.org/jdk.git pull/30898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30898`

View PR using the GUI difftool: \
`$ git pr show -t 30898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30898.diff">https://git.openjdk.org/jdk/pull/30898.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30898#issuecomment-4305561289)
</details>
