### PR TITLE
8383174: Improve exceptions in Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_getNextToken

### DIFF
--- a/src/java.base/windows/native/libnet/NTLMAuthSequence.c
+++ b/src/java.base/windows/native/libnet/NTLMAuthSequence.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,7 +231,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequenc
 
     if (ss < 0) {
         SetLastError(ss);
-        JNU_ThrowIOExceptionWithLastError(env, "InitializeSecurityContext");
+        JNU_ThrowIOExceptionWithMessageAndLastError(env, "InitializeSecurityContext");
         endSequence (pCred, pCtx, env, status);
         return 0;
     }
@@ -241,7 +241,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequenc
 
         if (ss < 0) {
             SetLastError(ss);
-            JNU_ThrowIOExceptionWithLastError(env, "CompleteAuthToken");
+            JNU_ThrowIOExceptionWithMessageAndLastError(env, "CompleteAuthToken");
             endSequence (pCred, pCtx, env, status);
             return 0;
         }


### PR DESCRIPTION
There are 2 exceptions in Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_getNextToken
where we could add the message to the exception instead just printing a text associated with the error (code).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383174](https://bugs.openjdk.org/browse/JDK-8383174): Improve exceptions in Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_getNextToken (**Enhancement** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30911/head:pull/30911` \
`$ git checkout pull/30911`

Update a local copy of the PR: \
`$ git checkout pull/30911` \
`$ git pull https://git.openjdk.org/jdk.git pull/30911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30911`

View PR using the GUI difftool: \
`$ git pr show -t 30911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30911.diff">https://git.openjdk.org/jdk/pull/30911.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30911#issuecomment-4311717094)
</details>
