### PR TITLE
8383173: Adjust CopyAVX3Threshold for AMD AVX512 targets

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1927,13 +1927,16 @@ void VM_Version::get_processor_features() {
   if (FLAG_IS_DEFAULT(UseCopySignIntrinsic)) {
       FLAG_SET_DEFAULT(UseCopySignIntrinsic, true);
   }
-  // CopyAVX3Threshold is the threshold at which 64-byte instructions are used
-  // for implementing the array copy and clear operations.
-  // The Intel platforms that supports the serialize instruction
-  // have improved implementation of 64-byte load/stores and so the default
-  // threshold is set to 0 for these platforms.
+  // CopyAVX3Threshold is the threshold at which 64-byte vector instructions
+  // are used for implementing the array copy, fill and clear operations.
+  // The Intel platforms that support the serialize instruction and the AMD
+  // platforms with native 512-bit datapath have improved implementation of
+  // 64-byte load/stores and so the default threshold is set to 0 for these
+  // platforms.
   if (FLAG_IS_DEFAULT(CopyAVX3Threshold)) {
     if (is_intel() && is_intel_server_family() && supports_serialize()) {
+      FLAG_SET_DEFAULT(CopyAVX3Threshold, 0);
+    } else if (is_amd() && is_amd_avx512_datapath_server_family()) {
       FLAG_SET_DEFAULT(CopyAVX3Threshold, 0);
     } else {
       FLAG_SET_DEFAULT(CopyAVX3Threshold, AVX3Threshold);

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -834,6 +834,7 @@ public:
   static bool is_P6()             { return cpu_family() >= 6; }
   static bool is_intel_server_family()    { return cpu_family() == 6 || cpu_family() == 18 || cpu_family() == 19; }
   static bool is_amd()            { assert_is_initialized(); return _cpuid_info.std_vendor_name_0 == 0x68747541; } // 'htuA'
+  static bool is_amd_avx512_datapath_server_family()  { return cpu_family() >= 0x1a; }
   static bool is_hygon()          { assert_is_initialized(); return _cpuid_info.std_vendor_name_0 == 0x6F677948; } // 'ogyH'
   static bool is_amd_family()     { return is_amd() || is_hygon(); }
   static bool is_intel()          { assert_is_initialized(); return _cpuid_info.std_vendor_name_0 == 0x756e6547; } // 'uneG'


### PR DESCRIPTION

After JDK-8380079 Copy/Fill/Clear memory stubs now use CopyAVX3Threhold to generate code using either 64 or 32 byte vector register.  On AMD targets supporting AVX512 ISA in Datapath this threshold value should be set to 0.

Following are the performance numbers of existing micros on AMD Turin at fixed frequency of 2.1GHz.

Benchmark | Length | Score CopyAVX3Threshold=4096   (ns/op) | Score CopyAVX3Threshold=0   (ns/op) | Gain%
-- | -- | -- | -- | --
ArrayCopyAligned.testByte | 1 | 2.12 | 2.03 | 4.06
ArrayCopyAligned.testByte | 3 | 2.10 | 2.05 | 2.57
ArrayCopyAligned.testByte | 5 | 2.06 | 2.12 | -2.92
ArrayCopyAligned.testByte | 10 | 2.13 | 2.10 | 1.17
ArrayCopyAligned.testByte | 20 | 2.09 | 2.10 | -0.72
ArrayCopyAligned.testByte | 70 | 3.97 | 3.90 | 1.72
ArrayCopyAligned.testByte | 150 | 4.65 | 4.61 | 0.88
ArrayCopyAligned.testByte | 300 | 7.30 | 6.97 | 4.54
ArrayCopyAligned.testByte | 600 | 11.19 | 8.69 | 22.32
ArrayCopyAligned.testByte | 1200 | 15.99 | 13.61 | 14.90
ArrayCopyAligned.testChar | 1 | 2.17 | 2.04 | 6.00
ArrayCopyAligned.testChar | 3 | 2.16 | 2.03 | 5.61
ArrayCopyAligned.testChar | 5 | 2.10 | 2.04 | 3.09
ArrayCopyAligned.testChar | 10 | 2.03 | 2.14 | -5.57
ArrayCopyAligned.testChar | 20 | 3.83 | 3.89 | -1.54
ArrayCopyAligned.testChar | 70 | 4.68 | 4.67 | 0.02
ArrayCopyAligned.testChar | 150 | 7.27 | 6.71 | 7.80
ArrayCopyAligned.testChar | 300 | 10.74 | 7.82 | 27.23
ArrayCopyAligned.testChar | 600 | 16.65 | 13.11 | 21.25
ArrayCopyAligned.testChar | 1200 | 27.35 | 27.01 | 1.24
ArrayCopyAligned.testInt | 1 | 3.40 | 3.37 | 1.03
ArrayCopyAligned.testInt | 3 | 3.39 | 3.38 | 0.30
ArrayCopyAligned.testInt | 5 | 3.43 | 3.36 | 1.90
ArrayCopyAligned.testInt | 10 | 3.80 | 3.83 | -0.82
ArrayCopyAligned.testInt | 20 | 3.81 | 3.90 | -2.28
ArrayCopyAligned.testInt | 70 | 8.11 | 6.90 | 14.88
ArrayCopyAligned.testInt | 150 | 9.64 | 9.25 | 4.11
ArrayCopyAligned.testInt | 300 | 17.64 | 16.04 | 9.07
ArrayCopyAligned.testInt | 600 | 30.98 | 39.10 | -26.24
ArrayCopyAligned.testInt | 1200 | 61.43 | 61.06 | 0.61
ArrayCopyAligned.testLong | 1 | 3.43 | 3.43 | 0.20
ArrayCopyAligned.testLong | 3 | 3.45 | 3.43 | 0.58
ArrayCopyAligned.testLong | 5 | 3.96 | 3.93 | 0.78
ArrayCopyAligned.testLong | 10 | 3.90 | 4.08 | -4.56
ArrayCopyAligned.testLong | 20 | 4.60 | 4.64 | -0.93
ArrayCopyAligned.testLong | 70 | 11.46 | 9.28 | 19.09
ArrayCopyAligned.testLong | 150 | 18.22 | 14.32 | 21.39
ArrayCopyAligned.testLong | 300 | 25.29 | 26.70 | -5.57
ArrayCopyAligned.testLong | 600 | 45.97 | 47.76 | -3.91
ArrayCopyAligned.testLong | 1200 | 81.19 | 78.23 | 3.65
ArrayCopyAlignedLarge.testByte | 100000 | 1813.24 | 1796.71 | 0.91
ArrayCopyAlignedLarge.testByte | 1000000 | 29895.35 | 29181.09 | 2.39
ArrayCopyAlignedLarge.testByte | 2000000 | 57863.46 | 65288.73 | -12.83
ArrayCopyAlignedLarge.testByte | 5000000 | 134219.22 | 134549.62 | -0.25
ArrayCopyAlignedLarge.testByte | 10000000 | 266908.97 | 269037.34 | -0.80
ArrayCopyUnalignedBoth.testByte | 1 | 2.12 | 2.08 | 2.26
ArrayCopyUnalignedBoth.testByte | 3 | 2.18 | 2.12 | 2.76
ArrayCopyUnalignedBoth.testByte | 5 | 2.10 | 2.12 | -0.81
ArrayCopyUnalignedBoth.testByte | 10 | 2.11 | 2.16 | -2.18
ArrayCopyUnalignedBoth.testByte | 20 | 2.10 | 2.12 | -0.67
ArrayCopyUnalignedBoth.testByte | 70 | 4.01 | 3.91 | 2.49
ArrayCopyUnalignedBoth.testByte | 150 | 4.67 | 4.61 | 1.43
ArrayCopyUnalignedBoth.testByte | 300 | 7.27 | 6.81 | 6.32
ArrayCopyUnalignedBoth.testByte | 600 | 15.76 | 9.04 | 42.64
ArrayCopyUnalignedBoth.testByte | 1200 | 16.38 | 13.96 | 14.78
ArrayCopyUnalignedBoth.testChar | 1 | 2.04 | 2.14 | -5.10
ArrayCopyUnalignedBoth.testChar | 3 | 2.08 | 2.14 | -3.28
ArrayCopyUnalignedBoth.testChar | 5 | 2.03 | 2.14 | -5.57
ArrayCopyUnalignedBoth.testChar | 10 | 2.03 | 2.16 | -6.40
ArrayCopyUnalignedBoth.testChar | 20 | 3.85 | 3.89 | -1.04
ArrayCopyUnalignedBoth.testChar | 70 | 4.63 | 4.66 | -0.56
ArrayCopyUnalignedBoth.testChar | 150 | 7.42 | 7.02 | 5.39
ArrayCopyUnalignedBoth.testChar | 300 | 10.78 | 9.03 | 16.21
ArrayCopyUnalignedBoth.testChar | 600 | 16.90 | 13.55 | 19.83
ArrayCopyUnalignedBoth.testChar | 1200 | 27.09 | 25.78 | 4.82
ArrayCopyUnalignedBoth.testInt | 1 | 3.48 | 3.50 | -0.46
ArrayCopyUnalignedBoth.testInt | 3 | 3.35 | 3.49 | -4.27
ArrayCopyUnalignedBoth.testInt | 5 | 3.38 | 3.39 | -0.53
ArrayCopyUnalignedBoth.testInt | 10 | 3.81 | 3.79 | 0.32
ArrayCopyUnalignedBoth.testInt | 20 | 3.92 | 3.94 | -0.56
ArrayCopyUnalignedBoth.testInt | 70 | 8.08 | 6.88 | 14.84
ArrayCopyUnalignedBoth.testInt | 150 | 11.44 | 8.85 | 22.65
ArrayCopyUnalignedBoth.testInt | 300 | 18.41 | 15.91 | 13.59
ArrayCopyUnalignedBoth.testInt | 600 | 31.12 | 34.97 | -12.38
ArrayCopyUnalignedBoth.testInt | 1200 | 61.55 | 61.65 | -0.15
ArrayCopyUnalignedBoth.testLong | 1 | 3.45 | 3.40 | 1.59
ArrayCopyUnalignedBoth.testLong | 3 | 3.40 | 3.34 | 1.53
ArrayCopyUnalignedBoth.testLong | 5 | 3.80 | 3.77 | 0.66
ArrayCopyUnalignedBoth.testLong | 10 | 3.85 | 4.12 | -6.96
ArrayCopyUnalignedBoth.testLong | 20 | 4.68 | 4.66 | 0.62
ArrayCopyUnalignedBoth.testLong | 70 | 13.46 | 9.37 | 30.40
ArrayCopyUnalignedBoth.testLong | 150 | 19.80 | 14.20 | 28.26
ArrayCopyUnalignedBoth.testLong | 300 | 26.66 | 25.65 | 3.78
ArrayCopyUnalignedBoth.testLong | 600 | 46.53 | 46.81 | -0.60
ArrayCopyUnalignedBoth.testLong | 1200 | 81.03 | 81.88 | -1.06
ArrayCopyUnalignedDst.testByte | 1 | 2.10 | 2.08 | 0.57
ArrayCopyUnalignedDst.testByte | 10 | 2.10 | 2.12 | -0.71
ArrayCopyUnalignedDst.testByte | 150 | 4.71 | 4.67 | 0.76
ArrayCopyUnalignedDst.testByte | 1200 | 16.24 | 13.45 | 17.17
ArrayCopyUnalignedDst.testChar | 1 | 2.05 | 2.03 | 0.59
ArrayCopyUnalignedDst.testChar | 10 | 2.04 | 2.06 | -0.93
ArrayCopyUnalignedDst.testChar | 150 | 7.64 | 7.66 | -0.28
ArrayCopyUnalignedDst.testChar | 1200 | 27.36 | 25.23 | 7.79
ArrayCopyUnalignedDst.testInt | 1 | 3.45 | 3.39 | 1.74
ArrayCopyUnalignedDst.testInt | 10 | 3.75 | 3.83 | -2.03
ArrayCopyUnalignedDst.testInt | 150 | 11.13 | 8.90 | 20.07
ArrayCopyUnalignedDst.testInt | 1200 | 70.83 | 69.98 | 1.20
ArrayCopyUnalignedDst.testLong | 1 | 3.43 | 3.43 | 0.03
ArrayCopyUnalignedDst.testLong | 10 | 3.92 | 3.90 | 0.54
ArrayCopyUnalignedDst.testLong | 150 | 19.20 | 15.03 | 21.73
ArrayCopyUnalignedDst.testLong | 1200 | 81.37 | 81.55 | -0.23
ArrayCopyUnalignedSrc.testByte | 1 | 2.03 | 2.11 | -3.74
ArrayCopyUnalignedSrc.testByte | 10 | 2.19 | 2.10 | 4.12
ArrayCopyUnalignedSrc.testByte | 150 | 4.69 | 4.64 | 1.13
ArrayCopyUnalignedSrc.testByte | 1200 | 16.83 | 13.67 | 18.76
ArrayCopyUnalignedSrc.testChar | 1 | 2.13 | 2.08 | 2.30
ArrayCopyUnalignedSrc.testChar | 10 | 2.09 | 2.08 | 0.34
ArrayCopyUnalignedSrc.testChar | 150 | 7.29 | 7.02 | 3.70
ArrayCopyUnalignedSrc.testChar | 1200 | 27.08 | 25.13 | 7.20
ArrayCopyUnalignedSrc.testInt | 1 | 3.37 | 3.37 | 0.09
ArrayCopyUnalignedSrc.testInt | 10 | 3.82 | 3.84 | -0.39
ArrayCopyUnalignedSrc.testInt | 150 | 15.82 | 9.17 | 42.02
ArrayCopyUnalignedSrc.testInt | 1200 | 67.75 | 60.27 | 11.03
ArrayCopyUnalignedSrc.testLong | 1 | 3.42 | 3.38 | 1.20
ArrayCopyUnalignedSrc.testLong | 10 | 3.83 | 3.90 | -1.62
ArrayCopyUnalignedSrc.testLong | 150 | 19.06 | 13.50 | 29.15
ArrayCopyUnalignedSrc.testLong | 1200 | 79.96 | 79.33 | 0.80



Kindly review and share your feeback.

Best Regards,
Jatin


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383173](https://bugs.openjdk.org/browse/JDK-8383173): Adjust CopyAVX3Threshold for AMD AVX512 targets (**Enhancement** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30963/head:pull/30963` \
`$ git checkout pull/30963`

Update a local copy of the PR: \
`$ git checkout pull/30963` \
`$ git pull https://git.openjdk.org/jdk.git pull/30963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30963`

View PR using the GUI difftool: \
`$ git pr show -t 30963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30963.diff">https://git.openjdk.org/jdk/pull/30963.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30963#issuecomment-4332882669)
</details>
