### PR TITLE
8383541: Safefetch should return the error value when accessing pages protected with PAGE_GUARD on windows-aarch64

### DIFF
--- a/src/hotspot/os/windows/safefetch_static_windows.cpp
+++ b/src/hotspot/os/windows/safefetch_static_windows.cpp
@@ -46,7 +46,8 @@ extern "C" char _SafeFetchN_fault[];
 
 bool handle_safefetch(int exception_code, address pc, void* context) {
   CONTEXT* ctx = (CONTEXT*)context;
-  if (exception_code == EXCEPTION_ACCESS_VIOLATION && ctx != nullptr) {
+  if ((exception_code == EXCEPTION_ACCESS_VIOLATION ||
+       exception_code == EXCEPTION_GUARD_PAGE) && ctx != nullptr) {
     if (pc == (address)_SafeFetch32_fault) {
       os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
       return true;

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -28,6 +28,7 @@
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "concurrentTestRunner.inline.hpp"
 #include "unittest.hpp"
 
@@ -838,6 +839,38 @@ TEST_VM(os_windows, reserve_memory_special_concurrent) {
   ReserveMemorySpecialRunnable runnable;
   ConcurrentTestRunner testRunner(&runnable, 30, 15000);
   testRunner.run();
+}
+
+TEST_VM(os_windows, SafeFetchN_with_page_guard_protection) {
+  const DWORD page_size = (DWORD)os::vm_page_size();
+
+  void* p = ::VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  ASSERT_NE(p, nullptr) << "VirtualAlloc failed";
+
+  DWORD old_protect;
+  BOOL res = ::VirtualProtect(p, page_size, PAGE_READWRITE | PAGE_GUARD, &old_protect);
+  ASSERT_TRUE(res) << "VirtualProtect failed";
+
+  intptr_t result = SafeFetchN((intptr_t*)p, -1);
+  ASSERT_EQ((intptr_t)-1, result) << "SafeFetchN should return errValue for a page protected with PAGE_GUARD";
+
+  ::VirtualFree(p, 0, MEM_RELEASE);
+}
+
+TEST_VM(os_windows, SafeFetch32_with_page_guard_protection) {
+  const DWORD page_size = (DWORD)os::vm_page_size();
+
+  void* p = ::VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  ASSERT_NE(p, nullptr) << "VirtualAlloc failed";
+
+  DWORD old_protect;
+  BOOL res = ::VirtualProtect(p, page_size, PAGE_READWRITE | PAGE_GUARD, &old_protect);
+  ASSERT_TRUE(res) << "VirtualProtect failed";
+
+  int result = SafeFetch32((int*)p, -1);
+  ASSERT_EQ(-1, result) << "SafeFetch32 should return errValue for a page protected with PAGE_GUARD";
+
+  ::VirtualFree(p, 0, MEM_RELEASE);
 }
 
 #endif


### PR DESCRIPTION
Safefetch should detect accesses to pages protected with PAGE_GUARD on Windows AArch64. This affects Windows AArch64 since it does not use SEH like Windows x64. The new Windows gtests pass on both Windows x64 and Windows AArch64 builds.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383541](https://bugs.openjdk.org/browse/JDK-8383541): Safefetch should return the error value when accessing pages protected with PAGE_GUARD on windows-aarch64 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mat Carter](https://openjdk.org/census#macarte) (@macarte - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30973/head:pull/30973` \
`$ git checkout pull/30973`

Update a local copy of the PR: \
`$ git checkout pull/30973` \
`$ git pull https://git.openjdk.org/jdk.git pull/30973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30973`

View PR using the GUI difftool: \
`$ git pr show -t 30973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30973.diff">https://git.openjdk.org/jdk/pull/30973.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30973#issuecomment-4338587852)
</details>
