### PR TITLE
8294284: Loom: make use of frame::is_older() and frame::id() to reduce dependency on growth direction of stacks

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -252,6 +252,10 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
+// Return true if the frame is younger (more recent activation) than the frame represented by id
+inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
+                                                    return this->id() < id ; }
+
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -250,7 +250,7 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 
 // Return true if the frame is older (less recent activation) than the frame represented by id
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() > id ; }
+                                                    return id_is_older_than(this->id(), id); }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   return id > other_id;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -252,10 +252,6 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
-// Return true if the frame is younger (more recent activation) than the frame represented by id
-inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() < id ; }
-
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -256,6 +256,16 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr
 inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() < id ; }
 
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id < other_id;
+}
+
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -253,12 +253,10 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr
                                                     return this->id() > id ; }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;
 }
 
 inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id < other_id;
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -557,7 +557,7 @@ void MacroAssembler::pop_cont_fastpath(Register java_thread) {
   if (!Continuations::enabled()) return;
   Label done;
   ldr(rscratch1, Address(java_thread, JavaThread::cont_fastpath_offset()));
-  cmp(sp, rscratch1);
+  cmp(rfp, rscratch1);
   br(Assembler::LO, done);
   str(zr, Address(java_thread, JavaThread::cont_fastpath_offset()));
   bind(done);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -546,9 +546,9 @@ void MacroAssembler::push_cont_fastpath(Register java_thread) {
   if (!Continuations::enabled()) return;
   Label done;
   ldr(rscratch1, Address(java_thread, JavaThread::cont_fastpath_offset()));
-  cmp(sp, rscratch1);
+  cmp(rfp, rscratch1);
   br(Assembler::LS, done);
-  mov(rscratch1, sp); // we can't use sp as the source in str
+  mov(rscratch1, rfp); // we can't use sp as the source in str
   str(rscratch1, Address(java_thread, JavaThread::cont_fastpath_offset()));
   bind(done);
 }

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -659,7 +659,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   }
 
   __ mov(rscratch2, rscratch1);
-  __ push_cont_fastpath(rthread); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about; kills rscratch1
+  __ push_cont_fastpath(rthread); // Set JavaThread::_cont_fastpath to the id of the oldest interpreted frame we know about; kills rscratch1
   __ mov(rscratch1, rscratch2);
 
   // 6243940 We might end up in handle_wrong_method if

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1160,7 +1160,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
     compiled_entry_offset = __ pc() - start;
     __ enter();
 
-    __ mov(c_rarg1, sp);
+    __ mov(c_rarg1, rfp);
 
     frame_complete = __ pc() - start;
     address the_pc = __ pc();

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -176,7 +176,15 @@ inline intptr_t* frame::id(void) const { return unextended_sp(); }
 
 // Return true if the frame is older (less recent activation) than the frame represented by id
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() > id ; }
+                                                    return id_is_older_than(this->id(), id); }
+
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  return id < other_id;
+}
 
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -151,13 +151,6 @@ inline bool frame::is_older(intptr_t* id) const {
    return this->id() > id;
 }
 
-// Return true if the frame is younger (more recent activation) than
-// the frame represented by id
-inline bool frame::is_younger(intptr_t* id) const {
-  assert(this->id() != nullptr && id != nullptr, "null frame id");
-  return this->id() < id ;
-}
-
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -152,12 +152,10 @@ inline bool frame::is_older(intptr_t* id) const {
 }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;
 }
 
 inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id < other_id;
 }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -151,6 +151,13 @@ inline bool frame::is_older(intptr_t* id) const {
    return this->id() > id;
 }
 
+// Return true if the frame is younger (more recent activation) than
+// the frame represented by id
+inline bool frame::is_younger(intptr_t* id) const {
+  assert(this->id() != nullptr && id != nullptr, "null frame id");
+  return this->id() < id ;
+}
+
 inline int frame::frame_size() const {
   // Stack grows towards smaller addresses on PPC64: sender is at a higher address.
   return sender_sp() - sp();

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -148,7 +148,7 @@ inline intptr_t* frame::id(void) const {
 inline bool frame::is_older(intptr_t* id) const {
    assert(this->id() != nullptr && id != nullptr, "null frame id");
    // Stack grows towards smaller addresses on ppc64.
-   return this->id() > id;
+   return id_is_older_than(this->id(), id);
 }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -158,6 +158,16 @@ inline bool frame::is_younger(intptr_t* id) const {
   return this->id() < id ;
 }
 
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id < other_id;
+}
+
 inline int frame::frame_size() const {
   // Stack grows towards smaller addresses on PPC64: sender is at a higher address.
   return sender_sp() - sp();

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -925,7 +925,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
 
   remove_top_frame_given_fp(fp, R21_sender_SP, R23_tmp3, /*return_pc*/ R0, R11_scratch1);
   mtlr(R0);
-  pop_cont_fastpath();
+  pop_cont_fastpath(R11_scratch1, R12_scratch2);
   JFR_ONLY(leave_jfr_critical_section();)
 
   BLOCK_COMMENT("} remove_activation");
@@ -2050,9 +2050,9 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result, address
   mr_if_needed(R4_ARG2, arg_1);
   assert(arg_2 != R4_ARG2, "smashed argument");
   mr_if_needed(R5_ARG3, arg_2, true /* allow_noreg */);
-  push_cont_fastpath();
+  push_cont_fastpath(R11_scratch1, R12_scratch2);
   call_VM(noreg /* oop_result */, entry_point, false /*check_exceptions*/, &resume_pc /* last_java_pc */);
-  pop_cont_fastpath();
+  pop_cont_fastpath(R11_scratch1, R12_scratch2);
 
 #ifdef ASSERT
   lwa(tmp, in_bytes(JavaThread::interp_at_preemptable_vmcall_cnt_offset()), R16_thread);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -4510,27 +4510,29 @@ void MacroAssembler::cache_wbsync(bool is_presync) {
   }
 }
 
-void MacroAssembler::push_cont_fastpath() {
+void MacroAssembler::push_cont_fastpath(Register tmp_fp, Register tmp_saved) {
   if (!Continuations::enabled()) return;
 
   Label done;
-  ld_ptr(R0, JavaThread::cont_fastpath_offset(), R16_thread);
-  cmpld(CR0, R1_SP, R0);
-  ble(CR0, done);          // if (SP <= _cont_fastpath) goto done;
-  st_ptr(R1_SP, JavaThread::cont_fastpath_offset(), R16_thread);
+  ld(tmp_fp, _abi0(callers_sp), R1_SP);
+  ld_ptr(tmp_saved, JavaThread::cont_fastpath_offset(), R16_thread);
+  cmpld(CR0, tmp_fp, tmp_saved);
+  ble(CR0, done);
+  st_ptr(tmp_fp, JavaThread::cont_fastpath_offset(), R16_thread);
   bind(done);
 }
 
-void MacroAssembler::pop_cont_fastpath() {
+void MacroAssembler::pop_cont_fastpath(Register tmp_fp, Register tmp_saved) {
   if (!Continuations::enabled()) return;
 
-  Label done;
-  ld_ptr(R0, JavaThread::cont_fastpath_offset(), R16_thread);
-  cmpld(CR0, R1_SP, R0);
-  blt(CR0, done);          // if (SP < _cont_fastpath) goto done;
-  li(R0, 0);
-  st_ptr(R0, JavaThread::cont_fastpath_offset(), R16_thread);
-  bind(done);
+   Label done;
+   ld(tmp_fp, _abi0(callers_sp), R1_SP);
+   ld_ptr(tmp_saved, JavaThread::cont_fastpath_offset(), R16_thread);
+   cmpld(CR0, tmp_fp, tmp_saved);
+   blt(CR0, done);
+   li(tmp_saved, 0);
+   st_ptr(tmp_saved, JavaThread::cont_fastpath_offset(), R16_thread);
+   bind(done);
 }
 
 // Function to flip between unlocked and locked state (fast locking).

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -687,8 +687,8 @@ class MacroAssembler: public Assembler {
   // Method handle support (JSR 292).
   RegisterOrConstant argument_offset(RegisterOrConstant arg_slot, Register temp_reg, int extra_slot_offset = 0);
 
-  void push_cont_fastpath();
-  void pop_cont_fastpath();
+  void push_cont_fastpath(Register tmp_fp, Register tmp_saved);
+  void pop_cont_fastpath(Register tmp_fp, Register tmp_saved);
   void atomically_flip_locked_state(bool is_unlock, Register obj, Register tmp, Label& failed, int semantics);
   void fast_lock(Register box, Register obj, Register t1, Register t2, Label& slow);
   void fast_unlock(Register obj, Register t1, Label& slow);

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1164,7 +1164,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
     }
   }
 
-  __ push_cont_fastpath(); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about
+  __ push_cont_fastpath(R11_scratch1, R12_scratch2); // Set JavaThread::_cont_fastpath to the fp of the oldest interpreted frame we know about
 
   BLOCK_COMMENT("Store method");
   // Store method into thread->callee_target.
@@ -1736,7 +1736,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
     __ lwz(reg_is_cont,    Interpreter::stackElementSize*2, R15_esp);
     __ lwz(reg_is_virtual, Interpreter::stackElementSize*1, R15_esp);
 
-    __ push_cont_fastpath();
+    __ push_cont_fastpath(R11_scratch1, R12_scratch2);
 
     OopMap* map = continuation_enter_setup(masm, framesize_words);
 
@@ -1883,6 +1883,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
                                    int& framesize_words,
                                    int& compiled_entry_offset) {
   Register tmp = R10_ARG8;
+  Register cur_fp = tmp;
 
   const int framesize_bytes = (int)align_up((int)frame::native_abi_reg_args_size, frame::alignment_in_bytes);
   framesize_words = framesize_bytes / wordSize;
@@ -1908,7 +1909,8 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ calculate_address_from_global_toc(tmp, last_java_pc); // will be relocated
   __ set_last_Java_frame(R1_SP, tmp);
-  __ call_VM_leaf(Continuation::freeze_entry(), R16_thread, R1_SP);
+  __ ld(cur_fp, _abi0(callers_sp), R1_SP);
+  __ call_VM_leaf(Continuation::freeze_entry(), R16_thread, cur_fp);
   __ reset_last_Java_frame();
 
   Label L_pinned;
@@ -2392,9 +2394,9 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
     // The following call will not be preempted.
     // push_cont_fastpath forces freeze slow path in case we try to preempt where we will pin the
     // vthread to the carrier (see FreezeBase::recurse_freeze_native_frame()).
-    __ push_cont_fastpath();
+    __ push_cont_fastpath(R11_scratch1, R12_scratch2);
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_locking_C), r_oop, r_box, R16_thread);
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
     __ reset_last_Java_frame();
 
     RegisterSaver::restore_argument_registers_and_pop_frame(masm, frame_size, total_c_args, out_regs);

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -313,7 +313,7 @@ class StubGenerator: public StubCodeGenerator {
       __ cmpwi(CR6, r_arg_result_type, T_FLOAT);
       __ cmpwi(CR7, r_arg_result_type, T_DOUBLE);
 
-      __ pop_cont_fastpath(); // kills CR0, uses R16_thread
+      __ pop_cont_fastpath(R11_scratch1, R12_scratch2); // kills CR0, uses R16_thread
 
       // restore non-volatile registers
       __ restore_nonvolatile_registers(r_entryframe_fp, -(frame::entry_frame_locals_size + save_nonvolatile_registers_size),

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -688,9 +688,9 @@ address TemplateInterpreterGenerator::generate_safept_entry_for(TosState state, 
   address entry = __ pc();
 
   __ push(state);
-  __ push_cont_fastpath();
+  __ push_cont_fastpath(R11_scratch1, R12_scratch2);
   __ call_VM(noreg, runtime_entry);
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
   __ dispatch_via(vtos, Interpreter::_normal_table.table_for(vtos));
 
   return entry;
@@ -1456,9 +1456,9 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // j.l.Object::wait calls are preempted which don't return a result.
     __ std(result_handler_addr, _ijava_state_neg(lresult), R11_scratch1);
   }
-  __ push_cont_fastpath();
+  __ push_cont_fastpath(R11_scratch1, R12_scratch2);
   __ call_c(native_method_fd);
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
 
   __ li(R0, 0);
   __ ld(R11_scratch1, 0, R1_SP);
@@ -2137,7 +2137,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     // we will reexecute the call that called us.
     __ merge_frames(/*top_frame_sp*/ R21_sender_SP, /*reload return_pc*/ return_pc, R11_scratch1, R12_scratch2);
     __ mtlr(return_pc);
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
     __ blr();
 
     // The non-deoptimized case.
@@ -2149,7 +2149,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
     // Get out of the current method and re-execute the call that called us.
     __ merge_frames(/*top_frame_sp*/ R21_sender_SP, /*return_pc*/ noreg, R11_scratch1, R12_scratch2);
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
     __ restore_interpreter_state(R11_scratch1, false /*bcp_and_mdx_only*/, true /*restore_top_frame_sp*/);
     if (ProfileInterpreter) {
       __ set_method_data_pointer_for_bcp();
@@ -2208,7 +2208,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
     // Remove the current activation.
     __ merge_frames(/*top_frame_sp*/ R21_sender_SP, /*return_pc*/ noreg, R11_scratch1, R12_scratch2);
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
 
     __ mr(R4_ARG2, return_pc);
     __ mtlr(R3_RET);

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -2130,9 +2130,9 @@ void TemplateTable::_return(TosState state) {
     __ andi_(R11_scratch1, R11_scratch1, SafepointMechanism::poll_bit());
     __ beq(CR0, no_safepoint);
     __ push(state);
-    __ push_cont_fastpath();
+    __ push_cont_fastpath(R11_scratch1, R12_scratch2);
     __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::at_safepoint));
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
     __ pop(state);
     __ bind(no_safepoint);
   }

--- a/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
@@ -164,13 +164,13 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
   __ bctrl(); // loads target Method* into R19_method
   __ block_comment("} load target ");
 
-  __ push_cont_fastpath();
+  __ push_cont_fastpath(R11_scratch1, R12_scratch2);
 
   __ ld(call_target_address, in_bytes(Method::from_compiled_offset()), R19_method);
   __ mtctr(call_target_address);
   __ bctrl();
 
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath(R11_scratch1, R12_scratch2);
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -243,10 +243,6 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
-// Return true if the frame is younger (more recent activation) than the frame represented by id
-inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() < id ; }
-
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -241,7 +241,7 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 
 // Return true if the frame is older (less recent activation) than the frame represented by id
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() > id ; }
+                                                    return id_is_older_than(this->id(), id); }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   return id > other_id;

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -244,12 +244,10 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr
                                                     return this->id() > id ; }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;
 }
 
 inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id < other_id;
 }
 

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -243,6 +243,10 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
+// Return true if the frame is younger (more recent activation) than the frame represented by id
+inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
+                                                    return this->id() < id ; }
+
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -247,6 +247,16 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr
 inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() < id ; }
 
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id < other_id;
+}
+
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -212,8 +212,8 @@ void MacroAssembler::push_cont_fastpath(Register java_thread) {
   if (!Continuations::enabled()) return;
   Label done;
   ld(t0, Address(java_thread, JavaThread::cont_fastpath_offset()));
-  bleu(sp, t0, done);
-  sd(sp, Address(java_thread, JavaThread::cont_fastpath_offset()));
+  bleu(fp, t0, done);
+  sd(fp, Address(java_thread, JavaThread::cont_fastpath_offset()));
   bind(done);
 }
 
@@ -221,7 +221,7 @@ void MacroAssembler::pop_cont_fastpath(Register java_thread) {
   if (!Continuations::enabled()) return;
   Label done;
   ld(t0, Address(java_thread, JavaThread::cont_fastpath_offset()));
-  bltu(sp, t0, done);
+  bltu(fp, t0, done);
   sd(zr, Address(java_thread, JavaThread::cont_fastpath_offset()));
   bind(done);
 }

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -578,7 +578,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
     }
   }
 
-  __ push_cont_fastpath(xthread); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about
+  __ push_cont_fastpath(xthread); // Set JavaThread::_cont_fastpath to the fp of the oldest interpreted frame we know about
 
   // 6243940 We might end up in handle_wrong_method if
   // the callee is deoptimized as we race thru here. If that
@@ -1077,7 +1077,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
   compiled_entry_offset = __ pc() - start;
   __ enter();
 
-  __ mv(c_rarg1, sp);
+  __ mv(c_rarg1, fp);
 
   // Post call nops must be natural aligned due to cmodx rules.
   __ align(NativeInstruction::instruction_size);

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -144,7 +144,15 @@ inline intptr_t* frame::id(void) const {
 inline bool frame::is_older(intptr_t* id) const {
   assert(this->id() != nullptr && id != nullptr, "null frame id");
   // Stack grows towards smaller addresses on z/Architecture.
-  return this->id() > id;
+  return id_is_older_than(this->id(), id);
+}
+
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  return id < other_id;
 }
 
 inline int frame::frame_size() const {

--- a/src/hotspot/cpu/x86/continuationEntry_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationEntry_x86.inline.hpp
@@ -30,6 +30,7 @@
 #include "oops/method.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/registerMap.hpp"
+#include "utilities/align.hpp"
 #include "utilities/macros.hpp"
 
 inline frame ContinuationEntry::to_frame() const {
@@ -41,6 +42,25 @@ inline frame ContinuationEntry::to_frame() const {
 
 inline intptr_t* ContinuationEntry::entry_fp() const {
   return (intptr_t*)((address)this + size());
+}
+
+inline intptr_t* ContinuationEntry::bottom_sender_sp() const {
+  // the entry frame is extended if the bottom frame has stack arguments
+  int entry_frame_extension = entry_frame_extension_words();
+  intptr_t* sp = entry_sp() - entry_frame_extension;
+#ifdef _LP64
+  sp = align_down(sp, frame::frame_alignment);
+#endif
+  return sp;
+}
+
+inline bool ContinuationEntry::should_flush_stack_processing(uintptr_t watermark) const {
+  intptr_t* boundary_sp = (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size());
+  return watermark <= (uintptr_t)boundary_sp;
+}
+
+inline bool ContinuationEntry::is_valid_bottom_frame_sp(intptr_t* sp) const {
+  return sp != nullptr && sp <= entry_sp();
 }
 
 inline void ContinuationEntry::update_register_map(RegisterMap* map) const {

--- a/src/hotspot/cpu/x86/continuationEntry_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationEntry_x86.inline.hpp
@@ -44,25 +44,6 @@ inline intptr_t* ContinuationEntry::entry_fp() const {
   return (intptr_t*)((address)this + size());
 }
 
-inline intptr_t* ContinuationEntry::bottom_sender_sp() const {
-  // the entry frame is extended if the bottom frame has stack arguments
-  int entry_frame_extension = entry_frame_extension_words();
-  intptr_t* sp = entry_sp() - entry_frame_extension;
-#ifdef _LP64
-  sp = align_down(sp, frame::frame_alignment);
-#endif
-  return sp;
-}
-
-inline bool ContinuationEntry::should_flush_stack_processing(uintptr_t watermark) const {
-  intptr_t* boundary_sp = (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size());
-  return watermark <= (uintptr_t)boundary_sp;
-}
-
-inline bool ContinuationEntry::is_valid_bottom_frame_sp(intptr_t* sp) const {
-  return sp != nullptr && sp <= entry_sp();
-}
-
 inline void ContinuationEntry::update_register_map(RegisterMap* map) const {
   intptr_t** fp = (intptr_t**)(bottom_sender_sp() - frame::sender_sp_offset);
   frame::update_map_with_saved_link(map, fp);

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -238,10 +238,6 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
-// Return true if the frame is younger (more recent activation) than the frame represented by id
-inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() < id ; }
-
 inline intptr_t* frame::link() const              { return *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -239,12 +239,10 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr
                                                     return this->id() > id ; }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;
 }
 
 inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
-  assert(id != nullptr && other_id != nullptr, "null frame id");
   return id < other_id;
 }
 

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -236,7 +236,7 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 
 // Return true if the frame is older (less recent activation) than the frame represented by id
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() > id ; }
+                                                    return id_is_older_than(this->id(), id); }
 
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   return id > other_id;

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -238,10 +238,6 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
-// Return true if the frame is younger (more recent activation) than the frame represented by id
-inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
-                                                    return this->id() < id ; }
-
 inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
   assert(id != nullptr && other_id != nullptr, "null frame id");
   return id > other_id;

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -242,6 +242,16 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr
 inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() < id ; }
 
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  assert(id != nullptr && other_id != nullptr, "null frame id");
+  return id < other_id;
+}
+
 inline intptr_t* frame::link() const              { return *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -238,6 +238,10 @@ inline intptr_t* frame::id(void) const { return real_fp(); }
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
                                                     return this->id() > id ; }
 
+// Return true if the frame is younger (more recent activation) than the frame represented by id
+inline bool frame::is_younger(intptr_t* id) const   { assert(this->id() != nullptr && id != nullptr, "null frame id");
+                                                    return this->id() < id ; }
+
 inline intptr_t* frame::link() const              { return *(intptr_t **)addr_at(link_offset); }
 
 inline intptr_t* frame::link_or_null() const {

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -359,7 +359,7 @@ void InterpreterMacroAssembler::call_VM_preemptable_helper(Register oop_result,
   call_VM_base(noreg, rax, entry_point, number_of_arguments, false);
   pop(rscratch1);
 
-  pop_cont_fastpath_frame();
+  pop_cont_fastpath();
 
 #ifdef ASSERT
   {
@@ -1056,7 +1056,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
 
   pop(ret_addr);                     // get return address
   mov(rsp, rbx);                     // set sp to sender sp
-  pop_cont_fastpath();
+  pop_cont_fastpath_unwind();
 
 }
 

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -359,7 +359,7 @@ void InterpreterMacroAssembler::call_VM_preemptable_helper(Register oop_result,
   call_VM_base(noreg, rax, entry_point, number_of_arguments, false);
   pop(rscratch1);
 
-  pop_cont_fastpath();
+  pop_cont_fastpath_frame();
 
 #ifdef ASSERT
   {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2432,9 +2432,9 @@ void MacroAssembler::push_cont_fastpath() {
   if (!Continuations::enabled()) return;
 
   Label L_done;
-  cmpptr(rsp, Address(r15_thread, JavaThread::cont_fastpath_offset()));
+  cmpptr(rbp, Address(r15_thread, JavaThread::cont_fastpath_offset()));
   jccb(Assembler::belowEqual, L_done);
-  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), rsp);
+  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), rbp);
   bind(L_done);
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2438,7 +2438,7 @@ void MacroAssembler::push_cont_fastpath() {
   bind(L_done);
 }
 
-void MacroAssembler::pop_cont_fastpath() {
+void MacroAssembler::pop_cont_fastpath_unwind() {
   if (!Continuations::enabled()) return;
 
   Label L_done;
@@ -2448,7 +2448,7 @@ void MacroAssembler::pop_cont_fastpath() {
   bind(L_done);
 }
 
-void MacroAssembler::pop_cont_fastpath_frame() {
+void MacroAssembler::pop_cont_fastpath() {
   if (!Continuations::enabled()) return;
 
   Label L_done;

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2448,6 +2448,16 @@ void MacroAssembler::pop_cont_fastpath() {
   bind(L_done);
 }
 
+void MacroAssembler::pop_cont_fastpath_frame() {
+  if (!Continuations::enabled()) return;
+
+  Label L_done;
+  cmpptr(rbp, Address(r15_thread, JavaThread::cont_fastpath_offset()));
+  jccb(Assembler::below, L_done);
+  movptr(Address(r15_thread, JavaThread::cont_fastpath_offset()), 0);
+  bind(L_done);
+}
+
 #ifdef ASSERT
 void MacroAssembler::stop_if_in_cont(Register cont, const char* name) {
   Label no_cont;

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -474,8 +474,8 @@ class MacroAssembler: public Assembler {
   void pop_CPU_state();
 
   void push_cont_fastpath();
+  void pop_cont_fastpath_unwind();
   void pop_cont_fastpath();
-  void pop_cont_fastpath_frame();
 
   DEBUG_ONLY(void stop_if_in_cont(Register cont_reg, const char* name);)
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -475,6 +475,7 @@ class MacroAssembler: public Assembler {
 
   void push_cont_fastpath();
   void pop_cont_fastpath();
+  void pop_cont_fastpath_frame();
 
   DEBUG_ONLY(void stop_if_in_cont(Register cont_reg, const char* name);)
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2361,7 +2361,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // and pin the vthread. Otherwise the fast path won't find it since we don't walk the stack.
     __ push_cont_fastpath();
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_locking_C), 3);
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath_frame();
     restore_args(masm, total_c_args, c_arg, out_regs);
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2361,7 +2361,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // and pin the vthread. Otherwise the fast path won't find it since we don't walk the stack.
     __ push_cont_fastpath();
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_locking_C), 3);
-    __ pop_cont_fastpath_frame();
+    __ pop_cont_fastpath();
     restore_args(masm, total_c_args, c_arg, out_regs);
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -980,7 +980,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
     }
   }
 
-  __ push_cont_fastpath(); // Set JavaThread::_cont_fastpath to the sp of the oldest interpreted frame we know about
+  __ push_cont_fastpath(); // Set JavaThread::_cont_fastpath to the id of the oldest interpreted frame we know about
 
   // 6243940 We might end up in handle_wrong_method if
   // the callee is deoptimized as we race thru here. If that

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1585,7 +1585,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ set_last_Java_frame(rsp, rbp, the_pc, rscratch1);
   __ movptr(c_rarg0, r15_thread);
-  __ movptr(c_rarg1, rsp);
+  __ movptr(c_rarg1, rbp);
   __ call_VM_leaf(Continuation::freeze_entry(), 2);
   __ reset_last_Java_frame(true);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -362,7 +362,7 @@ address StubGenerator::generate_call_stub(address& return_address) {
   }
 #endif
 
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath_unwind();
 
   // restore regs belonging to calling function
 #ifdef _WIN64

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -303,7 +303,7 @@ address TemplateInterpreterGenerator::generate_safept_entry_for(
   __ push(state);
   __ push_cont_fastpath();
   __ call_VM(noreg, runtime_entry);
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath_frame();
 
   __ dispatch_via(vtos, Interpreter::_normal_table.table_for(vtos));
   return entry;
@@ -962,7 +962,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // 32: result potentially in rdx:rax or ST0
   // 64: result potentially in rax or xmm0
 
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath_frame();
 
   // Verify or restore cpu control state after JNI call
   __ restore_cpu_control_state_after_jni(rscratch1);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -303,7 +303,7 @@ address TemplateInterpreterGenerator::generate_safept_entry_for(
   __ push(state);
   __ push_cont_fastpath();
   __ call_VM(noreg, runtime_entry);
-  __ pop_cont_fastpath_frame();
+  __ pop_cont_fastpath();
 
   __ dispatch_via(vtos, Interpreter::_normal_table.table_for(vtos));
   return entry;
@@ -962,7 +962,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // 32: result potentially in rdx:rax or ST0
   // 64: result potentially in rax or xmm0
 
-  __ pop_cont_fastpath_frame();
+  __ pop_cont_fastpath();
 
   // Verify or restore cpu control state after JNI call
   __ restore_cpu_control_state_after_jni(rscratch1);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -2140,7 +2140,7 @@ void TemplateTable::_return(TosState state) {
     __ push_cont_fastpath();
     __ call_VM(noreg, CAST_FROM_FN_PTR(address,
                                        InterpreterRuntime::at_safepoint));
-    __ pop_cont_fastpath_frame();
+    __ pop_cont_fastpath();
     __ pop(state);
     __ bind(no_safepoint);
   }

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -2140,7 +2140,7 @@ void TemplateTable::_return(TosState state) {
     __ push_cont_fastpath();
     __ call_VM(noreg, CAST_FROM_FN_PTR(address,
                                        InterpreterRuntime::at_safepoint));
-    __ pop_cont_fastpath();
+    __ pop_cont_fastpath_frame();
     __ pop(state);
     __ bind(no_safepoint);
   }

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -298,7 +298,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
 
   __ call(Address(rbx, Method::from_compiled_offset()));
 
-  __ pop_cont_fastpath();
+  __ pop_cont_fastpath_frame();
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -298,7 +298,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
 
   __ call(Address(rbx, Method::from_compiled_offset()));
 
-  __ pop_cont_fastpath_frame();
+  __ pop_cont_fastpath();
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -167,6 +167,14 @@ inline bool frame::is_older(intptr_t* id) const {
   return false;
 }
 
+inline bool frame::id_is_older_than(intptr_t* id, intptr_t* other_id) {
+  return id > other_id;
+}
+
+inline bool frame::id_is_younger_than(intptr_t* id, intptr_t* other_id) {
+  return id < other_id;
+}
+
 inline intptr_t* frame::entry_frame_argument_at(int offset) const {
   ShouldNotCallThis();
   return nullptr;

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -433,7 +433,7 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
 
   intptr_t* slowpath_boundary = entry->entry_fp();
   intptr_t* old = prev->parent_cont_fastpath();
-  if (old == nullptr || slowpath_boundary > old) {
+  if (old == nullptr || frame::id_is_older_than(slowpath_boundary, old)) {
     prev->set_parent_cont_fastpath(slowpath_boundary);
   }
 }

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -415,7 +415,6 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   }
 
   if (is_frame_in_continuation(entry, f)) {
-    //thread->push_cont_fastpath(f.id());
     thread->push_cont_fastpath(entry->entry_fp());
     return;
   }
@@ -437,12 +436,6 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   if (old == nullptr || slowpath_boundary > old) {
     prev->set_parent_cont_fastpath(slowpath_boundary);
   }
-
-  /*
-  assert(is_frame_in_continuation(entry, f), "");
-  if (f.is_older(prev->parent_cont_fastpath())) {
-    prev->set_parent_cont_fastpath(f.id());
-  }*/
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -429,8 +429,8 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
     return;
   }
   assert(is_frame_in_continuation(entry, f), "");
-  if (f.sp() > prev->parent_cont_fastpath()) {
-    prev->set_parent_cont_fastpath(f.sp());
+  if (f.is_older(prev->parent_cont_fastpath())) {
+    prev->set_parent_cont_fastpath(f.id());
   }
 }
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -415,7 +415,7 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   }
 
   if (is_frame_in_continuation(entry, f)) {
-    thread->push_cont_fastpath(f.sp());
+    thread->push_cont_fastpath(f.id());
     return;
   }
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -222,7 +222,7 @@ bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, cons
   return entry->to_frame().is_older(f.id());
 }
 
-ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, const frame& f) {
+ContinuationEntry* Continuation::get_continuation_entry_for_frame(JavaThread* thread, const frame& f) {
   assert(thread != nullptr, "");
   ContinuationEntry* entry = thread->last_continuation();
   while (entry != nullptr && !is_frame_in_continuation(entry, f)) {
@@ -234,12 +234,16 @@ ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* threa
 ContinuationEntry* Continuation::get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f) {
   assert(is_continuation_enterSpecial(f), "");
   ContinuationEntry* entry = (ContinuationEntry*)f.unextended_sp();
-  //assert(entry == get_continuation_entry_for_sp(thread, f.sp()-2), "mismatched entry");
+  ContinuationEntry* expected = thread->last_continuation();
+  while (expected != nullptr && expected->entry_sp() != f.unextended_sp()) {
+    expected = expected->parent();
+  }
+  assert(entry == expected, "mismatched entry");
   return entry;
 }
 
 bool Continuation::is_frame_in_continuation(JavaThread* thread, const frame& f) {
-  return f.is_heap_frame() || (get_continuation_entry_for_sp(thread, f) != nullptr);
+  return f.is_heap_frame() || (get_continuation_entry_for_frame(thread, f) != nullptr);
 }
 
 static frame continuation_top_frame(const ContinuationWrapper& cont, RegisterMap* map) {
@@ -265,7 +269,7 @@ frame Continuation::last_frame(oop continuation, RegisterMap *map) {
 
 frame Continuation::top_frame(const frame& callee, RegisterMap* map) {
   assert(map != nullptr, "");
-  ContinuationEntry* ce = get_continuation_entry_for_sp(map->thread(), callee);
+  ContinuationEntry* ce = get_continuation_entry_for_frame(map->thread(), callee);
   assert(ce != nullptr, "");
   oop continuation = ce->cont_oop(map->thread());
   ContinuationWrapper cont(continuation);
@@ -336,7 +340,7 @@ bool Continuation::is_scope_bottom(oop cont_scope, const frame& f, const Registe
   if (map->in_cont()) {
     continuation = map->cont();
   } else {
-    ContinuationEntry* ce = get_continuation_entry_for_sp(map->thread(), f);
+    ContinuationEntry* ce = get_continuation_entry_for_frame(map->thread(), f);
     if (ce == nullptr) {
       return false;
     }
@@ -375,7 +379,7 @@ bool Continuation::unpin(JavaThread* current) {
 
 frame Continuation::continuation_bottom_sender(JavaThread* thread, const frame& callee, intptr_t* sender_sp) {
   assert (thread != nullptr, "");
-  ContinuationEntry* ce = get_continuation_entry_for_sp(thread, callee);
+  ContinuationEntry* ce = get_continuation_entry_for_frame(thread, callee);
   assert(ce != nullptr, "callee.sp(): " INTPTR_FORMAT, p2i(callee.sp()));
 
   log_develop_debug(continuations)("continuation_bottom_sender: [" JLONG_FORMAT "] [%d] callee: " INTPTR_FORMAT

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -231,10 +231,10 @@ bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, cons
   return is_sp_in_continuation(entry, f.sp());
 }
 
-ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, intptr_t* const sp) {
+ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, const frame& f) {
   assert(thread != nullptr, "");
   ContinuationEntry* entry = thread->last_continuation();
-  while (entry != nullptr && !is_sp_in_continuation(entry, sp)) {
+  while (entry != nullptr && !is_sp_in_continuation(entry, f.sp())) {
     entry = entry->parent();
   }
   return entry;
@@ -243,12 +243,12 @@ ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* threa
 ContinuationEntry* Continuation::get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f) {
   assert(is_continuation_enterSpecial(f), "");
   ContinuationEntry* entry = (ContinuationEntry*)f.unextended_sp();
-  assert(entry == get_continuation_entry_for_sp(thread, f.sp()-2), "mismatched entry");
+  //assert(entry == get_continuation_entry_for_sp(thread, f.sp()-2), "mismatched entry");
   return entry;
 }
 
 bool Continuation::is_frame_in_continuation(JavaThread* thread, const frame& f) {
-  return f.is_heap_frame() || (get_continuation_entry_for_sp(thread, f.sp()) != nullptr);
+  return f.is_heap_frame() || (get_continuation_entry_for_sp(thread, f) != nullptr);
 }
 
 static frame continuation_top_frame(const ContinuationWrapper& cont, RegisterMap* map) {
@@ -274,7 +274,7 @@ frame Continuation::last_frame(oop continuation, RegisterMap *map) {
 
 frame Continuation::top_frame(const frame& callee, RegisterMap* map) {
   assert(map != nullptr, "");
-  ContinuationEntry* ce = get_continuation_entry_for_sp(map->thread(), callee.sp());
+  ContinuationEntry* ce = get_continuation_entry_for_sp(map->thread(), callee);
   assert(ce != nullptr, "");
   oop continuation = ce->cont_oop(map->thread());
   ContinuationWrapper cont(continuation);
@@ -345,7 +345,7 @@ bool Continuation::is_scope_bottom(oop cont_scope, const frame& f, const Registe
   if (map->in_cont()) {
     continuation = map->cont();
   } else {
-    ContinuationEntry* ce = get_continuation_entry_for_sp(map->thread(), f.sp());
+    ContinuationEntry* ce = get_continuation_entry_for_sp(map->thread(), f);
     if (ce == nullptr) {
       return false;
     }
@@ -384,7 +384,7 @@ bool Continuation::unpin(JavaThread* current) {
 
 frame Continuation::continuation_bottom_sender(JavaThread* thread, const frame& callee, intptr_t* sender_sp) {
   assert (thread != nullptr, "");
-  ContinuationEntry* ce = get_continuation_entry_for_sp(thread, callee.sp());
+  ContinuationEntry* ce = get_continuation_entry_for_sp(thread, callee);
   assert(ce != nullptr, "callee.sp(): " INTPTR_FORMAT, p2i(callee.sp()));
 
   log_develop_debug(continuations)("continuation_bottom_sender: [" JLONG_FORMAT "] [%d] callee: " INTPTR_FORMAT

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -222,19 +222,19 @@ bool Continuation::is_continuation_entry_frame(const frame& f, const RegisterMap
 // least on PPC64 unextended_sp < sp is possible as interpreted frames are trimmed
 // to the actual size of the expression stack before calls. The problem there is
 // that even unextended_sp < entry_sp < sp is possible for an interpreted frame.
-static inline bool is_sp_in_continuation(const ContinuationEntry* entry, intptr_t* const sp) {
+static inline bool is_sp_in_continuation(const ContinuationEntry* entry, const frame& f) {
   // entry_sp() returns the unextended_sp which is always greater or equal to the actual sp
-  return entry->entry_sp() > sp;
+  return entry->entry_sp() > f.sp();
 }
 
 bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, const frame& f) {
-  return is_sp_in_continuation(entry, f.sp());
+  return is_sp_in_continuation(entry, f);
 }
 
 ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, const frame& f) {
   assert(thread != nullptr, "");
   ContinuationEntry* entry = thread->last_continuation();
-  while (entry != nullptr && !is_sp_in_continuation(entry, f.sp())) {
+  while (entry != nullptr && !is_sp_in_continuation(entry, f)) {
     entry = entry->parent();
   }
   return entry;
@@ -419,7 +419,7 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
     return;
   }
 
-  if (is_sp_in_continuation(entry, f.sp())) {
+  if (is_sp_in_continuation(entry, f)) {
     thread->push_cont_fastpath(f.sp());
     return;
   }
@@ -428,12 +428,12 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   do {
     prev = entry;
     entry = entry->parent();
-  } while (entry != nullptr && !is_sp_in_continuation(entry, f.sp()));
+  } while (entry != nullptr && !is_sp_in_continuation(entry, f));
 
   if (entry == nullptr) {
     return;
   }
-  assert(is_sp_in_continuation(entry, f.sp()), "");
+  assert(is_sp_in_continuation(entry, f), "");
   if (f.sp() > prev->parent_cont_fastpath()) {
     prev->set_parent_cont_fastpath(f.sp());
   }

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -224,8 +224,7 @@ bool Continuation::is_continuation_entry_frame(const frame& f, const RegisterMap
 // that even unextended_sp < entry_sp < sp is possible for an interpreted frame.
 static inline bool is_sp_in_continuation(const ContinuationEntry* entry, const frame& f) {
   // entry_sp() returns the unextended_sp which is always greater or equal to the actual sp
-  //return entry->entry_sp() > f.sp();
-  return entry->entry_fp() > f.real_fp();
+  return f.is_younger(entry->entry_fp());
 }
 
 bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, const frame& f) {

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -412,15 +412,15 @@ void Continuation::set_cont_fastpath_thread_state(JavaThread* thread) {
   thread->set_cont_fastpath_thread_state(fast);
 }
 
-void Continuation::notify_deopt(JavaThread* thread, intptr_t* sp) {
+void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   ContinuationEntry* entry = thread->last_continuation();
 
   if (entry == nullptr) {
     return;
   }
 
-  if (is_sp_in_continuation(entry, sp)) {
-    thread->push_cont_fastpath(sp);
+  if (is_sp_in_continuation(entry, f.sp())) {
+    thread->push_cont_fastpath(f.sp());
     return;
   }
 
@@ -428,14 +428,14 @@ void Continuation::notify_deopt(JavaThread* thread, intptr_t* sp) {
   do {
     prev = entry;
     entry = entry->parent();
-  } while (entry != nullptr && !is_sp_in_continuation(entry, sp));
+  } while (entry != nullptr && !is_sp_in_continuation(entry, f.sp()));
 
   if (entry == nullptr) {
     return;
   }
-  assert(is_sp_in_continuation(entry, sp), "");
-  if (sp > prev->parent_cont_fastpath()) {
-    prev->set_parent_cont_fastpath(sp);
+  assert(is_sp_in_continuation(entry, f.sp()), "");
+  if (f.sp() > prev->parent_cont_fastpath()) {
+    prev->set_parent_cont_fastpath(f.sp());
   }
 }
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -219,7 +219,7 @@ bool Continuation::is_continuation_entry_frame(const frame& f, const RegisterMap
 }
 
 bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, const frame& f) {
-  return f.is_younger(entry->entry_fp());
+  return entry->to_frame().is_older(f.id());
 }
 
 ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, const frame& f) {

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -224,7 +224,8 @@ bool Continuation::is_continuation_entry_frame(const frame& f, const RegisterMap
 // that even unextended_sp < entry_sp < sp is possible for an interpreted frame.
 static inline bool is_sp_in_continuation(const ContinuationEntry* entry, const frame& f) {
   // entry_sp() returns the unextended_sp which is always greater or equal to the actual sp
-  return entry->entry_sp() > f.sp();
+  //return entry->entry_sp() > f.sp();
+  return entry->entry_fp() > f.real_fp();
 }
 
 bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, const frame& f) {

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -415,7 +415,8 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   }
 
   if (is_frame_in_continuation(entry, f)) {
-    thread->push_cont_fastpath(f.id());
+    //thread->push_cont_fastpath(f.id());
+    thread->push_cont_fastpath(entry->entry_fp());
     return;
   }
 
@@ -428,10 +429,20 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   if (entry == nullptr) {
     return;
   }
+
+  assert(is_frame_in_continuation(entry, f), "");
+
+  intptr_t* slowpath_boundary = entry->entry_fp();
+  intptr_t* old = prev->parent_cont_fastpath();
+  if (old == nullptr || slowpath_boundary > old) {
+    prev->set_parent_cont_fastpath(slowpath_boundary);
+  }
+
+  /*
   assert(is_frame_in_continuation(entry, f), "");
   if (f.is_older(prev->parent_cont_fastpath())) {
     prev->set_parent_cont_fastpath(f.id());
-  }
+  }*/
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -218,23 +218,14 @@ bool Continuation::is_continuation_entry_frame(const frame& f, const RegisterMap
   return m != nullptr && m->intrinsic_id() == vmIntrinsics::_Continuation_enter;
 }
 
-// The parameter `sp` should be the actual sp and not the unextended sp because at
-// least on PPC64 unextended_sp < sp is possible as interpreted frames are trimmed
-// to the actual size of the expression stack before calls. The problem there is
-// that even unextended_sp < entry_sp < sp is possible for an interpreted frame.
-static inline bool is_sp_in_continuation(const ContinuationEntry* entry, const frame& f) {
-  // entry_sp() returns the unextended_sp which is always greater or equal to the actual sp
-  return f.is_younger(entry->entry_fp());
-}
-
 bool Continuation::is_frame_in_continuation(const ContinuationEntry* entry, const frame& f) {
-  return is_sp_in_continuation(entry, f);
+  return f.is_younger(entry->entry_fp());
 }
 
 ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, const frame& f) {
   assert(thread != nullptr, "");
   ContinuationEntry* entry = thread->last_continuation();
-  while (entry != nullptr && !is_sp_in_continuation(entry, f)) {
+  while (entry != nullptr && !is_frame_in_continuation(entry, f)) {
     entry = entry->parent();
   }
   return entry;
@@ -419,7 +410,7 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
     return;
   }
 
-  if (is_sp_in_continuation(entry, f)) {
+  if (is_frame_in_continuation(entry, f)) {
     thread->push_cont_fastpath(f.sp());
     return;
   }
@@ -428,12 +419,12 @@ void Continuation::notify_deopt(JavaThread* thread, const frame& f) {
   do {
     prev = entry;
     entry = entry->parent();
-  } while (entry != nullptr && !is_sp_in_continuation(entry, f));
+  } while (entry != nullptr && !is_frame_in_continuation(entry, f));
 
   if (entry == nullptr) {
     return;
   }
-  assert(is_sp_in_continuation(entry, f), "");
+  assert(is_frame_in_continuation(entry, f), "");
   if (f.sp() > prev->parent_cont_fastpath()) {
     prev->set_parent_cont_fastpath(f.sp());
   }

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -93,7 +93,7 @@ public:
   static freeze_result try_preempt(JavaThread* target, oop continuation);
 
   static ContinuationEntry* get_continuation_entry_for_continuation(JavaThread* thread, oop continuation);
-  static ContinuationEntry* get_continuation_entry_for_sp(JavaThread* thread, const frame& f);
+  static ContinuationEntry* get_continuation_entry_for_frame(JavaThread* thread, const frame& f);
   static ContinuationEntry* get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f);
 
   static bool is_continuation_mounted(JavaThread* thread, oop continuation);

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -93,7 +93,7 @@ public:
   static freeze_result try_preempt(JavaThread* target, oop continuation);
 
   static ContinuationEntry* get_continuation_entry_for_continuation(JavaThread* thread, oop continuation);
-  static ContinuationEntry* get_continuation_entry_for_sp(JavaThread* thread, intptr_t* const sp);
+  static ContinuationEntry* get_continuation_entry_for_sp(JavaThread* thread, const frame& f);
   static ContinuationEntry* get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f);
 
   static bool is_continuation_mounted(JavaThread* thread, oop continuation);

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -124,7 +124,7 @@ public:
   static frame continuation_bottom_sender(JavaThread* thread, const frame& callee, intptr_t* sender_sp);
   static address get_top_return_pc_post_barrier(JavaThread* thread, address pc);
   static void set_cont_fastpath_thread_state(JavaThread* thread);
-  static void notify_deopt(JavaThread* thread, intptr_t* sp);
+  static void notify_deopt(JavaThread* thread, const frame& f);
 
   // access frame data
 

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -76,25 +76,28 @@ ContinuationEntry* ContinuationEntry::from_frame(const frame& f) {
   return (ContinuationEntry*)f.unextended_sp();
 }
 
-NOINLINE static void flush_stack_processing(JavaThread* thread, intptr_t* sp) {
+NOINLINE static void flush_stack_processing(JavaThread* thread, intptr_t* boundary_id) {
   log_develop_trace(continuations)("flush_stack_processing");
-  for (StackFrameStream fst(thread, true, true); fst.current()->sp() <= sp; fst.next()) {
+  for(StackFrameStream fst(thread, true, true); !frame::id_is_older_than(fst.current()->id(), boundary_id) ; fst.next())
+  {
     ;
   }
 }
 
-inline void maybe_flush_stack_processing(JavaThread* thread, intptr_t* sp) {
+inline void maybe_flush_stack_processing(JavaThread* thread, intptr_t* boundary_sp, intptr_t* boundary_id) {
   StackWatermark* sw;
   uintptr_t watermark;
   if ((sw = StackWatermarkSet::get(thread, StackWatermarkKind::gc)) != nullptr
         && (watermark = sw->watermark()) != 0
-        && watermark <= (uintptr_t)sp) {
-    flush_stack_processing(thread, sp);
+        && watermark <= (uintptr_t)boundary_sp) {
+    flush_stack_processing(thread, boundary_id);
   }
 }
 
 void ContinuationEntry::flush_stack_processing(JavaThread* thread) const {
-  maybe_flush_stack_processing(thread, (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size()));
+  intptr_t* boundary_sp = (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size());
+  intptr_t* boundary_id = entry_fp();
+  maybe_flush_stack_processing(thread, boundary_sp, boundary_id);
 }
 
 #ifndef PRODUCT
@@ -130,7 +133,9 @@ bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
                     RegisterMap::WalkContinuation::skip);
     frame f;
     for (f = thread->last_frame();
-         !f.is_first_frame() && f.sp() <= unextended_sp && !Continuation::is_continuation_enterSpecial(f);
+         !f.is_first_frame() &&
+         !frame::id_is_older_than(f.id(), entry->entry_fp()) &&
+         !Continuation::is_continuation_enterSpecial(f);
          f = f.sender(&map)) {
       interpreted_bottom = f.is_interpreted_frame();
     }

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -84,20 +84,18 @@ NOINLINE static void flush_stack_processing(JavaThread* thread, intptr_t* bounda
   }
 }
 
-inline void maybe_flush_stack_processing(JavaThread* thread, intptr_t* boundary_sp, intptr_t* boundary_id) {
+inline void maybe_flush_stack_processing(JavaThread* thread, const ContinuationEntry* entry) {
   StackWatermark* sw;
   uintptr_t watermark;
   if ((sw = StackWatermarkSet::get(thread, StackWatermarkKind::gc)) != nullptr
         && (watermark = sw->watermark()) != 0
-        && watermark <= (uintptr_t)boundary_sp) {
-    flush_stack_processing(thread, boundary_id);
+        && entry->should_flush_stack_processing(watermark)) {
+    flush_stack_processing(thread, entry->entry_fp());
   }
 }
 
 void ContinuationEntry::flush_stack_processing(JavaThread* thread) const {
-  intptr_t* boundary_sp = (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size());
-  intptr_t* boundary_id = entry_fp();
-  maybe_flush_stack_processing(thread, boundary_sp, boundary_id);
+  maybe_flush_stack_processing(thread, this);
 }
 
 #ifndef PRODUCT
@@ -144,7 +142,7 @@ bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
   }
 
   assert(sp != nullptr, "");
-  assert(sp <= entry->entry_sp(), "");
+  assert(entry->is_valid_bottom_frame_sp(sp), "");
   address pc = ContinuationHelper::return_address_at(
                  sp - frame::sender_sp_ret_address_offset());
 

--- a/src/hotspot/share/runtime/continuationEntry.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.hpp
@@ -103,6 +103,8 @@ class ContinuationEntry {
   intptr_t* entry_sp() const { return (intptr_t*)this; }
   intptr_t* entry_fp() const;
 
+  int entry_frame_extension_words() const;
+
   static address thaw_call_pc_address() { return (address)&_thaw_call_pc; }
   static address cleanup_pc() { return _cleanup_pc; }
 
@@ -133,6 +135,8 @@ class ContinuationEntry {
   void flush_stack_processing(JavaThread* thread) const;
 
   inline intptr_t* bottom_sender_sp() const;
+  inline bool should_flush_stack_processing(uintptr_t watermark) const;
+  inline bool is_valid_bottom_frame_sp(intptr_t* sp) const;
   inline oop cont_oop(const JavaThread* thread) const;
   inline oop scope(const JavaThread* thread) const;
   inline static oop cont_oop_or_null(const ContinuationEntry* ce, const JavaThread* thread);

--- a/src/hotspot/share/runtime/continuationEntry.inline.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.inline.hpp
@@ -39,6 +39,25 @@ inline int ContinuationEntry::entry_frame_extension_words() const {
   return argsize() > 0 ? argsize() + frame::metadata_words_at_top : 0;
 }
 
+inline intptr_t* ContinuationEntry::bottom_sender_sp() const {
+  // the entry frame is extended if the bottom frame has stack arguments
+  int entry_frame_extension = entry_frame_extension_words();
+  intptr_t* sp = entry_sp() - entry_frame_extension;
+#ifdef _LP64
+  sp = align_down(sp, frame::frame_alignment);
+#endif
+  return sp;
+}
+
+inline bool ContinuationEntry::should_flush_stack_processing(uintptr_t watermark) const {
+  intptr_t* boundary_sp = (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size());
+  return watermark <= (uintptr_t)boundary_sp;
+}
+
+inline bool ContinuationEntry::is_valid_bottom_frame_sp(intptr_t* sp) const {
+  return sp != nullptr && sp <= entry_sp();
+}
+
 inline bool is_stack_watermark_processing_started(const JavaThread* thread) {
   StackWatermark* sw = StackWatermarkSet::get(const_cast<JavaThread*>(thread), StackWatermarkKind::gc);
 

--- a/src/hotspot/share/runtime/continuationEntry.inline.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.inline.hpp
@@ -32,6 +32,7 @@
 #include "runtime/frame.hpp"
 #include "runtime/stackWatermarkSet.inline.hpp"
 #include "runtime/thread.hpp"
+#include "runtime/stackOrder.hpp"
 #include "utilities/align.hpp"
 #include CPU_HEADER_INLINE(continuationEntry)
 
@@ -42,7 +43,7 @@ inline int ContinuationEntry::entry_frame_extension_words() const {
 inline intptr_t* ContinuationEntry::bottom_sender_sp() const {
   // the entry frame is extended if the bottom frame has stack arguments
   int entry_frame_extension = entry_frame_extension_words();
-  intptr_t* sp = entry_sp() - entry_frame_extension;
+  intptr_t* sp = StackOrder::towards_younger(entry_sp(), entry_frame_extension);
 #ifdef _LP64
   sp = align_down(sp, frame::frame_alignment);
 #endif
@@ -50,12 +51,12 @@ inline intptr_t* ContinuationEntry::bottom_sender_sp() const {
 }
 
 inline bool ContinuationEntry::should_flush_stack_processing(uintptr_t watermark) const {
-  intptr_t* boundary_sp = (intptr_t*)((uintptr_t)entry_sp() + ContinuationEntry::size());
-  return watermark <= (uintptr_t)boundary_sp;
+  intptr_t* boundary_sp = StackOrder::towards_older(entry_sp(), ContinuationEntry::size());
+  return StackOrder::is_younger_or_equal(reinterpret_cast<intptr_t*>(watermark), boundary_sp);
 }
 
 inline bool ContinuationEntry::is_valid_bottom_frame_sp(intptr_t* sp) const {
-  return sp != nullptr && sp <= entry_sp();
+  return sp != nullptr && StackOrder::is_younger_or_equal(sp, entry_sp());
 }
 
 inline bool is_stack_watermark_processing_started(const JavaThread* thread) {

--- a/src/hotspot/share/runtime/continuationEntry.inline.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.inline.hpp
@@ -35,14 +35,8 @@
 #include "utilities/align.hpp"
 #include CPU_HEADER_INLINE(continuationEntry)
 
-inline intptr_t* ContinuationEntry::bottom_sender_sp() const {
-  // the entry frame is extended if the bottom frame has stack arguments
-  int entry_frame_extension = argsize() > 0 ? argsize() + frame::metadata_words_at_top : 0;
-  intptr_t* sp = entry_sp() - entry_frame_extension;
-#ifdef _LP64
-  sp = align_down(sp, frame::frame_alignment);
-#endif
-  return sp;
+inline int ContinuationEntry::entry_frame_extension_words() const {
+  return argsize() > 0 ? argsize() + frame::metadata_words_at_top : 0;
 }
 
 inline bool is_stack_watermark_processing_started(const JavaThread* thread) {
@@ -69,5 +63,4 @@ inline oop ContinuationEntry::cont_oop_or_null(const ContinuationEntry* ce, cons
 inline oop ContinuationEntry::scope(const JavaThread* thread) const {
   return Continuation::continuation_scope(cont_oop(thread));
 }
-
 #endif // SHARE_VM_RUNTIME_CONTINUATIONENTRY_INLINE_HPP

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -444,7 +444,7 @@ protected:
   // slow path
   virtual stackChunkOop allocate_chunk_slow(size_t stack_size, int argsize_md) = 0;
 
-  int cont_size() { return pointer_delta_as_int(_cont_stack_bottom, _cont_stack_top); }
+  int cont_size() { return StackOrder::words_between(_cont_stack_bottom, _cont_stack_top); }
 
 private:
   // slow path
@@ -682,7 +682,7 @@ void FreezeBase::freeze_fast_existing_chunk() {
     // increase max_size by what we're freezing minus the overlap
     chunk->set_max_thawing_size(chunk->max_thawing_size() + cont_size() - _cont.argsize() - frame::metadata_words_at_top);
 
-    intptr_t* const bottom_sp = _cont_stack_bottom - _cont.argsize() - frame::metadata_words_at_top;
+    intptr_t* const bottom_sp = StackOrder::towards_younger(_cont_stack_bottom, _cont.argsize() + frame::metadata_words_at_top);
     assert(bottom_sp == _bottom_address, "");
     // Because the chunk isn't empty, we know there's a caller in the chunk, therefore the bottom-most frame
     // should have a return barrier (installed back when we thawed it).
@@ -960,11 +960,11 @@ inline freeze_result FreezeBase::recurse_freeze_java_frame(const frame& f, frame
   _freeze_size += fsize;
   NOT_PRODUCT(_frames++;)
 
-  assert(FKind::frame_bottom(f) <= _bottom_address, "");
+  assert(StackOrder::is_younger_or_equal(FKind::frame_bottom(f), _bottom_address), "");
 
   // We don't use FKind::frame_bottom(f) == _bottom_address because on x64 there's sometimes an extra word between
   // enterSpecial and an interpreted frame
-  if (FKind::frame_bottom(f) >= _bottom_address - 1) {
+  if (StackOrder::contains_closed(FKind::frame_bottom(f), StackOrder::towards_younger(_bottom_address, 1), _bottom_address)) {
     return finalize_freeze(f, caller, argsize); // recursion end
   } else {
     frame senderf = sender<FKind>(f);
@@ -1206,7 +1206,7 @@ static void verify_frame_top(const frame& f, intptr_t* top) {
   ResourceMark rm;
   InterpreterOopMap mask;
   f.interpreted_frame_oop_map(&mask);
-  assert(top <= ContinuationHelper::InterpretedFrame::frame_top(f, &mask),
+  assert(StackOrder::is_younger_or_equal(top, ContinuationHelper::InterpretedFrame::frame_top(f, &mask)),
          "frame_top: " INTPTR_FORMAT " Interpreted::frame_top: " INTPTR_FORMAT,
            p2i(top), p2i(ContinuationHelper::InterpretedFrame::frame_top(f, &mask)));
 }
@@ -1222,7 +1222,7 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_interpreted_frame(frame& f, fr
   // The frame's top never includes the stack arguments to the callee
   intptr_t* const stack_frame_top = ContinuationHelper::InterpretedFrame::frame_top(f, callee_argsize, callee_interpreted);
   intptr_t* const stack_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(f);
-  const int fsize = pointer_delta_as_int(stack_frame_bottom, stack_frame_top);
+  const int fsize = StackOrder::words_between(stack_frame_bottom, stack_frame_top);
 
   DEBUG_ONLY(verify_frame_top(f, stack_frame_top));
 
@@ -1250,12 +1250,12 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_interpreted_frame(frame& f, fr
 
   intptr_t* heap_frame_top = ContinuationHelper::InterpretedFrame::frame_top(hf, callee_argsize, callee_interpreted);
   intptr_t* heap_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(hf);
-  assert(heap_frame_bottom == heap_frame_top + fsize, "");
+  assert(heap_frame_bottom == StackOrder::towards_older(heap_frame_top, fsize), "");
 
   // Some architectures (like AArch64/PPC64/RISC-V) add padding between the locals and the fixed_frame to keep the fp 16-byte-aligned.
   // On those architectures we freeze the padding in order to keep the same fp-relative offsets in the fixed_frame.
   copy_to_chunk(stack_frame_top, heap_frame_top, fsize);
-  assert(!is_bottom_frame || !caller.is_interpreted_frame() || (heap_frame_top + fsize) == (caller.unextended_sp() + argsize), "");
+  assert(!is_bottom_frame || !caller.is_interpreted_frame() || StackOrder::towards_older(heap_frame_top, fsize) == StackOrder::towards_older(caller.unextended_sp(), argsize), "");
 
   relativize_interpreted_frame_metadata(f, hf);
 
@@ -1281,7 +1281,7 @@ freeze_result FreezeBase::recurse_freeze_compiled_frame(frame& f, frame& caller,
   intptr_t* const stack_frame_bottom = ContinuationHelper::CompiledFrame::frame_bottom(f);
   // including metadata between f and its stackargs
   const int argsize = ContinuationHelper::CompiledFrame::stack_argsize(f) + frame::metadata_words_at_top;
-  const int fsize = pointer_delta_as_int(stack_frame_bottom + argsize, stack_frame_top);
+  const int fsize = StackOrder::words_between(StackOrder::towards_older(stack_frame_bottom, argsize), stack_frame_top);
 
   log_develop_trace(continuations)("recurse_freeze_compiled_frame %s _size: %d fsize: %d argsize: %d",
                              ContinuationHelper::Frame::frame_method(f) != nullptr ?
@@ -1305,7 +1305,7 @@ freeze_result FreezeBase::recurse_freeze_compiled_frame(frame& f, frame& caller,
   intptr_t* heap_frame_top = ContinuationHelper::CompiledFrame::frame_top(hf, callee_argsize, callee_interpreted);
 
   copy_to_chunk(stack_frame_top, heap_frame_top, fsize);
-  assert(!is_bottom_frame || !caller.is_compiled_frame() || (heap_frame_top + fsize) == (caller.unextended_sp() + argsize), "");
+  assert(!is_bottom_frame || !caller.is_compiled_frame() || StackOrder::towards_older(heap_frame_top, fsize) == StackOrder::towards_older(caller.unextended_sp(), argsize), "");
 
   if (caller.is_interpreted_frame()) {
     // When thawing the frame we might need to add alignment (see Thaw::align)
@@ -2662,7 +2662,7 @@ intptr_t* ThawBase::handle_preempted_continuation(intptr_t* sp, Continuation::pr
     // we copied the fp patched during freeze, which will now have to be fixed.
     assert(top.is_runtime_frame() || top.is_native_frame(), "");
     int fsize = top.cb()->frame_size();
-    patch_pd(top, sp + fsize);
+    patch_pd(top, StackOrder::towards_older(sp, fsize));
   }
 
   if (preempt_kind == Continuation::object_wait) {
@@ -2772,29 +2772,29 @@ NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& c
 
   frame f = new_stack_frame<ContinuationHelper::InterpretedFrame>(hf, caller, is_bottom_frame);
 
-  intptr_t* const stack_frame_top = f.sp() + frame::metadata_words_at_top;
+  intptr_t* const stack_frame_top = StackOrder::towards_older(f.sp(), frame::metadata_words_at_top);
   intptr_t* const stack_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(f);
-  intptr_t* const heap_frame_top = hf.unextended_sp() + frame::metadata_words_at_top;
+  intptr_t* const heap_frame_top = StackOrder::towards_older(hf.unextended_sp(), frame::metadata_words_at_top);
   intptr_t* const heap_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(hf);
 
   assert(hf.is_heap_frame(), "should be");
   assert(!f.is_heap_frame(), "should not be");
 
-  const int fsize = pointer_delta_as_int(heap_frame_bottom, heap_frame_top);
-  assert((stack_frame_bottom == stack_frame_top + fsize), "");
+  const int fsize = StackOrder::words_between(heap_frame_bottom, heap_frame_top);
+  assert((stack_frame_bottom == StackOrder::towards_older(stack_frame_top, fsize)), "");
 
   // Some architectures (like AArch64/PPC64/RISC-V) add padding between the locals and the fixed_frame to keep the fp 16-byte-aligned.
   // On those architectures we freeze the padding in order to keep the same fp-relative offsets in the fixed_frame.
   copy_from_chunk(heap_frame_top, stack_frame_top, fsize);
 
   // Make sure the relativized locals is already set.
-  assert(f.interpreter_frame_local_at(0) == stack_frame_bottom - 1, "invalid frame bottom");
+  assert(f.interpreter_frame_local_at(0) == StackOrder::towards_younger(stack_frame_bottom, 1), "invalid frame bottom");
 
   derelativize_interpreted_frame_metadata(hf, f);
   patch(f, caller, is_bottom_frame);
 
   assert(f.is_interpreted_frame_valid(_cont.thread()), "invalid thawed frame");
-  assert(stack_frame_bottom <= ContinuationHelper::Frame::frame_top(caller), "");
+  assert(StackOrder::is_younger_or_equal(stack_frame_bottom, ContinuationHelper::Frame::frame_top(caller)), "");
 
   CONT_JFR_ONLY(_jfr_info.record_interpreted_frame();)
 
@@ -2809,7 +2809,7 @@ NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& c
     _cont.tail()->fix_thawed_frame(caller, SmallRegisterMap::instance_no_args());
   } else if (_cont.tail()->has_bitmap() && locals > 0) {
     assert(hf.is_heap_frame(), "should be");
-    address start = (address)(heap_frame_bottom - locals);
+    address start = (address)(StackOrder::towards_younger(heap_frame_bottom, locals));
     address end = (address)heap_frame_bottom;
     clear_bitmap_bits(start, end);
   }
@@ -2849,10 +2849,10 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
 
   const int added_argsize = (is_bottom_frame || caller.is_interpreted_frame()) ? hf.compiled_frame_stack_argsize() : 0;
   int fsize = ContinuationHelper::CompiledFrame::size(hf) + added_argsize;
-  assert(fsize <= (int)(caller.unextended_sp() - f.unextended_sp()), "");
+  assert(fsize <= StackOrder::words_between(caller.unextended_sp(), f.unextended_sp()), "");
 
-  intptr_t* from = heap_frame_top - frame::metadata_words_at_bottom;
-  intptr_t* to   = stack_frame_top - frame::metadata_words_at_bottom;
+  intptr_t* from = StackOrder::towards_younger(heap_frame_top, frame::metadata_words_at_bottom);
+  intptr_t* to   = StackOrder::towards_younger(stack_frame_top, frame::metadata_words_at_bottom);
   // copy metadata, except the metadata at the top of the (unextended) entry frame
   int sz = fsize + frame::metadata_words_at_bottom + (is_bottom_frame && added_argsize == 0 ? 0 : frame::metadata_words_at_top);
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2266,9 +2266,10 @@ void ThawBase::thaw_lockstack(stackChunkOop chunk) {
 }
 
 void ThawBase::copy_from_chunk(intptr_t* from, intptr_t* to, int size) {
-  assert(to >= _top_stack_address, "overwrote past thawing space"
+  intptr_t* write_end = StackOrder::towards_older(to, size);
+  assert(StackOrder::is_older_or_equal(to, _top_stack_address), "overwrote past thawing space"
     " to: " INTPTR_FORMAT " top_address: " INTPTR_FORMAT, p2i(to), p2i(_top_stack_address));
-  assert(to + size <= _cont.entrySP(), "overwrote past thawing space");
+  assert(StackOrder::is_younger_or_equal(write_end, _cont.entrySP()), "overwrote past thawing space");
   _cont.tail()->copy_from_chunk_to_stack(from, to, size);
   CONT_JFR_ONLY(_jfr_info.record_size_copied(size);)
 }
@@ -2859,8 +2860,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
   // If we're the bottom-most thawed frame, we're writing to within one word from entrySP
   // (we might have one padding word for alignment)
   intptr_t* write_end = StackOrder::towards_older(to, sz);
-  //assert(!is_bottom_frame || (_cont.entrySP() - 1 <= write_end && write_end <= _cont.entrySP()), "");
-  assert(!is_bottom_frame || StackOrder::contains_closed(write_end, _cont.entrySP(), _cont.entrySP() - 1), "");
+  assert(!is_bottom_frame || StackOrder::contains_closed(write_end, _cont.entrySP(), StackOrder::towards_younger(_cont.entrySP(), 1)), "");
   assert(!is_bottom_frame || hf.compiled_frame_stack_argsize() != 0 || (write_end && write_end == _cont.entrySP()), "");
 
   copy_from_chunk(from, to, sz); // copying good oops because we invoked barriers above

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -228,8 +228,9 @@ template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thr
 template<typename ConfigT>
 static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* fp))
   assert(fp == current->frame_anchor()->last_Java_fp(), "");
-
-  if (current->raw_cont_fastpath() > current->last_continuation()->entry_fp() || current->raw_cont_fastpath() < fp) {
+  intptr_t* boundary = current->raw_cont_fastpath();
+  if (boundary != nullptr && (frame::id_is_older_than(boundary, current->last_continuation()->entry_fp()) ||
+      frame::id_is_younger_than(boundary, fp))) {
     current->set_cont_fastpath(nullptr);
   }
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -3054,8 +3054,9 @@ void ThawBase::push_return_frame(const frame& f) { // see generate_cont_thaw
     f.print_value_on(&ls);
   }
 
-  assert(f.sp() - frame::metadata_words_at_bottom >= _top_stack_address, "overwrote past thawing space"
-    " to: " INTPTR_FORMAT " top_address: " INTPTR_FORMAT, p2i(f.sp() - frame::metadata_words), p2i(_top_stack_address));
+  intptr_t* write_begin = StackOrder::towards_younger(f.sp(), frame::metadata_words_at_bottom);
+  assert(StackOrder::is_older_or_equal(write_begin, _top_stack_address), "overwrote past thawing space"
+    " to: " INTPTR_FORMAT " top_address: " INTPTR_FORMAT, p2i(write_begin), p2i(_top_stack_address));
   ContinuationHelper::Frame::patch_pc(f, f.raw_pc()); // in case we want to deopt the frame in a full transition, this is checked.
   ContinuationHelper::push_pd(f);
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2122,7 +2122,7 @@ private:
   inline void patch_pd(frame& f, intptr_t* caller_sp);
   inline intptr_t* align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom);
 
-  void maybe_set_fastpath(intptr_t* id) { if (id > _fastpath) _fastpath = id; }
+  void maybe_set_fastpath(intptr_t* id) { if (frame::id_is_older_than(id, _fastpath)) _fastpath = id; }
 
   static inline void derelativize_interpreted_frame_metadata(const frame& hf, const frame& f);
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2867,7 +2867,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
   // f.is_deoptimized_frame() is always false and we must test hf.is_deoptimized_frame() (see comment above)
   assert(!f.is_deoptimized_frame(), "");
   if (hf.is_deoptimized_frame()) {
-    maybe_set_fastpath(f.sp());
+    maybe_set_fastpath(f.id());
     f.set_deoptimized();
   } else if (_thread->is_interp_only_mode()
               || (stub_caller && f.cb()->as_nmethod()->is_marked_for_deoptimization())) {
@@ -2881,7 +2881,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
     f.deoptimize(nullptr); // the null thread simply avoids the assertion in deoptimize which we're not set up for
     assert(f.is_deoptimized_frame(), "");
     assert(ContinuationHelper::Frame::is_deopt_return(f.raw_pc(), f), "");
-    maybe_set_fastpath(f.sp());
+    maybe_set_fastpath(f.id());
     assert(!_should_patch_caller_pc, "");
     _should_patch_caller_pc = true;
   }

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -226,8 +226,9 @@ template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thr
 // Entry point to freeze. Transitions are handled manually
 // Called from gen_continuation_yield() in sharedRuntime_<cpu>.cpp through Continuation::freeze_entry();
 template<typename ConfigT>
-static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* sp))
-  assert(sp == current->frame_anchor()->last_Java_sp(), "");
+static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* fp))
+  // Safe to compare, as rsp and rbp are the same when Continuation::freeze_entry() is invoked, because there has just been a call to __enter();
+  assert(fp == current->frame_anchor()->last_Java_sp(), "");
 
   if (current->raw_cont_fastpath() > current->last_continuation()->entry_sp() || current->raw_cont_fastpath() < sp) {
     current->set_cont_fastpath(nullptr);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -510,7 +510,7 @@ FreezeBase::FreezeBase(JavaThread* thread, ContinuationWrapper& cont, intptr_t* 
 
   assert(!Interpreter::contains(_cont.entryPC()), "");
 
-  _bottom_address = _cont.entrySP() - _cont.entry_frame_extension();
+  _bottom_address = StackOrder::towards_younger(_cont.entrySP(), _cont.entry_frame_extension());
 #ifdef _LP64
   if (((intptr_t)_bottom_address & 0xf) != 0) {
     _bottom_address--;
@@ -519,9 +519,9 @@ FreezeBase::FreezeBase(JavaThread* thread, ContinuationWrapper& cont, intptr_t* 
 #endif
 
   log_develop_trace(continuations)("bottom_address: " INTPTR_FORMAT " entrySP: " INTPTR_FORMAT " argsize: " PTR_FORMAT,
-                p2i(_bottom_address), p2i(_cont.entrySP()), (_cont.entrySP() - _bottom_address) << LogBytesPerWord);
+                p2i(_bottom_address), p2i(_cont.entrySP()), (long unsigned int)StackOrder::words_between(_cont.entrySP(), _bottom_address) << LogBytesPerWord);
   assert(_bottom_address != nullptr, "");
-  assert(_bottom_address <= _cont.entrySP(), "");
+  assert(StackOrder::is_younger_or_equal(_bottom_address, _cont.entrySP()), "");
   DEBUG_ONLY(_last_write = nullptr;)
 
   assert(_cont.chunk_invariant(), "");
@@ -539,7 +539,7 @@ FreezeBase::FreezeBase(JavaThread* thread, ContinuationWrapper& cont, intptr_t* 
   }
 
   // properties of the continuation on the stack; all sizes are in words
-  _cont_stack_top    = frame_sp + (!preempt ? doYield_stub_frame_size : 0); // we don't freeze the doYield stub frame
+  _cont_stack_top    = StackOrder::towards_older(frame_sp, (!preempt ? doYield_stub_frame_size : 0)); // we don't freeze the doYield stub frame
   _cont_stack_bottom = _cont.entrySP() + (_cont.argsize() == 0 ? frame::metadata_words_at_top : 0)
       - ContinuationHelper::frame_align_words(_cont.argsize()); // see alignment in thaw
 
@@ -788,8 +788,8 @@ void FreezeBase::freeze_fast_copy(stackChunkOop chunk, int chunk_start_sp CONT_J
     adjust = 0;
   }
 #endif
-  intptr_t* from = _cont_stack_top - adjust;
-  intptr_t* to   = chunk_top - adjust;
+  intptr_t* from = StackOrder::towards_younger(_cont_stack_top, adjust);
+  intptr_t* to   = StackOrder::towards_younger(chunk_top, adjust);
   copy_to_chunk(from, to, cont_size() + adjust);
   // Because we're not patched yet, the chunk is now in a bad state
 
@@ -922,7 +922,7 @@ frame FreezeBase::freeze_start_frame_on_preempt() {
 
 // The parameter callee_argsize includes metadata that has to be part of caller/callee overlap.
 NOINLINE freeze_result FreezeBase::recurse_freeze(frame& f, frame& caller, int callee_argsize, bool callee_interpreted, bool top) {
-  assert(f.unextended_sp() < _bottom_address, ""); // see recurse_freeze_java_frame
+  assert(StackOrder::is_younger(f.unextended_sp(), _bottom_address), ""); // see recurse_freeze_java_frame
   assert(f.is_interpreted_frame() || ((top && _preempt) == ContinuationHelper::Frame::is_stub(f.cb()))
          || ((top && _preempt) == f.is_native_frame()), "");
 
@@ -2076,7 +2076,7 @@ protected:
       _fastpath(nullptr) {
     DEBUG_ONLY(_top_unextended_sp_before_thaw = nullptr;)
     assert (cont.tail() != nullptr, "no last chunk");
-    DEBUG_ONLY(_top_stack_address = _cont.entrySP() - thaw_size(cont.tail());)
+    DEBUG_ONLY(_top_stack_address = StackOrder::towards_younger(_cont.entrySP(), thaw_size(cont.tail()));)
   }
 
   void clear_chunk(stackChunkOop chunk);
@@ -2981,10 +2981,10 @@ void ThawBase::recurse_thaw_native_frame(const frame& hf, frame& caller, int num
   intptr_t* const heap_frame_top = hf.unextended_sp();
 
   int fsize = ContinuationHelper::NativeFrame::size(hf);
-  assert(fsize <= (int)(caller.unextended_sp() - f.unextended_sp()), "");
+  assert(fsize <= StackOrder::words_between(caller.unextended_sp(), f.unextended_sp()), "");
 
-  intptr_t* from = heap_frame_top - frame::metadata_words_at_bottom;
-  intptr_t* to   = stack_frame_top - frame::metadata_words_at_bottom;
+  intptr_t* from = StackOrder::towards_younger(heap_frame_top, frame::metadata_words_at_bottom);
+  intptr_t* to   = StackOrder::towards_younger(stack_frame_top, frame::metadata_words_at_bottom);
   int sz = fsize + frame::metadata_words_at_bottom;
 
   copy_from_chunk(from, to, sz); // copying good oops because we invoked barriers above

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -227,8 +227,7 @@ template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thr
 // Called from gen_continuation_yield() in sharedRuntime_<cpu>.cpp through Continuation::freeze_entry();
 template<typename ConfigT>
 static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* fp))
-  // Safe to compare, as rsp and rbp are the same when Continuation::freeze_entry() is invoked, because there has just been a call to __enter();
-  assert(fp == current->frame_anchor()->last_Java_sp(), "");
+  assert(fp == current->frame_anchor()->last_Java_fp(), "");
 
   if (current->raw_cont_fastpath() > current->last_continuation()->entry_fp() || current->raw_cont_fastpath() < fp) {
     current->set_cont_fastpath(nullptr);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -227,7 +227,7 @@ template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thr
 // Called from gen_continuation_yield() in sharedRuntime_<cpu>.cpp through Continuation::freeze_entry();
 template<typename ConfigT>
 static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* fp))
-  assert(fp == current->frame_anchor()->last_Java_fp(), "");
+  assert(fp == (intptr_t*)(current->frame_anchor()->last_Java_fp()), "");
   intptr_t* boundary = current->raw_cont_fastpath();
   if (boundary != nullptr && (frame::id_is_older_than(boundary, current->last_continuation()->entry_fp()) ||
       frame::id_is_younger_than(boundary, fp))) {
@@ -2122,7 +2122,7 @@ private:
   inline void patch_pd(frame& f, intptr_t* caller_sp);
   inline intptr_t* align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom);
 
-  void maybe_set_fastpath(intptr_t* sp) { if (sp > _fastpath) _fastpath = sp; }
+  void maybe_set_fastpath(intptr_t* id) { if (id > _fastpath) _fastpath = id; }
 
   static inline void derelativize_interpreted_frame_metadata(const frame& hf, const frame& f);
 
@@ -2798,7 +2798,7 @@ NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& c
 
   CONT_JFR_ONLY(_jfr_info.record_interpreted_frame();)
 
-  maybe_set_fastpath(f.sp());
+  maybe_set_fastpath(f.id());
 
   Method* m = hf.interpreter_frame_method();
   assert(!m->is_native() || !is_bottom_frame, "should be top frame of thaw_top case; missing caller frame");

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -964,7 +964,7 @@ inline freeze_result FreezeBase::recurse_freeze_java_frame(const frame& f, frame
 
   // We don't use FKind::frame_bottom(f) == _bottom_address because on x64 there's sometimes an extra word between
   // enterSpecial and an interpreted frame
-  if (StackOrder::contains_closed(FKind::frame_bottom(f), StackOrder::towards_younger(_bottom_address, 1), _bottom_address)) {
+  if (StackOrder::contains_closed(FKind::frame_bottom(f), _bottom_address, StackOrder::towards_younger(_bottom_address, 1))) {
     return finalize_freeze(f, caller, argsize); // recursion end
   } else {
     frame senderf = sender<FKind>(f);
@@ -2858,8 +2858,10 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
 
   // If we're the bottom-most thawed frame, we're writing to within one word from entrySP
   // (we might have one padding word for alignment)
-  assert(!is_bottom_frame || (_cont.entrySP() - 1 <= to + sz && to + sz <= _cont.entrySP()), "");
-  assert(!is_bottom_frame || hf.compiled_frame_stack_argsize() != 0 || (to + sz && to + sz == _cont.entrySP()), "");
+  intptr_t* write_end = StackOrder::towards_older(to, sz);
+  //assert(!is_bottom_frame || (_cont.entrySP() - 1 <= write_end && write_end <= _cont.entrySP()), "");
+  assert(!is_bottom_frame || StackOrder::contains_closed(write_end, _cont.entrySP(), _cont.entrySP() - 1), "");
+  assert(!is_bottom_frame || hf.compiled_frame_stack_argsize() != 0 || (write_end && write_end == _cont.entrySP()), "");
 
   copy_from_chunk(from, to, sz); // copying good oops because we invoked barriers above
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -230,11 +230,11 @@ static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* fp))
   // Safe to compare, as rsp and rbp are the same when Continuation::freeze_entry() is invoked, because there has just been a call to __enter();
   assert(fp == current->frame_anchor()->last_Java_sp(), "");
 
-  if (current->raw_cont_fastpath() > current->last_continuation()->entry_sp() || current->raw_cont_fastpath() < sp) {
+  if (current->raw_cont_fastpath() > current->last_continuation()->entry_fp() || current->raw_cont_fastpath() < fp) {
     current->set_cont_fastpath(nullptr);
   }
 
-  return checked_cast<int>(ConfigT::freeze(current, sp));
+  return checked_cast<int>(ConfigT::freeze(current, fp));
 JRT_END
 
 JRT_LEAF(int, Continuation::prepare_thaw(JavaThread* thread, bool return_barrier))

--- a/src/hotspot/share/runtime/continuationHelper.inline.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.inline.hpp
@@ -95,7 +95,7 @@ inline address ContinuationHelper::InterpretedFrame::return_pc(const frame& f) {
 }
 
 inline int ContinuationHelper::InterpretedFrame::size(const frame&f) {
-  return pointer_delta_as_int(InterpretedFrame::frame_bottom(f), InterpretedFrame::frame_top(f));
+  return StackOrder::words_between(InterpretedFrame::frame_bottom(f), InterpretedFrame::frame_top(f));
 }
 
 inline int ContinuationHelper::InterpretedFrame::stack_argsize(const frame& f) {
@@ -133,7 +133,7 @@ inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f)
 }
 
 inline intptr_t* ContinuationHelper::NonInterpretedFrame::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
-  return f.unextended_sp() + (callee_interpreted ? 0 : callee_argsize);
+  return StackOrder::towards_older(f.unextended_sp(), callee_interpreted ? 0 : callee_argsize);
 }
 
 inline intptr_t* ContinuationHelper::NonInterpretedFrame::frame_top(const frame& f) { // inclusive; this will be copied with the frame
@@ -141,7 +141,7 @@ inline intptr_t* ContinuationHelper::NonInterpretedFrame::frame_top(const frame&
 }
 
 inline intptr_t* ContinuationHelper::NonInterpretedFrame::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
-  return f.unextended_sp() + f.cb()->frame_size();
+  return StackOrder::towards_older(f.unextended_sp(), f.cb()->frame_size());
 }
 
 inline int ContinuationHelper::NonInterpretedFrame::size(const frame& f) {

--- a/src/hotspot/share/runtime/continuationHelper.inline.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.inline.hpp
@@ -110,13 +110,13 @@ inline int ContinuationHelper::InterpretedFrame::expression_stack_size(const fra
 
 #ifdef ASSERT
 inline bool ContinuationHelper::InterpretedFrame::is_owning_locks(const frame& f) {
-  assert(f.interpreter_frame_monitor_end() <= f.interpreter_frame_monitor_begin(), "must be");
+  assert(StackOrder::is_younger_or_equal((intptr_t*)f.interpreter_frame_monitor_end(), (intptr_t*)f.interpreter_frame_monitor_begin()), "must be");
   if (f.interpreter_frame_monitor_end() == f.interpreter_frame_monitor_begin()) {
     return false;
   }
 
   for (BasicObjectLock* current = f.previous_monitor_in_interpreter_frame(f.interpreter_frame_monitor_begin());
-        current >= f.interpreter_frame_monitor_end();
+        StackOrder::is_older_or_equal((intptr_t*)current, (intptr_t*)f.interpreter_frame_monitor_end());
         current = f.previous_monitor_in_interpreter_frame(current)) {
 
       oop obj = current->obj();

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -887,7 +887,13 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
 
   frame stub_frame = thread->last_frame();
 
-  Continuation::notify_deopt(thread, stub_frame);
+  RegisterMap map(thread, RegisterMap::UpdateMap::skip, RegisterMap::ProcessFrames::include, RegisterMap::WalkContinuation::skip);
+  frame deoptee = stub_frame.sender(&map);
+
+  //Continuation::notify_deopt(thread, stub_frame);
+  if (!deoptee.is_first_frame()) {
+    Continuation::notify_deopt(thread, deoptee);
+  }
 
   // Since the frame to unpack is the top frame of this thread, the vframe_array_head
   // must point to the vframeArray for the unpack frame.

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -887,7 +887,7 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
 
   frame stub_frame = thread->last_frame();
 
-  Continuation::notify_deopt(thread, stub_frame.sp());
+  Continuation::notify_deopt(thread, stub_frame);
 
   // Since the frame to unpack is the top frame of this thread, the vframe_array_head
   // must point to the vframeArray for the unpack frame.
@@ -1795,7 +1795,7 @@ void Deoptimization::deoptimize_single_frame(JavaThread* thread, frame fr, Deopt
     xtty->tail("deoptimized");
   }
 
-  Continuation::notify_deopt(thread, fr.sp());
+  Continuation::notify_deopt(thread, fr);
 
   // Patch the compiled method so that when execution returns to it we will
   // deopt the execution state and return to the interpreter.

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -890,7 +890,6 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
   RegisterMap map(thread, RegisterMap::UpdateMap::skip, RegisterMap::ProcessFrames::include, RegisterMap::WalkContinuation::skip);
   frame deoptee = stub_frame.sender(&map);
 
-  //Continuation::notify_deopt(thread, stub_frame);
   if (!deoptee.is_first_frame()) {
     Continuation::notify_deopt(thread, deoptee);
   }

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -172,7 +172,6 @@ class frame {
   // A null id is only valid when comparing for equality.
 
   intptr_t* id(void) const;
-  bool is_younger(intptr_t* id) const;
   bool is_older(intptr_t* id) const;
   static bool id_is_older_than(intptr_t* id, intptr_t* other_id);
   static bool id_is_younger_than(intptr_t* id, intptr_t* other_id);

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -174,6 +174,8 @@ class frame {
   intptr_t* id(void) const;
   bool is_younger(intptr_t* id) const;
   bool is_older(intptr_t* id) const;
+  static bool id_is_older_than(intptr_t* id, intptr_t* other_id);
+  static bool id_is_younger_than(intptr_t* id, intptr_t* other_id);
 
   // testers
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -481,7 +481,7 @@ class JavaThread: public Thread {
   int _frames_to_pop_failed_realloc;
 
   ContinuationEntry* _cont_entry;
-  intptr_t* _cont_fastpath; // the sp of the oldest known interpreted/call_stub/upcall_stub/native_wrapper
+  intptr_t* _cont_fastpath; // the id of the oldest known interpreted/call_stub/upcall_stub/native_wrapper
                             // frame inside the continuation that we know about
   int _cont_fastpath_thread_state; // whether global thread state allows continuation fastpath (JVMTI)
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -703,7 +703,7 @@ private:
   // Continuation support
   ContinuationEntry* last_continuation() const { return _cont_entry; }
   void set_cont_fastpath(intptr_t* x)          { _cont_fastpath = x; }
-  void push_cont_fastpath(intptr_t* fp)        { if (fp > _cont_fastpath) _cont_fastpath = fp; }
+  void push_cont_fastpath(intptr_t* fp)        { if (frame::id_is_older_than(fp, _cont_fastpath)) _cont_fastpath = fp; }
   void set_cont_fastpath_thread_state(bool x)  { _cont_fastpath_thread_state = (int)x; }
   intptr_t* raw_cont_fastpath() const          { return _cont_fastpath; }
   bool cont_fastpath() const                   { return _cont_fastpath == nullptr && _cont_fastpath_thread_state != 0; }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -703,7 +703,7 @@ private:
   // Continuation support
   ContinuationEntry* last_continuation() const { return _cont_entry; }
   void set_cont_fastpath(intptr_t* x)          { _cont_fastpath = x; }
-  void push_cont_fastpath(intptr_t* sp)        { if (sp > _cont_fastpath) _cont_fastpath = sp; }
+  void push_cont_fastpath(intptr_t* fp)        { if (fp > _cont_fastpath) _cont_fastpath = fp; }
   void set_cont_fastpath_thread_state(bool x)  { _cont_fastpath_thread_state = (int)x; }
   intptr_t* raw_cont_fastpath() const          { return _cont_fastpath; }
   bool cont_fastpath() const                   { return _cont_fastpath == nullptr && _cont_fastpath_thread_state != 0; }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3368,7 +3368,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
                   RegisterMap::WalkContinuation::skip);
   frame sender = fr.sender(&map);
   if (sender.is_interpreted_frame()) {
-    current->push_cont_fastpath(sender.unextended_sp());
+    current->push_cont_fastpath(sender.id());
   }
 
   return buf;

--- a/src/hotspot/share/runtime/stackOrder.hpp
+++ b/src/hotspot/share/runtime/stackOrder.hpp
@@ -32,7 +32,7 @@
 
 class StackOrder : public AllStatic {
 private:
-    // Defines the direction of stack growth, true on dows-growing, false on up-growing.
+    // Defines the direction of stack growth, true on down-growing, false on up-growing.
     // Now defines the direction globally, can be platform-specific.
     static inline bool older_frame_address_is_greater() {
         return true;
@@ -79,9 +79,10 @@ public:
         return checked_cast<int>(bytes / sizeof(intptr_t));
     }
 
-    static inline bool contains_closed(const intptr_t* p, const intptr_t* younger, const intptr_t* older) {
+    static inline bool contains_closed(const intptr_t* p, const intptr_t* older, const intptr_t* younger) {
         assert(p != nullptr && younger != nullptr && older != nullptr, "");
-        return is_younger_or_equal(younger, p) && is_older_or_equal(p, older);
+        assert(is_older_or_equal(older, younger), "");
+        return is_younger_or_equal(p, older) && is_older_or_equal(p, younger);
     }
 };
 

--- a/src/hotspot/share/runtime/stackOrder.hpp
+++ b/src/hotspot/share/runtime/stackOrder.hpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+ #ifndef SHARE_RUNTIME_STACKORDER_HPP
+ #define SHARE_RUNTIME_STACKORDER_HPP
+
+ #include "memory/allStatic.hpp"
+ #include "utilities/checkedCast.hpp"
+ #include "utilities/globalDefinitions.hpp"
+ #include "utilities/macros.hpp"
+
+class StackOrder : public AllStatic {
+private:
+    // Defines the direction of stack growth, true on dows-growing, false on up-growing.
+    // Now defines the direction globally, can be platform-specific.
+    static inline bool older_frame_address_is_greater() {
+        return true;
+    };
+
+public:
+    static inline intptr_t* towards_older(intptr_t* p, int words) {
+        assert(p != nullptr && words >= 0, "");
+        return older_frame_address_is_greater() ? p + words : p - words;
+    }
+
+    static inline intptr_t* towards_younger(intptr_t* p, int words) {
+        assert(p != nullptr && words >= 0, "");
+        return older_frame_address_is_greater() ? p - words : p + words;
+    }
+
+    static inline bool is_older(const intptr_t* a, const intptr_t* b) {
+        assert(a != nullptr, "");
+        assert(b != nullptr, "");
+        const uintptr_t ua = reinterpret_cast<uintptr_t>(a);
+        const uintptr_t ub = reinterpret_cast<uintptr_t>(b);
+        return older_frame_address_is_greater() ? ua > ub : ua < ub;
+    }
+
+    static inline bool is_older_or_equal(const intptr_t* a, const intptr_t* b) {
+        return a == b || is_older(a, b);
+    }
+
+    static inline bool is_younger(const intptr_t* a, const intptr_t* b) {
+        return is_older(b, a);
+    }
+
+    static inline bool is_younger_or_equal(const intptr_t* a, const intptr_t* b) {
+        return a == b || is_younger(a, b);
+    }
+
+    static inline int words_between(const intptr_t* older, const intptr_t* younger) {
+        assert(younger != nullptr && older != nullptr, "");
+        assert(is_older_or_equal(older, younger), "");
+        const uintptr_t uolder = reinterpret_cast<uintptr_t>(older);
+        const uintptr_t uyonger = reinterpret_cast<uintptr_t>(younger);
+        const uintptr_t bytes = older_frame_address_is_greater() ? (uolder - uyonger) : (uyonger - uolder);
+        assert(bytes % sizeof(intptr_t) == 0, "");
+        return checked_cast<int>(bytes / sizeof(intptr_t));
+    }
+
+    static inline bool contains_closed(const intptr_t* p, const intptr_t* younger, const intptr_t* older) {
+        assert(p != nullptr && younger != nullptr && older != nullptr, "");
+        return is_younger_or_equal(younger, p) && is_older_or_equal(p, older);
+    }
+};
+
+
+#endif // SHARE_RUNTIME_STACKORDER_HPP


### PR DESCRIPTION
Hi, please ignore this PR if you did not get a link to it explicitly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8294284](https://bugs.openjdk.org/browse/JDK-8294284): Loom: make use of frame::is_older() and frame::id() to reduce dependency on growth direction of stacks (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30916/head:pull/30916` \
`$ git checkout pull/30916`

Update a local copy of the PR: \
`$ git checkout pull/30916` \
`$ git pull https://git.openjdk.org/jdk.git pull/30916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30916`

View PR using the GUI difftool: \
`$ git pr show -t 30916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30916.diff">https://git.openjdk.org/jdk/pull/30916.diff</a>

</details>
