### PR TITLE
8382934: LateInlineQueueDrainTest.java fails without diagnostic option

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/LateInlineQueueDrainTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlineQueueDrainTest.java
@@ -22,21 +22,21 @@
  */
 
 /*
- * @test
+ * @test id=vector
  * @bug 8381362
  * @summary Verify no crash for vector late-inline queue draining when MH/virtual late inlining is disabled
  * @modules jdk.incubator.vector
- * @run main/othervm -Xcomp
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-IncrementalInlineVirtual -XX:-IncrementalInlineMH -XX:-UseInlineCaches
  *                   ${test.main.class} vector
  */
 
 /*
- * @test
+ * @test id=nonverctor
  * @bug 8381362
  * @summary Verify no crash for non-vector late-inline queue draining when MH/virtual late inlining is disabled
  * @modules jdk.incubator.vector
- * @run main/othervm -Xcomp
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-IncrementalInlineVirtual -XX:-IncrementalInlineMH -XX:-UseInlineCaches
  *                   -XX:LiveNodeCountInliningCutoff=50
  *                   -XX:CompileCommand=compileonly,${test.main.class}::nonVector*
@@ -46,8 +46,10 @@
 
 package compiler.inlining;
 
-import jdk.incubator.vector.*;
 import java.lang.invoke.VarHandle;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorShuffle;
 
 public class LateInlineQueueDrainTest {
     private static final int SIZE = 60_000;
@@ -59,14 +61,9 @@ public class LateInlineQueueDrainTest {
             throw new RuntimeException("Expected one argument: vector|nonvector");
         }
         switch (args[0]) {
-            case "vector":
-                vectorWorkload();
-                break;
-            case "nonvector":
-                nonVectorWorkload();
-                break;
-            default:
-                throw new RuntimeException("Unknown mode: " + args[0]);
+            case "vector" -> vectorWorkload();
+            case "nonvector" -> nonVectorWorkload();
+            default -> throw new RuntimeException("Unknown mode: " + args[0]);
         }
         System.out.println("PASS " + args[0] + " " + sink);
     }

--- a/test/hotspot/jtreg/compiler/inlining/LateInlineQueueDrainTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlineQueueDrainTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test id=vector
+ * @test
  * @bug 8381362
  * @summary Verify no crash for vector late-inline queue draining when MH/virtual late inlining is disabled
  * @modules jdk.incubator.vector
@@ -32,7 +32,7 @@
  */
 
 /*
- * @test id=nonverctor
+ * @test
  * @bug 8381362
  * @summary Verify no crash for non-vector late-inline queue draining when MH/virtual late inlining is disabled
  * @modules jdk.incubator.vector
@@ -46,10 +46,8 @@
 
 package compiler.inlining;
 
+import jdk.incubator.vector.*;
 import java.lang.invoke.VarHandle;
-
-import jdk.incubator.vector.FloatVector;
-import jdk.incubator.vector.VectorShuffle;
 
 public class LateInlineQueueDrainTest {
     private static final int SIZE = 60_000;
@@ -61,9 +59,14 @@ public class LateInlineQueueDrainTest {
             throw new RuntimeException("Expected one argument: vector|nonvector");
         }
         switch (args[0]) {
-            case "vector" -> vectorWorkload();
-            case "nonvector" -> nonVectorWorkload();
-            default -> throw new RuntimeException("Unknown mode: " + args[0]);
+            case "vector":
+                vectorWorkload();
+                break;
+            case "nonvector":
+                nonVectorWorkload();
+                break;
+            default:
+                throw new RuntimeException("Unknown mode: " + args[0]);
         }
         System.out.println("PASS " + args[0] + " " + sink);
     }


### PR DESCRIPTION
Hi all,

This PR add -XX:+UnlockDiagnosticVMOptions for both nonvector and vector. Test-fix only, no risk.

Change has been verified by run this test with release build and fastdebug build.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382934](https://bugs.openjdk.org/browse/JDK-8382934): LateInlineQueueDrainTest.java fails without diagnostic option (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30901/head:pull/30901` \
`$ git checkout pull/30901`

Update a local copy of the PR: \
`$ git checkout pull/30901` \
`$ git pull https://git.openjdk.org/jdk.git pull/30901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30901`

View PR using the GUI difftool: \
`$ git pr show -t 30901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30901.diff">https://git.openjdk.org/jdk/pull/30901.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30901#issuecomment-4305823430)
</details>
