### PR TITLE
8383485: [S390X] Add patching support for LIR_Assembler::leal

### DIFF
--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2891,17 +2891,13 @@ void LIR_Assembler::leal(LIR_Opr addr_opr, LIR_Opr dest, LIR_PatchCode patch_cod
   Register reg = dest->as_pointer_register();
   assert(addr->scale() == LIR_Address::times_1, "scaling unsupported");
 
-  if (addr->index()->is_illegal()) {
-    if (patch_code != lir_patch_none) {
+  if (addr->index()->is_illegal() && patch_code != lir_patch_none) {
       PatchingStub* patch = new PatchingStub(_masm, PatchingStub::access_field_id);
 
       // TODO: Use load_const_32to64 here by extending NativeMovRegMem to support both the instruction patterns.
       __ load_const(Z_R0_scratch, (intptr_t)0);
       __ z_agrk(reg, addr->base()->as_pointer_register(), Z_R0_scratch);
       patching_epilog(patch, patch_code, addr->base()->as_register(), info);
-    } else {
-      __ load_address(reg, as_Address(addr));
-    }
   } else {
     __ load_address(reg, as_Address(addr));
   }

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2892,12 +2892,12 @@ void LIR_Assembler::leal(LIR_Opr addr_opr, LIR_Opr dest, LIR_PatchCode patch_cod
   assert(addr->scale() == LIR_Address::times_1, "scaling unsupported");
 
   if (addr->index()->is_illegal() && patch_code != lir_patch_none) {
-      PatchingStub* patch = new PatchingStub(_masm, PatchingStub::access_field_id);
+    PatchingStub* patch = new PatchingStub(_masm, PatchingStub::access_field_id);
 
-      // TODO: Use load_const_32to64 here by extending NativeMovRegMem to support both the instruction patterns.
-      __ load_const(Z_R0_scratch, (intptr_t)0);
-      __ z_agrk(reg, addr->base()->as_pointer_register(), Z_R0_scratch);
-      patching_epilog(patch, patch_code, addr->base()->as_register(), info);
+    // TODO: Use load_const_32to64 here by extending NativeMovRegMem to support both instruction patterns.
+    __ load_const(Z_R0_scratch, (intptr_t)0);
+    __ z_agrk(reg, addr->base()->as_pointer_register(), Z_R0_scratch);
+    patching_epilog(patch, patch_code, addr->base()->as_register(), info);
   } else {
     __ load_address(reg, as_Address(addr));
   }

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2895,6 +2895,7 @@ void LIR_Assembler::leal(LIR_Opr addr_opr, LIR_Opr dest, LIR_PatchCode patch_cod
     if (patch_code != lir_patch_none) {
       PatchingStub* patch = new PatchingStub(_masm, PatchingStub::access_field_id);
 
+      // TODO: Use load_const_32to64 here by extending NativeMovRegMem to support both the instruction patterns.
       __ load_const(Z_R0_scratch, (intptr_t)0);
       __ z_agrk(reg, addr->base()->as_pointer_register(), Z_R0_scratch);
       patching_epilog(patch, patch_code, addr->base()->as_register(), info);
@@ -2902,7 +2903,7 @@ void LIR_Assembler::leal(LIR_Opr addr_opr, LIR_Opr dest, LIR_PatchCode patch_cod
       __ load_address(reg, as_Address(addr));
     }
   } else {
-      __ load_address(reg, as_Address(addr));
+    __ load_address(reg, as_Address(addr));
   }
 }
 

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2884,10 +2884,26 @@ void LIR_Assembler::on_spin_wait() {
 }
 
 void LIR_Assembler::leal(LIR_Opr addr_opr, LIR_Opr dest, LIR_PatchCode patch_code, CodeEmitInfo* info) {
-  assert(patch_code == lir_patch_none, "Patch code not supported");
+  assert(addr_opr->is_address(), "must be an address");
+  assert(dest->is_register(), "must be a register");
+
   LIR_Address* addr = addr_opr->as_address_ptr();
+  Register reg = dest->as_pointer_register();
   assert(addr->scale() == LIR_Address::times_1, "scaling unsupported");
-  __ load_address(dest->as_pointer_register(), as_Address(addr));
+
+  if (addr->index()->is_illegal()) {
+    if (patch_code != lir_patch_none) {
+      PatchingStub* patch = new PatchingStub(_masm, PatchingStub::access_field_id);
+
+      __ load_const(Z_R0_scratch, (intptr_t)0);
+      __ z_agrk(reg, addr->base()->as_pointer_register(), Z_R0_scratch);
+      patching_epilog(patch, patch_code, addr->base()->as_register(), info);
+    } else {
+      __ load_address(reg, as_Address(addr));
+    }
+  } else {
+      __ load_address(reg, as_Address(addr));
+  }
 }
 
 void LIR_Assembler::get_thread(LIR_Opr result_reg) {


### PR DESCRIPTION
The GC interface of zGC and ShenandoahGC use LIR_Assembler::leal with patching in C1 platform code. Patching for leal needs to be added before these ports.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383485](https://bugs.openjdk.org/browse/JDK-8383485): [S390X] Add patching support for LIR_Assembler::leal (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30968/head:pull/30968` \
`$ git checkout pull/30968`

Update a local copy of the PR: \
`$ git checkout pull/30968` \
`$ git pull https://git.openjdk.org/jdk.git pull/30968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30968`

View PR using the GUI difftool: \
`$ git pr show -t 30968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30968.diff">https://git.openjdk.org/jdk/pull/30968.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30968#issuecomment-4334153168)
</details>
