### PR TITLE
8382222: sun/security/ssl/SSLSocketImpl/SSLSocketBruteForceClose.java fails sporadically

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketBruteForceClose.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketBruteForceClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class SSLSocketBruteForceClose extends SSLSocketTemplate {
     protected void configureClientSocket(SSLSocket socket) {
         try {
             socket.setSoLinger(true, 3);
-            socket.setSoTimeout(1000);
+            socket.setSoTimeout(5000);
         } catch (SocketException exc) {
             throw new RuntimeException("Could not configure client socket", exc);
         }


### PR DESCRIPTION
Increase socket timeout in the test.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382222](https://bugs.openjdk.org/browse/JDK-8382222): sun/security/ssl/SSLSocketImpl/SSLSocketBruteForceClose.java fails sporadically (**Enhancement** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30956/head:pull/30956` \
`$ git checkout pull/30956`

Update a local copy of the PR: \
`$ git checkout pull/30956` \
`$ git pull https://git.openjdk.org/jdk.git pull/30956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30956`

View PR using the GUI difftool: \
`$ git pr show -t 30956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30956.diff">https://git.openjdk.org/jdk/pull/30956.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30956#issuecomment-4331049460)
</details>
