### PR TITLE
8331996: JFR: Add boolean check before loading event classes

### DIFF
--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -118,6 +118,11 @@ public class Socket implements java.io.Closeable {
     private static final int CLOSED         = 1 << 3;
     private static final int SHUT_IN        = 1 << 9;
     private static final int SHUT_OUT       = 1 << 10;
+
+    // Flag set by jdk.internal.event.JFRTracing to indicate if
+    // socket reads and writes should be traced by JFR.
+    private static boolean jfrTracing;
+
     private volatile int state;
 
     // used to coordinate creating and closing underlying socket
@@ -970,7 +975,7 @@ public class Socket implements java.io.Closeable {
         }
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            if (!SocketReadEvent.enabled()) {
+            if (!jfrTracing || !SocketReadEvent.enabled()) {
                 return implRead(b, off, len);
             }
             long start = SocketReadEvent.timestamp();
@@ -1083,7 +1088,7 @@ public class Socket implements java.io.Closeable {
         }
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            if (!SocketWriteEvent.enabled()) {
+            if (!jfrTracing || !SocketWriteEvent.enabled()) {
                 implWrite(b, off, len);
                 return;
             }

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -975,13 +975,13 @@ public class Socket implements java.io.Closeable {
         }
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            if (!jfrTracing || !SocketReadEvent.enabled()) {
-                return implRead(b, off, len);
+            if (jfrTracing && SocketReadEvent.enabled()) {
+                long start = SocketReadEvent.timestamp();
+                int nbytes = implRead(b, off, len);
+                SocketReadEvent.offer(start, nbytes, parent.getRemoteSocketAddress(), getSoTimeout());
+                return nbytes;
             }
-            long start = SocketReadEvent.timestamp();
-            int nbytes = implRead(b, off, len);
-            SocketReadEvent.offer(start, nbytes, parent.getRemoteSocketAddress(), getSoTimeout());
-            return nbytes;
+            return implRead(b, off, len);
         }
 
         private int implRead(byte[] b, int off, int len) throws IOException {
@@ -1088,13 +1088,13 @@ public class Socket implements java.io.Closeable {
         }
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            if (!jfrTracing || !SocketWriteEvent.enabled()) {
+            if (jfrTracing && SocketWriteEvent.enabled()) {
+                long start = SocketWriteEvent.timestamp();
                 implWrite(b, off, len);
+                SocketWriteEvent.offer(start, len, parent.getRemoteSocketAddress());
                 return;
             }
-            long start = SocketWriteEvent.timestamp();
             implWrite(b, off, len);
-            SocketWriteEvent.offer(start, len, parent.getRemoteSocketAddress());
         }
 
         private void implWrite(byte[] b, int off, int len) throws IOException {

--- a/src/java.base/share/classes/jdk/internal/event/JFRTracing.java
+++ b/src/java.base/share/classes/jdk/internal/event/JFRTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/event/JFRTracing.java
+++ b/src/java.base/share/classes/jdk/internal/event/JFRTracing.java
@@ -30,18 +30,24 @@ import java.io.FileOutputStream;
 import java.io.RandomAccessFile;
 import java.lang.Throwable;
 import java.lang.reflect.Field;
+import java.net.Socket;
 
 /**
  * Helper class to enable JFR tracing.
  */
 public final class JFRTracing {
 
-  public static void enable() throws NoSuchFieldException, IllegalAccessException {
+  public static void enable() throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
       enable(Throwable.class);
       enable(FileInputStream.class);
       enable(FileOutputStream.class);
       enable(FileChannelImpl.class);
       enable(RandomAccessFile.class);
+      enable(Class.forName("sun.nio.ch.AsynchronousFileChannelImpl"));
+      enable(Socket.class);
+      enable(Class.forName("sun.nio.ch.SocketChannelImpl"));
+      enable(Class.forName("sun.nio.ch.SocketInputStream"));
+      enable(Class.forName("sun.nio.ch.SocketOutputStream"));
   }
 
   private static void enable(Class<?> clazz) throws NoSuchFieldException, IllegalAccessException {

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousFileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousFileChannelImpl.java
@@ -44,6 +44,10 @@ abstract class AsynchronousFileChannelImpl
 {
     private static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
+    // Flag set by jdk.internal.event.JFRTracing to indicate if
+    // file force should be traced by JFR.
+    protected static boolean jfrTracing;
+
     // close support
     protected final ReadWriteLock closeLock = new ReentrantReadWriteLock();
     protected volatile boolean closed;

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -635,13 +635,13 @@ public class FileChannelImpl
 
     @Override
     public void force(boolean metaData) throws IOException {
-        if (!jfrTracing || !FileForceEvent.enabled()) {
+        if (jfrTracing && FileForceEvent.enabled()) {
+            long start = FileForceEvent.timestamp();
             implForce(metaData);
+            FileForceEvent.offer(start, path, metaData);
             return;
         }
-        long start = FileForceEvent.timestamp();
         implForce(metaData);
-        FileForceEvent.offer(start, path, metaData);
     }
 
     // Assume at first that the underlying kernel supports sendfile/equivalent;

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -75,7 +75,7 @@ public class FileChannelImpl
     private static final FileDispatcher nd = new FileDispatcherImpl();
 
     // Flag set by jdk.internal.event.JFRTracing to indicate if
-    // file reads and writes should be traced by JFR.
+    // file reads, writes, and force should be traced by JFR.
     private static boolean jfrTracing;
 
     // File descriptor
@@ -635,7 +635,7 @@ public class FileChannelImpl
 
     @Override
     public void force(boolean metaData) throws IOException {
-        if (!FileForceEvent.enabled()) {
+        if (!jfrTracing || !FileForceEvent.enabled()) {
             implForce(metaData);
             return;
         }

--- a/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
@@ -176,7 +176,7 @@ public class SimpleAsynchronousFileChannelImpl
 
     @Override
     public void force(boolean metaData) throws IOException {
-        if (!FileForceEvent.enabled()) {
+        if (!jfrTracing || !FileForceEvent.enabled()) {
             implForce(metaData);
             return;
         }

--- a/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
@@ -176,13 +176,13 @@ public class SimpleAsynchronousFileChannelImpl
 
     @Override
     public void force(boolean metaData) throws IOException {
-        if (!jfrTracing || !FileForceEvent.enabled()) {
+        if (jfrTracing && FileForceEvent.enabled()) {
+            long start = FileForceEvent.timestamp();
             implForce(metaData);
+            FileForceEvent.offer(start, path, metaData);
             return;
         }
-        long start = FileForceEvent.timestamp();
         implForce(metaData);
-        FileForceEvent.offer(start, path, metaData);
     }
 
     @Override

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -488,13 +488,13 @@ class SocketChannelImpl
 
     @Override
     public int read(ByteBuffer buf) throws IOException {
-        if (!jfrTracing || !SocketReadEvent.enabled()) {
-            return implRead(buf);
+        if (jfrTracing && SocketReadEvent.enabled()) {
+            long start = SocketReadEvent.timestamp();
+            int nbytes = implRead(buf);
+            SocketReadEvent.offer(start, nbytes, remoteAddress(), 0);
+            return nbytes;
         }
-        long start = SocketReadEvent.timestamp();
-        int nbytes = implRead(buf);
-        SocketReadEvent.offer(start, nbytes, remoteAddress(), 0);
-        return nbytes;
+        return implRead(buf);
     }
 
 
@@ -502,13 +502,13 @@ class SocketChannelImpl
     public long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException
     {
-        if (!jfrTracing || !SocketReadEvent.enabled()) {
-            return implRead(dsts, offset, length);
+        if (jfrTracing && SocketReadEvent.enabled()) {
+            long start = SocketReadEvent.timestamp();
+            long nbytes = implRead(dsts, offset, length);
+            SocketReadEvent.offer(start, nbytes, remoteAddress(), 0);
+            return nbytes;
         }
-        long start = SocketReadEvent.timestamp();
-        long nbytes = implRead(dsts, offset, length);
-        SocketReadEvent.offer(start, nbytes, remoteAddress(), 0);
-        return nbytes;
+        return implRead(dsts, offset, length);
     }
 
     /**
@@ -613,26 +613,26 @@ class SocketChannelImpl
 
     @Override
     public int write(ByteBuffer buf) throws IOException {
-        if (!jfrTracing || !SocketWriteEvent.enabled()) {
-            return implWrite(buf);
+        if (jfrTracing && SocketWriteEvent.enabled()) {
+            long start = SocketWriteEvent.timestamp();
+            int nbytes = implWrite(buf);
+            SocketWriteEvent.offer(start, nbytes, remoteAddress());
+            return nbytes;
         }
-        long start = SocketWriteEvent.timestamp();
-        int nbytes = implWrite(buf);
-        SocketWriteEvent.offer(start, nbytes, remoteAddress());
-        return nbytes;
+        return implWrite(buf);
     }
 
     @Override
     public long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException
     {
-        if (!jfrTracing || !SocketWriteEvent.enabled()) {
-            return implWrite(srcs, offset, length);
+        if (jfrTracing && SocketWriteEvent.enabled()) {
+            long start = SocketWriteEvent.timestamp();
+            long nbytes = implWrite(srcs, offset, length);
+            SocketWriteEvent.offer(start, nbytes, remoteAddress());
+            return nbytes;
         }
-        long start = SocketWriteEvent.timestamp();
-        long nbytes = implWrite(srcs, offset, length);
-        SocketWriteEvent.offer(start, nbytes, remoteAddress());
-        return nbytes;
+        return implWrite(srcs, offset, length);
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -76,6 +76,10 @@ class SocketChannelImpl
     // Used to make native read and write calls
     private static final NativeDispatcher nd = new SocketDispatcher();
 
+    // Flag set by jdk.internal.event.JFRTracing to indicate if
+    // socket reads and writes should be traced by JFR.
+    private static boolean jfrTracing;
+
     // The protocol family of the socket
     private final ProtocolFamily family;
 
@@ -484,7 +488,7 @@ class SocketChannelImpl
 
     @Override
     public int read(ByteBuffer buf) throws IOException {
-        if (!SocketReadEvent.enabled()) {
+        if (!jfrTracing || !SocketReadEvent.enabled()) {
             return implRead(buf);
         }
         long start = SocketReadEvent.timestamp();
@@ -498,7 +502,7 @@ class SocketChannelImpl
     public long read(ByteBuffer[] dsts, int offset, int length)
         throws IOException
     {
-        if (!SocketReadEvent.enabled()) {
+        if (!jfrTracing || !SocketReadEvent.enabled()) {
             return implRead(dsts, offset, length);
         }
         long start = SocketReadEvent.timestamp();
@@ -609,7 +613,7 @@ class SocketChannelImpl
 
     @Override
     public int write(ByteBuffer buf) throws IOException {
-        if (!SocketWriteEvent.enabled()) {
+        if (!jfrTracing || !SocketWriteEvent.enabled()) {
             return implWrite(buf);
         }
         long start = SocketWriteEvent.timestamp();
@@ -622,7 +626,7 @@ class SocketChannelImpl
     public long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException
     {
-        if (!SocketWriteEvent.enabled()) {
+        if (!jfrTracing || !SocketWriteEvent.enabled()) {
             return implWrite(srcs, offset, length);
         }
         long start = SocketWriteEvent.timestamp();

--- a/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
@@ -38,6 +38,7 @@ class SocketInputStream extends InputStream {
     // Flag set by jdk.internal.event.JFRTracing to indicate if
     // socket reads should be traced by JFR.
     private static boolean jfrTracing;
+
     private final SocketChannelImpl sc;
     private final IntSupplier timeoutSupplier;
 
@@ -77,13 +78,13 @@ class SocketInputStream extends InputStream {
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         int timeout = timeoutSupplier.getAsInt();
-        if (!jfrTracing || !SocketReadEvent.enabled()) {
-            return implRead(b, off, len, timeout);
+        if (jfrTracing && SocketReadEvent.enabled()) {
+            long start = SocketReadEvent.timestamp();
+            int n = implRead(b, off, len, timeout);
+            SocketReadEvent.offer(start, n, sc.remoteAddress(), timeout);
+            return n;
         }
-        long start = SocketReadEvent.timestamp();
-        int n = implRead(b, off, len, timeout);
-        SocketReadEvent.offer(start, n, sc.remoteAddress(), timeout);
-        return n;
+        return implRead(b, off, len, timeout);
     }
 
     @Override

--- a/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
@@ -35,6 +35,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * An InputStream that reads bytes from a socket channel.
  */
 class SocketInputStream extends InputStream {
+    // Flag set by jdk.internal.event.JFRTracing to indicate if
+    // socket reads should be traced by JFR.
+    private static boolean jfrTracing;
     private final SocketChannelImpl sc;
     private final IntSupplier timeoutSupplier;
 
@@ -74,7 +77,7 @@ class SocketInputStream extends InputStream {
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         int timeout = timeoutSupplier.getAsInt();
-        if (!SocketReadEvent.enabled()) {
+        if (!jfrTracing || !SocketReadEvent.enabled()) {
             return implRead(b, off, len, timeout);
         }
         long start = SocketReadEvent.timestamp();

--- a/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
@@ -36,6 +36,7 @@ class SocketOutputStream extends OutputStream {
     // Flag set by jdk.internal.event.JFRTracing to indicate if
     // socket writes should be traced by JFR.
     private static boolean jfrTracing;
+
     private final SocketChannelImpl sc;
 
     /**
@@ -60,13 +61,13 @@ class SocketOutputStream extends OutputStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        if (!jfrTracing || !SocketWriteEvent.enabled()) {
+        if (jfrTracing && SocketWriteEvent.enabled()) {
+            long start = SocketWriteEvent.timestamp();
             sc.blockingWriteFully(b, off, len);
+            SocketWriteEvent.offer(start, len, sc.remoteAddress());
             return;
         }
-        long start = SocketWriteEvent.timestamp();
         sc.blockingWriteFully(b, off, len);
-        SocketWriteEvent.offer(start, len, sc.remoteAddress());
     }
 
     @Override

--- a/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
@@ -33,6 +33,9 @@ import java.io.OutputStream;
  * An OutputStream that writes bytes to a socket channel.
  */
 class SocketOutputStream extends OutputStream {
+    // Flag set by jdk.internal.event.JFRTracing to indicate if
+    // socket writes should be traced by JFR.
+    private static boolean jfrTracing;
     private final SocketChannelImpl sc;
 
     /**
@@ -57,7 +60,7 @@ class SocketOutputStream extends OutputStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        if (!SocketWriteEvent.enabled()) {
+        if (!jfrTracing || !SocketWriteEvent.enabled()) {
             sc.blockingWriteFully(b, off, len);
             return;
         }

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
@@ -216,7 +216,7 @@ public class WindowsAsynchronousFileChannelImpl
 
     @Override
     public void force(boolean metaData) throws IOException {
-        if (!FileForceEvent.enabled()) {
+        if (!jfrTracing || !FileForceEvent.enabled()) {
             implForce(metaData);
             return;
         }

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
@@ -216,13 +216,13 @@ public class WindowsAsynchronousFileChannelImpl
 
     @Override
     public void force(boolean metaData) throws IOException {
-        if (!jfrTracing || !FileForceEvent.enabled()) {
+        if (jfrTracing && FileForceEvent.enabled()) {
+            long start = FileForceEvent.timestamp();
             implForce(metaData);
+            FileForceEvent.offer(start, path, metaData);
             return;
         }
-        long start = FileForceEvent.timestamp();
         implForce(metaData);
-        FileForceEvent.offer(start, path, metaData);
     }
 
     // -- file locking --

--- a/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
+++ b/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
@@ -40,6 +40,7 @@ import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -84,126 +85,80 @@ public class TestEventsNotLoadedWithoutJfr {
 
         private static void exerciseFileForce() throws IOException, ExecutionException, InterruptedException {
             Path tmp = Files.createTempFile(Path.of(""), "TestEventsNotLoadedWithoutJfr", ".tmp");
-            try {
-                String s = "short";
-                ByteBuffer data = ByteBuffer.allocate(s.length());
-                data.put(s.getBytes());
-                data.flip();
+            ByteBuffer buffer = StandardCharsets.UTF_8.encode("short");
+            buffer.flip();
 
-                // Check both AsynchronousFileChannel and FileChannelImpl
-                try (AsynchronousFileChannel afc = AsynchronousFileChannel.open(tmp, READ, WRITE)) {
-                    int expectedWritten = data.remaining();
-                    int actualWritten = afc.write(data, 0).get();
-                    assertEquals(actualWritten, expectedWritten, "Unexpected amount written.");
-                    afc.force(true);
-                }
-                data.flip();
-                try (FileChannel fc = FileChannel.open(tmp, READ, WRITE)) {
-                    int expectedWritten = data.remaining();
-                    int actualWritten = fc.write(data);
-                    assertEquals(actualWritten, expectedWritten, "Unexpected amount written.");
-                    fc.force(true);
-                }
-            } finally {
-                Files.deleteIfExists(tmp);
+            // Check both AsynchronousFileChannel and FileChannelImpl
+            try (AsynchronousFileChannel afc = AsynchronousFileChannel.open(tmp, READ, WRITE)) {
+                int expectedWritten = buffer.remaining();
+                int actualWritten = afc.write(buffer, 0).get();
+                assertEquals(actualWritten, expectedWritten, "Unexpected amount written.");
+                afc.force(true);
+            }
+            buffer.flip();
+            try (FileChannel fc = FileChannel.open(tmp, READ, WRITE)) {
+                int expectedWritten = buffer.remaining();
+                int actualWritten = fc.write(buffer);
+                assertEquals(actualWritten, expectedWritten, "Unexpected amount written.");
+                fc.force(true);
             }
         }
 
         // Exercises inner Socket$SocketInputStream / Socket$SocketOutputStream
-        private static void exerciseSocket() throws IOException, InterruptedException {
+        private static void exerciseSocket() throws IOException {
             try (ServerSocket ss = new ServerSocket()) {
                 ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
-                Thread clientThread = new Thread(() -> {
-                    try (Socket client = new Socket()) {
-                        client.connect(ss.getLocalSocketAddress());
-                        try (InputStream in = client.getInputStream();
-                             OutputStream out = client.getOutputStream()) {
-                            out.write(CLIENT_MSG);
-                            byte[] buf = new byte[SERVER_MSG.length];
-                            in.read(buf);
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
+                try (Socket client = new Socket()) {
+                    client.connect(ss.getLocalSocketAddress());
+                    try (Socket server = ss.accept();
+                         OutputStream out = server.getOutputStream()) {
+                        out.write(SERVER_MSG);
                     }
-                });
-                clientThread.start();
-
-                try (Socket server = ss.accept();
-                     InputStream in = server.getInputStream();
-                     OutputStream out = server.getOutputStream()) {
-                    byte[] buf = new byte[CLIENT_MSG.length];
-                    in.read(buf);
-                    out.write(SERVER_MSG);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    try (InputStream in = client.getInputStream()) {
+                        byte[] buf = new byte[SERVER_MSG.length];
+                        in.read(buf);
+                    }
                 }
-
-                clientThread.join();
             }
         }
 
-        private static void exerciseSocketChannelImpl() {
+        private static void exerciseSocketChannelImpl() throws IOException {
             try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
                 ssc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
-                Thread serverThread = new Thread(() -> {
+                try (SocketChannel client = SocketChannel.open()) {
+                    client.connect(ssc.getLocalAddress());
+                    // Exercise write(ByteBuffer[], int, int)
+                    client.write(new ByteBuffer[]{ByteBuffer.wrap(CLIENT_MSG)}, 0, 1);
                     try (SocketChannel server = ssc.accept()) {
                         // Exercise write(ByteBuffer) and read(ByteBuffer)
                         ByteBuffer buf = ByteBuffer.allocate(CLIENT_MSG.length);
                         server.read(buf);
                         server.write(ByteBuffer.wrap(SERVER_MSG));
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
                     }
-                });
-                serverThread.start();
-
-                try (SocketChannel client = SocketChannel.open()) {
-                    client.connect(ssc.getLocalAddress());
-                    // Exercise write(ByteBuffer[], int, int) and read(ByteBuffer[], int, int)
-                    client.write(new ByteBuffer[]{ByteBuffer.wrap(CLIENT_MSG)}, 0, 1);
+                    // Exercise and read(ByteBuffer[], int, int)
                     ByteBuffer buf = ByteBuffer.allocate(SERVER_MSG.length);
                     client.read(new ByteBuffer[]{buf}, 0, 1);
                 }
-
-                serverThread.join();
-            } catch (IOException |InterruptedException e) {
-                throw new RuntimeException(e);
             }
         }
 
-        private static void exerciseSocketInputStream() {
+        private static void exerciseSocketInputStream() throws IOException {
             try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
                 ssc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
-                Thread serverThread = new Thread(() -> {
-                   try (SocketChannel server = ssc.accept()) {
-                       try (InputStream in = server.socket().getInputStream();
-                            OutputStream out = server.socket().getOutputStream()) {
-                           byte[] buf = new byte[CLIENT_MSG.length];
-                           in.read(buf);
-                           out.write(SERVER_MSG);
-                       }
-                   } catch (Exception e) {
-                       throw new RuntimeException(e);
-                   }
-                });
-                serverThread.start();
-
                 try (SocketChannel client = SocketChannel.open()) {
                     client.connect(ssc.getLocalAddress());
-                    try (InputStream in = client.socket().getInputStream();
-                         OutputStream out = client.socket().getOutputStream()) {
-                        out.write(CLIENT_MSG);
+                    try (SocketChannel server = ssc.accept();
+                         OutputStream out = server.socket().getOutputStream()) {
+                        out.write(SERVER_MSG);
+                    }
+                    try (InputStream in = client.socket().getInputStream()) {
                         byte[] buf = new byte[SERVER_MSG.length];
                         in.read(buf);
                     }
                 }
-
-                serverThread.join();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
             }
         }
     }

--- a/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
+++ b/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.io;
+
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+
+import java.nio.channels.FileChannel;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @summary Verify that file and socket event classes are not loaded when JFR is off.
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.event.io.TestEventsNotLoadedWithoutJfr
+ */
+public class TestEventsNotLoadedWithoutJfr {
+    public static void main(String[] args) throws Throwable {
+        List<String> a = new ArrayList<>();
+        a.add("-Xlog:class+load=trace");
+        a.add(TestEventsNotLoadedWithoutJfr.Helper.class.getName());
+        Process p = ProcessTools.createTestJavaProcessBuilder(a).start();
+        OutputAnalyzer output = new OutputAnalyzer(p);
+        output.waitFor();
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain("jdk.internal.event.FileForceEvent");
+        output.shouldNotContain("jdk.internal.event.SocketWriteEvent");
+        output.shouldNotContain("jdk.internal.event.SocketReadEvent");
+    }
+
+    public static class Helper {
+        private static final String HOSTNAME = "127.0.0.1";
+        private static final byte[] SERVER_MSG = "server message".getBytes();
+        private static final byte[] CLIENT_MSG = "client message".getBytes();
+
+        public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {
+            exerciseFileForce();
+            exerciseSocket();
+            exerciseSocketChannelImpl();
+            exerciseSocketInputStream();
+        }
+
+        private static void exerciseFileForce() throws IOException, ExecutionException, InterruptedException {
+            File tmp = Utils.createTempFile("TestEventsNotLoadedWithoutJfr", ".tmp").toFile();
+            String s = "unremarkable data";
+            ByteBuffer data = ByteBuffer.allocate(s.length());
+            data.put(s.getBytes());
+
+            // Check both AsynchronousFileChannel and FileChannelImpl
+            try (AsynchronousFileChannel afc = AsynchronousFileChannel.open(tmp.toPath(), READ, WRITE)) {
+                data.flip();
+                afc.write(data, 0).get();
+                afc.force(true);
+            }
+            try (FileChannel fc = FileChannel.open(tmp.toPath(), READ, WRITE)) {
+                data.clear();
+                fc.write(data);
+                fc.force(true);
+            }
+        }
+
+        // Exercises inner Socket$SocketInputStream / Socket$SocketOutputStream
+        private static void exerciseSocket() {
+            try (ServerSocket ss = new ServerSocket()) {
+                ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+                Thread serverThread = new Thread(() -> {
+                   try (Socket server = ss.accept();
+                        InputStream in = server.getInputStream();
+                        OutputStream out = server.getOutputStream()) {
+                       byte[] buf = new byte[CLIENT_MSG.length];
+                       in.read(buf);
+                       out.write(SERVER_MSG);
+                   } catch (Exception e) {
+                       throw new RuntimeException(e);
+                   }
+                });
+                serverThread.start();
+
+                try (Socket client = new Socket()) {
+                    client.connect(ss.getLocalSocketAddress());
+                    try (InputStream in = client.getInputStream();
+                    OutputStream out = client.getOutputStream()) {
+                        out.write(CLIENT_MSG);
+                        byte[] buf = new byte[SERVER_MSG.length];
+                        in.read(buf);
+                    }
+                }
+
+                serverThread.join();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static void exerciseSocketChannelImpl() {
+            try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
+                ssc.bind(new InetSocketAddress(HOSTNAME, 0));
+
+                Thread serverThread = new Thread(() -> {
+                    try (SocketChannel server = ssc.accept()) {
+                        // Exercise write(ByteBuffer) and read(ByteBuffer)
+                        ByteBuffer buf = ByteBuffer.allocate(CLIENT_MSG.length);
+                        server.read(buf);
+                        server.write(ByteBuffer.wrap(SERVER_MSG));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                serverThread.start();
+
+                try (SocketChannel client = SocketChannel.open()) {
+                    client.connect(ssc.getLocalAddress());
+                    // Exercise write(ByteBuffer[], int, int) and read(ByteBuffer[], int, int)
+                    client.write(new ByteBuffer[]{ByteBuffer.wrap(CLIENT_MSG)}, 0, 1);
+                    ByteBuffer buf = ByteBuffer.allocate(SERVER_MSG.length);
+                    client.read(new ByteBuffer[]{buf}, 0, 1);
+                }
+
+                serverThread.join();
+            } catch (IOException |InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static void exerciseSocketInputStream() {
+            try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
+                ssc.bind(new InetSocketAddress(HOSTNAME, 0));
+
+                Thread serverThread = new Thread(() -> {
+                   try (SocketChannel server = ssc.accept()) {
+                       try (InputStream in = server.socket().getInputStream();
+                            OutputStream out = server.socket().getOutputStream()) {
+                           byte[] buf = new byte[CLIENT_MSG.length];
+                           in.read(buf);
+                           out.write(SERVER_MSG);
+                       }
+                   } catch (Exception e) {
+                       throw new RuntimeException(e);
+                   }
+                });
+                serverThread.start();
+
+                try (SocketChannel client = SocketChannel.open()) {
+                    client.connect(ssc.getLocalAddress());
+                    try (InputStream in = client.socket().getInputStream();
+                         OutputStream out = client.socket().getOutputStream()) {
+                        out.write(CLIENT_MSG);
+                        byte [] buf = new byte[SERVER_MSG.length];
+                        in.read(buf);
+                    }
+                }
+
+                serverThread.join();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+}
+

--- a/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
+++ b/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
+++ b/test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java
@@ -25,8 +25,8 @@ package jdk.jfr.event.io;
 
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
+import static jdk.test.lib.Asserts.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -40,13 +40,14 @@ import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -71,7 +72,6 @@ public class TestEventsNotLoadedWithoutJfr {
     }
 
     public static class Helper {
-        private static final String HOSTNAME = "127.0.0.1";
         private static final byte[] SERVER_MSG = "server message".getBytes();
         private static final byte[] CLIENT_MSG = "client message".getBytes();
 
@@ -83,61 +83,69 @@ public class TestEventsNotLoadedWithoutJfr {
         }
 
         private static void exerciseFileForce() throws IOException, ExecutionException, InterruptedException {
-            File tmp = Utils.createTempFile("TestEventsNotLoadedWithoutJfr", ".tmp").toFile();
-            String s = "unremarkable data";
-            ByteBuffer data = ByteBuffer.allocate(s.length());
-            data.put(s.getBytes());
-
-            // Check both AsynchronousFileChannel and FileChannelImpl
-            try (AsynchronousFileChannel afc = AsynchronousFileChannel.open(tmp.toPath(), READ, WRITE)) {
+            Path tmp = Files.createTempFile(Path.of(""), "TestEventsNotLoadedWithoutJfr", ".tmp");
+            try {
+                String s = "short";
+                ByteBuffer data = ByteBuffer.allocate(s.length());
+                data.put(s.getBytes());
                 data.flip();
-                afc.write(data, 0).get();
-                afc.force(true);
-            }
-            try (FileChannel fc = FileChannel.open(tmp.toPath(), READ, WRITE)) {
-                data.clear();
-                fc.write(data);
-                fc.force(true);
+
+                // Check both AsynchronousFileChannel and FileChannelImpl
+                try (AsynchronousFileChannel afc = AsynchronousFileChannel.open(tmp, READ, WRITE)) {
+                    int expectedWritten = data.remaining();
+                    int actualWritten = afc.write(data, 0).get();
+                    assertEquals(actualWritten, expectedWritten, "Unexpected amount written.");
+                    afc.force(true);
+                }
+                data.flip();
+                try (FileChannel fc = FileChannel.open(tmp, READ, WRITE)) {
+                    int expectedWritten = data.remaining();
+                    int actualWritten = fc.write(data);
+                    assertEquals(actualWritten, expectedWritten, "Unexpected amount written.");
+                    fc.force(true);
+                }
+            } finally {
+                Files.deleteIfExists(tmp);
             }
         }
 
         // Exercises inner Socket$SocketInputStream / Socket$SocketOutputStream
-        private static void exerciseSocket() {
+        private static void exerciseSocket() throws IOException, InterruptedException {
             try (ServerSocket ss = new ServerSocket()) {
                 ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
-                Thread serverThread = new Thread(() -> {
-                   try (Socket server = ss.accept();
-                        InputStream in = server.getInputStream();
-                        OutputStream out = server.getOutputStream()) {
-                       byte[] buf = new byte[CLIENT_MSG.length];
-                       in.read(buf);
-                       out.write(SERVER_MSG);
-                   } catch (Exception e) {
-                       throw new RuntimeException(e);
-                   }
-                });
-                serverThread.start();
-
-                try (Socket client = new Socket()) {
-                    client.connect(ss.getLocalSocketAddress());
-                    try (InputStream in = client.getInputStream();
-                    OutputStream out = client.getOutputStream()) {
-                        out.write(CLIENT_MSG);
-                        byte[] buf = new byte[SERVER_MSG.length];
-                        in.read(buf);
+                Thread clientThread = new Thread(() -> {
+                    try (Socket client = new Socket()) {
+                        client.connect(ss.getLocalSocketAddress());
+                        try (InputStream in = client.getInputStream();
+                             OutputStream out = client.getOutputStream()) {
+                            out.write(CLIENT_MSG);
+                            byte[] buf = new byte[SERVER_MSG.length];
+                            in.read(buf);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
                     }
+                });
+                clientThread.start();
+
+                try (Socket server = ss.accept();
+                     InputStream in = server.getInputStream();
+                     OutputStream out = server.getOutputStream()) {
+                    byte[] buf = new byte[CLIENT_MSG.length];
+                    in.read(buf);
+                    out.write(SERVER_MSG);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
                 }
 
-                serverThread.join();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+                clientThread.join();
             }
         }
 
         private static void exerciseSocketChannelImpl() {
             try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
-                ssc.bind(new InetSocketAddress(HOSTNAME, 0));
+                ssc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
                 Thread serverThread = new Thread(() -> {
                     try (SocketChannel server = ssc.accept()) {
@@ -167,7 +175,7 @@ public class TestEventsNotLoadedWithoutJfr {
 
         private static void exerciseSocketInputStream() {
             try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
-                ssc.bind(new InetSocketAddress(HOSTNAME, 0));
+                ssc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
                 Thread serverThread = new Thread(() -> {
                    try (SocketChannel server = ssc.accept()) {
@@ -188,7 +196,7 @@ public class TestEventsNotLoadedWithoutJfr {
                     try (InputStream in = client.socket().getInputStream();
                          OutputStream out = client.socket().getOutputStream()) {
                         out.write(CLIENT_MSG);
-                        byte [] buf = new byte[SERVER_MSG.length];
+                        byte[] buf = new byte[SERVER_MSG.length];
                         in.read(buf);
                     }
                 }
@@ -198,7 +206,6 @@ public class TestEventsNotLoadedWithoutJfr {
                 throw new RuntimeException(e);
             }
         }
-
     }
 }
 


### PR DESCRIPTION
This PR guards usage of FileForce, SocketRead, and SocketWrite events with `jfrTracing` to prevent those classes from being loaded when JFR is not in use. This is the same technique as what's currently used with exception events and FileRead/FileWrite events.

I used NMT and a simple test app that exercises file force and socket IO paths to check for a difference in memory usage.
**NMT Before:** 
Classes=1188, Metadata used=966064 B, Class space used=93008 B
**NMT After:**
Classes=1182, Metadata used=943728 B, Class space used=89456 B
Note that the difference in amount used doesn't actually change amount committed because the backing memory is pre-allocated in chunks with larger granularity.

Testing:
- new test test/jdk/jdk/jfr/event/io/TestEventsNotLoadedWithoutJfr.java to check the guards work properly
- tier 1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8331996](https://bugs.openjdk.org/browse/JDK-8331996): JFR: Add boolean check before loading event classes (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30948/head:pull/30948` \
`$ git checkout pull/30948`

Update a local copy of the PR: \
`$ git checkout pull/30948` \
`$ git pull https://git.openjdk.org/jdk.git pull/30948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30948`

View PR using the GUI difftool: \
`$ git pr show -t 30948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30948.diff">https://git.openjdk.org/jdk/pull/30948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30948#issuecomment-4329659094)
</details>
