### PR TITLE
8381567: Refactor ProcessHandleImpl children

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -120,7 +120,7 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
                 pid_t ppid = (pid_t) ProcessBuffer[i].pi_ppid;
 
                 // Get the parent pid, and start time
-                if (pid == 0 || ppid == pid) {
+                if (pid == java_lang_ProcessHandleImpl_ALL_CHILDREN_PID || ppid == pid) {
                     if (count < arraySize) {
                         // Only store if it fits
                         pids[count] = (jlong) childpid;

--- a/src/java.base/linux/native/libjava/ProcessHandleImpl_linux.c
+++ b/src/java.base/linux/native/libjava/ProcessHandleImpl_linux.c
@@ -64,7 +64,7 @@ void os_initNative(JNIEnv *env, jclass clazz) {
  * Return pids of active processes, and optionally parent pids and
  * start times for each process.
  * For a specific non-zero pid, only the direct children are returned.
- * If the pid is zero, all active processes are returned.
+ * If the pid is ALL_CHILDREN_PID, all active processes are returned.
  * Reads /proc and accumulates any process following the rules above.
  * The resulting pids are stored into an array of longs named jarray.
  * The number of pids is returned if they all fit.
@@ -153,7 +153,7 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 
             // Get the parent pid, and start time
             ppid = os_getParentPidAndTimings(env, childpid, &totalTime, &startTime);
-            if (ppid >= 0 && (pid == 0 || ppid == pid)) {
+            if (ppid >= 0 && (pid == java_lang_ProcessHandleImpl_ALL_CHILDREN_PID || ppid == pid)) {
                 if (count < arraySize) {
                     // Only store if it fits
                     pids[count] = (jlong) childpid;

--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -50,7 +50,7 @@ void os_initNative(JNIEnv *env, jclass clazz) {}
  * Return pids of active processes, and optionally parent pids and
  * start times for each process.
  * For a specific non-zero pid jpid, only the direct children are returned.
- * If the pid jpid is zero, all active processes are returned.
+ * If the pid jpid is ALL_CHILDREN_PID, all active processes are returned.
  * Uses sysctl to accumulates any process following the rules above.
  * The resulting pids are stored into an array of longs named jarray.
  * The number of pids is returned if they all fit.
@@ -153,8 +153,10 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
         }
 
         // Process each entry in the buffer
+        // Pid 0 has itself as a parent, return only the other children
         for (i = nentries; --i >= 0; ++kp) {
-            if (pid == 0 || kp->kp_eproc.e_ppid == pid) {
+            if (pid == java_lang_ProcessHandleImpl_ALL_CHILDREN_PID ||
+                    (kp->kp_eproc.e_ppid == pid && kp->kp_eproc.e_ppid != (jlong) kp->kp_proc.p_pid)) {
                 if (count < arraySize) {
                     // Only store if it fits
                     pids[count] = (jlong) kp->kp_proc.p_pid;

--- a/src/java.base/share/classes/java/lang/ProcessHandle.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandle.java
@@ -181,7 +181,7 @@ public interface ProcessHandle extends Comparable<ProcessHandle> {
      *         does not support this operation
      */
     static Stream<ProcessHandle> allProcesses() {
-        return ProcessHandleImpl.children(0);
+        return ProcessHandleImpl.allProcesses();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -313,8 +313,11 @@ final class ProcessHandleImpl implements ProcessHandle {
      *         if the child process does not have a parent
      */
     public Optional<ProcessHandle> parent() {
+        // Return empty parent if the pid can't be found or it is at the top of the hierarchy.
+        // A pid that is its own parent is at the top of the hierarchy.
+        // For example, on MacOSX, pid 0 is such a process.
         long ppid = parent0(pid, startTime);
-        if (ppid <= 0) {
+        if (ppid < 0 || (ppid == pid)) {
             return Optional.empty();
         }
         return get(ppid);

--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -224,6 +224,26 @@ final class ProcessHandleImpl implements ProcessHandle {
     /* The start time of a Process that does not exist. */
     private static final long STARTTIME_PROCESS_UNKNOWN = -1;
 
+    /* Sentinel pid to return all processes. */
+    private static final long ALL_CHILDREN_PID = -1L;
+
+    /**
+     * Returns a snapshot of all processes visible to the current process.
+     * <p>
+     * <em>Note that processes are created and terminate asynchronously. There
+     * is no guarantee that a process in the stream is alive or that no other
+     * processes may have been created since the inception of the snapshot.
+     * </em>
+     *
+     * @return a Stream of ProcessHandles for all processes
+     * @throws UnsupportedOperationException if the implementation
+     *         does not support this operation
+     */
+    static Stream<ProcessHandle> allProcesses() {
+
+        return children(ProcessHandleImpl.ALL_CHILDREN_PID);
+    }
+
     /**
      * Private constructor.  Instances are created by the {@code get(long)} factory.
      * @param pid the pid for this instance
@@ -311,7 +331,7 @@ final class ProcessHandleImpl implements ProcessHandle {
 
     /**
      * Returns the number of pids filled in to the array.
-     * @param pid if {@code pid} equals zero, then all known processes are returned;
+     * @param pid if {@code pid} equals ALL_CHILDREN_PID, then all known processes are returned;
      *      otherwise only direct child process pids are returned
      * @param pids an allocated long array to receive the pids
      * @param ppids an allocated long array to receive the parent pids; may be null
@@ -431,17 +451,22 @@ final class ProcessHandleImpl implements ProcessHandle {
             pids = new long[size];
             ppids = new long[size];
             starttimes = new long[size];
-            size = getProcessPids0(0, pids, ppids, starttimes);
+            size = getProcessPids0(ALL_CHILDREN_PID, pids, ppids, starttimes);
         }
 
         int next = 0;       // index of next process to check
-        int count = -1;     // count of subprocesses scanned
+        int count = 0;     // count of subprocesses scanned
         long ppid = pid;    // start looking for this parent
         long ppStart = 0;
         // Find the start time of the parent
         for (int i = 0; i < size; i++) {
             if (pids[i] == ppid) {
+                // Found the parent, swap it to the end and do not look at it again
                 ppStart = starttimes[i];
+                swap(pids, i, size - 1);
+                swap(ppids, i, size - 1);
+                swap(starttimes, i, size - 1);
+                size--;
                 break;
             }
         }
@@ -458,9 +483,13 @@ final class ProcessHandleImpl implements ProcessHandle {
                     next++;
                 }
             }
-            ppid = pids[++count];   // pick up the next pid to scan for
+            if (count >= next) {
+                break;
+            }
+            ppid = pids[count];   // pick up the next pid to scan for
             ppStart = starttimes[count];    // and its start time
-        } while (count < next);
+            count++;
+        } while (true);
 
         final long[] cpids = pids;
         final long[] stimes = starttimes;

--- a/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
+++ b/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
@@ -273,7 +273,7 @@ Java_java_lang_ProcessHandleImpl_getProcessPids0(JNIEnv *env,
             // Now walk the snapshot of processes, and
             // save information about each process in turn
             do {
-                if (ppid == java_lang_ProcessHandleImpl_ALL_CHILDREN_PID ||
+                if (ppid == (DWORD)java_lang_ProcessHandleImpl_ALL_CHILDREN_PID ||
                     (pe32.th32ParentProcessID > 0
                     && (pe32.th32ParentProcessID == ppid))) {
                     if (count < arraySize) {

--- a/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
+++ b/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
@@ -273,7 +273,7 @@ Java_java_lang_ProcessHandleImpl_getProcessPids0(JNIEnv *env,
             // Now walk the snapshot of processes, and
             // save information about each process in turn
             do {
-                if (ppid == 0 ||
+                if (ppid == java_lang_ProcessHandleImpl_ALL_CHILDREN_PID ||
                     (pe32.th32ParentProcessID > 0
                     && (pe32.th32ParentProcessID == ppid))) {
                     if (count < arraySize) {

--- a/test/jdk/java/lang/ProcessHandle/TreeTest.java
+++ b/test/jdk/java/lang/ProcessHandle/TreeTest.java
@@ -42,6 +42,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
@@ -471,6 +474,26 @@ public class TreeTest extends ProcessUtil {
         }
     }
 
+    private static Stream<Arguments> pidSource() {
+        return Stream.of(
+                Arguments.of(ProcessHandle.of(1)),
+                Arguments.of(Optional.of(ProcessHandle.current())));
+    }
+
+    // Verify that process hierarchy is not unexpectedly large
+    @ParameterizedTest
+    @MethodSource("pidSource")
+    void alwaysEmptyAtTheTop(Optional<ProcessHandle> current) {
+        final int MAX_DEPTH = 100; // The hierarchy should not be anywhere close to this deep
+        for (int depth = 0; depth < MAX_DEPTH; depth++) {
+            current = current.get().parent();
+            if (current.isEmpty()) {
+                return; // Last/top parent, normal exit
+            }
+        }
+        Assertions.fail("Traversal from process to root of process hierarchy exceeded 100");
+    }
+
     @Test
     @EnabledOnOs(OS.MAC)
     void pidZeroTest() {
@@ -485,5 +508,9 @@ public class TreeTest extends ProcessUtil {
         Stream<ProcessHandle> allProcesses = ProcessHandle.allProcesses();
         long pZeroCount = allProcesses.filter(p -> p.equals(pZero)).count();
         Assertions.assertEquals(1, pZeroCount, "pid 0 should appear exactly once in a list of all processes");
+
+        ProcessHandle pOne = ProcessHandle.of(1).orElseThrow();
+        Assertions.assertEquals(Optional.empty(), pZero.parent(), "Parent of pid zero should be Optional.empty");
+        Assertions.assertEquals(pZero, pOne.parent().orElseThrow(), "Parent of pid 1 should be pid 0");
     }
 }

--- a/test/jdk/java/lang/ProcessHandle/TreeTest.java
+++ b/test/jdk/java/lang/ProcessHandle/TreeTest.java
@@ -474,10 +474,17 @@ public class TreeTest extends ProcessUtil {
         }
     }
 
-    private static Stream<Arguments> pidSource() {
-        return Stream.of(
-                Arguments.of(ProcessHandle.of(1)),
-                Arguments.of(Optional.of(ProcessHandle.current())));
+    private static List<Arguments> pidSource() {
+        List<Arguments> args = new ArrayList<>();
+        args.add(Arguments.of(Optional.of(ProcessHandle.current())));
+        if (OS.LINUX.isCurrentOs()) {
+            args.add(Arguments.of(ProcessHandle.of(1)));
+        }
+        if (OS.MAC.isCurrentOs()) {
+            args.add(Arguments.of(ProcessHandle.of(0)));
+            args.add(Arguments.of(ProcessHandle.of(1)));
+        }
+        return args;
     }
 
     // Verify that process hierarchy is not unexpectedly large

--- a/test/jdk/java/lang/ProcessHandle/TreeTest.java
+++ b/test/jdk/java/lang/ProcessHandle/TreeTest.java
@@ -40,6 +40,8 @@ import java.util.stream.Stream;
 import jdk.test.lib.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /*
  * @test
@@ -469,4 +471,19 @@ public class TreeTest extends ProcessUtil {
         }
     }
 
+    @Test
+    @EnabledOnOs(OS.MAC)
+    void pidZeroTest() {
+        ProcessHandle pZero = ProcessHandle.of(0).orElseThrow();
+        Assertions.assertFalse(pZero.children().toList().contains(pZero),
+                    "pid 0 should not be a child of pid 0");
+
+        Assertions.assertFalse(pZero.descendants().toList().contains(pZero),
+                    "pid 0 should not be a descendant of pid 0");
+
+        // Verify that (on MacOS) pid 0 is listed as one of allProcesses()
+        Stream<ProcessHandle> allProcesses = ProcessHandle.allProcesses();
+        long pZeroCount = allProcesses.filter(p -> p.equals(pZero)).count();
+        Assertions.assertEquals(1, pZeroCount, "pid 0 should appear exactly once in a list of all processes");
+    }
 }


### PR DESCRIPTION
Refactor ProcessHandleImpl.children and its native implementation dependencies to use -1 for the sentinel for all processes.  The value of zero could be mistaken for pid 0 on MacOSX.

The implementations ensure that the parent pid is not returned when requesting children or descendants.
Added tests for MacOS with pid 0 for children, descendants, and allProcesses.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8381567](https://bugs.openjdk.org/browse/JDK-8381567)

### Issue
 * [JDK-8381567](https://bugs.openjdk.org/browse/JDK-8381567): ProcessHandle.descendants fails with ArrayIndexOutOfBoundException for process 0 (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30923/head:pull/30923` \
`$ git checkout pull/30923`

Update a local copy of the PR: \
`$ git checkout pull/30923` \
`$ git pull https://git.openjdk.org/jdk.git pull/30923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30923`

View PR using the GUI difftool: \
`$ git pr show -t 30923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30923.diff">https://git.openjdk.org/jdk/pull/30923.diff</a>

</details>
