### PR TITLE
8382881: Swap min/max values and avoid equals min/max values in MinMaxVector

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/MinMaxVector.java
+++ b/test/micro/org/openjdk/bench/java/lang/MinMaxVector.java
@@ -113,21 +113,22 @@ public class MinMaxVector
             // such that when the values in the same index are compared for min/max,
             // the probability that a new min/max value is found has the probability P.
             do {
-                long max = ThreadLocalRandom.current().nextLong(10);
+                long max = ThreadLocalRandom.current().nextLong(1, 10);
                 result = new long[2][size];
                 result[0][0] = max;
                 result[1][0] = max - 1;
 
-                aboveCount = 0;
+                // Assume that the first value is above the initial value
+                aboveCount = 1;
                 for (int i = 1; i < result[0].length; i++) {
                     long value;
                     if (ThreadLocalRandom.current().nextLong(101) <= probability) {
-                        long increment = ThreadLocalRandom.current().nextLong(10);
+                        long increment = ThreadLocalRandom.current().nextLong(1, 10);
                         value = max + increment;
                         aboveCount++;
                     } else {
                         // Decrement by at least 1
-                        long diffToMax = ThreadLocalRandom.current().nextLong(10) + 1;
+                        long diffToMax = ThreadLocalRandom.current().nextLong(1, 10);
                         value = max - diffToMax;
                     }
                     result[0][i] = value;
@@ -135,7 +136,7 @@ public class MinMaxVector
                     max = Math.max(max, value);
                 }
 
-                abovePercent = ((aboveCount + 1) * 100) / size;
+                abovePercent = (aboveCount * 100) / size;
             } while (abovePercent != probability);
 
             return result;
@@ -222,7 +223,7 @@ public class MinMaxVector
         int result = 0;
         for (int i = 0; i < state.size; i++) {
             final int v = 11 * state.minIntA[i];
-            result = Math.min(result, v);
+            result = Math.min(v, result);
         }
         return result;
     }
@@ -232,7 +233,7 @@ public class MinMaxVector
         int result = 0;
         for (int i = 0; i < state.size; i++) {
             final int v = state.minIntA[i];
-            result = Math.min(result, v);
+            result = Math.min(v, result);
         }
         return result;
     }
@@ -242,7 +243,7 @@ public class MinMaxVector
         int result = 0;
         for (int i = 0; i < state.size; i++) {
             final int v = 11 * state.maxIntA[i];
-            result = Math.max(result, v);
+            result = Math.max(v, result);
         }
         return result;
     }
@@ -252,7 +253,7 @@ public class MinMaxVector
         int result = 0;
         for (int i = 0; i < state.size; i++) {
             final int v = state.maxIntA[i];
-            result = Math.max(result, v);
+            result = Math.max(v, result);
         }
         return result;
     }
@@ -286,7 +287,7 @@ public class MinMaxVector
         long result = 0;
         for (int i = 0; i < state.size; i++) {
             final long v = 11 * state.minLongA[i];
-            result = Math.min(result, v);
+            result = Math.min(v, result);
         }
         return result;
     }
@@ -296,7 +297,7 @@ public class MinMaxVector
         long result = 0;
         for (int i = 0; i < state.size; i++) {
             final long v = state.minLongA[i];
-            result = Math.min(result, v);
+            result = Math.min(v, result);
         }
         return result;
     }
@@ -306,7 +307,7 @@ public class MinMaxVector
         long result = 0;
         for (int i = 0; i < state.size; i++) {
             final long v = 11 * state.maxLongA[i];
-            result = Math.max(result, v);
+            result = Math.max(v, result);
         }
         return result;
     }
@@ -316,7 +317,7 @@ public class MinMaxVector
         long result = 0;
         for (int i = 0; i < state.size; i++) {
             final long v = state.maxLongA[i];
-            result = Math.max(result, v);
+            result = Math.max(v, result);
         }
         return result;
     }

--- a/test/micro/org/openjdk/bench/java/lang/MinMaxVector.java
+++ b/test/micro/org/openjdk/bench/java/lang/MinMaxVector.java
@@ -56,11 +56,11 @@ public class MinMaxVector
         int size;
 
         /**
-         * Probability of one of the min/max branches being taken.
+         * Probability of going down one of the min/max branch sides.
          * For max, this value represents the percentage of branches in which
-         * the value will be bigger or equal than the current max.
+         * the value will be bigger than the current max.
          * For min, this value represents the percentage of branches in which
-         * the value will be smaller or equal than the current min.
+         * the value will be smaller than the current min.
          */
         @Param({"50", "80", "100"})
         int probability;


### PR DESCRIPTION
Applied the fixes as suggested in the issue. I applied the fix in #30900 on top of the fix in this PR to observe the differences.

Before the fix, one would see:

```
$ TEST="micro:org.openjdk.bench.java.lang.MinMaxVector.longReductionSimpleMax" MICRO="FORK=1;OPTIONS=-p probability=100 -jvmArgsAppend -XX:-UseSuperWord -jvmArgsAppend -XX:+PrintMethodData" make test
...
------------------------------------------------------------------------
static java.lang.Math::max(JJ)J
  interpreter_invocation_count:      488657
  invocation_counter:                488657
  backedge_counter:                       0
  decompile_count:                        0
  mdo size: 328 bytes

   0 lload_0
   1 lload_2
   2 lcmp
   3 iflt 10
  0    bci: 3    BranchData         taken(447750) displacement(56)
                                    not taken(40372)
   6 lload_0
   7 goto 11
  32   bci: 7    JumpData           taken(40372) displacement(24)
  10 lload_2
  11 lreturn
```

We see that branch taken is ~90% instead of the desired 100%. Also, the high branch taken is the opposite of what the `probability` java doc states.

After the fix we see:

```
$ TEST="micro:org.openjdk.bench.java.lang.MinMaxVector.longReductionSimpleMax" MICRO="FORK=1;OPTIONS=-p probability=100 -jvmArgsAppend -XX:-UseSuperWord -jvmArgsAppend -XX:+PrintMethodData" make test
...
static java.lang.Math::max(JJ)J
  interpreter_invocation_count:      551119
  invocation_counter:                551119
  backedge_counter:                       0
  decompile_count:                        0
  mdo size: 328 bytes

   0 lload_0
   1 lload_2
   2 lcmp
   3 iflt 10
  0    bci: 3    BranchData         taken(1721) displacement(56)
                                    not taken(548864)
   6 lload_0
   7 goto 11
  32   bci: 7    JumpData           taken(548865) displacement(24)
  10 lload_2
  11 lreturn
```

With the fix the branch not taken is ~99%, which is almost the 100% we defined in the probability. Also, the branch not taken aligns with the behavior specified in the java doc of `probability`.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382881](https://bugs.openjdk.org/browse/JDK-8382881): Swap min/max values and avoid equals min/max values in MinMaxVector (**Enhancement** - P4)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30912/head:pull/30912` \
`$ git checkout pull/30912`

Update a local copy of the PR: \
`$ git checkout pull/30912` \
`$ git pull https://git.openjdk.org/jdk.git pull/30912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30912`

View PR using the GUI difftool: \
`$ git pr show -t 30912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30912.diff">https://git.openjdk.org/jdk/pull/30912.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30912#issuecomment-4311758606)
</details>
