### PR TITLE
8383162: jpackage: decouple WinMsiPackager and RTF converter

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/RtfConverter.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/RtfConverter.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jpackage.internal;
+
+import static jdk.jpackage.internal.util.function.ThrowingConsumer.toConsumer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Stream;
+import jdk.jpackage.internal.util.function.ExceptionBox;
+
+sealed interface RtfConverter {
+
+    void convert(Path path) throws IOException;
+
+    static boolean isRtfFile(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            return false;
+        }
+
+        try (InputStream fin = Files.newInputStream(path)) {
+            byte[] firstBits = new byte[7];
+
+            if (fin.read(firstBits) == firstBits.length) {
+                String header = new String(firstBits);
+                return "{\\rtf1\\".equals(header);
+            }
+        }
+
+        return false;
+    }
+
+    static Optional<RtfConverter> createSimple(Path path) throws IOException {
+        if (isRtfFile(path)) {
+            return Optional.of(Details.Simple.VALUE);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    static final class Details {
+        private enum Simple implements RtfConverter {
+
+            VALUE;
+
+            @Override
+            public void convert(Path path) throws IOException {
+                var content = Files.readAllLines(path);
+                try (var w = Files.newBufferedWriter(path, Charset.forName("Windows-1252"))) {
+                    convert(content.stream(), w);
+                }
+            }
+
+            private void convert(Stream<String> textFile, Appendable sink) throws IOException {
+
+                sink.append("{\\rtf1\\ansi\\ansicpg1252\\deff0\\deflang1033"
+                        + "{\\fonttbl{\\f0\\fnil\\fcharset0 Arial;}}\n"
+                        + "\\viewkind4\\uc1\\pard\\sa200\\sl276"
+                        + "\\slmult1\\lang9\\fs20 ");
+
+                try {
+                    textFile.forEach(toConsumer(l -> {
+                        for (char c : l.toCharArray()) {
+                            // 0x00 <= ch < 0x20 Escaped (\'hh)
+                            // 0x20 <= ch < 0x80 Raw(non - escaped) char
+                            // 0x80 <= ch <= 0xFF Escaped(\ 'hh)
+                            // 0x5C, 0x7B, 0x7D (special RTF characters
+                            // \,{,})Escaped(\'hh)
+                            // ch > 0xff Escaped (\\ud###?)
+                            if (c < 0x10) {
+                                sink.append("\\'0");
+                                sink.append(Integer.toHexString(c));
+                            } else if (c > 0xff) {
+                                sink.append("\\ud");
+                                sink.append(Integer.toString(c));
+                                // \\uc1 is in the header and in effect
+                                // so we trail with a replacement char if
+                                // the font lacks that character - '?'
+                                sink.append("?");
+                            } else if ((c < 0x20) || (c >= 0x80) ||
+                                    (c == 0x5C) || (c == 0x7B) ||
+                                    (c == 0x7D)) {
+                                sink.append("\\'");
+                                sink.append(Integer.toHexString(c));
+                            } else {
+                                sink.append(c);
+                            }
+                        }
+                        // blank lines are interpreted as paragraph breaks
+                        if (l.length() < 1) {
+                            sink.append("\\par");
+                        } else {
+                            sink.append(" ");
+                        }
+                        sink.append("\r\n");
+                    }));
+                } catch (ExceptionBox ex) {
+                    switch (ExceptionBox.unbox(ex)) {
+                        case IOException ioex -> {
+                            throw ioex;
+                        }
+                        default -> {
+                            throw ex;
+                        }
+                    }
+                }
+
+                sink.append("}\r\n");
+            }
+        }
+
+    }
+}

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiPackager.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiPackager.java
@@ -24,12 +24,10 @@
  */
 
 package jdk.jpackage.internal;
+import static jdk.jpackage.internal.util.function.ThrowingConsumer.toConsumer;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.io.Writer;
-import java.nio.charset.Charset;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -169,19 +167,18 @@ final class WinMsiPackager implements Consumer<PackagingPipeline.Builder> {
 
     private void prepareConfigFiles() throws IOException {
 
-        pkg.licenseFile().ifPresent(licenseFile -> {
+        pkg.licenseFile().ifPresent(toConsumer(licenseFile -> {
             // need to copy license file to the working directory
             // and convert to rtf if needed
             Path destFile = env.configDir().resolve(licenseFile.getFileName());
 
-            try {
-                IOUtils.copyFile(licenseFile, destFile);
-            } catch (IOException ex) {
-                throw new UncheckedIOException(ex);
-            }
-            destFile.toFile().setWritable(true);
-            ensureByMutationFileIsRTF(destFile);
-        });
+            IOUtils.copyFile(licenseFile, destFile);
+
+            RtfConverter.createSimple(licenseFile).ifPresent(toConsumer(rtfConverter -> {
+                destFile.toFile().setWritable(true);
+                rtfConverter.convert(destFile);
+            }));
+        }));
 
         for (var wixFragment : wixFragments) {
             wixFragment.initFromParams(env, pkg);
@@ -399,74 +396,6 @@ final class WinMsiPackager implements Consumer<PackagingPipeline.Builder> {
                     "error.read-wix-l10n-file", wxlPath.toAbsolutePath().normalize()), ex);
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
-        }
-    }
-
-    private static void ensureByMutationFileIsRTF(Path f) {
-        try {
-            boolean existingLicenseIsRTF = false;
-
-            try (InputStream fin = Files.newInputStream(f)) {
-                byte[] firstBits = new byte[7];
-
-                if (fin.read(firstBits) == firstBits.length) {
-                    String header = new String(firstBits);
-                    existingLicenseIsRTF = "{\\rtf1\\".equals(header);
-                }
-            }
-
-            if (!existingLicenseIsRTF) {
-                List<String> oldLicense = Files.readAllLines(f);
-                try (Writer w = Files.newBufferedWriter(
-                        f, Charset.forName("Windows-1252"))) {
-                    w.write("{\\rtf1\\ansi\\ansicpg1252\\deff0\\deflang1033"
-                            + "{\\fonttbl{\\f0\\fnil\\fcharset0 Arial;}}\n"
-                            + "\\viewkind4\\uc1\\pard\\sa200\\sl276"
-                            + "\\slmult1\\lang9\\fs20 ");
-                    oldLicense.forEach(l -> {
-                        try {
-                            for (char c : l.toCharArray()) {
-                                // 0x00 <= ch < 0x20 Escaped (\'hh)
-                                // 0x20 <= ch < 0x80 Raw(non - escaped) char
-                                // 0x80 <= ch <= 0xFF Escaped(\ 'hh)
-                                // 0x5C, 0x7B, 0x7D (special RTF characters
-                                // \,{,})Escaped(\'hh)
-                                // ch > 0xff Escaped (\\ud###?)
-                                if (c < 0x10) {
-                                    w.write("\\'0");
-                                    w.write(Integer.toHexString(c));
-                                } else if (c > 0xff) {
-                                    w.write("\\ud");
-                                    w.write(Integer.toString(c));
-                                    // \\uc1 is in the header and in effect
-                                    // so we trail with a replacement char if
-                                    // the font lacks that character - '?'
-                                    w.write("?");
-                                } else if ((c < 0x20) || (c >= 0x80) ||
-                                        (c == 0x5C) || (c == 0x7B) ||
-                                        (c == 0x7D)) {
-                                    w.write("\\'");
-                                    w.write(Integer.toHexString(c));
-                                } else {
-                                    w.write(c);
-                                }
-                            }
-                            // blank lines are interpreted as paragraph breaks
-                            if (l.length() < 1) {
-                                w.write("\\par");
-                            } else {
-                                w.write(" ");
-                            }
-                            w.write("\r\n");
-                        } catch (IOException e) {
-                            Log.verbose(e);
-                        }
-                    });
-                    w.write("}\r\n");
-                }
-            }
-        } catch (IOException e) {
-            Log.verbose(e);
         }
     }
 


### PR DESCRIPTION
Move the functionality for converting a plain-text license file to an RTF file into a separate class.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383162](https://bugs.openjdk.org/browse/JDK-8383162): jpackage: decouple WinMsiPackager and RTF converter (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30904/head:pull/30904` \
`$ git checkout pull/30904`

Update a local copy of the PR: \
`$ git checkout pull/30904` \
`$ git pull https://git.openjdk.org/jdk.git pull/30904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30904`

View PR using the GUI difftool: \
`$ git pr show -t 30904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30904.diff">https://git.openjdk.org/jdk/pull/30904.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30904#issuecomment-4309071680)
</details>
