### PR TITLE
8383396: Parallel: Avoid reloading klass when pushing promoted object contents

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -294,7 +294,7 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
 
     ContinuationGCSupport::transform_stack_chunk(obj);
 
-    push_contents(obj);
+    push_contents(obj, obj->klass());
 
     // Save the markWord of promotion-failed objs in _preserved_marks for later
     // restoration. This way we don't have to walk the young-gen to locate

--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -165,7 +165,7 @@ class PSPromotionManager {
 
   template <class T> inline void claim_or_forward_depth(T* p);
 
-  void push_contents(oop obj);
+  void push_contents(oop obj, Klass* klass);
   void push_contents_bounded(oop obj, HeapWord* left, HeapWord* right);
 };
 

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -121,10 +121,10 @@ inline void InstanceRefKlass::oop_oop_iterate_reverse<narrowOop, PSPushContentsC
   InstanceKlass::oop_oop_iterate_reverse<narrowOop>(obj, closure);
 }
 
-inline void PSPromotionManager::push_contents(oop obj) {
-  if (!obj->klass()->is_typeArray_klass()) {
+inline void PSPromotionManager::push_contents(oop obj, Klass* klass) {
+  if (!klass->is_typeArray_klass()) {
     PSPushContentsClosure pcc(this);
-    obj->oop_iterate_backwards(&pcc);
+    obj->oop_iterate_backwards(&pcc, klass);
   }
 }
 
@@ -303,7 +303,7 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
       push_objArray(o, new_obj);
     } else {
       // we'll just push its contents
-      push_contents(new_obj);
+      push_contents(new_obj, klass);
 
       if (StringDedup::is_enabled_string(klass) &&
           psStringDedup::is_candidate_from_evacuation(new_obj, new_obj_is_tenured)) {


### PR DESCRIPTION
Simple patch of adding another arg to `PSPromotionManager::push_contents`, in order to avoid reloading `klass`.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383396](https://bugs.openjdk.org/browse/JDK-8383396): Parallel: Avoid reloading klass when pushing promoted object contents (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30943/head:pull/30943` \
`$ git checkout pull/30943`

Update a local copy of the PR: \
`$ git checkout pull/30943` \
`$ git pull https://git.openjdk.org/jdk.git pull/30943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30943`

View PR using the GUI difftool: \
`$ git pr show -t 30943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30943.diff">https://git.openjdk.org/jdk/pull/30943.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30943#issuecomment-4326972482)
</details>
