### PR TITLE
8383420: SIGSEGV in PhaseChaitin::gather_lrg_masks

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -646,12 +646,13 @@ void CallGenerator::do_late_inline_helper() {
     for (uint i1 = 0; i1 < size; i1++) {
       map->init_req(i1, call->in(i1));
     }
-    // Call node has in[ReturnAdr] set to top() node.
-    // Replace it with corresponding node if it exists.
+    // Call node has in(ReturnAdr) set to top() node.
+    // We have to set map->in(ReturnAdr) to correct value
+    // because it is used by uncommon traps.
     Node* ret_adr = C->start()->proj_out_or_null(TypeFunc::ReturnAdr);
-    if (ret_adr != nullptr) {
-      map->set_req(TypeFunc::ReturnAdr, ret_adr);
-    }
+    precond(ret_adr != nullptr);
+    map->set_req(TypeFunc::ReturnAdr, ret_adr);
+
     // Make sure the state is a MergeMem for parsing.
     if (!map->in(TypeFunc::Memory)->is_MergeMem()) {
       Node* mem = MergeMemNode::make(map->in(TypeFunc::Memory));
@@ -666,6 +667,7 @@ void CallGenerator::do_late_inline_helper() {
       map->set_req(TypeFunc::Parms + i1, top);
     }
     jvms->set_map(map);
+    precond(ret_adr == jvms->map()->returnadr());
 
     // Make enough space in the expression stack to transfer
     // the incoming arguments and return value.

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -646,7 +646,12 @@ void CallGenerator::do_late_inline_helper() {
     for (uint i1 = 0; i1 < size; i1++) {
       map->init_req(i1, call->in(i1));
     }
-
+    // Call node has in[ReturnAdr] set to top() node.
+    // Replace it with corresponding node if it exists.
+    Node* ret_adr = C->start()->proj_out_or_null(TypeFunc::ReturnAdr);
+    if (ret_adr != nullptr) {
+      map->set_req(TypeFunc::ReturnAdr, ret_adr);
+    }
     // Make sure the state is a MergeMem for parsing.
     if (!map->in(TypeFunc::Memory)->is_MergeMem()) {
       Node* mem = MergeMemNode::make(map->in(TypeFunc::Memory));

--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -353,7 +353,8 @@ public:
     return _names.at(idx);
   }
 
-  uint live_range_id(const Node *node) const {
+  uint live_range_id(const Node* node) const {
+    precond(node != nullptr);
     return _names.at(node->_idx);
   }
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -4145,7 +4145,9 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
   call->init_req(TypeFunc::Control,   head->init_control());
   call->init_req(TypeFunc::I_O,       C->top());       // Does no I/O.
   call->init_req(TypeFunc::Memory,    mem_phi->in(LoopNode::EntryControl));
-  call->init_req(TypeFunc::ReturnAdr, C->start()->proj_out_or_null(TypeFunc::ReturnAdr));
+  Node* ret = new ParmNode(C->start(), TypeFunc::ReturnAdr);
+  _igvn.register_new_node_with_optimizer(ret);
+  call->init_req(TypeFunc::ReturnAdr, ret);
   Node* frame = new ParmNode(C->start(), TypeFunc::FramePtr);
   _igvn.register_new_node_with_optimizer(frame);
   call->init_req(TypeFunc::FramePtr,  frame);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -4145,9 +4145,7 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
   call->init_req(TypeFunc::Control,   head->init_control());
   call->init_req(TypeFunc::I_O,       C->top());       // Does no I/O.
   call->init_req(TypeFunc::Memory,    mem_phi->in(LoopNode::EntryControl));
-  Node* ret = new ParmNode(C->start(), TypeFunc::ReturnAdr);
-  _igvn.register_new_node_with_optimizer(ret);
-  call->init_req(TypeFunc::ReturnAdr, ret);
+  call->init_req(TypeFunc::ReturnAdr, C->top());
   Node* frame = new ParmNode(C->start(), TypeFunc::FramePtr);
   _igvn.register_new_node_with_optimizer(frame);
   call->init_req(TypeFunc::FramePtr,  frame);


### PR DESCRIPTION
Running AOT compilation testing with `-XX:CompileThreshold=100 -XX:-TieredCompilation -XX:+AlwaysIncrementalInline` hits this issue. The dump shows that `in(TypeFunc::ReturnAdr)` (5th) input in `CallLeafNoFPDirect` node is NULL:
```
40 CallLeafNoFPDirect === 304 0 102 96 _ 107 110 112 0 [[ 41 39 150 ]] arrayof_jint_fill # void ( ptr:NotNull+bot, int, long, half ) !jvms: MutableBigInteger::divideKnuth @ bci:194 (line 1307) MutableBigInteger::divideKnuth @ bci:4 (line 1255)
```
VM crashed when `live_range_id()` tries to read `_idx` of this input in `PhaseChaitin::gather_lrg_masks()`:
```
      // Prepare register mask for each input
      for( uint k = input_edge_start; k < cnt; k++ ) {
        uint vreg_in = _lrg_map.live_range_id(n->in(k));
```
This input for `CallLeafNoFPNode` is set in `PhaseIdealLoop::intrinsify_fill()`:
```
  call->init_req(TypeFunc::ReturnAdr, C->start()->proj_out_or_null(TypeFunc::ReturnAdr));
```
But `proj_out_or_null(TypeFunc::ReturnAdr)` can return `nullptr` if such projection is not created yet.
Note, for `FramePtr` input it creates new projection:
```
  Node* frame = new ParmNode(C->start(), TypeFunc::FramePtr);
  _igvn.register_new_node_with_optimizer(frame);
  call->init_req(TypeFunc::FramePtr, frame);
```
I looked on other places and they create ParmNode(C->start(), TypeFunc:: ReturnAdr) when they need it.

After more deep investigation I found that with `-XX:+AlwaysIncrementalInline` we delay inlining after parsing and when we inline call we don't set `ReturnAdr` input in new `map`. See changes in `CallGenerator::do_late_inline_helper()` which fixit.

Regarding `ReturnAdr` input for `CallLeafNoFPNode`. It should be set to `top()` as we do for other runtime calls.

I also added `precond()` to `live_range_id()` method to throw an assert instead of SEGV.

Note, I was not able to reproduce this failure with normal JIT compilation. But I think it still could happen. So I am fixing it in mainline JDK.

Testing tiet1-4,comp-stress, AOT code compilation changes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383420](https://bugs.openjdk.org/browse/JDK-8383420): SIGSEGV in PhaseChaitin::gather_lrg_masks (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**) Review applies to [03531cca](https://git.openjdk.org/jdk/pull/30952/files/03531ccaf2d7b28b7d5246a230eb3786e2714020)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30952/head:pull/30952` \
`$ git checkout pull/30952`

Update a local copy of the PR: \
`$ git checkout pull/30952` \
`$ git pull https://git.openjdk.org/jdk.git pull/30952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30952`

View PR using the GUI difftool: \
`$ git pr show -t 30952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30952.diff">https://git.openjdk.org/jdk/pull/30952.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30952#issuecomment-4329900172)
</details>
