### PR TITLE
8177841: Some java/awt/Robot tests can be improved

### DIFF
--- a/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
+++ b/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,13 @@ import javax.swing.UIManager;
  * @test
  * @key headful
  * @bug 8073320
- * @summary  Windows HiDPI support
- * @author Alexander Scherbatiy
+ * @summary Windows HiDPI support (multi-scale)
  * @requires (os.family == "windows")
- * @run main/othervm -Dsun.java2d.win.uiScale=2 HiDPIRobotMouseClick
+ * @run main/othervm -Dsun.java2d.win.uiScale=1   HiDPIRobotMouseClick
+ * @run main/othervm -Dsun.java2d.win.uiScale=1.25 HiDPIRobotMouseClick
+ * @run main/othervm -Dsun.java2d.win.uiScale=1.5 HiDPIRobotMouseClick
+ * @run main/othervm -Dsun.java2d.win.uiScale=2   HiDPIRobotMouseClick
+ * @run main/othervm -Dsun.java2d.win.uiScale=2.5 HiDPIRobotMouseClick
  */
 
 public class HiDPIRobotMouseClick {
@@ -46,9 +49,12 @@ public class HiDPIRobotMouseClick {
 
     public static void main(String[] args) throws Exception {
 
+        String scale = System.getProperty("sun.java2d.win.uiScale", "default");
+        System.out.println("Running with DPI scale: " + scale);
+
         try {
             UIManager.setLookAndFeel(
-                    "com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+                "com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
         } catch (Exception e) {
             return;
         }
@@ -58,7 +64,6 @@ public class HiDPIRobotMouseClick {
         frame.setUndecorated(true);
 
         frame.addMouseListener(new MouseAdapter() {
-
             @Override
             public void mouseClicked(MouseEvent e) {
                 mouseX = e.getXOnScreen();
@@ -79,12 +84,17 @@ public class HiDPIRobotMouseClick {
         int y = (int) rect.getCenterY();
 
         robot.mouseMove(x, y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
 
         if (x != mouseX || y != mouseY) {
-            throw new RuntimeException("Wrong mouse click point!");
+            throw new RuntimeException(
+                "Wrong mouse click point at scale " + scale +
+                "! Expected: (" + x + "," + y +
+                ") Got: (" + mouseX + "," + mouseY + ")");
         }
+
+        System.out.println("PASS at scale: " + scale);
     }
 }

--- a/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
+++ b/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
@@ -90,17 +90,8 @@ public class HiDPIRobotMouseClick {
 
         if (x != mouseX || y != mouseY) {
             throw new RuntimeException(
-                "Wrong mouse click point at scale "
-                + scale
-                +"! Expected: ("
-                + x
-                + ","
-                + y
-                +") Got: ("
-                + mouseX
-                + ","
-                + mouseY
-                + ")");
+                "Wrong mouse click point at scale %s! Expected: (%d,%d) Got: (%d,%d)"
+                .formatted(scale, x, y, mouseX, mouseY));
         }
 
         System.out.println("PASS at scale: " + scale);

--- a/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
+++ b/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
@@ -91,15 +91,15 @@ public class HiDPIRobotMouseClick {
         if (x != mouseX || y != mouseY) {
             throw new RuntimeException(
                 "Wrong mouse click point at scale "
-                + scale 
-                +"! Expected: (" 
-                + x 
-                + "," 
-                + y 
-                +") Got: (" 
-                + mouseX 
-                + "," 
-                + mouseY 
+                + scale
+                +"! Expected: ("
+                + x
+                + ","
+                + y
+                +") Got: ("
+                + mouseX
+                + ","
+                + mouseY
                 + ")");
         }
 

--- a/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
+++ b/test/jdk/java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java
@@ -90,9 +90,17 @@ public class HiDPIRobotMouseClick {
 
         if (x != mouseX || y != mouseY) {
             throw new RuntimeException(
-                "Wrong mouse click point at scale " + scale +
-                "! Expected: (" + x + "," + y +
-                ") Got: (" + mouseX + "," + mouseY + ")");
+                "Wrong mouse click point at scale "
+                + scale 
+                +"! Expected: (" 
+                + x 
+                + "," 
+                + y 
+                +") Got: (" 
+                + mouseX 
+                + "," 
+                + mouseY 
+                + ")");
         }
 
         System.out.println("PASS at scale: " + scale);


### PR DESCRIPTION
This is test enhancement of 'java/awt/Robot/HiDPIMouseClick/HiDPIRobotMouseClick.java'.

Modified it to test on multiple uiScale modes.

Tested on windows(Passed)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8177841](https://bugs.openjdk.org/browse/JDK-8177841): Some java/awt/Robot tests can be improved (**Bug** - P4)


### Reviewers
 * [Manukumar V S](https://openjdk.org/census#mvs) (@manukumarvs - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30981/head:pull/30981` \
`$ git checkout pull/30981`

Update a local copy of the PR: \
`$ git checkout pull/30981` \
`$ git pull https://git.openjdk.org/jdk.git pull/30981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30981`

View PR using the GUI difftool: \
`$ git pr show -t 30981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30981.diff">https://git.openjdk.org/jdk/pull/30981.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30981#issuecomment-4341231002)
</details>
