### PR TITLE
8381862: Refactor remaining TestNG tests under jdk/net/ExtendedSocketOption to use JUnit

### DIFF
--- a/test/jdk/jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
@@ -120,7 +120,7 @@ public class AsynchronousSocketChannelNAPITest {
                             initialRun = false;
                             originalClientID = clientID;
                         } else {
-                            assertEquals(clientID, originalClientID);
+                            assertEquals(originalClientID, clientID);
                         }
                     }
                 }

--- a/test/jdk/jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
@@ -28,13 +28,9 @@
  * @modules jdk.net
  * @summary Check ExtendedSocketOption NAPI_ID support for AsynchronousSocketChannel and
  *          AsynchronousServerSocketChannel
- * @run testng AsynchronousSocketChannelNAPITest
- * @run testng/othervm -Djava.net.preferIPv4Stack=true AsynchronousSocketChannelNAPITest
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
-
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -43,27 +39,26 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
-import java.util.Optional;
 
-import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static jdk.net.ExtendedSocketOptions.SO_INCOMING_NAPI_ID;
+import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AsynchronousSocketChannelNAPITest {
-    private InetAddress hostAddr;
+    private static InetAddress hostAddr;
     private static final Class<SocketException> SE = SocketException.class;
     private static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
     private static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
 
-    @BeforeTest
-    public void setup() throws IOException {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() throws IOException {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
         try (var sc = AsynchronousSocketChannel.open();
              var ssc = AsynchronousServerSocketChannel.open()) {
             if (!sc.supportedOptions().contains(SO_INCOMING_NAPI_ID)) {
@@ -73,7 +68,7 @@ public class AsynchronousSocketChannelNAPITest {
                 assertThrows(UOE, () -> ssc.getOption(SO_INCOMING_NAPI_ID));
                 assertThrows(UOE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, 42));
                 assertThrows(UOE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, null));
-                throw new SkipException("NAPI ID not supported on this system");
+                Assumptions.abort("NAPI ID not supported on this system");
             }
         }
         hostAddr = InetAddress.getLocalHost();
@@ -82,7 +77,7 @@ public class AsynchronousSocketChannelNAPITest {
     @Test
     public void testSetGetOptionSocketChannel() throws IOException {
         try (var sc = AsynchronousSocketChannel.open()) {
-            assertEquals((int) sc.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) sc.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> sc.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> sc.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -91,7 +86,7 @@ public class AsynchronousSocketChannelNAPITest {
     @Test
     public void testSetGetOptionServerSocketChannel() throws IOException {
         try (var ssc = AsynchronousServerSocketChannel.open()) {
-            assertEquals((int) ssc.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) ssc.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -108,13 +103,13 @@ public class AsynchronousSocketChannelNAPITest {
                 c.connect(ss.getLocalAddress()).get();
 
                 try (var s = ss.accept().get()) {
-                    assertEquals((int) s.getOption(SO_INCOMING_NAPI_ID), 0);
+                    assertEquals(0, (int) s.getOption(SO_INCOMING_NAPI_ID));
 
                     for (int i = 0; i < 10; i++) {
                         s.write(ByteBuffer.wrap("test".getBytes()));
 
                         socketID = s.getOption(SO_INCOMING_NAPI_ID);
-                        assertEquals(socketID, 0, "AsynchronousSocketChannel: Sender");
+                        assertEquals(0, socketID, "AsynchronousSocketChannel: Sender");
 
                         c.read(ByteBuffer.allocate(128)).get();
                         clientID = ss.getOption(SO_INCOMING_NAPI_ID);

--- a/test/jdk/jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java
@@ -27,13 +27,9 @@
  * @library /test/lib
  * @modules jdk.net
  * @summary Check ExtendedSocketOption NAPI_ID support for DatagramChannel
- * @run testng DatagramChannelNAPITest
- * @run testng/othervm -Djava.net.preferIPv4Stack=true DatagramChannelNAPITest
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
-
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -41,32 +37,32 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
-import java.util.Optional;
 
-import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import static jdk.net.ExtendedSocketOptions.SO_INCOMING_NAPI_ID;
+import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatagramChannelNAPITest {
-    private InetAddress hostAddr;
+    private static InetAddress hostAddr;
     private static final Class<SocketException> SE = SocketException.class;
     private static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
     private static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
 
-    @BeforeTest
-    public void setup() throws IOException {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() throws IOException {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
         try (var dc = DatagramChannel.open()) {
             if (!dc.supportedOptions().contains(SO_INCOMING_NAPI_ID)) {
                 assertThrows(UOE, () -> dc.getOption(SO_INCOMING_NAPI_ID));
                 assertThrows(UOE, () -> dc.setOption(SO_INCOMING_NAPI_ID, 42));
                 assertThrows(UOE, () -> dc.setOption(SO_INCOMING_NAPI_ID, null));
-                throw new SkipException("NAPI ID not supported on this system");
+                Assumptions.abort("NAPI ID not supported on this system");
             }
         }
         hostAddr = InetAddress.getLocalHost();
@@ -75,7 +71,7 @@ public class DatagramChannelNAPITest {
     @Test
     public void testSetGetOptionDatagramChannel() throws IOException {
         try (var dc = DatagramChannel.open()) {
-            assertEquals((int) dc.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) dc.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> dc.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> dc.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -95,7 +91,7 @@ public class DatagramChannelNAPITest {
                 for (int i = 0; i < 10; i++) {
                     s.send(ByteBuffer.wrap("test".getBytes()), addr);
                     senderID = s.getOption(SO_INCOMING_NAPI_ID);
-                    assertEquals(senderID, 0, "DatagramChannel: Sender");
+                    assertEquals(0, senderID, "DatagramChannel: Sender");
 
                     r.receive(ByteBuffer.allocate(128));
                     receiverID = r.getOption(SO_INCOMING_NAPI_ID);
@@ -103,9 +99,9 @@ public class DatagramChannelNAPITest {
                     // check ID remains consistent
                     if (initialRun) {
                         assertTrue(receiverID >= 0, "DatagramChannel: Receiver");
+                        initialRun = false;
                     } else {
                         assertEquals(receiverID, tempID);
-                        initialRun = false;
                     }
                     tempID = receiverID;
                 }

--- a/test/jdk/jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java
@@ -79,7 +79,7 @@ public class DatagramChannelNAPITest {
 
     @Test
     public void testDatagramChannel() throws Exception {
-        int senderID, receiverID, tempID = 0;
+        int senderID, receiverID, originalID = 0;
         boolean initialRun = true;
         try (var r = DatagramChannel.open()) {
             r.bind(new InetSocketAddress(hostAddr, 0));
@@ -100,10 +100,10 @@ public class DatagramChannelNAPITest {
                     if (initialRun) {
                         assertTrue(receiverID >= 0, "DatagramChannel: Receiver");
                         initialRun = false;
+                        originalID = receiverID;
                     } else {
-                        assertEquals(receiverID, tempID);
+                        assertEquals(originalID, receiverID);
                     }
-                    tempID = receiverID;
                 }
             }
         }

--- a/test/jdk/jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java
@@ -27,46 +27,42 @@
  * @library /test/lib
  * @modules jdk.net
  * @summary Check ExtendedSocketOption NAPI_ID support for DatagramSocket
- * @run testng DatagramSocketNAPITest
- * @run testng/othervm -Djava.net.preferIPv4Stack=true DatagramSocketNAPITest
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
 
 import java.io.IOException;
-import java.net.DatagramSocket;
 import java.net.DatagramPacket;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
-import java.util.Optional;
 
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertThrows;
 import static jdk.net.ExtendedSocketOptions.SO_INCOMING_NAPI_ID;
+import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatagramSocketNAPITest {
-    private InetAddress hostAddr;
+    private static InetAddress hostAddr;
     private static final Class<SocketException> SE = SocketException.class;
     private static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
     private static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
 
-    @BeforeTest
-    public void setup() throws IOException {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() throws IOException {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
         try (var ds = new DatagramSocket()) {
             if (!ds.supportedOptions().contains(SO_INCOMING_NAPI_ID)) {
                 assertThrows(UOE, () -> ds.getOption(SO_INCOMING_NAPI_ID));
                 assertThrows(UOE, () -> ds.setOption(SO_INCOMING_NAPI_ID, 42));
                 assertThrows(UOE, () -> ds.setOption(SO_INCOMING_NAPI_ID, null));
-                throw new SkipException("NAPI ID not supported on this system");
+                Assumptions.abort("NAPI ID not supported on this system");
             }
         }
         hostAddr = InetAddress.getLocalHost();
@@ -75,7 +71,7 @@ public class DatagramSocketNAPITest {
     @Test
     public void testSetGetOptionDatagramSocket() throws IOException {
         try (var ds = new DatagramSocket()) {
-            assertEquals((int) ds.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) ds.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> ds.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> ds.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -94,7 +90,7 @@ public class DatagramSocketNAPITest {
                 for (int i = 0; i < 10; i++) {
                     s.send(sendPkt);
                     senderID = s.getOption(SO_INCOMING_NAPI_ID);
-                    assertEquals(senderID, 0, "DatagramSocket: Sender");
+                    assertEquals(0, senderID, "DatagramSocket: Sender");
 
                     var receivePkt = new DatagramPacket(new byte[128], 128);
                     r.receive(receivePkt);
@@ -103,9 +99,9 @@ public class DatagramSocketNAPITest {
                     // check ID remains consistent
                     if (initialRun) {
                         assertTrue(receiverID >= 0, "DatagramSocket: Receiver");
+                        initialRun = false;
                     } else {
                         assertEquals(receiverID, tempID);
-                        initialRun = false;
                     }
                     tempID = receiverID;
                 }

--- a/test/jdk/jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java
@@ -79,7 +79,7 @@ public class DatagramSocketNAPITest {
 
     @Test
     public void testDatagramSocket() throws Exception {
-        int senderID, receiverID, tempID = 0;
+        int senderID, receiverID, originalID = 0;
         boolean initialRun = true;
         try (var r = new DatagramSocket(new InetSocketAddress(hostAddr, 0))) {
             var port = r.getLocalPort();
@@ -100,10 +100,10 @@ public class DatagramSocketNAPITest {
                     if (initialRun) {
                         assertTrue(receiverID >= 0, "DatagramSocket: Receiver");
                         initialRun = false;
+                        originalID = receiverID;
                     } else {
-                        assertEquals(receiverID, tempID);
+                        assertEquals(originalID, receiverID);
                     }
-                    tempID = receiverID;
                 }
             }
         }

--- a/test/jdk/jdk/net/ExtendedSocketOption/DontFragmentTest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DontFragmentTest.java
@@ -27,8 +27,8 @@
  * @modules jdk.net
  * @library /test/lib
  * @build jdk.test.lib.Platform jdk.test.lib.net.IPSupport
- * @run main/othervm DontFragmentTest ipv4
- * @run main/othervm DontFragmentTest ipv6
+ * @run main/othervm ${test.main.class} ipv4
+ * @run main/othervm ${test.main.class} ipv6
  */
 
 import java.io.IOException;

--- a/test/jdk/jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java
@@ -94,7 +94,7 @@ public class SocketChannelNAPITest {
 
     @Test
     public void testSocketChannel() throws Exception {
-        int sID, cID, tempID = 0;
+        int sID, cID, originalID = 0;
         boolean initialRun = true;
         try (var ss = ServerSocketChannel.open()) {
             ss.bind(new InetSocketAddress(hostAddr, 0));
@@ -117,10 +117,10 @@ public class SocketChannelNAPITest {
                         if (initialRun) {
                             assertTrue(cID >= 0, "SocketChannel: Receiver");
                             initialRun = false;
+                            originalID = cID;
                         } else {
-                            assertEquals(cID, tempID);
+                            assertEquals(originalID, cID);
                         }
-                        tempID = cID;
                     }
                 }
             }

--- a/test/jdk/jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java
@@ -28,13 +28,9 @@
  * @modules jdk.net
  * @summary Check ExtendedSocketOption NAPI_ID support for SocketChannel and
  *          ServerSocketChannel
- * @run testng SocketChannelNAPITest
- * @run testng/othervm -Djava.net.preferIPv4Stack=true SocketChannelNAPITest
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
-
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -43,27 +39,26 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.Optional;
 
-import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static jdk.net.ExtendedSocketOptions.SO_INCOMING_NAPI_ID;
+import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketChannelNAPITest {
-    private InetAddress hostAddr;
+    private static InetAddress hostAddr;
     private static final Class<SocketException> SE = SocketException.class;
     private static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
     private static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
 
-    @BeforeTest
-    public void setup() throws IOException {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() throws IOException {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
         try (var s = SocketChannel.open();
              var ssc = ServerSocketChannel.open()) {
             if (!s.supportedOptions().contains(SO_INCOMING_NAPI_ID)) {
@@ -73,7 +68,7 @@ public class SocketChannelNAPITest {
                 assertThrows(UOE, () -> ssc.getOption(SO_INCOMING_NAPI_ID));
                 assertThrows(UOE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, 42));
                 assertThrows(UOE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, null));
-                throw new SkipException("NAPI ID not supported on this system");
+                Assumptions.abort("NAPI ID not supported on this system");
             }
         }
         hostAddr = InetAddress.getLocalHost();
@@ -82,7 +77,7 @@ public class SocketChannelNAPITest {
     @Test
     public void testSetGetOptionSocketChannel() throws IOException {
         try (var sc = SocketChannel.open()) {
-            assertEquals((int) sc.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) sc.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> sc.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> sc.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -91,7 +86,7 @@ public class SocketChannelNAPITest {
     @Test
     public void testSetGetOptionServerSocketChannel() throws IOException {
         try (var ssc = ServerSocketChannel.open()) {
-            assertEquals((int) ssc.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) ssc.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> ssc.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -108,12 +103,12 @@ public class SocketChannelNAPITest {
                 c.connect(ss.getLocalAddress());
 
                 try (var s = ss.accept()) {
-                    assertEquals((int) ss.getOption(SO_INCOMING_NAPI_ID), 0);
+                    assertEquals(0, (int) ss.getOption(SO_INCOMING_NAPI_ID));
 
                     for (int i = 0; i < 10; i++) {
                         s.write(ByteBuffer.wrap("test".getBytes()));
                         sID = s.getOption(SO_INCOMING_NAPI_ID);
-                        assertEquals(sID, 0, "SocketChannel: Sender");
+                        assertEquals(0, sID, "SocketChannel: Sender");
 
                         c.read(ByteBuffer.allocate(128));
                         cID = c.getOption(SO_INCOMING_NAPI_ID);
@@ -121,9 +116,9 @@ public class SocketChannelNAPITest {
                         // check ID remains consistent
                         if (initialRun) {
                             assertTrue(cID >= 0, "SocketChannel: Receiver");
+                            initialRun = false;
                         } else {
                             assertEquals(cID, tempID);
-                            initialRun = false;
                         }
                         tempID = cID;
                     }

--- a/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
@@ -28,8 +28,8 @@
  * @modules jdk.net
  * @summary Check ExtendedSocketOption NAPI_ID support for Socket and
  *          ServerSocket
- * @run testng SocketNAPITest
- * @run testng/othervm -Djava.net.preferIPv4Stack=true SocketNAPITest
+ * @run junit SocketNAPITest
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true SocketNAPITest
  */
 
 import java.io.BufferedReader;
@@ -41,31 +41,26 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
-import java.util.Optional;
 
-import org.testng.SkipException;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
-import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static jdk.net.ExtendedSocketOptions.SO_INCOMING_NAPI_ID;
+import static jdk.test.lib.net.IPSupport.diagnoseConfigurationIssue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketNAPITest {
-    private InetAddress hostAddr;
+    private static InetAddress hostAddr;
     private static final Class<SocketException> SE = SocketException.class;
     private static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
     private static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
 
-    @BeforeTest
-    public void setup() throws IOException {
-        Optional<String> configurationIssue = diagnoseConfigurationIssue();
-        configurationIssue.map(SkipException::new).ifPresent(x -> {
-            throw x;
-        });
+    @BeforeAll
+    public static void setup() throws IOException {
+        diagnoseConfigurationIssue().ifPresent(Assumptions::abort);
         try (var s = new Socket();
              var ss = new ServerSocket()) {
             if (!s.supportedOptions().contains(SO_INCOMING_NAPI_ID)) {
@@ -75,7 +70,7 @@ public class SocketNAPITest {
                 assertThrows(UOE, () -> ss.getOption(SO_INCOMING_NAPI_ID));
                 assertThrows(UOE, () -> ss.setOption(SO_INCOMING_NAPI_ID, 42));
                 assertThrows(UOE, () -> ss.setOption(SO_INCOMING_NAPI_ID, null));
-                throw new SkipException("NAPI ID not supported on this system");
+                Assumptions.abort("NAPI ID not supported on this system");
             }
         }
         hostAddr = InetAddress.getLocalHost();
@@ -84,7 +79,7 @@ public class SocketNAPITest {
     @Test
     public void testSetGetOptionSocket() throws IOException {
         try (var s = new Socket()) {
-            assertEquals((int) s.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) s.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> s.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> s.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -93,7 +88,7 @@ public class SocketNAPITest {
     @Test
     public void testSetGetOptionServerSocket() throws IOException {
         try (var ss = new ServerSocket()) {
-            assertEquals((int) ss.getOption(SO_INCOMING_NAPI_ID), 0);
+            assertEquals(0, (int) ss.getOption(SO_INCOMING_NAPI_ID));
             assertThrows(SE, () -> ss.setOption(SO_INCOMING_NAPI_ID, 42));
             assertThrows(IAE, () -> ss.setOption(SO_INCOMING_NAPI_ID, null));
         }
@@ -103,7 +98,7 @@ public class SocketNAPITest {
     public void testSocket() throws Exception {
         int cID, sID;
         int temp_sID = 0, temp_cID = 0;
-        boolean initialRun = false;
+        boolean initialRun = true;
         // server socket
         try (var ss = new ServerSocket()) {
             ss.bind(new InetSocketAddress(hostAddr, 0));
@@ -138,10 +133,10 @@ public class SocketNAPITest {
                         if(initialRun) {
                             assertTrue(sID >= 0, "Socket: Server");
                             assertTrue(cID >= 0, "Socket: Client");
+                            initialRun = false;
                         } else {
                             assertEquals(temp_cID, cID);
                             assertEquals(temp_sID, sID);
-                            initialRun = false;
                         }
                         temp_sID = sID;
                         temp_cID = cID;

--- a/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
@@ -28,8 +28,8 @@
  * @modules jdk.net
  * @summary Check ExtendedSocketOption NAPI_ID support for Socket and
  *          ServerSocket
- * @run junit SocketNAPITest
- * @run junit/othervm -Djava.net.preferIPv4Stack=true SocketNAPITest
+ * @run junit ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true ${test.main.class}
  */
 
 import java.io.BufferedReader;

--- a/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
@@ -97,7 +97,7 @@ public class SocketNAPITest {
     @Test
     public void testSocket() throws Exception {
         int cID, sID;
-        int temp_sID = 0, temp_cID = 0;
+        int original_sID = 0, original_cID = 0;
         boolean initialRun = true;
         // server socket
         try (var ss = new ServerSocket()) {
@@ -134,12 +134,12 @@ public class SocketNAPITest {
                             assertTrue(sID >= 0, "Socket: Server");
                             assertTrue(cID >= 0, "Socket: Client");
                             initialRun = false;
+                            original_sID = sID;
+                            original_cID = cID;
                         } else {
-                            assertEquals(temp_cID, cID);
-                            assertEquals(temp_sID, sID);
+                            assertEquals(original_cID, cID);
+                            assertEquals(original_sID, sID);
                         }
-                        temp_sID = sID;
-                        temp_cID = cID;
                     }
                 }
             }

--- a/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/SocketNAPITest.java
@@ -130,7 +130,7 @@ public class SocketNAPITest {
                         // check ID remains consistent
                         sID = s.getOption(SO_INCOMING_NAPI_ID);
                         cID = c.getOption(SO_INCOMING_NAPI_ID);
-                        if(initialRun) {
+                        if (initialRun) {
                             assertTrue(sID >= 0, "Socket: Server");
                             assertTrue(cID >= 0, "Socket: Client");
                             initialRun = false;


### PR DESCRIPTION
Hi all,

I have migrated these classes to JUnit:
- `jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java`
- `jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java`
- `jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java`
- `jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java`
- `jdk/net/ExtendedSocketOption/SocketNAPITest.java`

The former `@BeforeTest` has been converted to a static `@BeforeAll`, as this better reflects the intended scope.

Additionally, I noticed an issue in the `testSocket` method where `initialRun` remained `true` for all tests (and conversely remained `false` in `SocketNAPITest`). 
I have corrected this so that the intended consistency check is properly exercised.
Please let me know if this change introduces any unintended side effects.

Thanks.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381862](https://bugs.openjdk.org/browse/JDK-8381862): Refactor remaining TestNG tests under jdk/net/ExtendedSocketOption to use JUnit (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30964/head:pull/30964` \
`$ git checkout pull/30964`

Update a local copy of the PR: \
`$ git checkout pull/30964` \
`$ git pull https://git.openjdk.org/jdk.git pull/30964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30964`

View PR using the GUI difftool: \
`$ git pr show -t 30964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30964.diff">https://git.openjdk.org/jdk/pull/30964.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30964#issuecomment-4333244436)
</details>
