### PR TITLE
8383163: Build without CDS broken after 8382170

### DIFF
--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -67,9 +67,11 @@ void FreeHeap(void* p) {
   os::free(p);
 }
 
-#if INCLUDE_CDS
+// These are used by the Serviceability Agent even if CDS is disabled
 void* MetaspaceObj::_aot_metaspace_base = nullptr;
 void* MetaspaceObj::_aot_metaspace_top  = nullptr;
+
+#if INCLUDE_CDS
 volatile bool MetaspaceObj::_aot_metaspace_range_initialized = false;
 
 void MetaspaceObj::set_aot_metaspace_range(void* base, void* top) {

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -260,6 +260,11 @@ class MetaspaceObj {
   //   void deallocate_contents(ClassLoaderData* loader_data);
 
   friend class VMStructs;
+
+  // These are used by the Serviceability Agent even if CDS is disabled
+  static void* _aot_metaspace_base;  // (inclusive) low address
+  static void* _aot_metaspace_top;   // (exclusive) high address
+
  public:
 
   // Returns true if the pointer points to a valid MetaspaceObj. A valid
@@ -277,8 +282,6 @@ private:
   // two pointers to quickly determine if a MetaspaceObj is in the
   // AOT cache.
   // When AOT/CDS is not enabled, both pointers are set to null.
-  static void* _aot_metaspace_base;  // (inclusive) low address
-  static void* _aot_metaspace_top;   // (exclusive) high address
   static volatile bool _aot_metaspace_range_initialized;
   static bool aot_metaspace_range_initialized();
 


### PR DESCRIPTION
`MetaspaceObj::{_aot_metaspace_base, _aot_metaspace_top}` are queried by the Serviceability Agent even if CDS is disabled from the JVM build, so they need to be in the JVM (with `nullptr` as their values). 

https://github.com/openjdk/jdk/blob/0091060d34dd72d05beffea1e9e5e21d5538d798/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/MetaspaceObj.java#L48-L49

We could try to fix SA to make the query conditional, but as we are shifting the effort towards https://openjdk.org/jeps/528, I think we should just leave SA as-is.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383163](https://bugs.openjdk.org/browse/JDK-8383163): Build without CDS broken after 8382170 (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30908/head:pull/30908` \
`$ git checkout pull/30908`

Update a local copy of the PR: \
`$ git checkout pull/30908` \
`$ git pull https://git.openjdk.org/jdk.git pull/30908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30908`

View PR using the GUI difftool: \
`$ git pr show -t 30908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30908.diff">https://git.openjdk.org/jdk/pull/30908.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30908#issuecomment-4309470369)
</details>
