### PR TITLE
8308878: com/sun/net/httpserver/simpleserver/OutputFilterTest.java fails with assertion errors in IPv6 only environment

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/OutputFilterTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/OutputFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,6 +118,7 @@ public class OutputFilterTest {
         var filter = SimpleFileServer.createOutputFilter(baos, VERBOSE);
         var server = HttpServer.create(LOOPBACK_ADDR, 10, "/", handler, filter);
         server.start();
+        final String serverIP = server.getAddress().getAddress().getHostAddress();
         try (baos) {
             var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
             var request = HttpRequest.newBuilder(uri(server, "")).build();
@@ -129,8 +130,9 @@ public class OutputFilterTest {
             server.stop(0);
             baos.flush();
             var filterOutput = baos.toString(UTF_8);
-            var pattern = Pattern.compile("""
-                    127\\.0\\.0\\.1 - - \\[[\\s\\S]+] "GET / HTTP/1\\.1" 200 -
+            System.err.println("server output:\n" + filterOutput);
+            var pattern = Pattern.compile(serverIP + " " + """
+                    - - \\[[\\s\\S]+] "GET / HTTP/1\\.1" 200 -
                     Resource requested: /foo/bar
                     (>[\\s\\S]+:[\\s\\S]+)+
                     >
@@ -170,6 +172,7 @@ public class OutputFilterTest {
         var filter = SimpleFileServer.createOutputFilter(baos, VERBOSE);
         var server = HttpServer.create(LOOPBACK_ADDR, 10, "/", handler, filter);
         server.start();
+        final String serverIP = server.getAddress().getAddress().getHostAddress();
         try (baos) {
             var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
             var request = HttpRequest.newBuilder(uri(server, "")).build();
@@ -181,8 +184,9 @@ public class OutputFilterTest {
             server.stop(0);
             baos.flush();
             var filterOutput = baos.toString(UTF_8);
-            var pattern = Pattern.compile("""
-                    127\\.0\\.0\\.1 - - \\[[\\s\\S]+] "GET / HTTP/1\\.1" 200 -
+            System.err.println("server output:\n" + filterOutput);
+            var pattern = Pattern.compile(serverIP + " " + """
+                    - - \\[[\\s\\S]+] "GET / HTTP/1\\.1" 200 -
                     (>[\\s\\S]+:[\\s\\S]+)+
                     >
                     (<[\\s\\S]+:[\\s\\S]+)+
@@ -262,6 +266,7 @@ public class OutputFilterTest {
         var filter = SimpleFileServer.createOutputFilter(baos, VERBOSE);
         var server = HttpServer.create(LOOPBACK_ADDR, 0, "/", handler, filter);
         server.start();
+        final String serverIP = server.getAddress().getAddress().getHostAddress();
         try (baos) {
             var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
             var request = HttpRequest.newBuilder(uri(server, "aFile\u0000.txt")).build();
@@ -272,8 +277,9 @@ public class OutputFilterTest {
             server.stop(0);
             baos.flush();
             var filterOutput = baos.toString(UTF_8);
-            var pattern = Pattern.compile("""
-                    127\\.0\\.0\\.1 - - \\[[\\s\\S]+] "GET /aFile%00\\.txt HTTP/1\\.1" 404 -
+            System.err.println("server output:\n" + filterOutput);
+            var pattern = Pattern.compile(serverIP + " " + """
+                    - - \\[[\\s\\S]+] "GET /aFile%00\\.txt HTTP/1\\.1" 404 -
                     Resource requested: could not resolve request URI path
                     (>[\\s\\S]+:[\\s\\S]+)+
                     >

--- a/test/jdk/com/sun/net/httpserver/simpleserver/OutputFilterTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/OutputFilterTest.java
@@ -118,7 +118,7 @@ public class OutputFilterTest {
         var filter = SimpleFileServer.createOutputFilter(baos, VERBOSE);
         var server = HttpServer.create(LOOPBACK_ADDR, 10, "/", handler, filter);
         server.start();
-        final String serverIP = server.getAddress().getAddress().getHostAddress();
+        final String serverIPPattern = Pattern.quote(server.getAddress().getAddress().getHostAddress());
         try (baos) {
             var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
             var request = HttpRequest.newBuilder(uri(server, "")).build();
@@ -131,7 +131,7 @@ public class OutputFilterTest {
             baos.flush();
             var filterOutput = baos.toString(UTF_8);
             System.err.println("server output:\n" + filterOutput);
-            var pattern = Pattern.compile(serverIP + " " + """
+            var pattern = Pattern.compile(serverIPPattern + " " + """
                     - - \\[[\\s\\S]+] "GET / HTTP/1\\.1" 200 -
                     Resource requested: /foo/bar
                     (>[\\s\\S]+:[\\s\\S]+)+
@@ -172,7 +172,7 @@ public class OutputFilterTest {
         var filter = SimpleFileServer.createOutputFilter(baos, VERBOSE);
         var server = HttpServer.create(LOOPBACK_ADDR, 10, "/", handler, filter);
         server.start();
-        final String serverIP = server.getAddress().getAddress().getHostAddress();
+        final String serverIPPattern = Pattern.quote(server.getAddress().getAddress().getHostAddress());
         try (baos) {
             var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
             var request = HttpRequest.newBuilder(uri(server, "")).build();
@@ -185,7 +185,7 @@ public class OutputFilterTest {
             baos.flush();
             var filterOutput = baos.toString(UTF_8);
             System.err.println("server output:\n" + filterOutput);
-            var pattern = Pattern.compile(serverIP + " " + """
+            var pattern = Pattern.compile(serverIPPattern + " " + """
                     - - \\[[\\s\\S]+] "GET / HTTP/1\\.1" 200 -
                     (>[\\s\\S]+:[\\s\\S]+)+
                     >
@@ -266,7 +266,7 @@ public class OutputFilterTest {
         var filter = SimpleFileServer.createOutputFilter(baos, VERBOSE);
         var server = HttpServer.create(LOOPBACK_ADDR, 0, "/", handler, filter);
         server.start();
-        final String serverIP = server.getAddress().getAddress().getHostAddress();
+        final String serverIPPattern = Pattern.quote(server.getAddress().getAddress().getHostAddress());
         try (baos) {
             var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
             var request = HttpRequest.newBuilder(uri(server, "aFile\u0000.txt")).build();
@@ -278,7 +278,7 @@ public class OutputFilterTest {
             baos.flush();
             var filterOutput = baos.toString(UTF_8);
             System.err.println("server output:\n" + filterOutput);
-            var pattern = Pattern.compile(serverIP + " " + """
+            var pattern = Pattern.compile(serverIPPattern + " " + """
                     - - \\[[\\s\\S]+] "GET /aFile%00\\.txt HTTP/1\\.1" 404 -
                     Resource requested: could not resolve request URI path
                     (>[\\s\\S]+:[\\s\\S]+)+


### PR DESCRIPTION
Can I please get a review of this test-only change which addresses the issue noted in https://bugs.openjdk.org/browse/JDK-8308878?

The commit in this PR updates the test to not hardcode a IPv4 address and instead use the server's bound address when looking for the server's IP address in the output.

With this change the test now passes in IPv4 as well as IPv6 environments.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308878](https://bugs.openjdk.org/browse/JDK-8308878): com/sun/net/httpserver/simpleserver/OutputFilterTest.java fails with assertion errors in IPv6 only environment (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30934/head:pull/30934` \
`$ git checkout pull/30934`

Update a local copy of the PR: \
`$ git checkout pull/30934` \
`$ git pull https://git.openjdk.org/jdk.git pull/30934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30934`

View PR using the GUI difftool: \
`$ git pr show -t 30934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30934.diff">https://git.openjdk.org/jdk/pull/30934.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30934#issuecomment-4321414718)
</details>
