### PR TITLE
8317124: use reproducible random in HotSpot tests

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/cmove/TestScalarConditionalMoveCmpObj.java
+++ b/test/hotspot/jtreg/compiler/c2/cmove/TestScalarConditionalMoveCmpObj.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025, Rivos Inc. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +31,7 @@ import jdk.test.lib.Utils;
 
 /*
  * @test
+ * @key randomness
  * @summary Test conditional move + compare object.
  * @library /test/lib /
  * @run driver ${test.main.class}
@@ -300,7 +302,7 @@ public class TestScalarConditionalMoveCmpObj {
         for (int i = 0; i < a.length; i++) {
             b[i] = a[i];
         }
-        Random rand = new Random();
+        Random rand = Utils.getRandomInstance();
         for (int i = 0; i < SIZE; i++) {
             if (rand.nextInt(5) == 0) {
                 Object t = b[i];

--- a/test/hotspot/jtreg/compiler/c2/gvn/TestBoolNodeGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/TestBoolNodeGVN.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 Red Hat and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +27,11 @@ package compiler.c2.gvn;
 import compiler.lib.ir_framework.*;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * @test
+ * @key randomness
  * @bug 8327381
  * @summary Refactor boolean node tautology transformations
  * @library /test/lib /
@@ -139,7 +142,7 @@ public class TestBoolNodeGVN {
     private static void testCorrectness() {
         int[] values = {
                 -100, -42, -16, -8, -5, -1, 0, 1, 5, 8, 16, 42, 100,
-                new Random().nextInt(), Integer.MAX_VALUE, Integer.MIN_VALUE
+                Utils.getRandomInstance().nextInt(), Integer.MAX_VALUE, Integer.MIN_VALUE
         };
 
         for (int x : values) {

--- a/test/hotspot/jtreg/compiler/conversions/TestMoveConvI2LOrCastIIThruAddIs.java
+++ b/test/hotspot/jtreg/compiler/conversions/TestMoveConvI2LOrCastIIThruAddIs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,12 @@ package compiler.conversions;
 
 import java.util.Objects;
 import java.util.Random;
+import jdk.test.lib.Utils;
 import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @bug 8254317 8256730
  * @requires vm.compiler2.enabled
  * @summary Exercises the optimization that moves integer-to-long conversions
@@ -157,7 +159,7 @@ public class TestMoveConvI2LOrCastIIThruAddIs {
         // We use a random number generator to avoid constant propagation in C2
         // and produce a variable ("a" in the different tests) with a finite,
         // small value range.
-        Random rnd = new Random();
+        Random rnd = Utils.getRandomInstance();
         switch(args[0]) {
         case "functional":
             // Small, functional tests.

--- a/test/hotspot/jtreg/compiler/gallery/NormalMapping.java
+++ b/test/hotspot/jtreg/compiler/gallery/NormalMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.io.IOException;
 import java.util.Random;
+import jdk.test.lib.Utils;
 import javax.swing.JPanel;
 import java.awt.Font;
 
@@ -78,7 +79,7 @@ import java.util.Arrays;
  * - MyDrawingPanel: drawing all the parts to the screen.
  */
 public class NormalMapping {
-    public static Random RANDOM = new Random();
+    public static Random RANDOM = Utils.getRandomInstance();
 
     // Increasing this number will make the demo slower.
     public static final int NUMBER_OF_LIGHTS = 5;

--- a/test/hotspot/jtreg/compiler/hotcode/StressHotCodeCollector.java
+++ b/test/hotspot/jtreg/compiler/hotcode/StressHotCodeCollector.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +25,7 @@
 
 /*
  * @test
+ * @key randomness
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -38,6 +40,7 @@ package compiler.hotcode;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.whitebox.WhiteBox;
@@ -89,7 +92,7 @@ public class StressHotCodeCollector {
         generateCode();
 
         long start = System.currentTimeMillis();
-        Random random = new Random();
+        Random random = Utils.getRandomInstance();
 
         while (System.currentTimeMillis() - start < RUN_MILLIS) {
             for (TestMethod m : methods) {

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2025, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8365206
  * @summary Verify NaN sign and significand bits are preserved across conversions,
  *          float -> float16 -> float
@@ -55,6 +56,7 @@ import compiler.whitebox.CompilerWhiteBoxTest;
 import jdk.test.whitebox.WhiteBox;
 import java.lang.reflect.Method;
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class Binary16ConversionNaN_2 {
 
@@ -77,7 +79,7 @@ public class Binary16ConversionNaN_2 {
         float[] nVal = new float[1024];
         float[] nRes = new float[1024];
 
-        Random rand = new Random();
+        Random rand = Utils.getRandomInstance();
 
         // A NaN has a nonzero significand
         for (int i = 1; i <= 0x3ff; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
@@ -24,9 +24,9 @@
 /*
  * @test id=Xbatch
  * @key randomness
- * @library /test/lib
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @library /test/lib
  * @run main/othervm/timeout=480 -Xbatch -XX:-TieredCompilation
  *                   -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::test*
  *                   compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
@@ -35,9 +35,9 @@
 /*
  * @test id=Xcomp-run-inline
  * @key randomness
- * @library /test/lib
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @library /test/lib
  * @run main/othervm/timeout=480 -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::run*,*TestPartialPeel*::test*
  *                   -XX:CompileCommand=inline,*TestPartialPeelAtUnsignedTestsNegativeLimit::test*
@@ -48,9 +48,9 @@
 /*
  * @test id=Xcomp-compile-test
  * @key randomness
- * @library /test/lib
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @library /test/lib
  * @run main/othervm/timeout=480 -Xcomp -XX:-TieredCompilation -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::test*
  *                   compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
  */
@@ -58,11 +58,11 @@
 /*
  * @test id=vanilla
  * @key randomness
- * @library /test/lib
  * @bug 8332920
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
  *          Only run this test with C2 since it is time-consuming and only tests a C2 issue.
+ * @library /test/lib
  * @run main/timeout=480 compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
 
 /*
  * @test id=Xbatch
+ * @key randomness
+ * @library /test/lib
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
  * @run main/othervm/timeout=480 -Xbatch -XX:-TieredCompilation
@@ -32,6 +34,8 @@
 
 /*
  * @test id=Xcomp-run-inline
+ * @key randomness
+ * @library /test/lib
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
  * @run main/othervm/timeout=480 -Xcomp -XX:-TieredCompilation
@@ -43,6 +47,8 @@
 
 /*
  * @test id=Xcomp-compile-test
+ * @key randomness
+ * @library /test/lib
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
  * @run main/othervm/timeout=480 -Xcomp -XX:-TieredCompilation -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::test*
@@ -51,6 +57,8 @@
 
 /*
  * @test id=vanilla
+ * @key randomness
+ * @library /test/lib
  * @bug 8332920
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
@@ -61,6 +69,7 @@
 package compiler.loopopts;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 import static java.lang.Integer.*;
 
@@ -69,7 +78,7 @@ public class TestPartialPeelAtUnsignedTestsNegativeLimit {
     static int iterations = 0;
     static int iFld2;
     static boolean flag;
-    final static Random RANDOM = new Random();
+    final static Random RANDOM = Utils.getRandomInstance();
 
     public static void main(String[] args) {
         compareUnsigned(3, 3); // Load Integer class for -Xcomp

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeCompilation.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeCompilation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@ package compiler.loopopts.superword;
 
 /*
  * @test
+ * @key randomness
+ * @library /test/lib
  * @bug 8327978
  * @summary Test compile time for large compilation, where SuperWord takes especially much time.
  * @run main/othervm/timeout=30 -Xbatch
@@ -34,9 +36,10 @@ package compiler.loopopts.superword;
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestLargeCompilation {
-    private static final Random random = new Random();
+    private static final Random random = Utils.getRandomInstance();
     static final int RANGE_CON = 1024 * 8;
 
     static int init = 593436;

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeCompilation.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeCompilation.java
@@ -26,9 +26,9 @@ package compiler.loopopts.superword;
 /*
  * @test
  * @key randomness
- * @library /test/lib
  * @bug 8327978
  * @summary Test compile time for large compilation, where SuperWord takes especially much time.
+ * @library /test/lib
  * @run main/othervm/timeout=30 -Xbatch
  *                              -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestLargeCompilation::test*
  *                              -XX:+IgnoreUnrecognizedVMOptions -XX:LoopUnrollLimit=1000

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskTrueCount.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskTrueCount.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +47,7 @@ public class TestVectorMaskTrueCount {
     private static final VectorSpecies<Double> SPECIES_D = DoubleVector.SPECIES_128;
     private static final VectorSpecies<Integer> SPECIES_I = IntVector.SPECIES_128;
     private static final int LENGTH = 1024;
-    private static final Random RD = new Random();
+    private static final Random RD = Utils.getRandomInstance();
     private static boolean[] ba;
     private static boolean[] bb;
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectorDoubleRandom.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectorDoubleRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,6 +37,7 @@
 package compiler.vectorization;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 import static compiler.lib.golden.GoldenRound.golden_round;
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.IRNode;
@@ -47,7 +48,7 @@ import compiler.lib.ir_framework.TestFramework;
 import compiler.lib.ir_framework.Warmup;
 
 public class TestRoundVectorDoubleRandom {
-  private static final Random rand = new Random();
+  private static final Random rand = Utils.getRandomInstance();
 
   private static final int ITERS  = 11000;
   private static final int ARRLEN = rand.nextInt(4096-997) + 997;

--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectorFloatAll.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectorFloatAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,6 +24,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8321010
  * @summary Test vector intrinsic for Math.round(float) in full 32 bits range
  *
@@ -37,10 +38,11 @@
 package compiler.vectorization;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 import static compiler.lib.golden.GoldenRound.golden_round;
 
 public class TestRoundVectorFloatAll {
-  private static final Random rand = new Random();
+  private static final Random rand = Utils.getRandomInstance();
 
   private static final int ITERS  = 11000;
   private static final int ARRLEN = rand.nextInt(4096-997) + 997;

--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectorFloatRandom.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectorFloatRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,6 +37,7 @@
 package compiler.vectorization;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 import static compiler.lib.golden.GoldenRound.golden_round;
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.IRNode;
@@ -47,7 +48,7 @@ import compiler.lib.ir_framework.TestFramework;
 import compiler.lib.ir_framework.Warmup;
 
 public class TestRoundVectorFloatRandom {
-  private static final Random rand = new Random();
+  private static final Random rand = Utils.getRandomInstance();
 
   private static final int ITERS  = 11000;
   private static final int ARRLEN = rand.nextInt(4096-997) + 997;

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/AllocationProfile.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/AllocationProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,6 +24,7 @@
  */
 
 import java.util.*;
+import jdk.test.lib.Utils;
 
 public class AllocationProfile {
 
@@ -47,7 +48,7 @@ public class AllocationProfile {
      * Returns random allocation size measured in words
      */
     public long randomAllocationSize() {
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         return r.nextInt((int)(maximumSingleAllocationSize - minimumSingleAllocationSize + 1)) + minimumSingleAllocationSize;
     }
 

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocation.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocation.java
@@ -26,6 +26,7 @@
 /*
  * @test id=debug
  * @bug 8251158
+ * @key randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc java.management
  * @build jdk.test.whitebox.WhiteBox
@@ -37,6 +38,7 @@
 /*
  * @test id=ndebug
  * @bug 8251158
+ * @key randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc java.management
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/NMT/NMTInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTInitializationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@
 /**
  * @test id=normal-off
  * @bug 8256844
+ * @key randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -54,6 +55,7 @@
 /**
  * @test id=normal-detail
  * @bug 8256844
+ * @key randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -63,6 +65,7 @@
 /**
  * @test id=default_long-off
  * @bug 8256844
+ * @key randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -72,6 +75,7 @@
 /**
  * @test id=default_long-detail
  * @bug 8256844
+ * @key randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -87,6 +91,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Random;
+import jdk.test.lib.Utils;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -95,7 +100,7 @@ public class NMTInitializationTest {
     final static boolean debug = true;
 
     static String randomString() {
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         int len = r.nextInt(100) + 100;
         StringBuilder bld = new StringBuilder();
         for (int i = 0; i < len; i ++) {


### PR DESCRIPTION
Replaced new Random() with Utils.getRandomInstance() in 14 open hotspot test files. 
Added @key randomness and @library /test/lib where missing.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8317124: use reproducible random in HotSpot tests`

### Issue
 * [JDK-8317124](https://bugs.openjdk.org/browse/JDK-8317124): use reproducible random in HotSpot tests (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Ekaterina Pavlova](https://openjdk.org/census#epavlova) (@katyapav - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30949/head:pull/30949` \
`$ git checkout pull/30949`

Update a local copy of the PR: \
`$ git checkout pull/30949` \
`$ git pull https://git.openjdk.org/jdk.git pull/30949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30949`

View PR using the GUI difftool: \
`$ git pr show -t 30949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30949.diff">https://git.openjdk.org/jdk/pull/30949.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30949#issuecomment-4328656424)
</details>
