### PR TITLE
8381984: Test jdk/nio/zipfs/ZipFSTester.java fails with mismatched timestamp

### DIFF
--- a/test/jdk/jdk/nio/zipfs/ZipFSTester.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSTester.java
@@ -646,6 +646,11 @@ public class ZipFSTester {
     @Test
     void testTime() throws Exception {
         var jar = Utils.createJarFile(System.currentTimeMillis() + ".jar", jarContents);
+        // Read JAR source once before capturing file attributes.
+        // This stabilizes access time before the copy operation.
+        try (InputStream in = Files.newInputStream(jar)) {
+            in.transferTo(OutputStream.nullOutputStream()); // output is irrelevant
+        }
         BasicFileAttributes attrs = Files
                         .getFileAttributeView(jar, BasicFileAttributeView.class)
                         .readAttributes();


### PR DESCRIPTION
Please review this PR which addresses a mismatched timestamp failure for the access time assertion in _test/jdk/jdk/nio/zipfs/ZipFSTester.java_. These failures have been intermittently occurring on some `macosx-aarch64` hosts.

For context, this problem was surfaced by JDK-8378884 (a JUnit conversion). While the conversion itself did not cause the problem, it exposed an implicit ordering dependency in the test. In the main-based test flow, `testTime` was executed only after `test0` (which is now `entryParentTest`). `test0` reads the shared JAR file, accessing it and stabilizing the access timestamp before being captured by the file attributes later in `testTime`. The act of stabilizing is attributed to APFS access time semantics.

After the JUnit conversion, we began to observe the intermittent failures. As the default test execution order for JUnit is non-deterministic, `testTime` no longer runs after `entryParentTest`. Later in JDK-8380848, `testTime` is changed to generate its own JAR file altogether.

Currently, `testTime` captures file attributes on a freshly created JAR whose access time may not yet have been advanced by an initial read. Since `Files.copy(jar, dst, COPY_ATTRIBUTES)` captures the source file attributes before reading the source contents, the access time assertion may fail if the JAR is accessed after the initial file attributes were captured but before the copy operation. This manifests as a failure on the affected hosts when the differing access timestamps cross a second boundary, since the assertion is done with 1-second granularity.

To solve this, this PR reads the JAR file once before the attributes are captured. That way, the access time is stable before the copy operation captures the source attributes used by the assertion. I confirmed this fix on the affected hosts by using sleeps to widen the timing window and confirming that the copied attributes no longer show a shifted access time.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381984](https://bugs.openjdk.org/browse/JDK-8381984): Test jdk/nio/zipfs/ZipFSTester.java fails with mismatched timestamp (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30960/head:pull/30960` \
`$ git checkout pull/30960`

Update a local copy of the PR: \
`$ git checkout pull/30960` \
`$ git pull https://git.openjdk.org/jdk.git pull/30960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30960`

View PR using the GUI difftool: \
`$ git pr show -t 30960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30960.diff">https://git.openjdk.org/jdk/pull/30960.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30960#issuecomment-4331789771)
</details>
