### PR TITLE
8383545: Gcc warning in bsmAttribute.hpp: comparison is always true

### DIFF
--- a/src/hotspot/share/oops/bsmAttribute.hpp
+++ b/src/hotspot/share/oops/bsmAttribute.hpp
@@ -73,7 +73,7 @@ public:
   }
 
   void set_argument(u2 index, u2 value) {
-    assert(index >= 0 && index < argument_count(), "invariant");
+    assert(index < argument_count(), "invariant");
     argument_indexes()[index] = value;
   }
 


### PR DESCRIPTION
Please review this trivial change.

I use `gcc --save-temps` to see the output of the preprocessor and assembly code. With my gcc (10.3.0), I get a warning about the `index >= 0` comparison when `index` is an unsigned type.

I don't know why this warning is given only with `--save-temps`, but it seems that the `index >= 0` can be safely deleted.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383545](https://bugs.openjdk.org/browse/JDK-8383545): Gcc warning in bsmAttribute.hpp: comparison is always true (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30977/head:pull/30977` \
`$ git checkout pull/30977`

Update a local copy of the PR: \
`$ git checkout pull/30977` \
`$ git pull https://git.openjdk.org/jdk.git pull/30977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30977`

View PR using the GUI difftool: \
`$ git pr show -t 30977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30977.diff">https://git.openjdk.org/jdk/pull/30977.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30977#issuecomment-4339214274)
</details>
