### PR TITLE
8383178: ConnectionGraph::split_unique_types should check for timeout

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -30,6 +30,7 @@
 #include "memory/allocation.hpp"
 #include "memory/resourceArea.hpp"
 #include "opto/arraycopynode.hpp"
+#include "opto/c2_globals.hpp"
 #include "opto/c2compiler.hpp"
 #include "opto/callnode.hpp"
 #include "opto/castnode.hpp"
@@ -42,6 +43,7 @@
 #include "opto/narrowptrnode.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/rootnode.hpp"
+#include "runtime/timer.hpp"
 #include "utilities/macros.hpp"
 
 ConnectionGraph::ConnectionGraph(Compile * C, PhaseIterGVN *igvn, int invocation) :
@@ -60,7 +62,11 @@ ConnectionGraph::ConnectionGraph(Compile * C, PhaseIterGVN *igvn, int invocation
   _invocation(invocation),
   _build_iterations(0),
   _build_time(0.),
+  _timer(),
   _node_map(C->comp_arena()) {
+  // timer to check for EscapeAnalysisTimeout
+  _timer.start();
+
   // Add unknown java object.
   add_java_object(C->top(), PointsToNode::GlobalEscape);
   phantom_obj = ptnode_adr(C->top()->_idx)->as_JavaObject();
@@ -2437,15 +2443,13 @@ bool ConnectionGraph::complete_connection_graph(
   int java_objects_length = java_objects_worklist.length();
   elapsedTimer build_time;
   build_time.start();
-  elapsedTimer time;
   bool timeout = false;
   int new_edges = 1;
   int iterations = 0;
   do {
     while ((new_edges > 0) &&
            (iterations++ < GRAPH_BUILD_ITER_LIMIT)) {
-      double start_time = time.seconds();
-      time.start();
+      double start_time = TimeHelper::counter_to_seconds(_timer.active_ticks());
       new_edges = 0;
       // Propagate references to phantom_object for nodes pushed on _worklist
       // by find_non_escaped_objects() and find_field_value().
@@ -2458,11 +2462,10 @@ bool ConnectionGraph::complete_connection_graph(
         if ((next % SAMPLE_SIZE) == 0) {
           // Each 4 iterations calculate how much time it will take
           // to complete graph construction.
-          time.stop();
           // Poll for requests from shutdown mechanism to quiesce compiler
           // because Connection graph construction may take long time.
           CompileBroker::maybe_block();
-          double stop_time = time.seconds();
+          double stop_time = TimeHelper::counter_to_seconds(_timer.active_ticks());
           double time_per_iter = (stop_time - start_time) / (double)SAMPLE_SIZE;
           double time_until_end = time_per_iter * (double)(java_objects_length - next);
           if ((start_time + time_until_end) >= EscapeAnalysisTimeout) {
@@ -2470,7 +2473,6 @@ bool ConnectionGraph::complete_connection_graph(
             break; // Timeout
           }
           start_time = stop_time;
-          time.start();
         }
 #undef SAMPLE_SIZE
 
@@ -2482,15 +2484,13 @@ bool ConnectionGraph::complete_connection_graph(
           return false; // Nothing to do.
         }
       }
-      time.stop();
-      if (time.seconds() >= EscapeAnalysisTimeout) {
+      if (TimeHelper::counter_to_seconds(_timer.active_ticks()) >= EscapeAnalysisTimeout) {
         timeout = true;
         break;
       }
       _compile->print_method(PHASE_EA_COMPLETE_CONNECTION_GRAPH_ITER, 5);
     }
     if ((iterations < GRAPH_BUILD_ITER_LIMIT) && !timeout) {
-      time.start();
       // Find fields which have unknown value.
       int fields_length = oop_fields_worklist.length();
       for (int next = 0; next < fields_length; next++) {
@@ -2501,8 +2501,7 @@ bool ConnectionGraph::complete_connection_graph(
           // Need an other cycle to propagate references to phantom_object.
         }
       }
-      time.stop();
-      if (time.seconds() >= EscapeAnalysisTimeout) {
+      if (TimeHelper::counter_to_seconds(_timer.active_ticks()) >= EscapeAnalysisTimeout) {
         timeout = true;
         break;
       }
@@ -4802,6 +4801,19 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
 
   _compile->print_method(PHASE_EA_AFTER_SPLIT_UNIQUE_TYPES_1, 5);
 
+  auto check_timeout = [&]() {
+    if (TimeHelper::counter_to_seconds(_timer.active_ticks()) < EscapeAnalysisTimeout) {
+      return false;
+    }
+
+    assert(ExitEscapeAnalysisOnTimeout, "split_unique_types reached time limit, num_alias_types = %u", new_index_end - new_index_start);
+    _compile->record_failure(_invocation > 0 ? C2Compiler::retry_no_iterative_escape_analysis() : C2Compiler::retry_no_escape_analysis());
+    return true;
+  };
+  if (check_timeout()) {
+    return;
+  }
+
   //  Phase 2:  Process MemNode's from memnode_worklist. compute new address type and
   //            compute new values for Memory inputs  (the Memory inputs are not
   //            actually updated until phase 4.)
@@ -4921,6 +4933,10 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
   //            instance type to the input corresponding to its alias index.
   uint length = mergemem_worklist.length();
   for( uint next = 0; next < length; ++next ) {
+    if (check_timeout()) {
+      return;
+    }
+
     MergeMemNode* nmm = mergemem_worklist.at(next);
     assert(!visited.test_set(nmm->_idx), "should not be visited before");
     // Note: we don't want to use MergeMemStream here because we only want to
@@ -5003,6 +5019,10 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
   }
 
   _compile->print_method(PHASE_EA_AFTER_SPLIT_UNIQUE_TYPES_3, 5);
+
+  if (check_timeout()) {
+    return;
+  }
 
   //  Phase 4:  Update the inputs of non-instance memory Phis and
   //            the Memory input of memnodes

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -28,6 +28,7 @@
 #include "opto/addnode.hpp"
 #include "opto/idealGraphPrinter.hpp"
 #include "opto/node.hpp"
+#include "runtime/timer.hpp"
 #include "utilities/growableArray.hpp"
 
 //
@@ -348,6 +349,8 @@ private:
   int              _invocation; // Current number of analysis invocation
   int        _build_iterations; // Number of iterations took to build graph
   double           _build_time; // Time (sec) took to build graph
+
+  elapsedTimer          _timer; // The timer that keeps track of how long EA has run
 
 public:
   JavaObjectNode* phantom_obj; // Unknown object

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestSplitUniqueTypesTimeout.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestSplitUniqueTypesTimeout.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.escapeAnalysis;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/*
+ * @test
+ * @bug 8383178
+ * @summary C2 should bail out compilation if escape analysis times out in
+ *          ConnectionGraph::split_unique_types
+ * @run main/othervm/timeout=5 -Xbatch -XX:-TieredCompilation -XX:EscapeAnalysisTimeout=1
+ *                             -XX:CompileCommand=dontinline,${test.main.class}::test
+ *                             -XX:CompileCommand=delayinline,*Vec4i::*
+ *                             ${test.main.class}
+ */
+public class TestSplitUniqueTypesTimeout {
+    public static void main(String[] args) {
+        try (Arena arena = Arena.ofConfined()) {
+            long dAddress = arena.allocate(32L).address();
+            long sAddress = dAddress + 16L;
+            Vec4i d = new Vec4i(dAddress);
+            Vec4i s = new Vec4i(sAddress);
+            for (int i = 0; i < 20000; i++) {
+                test(d, s);
+            }
+        }
+    }
+
+    private record Vec4i(long address) {
+        private MemorySegment asSegment() {
+            return MemorySegment.ofAddress(address).reinterpret(16L);
+        }
+
+        int x() { return asSegment().get(ValueLayout.JAVA_INT_UNALIGNED, 0L); }
+        int y() { return asSegment().get(ValueLayout.JAVA_INT_UNALIGNED, 4L); }
+        int z() { return asSegment().get(ValueLayout.JAVA_INT_UNALIGNED, 8L); }
+        int w() { return asSegment().get(ValueLayout.JAVA_INT_UNALIGNED, 12L); }
+
+        Vec4i x(int value) {
+            asSegment().set(ValueLayout.JAVA_INT_UNALIGNED, 0L, value);
+            return this;
+        }
+        Vec4i y(int value) {
+            asSegment().set(ValueLayout.JAVA_INT_UNALIGNED, 4L, value);
+            return this;
+        }
+        Vec4i z(int value) {
+            asSegment().set(ValueLayout.JAVA_INT_UNALIGNED, 8L, value);
+            return this;
+        }
+        Vec4i w(int value) {
+            asSegment().set(ValueLayout.JAVA_INT_UNALIGNED, 12L, value);
+            return this;
+        }
+    }
+
+    // This function, after fully inlined, contains 256 allocations, stalling escape analysis. We
+    // use CompileCommand to force inline its callees so the code is more readable, using
+    // MethodHandles will achieve the same effect without additional flags.
+    private static void test(Vec4i d, Vec4i s) {
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+        d.x(s.x()).y(s.y()).z(s.z()).w(s.w());
+    }
+}


### PR DESCRIPTION
Hi,

`ConnectionGraph::split_unique_types` uses an algorithm with a high runtime complexity. It traverses through all the `MergeMemNode`s, for each of them, it then traverses through all memory alias classes, and for each alias class, it traverses the graph to find a suitable input to the `MergeMemNode` at the index corresponding to the current alias class.

In the regression test, the function has numerous allocations one after another, this makes the complexity of `ConnectionGraph::split_unique_types` be cubic with respect to the graph size, stalling the compilation for a very long time.

While it is reasonable that we try to optimize the algorithm to be less complex, we should also ensure that `ConnectionGraph::split_unique_types` conforms `EscapeAnalysisTimeout`. I think these 2 are complementary, so this PR addresses the second point, that is to bail out from escape analysis if `split_unique_types` runs for too long.

Testing:

- [ ] tier1-4,hs-comp-stress

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383178](https://bugs.openjdk.org/browse/JDK-8383178): ConnectionGraph::split_unique_types should check for timeout (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30915/head:pull/30915` \
`$ git checkout pull/30915`

Update a local copy of the PR: \
`$ git checkout pull/30915` \
`$ git pull https://git.openjdk.org/jdk.git pull/30915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30915`

View PR using the GUI difftool: \
`$ git pr show -t 30915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30915.diff">https://git.openjdk.org/jdk/pull/30915.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30915#issuecomment-4312132215)
</details>
