### PR TITLE
8381413: G1: Verification accesses G1CollectorState checking whether in concurrent start gc after it has been reset for this pause

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2650,6 +2650,7 @@ void G1CollectedHeap::verify_after_young_collection(G1HeapVerifier::G1VerifyType
   if (collector_state()->is_in_concurrent_start_gc()) {
     log_debug(gc, verify)("Marking state");
     _verifier->verify_marking_state();
+    _verifier->verify_bitmap_clear(true /* above_tams_only */);
   }
   _verifier->verify_free_regions_card_tables_clean();
 
@@ -2733,12 +2734,12 @@ void G1CollectedHeap::do_collection_pause_at_safepoint(size_t allocation_word_si
   // Perform the collection.
   G1YoungCollector collector(gc_cause(), allocation_word_size);
   collector.collect();
-
+  // Update collector state.
+  _collector_state = collector.next_state();
   // It should now be safe to tell the concurrent mark thread to start
   // without its logging output interfering with the logging output
   // that came from the pause.
   if (should_start_concurrent_mark_operation) {
-    verifier()->verify_bitmap_clear(true /* above_tams_only */);
     // CAUTION: after the start_concurrent_cycle() call below, the concurrent marking
     // thread(s) could be running concurrently with us. Make sure that anything
     // after this point does not assume that we are the only GC thread running.

--- a/src/hotspot/share/gc/g1/g1CollectorState.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectorState.hpp
@@ -111,11 +111,6 @@ public:
   // Pause kind queries
   inline static void assert_is_young_pause(Pause type);
 
-  inline static bool is_young_only_pause(Pause type);
-  inline static bool is_concurrent_start_pause(Pause type);
-  inline static bool is_prepare_mixed_pause(Pause type);
-  inline static bool is_mixed_pause(Pause type);
-
   inline static bool is_concurrent_cycle_pause(Pause type);
 };
 

--- a/src/hotspot/share/gc/g1/g1CollectorState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectorState.inline.hpp
@@ -98,29 +98,6 @@ inline void G1CollectorState::assert_is_young_pause(Pause type) {
   assert(type != Pause::Cleanup, "must be");
 }
 
-inline bool G1CollectorState::is_young_only_pause(Pause type) {
-  assert_is_young_pause(type);
-  return type == Pause::ConcurrentStartUndo ||
-         type == Pause::ConcurrentStartFull ||
-         type == Pause::PrepareMixed ||
-         type == Pause::Normal;
-}
-
-inline bool G1CollectorState::is_mixed_pause(Pause type) {
-  assert_is_young_pause(type);
-  return type == Pause::Mixed;
-}
-
-inline bool G1CollectorState::is_prepare_mixed_pause(Pause type) {
-  assert_is_young_pause(type);
-  return type == Pause::PrepareMixed;
-}
-
-inline bool G1CollectorState::is_concurrent_start_pause(Pause type) {
-  assert_is_young_pause(type);
-  return type == Pause::ConcurrentStartFull || type == Pause::ConcurrentStartUndo;
-}
-
 inline bool G1CollectorState::is_concurrent_cycle_pause(Pause type) {
   return type == Pause::Cleanup || type == Pause::Remark;
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -732,13 +732,16 @@ bool G1Policy::need_to_start_conc_mark(const char* source, size_t allocation_wor
   if (about_to_start_mixed_phase()) {
     return false;
   }
+  return need_to_start_conc_mark(source, *collector_state(), allocation_word_size);
+}
 
+bool G1Policy::need_to_start_conc_mark(const char* source, const G1CollectorState& state, size_t allocation_word_size) const {
   size_t marking_initiating_old_gen_threshold = _ihop_control->old_gen_threshold_for_conc_mark_start();
   size_t non_young_occupancy = _g1h->non_young_occupancy_after_allocation(allocation_word_size);
 
   bool result = false;
   if (non_young_occupancy > marking_initiating_old_gen_threshold) {
-    result = collector_state()->is_in_young_only_phase();
+    result = state.is_in_young_only_phase();
     log_debug(gc, ergo, ihop)("%s non-young occupancy: %zuB allocation request: %zuB threshold: %zuB (%1.2f) source: %s",
                               result ? "Request concurrent cycle initiation (occupancy higher than threshold)" : "Do not request concurrent cycle initiation (still doing mixed collections)",
                               non_young_occupancy, allocation_word_size * HeapWordSize, marking_initiating_old_gen_threshold, (double) marking_initiating_old_gen_threshold / _g1h->capacity() * 100, source);
@@ -777,23 +780,24 @@ double G1Policy::pending_cards_processing_time() const {
 // Anything below that is considered to be zero
 #define MIN_TIMER_GRANULARITY 0.0000001
 
-void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mark,
-                                           bool allocation_failure,
-                                           size_t allocation_word_size) {
+G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mark,
+                                                       bool allocation_failure,
+                                                       size_t allocation_word_size) {
   G1GCPhaseTimes* p = phase_times();
 
   double start_time_sec = cur_pause_start_sec();
   double end_time_sec = Ticks::now().seconds();
   double pause_time_ms = (end_time_sec - start_time_sec) * 1000.0;
 
-  Pause this_pause = collector_state()->gc_pause_type(concurrent_operation_is_full_mark);
-  bool is_young_only_pause = G1CollectorState::is_young_only_pause(this_pause);
+  G1CollectorState next_state = *collector_state();
 
-  if (G1CollectorState::is_concurrent_start_pause(this_pause)) {
+  bool is_young_only_pause = collector_state()->is_in_young_only_phase();
+
+  if (collector_state()->is_in_concurrent_start_gc()) {
     assert(!collector_state()->initiate_conc_mark_if_possible(), "we should have cleared it by now");
-    collector_state()->set_in_normal_young_gc();
-  } else {
-    maybe_start_marking(allocation_word_size);
+    next_state.set_in_normal_young_gc();
+  } else if (!about_to_start_mixed_phase() && need_to_start_conc_mark("end of GC", next_state, allocation_word_size)) {
+    next_state.set_initiate_conc_mark_if_possible(true);
   }
 
   double app_time_ms = (start_time_sec * 1000.0 - _analytics->prev_collection_pause_end_ms());
@@ -930,26 +934,28 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
                           phase_times()->sum_thread_work_items(G1GCPhaseTimes::MergePSS, G1GCPhaseTimes::MergePSSToYoungGenCards));
   }
 
-  record_pause(this_pause, start_time_sec, end_time_sec);
+  record_pause(collector_state()->gc_pause_type(concurrent_operation_is_full_mark), start_time_sec, end_time_sec);
 
-  if (G1CollectorState::is_prepare_mixed_pause(this_pause)) {
-    assert(!G1CollectorState::is_concurrent_start_pause(this_pause),
+  if (collector_state()->is_in_prepare_mixed_gc()) {
+    assert(!collector_state()->is_in_concurrent_start_gc(),
            "The young GC before mixed is not allowed to be concurrent start GC");
     // This has been the young GC before we start doing mixed GCs. We already
     // decided to start mixed GCs much earlier, so there is nothing to do except
     // advancing the state.
-    collector_state()->set_in_space_reclamation_phase();
-  } else if (G1CollectorState::is_mixed_pause(this_pause)) {
+    next_state.set_in_space_reclamation_phase();
+  } else if (collector_state()->is_in_mixed_phase()) {
     // This is a mixed GC. Here we decide whether to continue doing more
     // mixed GCs or not.
     if (!next_gc_should_be_mixed()) {
       log_debug(gc, ergo)("do not continue mixed GCs (candidate old regions not available)");
-      collector_state()->set_in_normal_young_gc();
+      next_state.set_in_normal_young_gc();
 
       assert(!candidates()->has_more_marking_candidates(),
              "only end mixed if all candidates from marking were processed");
 
-      maybe_start_marking(allocation_word_size);
+      if (need_to_start_conc_mark("end of GC", next_state, allocation_word_size)) {
+        next_state.set_initiate_conc_mark_if_possible(true);
+      }
     }
   } else {
     assert(is_young_only_pause, "must be");
@@ -957,7 +963,7 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
 
   _eden_surv_rate_group->start_adding_regions();
 
-  assert(!(G1CollectorState::is_concurrent_start_pause(this_pause) && collector_state()->is_in_concurrent_cycle()),
+  assert(!(collector_state()->is_in_concurrent_start_gc() && collector_state()->is_in_concurrent_cycle()),
          "If the last pause has been concurrent start, we should not have been in the marking cycle");
 
   _free_regions_at_end_of_collection = _g1h->num_free_regions();
@@ -1002,6 +1008,8 @@ void G1Policy::record_young_collection_end(bool concurrent_operation_is_full_mar
   cr->adjust_after_gc(pending_cards_time_ms,
                       pending_cards,
                       pending_cards_time_goal_ms);
+
+  return next_state;
 }
 
 G1IHOPControl* G1Policy::create_ihop_control(const G1OldGenAllocationTracker* old_gen_alloc_tracker,
@@ -1344,15 +1352,6 @@ void G1Policy::record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_se
 
 void G1Policy::abandon_collection_set_candidates() {
   _collection_set->abandon_all_candidates();
-}
-
-void G1Policy::maybe_start_marking(size_t allocation_word_size) {
-  if (need_to_start_conc_mark("end of GC", allocation_word_size)) {
-    // Note: this might have already been set, if during the last
-    // pause we decided to start a cycle but at the beginning of
-    // this pause we decided to postpone it. That's OK.
-    collector_state()->set_initiate_conc_mark_if_possible(true);
-  }
 }
 
 void G1Policy::update_gc_pause_time_ratios(Pause gc_type, double start_time_sec, double end_time_sec) {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -258,8 +258,6 @@ public:
 
 private:
   void abandon_collection_set_candidates();
-  // Sets up marking if proper conditions are met.
-  void maybe_start_marking(size_t allocation_word_size);
   // Manage time-to-mixed tracking.
   void update_time_to_mixed_tracking(Pause gc_type, double start, double end);
   // Record the given STW pause with the given start and end times (in s).
@@ -297,6 +295,7 @@ public:
   void record_young_gc_pause_end(bool evacuation_failed);
 
   bool need_to_start_conc_mark(const char* source, size_t allocation_word_size) const;
+  bool need_to_start_conc_mark(const char* source, const G1CollectorState& state, size_t allocation_word_size) const;
 
   bool concurrent_operation_is_full_mark(const char* msg, size_t allocation_word_size);
 
@@ -305,9 +304,10 @@ public:
   // Record the start and end of the actual collection part of the evacuation pause.
   void record_pause_start_time();
   void record_young_collection_start();
-  void record_young_collection_end(bool concurrent_operation_is_full_mark,
-                                   bool allocation_failure,
-                                   size_t allocation_word_size);
+  // Returns the next CollectorState based on current state without modifying the latter.
+  G1CollectorState record_young_collection_end(bool concurrent_operation_is_full_mark,
+                                               bool allocation_failure,
+                                               size_t allocation_word_size);
 
   // Record the start and end of a full collection.
   void record_full_collection_start();

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -70,7 +70,6 @@
 class G1YoungGCTraceTime {
   G1YoungCollector* _collector;
 
-  G1CollectorState::Pause _pause_type;
   GCCause::Cause _pause_cause;
 
   static const uint MaxYoungGCNameLength = 128;
@@ -90,10 +89,11 @@ class G1YoungGCTraceTime {
                            _collector->evacuation_alloc_failed() && _collector->evacuation_pinned() ? " / " : "",
                            _collector->evacuation_pinned() ? "Pinned" : "");
     }
+    G1CollectorState::Pause pause = _collector->collector_state()->gc_pause_type(_collector->concurrent_operation_is_full_mark());
     os::snprintf_checked(_young_gc_name_data,
                          MaxYoungGCNameLength,
                          "Pause Young (%s) (%s)%s",
-                         G1CollectorState::to_string(_pause_type),
+                         G1CollectorState::to_string(pause),
                          GCCause::to_string(_pause_cause),
                          evacuation_failed_string);
     return _young_gc_name_data;
@@ -102,10 +102,6 @@ class G1YoungGCTraceTime {
 public:
   G1YoungGCTraceTime(G1YoungCollector* collector, GCCause::Cause cause) :
     _collector(collector),
-    // Take snapshot of current pause type at start as it may be modified during gc.
-    // The strings for all Concurrent Start pauses are the same, so the parameter
-    // does not matter here.
-    _pause_type(_collector->collector_state()->gc_pause_type(false /* concurrent_operation_is_full_mark */)),
     _pause_cause(cause),
     // Fake a "no cause" and manually add the correct string in update_young_gc_name()
     // to make the string look more natural.
@@ -131,24 +127,23 @@ public:
 };
 
 class G1YoungGCJFRTracerMark : public G1JFRTracerMark {
+  G1YoungCollector* _young_collector;
   G1EvacInfo _evacuation_info;
 
   G1NewTracer* tracer() const { return (G1NewTracer*)_tracer; }
 
 public:
-
   G1EvacInfo* evacuation_info() { return &_evacuation_info; }
 
-  G1YoungGCJFRTracerMark(STWGCTimer* gc_timer_stw, G1NewTracer* gc_tracer_stw, GCCause::Cause cause) :
-    G1JFRTracerMark(gc_timer_stw, gc_tracer_stw), _evacuation_info() { }
-
-  void report_pause_type(G1CollectorState::Pause type) {
-    tracer()->report_young_gc_pause(type);
-  }
+  G1YoungGCJFRTracerMark(G1YoungCollector* young_collector) :
+    G1JFRTracerMark(young_collector->gc_timer_stw(), young_collector->gc_tracer_stw()),
+    _young_collector(young_collector),
+    _evacuation_info() { }
 
   ~G1YoungGCJFRTracerMark() {
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
+    tracer()->report_young_gc_pause(g1h->collector_state()->gc_pause_type(_young_collector->concurrent_operation_is_full_mark()));
     tracer()->report_evacuation_info(&_evacuation_info);
     tracer()->report_tenuring_threshold(g1h->policy()->tenuring_threshold());
   }
@@ -1109,6 +1104,7 @@ G1YoungCollector::G1YoungCollector(GCCause::Cause gc_cause,
   _g1h(G1CollectedHeap::heap()),
   _gc_cause(gc_cause),
   _allocation_word_size(allocation_word_size),
+  _next_state(),
   _concurrent_operation_is_full_mark(false),
   _evac_failure_regions()
 {
@@ -1124,7 +1120,7 @@ void G1YoungCollector::collect() {
   G1YoungGCTraceTime tm(this, _gc_cause);
 
   // JFR
-  G1YoungGCJFRTracerMark jtm(gc_timer_stw(), gc_tracer_stw(), _gc_cause);
+  G1YoungGCJFRTracerMark jtm(this);
   // JStat/MXBeans
   G1YoungGCMonitoringScope ms(monitoring_support(),
                               !collection_set()->candidates()->is_empty() /* all_memory_pools_affected */);
@@ -1172,10 +1168,6 @@ void G1YoungCollector::collect() {
     // evacuation, eventually aborting it.
     _concurrent_operation_is_full_mark = policy()->concurrent_operation_is_full_mark("Revise IHOP", _allocation_word_size);
 
-    // Need to report the collection pause now since record_collection_pause_end()
-    // modifies it to the next state.
-    jtm.report_pause_type(collector_state()->gc_pause_type(_concurrent_operation_is_full_mark));
-
-    policy()->record_young_collection_end(_concurrent_operation_is_full_mark, evacuation_alloc_failed(), _allocation_word_size);
+    _next_state = policy()->record_young_collection_end(_concurrent_operation_is_full_mark, evacuation_alloc_failed(), _allocation_word_size);
   }
 }

--- a/src/hotspot/share/gc/g1/g1YoungCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1YOUNGCOLLECTOR_HPP
 #define SHARE_GC_G1_G1YOUNGCOLLECTOR_HPP
 
+#include "gc/g1/g1CollectorState.hpp"
 #include "gc/g1/g1EvacFailureRegions.hpp"
 #include "gc/g1/g1YoungGCAllocationFailureInjector.hpp"
 #include "gc/shared/gcCause.hpp"
@@ -54,6 +55,7 @@ class WorkerThreads;
 class outputStream;
 
 class G1YoungCollector {
+  friend class G1YoungGCJFRTracerMark;
   friend class G1YoungGCNotifyPauseMark;
   friend class G1YoungGCTraceTime;
   friend class G1YoungGCVerifierMark;
@@ -80,6 +82,7 @@ class G1YoungCollector {
   GCCause::Cause _gc_cause;
   size_t _allocation_word_size;
 
+  G1CollectorState _next_state;
   bool _concurrent_operation_is_full_mark;
 
   // Evacuation failure tracking.
@@ -141,6 +144,7 @@ public:
                    size_t allocation_word_size);
   void collect();
 
+  G1CollectorState next_state() const { return _next_state; }
   bool concurrent_operation_is_full_mark() const { return _concurrent_operation_is_full_mark; }
 };
 


### PR DESCRIPTION
Hi all,

  please review this change that moves setting the next collector state out to after the actual collection, after `G1YoungCollector` completely executed.

It does so by letting `G1YoungCollector`(by extension of `G1Policy::record_young_collection_end()`) return the next collector state instead of modifying it at the end of GC (it still does and need to at start of gc). This imo removes lots of complexity about reasoning what the global `CollectorState` currently contains or not.

This allows bitmap verification move from just before starting the concurrent mark to after-young-gc verification if we are in a concurrent start pause (which this change enables), and actually do the verification (which we fixed in an earlier PR).
Also improves the `G1YoungGCJFRTracerMark` and `G1YoungGCTraceTime` to not need be careful about what `G1CollectorState` we are in. I.e. there is no need to save pause types.

Testing: gha, tier1-3

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381413](https://bugs.openjdk.org/browse/JDK-8381413): G1: Verification accesses G1CollectorState checking whether in concurrent start gc after it has been reset for this pause (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30921/head:pull/30921` \
`$ git checkout pull/30921`

Update a local copy of the PR: \
`$ git checkout pull/30921` \
`$ git pull https://git.openjdk.org/jdk.git pull/30921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30921`

View PR using the GUI difftool: \
`$ git pr show -t 30921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30921.diff">https://git.openjdk.org/jdk/pull/30921.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30921#issuecomment-4313379522)
</details>
