### PR TITLE
8383366: Missing call store_archive_data() on one of paths in generate_kyber12To16_avx512()

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_kyber.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_kyber.cpp
@@ -957,6 +957,9 @@ address generate_kyber12To16_avx512(StubGenerator *stubgen,
     __ mov64(rax, 0); // return 0
     __ ret(0);
 
+    // record the stub entry and end
+    stubgen->store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -2601,10 +2601,6 @@ address AOTStubData::load_archive_data(StubId stub_id, address& end, GrowableArr
   StubAddrRange &range = _ranges[idx];
   int base = range.start_index();
   if (base < 0) {
-#ifdef ASSERT
-    // reset index so we can idenitfy which ones we failed to find
-    range.init_entry(-2, 0);
-#endif
     return nullptr;
   }
   int count = range.count();

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -2601,7 +2601,7 @@ address AOTStubData::load_archive_data(StubId stub_id, address& end, GrowableArr
   StubAddrRange &range = _ranges[idx];
   int base = range.start_index();
   if (base < 0) {
-#ifdef DEBUG
+#ifdef ASSERT
     // reset index so we can idenitfy which ones we failed to find
     range.init_entry(-2, 0);
 #endif
@@ -2681,3 +2681,23 @@ void AOTStubData::store_archive_data(StubId stub_id, address start, address end,
   }
   range.init_entry(base, _address_array.length() - base);
 }
+
+void AOTStubData::stub_epilog(StubId stub_id) {
+  DEBUG_ONLY(check_stored(stub_id));
+}
+
+#ifdef ASSERT
+void AOTStubData::check_stored(StubId stub_id) {
+  // Only need to check if we are dumping
+  //
+  // This excludes cases where the cache got closed because of error
+  // plus the pre-universe stubs we can never store because they are
+  // generated prior to cache opening.
+  if (is_dumping()) {
+    int idx = StubInfo::stubgen_offset_in_blob(_blob_id, stub_id);
+    assert(idx >= 0 && idx < _stub_cnt, "invalid index %d for stub count %d", idx, _stub_cnt);
+    StubAddrRange& range = _ranges[idx];
+    assert(range.start_index() != -1, "missing store_archive_data for generated stub %s", StubInfo::name(stub_id));
+  }
+}
+#endif

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -266,6 +266,10 @@ public:
   address load_archive_data(StubId stub_id, address &end, GrowableArray<address>* entries = nullptr, GrowableArray<address>* extras = nullptr) NOT_CDS_RETURN_(nullptr);
   void store_archive_data(StubId stub_id, address start, address end, GrowableArray<address>* entries = nullptr, GrowableArray<address>* extras = nullptr) NOT_CDS_RETURN;
 
+  void stub_epilog(StubId stub_id);
+#ifdef ASSERT
+  void check_stored(StubId stub_id);
+#endif
   const AOTStubData* as_const() { return (const AOTStubData*)this; }
 };
 

--- a/src/hotspot/share/runtime/stubCodeGenerator.cpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.cpp
@@ -178,6 +178,9 @@ void StubCodeGenerator::stub_prolog(StubCodeDesc* cdesc) {
 }
 
 void StubCodeGenerator::stub_epilog(StubCodeDesc* cdesc) {
+  if (_stub_data != nullptr && _stub_data->is_dumping()) {
+    _stub_data->stub_epilog(cdesc->stub_id());
+  }
   print_stub_code_desc(cdesc);
 }
 
@@ -259,15 +262,18 @@ void StubCodeGenerator::verify_stub(StubId stub_id) {
 
 // Implementation of CodeMark
 
-StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, const char* group, const char* name) {
+StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, const char* group, const char* name, StubId stub_id) {
   _cgen  = cgen;
-  _cdesc = new StubCodeDesc(group, name, _cgen->assembler()->pc());
+  _cdesc = new StubCodeDesc(group, name, _cgen->assembler()->pc(), nullptr, stub_id);
   _cgen->stub_prolog(_cdesc);
   // define the stub's beginning (= entry point) to be after the prolog:
   _cdesc->set_begin(_cgen->assembler()->pc());
 }
 
-StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, StubId stub_id) : StubCodeMark(cgen, "StubRoutines", StubRoutines::get_stub_name(stub_id)) {
+StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, const char* group, const char* name) : StubCodeMark(cgen, group, name, StubId::NO_STUBID) {
+}
+
+StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, StubId stub_id) : StubCodeMark(cgen, "StubRoutines", StubRoutines::get_stub_name(stub_id), stub_id) {
 #ifdef ASSERT
   cgen->verify_stub(stub_id);
 #endif

--- a/src/hotspot/share/runtime/stubCodeGenerator.hpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.hpp
@@ -50,6 +50,8 @@ class StubCodeDesc: public CHeapObj<mtCode> {
   address              _end;      // points to the first byte after the stub code (excluded)
   uint                 _disp;     // Displacement relative base address in buffer.
   bool                 _loaded_from_cache;
+  // id when this is an enumerated stub otherwise StubId::NO_STUBID
+  StubId               _stub_id;
 
   friend class StubCodeMark;
   friend class StubCodeGenerator;
@@ -75,7 +77,7 @@ class StubCodeDesc: public CHeapObj<mtCode> {
 
   static StubCodeDesc* desc_for(address pc);     // returns the code descriptor for the code containing pc or null
 
-  StubCodeDesc(const char* group, const char* name, address begin, address end = nullptr) {
+  StubCodeDesc(const char* group, const char* name, address begin, address end = nullptr, StubId stub_id = StubId::NO_STUBID) {
     assert(!_frozen, "no modifications allowed");
     assert(name != nullptr, "no name specified");
     _next           = _list;
@@ -86,6 +88,7 @@ class StubCodeDesc: public CHeapObj<mtCode> {
     _disp           = 0;
     _list           = this;
     _loaded_from_cache = false;
+    _stub_id = stub_id;
   };
 
   static void freeze();
@@ -99,6 +102,7 @@ class StubCodeDesc: public CHeapObj<mtCode> {
   int         size_in_bytes() const              { return pointer_delta_as_int(_end, _begin); }
   bool        contains(address pc) const         { return _begin <= pc && pc < _end; }
   bool        loaded_from_cache() const          { return _loaded_from_cache; }
+  StubId      stub_id() const                    { return _stub_id; }
   void        print_on(outputStream* st) const;
   void        print() const;
 };
@@ -199,7 +203,8 @@ class StubCodeMark: public StackObj {
   StubCodeGenerator* _cgen;
   StubCodeDesc*      _cdesc;
 
- public:
+  StubCodeMark(StubCodeGenerator* cgen, const char* group, const char* name, StubId stub_id);
+    public:
   StubCodeMark(StubCodeGenerator* cgen, const char* group, const char* name);
   StubCodeMark(StubCodeGenerator* cgen, StubId stub_id);
   ~StubCodeMark();


### PR DESCRIPTION
This PR adds a (debug only) verification check to ensure that all StubGen stubs generated into a given blob have been recorded via a call to store_archive_data if an AOT code cache is being used. It also fixes a missing store in the AVX512 kyber12To16 generator.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383366](https://bugs.openjdk.org/browse/JDK-8383366): Missing call store_archive_data() on one of paths in generate_kyber12To16_avx512() (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30940/head:pull/30940` \
`$ git checkout pull/30940`

Update a local copy of the PR: \
`$ git checkout pull/30940` \
`$ git pull https://git.openjdk.org/jdk.git pull/30940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30940`

View PR using the GUI difftool: \
`$ git pr show -t 30940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30940.diff">https://git.openjdk.org/jdk/pull/30940.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30940#issuecomment-4326077114)
</details>
