### PR TITLE
8383367: jdk/jfr/event/oldobject/TestDFSWithSmallStack.java failed with -XX:+UseZGC -XX:+UseCompactObjectHeaders

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestDFSWithSmallStack.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestDFSWithSmallStack.java
@@ -36,6 +36,7 @@ import jdk.test.lib.jfr.Events;
  * @test id=dfsonly
  * @summary Tests that DFS works with a small stack
  * @library /test/lib /test/jdk
+ * @requires vm.flagless
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -Xmx2g -XX:VMThreadStackSize=512 jdk.jfr.event.oldobject.TestDFSWithSmallStack dfsonly
@@ -45,6 +46,7 @@ import jdk.test.lib.jfr.Events;
  * @test id=bfsdfs
  * @summary Tests that DFS works with a small stack
  * @library /test/lib /test/jdk
+ * @requires vm.flagless
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -Xmx2g -XX:VMThreadStackSize=512 jdk.jfr.event.oldobject.TestDFSWithSmallStack bfsdfs


### PR DESCRIPTION
Greetings,

Test jdk/jfr/event/oldobject/TestDFSWithSmallStack.java is the only test in the oldobject directory missing the vm. flagless directive. Adding it for consistency.

Thanks
Markus

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383367](https://bugs.openjdk.org/browse/JDK-8383367): jdk/jfr/event/oldobject/TestDFSWithSmallStack.java failed with -XX:+UseZGC -XX:+UseCompactObjectHeaders (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30937/head:pull/30937` \
`$ git checkout pull/30937`

Update a local copy of the PR: \
`$ git checkout pull/30937` \
`$ git pull https://git.openjdk.org/jdk.git pull/30937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30937`

View PR using the GUI difftool: \
`$ git pr show -t 30937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30937.diff">https://git.openjdk.org/jdk/pull/30937.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30937#issuecomment-4325021990)
</details>
