### PR TITLE
8383550: AsyncExceptionHandshakeClosure::do_thread() should not be passed nullptr

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -378,7 +378,7 @@ void Handshake::execute(HandshakeClosure* hs_cl, oop vthread) {
     execute(hs_cl, &tlh, target);
     assert(target->threadObj() == java_lang_VirtualThread::carrier_thread(vth()), "");
   } else {
-    // unmounted vthread, execute closure with the current thread
+    // unmounted vthread, execute closure with the continuation
     hs_cl->do_thread(nullptr);
   }
 }

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -378,7 +378,7 @@ void Handshake::execute(HandshakeClosure* hs_cl, oop vthread) {
     execute(hs_cl, &tlh, target);
     assert(target->threadObj() == java_lang_VirtualThread::carrier_thread(vth()), "");
   } else {
-    // unmounted vthread, execute closure with the continuation
+    // unmounted vthread, execute closure with the current thread
     hs_cl->do_thread(nullptr);
   }
 }

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -91,17 +91,9 @@ class AsyncExceptionHandshakeClosure : public AsyncHandshakeClosure {
   }
 
   void do_thread(Thread* thr) {
-    assert(thr != nullptr, "must be");
-
     PRAGMA_DIAG_PUSH
     PRAGMA_NONNULL_IGNORED
-    // Suppress GCC warning for nonnull.
-    // GCC (16.0.1 at least) reports "thr" might be nullptr, and it could be
-    // a potential bug to access class member. But it should be happened because
-    // we've already checked it with assert() in above.
-    //
-    // Assert for nullptr and PRAGMA is set before JavaThread::cast() because
-    // cast() would pass thr->is_Java_thread() to assert().
+    // Suppress GCC warning for nonnull as it doesn't recognize that `thr` is always the current thread.
     JavaThread* self = JavaThread::cast(thr);
     assert(self == JavaThread::current(), "must be");
 

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -91,10 +91,22 @@ class AsyncExceptionHandshakeClosure : public AsyncHandshakeClosure {
   }
 
   void do_thread(Thread* thr) {
+    assert(thr != nullptr, "must be");
+
+    PRAGMA_DIAG_PUSH
+    PRAGMA_NONNULL_IGNORED
+    // Suppress GCC warning for nonnull.
+    // GCC (16.0.1 at least) reports "thr" might be nullptr, and it could be
+    // a potential bug to access class member. But it should be happened because
+    // we've already checked it with assert() in above.
+    //
+    // Assert for nullptr and PRAGMA is set before JavaThread::cast() because
+    // cast() would pass thr->is_Java_thread() to assert().
     JavaThread* self = JavaThread::cast(thr);
     assert(self == JavaThread::current(), "must be");
 
     self->handle_async_exception(exception());
+    PRAGMA_DIAG_POP
   }
   oop exception() {
     assert(!_exception.is_empty(), "invariant");


### PR DESCRIPTION
I saw following error when I tried to biuld OpenJDK with gcc-c++-16.0.1-0.10.fc44.x86_64 on Fedora 44:

```
In file included from /home/yasuenag/github-forked/jdk/src/hotspot/share/runtime/objectMonitor.inline.hpp:36,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp:54,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp:32,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp:36,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/gc/shared/barrierSetConfig.inline.hpp:39,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/oops/access.inline.hpp:31,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/classfile/javaClasses.inline.hpp:31,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/precompiled/precompiled.hpp:32:
In member function ‘virtual void AsyncExceptionHandshakeClosure::do_thread(Thread*)’,
    inlined from ‘static void Handshake::execute(HandshakeClosure*, oop)’ at /home/yasuenag/github-forked/jdk/src/hotspot/share/runtime/handshake.cpp:382:21:
/home/yasuenag/github-forked/jdk/src/hotspot/share/runtime/javaThread.inline.hpp:97:33: error: ‘this’ pointer is null [-Werror=nonnull]
   97 | self->handle_async_exception(exception());
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
In file included from /home/yasuenag/github-forked/jdk/src/hotspot/share/oops/instanceKlass.hpp:36,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/classfile/javaClasses.hpp:29,
                 from /home/yasuenag/github-forked/jdk/src/hotspot/share/classfile/javaClasses.inline.hpp:28:
/home/yasuenag/github-forked/jdk/src/hotspot/share/runtime/javaThread.hpp: In static member function ‘static void Handshake::execute(HandshakeClosure*, oop)’:
/home/yasuenag/github-forked/jdk/src/hotspot/share/runtime/javaThread.hpp:239:8: note: in a call to non-static member function ‘void JavaThread::handle_async_exception(oop)’
  239 | void handle_async_exception(oop java_throwable);
      | ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

In `AsyncExceptionHandshakeClosure::do_thread()`, the argument shouldn't be null, so I added `assert()` to check nonnull. However it is not enough to suppress nonnull warning, thus I added pragma for it.

According to the comment in `Handshake::execute()`, call `do_thread()` with current thread for unmounted virtual thread, but `nullptr` in the argument means to process with continuation in `GetThreadSnapshotHandshakeClosure::do_thread()`. Thus I also fixed the comment in `Handshake::execute()`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383550](https://bugs.openjdk.org/browse/JDK-8383550): AsyncExceptionHandshakeClosure::do_thread() should not be passed nullptr (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30980/head:pull/30980` \
`$ git checkout pull/30980`

Update a local copy of the PR: \
`$ git checkout pull/30980` \
`$ git pull https://git.openjdk.org/jdk.git pull/30980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30980`

View PR using the GUI difftool: \
`$ git pr show -t 30980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30980.diff">https://git.openjdk.org/jdk/pull/30980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30980#issuecomment-4342221327)
</details>
