### PR TITLE
8381154: Shenandoah: Region states could be read in wrong order for comparisons

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -667,9 +667,8 @@ void ShenandoahRegionPartitions::retire_range_from_partition(
   for (idx_t idx = low_idx; idx <= high_idx; idx++) {
 #ifdef ASSERT
     ShenandoahHeapRegion* r = ShenandoahHeap::heap()->get_region(idx);
-    const auto state = r->state(); // read once to avoid harmless races in assert
     assert (in_free_set(partition, idx), "Must be in partition to remove from partition");
-    assert(ShenandoahHeapRegion::is_empty_state(state) || ShenandoahHeapRegion::is_trash(state), "Region must be empty or trash");
+    assert(r->is_empty_or_trash(), "Region must be empty or trash");
 #endif
     _membership[int(partition)].clear_bit(idx);
   }
@@ -2825,7 +2824,7 @@ size_t ShenandoahFreeSet::reserve_regions(size_t to_reserve, size_t to_reserve_o
         // be collected in the near future.
         if (r->is_trash() || !r->is_affiliated()) {
           // OLD regions that have available memory are already in the old_collector free set.
-          assert(r->is_empty() || r->is_trash(), "Not affiliated implies region %zu is empty", r->index());
+          assert(r->is_empty_or_trash(), "Not affiliated implies region %zu is empty", r->index());
           if (idx < old_collector_low_idx) {
             old_collector_low_idx = idx;
           }
@@ -3169,7 +3168,7 @@ void ShenandoahFreeSet::log_status() {
           size_t free = alloc_capacity(r);
           max = MAX2(max, free);
           size_t used_in_region = r->used();
-          if (r->is_empty() || r->is_trash()) {
+          if (r->is_empty_or_trash()) {
             used_in_region = 0;
             total_free_ext += free;
             if (last_idx + 1 == idx) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -223,7 +223,9 @@ ShenandoahFreeSetPartitionId ShenandoahFreeSet::prepare_to_promote_in_place(size
 }
 
 inline bool ShenandoahFreeSet::can_allocate_from(ShenandoahHeapRegion *r) const {
-  return r->is_empty() || (r->is_trash() && !_heap->is_concurrent_weak_root_in_progress());
+  const auto state = r->state();
+  return ShenandoahHeapRegion::is_empty_state(state)
+      || (ShenandoahHeapRegion::is_trash(state) && !_heap->is_concurrent_weak_root_in_progress());
 }
 
 inline bool ShenandoahFreeSet::can_allocate_from(size_t idx) const {
@@ -665,8 +667,9 @@ void ShenandoahRegionPartitions::retire_range_from_partition(
   for (idx_t idx = low_idx; idx <= high_idx; idx++) {
 #ifdef ASSERT
     ShenandoahHeapRegion* r = ShenandoahHeap::heap()->get_region(idx);
+    const auto state = r->state(); // read once to avoid harmless races in assert
     assert (in_free_set(partition, idx), "Must be in partition to remove from partition");
-    assert(r->is_empty() || r->is_trash(), "Region must be empty or trash");
+    assert(ShenandoahHeapRegion::is_empty_state(state) || ShenandoahHeapRegion::is_trash(state), "Region must be empty or trash");
 #endif
     _membership[int(partition)].clear_bit(idx);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -197,9 +197,10 @@ public:
   bool is_regular()                const { return state() == _regular; }
   bool is_humongous_continuation() const { return state() == _humongous_cont; }
   bool is_regular_pinned()         const { return state() == _pinned; }
-  bool is_trash()                  const { return state() == _trash; }
+  bool is_trash()                  const { return is_trash(state()); }
 
   // Derived state predicates (boolean combinations of individual states)
+  bool static is_trash(RegionState state) { return state == _trash; }
   bool static is_empty_state(RegionState state) { return state == _empty_committed || state == _empty_uncommitted; }
   bool static is_humongous_start_state(RegionState state) { return state == _humongous_start || state == _pinned_humongous_start; }
   bool is_empty()                  const { return is_empty_state(this->state()); }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -203,6 +203,7 @@ public:
   bool static is_trash(RegionState state) { return state == _trash; }
   bool static is_empty_state(RegionState state) { return state == _empty_committed || state == _empty_uncommitted; }
   bool static is_humongous_start_state(RegionState state) { return state == _humongous_start || state == _pinned_humongous_start; }
+  bool is_empty_or_trash()         const { auto cur_state = state(); return is_empty_state(cur_state) || cur_state == _trash; }
   bool is_empty()                  const { return is_empty_state(this->state()); }
   bool is_active()                 const { auto cur_state = state(); return !is_empty_state(cur_state) && cur_state != _trash; }
   bool is_humongous_start()        const { return is_humongous_start_state(state()); }


### PR DESCRIPTION
Fun race condition in this assertion:
```
assert(r->is_empty() || r->is_trash(), "Region must be empty or trash");
```
1. Region enters this function with `state == trash`
2. Assert observes `r->is_empty() == false`
3. Allocating thread observes region is trash and recycles it so that `state == empty`
4. Assert now evaluates the next operand and observes `r->is_trash() == false` and fails

The region was never in an invalid state, it just wasn't in the right state at the right time for this assertion

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381154](https://bugs.openjdk.org/browse/JDK-8381154): Shenandoah: Region states could be read in wrong order for comparisons (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30958/head:pull/30958` \
`$ git checkout pull/30958`

Update a local copy of the PR: \
`$ git checkout pull/30958` \
`$ git pull https://git.openjdk.org/jdk.git pull/30958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30958`

View PR using the GUI difftool: \
`$ git pr show -t 30958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30958.diff">https://git.openjdk.org/jdk/pull/30958.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30958#issuecomment-4331262694)
</details>
