### PR TITLE
8383462: G1: scan_root_regions should guarantee that the number of workers is nonzero

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1149,7 +1149,7 @@ bool G1ConcurrentMark::scan_root_regions(WorkerThreads* workers, bool concurrent
     // completing this work during GC.
     const uint num_workers = MIN2(num_remaining,
                                   _max_concurrent_workers);
-    assert(num_workers > 0, "no more remaining root regions to process");
+    guarantee(num_workers > 0, "no more remaining root regions to process");
 
     G1CMRootRegionScanTask task(this, concurrent);
     log_debug(gc, ergo)("Running %s using %u workers for %u work units.",


### PR DESCRIPTION
Hi all,

If the number of workers is zero in the dispatcher, it could become possible for the existing workers to stall indefinitely. There is already an assertion in place for this, which should be trivially turned into a guarantee in order to constrain release builds too.

Testing: GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383462](https://bugs.openjdk.org/browse/JDK-8383462): G1: scan_root_regions should guarantee that the number of workers is nonzero (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30962/head:pull/30962` \
`$ git checkout pull/30962`

Update a local copy of the PR: \
`$ git checkout pull/30962` \
`$ git pull https://git.openjdk.org/jdk.git pull/30962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30962`

View PR using the GUI difftool: \
`$ git pr show -t 30962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30962.diff">https://git.openjdk.org/jdk/pull/30962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30962#issuecomment-4332517275)
</details>
