### PR TITLE
8378464: PixelInterleavedSampleModel constructors and methods do not specify behavior when arguments are null or out of bounds

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/BandedSampleModel.java
@@ -167,9 +167,10 @@ public final class BandedSampleModel extends ComponentSampleModel
      * can be used with.  The new BandedSampleModel/DataBuffer
      * combination will represent an image with a subset of the bands
      * of the original BandedSampleModel/DataBuffer combination.
+     * @throws NullPointerException if {@code bands} is {@code null}
+     * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws RasterFormatException if the number of bands is greater than
      *                               the number of banks in this sample model.
-     * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {

--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -395,6 +395,11 @@ public class ComponentSampleModel extends SampleModel
      *              {@code ComponentSampleModel}
      * @return a {@code ComponentSampleModel} created with a subset
      *          of bands from this {@code ComponentSampleModel}.
+     * @throws NullPointerException if {@code bands} is {@code null}
+     * @throws IllegalArgumentException if the number of bands is not greater than 0
+     * @throws RasterFormatException if the number of bands is greater than
+     *                               the number of banks in this sample model.
+     * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {
        if (bands.length > bankIndices.length)

--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -399,7 +399,7 @@ public class ComponentSampleModel extends SampleModel
      * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws RasterFormatException if the number of bands is greater than
      *                               the number of banks in this sample model.
-     * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
+     * @throws ArrayIndexOutOfBoundsException if any of the band indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {
        if (bands.length > bankIndices.length)

--- a/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
@@ -159,7 +159,7 @@ public class PixelInterleavedSampleModel extends ComponentSampleModel
      * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws RasterFormatException if the number of bands is greater than
      *                               the number of bands in this sample model.
-     * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
+     * @throws ArrayIndexOutOfBoundsException if any of the band indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {
        if (bands.length > bandOffsets.length) {

--- a/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
@@ -78,6 +78,8 @@ public class PixelInterleavedSampleModel extends ComponentSampleModel
      *         less than any offset between bands
      * @throws IllegalArgumentException if {@code dataType} is not
      *         one of the supported data types
+     * @throws NullPointerException if {@code bandOffsets} is {@code null}
+     * @throws IllegalArgumentException if {@code bandOffsets.length} is 0
      */
     public PixelInterleavedSampleModel(int dataType,
                                        int w, int h,
@@ -153,8 +155,18 @@ public class PixelInterleavedSampleModel extends ComponentSampleModel
      * PixelInterleavedSampleModel/DataBuffer combination will represent
      * an image with a subset of the bands of the original
      * PixelInterleavedSampleModel/DataBuffer combination.
+     * @throws NullPointerException if {@code bands} is {@code null}
+     * @throws IllegalArgumentException if the number of bands is not greater than 0
+     * @throws RasterFormatException if the number of bands is greater than
+     *                               the number of banks in this sample model.
+     * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {
+       if (bands.length > bandOffsets.length) {
+            throw new RasterFormatException("There are only " +
+                                            bandOffsets.length +
+                                            " bands");
+        }
         int[] newBandOffsets = new int[bands.length];
         for (int i=0; i<bands.length; i++) {
             newBandOffsets[i] = bandOffsets[bands[i]];

--- a/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
@@ -158,7 +158,7 @@ public class PixelInterleavedSampleModel extends ComponentSampleModel
      * @throws NullPointerException if {@code bands} is {@code null}
      * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws RasterFormatException if the number of bands is greater than
-     *                               the number of banks in this sample model.
+     *                               the number of bands in this sample model.
      * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {

--- a/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/PixelInterleavedSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
@@ -307,7 +307,7 @@ public class SinglePixelPackedSampleModel extends SampleModel
      * SinglePixelPackedSampleModel/DataBuffer combination will represent
      * an image with a subset of the bands of the original
      * SinglePixelPackedSampleModel/DataBuffer combination.
-
+     *
      * @throws NullPointerException if {@code bands} is {@code null}
      * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws RasterFormatException if the length of the bands argument is

--- a/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
@@ -307,9 +307,13 @@ public class SinglePixelPackedSampleModel extends SampleModel
      * SinglePixelPackedSampleModel/DataBuffer combination will represent
      * an image with a subset of the bands of the original
      * SinglePixelPackedSampleModel/DataBuffer combination.
+
+     * @throws NullPointerException if {@code bands} is {@code null}
+     * @throws IllegalArgumentException if the number of bands is not greater than 0
      * @throws RasterFormatException if the length of the bands argument is
      *                                  greater than the number of bands in
      *                                  the sample model.
+     * @throws ArrayIndexOutOfBoundsException if any of the bank indices is out of bounds
      */
     public SampleModel createSubsetSampleModel(int[] bands) {
         if (bands.length > numBands)

--- a/test/jdk/java/awt/image/CreateSubsetSampleModelTest.java
+++ b/test/jdk/java/awt/image/CreateSubsetSampleModelTest.java
@@ -65,8 +65,6 @@ public class CreateSubsetSampleModelTest {
         SinglePixelPackedSampleModel sppsm2bands =
             new SinglePixelPackedSampleModel(TYPE_BYTE, 1, 1, twobands);
         testSubset(sppsm2bands);
-
-        testSubset(csm2bands);
     }
 
     static void cons(int[] bands, Class eType) {

--- a/test/jdk/java/awt/image/CreateSubsetSampleModelTest.java
+++ b/test/jdk/java/awt/image/CreateSubsetSampleModelTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8378464
+ * @summary test SampleModel.createSubsetSampleModel()
+ */
+
+import static java.awt.image.DataBuffer.*;
+import java.awt.image.BandedSampleModel;
+import java.awt.image.SampleModel;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.RasterFormatException;
+import java.awt.image.SinglePixelPackedSampleModel;
+
+public class CreateSubsetSampleModelTest {
+
+    static final int[] nullbands = null;
+    static final int[] zerobands = { };
+    static final int[] oneband = { 0 };
+    static final int[] twobands = { 0, 1 };
+    static final int[] threebands = { 0, 1, 2 };
+    static final int[] badbands = { 99 };
+
+    public static void main(String[] args) {
+
+        cons(nullbands, NullPointerException.class);
+        cons(zerobands, IllegalArgumentException.class);
+        cons(oneband, null);
+
+        PixelInterleavedSampleModel psm2bands =
+            new PixelInterleavedSampleModel(TYPE_BYTE, 1, 1, 1, 1, twobands);
+        testSubset(psm2bands);
+
+        ComponentSampleModel csm2bands =
+            new ComponentSampleModel(TYPE_BYTE, 1, 1, 1, 1, twobands);
+        testSubset(csm2bands);
+
+        BandedSampleModel bsm2bands =
+            new BandedSampleModel(TYPE_BYTE, 1, 1, 1, twobands, twobands);
+        testSubset(bsm2bands);
+
+        SinglePixelPackedSampleModel sppsm2bands =
+            new SinglePixelPackedSampleModel(TYPE_BYTE, 1, 1, twobands);
+        testSubset(sppsm2bands);
+
+        testSubset(csm2bands);
+    }
+
+    static void cons(int[] bands, Class eType) {
+        try {
+           new PixelInterleavedSampleModel(TYPE_BYTE, 1, 1, 1, 1, bands);
+        } catch (Exception e) {
+             if (eType == null || !(eType.isInstance(e))) {
+               throw new RuntimeException("failed for " + eType + " got " + e);
+           } else {
+               return;
+           }
+        }
+        if (eType != null) {
+            throw new RuntimeException("No exception for " + bands);
+        }
+    }
+
+    static void subset(SampleModel sm, int[] bands, Class eType) {
+        try {
+           sm.createSubsetSampleModel(bands);
+        } catch (Exception e) {
+             if (eType == null || !(eType.isInstance(e))) {
+               e.printStackTrace();
+               throw new RuntimeException("failed for " + eType + " got " + e);
+           } else {
+               return;
+           }
+        }
+        if (eType != null) {
+            throw new RuntimeException("No exception for " + bands);
+        }
+    }
+
+    static void testSubset(SampleModel sm) {
+        subset(sm, nullbands, NullPointerException.class);
+        subset(sm, zerobands, IllegalArgumentException.class);
+        subset(sm, oneband, null);
+        subset(sm, twobands, null);
+        subset(sm, threebands, RasterFormatException.class);
+        subset(sm, badbands, ArrayIndexOutOfBoundsException.class);
+    }
+}

--- a/test/jdk/java/awt/image/PixelInterleavedSMConstructor.java
+++ b/test/jdk/java/awt/image/PixelInterleavedSMConstructor.java
@@ -35,12 +35,14 @@ public class PixelInterleavedSMConstructor {
     static final int[] nullbands = null;
     static final int[] zerobands = { };
     static final int[] oneband = { 0 };
+    static final int[] negband = { -1 };
 
     public static void main(String[] args) {
 
         cons(nullbands, NullPointerException.class);
         cons(zerobands, IllegalArgumentException.class);
         cons(oneband, null);
+        cons(negband, IllegalArgumentException.class);
     }
 
     static void cons(int[] bands, Class eType) {

--- a/test/jdk/java/awt/image/PixelInterleavedSMConstructor.java
+++ b/test/jdk/java/awt/image/PixelInterleavedSMConstructor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8378464
+ * @summary test PixelInterleavedSampleModel constructor
+ */
+
+import static java.awt.image.DataBuffer.*;
+import java.awt.image.PixelInterleavedSampleModel;
+
+public class PixelInterleavedSMConstructor {
+
+    static final int[] nullbands = null;
+    static final int[] zerobands = { };
+    static final int[] oneband = { 0 };
+
+    public static void main(String[] args) {
+
+        cons(nullbands, NullPointerException.class);
+        cons(zerobands, IllegalArgumentException.class);
+        cons(oneband, null);
+    }
+
+    static void cons(int[] bands, Class eType) {
+        try {
+           new PixelInterleavedSampleModel(TYPE_BYTE, 1, 1, 1, 1, bands);
+        } catch (Exception e) {
+             if (eType == null || !(eType.isInstance(e))) {
+               throw new RuntimeException("failed for " + eType + " got " + e);
+           } else {
+               return;
+           }
+        }
+        if (eType != null) {
+            throw new RuntimeException("No exception for " + bands);
+        }
+    }
+}


### PR DESCRIPTION
This is mostly spec updates.
A PixelInterleavedSampleModel constructor did not specify what happens with some illegal arguments

It was also reported that the same problem exists for the createSubsetSampleModel so that is updated too, but I then went and looked at this method in other SampleModel subclasses and updated those too.

The super-class SampleModel. createSubsetSampleModel is NOT updated because in fact one subclass behaves differently because it supports only one band.
That subclass is handled in a related PR, not this one.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8383742](https://bugs.openjdk.org/browse/JDK-8383742) to be approved
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8378464](https://bugs.openjdk.org/browse/JDK-8378464): PixelInterleavedSampleModel constructors and methods do not specify behavior when arguments are null or out of bounds (**Enhancement** - P3)
 * [JDK-8383742](https://bugs.openjdk.org/browse/JDK-8383742): PixelInterleavedSampleModel constructors and methods do not specify behavior when arguments are null or out of bounds (**CSR**)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30902/head:pull/30902` \
`$ git checkout pull/30902`

Update a local copy of the PR: \
`$ git checkout pull/30902` \
`$ git pull https://git.openjdk.org/jdk.git pull/30902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30902`

View PR using the GUI difftool: \
`$ git pr show -t 30902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30902.diff">https://git.openjdk.org/jdk/pull/30902.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30902#issuecomment-4306929498)
</details>
