### PR TITLE
8373065: Test sun/awt/image/bug8038000.java failed: Pixels differ

### DIFF
--- a/src/java.desktop/share/native/common/awt/medialib/mlib_ImageCreate.c
+++ b/src/java.desktop/share/native/common/awt/medialib/mlib_ImageCreate.c
@@ -116,6 +116,7 @@
  *      mlib_ImageSetFormat() sets new value for the image format
  */
 
+#include <string.h>
 #include <stdlib.h>
 #include "mlib_image.h"
 #include "mlib_ImageRowTable.h"
@@ -313,10 +314,12 @@ mlib_image* mlib_ImageCreate(mlib_type type,
       return NULL;
   }
 
+
   data = mlib_malloc(wb * height);
   if (data == NULL) {
     return NULL;
   }
+  memset(data, 0, wb * height);
 
   image = (mlib_image *)mlib_malloc(sizeof(mlib_image));
   if (image == NULL) {

--- a/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
+++ b/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
@@ -1133,12 +1133,14 @@ fprintf(stderr,"Flags   : %d\n",dst->flags);
     {
         unsigned char *cP = (unsigned char *)mlib_ImageGetData(dst);
 
-        memset(cP, 0, mlib_ImageGetWidth(dst)*mlib_ImageGetHeight(dst));
+        if (ddata == NULL) { // zero medialib allocated memory
+            memset(cP, 0, mlib_ImageGetWidth(dst) * mlib_ImageGetHeight(dst) * mlib_ImageGetChannels(dst));
+        }
     }
 
     /* Perform the transformation */
-    if ((status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
-                                  MLIB_EDGE_SRC_EXTEND) != MLIB_SUCCESS))
+    status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter, MLIB_EDGE_SRC_EXTEND);
+    if (status != MLIB_SUCCESS)
     {
         printMedialibError(status);
         /* REMIND: Free the regions */

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -463,7 +463,6 @@ java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-a
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64
 sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8301177 linux-x64
-sun/awt/image/bug8038000.java 8373065 generic-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64

--- a/test/jdk/sun/awt/image/bug8038000.java
+++ b/test/jdk/sun/awt/image/bug8038000.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug     8038000 8047066
+ * @bug     8038000 8047066 8373065
  *
  * @summary Verifies that we could create different type of Rasters with height 1
  * and strideline which exceeds raster width.


### PR DESCRIPTION
The previous change results in a larger destination raster. 
AffineTransformOp does not always have a mapped value to write into every destination pixel.
The native memory allocated by medialib is not zeroed out and the code in the JDK bridge to it only zeroed out the first w*h bytes, not all channels.

So sometimes, you'd have residual data. The fix is to zero it out. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8373065](https://bugs.openjdk.org/browse/JDK-8373065): Test sun/awt/image/bug8038000.java failed: Pixels differ (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30976/head:pull/30976` \
`$ git checkout pull/30976`

Update a local copy of the PR: \
`$ git checkout pull/30976` \
`$ git pull https://git.openjdk.org/jdk.git pull/30976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30976`

View PR using the GUI difftool: \
`$ git pr show -t 30976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30976.diff">https://git.openjdk.org/jdk/pull/30976.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30976#issuecomment-4338862255)
</details>
