### PR TITLE
8373526: Add tooltips to API documentation elements

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
@@ -402,17 +402,19 @@ public class Navigation {
         HtmlTree link = switch (elem) {
             case ModuleElement mdle -> links.createLink(pathToRoot.resolve(
                     docPaths.moduleSummary(mdle)),
-                    Text.of(mdle.getQualifiedName()));
+                    Text.of(mdle.getQualifiedName()),
+                    getTitle(elem));
             case PackageElement pkg -> links.createLink(pathToRoot.resolve(
                     docPaths.forPackage(pkg).resolve(DocPaths.PACKAGE_SUMMARY)),
                     pkg.isUnnamed()
                             ? configuration.contents.defaultPackageLabel
-                            : Text.of(pkg.getQualifiedName()));
+                            : Text.of(pkg.getQualifiedName()),
+                    getTitle(elem));
             // Breadcrumb navigation displays nested classes as separate links.
             // Enclosing classes may be undocumented, in which case we just display the class name.
             case TypeElement type -> (configuration.isGeneratedDoc(type) && !configuration.utils.isHidden(type))
-                    ? links.createLink(pathToRoot.resolve(
-                            docPaths.forClass(type)), type.getSimpleName().toString())
+                    ? links.createLink(pathToRoot.resolve(docPaths.forClass(type)),
+                                    Text.of(type.getSimpleName().toString()), getTitle(elem))
                     : HtmlTree.SPAN(Text.of(type.getSimpleName().toString()));
             default -> throw new IllegalArgumentException(Objects.toString(elem));
         };
@@ -420,6 +422,28 @@ public class Navigation {
             link.setStyle(HtmlStyles.currentSelection);
         }
         contents.add(link);
+    }
+
+    private String getTitle(Element elem) {
+        return switch (elem) {
+            case ModuleElement moduleElement -> contents.moduleLabel + " " + moduleElement.getQualifiedName();
+            case PackageElement packageElement ->  packageElement.isUnnamed()
+                    ? contents.defaultPackageLabel.toString()
+                    : contents.packageLabel + " " + configuration.utils.getPackageName(packageElement);
+            case TypeElement typeElement -> {
+                String key = switch (typeElement.getKind()) {
+                    case INTERFACE       -> "doclet.Interface";
+                    case ENUM            -> "doclet.Enum";
+                    case RECORD          -> "doclet.RecordClass";
+                    case ANNOTATION_TYPE -> "doclet.AnnotationType";
+                    case CLASS           -> "doclet.Class";
+                    default -> throw new IllegalStateException(typeElement.getKind() + " " + typeElement);
+                };
+                yield configuration.getDocResources().getText(key) + " "
+                    + configuration.utils.getSimpleName(typeElement);
+            }
+            default -> throw new IllegalArgumentException(Objects.toString(elem));
+        };
     }
 
     private void addPageElementLink(Content list) {
@@ -526,8 +550,10 @@ public class Navigation {
 
     private void addSearch(Content target) {
         var resources = configuration.getDocResources();
+        var placeholder = resources.getText("doclet.search_placeholder");
         var inputText = HtmlTree.INPUT(HtmlAttr.InputType.TEXT, HtmlIds.SEARCH_INPUT)
-                .put(HtmlAttr.PLACEHOLDER, resources.getText("doclet.search_placeholder"))
+                .put(HtmlAttr.TITLE, placeholder)
+                .put(HtmlAttr.PLACEHOLDER, placeholder)
                 .put(HtmlAttr.ARIA_LABEL, resources.getText("doclet.search_in_documentation"))
                 .put(HtmlAttr.AUTOCOMPLETE, "off")
                 .put(HtmlAttr.SPELLCHECK, "false");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,9 +103,11 @@ public class TableOfContents {
                 .put(HtmlAttr.ARIA_LABEL, writer.resources.getText("doclet.table_of_contents"));
         var header = HtmlTree.DIV(HtmlStyles.tocHeader, writer.contents.contentsHeading);
         if (hasFilterInput) {
+            var filterLabel =  writer.resources.getText("doclet.filter_label");
             header.add(Entity.NO_BREAK_SPACE)
                     .add(HtmlTree.INPUT(HtmlAttr.InputType.TEXT, HtmlStyles.filterInput)
-                            .put(HtmlAttr.PLACEHOLDER, writer.resources.getText("doclet.filter_label"))
+                            .put(HtmlAttr.TITLE, filterLabel)
+                            .put(HtmlAttr.PLACEHOLDER, filterLabel)
                             .put(HtmlAttr.ARIA_LABEL, writer.resources.getText("doclet.filter_table_of_contents"))
                             .put(HtmlAttr.AUTOCOMPLETE, "off")
                             .put(HtmlAttr.SPELLCHECK, "false"))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
@@ -103,7 +103,7 @@ public class TableOfContents {
                 .put(HtmlAttr.ARIA_LABEL, writer.resources.getText("doclet.table_of_contents"));
         var header = HtmlTree.DIV(HtmlStyles.tocHeader, writer.contents.contentsHeading);
         if (hasFilterInput) {
-            var filterLabel =  writer.resources.getText("doclet.filter_label");
+            var filterLabel = writer.resources.getText("doclet.filter_label");
             header.add(Entity.NO_BREAK_SPACE)
                     .add(HtmlTree.INPUT(HtmlAttr.InputType.TEXT, HtmlStyles.filterInput)
                             .put(HtmlAttr.TITLE, filterLabel)

--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,9 +64,9 @@ public class TestCopyFiles extends JavadocTester {
                     <a href="../../../index-all.html">Index</a>""",
                 "phi-HEADER-phi",
                 """
-                    <a href="../../module-summary.html">acme.mdle</a>""",
+                    <a href="../../module-summary.html" title="Module acme.mdle">acme.mdle</a>""",
                 """
-                    <a href="../package-summary.html" class="current-selection">p</a>""",
+                    <a href="../package-summary.html" title="Package p" class="current-selection">p</a>""",
                 """
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>.""",
                 "<dt>Since:</",
@@ -101,9 +101,9 @@ public class TestCopyFiles extends JavadocTester {
                     <a href="../../../index-all.html">Index</a>""",
                 "phi-HEADER-phi",
                 """
-                    <a href="../../module-summary.html">acme.mdle</a>""",
+                    <a href="../../module-summary.html" title="Module acme.mdle">acme.mdle</a>""",
                 """
-                    <a href="../package-summary.html" class="current-selection">p</a>""",
+                    <a href="../package-summary.html" title="Package p" class="current-selection">p</a>""",
                 """
                     In a named module acme.module and named package <a href="../package-summary.html"><code>p</code></a>.""",
                 "<dt>Since:</",
@@ -125,9 +125,9 @@ public class TestCopyFiles extends JavadocTester {
                     <a href="../../../../../index-all.html">Index</a>""",
                 "phi-HEADER-phi",
                 """
-                    <a href="../../../../module-summary.html">acme2.mdle</a>""",
+                    <a href="../../../../module-summary.html" title="Module acme2.mdle">acme2.mdle</a>""",
                 """
-                    <a href="../../../package-summary.html" class="current-selection">p2</a>""",
+                    <a href="../../../package-summary.html" title="Package p2" class="current-selection">p2</a>""",
                 "SubSubReadme.html at third level of doc-file directory.",
                 // check footer
                 "phi-BOTTOM-phi"

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModulePackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModulePackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8178070 8196201 8184205 8246429 8198705
+ * @bug 8178070 8196201 8184205 8246429 8198705 8373526
  * @summary Test packages table in module summary pages
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -152,31 +152,31 @@ public class TestModulePackages extends JavadocTester {
         checkOutput("m/p/package-summary.html", true,
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="../module-summary.html">m</a></li>
-                    <li><a href="package-summary.html" class="current-selection">p</a></li>
+                    <li><a href="../module-summary.html" title="Module m">m</a></li>
+                    <li><a href="package-summary.html" title="Package p" class="current-selection">p</a></li>
                     </ol>
                     """);
         checkOutput("o/p/package-summary.html", true,
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="../module-summary.html">o</a></li>
-                    <li><a href="package-summary.html" class="current-selection">p</a></li>
+                    <li><a href="../module-summary.html" title="Module o">o</a></li>
+                    <li><a href="package-summary.html" title="Package p" class="current-selection">p</a></li>
                     </ol>
                     """);
         checkOutput("m/p/C.html", true,
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="../module-summary.html">m</a></li>
-                    <li><a href="package-summary.html">p</a></li>
-                    <li><a href="C.html" class="current-selection">C</a></li>
+                    <li><a href="../module-summary.html" title="Module m">m</a></li>
+                    <li><a href="package-summary.html" title="Package p">p</a></li>
+                    <li><a href="C.html" title="Class C" class="current-selection">C</a></li>
                     </ol>
                     """);
         checkOutput("o/p/C.html", true,
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="../module-summary.html">o</a></li>
-                    <li><a href="package-summary.html">p</a></li>
-                    <li><a href="C.html" class="current-selection">C</a></li>
+                    <li><a href="../module-summary.html" title="Module o">o</a></li>
+                    <li><a href="package-summary.html" title="Package p">p</a></li>
+                    <li><a href="C.html" title="Class C" class="current-selection">C</a></li>
                     </ol>
                     """);
         checkOutput("type-search-index.js", true,

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  *      8175823 8166306 8178043 8181622 8183511 8169819 8074407 8183037 8191464
  *      8164407 8192007 8182765 8196200 8196201 8196202 8196202 8205593 8202462
  *      8184205 8219060 8223378 8234746 8239804 8239816 8253117 8245058 8261976
+ *      8373526
  * @summary Test modules support in javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -587,16 +588,16 @@ public class TestModules extends JavadocTester {
                     <li class="nav-bar-cell1-rev">Module</li>""");
         checkOutput("moduleA/testpkgmdlA/class-use/TestClassInModuleA.html", true,
                 """
-                    <li><a href="../../module-summary.html">moduleA</a></li>""");
+                    <li><a href="../../module-summary.html" title="Module moduleA">moduleA</a></li>""");
         checkOutput("moduleB/testpkgmdlB/package-summary.html", true,
                 """
-                    <li><a href="../module-summary.html">moduleB</a></li>""");
+                    <li><a href="../module-summary.html" title="Module moduleB">moduleB</a></li>""");
         checkOutput("moduleB/testpkgmdlB/TestClassInModuleB.html", false,
                 """
                     <li><a href="../module-summary.html">Module</a></li>""");
         checkOutput("moduleB/testpkgmdlB/class-use/TestClassInModuleB.html", true,
                 """
-                    <li><a href="../../module-summary.html">moduleB</a></li>""");
+                    <li><a href="../../module-summary.html" title="Module moduleB">moduleB</a></li>""");
     }
 
     void checkNoModuleLink() {
@@ -823,19 +824,19 @@ public class TestModules extends JavadocTester {
     void checkModuleFilesAndLinks(boolean found) {
         checkFileAndOutput("moduleA/testpkgmdlA/package-summary.html", found,
                 """
-                    <li><a href="../module-summary.html">moduleA</a></li>""",
+                    <li><a href="../module-summary.html" title="Module moduleA">moduleA</a></li>""",
                 """
-                    <li><a href="../module-summary.html">moduleA</a></li>""");
+                    <li><a href="../module-summary.html" title="Module moduleA">moduleA</a></li>""");
         checkFileAndOutput("moduleA/testpkgmdlA/TestClassInModuleA.html", found,
                 """
-                    <li><a href="../module-summary.html">moduleA</a></li>""",
+                    <li><a href="../module-summary.html" title="Module moduleA">moduleA</a></li>""",
                 """
-                    <li><a href="../module-summary.html">moduleA</a></li>""");
+                    <li><a href="../module-summary.html" title="Module moduleA">moduleA</a></li>""");
         checkFileAndOutput("moduleB/testpkgmdlB/AnnotationType.html", found,
                 """
-                    <li><a href="../module-summary.html">moduleB</a></li>""",
+                    <li><a href="../module-summary.html" title="Module moduleB">moduleB</a></li>""",
                 """
-                    <li><a href="package-summary.html">testpkgmdlB</a></li>""");
+                    <li><a href="package-summary.html" title="Package testpkgmdlB">testpkgmdlB</a></li>""");
         checkFiles(found,
                 "moduleA/module-summary.html");
     }

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestModuleNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestModuleNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,11 @@ public class TestModuleNavigation extends JavadocTester {
                     <li><a href="../search.html">Search</a></li>
                     <li><a href="../help-doc.html#module">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents</div>
+                    """);
 
         checkOutput("overview-tree.html", true,
                 """
@@ -147,7 +151,11 @@ public class TestModuleNavigation extends JavadocTester {
                     <li><a href="search.html">Search</a></li>
                     <li class="nav-bar-cell1-rev">Help</li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents</div>
+                    """);
 
         checkOutput("m/p1/package-summary.html", true,
                 """
@@ -160,7 +168,11 @@ public class TestModuleNavigation extends JavadocTester {
                     <li><a href="../../search.html">Search</a></li>
                     <li><a href="../../help-doc.html#package">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents</div>
+                    """);
 
         checkOutput("m/p1/A.html", true,
                 """
@@ -173,7 +185,17 @@ public class TestModuleNavigation extends JavadocTester {
                     <li><a href="../../search.html">Search</a></li>
                     <li><a href="../../help-doc.html#class">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../../res\
+                    ource-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></b\
+                    utton></div>
+                    """);
     }
 
 

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug      7025314 8023700 7198273 8025633 8026567 8081854 8196027 8182765
  *           8196200 8196202 8223378 8258659 8261976 8320458 8329537 8350638
- *           8342705 8371021
+ *           8342705 8371021 8373526
  * @summary  Make sure the Next/Prev Class links iterate through all types.
  *           Make sure the navagation is 2 columns, not 3.
  * @library  /tools/lib ../../lib
@@ -84,7 +84,11 @@ public class TestNavigation extends JavadocTester {
                     <li><a href="../search.html">Search</a></li>
                     <li><a href="../help-doc.html#package">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents</div>
+                    """);
 
         checkOutput("pkg/A.html", true,
                 """
@@ -96,7 +100,17 @@ public class TestNavigation extends JavadocTester {
                     <li><a href="../search.html">Search</a></li>
                     <li><a href="../help-doc.html#class">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../resour\
+                    ce-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></butt\
+                    on></div>
+                    """);
 
         checkOutput("pkg/C.html", true,
                 """
@@ -108,7 +122,17 @@ public class TestNavigation extends JavadocTester {
                     <li><a href="../search.html">Search</a></li>
                     <li><a href="../help-doc.html#class">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../resour\
+                    ce-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></butt\
+                    on></div>
+                    """);
 
         checkOutput("pkg/E.html", true,
                 """
@@ -120,7 +144,17 @@ public class TestNavigation extends JavadocTester {
                     <li><a href="../search.html">Search</a></li>
                     <li><a href="../help-doc.html#class">Help</a></li>
                     <li><button id="theme-button" aria-label="Select Theme" title="Select Theme"></button></li>
-                    </ul>""");
+                    </ul>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../resour\
+                    ce-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></butt\
+                    on></div>
+                    """);
 
         checkOutput("pkg/I.html", true,
                 // Test for 4664607
@@ -186,10 +220,20 @@ public class TestNavigation extends JavadocTester {
         checkOrder("pkg1/A.X.html",
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="package-summary.html">pkg1</a></li>
-                    <li><a href="A.html">A</a></li>
-                    <li><a href="A.X.html" class="current-selection">X</a></li>
+                    <li><a href="package-summary.html" title="Package pkg1">pkg1</a></li>
+                    <li><a href="A.html" title="Class A">A</a></li>
+                    <li><a href="A.X.html" title="Class A.X" class="current-selection">X</a></li>
                     </ol>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../resour\
+                    ce-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></butt\
+                    on></div>
+                    """,
                 """
                     <ol class="toc-list" tabindex="-1">
                     <li><a href="#" tabindex="0">Description</a></li>
@@ -217,10 +261,20 @@ public class TestNavigation extends JavadocTester {
         checkOrder("pkg1/A.Y.html",
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="package-summary.html">pkg1</a></li>
-                    <li><a href="A.html">A</a></li>
-                    <li><a href="A.Y.html" class="current-selection">Y</a></li>
+                    <li><a href="package-summary.html" title="Package pkg1">pkg1</a></li>
+                    <li><a href="A.html" title="Class A">A</a></li>
+                    <li><a href="A.Y.html" title="Class A.Y" class="current-selection">Y</a></li>
                     </ol>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../resour\
+                    ce-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></butt\
+                    on></div>
+                    """,
                 """
                     <ol class="toc-list" tabindex="-1">
                     <li><a href="#" tabindex="0">Description</a></li>
@@ -238,11 +292,21 @@ public class TestNavigation extends JavadocTester {
         checkOrder("pkg1/A.X.IC.html",
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="package-summary.html">pkg1</a></li>
-                    <li><a href="A.html">A</a></li>
-                    <li><a href="A.X.html">X</a></li>
-                    <li><a href="A.X.IC.html" class="current-selection">IC</a></li>
+                    <li><a href="package-summary.html" title="Package pkg1">pkg1</a></li>
+                    <li><a href="A.html" title="Class A">A</a></li>
+                    <li><a href="A.X.html" title="Class A.X">X</a></li>
+                    <li><a href="A.X.IC.html" title="Class A.X.IC" class="current-selection">IC</a></li>
                     </ol>""",
+                """
+                    <nav role="navigation" class="toc" aria-label="Table of contents">
+                    <div class="toc-header">Contents&nbsp;<input type="text" class="filter-input" di\
+                    sabled title="Filter contents (type .)" placeholder="Filter contents (type .)" a\
+                    ria-label="Filter table of contents" autocomplete="off" spellcheck="false"><inpu\
+                    t type="reset" class="reset-filter" disabled tabindex="-1" value="Reset">&nbsp;<\
+                    button class="toc-sort-toggle" id="toc-lexical-order-toggle"><img src="../resour\
+                    ce-files/sort-a-z.svg" alt="Sort member details in lexicographical order"></butt\
+                    on></div>
+                    """,
                 """
                     <ol class="toc-list" tabindex="-1">
                     <li><a href="#" tabindex="0">Description</a></li>
@@ -425,7 +489,7 @@ public class TestNavigation extends JavadocTester {
                     </ul>""",
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="package-summary.html" class="current-selection">Unnamed Package</a></li>
+                    <li><a href="package-summary.html" title="Unnamed Package" class="current-selection">Unnamed Package</a></li>
                     </ol>""");
 
         checkOutput("C.html", true,
@@ -441,8 +505,8 @@ public class TestNavigation extends JavadocTester {
                     </ul>""",
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="package-summary.html">Unnamed Package</a></li>
-                    <li><a href="C.html" class="current-selection">C</a></li>
+                    <li><a href="package-summary.html" title="Unnamed Package">Unnamed Package</a></li>
+                    <li><a href="C.html" title="Class C" class="current-selection">C</a></li>
                     </ol>""");
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,15 +160,15 @@ public class TestPreview extends JavadocTester {
         checkOutput("java.base/preview/package-summary.html", true,
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="../module-summary.html">java.base</a></li>
-                    <li><a href="package-summary.html" class="current-selection">preview</a></li>
+                    <li><a href="../module-summary.html" title="Module java.base">java.base</a></li>
+                    <li><a href="package-summary.html" title="Package preview" class="current-selection">preview</a></li>
                     </ol>""");
         checkOutput("java.base/preview/Core.html", true,
                 """
                     <ol class="sub-nav-list">
-                    <li><a href="../module-summary.html">java.base</a></li>
-                    <li><a href="package-summary.html">preview</a></li>
-                    <li><a href="Core.html" class="current-selection">Core</a></li>
+                    <li><a href="../module-summary.html" title="Module java.base">java.base</a></li>
+                    <li><a href="package-summary.html" title="Package preview">preview</a></li>
+                    <li><a href="Core.html" title="Class Core" class="current-selection">Core</a></li>
                     </ol>""",
                 """
                     <div class="block">Preview feature. Links: <a href="CoreRecord.html" title="cla\

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -26,7 +26,7 @@
  * @bug 8141492 8071982 8141636 8147890 8166175 8168965 8176794 8175218 8147881
  *      8181622 8182263 8074407 8187521 8198522 8182765 8199278 8196201 8196202
  *      8184205 8214468 8222548 8223378 8234746 8241219 8254627 8247994 8263528
- *      8266808 8248863 8305710 8318082 8347058 8350638 8345555 8378228
+ *      8266808 8248863 8305710 8318082 8347058 8350638 8345555 8378228 8373526
  * @summary Test the search feature of javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -425,10 +425,10 @@ public class TestSearch extends JavadocTester {
                 """
                     <li><a href="search.html">Search</a></li>""",
                 """
-                    <div class="nav-list-search"><input type="text" id="search-input" disabled place\
-                    holder="Search documentation (type /)" aria-label="Search in documentation" auto\
-                    complete="off" spellcheck="false"><input type="reset" id="reset-search" disabled\
-                     value="Reset"></div>""");
+                    <div class="nav-list-search"><input type="text" id="search-input" disabled title\
+                    ="Search documentation (type /)" placeholder="Search documentation (type /)" ari\
+                    a-label="Search in documentation" autocomplete="off" spellcheck="false"><input t\
+                    ype="reset" id="reset-search" disabled value="Reset"></div>""");
         checkOutput(fileName, false,
                 "jquery-ui.min.css",
                 "jquery-3.7.1.min.js",


### PR DESCRIPTION
Please review a simple change to add tooltips (title attributes) to the links in the breadcrumb sub-navigation bar, as well as to the search and filter input fields. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373526](https://bugs.openjdk.org/browse/JDK-8373526): Add tooltips to API documentation elements (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30947/head:pull/30947` \
`$ git checkout pull/30947`

Update a local copy of the PR: \
`$ git checkout pull/30947` \
`$ git pull https://git.openjdk.org/jdk.git pull/30947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30947`

View PR using the GUI difftool: \
`$ git pr show -t 30947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30947.diff">https://git.openjdk.org/jdk/pull/30947.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30947#issuecomment-4328177963)
</details>
