### PR TITLE
8383515: Add guarantees to disallow running WorkerTasks with zero workers

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1149,7 +1149,6 @@ bool G1ConcurrentMark::scan_root_regions(WorkerThreads* workers, bool concurrent
     // completing this work during GC.
     const uint num_workers = MIN2(num_remaining,
                                   _max_concurrent_workers);
-    guarantee(num_workers > 0, "no more remaining root regions to process");
 
     G1CMRootRegionScanTask task(this, concurrent);
     log_debug(gc, ergo)("Running %s using %u workers for %u work units.",

--- a/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
@@ -101,8 +101,6 @@ void G1ConcurrentRefineThreadControl::activate() {
 }
 
 void G1ConcurrentRefineThreadControl::run_task(WorkerTask* task, uint num_workers) {
-  assert(num_workers >= 1, "must be");
-
   WithActiveWorkers w(_workers, num_workers);
   _workers->run_task(task);
 }

--- a/src/hotspot/share/gc/shared/workerThread.cpp
+++ b/src/hotspot/share/gc/shared/workerThread.cpp
@@ -39,6 +39,7 @@ WorkerTaskDispatcher::WorkerTaskDispatcher() :
     _end_semaphore() {}
 
 void WorkerTaskDispatcher::coordinator_distribute_task(WorkerTask* task, uint num_workers) {
+  guarantee(num_workers > 0, "must use at least one worker, deadlocks otherwise");
   // No workers are allowed to read the state variables until they have been signaled.
   _task = task;
   _not_finished.store_relaxed(num_workers);
@@ -129,9 +130,9 @@ WorkerThread* WorkerThreads::create_worker(uint name_suffix) {
 }
 
 uint WorkerThreads::set_active_workers(uint num_workers) {
-  assert(num_workers > 0 && num_workers <= _max_workers,
-         "Invalid number of active workers %u (should be 1-%u)",
-         num_workers, _max_workers);
+  guarantee(num_workers > 0 && num_workers <= _max_workers,
+            "Invalid number of active workers %u (should be 1-%u)",
+            num_workers, _max_workers);
 
   while (_created_workers < num_workers) {
     WorkerThread* const worker = create_worker(_created_workers);

--- a/src/hotspot/share/gc/shared/workerThread.cpp
+++ b/src/hotspot/share/gc/shared/workerThread.cpp
@@ -40,6 +40,7 @@ WorkerTaskDispatcher::WorkerTaskDispatcher() :
 
 void WorkerTaskDispatcher::coordinator_distribute_task(WorkerTask* task, uint num_workers) {
   guarantee(num_workers > 0, "must use at least one worker, deadlocks otherwise");
+
   // No workers are allowed to read the state variables until they have been signaled.
   _task = task;
   _not_finished.store_relaxed(num_workers);


### PR DESCRIPTION
Hi all,

  please review this enhancement that adds guarantee()s to the WorkerTask API so that trying to set or use zero worker threads fails immediately, also in release build. That would also have helped in the investigation for https://bugs.openjdk.org/browse/JDK-8381941.

Also removes some redundant similar asserts/guarantees.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383515](https://bugs.openjdk.org/browse/JDK-8383515): Add guarantees to disallow running WorkerTasks with zero workers (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30970/head:pull/30970` \
`$ git checkout pull/30970`

Update a local copy of the PR: \
`$ git checkout pull/30970` \
`$ git pull https://git.openjdk.org/jdk.git pull/30970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30970`

View PR using the GUI difftool: \
`$ git pr show -t 30970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30970.diff">https://git.openjdk.org/jdk/pull/30970.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30970#issuecomment-4335605450)
</details>
