### PR TITLE
8358216: GenShen: GC MXBean updates do not properly distinguish generational collection types and memory pools

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -292,7 +292,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   }
   heap->increment_total_collections(false);
 
-  ShenandoahGCSession session(cause, heap->global_generation());
+  ShenandoahGCSession session(cause, heap->global_generation(), heap->cycle_memory_manager());
 
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
 
@@ -335,7 +335,7 @@ void ShenandoahControlThread::stop_service() {
 
 void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCSession session(cause, heap->global_generation());
+  ShenandoahGCSession session(cause, heap->global_generation(), heap->cycle_memory_manager());
 
   heap->increment_total_collections(true);
 
@@ -346,7 +346,7 @@ void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
 void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point) {
   assert (point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCSession session(cause, heap->global_generation(), true,
+  ShenandoahGCSession session(cause, heap->global_generation(), heap->cycle_memory_manager(), true,
                               point == ShenandoahGC::ShenandoahDegenPoint::_degenerated_outside_cycle);
 
   heap->increment_total_collections(false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -404,7 +404,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
 
   switch (original_state) {
     case ShenandoahOldGeneration::FILLING: {
-      ShenandoahGCSession session(request.cause, old_generation);
+      ShenandoahGCSession session(request.cause, old_generation, _heap->old_gc_memory_manager());
       assert(gc_mode() == servicing_old, "Filling should be servicing old");
       _allow_old_preemption.set();
       old_generation->entry_coalesce_and_fill();
@@ -450,7 +450,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(const She
       // done by the bootstrapping young cycle.
       set_gc_mode(servicing_old);
     case ShenandoahOldGeneration::MARKING: {
-      ShenandoahGCSession session(request.cause, old_generation);
+      ShenandoahGCSession session(request.cause, old_generation, _heap->old_gc_memory_manager());
       bool marking_complete = resume_concurrent_old_cycle(old_generation, request.cause);
       if (marking_complete) {
         assert(old_generation->state() != ShenandoahOldGeneration::MARKING, "Should not still be marking");
@@ -539,13 +539,19 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
   // At this point:
   //  if (generation == YOUNG), this is a normal young cycle or a bootstrap cycle
   //  if (generation == GLOBAL), this is a GLOBAL cycle
+  assert(!generation->is_old(), "Old GC takes a different control path");
+
   // In either case, we want to age old objects if this is an aging cycle
   maybe_set_aging_cycle();
 
-  ShenandoahGCSession session(cause, generation);
-  TraceCollectorStats tcs(_heap->monitoring_support()->concurrent_collection_counters());
+  // Based on the generation, choose the correct memory manager for MXBean
+  GCMemoryManager* gc_memory_manager = generation->is_young()
+        ? _heap->young_gc_memory_manager()
+        : _heap->global_gc_memory_manager();
 
-  assert(!generation->is_old(), "Old GC takes a different control path");
+  ShenandoahGCSession session(cause, generation, gc_memory_manager);
+
+  TraceCollectorStats tcs(_heap->monitoring_support()->concurrent_collection_counters());
 
   ShenandoahConcurrentGC gc(generation, do_old_gc_bootstrap);
   _heap->increment_total_collections(false);
@@ -619,7 +625,7 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   _heap->increment_total_collections(true);
-  ShenandoahGCSession session(cause, _heap->global_generation());
+  ShenandoahGCSession session(cause, _heap->global_generation(), _heap->global_gc_memory_manager());
   maybe_set_aging_cycle();
   ShenandoahFullGC gc;
   gc.collect(cause);
@@ -630,7 +636,12 @@ void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(const Sh
   assert(_degen_point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
   _heap->increment_total_collections(false);
 
-  ShenandoahGCSession session(request.cause, request.generation, true,
+  // Based on the generation, choose the correct memory manager for MXBean
+  GCMemoryManager* gc_memory_manager = request.generation->is_young()
+        ? _heap->young_gc_memory_manager()
+        : _heap->global_gc_memory_manager();
+
+  ShenandoahGCSession session(request.cause, request.generation, gc_memory_manager, true,
                               _degen_point == ShenandoahGC::ShenandoahDegenPoint::_degenerated_outside_cycle);
   ShenandoahDegenGC gc(_degen_point, request.generation);
   gc.collect(request.cause);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -84,6 +84,9 @@ ShenandoahGenerationalHeap::ShenandoahGenerationalHeap(ShenandoahCollectorPolicy
   _min_plab_size(calculate_min_plab()),
   _max_plab_size(calculate_max_plab()),
   _regulator_thread(nullptr),
+  _young_gc_memory_manager("Shenandoah Young Gen GC Cycle"),
+  _old_gc_memory_manager("Shenandoah Old Gen GC Cycle"),
+  _global_gc_memory_manager("Shenandoah Global GC Cycle"),
   _young_gen_memory_pool(nullptr),
   _old_gen_memory_pool(nullptr) {
   assert(is_aligned(_min_plab_size, CardTable::card_size_in_words()), "min_plab_size must be aligned");
@@ -126,10 +129,22 @@ void ShenandoahGenerationalHeap::initialize_serviceability() {
   assert(mode()->is_generational(), "Only for the generational mode");
   _young_gen_memory_pool = new ShenandoahYoungGenMemoryPool(this);
   _old_gen_memory_pool = new ShenandoahOldGenMemoryPool(this);
-  cycle_memory_manager()->add_pool(_young_gen_memory_pool);
-  cycle_memory_manager()->add_pool(_old_gen_memory_pool);
   stw_memory_manager()->add_pool(_young_gen_memory_pool);
   stw_memory_manager()->add_pool(_old_gen_memory_pool);
+  _young_gc_memory_manager.add_pool(_young_gen_memory_pool);
+  _old_gc_memory_manager.add_pool(_old_gen_memory_pool);
+  _global_gc_memory_manager.add_pool(_young_gen_memory_pool);
+  _global_gc_memory_manager.add_pool(_old_gen_memory_pool);
+}
+
+GrowableArray<GCMemoryManager*> ShenandoahGenerationalHeap::memory_managers() {
+  assert(mode()->is_generational(), "Only for the generational mode");
+  GrowableArray<GCMemoryManager*> memory_managers(4);
+  memory_managers.append(stw_memory_manager());
+  memory_managers.append(&_young_gc_memory_manager);
+  memory_managers.append(&_old_gc_memory_manager);
+  memory_managers.append(&_global_gc_memory_manager);
+  return memory_managers;
 }
 
 GrowableArray<MemoryPool*> ShenandoahGenerationalHeap::memory_pools() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -120,6 +120,7 @@ public:
   // ---------- Serviceability
   //
   void initialize_serviceability() override;
+  GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;
 
   ShenandoahRegulatorThread* regulator_thread() const { return _regulator_thread;  }
@@ -137,6 +138,12 @@ public:
   // Balances generations, coalesces and fills old regions if necessary
   void complete_degenerated_cycle();
   void complete_concurrent_cycle();
+
+  // Generation-specific memory managers for MXBean reporting
+  GCMemoryManager* young_gc_memory_manager()   { return &_young_gc_memory_manager;  }
+  GCMemoryManager* old_gc_memory_manager()     { return &_old_gc_memory_manager;    }
+  GCMemoryManager* global_gc_memory_manager()  { return &_global_gc_memory_manager; }
+
 private:
   void initialize_controller() override;
   void entry_global_coalesce_and_fill();
@@ -145,6 +152,10 @@ private:
   void coalesce_and_fill_old_regions(bool concurrent);
 
   ShenandoahRegulatorThread* _regulator_thread;
+
+  GCMemoryManager _young_gc_memory_manager;
+  GCMemoryManager _old_gc_memory_manager;
+  GCMemoryManager _global_gc_memory_manager;
 
   MemoryPool* _young_gen_memory_pool;
   MemoryPool* _old_gen_memory_pool;

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -56,8 +56,11 @@ const char* ShenandoahGCSession::cycle_end_message(ShenandoahGenerationType type
   }
 }
 
-ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation,
-                                         bool is_degenerated, bool is_out_of_cycle) :
+ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause,
+                                         ShenandoahGeneration* generation,
+                                         GCMemoryManager* gc_memory_manager,
+                                         bool is_degenerated,
+                                         bool is_out_of_cycle) :
   _heap(ShenandoahHeap::heap()),
   _generation(generation),
   _timer(_heap->gc_timer()),
@@ -68,7 +71,7 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGenerat
   _tracer->report_gc_start(cause, _timer->gc_start());
   _heap->trace_heap_before_gc(_tracer);
 
-  _trace_cycle.initialize(_heap->cycle_memory_manager(), cause,
+  _trace_cycle.initialize(gc_memory_manager, cause,
           cycle_end_message(_generation->type()),
           /* allMemoryPoolsAffected */    true,
           /* recordGCBeginTime = */       true,

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -70,8 +70,11 @@ private:
 
   static const char* cycle_end_message(ShenandoahGenerationType type);
 public:
-  ShenandoahGCSession(GCCause::Cause cause, ShenandoahGeneration* generation,
-                      bool is_degenerated = false, bool is_out_of_cycle = false);
+  ShenandoahGCSession(GCCause::Cause cause,
+                      ShenandoahGeneration* generation,
+                      GCMemoryManager* gc_memory_manager,
+                      bool is_degenerated = false,
+                      bool is_out_of_cycle = false);
   ~ShenandoahGCSession();
 };
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java
@@ -94,11 +94,17 @@ public class TestSoftMaxHeapSizeAvailableCalc {
         public static void test() throws Exception {
             final int expectedMaxGcCount = Integer.getInteger("expectedMaxGcCount", 30);
             List<java.lang.management.GarbageCollectorMXBean> collectors = ManagementFactory.getGarbageCollectorMXBeans();
-            java.lang.management.GarbageCollectorMXBean cycleCollector = null;
+            // There are multiple types of GC cycles that exist for Generational Shenandoah (Global/Young/Old).
+            // Each generation has its own MXBean, so we must account for all types of GC cycles.
+            List<java.lang.management.GarbageCollectorMXBean> cycleCollectors = new ArrayList<>();
             for (java.lang.management.GarbageCollectorMXBean bean : collectors) {
-                if (bean.getName().contains("Cycles")) {
-                    cycleCollector = bean;
+                if (bean.getName().contains("Cycle")) {
+                    cycleCollectors.add(bean);
                 }
+            }
+
+            if (cycleCollectors.isEmpty()) {
+                throw new IllegalStateException("Could not find Shenandoah GC cycle type.");
             }
 
             // Allocate ~300MB of long-lived objects
@@ -116,7 +122,12 @@ public class TestSoftMaxHeapSizeAvailableCalc {
                 Thread.sleep(10); // Pace to generate garbage at speed of ~100M/s
             }
 
-            long gcCount = cycleCollector.getCollectionCount();
+            long gcCount = 0;
+
+            for (java.lang.management.GarbageCollectorMXBean bean : cycleCollectors) {
+                gcCount += bean.getCollectionCount();
+            }
+
             Asserts.assertLessThan(gcCount, (long) expectedMaxGcCount, "GC was triggered too many times. Expected to be less than: " + expectedMaxGcCount + ", triggered: " + gcCount);
         }
     }

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
@@ -180,7 +180,11 @@ public class TestStringDedupStress {
         Random rn = Utils.getRandomInstance();
 
         for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
-            if ("Shenandoah Cycles".equals(bean.getName())) {
+            String beanName = bean.getName();
+            if ("Shenandoah Cycles".equals(beanName) ||
+                "Shenandoah Young Gen GC Cycle".equals(beanName) ||
+                "Shenandoah Old Gen GC Cycle".equals(beanName) ||
+                "Shenandoah Global GC Cycle".equals(beanName)) {
                 gcCycleMBean = bean;
                 break;
             }

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestCycleEndMessage.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestCycleEndMessage.java
@@ -62,6 +62,10 @@ public class TestCycleEndMessage {
                     if (name.equals("Shenandoah Cycles") &&
                         (action.contains("Global") || action.contains("Young") || action.contains("Old"))) {
                         foundGenerationInCycle.set(true);
+                    } else if ((name.equals("Shenandoah Young Gen GC Cycle") && action.contains("Young")) ||
+                               (name.equals("Shenandoah Old Gen GC Cycle") && action.contains("Old")) ||
+                               (name.equals("Shenandoah Global GC Cycle") && action.contains("Global"))) {
+                        foundGenerationInCycle.set(true);
                     }
                 }
             }

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -147,7 +147,10 @@ public class TestPauseNotifications {
                             if (!isExpectedPauseAction(info.getGcAction())) {
                                 throw new IllegalStateException("Unknown action: " + info.getGcAction());
                             }
-                        } else if (name.equals("Shenandoah Cycles")) {
+                        } else if (name.equals("Shenandoah Cycles") ||
+                                   name.equals("Shenandoah Young Gen GC Cycle") ||
+                                   name.equals("Shenandoah Old Gen GC Cycle") ||
+                                   name.equals("Shenandoah Global GC Cycle")) {
                             cyclesCount.incrementAndGet();
                             cyclesDuration.addAndGet(d);
                         } else {


### PR DESCRIPTION
Added new memory managers for Generational Shenandoah, so that the MXBeans are correctly updated per cycle type. These new memory managers are: `Shenandoah Young Gen GC Cycle`, `Shenandoah Old Gen GC Cycle`, and `Shenandoah Global GC Cycle`. Replaced the `Shenandoah Cycles` memory manager for GenShen, which lumped all updates together rather than separating them by cycle type.

### Testing
The following tests had to be refactored to test for the new memory managers (all tests now pass):
- `test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java`
- `test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java`
- `test/hotspot/jtreg/gc/shenandoah/mxbeans/TestCycleEndMessage.java`
- `test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java`

Tested on Linux x86_64 server release and fastdebug build: `test/hotspot/jtreg/gc/shenandoah/`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8358216](https://bugs.openjdk.org/browse/JDK-8358216): GenShen: GC MXBean updates do not properly distinguish generational collection types and memory pools (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30957/head:pull/30957` \
`$ git checkout pull/30957`

Update a local copy of the PR: \
`$ git checkout pull/30957` \
`$ git pull https://git.openjdk.org/jdk.git pull/30957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30957`

View PR using the GUI difftool: \
`$ git pr show -t 30957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30957.diff">https://git.openjdk.org/jdk/pull/30957.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30957#issuecomment-4331176841)
</details>
