### PR TITLE
8383176: Shenandoah: Skip marked objects in final verification steps

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -1187,7 +1187,7 @@ void ShenandoahVerifier::verify_after_update_refs(ShenandoahGeneration* generati
           "After Updating References",
           _verify_remembered_disable,  // do not verify remembered set
           _verify_forwarded_none,      // no forwarded references
-          _verify_marked_complete,     // bitmaps might be stale, but alloc-after-mark should be well
+          _verify_marked_disable,      // no need to check unreachable objects, end of cycle
           _verify_cset_none,           // no cset references, all updated
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_nocset,      // no cset regions, trash regions have appeared
@@ -1204,7 +1204,7 @@ void ShenandoahVerifier::verify_after_gc(ShenandoahGeneration* generation) {
           "After GC",
           _verify_remembered_disable,  // do not verify remembered set
           _verify_forwarded_none,      // no forwarded references
-          _verify_marked_complete,     // bitmaps might be stale, but alloc-after-mark should be well
+          _verify_marked_disable,      // no need to check unreachable objects, end of cycle
           _verify_cset_none,           // no cset references, all updated
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_nocset,      // no cset regions, trash regions have appeared
@@ -1220,7 +1220,7 @@ void ShenandoahVerifier::verify_after_degenerated(ShenandoahGeneration* generati
           "After Degenerated GC",
           _verify_remembered_disable,  // do not verify remembered set
           _verify_forwarded_none,      // all objects are non-forwarded
-          _verify_marked_complete,     // all objects are marked in complete bitmap
+          _verify_marked_disable,      // no need to check unreachable objects, end of cycle
           _verify_cset_none,           // no cset references
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_notrash_nocset, // no trash, no cset
@@ -1248,14 +1248,14 @@ void ShenandoahVerifier::verify_after_fullgc(ShenandoahGeneration* generation) {
   verify_at_safepoint(
           generation,
           "After Full GC",
-          _verify_remembered_after_full_gc,  // verify read-write remembered set
-          _verify_forwarded_none,      // all objects are non-forwarded
-          _verify_marked_incomplete,   // all objects are marked in incomplete bitmap
-          _verify_cset_none,           // no cset references
-          _verify_liveness_disable,    // no reliable liveness data anymore
-          _verify_regions_notrash_nocset, // no trash, no cset
-          _verify_size_exact,           // expect generation and heap sizes to match exactly
-          _verify_gcstate_stable        // full gc cleaned up everything
+          _verify_remembered_after_full_gc, // verify read-write remembered set
+          _verify_forwarded_none,           // all objects are non-forwarded
+          _verify_marked_disable,           // no need to check unreachable objects, end of cycle
+          _verify_cset_none,                // no cset references
+          _verify_liveness_disable,         // no reliable liveness data anymore
+          _verify_regions_notrash_nocset,   // no trash, no cset
+          _verify_size_exact,               // expect generation and heap sizes to match exactly
+          _verify_gcstate_stable            // full gc cleaned up everything
   );
 }
 


### PR DESCRIPTION
Looking at verification timings, it looks like are are spending a lot of time verifying marked objects at final verification steps. This verification step is for the sake of GC code, not for the application. The application side was verified through reachable objects. Since we are at the end of the cycle, we do not expect GC code to care about marked objects anymore.

Skipping this verification saves quite a bit of time in testing pipelines. 

On my machine, `hotspot_gc_shenandoah` improves from 392min -> 375min of user CPU time spent. One particularly nasty stress test in our pipeline improves 11min -> 8min.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383176](https://bugs.openjdk.org/browse/JDK-8383176): Shenandoah: Skip marked objects in final verification steps (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30914/head:pull/30914` \
`$ git checkout pull/30914`

Update a local copy of the PR: \
`$ git checkout pull/30914` \
`$ git pull https://git.openjdk.org/jdk.git pull/30914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30914`

View PR using the GUI difftool: \
`$ git pr show -t 30914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30914.diff">https://git.openjdk.org/jdk/pull/30914.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30914#issuecomment-4312055985)
</details>
