### PR TITLE
Main: split the "verbose" property of the Main.ErrorReporter record i…

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/Main.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/Main.java
@@ -144,7 +144,7 @@ public final class Main {
         final var runner = new Runner(t -> {
             new ErrorReporter(_ -> {
                 t.printStackTrace(err);
-            }, Log::fatalError, Log.isVerbose()).reportError(t);
+            }, Log::fatalError, Log.isVerbose(), !Log.isVerbose()).reportError(t);
         });
 
         try {
@@ -234,17 +234,22 @@ public final class Main {
      * Always print the messages for exceptions of any type.
      */
 
-    record ErrorReporter(Consumer<Throwable> stackTracePrinter, Consumer<String> messagePrinter, boolean verbose) {
-        ErrorReporter {
+    public record ErrorReporter(
+            Consumer<Throwable> stackTracePrinter,
+            Consumer<String> messagePrinter,
+            boolean alwaysPrintStackTrace,
+            boolean printCommandOutput) {
+
+        public ErrorReporter {
             Objects.requireNonNull(stackTracePrinter);
             Objects.requireNonNull(messagePrinter);
         }
 
-        ErrorReporter(Consumer<Throwable> stackTracePrinter, Consumer<String> messagePrinter) {
-            this(stackTracePrinter, messagePrinter, true);
+        public ErrorReporter(Consumer<Throwable> stackTracePrinter, Consumer<String> messagePrinter) {
+            this(stackTracePrinter, messagePrinter, true, false);
         }
 
-        void reportError(Throwable t) {
+        public void reportError(Throwable t) {
 
             var unfoldedExceptions = new ArrayList<Exception>();
             ExceptionBox.visitUnboxedExceptionsRecursively(t, unfoldedExceptions::add);
@@ -267,7 +272,7 @@ public final class Main {
             var commandOutput = ((ExecutableAttributesWithCapturedOutput)result.execAttrs()).printableOutput();
             var printableCommandLine = result.execAttrs().printableCommandLine();
 
-            if (verbose) {
+            if (alwaysPrintStackTrace) {
                 stackTracePrinter.accept(ex);
             }
 
@@ -281,16 +286,18 @@ public final class Main {
             }
 
             messagePrinter.accept(I18N.format("message.error-header", msg));
-            messagePrinter.accept(I18N.format("message.failed-command-output-header"));
-            try (var lines = new BufferedReader(new StringReader(commandOutput)).lines()) {
-                lines.forEach(messagePrinter);
+            if (printCommandOutput) {
+                messagePrinter.accept(I18N.format("message.failed-command-output-header"));
+                try (var lines = new BufferedReader(new StringReader(commandOutput)).lines()) {
+                    lines.forEach(messagePrinter);
+                }
             }
         }
 
         private void printError(Throwable t, Optional<String> advice) {
             var isSelfContained = isSelfContained(t);
 
-            if (!isSelfContained || verbose) {
+            if (!isSelfContained || alwaysPrintStackTrace) {
                 stackTracePrinter.accept(t);
             }
 

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/MainTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/MainTest.java
@@ -186,16 +186,18 @@ public class MainTest extends JUnitAdapter {
 
     private static List<ErrorReporterTestSpec> test_ErrorReporter() {
         var testCases = new ArrayList<ErrorReporterTestSpec>();
-        for (var verbose : List.of(true, false)) {
-            test_ErrorReporter_Exception(verbose, testCases::add);
-            test_ErrorReporter_UnexpectedResultException(verbose, testCases::add);
-            test_ErrorReporter_suppressedExceptions(verbose, testCases::add);
+        for (var alwaysPrintStackTrace : List.of(true, false)) {
+            test_ErrorReporter_Exception(alwaysPrintStackTrace, testCases::add);
+            for (var printCommandOutput : List.of(true, false)) {
+                test_ErrorReporter_UnexpectedResultException(alwaysPrintStackTrace, printCommandOutput, testCases::add);
+                test_ErrorReporter_suppressedExceptions(alwaysPrintStackTrace, printCommandOutput, testCases::add);
+            }
         }
 
         return testCases;
     }
 
-    private static void test_ErrorReporter_Exception(boolean verbose, Consumer<ErrorReporterTestSpec> sink) {
+    private static void test_ErrorReporter_Exception(boolean alwaysPrintStackTrace, Consumer<ErrorReporterTestSpec> sink) {
 
         for (var makeCause : List.<UnaryOperator<Exception>>of(
                 ex -> ex,
@@ -220,6 +222,8 @@ public class MainTest extends JUnitAdapter {
             for (var expect : List.of(
                     new IOException("I/O error"),
                     new NullPointerException(),
+                    // Exception without a message
+                    new Exception(),
                     new JPackageException("Kaput!"),
                     new ConfigException("It is broken", "Fix it!"),
                     new ConfigException("It is broken. No advice how to fix it", (String)null),
@@ -232,13 +236,14 @@ public class MainTest extends JUnitAdapter {
                 }
 
                 var expectedOutput = new ArrayList<ExceptionFormatter>();
-                ErrorReporterTestSpec.expectExceptionFormatters(expect, verbose, expectedOutput::add);
-                sink.accept(ErrorReporterTestSpec.create(cause, expect, verbose, expectedOutput));
+                ErrorReporterTestSpec.expectExceptionFormatters(expect, alwaysPrintStackTrace, false, expectedOutput::add);
+                sink.accept(ErrorReporterTestSpec.create(cause, expect, alwaysPrintStackTrace, false, expectedOutput));
             }
         }
     }
 
-    private static void test_ErrorReporter_UnexpectedResultException(boolean verbose, Consumer<ErrorReporterTestSpec> sink) {
+    private static void test_ErrorReporter_UnexpectedResultException(
+            boolean alwaysPrintStackTrace, boolean printCommandOutput, Consumer<ErrorReporterTestSpec> sink) {
 
         var execAttrs = new CommandOutputControl.ProcessAttributes(Optional.of(12345L), List.of("foo", "--bar"));
 
@@ -263,8 +268,8 @@ public class MainTest extends JUnitAdapter {
             )) {
                 var cause = makeCause.apply(expect);
                 var expectedOutput = new ArrayList<ExceptionFormatter>();
-                ErrorReporterTestSpec.expectExceptionFormatters(expect, verbose, expectedOutput::add);
-                sink.accept(ErrorReporterTestSpec.create(cause, expect, verbose, expectedOutput));
+                ErrorReporterTestSpec.expectExceptionFormatters(expect, alwaysPrintStackTrace, printCommandOutput, expectedOutput::add);
+                sink.accept(ErrorReporterTestSpec.create(cause, expect, alwaysPrintStackTrace, printCommandOutput, expectedOutput));
             }
         }
     }
@@ -286,7 +291,8 @@ public class MainTest extends JUnitAdapter {
         }
     }
 
-    private static void test_ErrorReporter_suppressedExceptions(boolean verbose, Consumer<ErrorReporterTestSpec> sink) {
+    private static void test_ErrorReporter_suppressedExceptions(
+            boolean alwaysPrintStackTrace, boolean printCommandOutput, Consumer<ErrorReporterTestSpec> sink) {
 
         var execAttrs = new CommandOutputControl.ProcessAttributes(Optional.of(567L), List.of("foo", "--bar"));
 
@@ -329,10 +335,11 @@ public class MainTest extends JUnitAdapter {
 
                 var expectedOutput = new ArrayList<FormattedException>();
 
-                ErrorReporterTestSpec.expectOutputFragments(ExceptionBox.unbox(suppressed), verbose, expectedOutput::add);
-                ErrorReporterTestSpec.expectOutputFragments(main, verbose, expectedOutput::add);
+                ErrorReporterTestSpec.expectOutputFragments(
+                        ExceptionBox.unbox(suppressed), alwaysPrintStackTrace, printCommandOutput, expectedOutput::add);
+                ErrorReporterTestSpec.expectOutputFragments(main, alwaysPrintStackTrace, printCommandOutput, expectedOutput::add);
 
-                sink.accept(new ErrorReporterTestSpec(cause, verbose, expectedOutput));
+                sink.accept(new ErrorReporterTestSpec(cause, alwaysPrintStackTrace, printCommandOutput, expectedOutput));
             }
         }
     }
@@ -614,7 +621,11 @@ public class MainTest extends JUnitAdapter {
     }
 
 
-    record ErrorReporterTestSpec(Exception cause, boolean verbose, List<FormattedException> expectOutput) {
+    record ErrorReporterTestSpec(
+            Exception cause,
+            boolean alwaysPrintStackTrace,
+            boolean printCommandOutput,
+            List<FormattedException> expectOutput) {
 
         ErrorReporterTestSpec {
             Objects.requireNonNull(cause);
@@ -625,26 +636,40 @@ public class MainTest extends JUnitAdapter {
         }
 
         static ErrorReporterTestSpec create(
-                Exception cause, boolean verbose, List<ExceptionFormatter> expectOutput) {
-            return create(cause, cause, verbose, expectOutput);
+                Exception cause,
+                boolean alwaysPrintStackTrace,
+                boolean printCommandOutput,
+                List<ExceptionFormatter> expectOutput) {
+            return create(cause, cause, alwaysPrintStackTrace, printCommandOutput, expectOutput);
         }
 
         static ErrorReporterTestSpec create(
-                Exception cause, Exception expect, boolean verbose, List<ExceptionFormatter> expectOutput) {
+                Exception cause,
+                Exception expect,
+                boolean alwaysPrintStackTrace,
+                boolean printCommandOutput,
+                List<ExceptionFormatter> expectOutput) {
+
             Objects.requireNonNull(cause);
             Objects.requireNonNull(expect);
-            return new ErrorReporterTestSpec(cause, verbose, expectOutput.stream().map(formatter -> {
+
+            return new ErrorReporterTestSpec(cause, alwaysPrintStackTrace, printCommandOutput, expectOutput.stream().map(formatter -> {
                 return new FormattedException(formatter, expect);
             }).toList());
         }
 
-        static void expectExceptionFormatters(Exception ex, boolean verbose, Consumer<ExceptionFormatter> sink) {
+        static void expectExceptionFormatters(
+                Exception ex,
+                boolean alwaysPrintStackTrace,
+                boolean printCommandOutput,
+                Consumer<ExceptionFormatter> sink) {
+
             Objects.requireNonNull(ex);
             Objects.requireNonNull(sink);
 
             final var isSelfContained = (ex.getClass().getAnnotation(SelfContainedException.class) != null);
 
-            if (verbose || !(isSelfContained || ex instanceof UnexpectedResultException)) {
+            if (alwaysPrintStackTrace || !(isSelfContained || ex instanceof UnexpectedResultException)) {
                 sink.accept(ExceptionFormatter.STACK_TRACE);
             }
 
@@ -664,7 +689,10 @@ public class MainTest extends JUnitAdapter {
                     } else {
                         sink.accept(ExceptionFormatter.FAILED_COMMAND_TIMEDOUT_MESSAGE);
                     }
-                    sink.accept(ExceptionFormatter.FAILED_COMMAND_OUTPUT);
+
+                    if (printCommandOutput) {
+                        sink.accept(ExceptionFormatter.FAILED_COMMAND_OUTPUT);
+                    }
                 }
                 default -> {
                     if (isSelfContained) {
@@ -676,9 +704,14 @@ public class MainTest extends JUnitAdapter {
             }
         }
 
-        static void expectOutputFragments(Exception ex, boolean verbose, Consumer<FormattedException> sink) {
+        static void expectOutputFragments(
+                Exception ex,
+                boolean alwaysPrintStackTrace,
+                boolean printCommandOutput,
+                Consumer<FormattedException> sink) {
+
             Objects.requireNonNull(sink);
-            expectExceptionFormatters(ex, verbose, formatter -> {
+            expectExceptionFormatters(ex, alwaysPrintStackTrace, printCommandOutput, formatter -> {
                 sink.accept(formatter.bind(ex));
             });
         }
@@ -708,8 +741,12 @@ public class MainTest extends JUnitAdapter {
                 }).collect(Collectors.joining("+")));
             }
 
-            if (verbose) {
-                tokens.add("verbose");
+            if (alwaysPrintStackTrace) {
+                tokens.add("stacktrace-always");
+            }
+
+            if (printCommandOutput) {
+                tokens.add("command-output");
             }
 
             return tokens.stream().collect(Collectors.joining("; "));
@@ -723,7 +760,7 @@ public class MainTest extends JUnitAdapter {
                     t.printStackTrace(pw);
                 }, msg -> {
                     pw.println(msg);
-                }, verbose).reportError(cause);
+                }, alwaysPrintStackTrace, printCommandOutput).reportError(cause);
             }
 
             var expected = expectOutput.stream().map(FormattedException::format).collect(Collectors.joining(""));

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsValidationFailTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/OptionsValidationFailTest.java
@@ -99,7 +99,7 @@ public class OptionsValidationFailTest {
 
                 var errorReporter = new Main.ErrorReporter(ex -> {
                     ex.printStackTrace(err);
-                }, err::println, false);
+                }, err::println, false, true);
 
                 return parse(args).peekErrors(errors -> {
                     final var firstErr = errors.stream().findFirst().orElseThrow();


### PR DESCRIPTION
 - Split the "verbose" property of the Main.ErrorReporter record into `alwaysPrintStackTrace` and `printCommandOutput` properties
 - Make Main.ErrorReporter public
 -  MainTest: add test case for an exception with "null" message

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30905/head:pull/30905` \
`$ git checkout pull/30905`

Update a local copy of the PR: \
`$ git checkout pull/30905` \
`$ git pull https://git.openjdk.org/jdk.git pull/30905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30905`

View PR using the GUI difftool: \
`$ git pr show -t 30905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30905.diff">https://git.openjdk.org/jdk/pull/30905.diff</a>

</details>
