### PR TITLE
8347112: Copy nested directories in doc-files by default

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
@@ -169,8 +169,7 @@ public class DocFilesHandler {
                     }
                 }
             } else if (srcfile.isDirectory()) {
-                if (options.copyDocfileSubdirs()
-                        && !configuration.shouldExcludeDocFileDir(srcfile.getName())) {
+                if (!configuration.shouldExcludeDocFileDir(srcfile.getName())) {
                     DocPath dirDocPath = dstDocPath.resolve(srcfile.getName());
                     copyDirectory(srcfile, dirDocPath, first);
                 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -789,5 +789,10 @@ doclet.footer_specified=\
     The -footer option is no longer supported and will be ignored.\n\
     It may be removed in a future release.
 
+# L10N: do not localize the option name -docfilessubdirs
+doclet.docfilessubdirs_specified=\
+    Note: The -docfilessubdirs option is no longer required and\n\
+    may be removed in a future release.
+
 doclet.selectModule=\
     Select the module to search in.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -521,8 +521,8 @@ doclet.usage.author.description=\
     Include @author paragraphs
 
 doclet.usage.docfilessubdirs.description=\
-    Enables deep copying of 'doc-files' directories. Subdirectories and all\n\
-    contents are recursively copied to the destination
+    Enables deep copying of 'doc-files' directories. This option\n\
+    is no longer required.
 
 doclet.usage.splitindex.description=\
     Split index into one file per letter
@@ -598,7 +598,8 @@ doclet.usage.excludedocfilessubdir.parameters=\
     <name>,<name>,...
 doclet.usage.excludedocfilessubdir.description=\
     Exclude any 'doc-files' subdirectories with given name.\n\
-    ':' can also be used anywhere in the argument as a separator.
+    Use '*' to exclude all subdirectories. ':' can also be used\n\
+    anywhere in the argument as a separator.
 
 doclet.usage.group.parameters=\
     <name> <g1>,<g2>...

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -521,8 +521,8 @@ doclet.usage.author.description=\
     Include @author paragraphs
 
 doclet.usage.docfilessubdirs.description=\
-    Enables deep copying of 'doc-files' directories. This option\n\
-    is no longer required.
+    The -docfilessubdirs option is no longer required and\n\
+    may be removed in a future release.
 
 doclet.usage.splitindex.description=\
     Split index into one file per letter

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -407,7 +407,7 @@ public abstract class BaseConfiguration {
      */
     public boolean shouldExcludeDocFileDir(String docfilesubdir) {
         Set<String> excludedDocFileDirs = getOptions().excludedDocFileDirs();
-        return excludedDocFileDirs.contains(docfilesubdir);
+        return excludedDocFileDirs.contains(docfilesubdir) || excludedDocFileDirs.contains("*");
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
@@ -57,8 +57,8 @@ import static javax.tools.Diagnostic.Kind.ERROR;
  * returned by {@link BaseOptions#getSupportedOptions()}.
  *
  * <p>Some of the methods used to access the values of options
- * have names that begin with a verb, such as {@link #copyDocfileSubdirs}
- * or {@link #showVersion}. Unless otherwise stated,
+ * have names that begin with a verb, such as {@link #linkSource()}
+ * or {@link #showVersion()}. Unless otherwise stated,
  * these methods should all be taken as just accessing the value
  * of the associated option.
  */
@@ -71,12 +71,6 @@ public abstract class BaseOptions {
      * Allow JavaScript in doc comments.
      */
     private boolean allowScriptInComments = false;
-
-    /**
-     * Argument for command-line option {@code -docfilessubdirs}.
-     * True if we should recursively copy the doc-file subdirectories
-     */
-    private boolean copyDocfileSubdirs = false;
 
     /**
      * Argument for command-line option {@code --date}.
@@ -394,7 +388,6 @@ public abstract class BaseOptions {
                 new Option(resources, "-docfilessubdirs") {
                     @Override
                     public boolean process(String opt, List<String> args) {
-                        copyDocfileSubdirs = true;
                         return true;
                     }
                 },
@@ -760,14 +753,6 @@ public abstract class BaseOptions {
      */
     boolean allowScriptInComments() {
         return allowScriptInComments;
-    }
-
-    /**
-     * Argument for command-line option {@code -docfilessubdirs}.
-     * True if we should recursively copy the doc-file subdirectories
-     */
-    public boolean copyDocfileSubdirs() {
-        return copyDocfileSubdirs;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
@@ -388,6 +388,7 @@ public abstract class BaseOptions {
                 new Option(resources, "-docfilessubdirs") {
                     @Override
                     public boolean process(String opt, List<String> args) {
+                        messages.notice("doclet.docfilessubdirs_specified");
                         return true;
                     }
                 },

--- a/src/jdk.javadoc/share/man/javadoc.md
+++ b/src/jdk.javadoc/share/man/javadoc.md
@@ -485,8 +485,9 @@ The following options are provided by the standard doclet.
     ```
 
 <span id="option-docfilessubdirs">`-docfilessubdirs`</span>
-:   This option is no longer required as `javadoc` now recursively copies
-    subdirectories of `doc-files` directories by default. Use the
+:   This option is no longer required and may be removed in a future release.
+    The `javadoc` tool now recursively copies subdirectories of `doc-files`
+    directories by default. Use the
     [`-excludedocfilessubdir`](#option-excludedocfilessubdir) option to
     restrict the subdirectories to be copied.
 

--- a/src/jdk.javadoc/share/man/javadoc.md
+++ b/src/jdk.javadoc/share/man/javadoc.md
@@ -485,10 +485,9 @@ The following options are provided by the standard doclet.
     ```
 
 <span id="option-docfilessubdirs">`-docfilessubdirs`</span>
-:   Enables deep copying of `doc-files` directories. Subdirectories and all
-    contents are recursively copied to the destination. For example, the
-    directory `doc-files/example/images` and all of its contents are copied.
-    Use the [`-excludedocfilessubdir`](#option-excludedocfilessubdir) option to
+:   This option is no longer required as `javadoc` now recursively copies
+    subdirectories of `doc-files` directories by default. Use the
+    [`-excludedocfilessubdir`](#option-excludedocfilessubdir) option to
     restrict the subdirectories to be copied.
 
 <span id="option-doctitle">`-doctitle` *html-code*</span>
@@ -501,9 +500,9 @@ The following options are provided by the standard doclet.
     `javadoc -doctitle "<b>My Library</b><br>v1.0" com.mypackage`.
 
 <span id="option-excludedocfilessubdir">`-excludedocfilessubdir` *name1*`,`*name2...*</span>
-:   Excludes any subdirectories with the given names
-    when recursively copying `doc-files` subdirectories.
-    See [`-docfilessubdirs`](#option-docfilessubdirs).
+:   Excludes any subdirectories with the given names when recursively copying
+    `doc-files` subdirectories. You can use `*` to exclude all subdirectories
+    from being copied, but note that `*` must be quoted or escaped in the shell.
     For historical reasons, `:` can be used anywhere in the argument as a
     separator instead of `,`.
 

--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -140,11 +140,9 @@ public class TestCopyFiles extends JavadocTester {
 
         checkOutput(Output.OUT, true,
                 """
-                    The -docfilessubdirs option is no longer required and
-                    may be removed in a future release.""",
+                    The -docfilessubdirs option is no longer required""",
                 """
-                    The -footer option is no longer supported and will be ignored.
-                      It may be removed in a future release.""");
+                    The -footer option is no longer supported and will be ignored""");
 
         checkOrder("acme.mdle/p/doc-files/inpackage.html",
                 """

--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -126,8 +126,8 @@ public class TestCopyFiles extends JavadocTester {
     }
 
     @Test
-    public void testDocFilesInMultiModulePackagesWithRecursiveCopy() {
-        javadoc("-d", "multi-modules-out-recursive",
+    public void testDocFilesInMultiModulePackages() {
+        javadoc("-d", "multi-modules-out",
                 "-docfilessubdirs",
                 "-top", "phi-TOP-phi",
                 "-bottom", "phi-BOTTOM-phi",
@@ -193,41 +193,65 @@ public class TestCopyFiles extends JavadocTester {
     }
 
     @Test
-    public void testDocFilesInModulePackagesWithRecursiveCopy() {
-        javadoc("-d", "modules-out-recursive",
+    public void testDocFilesInMultiModulePackagesWithExclusion() {
+        javadoc("-d", "multi-modules-out-exclusion",
+                "-excludedocfilessubdir", "sub-dir",
                 "--module-source-path", testSrc("modules"),
-                "--module", "acme.mdle");
+                "--module", "acme.mdle,acme2.mdle");
         checkExit(Exit.OK);
+
         checkOutput("acme.mdle/p/doc-files/inpackage.html", true,
                 """
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>."""
         );
-        checkOutput("acme.mdle/p/doc-files/sub-dir/SubReadme.html", true,
+
+        checkFiles(false, "acme.mdle/p/doc-files/sub-dir");
+
+        checkOutput("acme2.mdle/p2/doc-files/inpackage.html", true,
                 """
-                    SubReadme.html at second level of doc-file directory for acme.module."""
+                    In a named module acme2.mdle and named package <a href="../package-summary.html"><code>p2</code></a>."""
         );
-        checkOutput("acme.mdle/p/doc-files/sub-dir/sub-dir-1/SubSubReadme.html", true,
-                """
-                    SubSubReadme.html at third level of doc-file directory."""
-        );
+
+        checkFiles(false, "acme2.mdle/p2/doc-files/sub-dir");
     }
 
     @Test
-    public void testDocFilesInModulePackagesWithRecursiveCopyWithExclusion() {
-        javadoc("-d", "modules-out-recursive-with-exclusion",
+    public void testDocFilesInModulePackagesWithExclusion() {
+        javadoc("-d", "modules-out-exclusion",
                 "-excludedocfilessubdir", "sub-dir-1",
                 "--module-source-path", testSrc("modules"),
                 "--module", "acme.mdle");
         checkExit(Exit.OK);
+
         checkOutput("acme.mdle/p/doc-files/inpackage.html", true,
                 """
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>."""
         );
+
         checkOutput("acme.mdle/p/doc-files/sub-dir/SubReadme.html", true,
                 """
                     SubReadme.html at second level of doc-file directory for acme.module."""
         );
-        checkFiles(false, "acme2.mdle/p2/doc-files/sub-dir/sub-dir-1");
+
+        checkFiles(false, "acme.mdle/p/doc-files/sub-dir/sub-dir-1");
+
+        checkFiles(false, "acme2.mdle/p2/doc-files");
+    }
+
+    @Test
+    public void testDocFilesInModulePackagesWithWildcardExclusion() {
+        javadoc("-d", "modules-out-wildcard-exclusion",
+                "-excludedocfilessubdir", "*",
+                "--module-source-path", testSrc("modules"),
+                "--module", "acme.mdle");
+        checkExit(Exit.OK);
+
+        checkOutput("acme.mdle/p/doc-files/inpackage.html", true,
+                """
+                    In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>."""
+        );
+
+        checkFiles(false, "acme.mdle/p/doc-files/sub-dir");
     }
 
     @Test
@@ -247,8 +271,9 @@ public class TestCopyFiles extends JavadocTester {
     }
 
     @Test
-    public void testDocFilesInPackagesWithRecursiveCopy() {
-        javadoc("-d", "packages-out-recursive",
+    public void testDocFilesInPackagesWithExclusion() {
+        javadoc("-d", "packages-out-exclusion",
+                "-excludedocfilessubdir", "sub-dir",
                 "-sourcepath", testSrc("packages"),
                 "p1");
         checkExit(Exit.OK);
@@ -257,16 +282,13 @@ public class TestCopyFiles extends JavadocTester {
                 "A named package in an unnamed module"
         );
 
-        checkOutput("p1/doc-files/sub-dir/SubReadme.html", true,
-                "<title>SubReadme</title>",
-                "SubReadme.html at second level of doc-file directory."
-        );
+        checkFiles(false, "p1/doc-files/sub-dir");
     }
 
     @Test
-    public void testDocFilesInPackagesWithRecursiveCopyWithExclusion() {
-        javadoc("-d", "packages-out-recursive-with-exclusion",
-                "-excludedocfilessubdir", "sub-dir",
+    public void testDocFilesInPackagesWithWildcardExclusion() {
+        javadoc("-d", "packages-out-wildcard-exclusion",
+                "-excludedocfilessubdir", "*",
                 "-sourcepath", testSrc("packages"),
                 "p1");
         checkExit(Exit.OK);
@@ -299,6 +321,44 @@ public class TestCopyFiles extends JavadocTester {
                     """,
                 "SubReadme.html at second level of doc-file directory for unnamed package."
         );
+    }
+
+    @Test
+    public void testDocFilesInUnnamedPackagesWithExclusion() {
+        javadoc("-d", "unnamed-out-exclusion",
+                "-windowtitle", "phi-WINDOW-TITLE-phi",
+                "-excludedocfilessubdir", "doc-file",
+                "-sourcepath", testSrc("unnamed"),
+                testSrc("unnamed/Foo.java")
+        );
+        checkExit(Exit.OK);
+        checkOutput("doc-files/inpackage.html", true,
+                """
+                    <title>(phi-WINDOW-TITLE-phi)</title>
+                    """,
+                "In an unnamed package"
+        );
+
+        checkFiles(false, "doc-files/doc-file");
+    }
+
+    @Test
+    public void testDocFilesInUnnamedPackagesWithWildcardExclusion() {
+        javadoc("-d", "unnamed-out-wildcard-exclusion",
+                "-windowtitle", "phi-WINDOW-TITLE-phi",
+                "-excludedocfilessubdir", "*",
+                "-sourcepath", testSrc("unnamed"),
+                testSrc("unnamed/Foo.java")
+        );
+        checkExit(Exit.OK);
+        checkOutput("doc-files/inpackage.html", true,
+                """
+                    <title>(phi-WINDOW-TITLE-phi)</title>
+                    """,
+                "In an unnamed package"
+        );
+
+        checkFiles(false, "doc-files/doc-file");
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -140,10 +140,10 @@ public class TestCopyFiles extends JavadocTester {
 
         checkOutput(Output.OUT, true,
                 """
-                    Note: The -docfilessubdirs option is no longer required and
+                    The -docfilessubdirs option is no longer required and
                     may be removed in a future release.""",
                 """
-                    warning: The -footer option is no longer supported and will be ignored.
+                    The -footer option is no longer supported and will be ignored.
                       It may be removed in a future release.""");
 
         checkOrder("acme.mdle/p/doc-files/inpackage.html",

--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug  8157349 8185985 8194953 8214738
+ * @bug  8157349 8185985 8194953 8214738 8347112
  * @summary  test copy of doc-files, and its contents for HTML meta content.
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -51,6 +51,11 @@ public class TestCopyFiles extends JavadocTester {
                 "--module-source-path", testSrc("modules"),
                 "--module", "acme.mdle");
         checkExit(Exit.OK);
+
+        checkOutput(Output.OUT, true,
+                """
+                    warning: The -footer option is no longer supported and will be ignored.
+                      It may be removed in a future release.""");
         checkOrder("acme.mdle/p/doc-files/inpackage.html",
                 """
                     "Hello World" (phi-WINDOW-TITLE-phi)""",
@@ -71,7 +76,51 @@ public class TestCopyFiles extends JavadocTester {
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>.""",
                 "<dt>Since:</",
                 "forever",
+                // check bottom
+                "phi-BOTTOM-phi"
+        );
+
+        checkOrder("acme.mdle/p/doc-files/sub-dir/SubReadme.html",
+                """
+                    SubReadme (phi-WINDOW-TITLE-phi)""",
+                "phi-TOP-phi",
+                // check top navbar
+                """
+                    <a href="../../package-tree.html">Tree</a>""",
+                """
+                    <a href="../../../../deprecated-list.html">Deprecated</a>""",
+                """
+                    <a href="../../../../index-all.html">Index</a>""",
+                "phi-HEADER-phi",
+                """
+                    <a href="../../../module-summary.html">acme.mdle</a>""",
+                """
+                    <a href="../../package-summary.html" class="current-selection">p</a>""",
+                """
+                   SubReadme.html at second level of doc-file directory for acme.module.""",
                 // check footer
+                "phi-BOTTOM-phi"
+        );
+
+        checkOrder("acme.mdle/p/doc-files/sub-dir/sub-dir-1/SubSubReadme.html",
+                """
+                    SubSubReadme (phi-WINDOW-TITLE-phi)""",
+                "phi-TOP-phi",
+                // check top navbar
+                """
+                    <a href="../../../package-tree.html">Tree</a>""",
+                """
+                    <a href="../../../../../deprecated-list.html">Deprecated</a>""",
+                """
+                    <a href="../../../../../index-all.html">Index</a>""",
+                "phi-HEADER-phi",
+                """
+                    <a href="../../../../module-summary.html">acme.mdle</a>""",
+                """
+                    <a href="../../../package-summary.html" class="current-selection">p</a>""",
+                """
+                   SubSubReadme.html at third level of doc-file directory.""",
+                // check bottom
                 "phi-BOTTOM-phi"
         );
     }
@@ -88,6 +137,15 @@ public class TestCopyFiles extends JavadocTester {
                 "--module-source-path", testSrc("modules"),
                 "--module", "acme.mdle,acme2.mdle");
         checkExit(Exit.OK);
+
+        checkOutput(Output.OUT, true,
+                """
+                    Note: The -docfilessubdirs option is no longer required and
+                    may be removed in a future release.""",
+                """
+                    warning: The -footer option is no longer supported and will be ignored.
+                      It may be removed in a future release.""");
+
         checkOrder("acme.mdle/p/doc-files/inpackage.html",
                 """
                     "Hello World" (phi-WINDOW-TITLE-phi)""",
@@ -108,7 +166,7 @@ public class TestCopyFiles extends JavadocTester {
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>.""",
                 "<dt>Since:</",
                 "forever",
-                // check footer
+                // check bottom
                 "phi-BOTTOM-phi"
         );
 
@@ -129,7 +187,7 @@ public class TestCopyFiles extends JavadocTester {
                 """
                     <a href="../../../package-summary.html" class="current-selection">p2</a>""",
                 "SubSubReadme.html at third level of doc-file directory.",
-                // check footer
+                // check bottom
                 "phi-BOTTOM-phi"
         );
     }
@@ -137,21 +195,27 @@ public class TestCopyFiles extends JavadocTester {
     @Test
     public void testDocFilesInModulePackagesWithRecursiveCopy() {
         javadoc("-d", "modules-out-recursive",
-                "-docfilessubdirs",
                 "--module-source-path", testSrc("modules"),
                 "--module", "acme.mdle");
         checkExit(Exit.OK);
         checkOutput("acme.mdle/p/doc-files/inpackage.html", true,
                 """
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>."""
+        );
+        checkOutput("acme.mdle/p/doc-files/sub-dir/SubReadme.html", true,
+                """
+                    SubReadme.html at second level of doc-file directory for acme.module."""
+        );
+        checkOutput("acme.mdle/p/doc-files/sub-dir/sub-dir-1/SubSubReadme.html", true,
+                """
+                    SubSubReadme.html at third level of doc-file directory."""
         );
     }
 
     @Test
     public void testDocFilesInModulePackagesWithRecursiveCopyWithExclusion() {
         javadoc("-d", "modules-out-recursive-with-exclusion",
-                "-docfilessubdirs",
-                "-excludedocfilessubdir", "sub-dir",
+                "-excludedocfilessubdir", "sub-dir-1",
                 "--module-source-path", testSrc("modules"),
                 "--module", "acme.mdle");
         checkExit(Exit.OK);
@@ -159,6 +223,11 @@ public class TestCopyFiles extends JavadocTester {
                 """
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>."""
         );
+        checkOutput("acme.mdle/p/doc-files/sub-dir/SubReadme.html", true,
+                """
+                    SubReadme.html at second level of doc-file directory for acme.module."""
+        );
+        checkFiles(false, "acme2.mdle/p2/doc-files/sub-dir/sub-dir-1");
     }
 
     @Test
@@ -170,12 +239,16 @@ public class TestCopyFiles extends JavadocTester {
         checkOutput("p1/doc-files/inpackage.html", true,
                 "A named package in an unnamed module"
         );
+
+        checkOutput("p1/doc-files/sub-dir/SubReadme.html", true,
+                "<title>SubReadme</title>",
+                "SubReadme.html at second level of doc-file directory."
+        );
     }
 
     @Test
     public void testDocFilesInPackagesWithRecursiveCopy() {
         javadoc("-d", "packages-out-recursive",
-                "-docfilessubdirs",
                 "-sourcepath", testSrc("packages"),
                 "p1");
         checkExit(Exit.OK);
@@ -193,7 +266,6 @@ public class TestCopyFiles extends JavadocTester {
     @Test
     public void testDocFilesInPackagesWithRecursiveCopyWithExclusion() {
         javadoc("-d", "packages-out-recursive-with-exclusion",
-                "-docfilessubdirs",
                 "-excludedocfilessubdir", "sub-dir",
                 "-sourcepath", testSrc("packages"),
                 "p1");
@@ -202,6 +274,8 @@ public class TestCopyFiles extends JavadocTester {
         checkOutput("p1/doc-files/inpackage.html", true,
                 "A named package in an unnamed module"
         );
+
+        checkFiles(false, "p1/doc-files/sub-dir");
     }
 
     @Test
@@ -218,23 +292,7 @@ public class TestCopyFiles extends JavadocTester {
                     """,
                 "In an unnamed package"
         );
-    }
 
-    @Test
-    public void testDocFilesInUnnamedPackagesWithRecursiveCopy() {
-        javadoc("-d", "unnamed-out-recursive",
-                "-docfilessubdirs",
-                "-windowtitle", "phi-WINDOW-TITLE-phi",
-                "-sourcepath", testSrc("unnamed"),
-                testSrc("unnamed/Foo.java")
-        );
-        checkExit(Exit.OK);
-        checkOutput("doc-files/inpackage.html", true,
-                """
-                    <title>(phi-WINDOW-TITLE-phi)</title>
-                    """,
-                "In an unnamed package"
-        );
         checkOutput("doc-files/doc-file/SubReadme.html", true,
                 """
                     <title>Beep Beep (phi-WINDOW-TITLE-phi)</title>

--- a/test/langtools/jdk/javadoc/doclet/testDocFileDir/TestDocFileDir.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocFileDir/TestDocFileDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4258405 4973606 8024096
+ * @bug 4258405 4973606 8024096 8347112
  * @summary This test verifies that the doc-file directory does not
  *          get overwritten when the sourcepath is equal to the destination
  *          directory.
@@ -71,14 +71,13 @@ public class TestDocFileDir extends JavadocTester {
             "This doc file did not get trashed.");
     }
 
-    // Exercising -docfilessubdirs and -excludedocfilessubdir
+    // Exercising -excludedocfilessubdir
     @Test
     public void test3() {
         String outdir = "out3";
         setOutputDirectoryCheck(DirectoryCheck.NONE);
         javadoc("-d", outdir,
                 "-sourcepath", testSrc,
-                "-docfilessubdirs",
                 "-excludedocfilessubdir", "subdir-excluded1:subdir-excluded2",
                 "pkg");
         checkExit(Exit.OK);


### PR DESCRIPTION
Please review a simple change to recursively copy subdirectories of `doc-files` directory by default in JavaDoc, making the `-docfilessubdirs` option a no-op. This also adds support for "*" as a wildcard argument to the `-excludedocfilessubdir` option to allow to restore the old behavior. 

The test changes mostly result from removing now-duplicate tests for recursive copying, and replacing them with tests for exclusion, including the new wildcard exclusion.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8357372](https://bugs.openjdk.org/browse/JDK-8357372) to be approved

### Issues
 * [JDK-8347112](https://bugs.openjdk.org/browse/JDK-8347112): Copy nested directories in doc-files by default (**Enhancement** - P3)
 * [JDK-8357372](https://bugs.openjdk.org/browse/JDK-8357372): Copy nested directories in doc-files by default (**CSR**)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30942/head:pull/30942` \
`$ git checkout pull/30942`

Update a local copy of the PR: \
`$ git checkout pull/30942` \
`$ git pull https://git.openjdk.org/jdk.git pull/30942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30942`

View PR using the GUI difftool: \
`$ git pr show -t 30942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30942.diff">https://git.openjdk.org/jdk/pull/30942.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30942#issuecomment-4326828695)
</details>
