### PR TITLE
8383161: [PPC64] MachCallDynamicJavaNode::ret_addr_offset() needs adaptation for COH

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -3214,7 +3214,7 @@ void MacroAssembler::store_klass_gap(Register dst_oop, Register val) {
   stw(val, oopDesc::klass_gap_offset_in_bytes(), dst_oop);
 }
 
-int MacroAssembler::instr_size_for_decode_klass_not_null() {
+int MacroAssembler::instr_size_for_load_klass() {
   static int computed_size = -1;
 
   // Not yet computed?
@@ -3222,10 +3222,10 @@ int MacroAssembler::instr_size_for_decode_klass_not_null() {
 
     // Determine by scratch emit.
     ResourceMark rm;
-    int code_size = 8 * BytesPerInstWord;
-    CodeBuffer cb("decode_klass_not_null scratch buffer", code_size, 0);
+    int code_size = 16 * BytesPerInstWord;
+    CodeBuffer cb("load_klass scratch buffer", code_size, 0);
     MacroAssembler* a = new MacroAssembler(&cb);
-    a->decode_klass_not_null(R11_scratch1);
+    a->load_klass(R11_scratch1, R11_scratch1);
     computed_size = a->offset();
   }
 

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -802,7 +802,7 @@ class MacroAssembler: public Assembler {
                            MacroAssembler::PreservationLevel preservation_level);
   void load_method_holder(Register holder, Register method);
 
-  static int instr_size_for_decode_klass_not_null();
+  static int instr_size_for_load_klass();
   void decode_klass_not_null(Register dst, Register src = noreg);
   Register encode_klass_not_null(Register dst, Register src = noreg);
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1187,7 +1187,9 @@ int MachCallDynamicJavaNode::ret_addr_offset() {
     assert(vtable_index == Method::invalid_vtable_index, "correct sentinel value");
     return 12;
   } else {
-    return 24 + MacroAssembler::instr_size_for_decode_klass_not_null();
+    int size = 24 + MacroAssembler::instr_size_for_decode_klass_not_null();
+    if (UseCompactObjectHeaders) size += 4; // one extra instruction
+    return size;
   }
 }
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1187,9 +1187,7 @@ int MachCallDynamicJavaNode::ret_addr_offset() {
     assert(vtable_index == Method::invalid_vtable_index, "correct sentinel value");
     return 12;
   } else {
-    int size = 24 + MacroAssembler::instr_size_for_decode_klass_not_null();
-    if (UseCompactObjectHeaders) size += 4; // one extra instruction
-    return size;
+    return 20 + MacroAssembler::instr_size_for_load_klass();
   }
 }
 


### PR DESCRIPTION
Trivial adaptation for COH. See JBS issue for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383161](https://bugs.openjdk.org/browse/JDK-8383161): [PPC64] MachCallDynamicJavaNode::ret_addr_offset() needs adaptation for COH (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30907/head:pull/30907` \
`$ git checkout pull/30907`

Update a local copy of the PR: \
`$ git checkout pull/30907` \
`$ git pull https://git.openjdk.org/jdk.git pull/30907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30907`

View PR using the GUI difftool: \
`$ git pr show -t 30907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30907.diff">https://git.openjdk.org/jdk/pull/30907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30907#issuecomment-4309059082)
</details>
