### PR TITLE
8383172: Create AbstractLRUReferencePolicy base class

### DIFF
--- a/src/hotspot/share/gc/shared/referencePolicy.cpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,21 +28,17 @@
 #include "gc/shared/referencePolicy.hpp"
 #include "memory/universe.hpp"
 #include "runtime/globals.hpp"
+#include "utilities/integerCast.hpp"
 
-LRUCurrentHeapPolicy::LRUCurrentHeapPolicy() {
-  setup();
-}
-
-// Capture state (of-the-VM) information needed to evaluate the policy
-void LRUCurrentHeapPolicy::setup() {
-  _max_interval = (Universe::heap()->free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB;
-  assert(_max_interval >= 0,"Sanity check");
+void AbstractLRUReferencePolicy::set_max_interval(jlong max_interval) {
+  assert(max_interval >= 0, "Sanity check");
+  _max_interval = max_interval;
 }
 
 // The oop passed in is the SoftReference object, and not
 // the object the SoftReference points to.
-bool LRUCurrentHeapPolicy::should_clear_reference(oop p,
-                                                  jlong timestamp_clock) {
+bool AbstractLRUReferencePolicy::should_clear_reference(oop p, jlong timestamp_clock) {
+  assert(_max_interval >= 0, "Forgot to call setup");
   jlong interval = timestamp_clock - java_lang_ref_SoftReference::timestamp(p);
   assert(interval >= 0, "Sanity check");
 
@@ -54,11 +50,12 @@ bool LRUCurrentHeapPolicy::should_clear_reference(oop p,
   return true;
 }
 
-/////////////////////// MaxHeap //////////////////////
-
-LRUMaxHeapPolicy::LRUMaxHeapPolicy() {
-  setup();
+// Capture state (of-the-VM) information needed to evaluate the policy
+void LRUCurrentHeapPolicy::setup() {
+  set_max_interval(integer_cast<jlong>(Universe::heap()->free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB);
 }
+
+/////////////////////// MaxHeap //////////////////////
 
 // Capture state (of-the-VM) information needed to evaluate the policy
 void LRUMaxHeapPolicy::setup() {
@@ -66,21 +63,5 @@ void LRUMaxHeapPolicy::setup() {
   max_heap -= Universe::heap()->used_at_last_gc();
   max_heap /= M;
 
-  _max_interval = max_heap * SoftRefLRUPolicyMSPerMB;
-  assert(_max_interval >= 0,"Sanity check");
-}
-
-// The oop passed in is the SoftReference object, and not
-// the object the SoftReference points to.
-bool LRUMaxHeapPolicy::should_clear_reference(oop p,
-                                             jlong timestamp_clock) {
-  jlong interval = timestamp_clock - java_lang_ref_SoftReference::timestamp(p);
-  assert(interval >= 0, "Sanity check");
-
-  // The interval will be zero if the ref was accessed since the last scavenge/gc.
-  if(interval <= _max_interval) {
-    return false;
-  }
-
-  return true;
+  set_max_interval(integer_cast<jlong>(max_heap) * SoftRefLRUPolicyMSPerMB);
 }

--- a/src/hotspot/share/gc/shared/referencePolicy.cpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.cpp
@@ -55,8 +55,6 @@ void LRUCurrentHeapPolicy::setup() {
   set_max_interval(integer_cast<jlong>(Universe::heap()->free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB);
 }
 
-/////////////////////// MaxHeap //////////////////////
-
 // Capture state (of-the-VM) information needed to evaluate the policy
 void LRUMaxHeapPolicy::setup() {
   size_t max_heap = MaxHeapSize;

--- a/src/hotspot/share/gc/shared/referencePolicy.hpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,28 +56,28 @@ class AlwaysClearPolicy : public ReferencePolicy {
   }
 };
 
-class LRUCurrentHeapPolicy : public ReferencePolicy {
+class AbstractLRUReferencePolicy : public ReferencePolicy {
  private:
-  jlong _max_interval;
+  jlong _max_interval = -1;
+
+ protected:
+  void set_max_interval(jlong max_interval);
 
  public:
-  LRUCurrentHeapPolicy();
-
-  // Capture state (of-the-VM) information needed to evaluate the policy
-  void setup();
-  virtual bool should_clear_reference(oop p, jlong timestamp_clock);
+  void setup() override = 0;
+  bool should_clear_reference(oop p, jlong timestamp_clock) final;
 };
 
-class LRUMaxHeapPolicy : public ReferencePolicy {
- private:
-  jlong _max_interval;
-
+class LRUCurrentHeapPolicy : public AbstractLRUReferencePolicy {
  public:
-  LRUMaxHeapPolicy();
-
   // Capture state (of-the-VM) information needed to evaluate the policy
-  void setup();
-  virtual bool should_clear_reference(oop p, jlong timestamp_clock);
+  void setup() final;
+};
+
+class LRUMaxHeapPolicy : public AbstractLRUReferencePolicy {
+ public:
+  // Capture state (of-the-VM) information needed to evaluate the policy
+  void setup() final;
 };
 
 #endif // SHARE_GC_SHARED_REFERENCEPOLICY_HPP

--- a/src/hotspot/share/gc/shared/referencePolicy.hpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.hpp
@@ -64,8 +64,8 @@ class AbstractLRUReferencePolicy : public ReferencePolicy {
   void set_max_interval(jlong max_interval);
 
  public:
-  void setup() override = 0;
   bool should_clear_reference(oop p, jlong timestamp_clock) final;
+  void setup() override = 0;
 };
 
 class LRUCurrentHeapPolicy : public AbstractLRUReferencePolicy {


### PR DESCRIPTION
Both `LRUCurrentHeapPolicy` and `LRUMaxHeapPolicy` have the same `bool should_clear_reference(oop p, jlong timestamp_clock)` implementation. 

ZGC has plans to add a third policy for Automatic heap sizing. So to avoid yet another copy paste, I suggest we create an abstract base class for LRU reference policies that all can use.

Also removed the constructor calls to setup, as they do nothing, because we always call setup explicitly before starting processing.

This patch did also subtly change the multiplication from unsigned (size_t * size_t) to signed (jlong * intx). Because `CheckMaxHeapSizeAndSoftRefLRUPolicyMSPerMB` checks against `max_uintx` rather than `max_jlong` on 64 bit platforms we would not constraint a `SoftRefLRUPolicyMSPerMB` which overflows. And signed overflow is still UB in C++. 

This looks like a bug in `CheckMaxHeapSizeAndSoftRefLRUPolicyMSPerMB`. And doing the unsigned multiplication in this patch, while avoiding UB would still cause asserts and/or incorrect behaviour, so I decided not to do this. Instead created [JDK-8383186](https://bugs.openjdk.org/browse/JDK-8383186) and is fixing it as a stand-alone bug fix.

Testing:
 * GHA
 * Tier 1-3 Oracle supported platforms
 * Shenandoah GC tests on linux x86_64

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383172](https://bugs.openjdk.org/browse/JDK-8383172): Create AbstractLRUReferencePolicy base class (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30918/head:pull/30918` \
`$ git checkout pull/30918`

Update a local copy of the PR: \
`$ git checkout pull/30918` \
`$ git pull https://git.openjdk.org/jdk.git pull/30918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30918`

View PR using the GUI difftool: \
`$ git pr show -t 30918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30918.diff">https://git.openjdk.org/jdk/pull/30918.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30918#issuecomment-4312495241)
</details>
