### PR TITLE
8383546: HeapReserver::Instance::reserve_heap() breaks 32-bit build

### DIFF
--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -656,11 +656,12 @@ ReservedHeapSpace HeapReserver::Instance::reserve_compressed_oops_heap(const siz
 #endif // _LP64
 
 ReservedHeapSpace HeapReserver::Instance::reserve_heap(size_t size, size_t alignment, size_t page_size) {
-  if (UseCompressedOops) {
 #ifdef _LP64
+  if (UseCompressedOops) {
     return reserve_compressed_oops_heap(size, alignment, page_size);
+  } else
 #endif
-  } else {
+  {
     return reserve_uncompressed_oops_heap(size, alignment, page_size);
   }
 }


### PR DESCRIPTION
Please review this trivial clean up:

I found this problem when experimenting with new handling of JVM flags (such as `-XX:+UseCompressedOops`). On 32-bit platforms, not every path of the function returns a value.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383546](https://bugs.openjdk.org/browse/JDK-8383546): HeapReserver::Instance::reserve_heap() breaks 32-bit build (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30978/head:pull/30978` \
`$ git checkout pull/30978`

Update a local copy of the PR: \
`$ git checkout pull/30978` \
`$ git pull https://git.openjdk.org/jdk.git pull/30978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30978`

View PR using the GUI difftool: \
`$ git pr show -t 30978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30978.diff">https://git.openjdk.org/jdk/pull/30978.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30978#issuecomment-4339311389)
</details>
