### PR TITLE
8382548: serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation failed with Test failed!

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
@@ -142,7 +142,7 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
         CodeCache cc = VM.getVM().getCodeCache();
         CodeBlob currentBlob = cc.findBlobUnsafe(pc());
 
-        // This case is different from HotSpot. See JDK-8371194 for details.
+        // This case is different from HotSpot. See JDK-8371194 and JDK-8382548 for details.
         if (currentBlob == null) { // current frame is native
           senderSP = getSenderSP(null);
         } else { // current frame is Java
@@ -155,7 +155,7 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
           } else if (currentBlob.getFrameSize() == 0) {
             senderSP = fp().addOffsetTo(2 * VM.getVM().getAddressSize());
           } else {
-            // Calculate sender SP and FP without FP as possible
+            // Calculate sender SP and FP without FP
             // because we cannot believe FP if PreserveFramePointer is disabled.
             senderSP = sp().addOffsetTo(currentBlob.getFrameSize());
             senderFP = senderSP.getAddressAt(-2 * VM.getVM().getAddressSize());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
@@ -109,6 +109,17 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
      };
    }
 
+   private JavaThread getJavaThreadFromThreadProxy(ThreadProxy tp) {
+     Threads threads = VM.getVM().getThreads();
+     for (int i = 0; i < threads.getNumberOfThreads(); i++) {
+       var jthread = threads.getJavaThreadAt(i);
+       if (tp.equals(jthread.getThreadProxy())) {
+         return jthread;
+       }
+     }
+     throw new DebuggerException("JavaThread not found");
+   }
+
    @Override
    public CFrame sender(ThreadProxy thread, Address senderSP, Address senderFP, Address senderPC) {
       if (linuxDbg().isSignalTrampoline(pc())) {
@@ -132,14 +143,24 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
         CodeBlob currentBlob = cc.findBlobUnsafe(pc());
 
         // This case is different from HotSpot. See JDK-8371194 for details.
-        if (currentBlob != null && (currentBlob.isContinuationStub() || currentBlob.isNativeMethod())) {
-          // Use FP since it should always be valid for these cases.
-          // TODO: These should be walked as Frames not CFrames.
-          senderSP = fp().addOffsetTo(2 * VM.getVM().getAddressSize());
-        } else {
-          CodeBlob codeBlob = cc.findBlobUnsafe(senderPC);
-          boolean useCodeBlob = codeBlob != null && codeBlob.getFrameSize() > 0;
-          senderSP = useCodeBlob ? senderFP.addOffsetTo((2 * VM.getVM().getAddressSize()) - codeBlob.getFrameSize()) : getSenderSP(null);
+        if (currentBlob == null) { // current frame is native
+          senderSP = getSenderSP(null);
+        } else { // current frame is Java
+          if (currentBlob.isContinuationStub()) {
+            var jthread = getJavaThreadFromThreadProxy(thread);
+            var contEntry = Continuation.getContinuationEntryForSP(jthread, sp());
+            senderSP = contEntry.getEntrySP();
+            senderFP = contEntry.getEntryFP();
+            senderPC = contEntry.getEntryPC();
+          } else if (currentBlob.getFrameSize() == 0) {
+            senderSP = fp().addOffsetTo(2 * VM.getVM().getAddressSize());
+          } else {
+            // Calculate sender SP and FP without FP as possible
+            // because we cannot believe FP if PreserveFramePointer is disabled.
+            senderSP = sp().addOffsetTo(currentBlob.getFrameSize());
+            senderFP = senderSP.getAddressAt(-2 * VM.getVM().getAddressSize());
+            senderPC = senderSP.getAddressAt(- VM.getVM().getAddressSize());
+          }
         }
       }
       if (senderSP == null) {


### PR DESCRIPTION
We could see jtreg test failure in TestJhsdbJstackMixedWithXComp.java due to unable unwinding from continuation stub.
SA could unwind mixed call stacks since [JDK-8377946](https://bugs.openjdk.org/browse/JDK-8377946), and enabled TestJhsdbJstackMixedWithXComp tests in it. Hence the problem has been suffered. The problem was reported in Valhalla, but it is potential to happen on upstream, thus I proposed the fix to upstream.

There are 2 problems in LinuxAARCH64CFrame:

1. On AArch64 which disables `PreserveFramePointer`, we cannot believe FP to unwind call stacks, thus we might not be able to unwind call stacks from Java frame (includes code blobs).
2. In continuation stub, we need to get SP/FP/PC from continuation entry.

So I fixed them in this PR, and it works on both upstream and Valhalla.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382548](https://bugs.openjdk.org/browse/JDK-8382548): serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation failed with Test failed! (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [af59eb36](https://git.openjdk.org/jdk/pull/30959/files/af59eb36fc430bef057f871cea5c483ce469f32b)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30959/head:pull/30959` \
`$ git checkout pull/30959`

Update a local copy of the PR: \
`$ git checkout pull/30959` \
`$ git pull https://git.openjdk.org/jdk.git pull/30959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30959`

View PR using the GUI difftool: \
`$ git pr show -t 30959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30959.diff">https://git.openjdk.org/jdk/pull/30959.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30959#issuecomment-4331332306)
</details>
