### PR TITLE
8382777: PrintMethodData not showing BranchData

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -29,6 +29,7 @@
 #include "cds/dynamicArchive.hpp"
 #include "classfile/classLoader.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
+#include "classfile/classPrinter.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
@@ -152,7 +153,7 @@ static void print_method_profiling_data() {
           m->method_data()->parameters_type_data()->print_data_on(&ss);
         }
         // Buffering to a stringStream, disable internal buffering so it's not done twice.
-        m->print_codes_on(&ss, 0, false);
+        m->print_codes_on(&ss, ClassPrinter::PRINT_METHOD_DATA, false);
         tty->print("%s", ss.as_string()); // print all at once
         total_size += m->method_data()->size_in_bytes();
       }

--- a/test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8382777
+ * @summary Test that PrintMethodData output matches expectations
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver ${test.main.class}
+ */
+
+package compiler.profiling;
+
+import compiler.lib.generators.Generator;
+import compiler.lib.generators.Generators;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestPrintMethodData {
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintMethodData",
+            "-XX:CompileCommand=compileonly,compiler.profiling.TestPrintMethodData::test*",
+            Launcher.class.getName());
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+        analyzer.shouldHaveExitValue(0);
+        analyzer.shouldContain("BranchData");
+        analyzer.shouldMatch("taken\\(\\d+\\)");
+    }
+
+    static long testLongReductionSimpleMax(long[] array) {
+        long result = Long.MIN_VALUE;
+        for (int i = 0; i < array.length; i++) {
+            var v = array[i];
+            result = Math.max(v, result);
+        }
+        return result;
+    }
+
+    static class Launcher {
+        private static final Generator<Long> GEN_LONG = Generators.G.longs();
+        private static final int SIZE = 1024;
+
+        static void main(String[] args) throws Exception {
+            long[] longs = new long[SIZE];
+            Generators.G.fill(GEN_LONG, longs);
+
+            for (int i = 0; i < 20_000; i++) {
+                testLongReductionSimpleMax(longs);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed printing method data contents, e.g. `BranchData` and added a test.

Additional testing:

- [X]  Linux x86_64 server fastdebug, tier1-3

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382777](https://bugs.openjdk.org/browse/JDK-8382777): PrintMethodData not showing BranchData (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30900/head:pull/30900` \
`$ git checkout pull/30900`

Update a local copy of the PR: \
`$ git checkout pull/30900` \
`$ git pull https://git.openjdk.org/jdk.git pull/30900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30900`

View PR using the GUI difftool: \
`$ git pr show -t 30900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30900.diff">https://git.openjdk.org/jdk/pull/30900.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30900#issuecomment-4305794775)
</details>
