### PR TITLE
8377975: Fails to parse PEM text with trailing whitespace on the first line

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Pem.java
+++ b/src/java.base/share/classes/sun/security/util/Pem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ import java.util.regex.Pattern;
  * A utility class for PEM format encoding.
  */
 public class Pem {
-    private static final char WS = 0x20;  // Whitespace
     private static final byte[] CRLF = new byte[] {'\r', '\n'};
 
     // Default algorithm from jdk.epkcs8.defaultAlgorithm in java.security
@@ -238,20 +237,21 @@ public class Pem {
         sb = new StringBuilder(1024);
 
         // Determine the line break using the char after the last hyphen
-        switch (is.read()) {
-            case WS -> {} // skip whitespace
-            case '\r' -> {
-                c = is.read();
-                if (c == '\n') {
-                    eol = '\n';
-                } else {
-                    eol = '\r';
-                    sb.append((char) c);
+        while (eol == 0) {
+            switch (is.read()) {
+                case '\s', '\t' -> {} // skip whitespace or tab
+                case '\r' -> {
+                    c = is.read();
+                    if (c == '\n') {
+                        eol = '\n';
+                    } else {
+                        eol = '\r';
+                        sb.append((char) c);
+                    }
                 }
+                case '\n' -> eol = '\n';
+                default -> throw new IOException("No EOL character found");
             }
-            case '\n' -> eol = '\n';
-            default ->
-                throw new IOException("No EOL character found");
         }
 
         // Read data until we find the first footer hyphen.
@@ -260,7 +260,7 @@ public class Pem {
                 case -1 ->
                     throw new EOFException("Incomplete header");
                 case '-' -> hyphen++;
-                case WS, '\t', '\r', '\n' -> {} // skip whitespace and tab
+                case '\s', '\t', '\r', '\n' -> {} // skip whitespace and tab
                 default -> sb.append((char) c);
             }
         } while (hyphen == 0);
@@ -298,7 +298,7 @@ public class Pem {
             }
         } while (hyphen < 5);
 
-        while ((c = is.read()) != eol && c != -1 && c != WS) {
+        while ((c = is.read()) != eol && c != -1 && c != '\s' && c != '\t') {
             // skip when eol is '\n', the line separator is likely "\r\n".
             if (c == '\r') {
                 continue;

--- a/test/jdk/java/security/PEM/PEMData.java
+++ b/test/jdk/java/security/PEM/PEMData.java
@@ -677,7 +677,7 @@ class PEMData {
 
     private static String toChar(char c) {
         return switch (c) {
-            case ' ' -> "sp";
+            case '\s' -> "sp";
             case '\t' -> "tab";
             default -> String.valueOf(c);
         };

--- a/test/jdk/java/security/PEM/PEMData.java
+++ b/test/jdk/java/security/PEM/PEMData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -663,5 +663,23 @@ class PEMData {
                     "  (" + a.charAt(i) + " vs " + b.charAt(i) + ")" + lenerr);
             }
         }
+    }
+
+    static Entry insertPostHeaderChar(Entry entry, char c) {
+        String pem = entry.pem();
+        int secondHyphen = pem.indexOf("-----", 5);
+        int i = secondHyphen + 5;
+        return new Entry(
+            entry.name() + "[" + toChar(c) + "]" ,
+            pem.substring(0, i) + c + pem.substring(i),
+            entry.clazz(), entry.provider(), entry.password());
+    }
+
+    private static String toChar(char c) {
+        return switch (c) {
+            case ' ' -> "sp";
+            case '\t' -> "tab";
+            default -> String.valueOf(c);
+        };
     }
 }

--- a/test/jdk/java/security/PEM/PEMDecoderTest.java
+++ b/test/jdk/java/security/PEM/PEMDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,8 @@ public class PEMDecoderTest {
     public static void main(String[] args) throws Exception {
         PEMDecoder decr;
 
+        PEMData.entryList.add(PEMData.insertPostHeaderChar(PEMData.ed25519priv, '\s'));
+        PEMData.entryList.add(PEMData.insertPostHeaderChar(PEMData.ed25519priv, '\t'));
         System.out.println("Decoder test:");
         PEMData.entryList.forEach(entry -> test(entry, false));
         System.out.println("Decoder test withFactory:");

--- a/test/jdk/java/security/PEM/PEMDecoderTest.java
+++ b/test/jdk/java/security/PEM/PEMDecoderTest.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @bug 8298420 8365288
+ * @bug 8298420 8365288 8377975
  * @library /test/lib
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.util


### PR DESCRIPTION
I need a review for a change to check for whitespaces and tabs that may follow a PEM header or footer.  The current code only checks for a whitespace, but ends without a EOL character, resulting in a failure.

Tony

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8377975](https://bugs.openjdk.org/browse/JDK-8377975): Fails to parse PEM text with trailing whitespace on the first line (**Bug** - P3)


### Reviewers
 * [Mikhail Yankelevich](https://openjdk.org/census#myankelevich) (@myankelev - Committer)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30909/head:pull/30909` \
`$ git checkout pull/30909`

Update a local copy of the PR: \
`$ git checkout pull/30909` \
`$ git pull https://git.openjdk.org/jdk.git pull/30909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30909`

View PR using the GUI difftool: \
`$ git pr show -t 30909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30909.diff">https://git.openjdk.org/jdk/pull/30909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30909#issuecomment-4309633732)
</details>
