### PR TITLE
8383183: Shenandoah: Mangle trashed regions up to top instead of end

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -577,7 +577,7 @@ void ShenandoahHeapRegion::recycle_internal() {
   }
 
   if (ZapUnusedHeapArea) {
-    SpaceMangler::mangle_region(MemRegion(bottom(), end()));
+    SpaceMangler::mangle_region(MemRegion(bottom(), top()));
   }
   set_top(bottom());
   set_affiliation(FREE);


### PR DESCRIPTION
In our fastdebug pipelines, a lot of time is spent in Concurrent Cleanup phases that trash the regions after the collection. In fastdebug modes, +ZapUnusedHeapArea is default, and we spend most of the time in zapping the region data.

But we know that we only allocated up to top(), so we can mangle only up to there. That is a major throughput win for non-full regions, which are the norm with `aggressive`. The remaining region tail would stay mangled, because we do full mangling on region creation and commit. 

On my machine, hotspot_gc_shenandoah improves from 392min -> 380min of user CPU time spent. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenadoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383183](https://bugs.openjdk.org/browse/JDK-8383183): Shenandoah: Mangle trashed regions up to top instead of end (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30917/head:pull/30917` \
`$ git checkout pull/30917`

Update a local copy of the PR: \
`$ git checkout pull/30917` \
`$ git pull https://git.openjdk.org/jdk.git pull/30917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30917`

View PR using the GUI difftool: \
`$ git pr show -t 30917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30917.diff">https://git.openjdk.org/jdk/pull/30917.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30917#issuecomment-4312442450)
</details>
