### PR TITLE
8343659: [IR Framework] Add @Skip and @SkipIR annotation to completely disable tests or individual IR rules instead of commenting them out

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/cmove/TestScalarConditionalMoveCmpObj.java
+++ b/test/hotspot/jtreg/compiler/c2/cmove/TestScalarConditionalMoveCmpObj.java
@@ -120,14 +120,14 @@ public class TestScalarConditionalMoveCmpObj {
     }
 
     // So far, CMoveL is not guaranteed to be generated, so @IR not verify CMOVE_L.
-    // TODO: enable CMOVE_L verification when it's guaranteed to generate CMOVE_L.
     //
     @Test
     @IR(failOn = {IRNode.STORE_VECTOR})
-    // @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_P, ">0"},
-    //     applyIf = {"UseCompressedOops", "false"})
-    // @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_N, ">0"},
-    //     applyIf = {"UseCompressedOops", "true"})
+    @SkipIR({2, 3}) // TODO: enable CMOVE_L verification when it's guaranteed to generate CMOVE_L.
+    @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_P, ">0"},
+        applyIf = {"UseCompressedOops", "false"})
+    @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_N, ">0"},
+        applyIf = {"UseCompressedOops", "true"})
     private static void testCMoveOEQforL(Object[] a, Object[] b, long[] c, long[] d, long[] r, long[] r2) {
         for (int i = 0; i < a.length; i++) {
             long cc = c[i];
@@ -139,10 +139,11 @@ public class TestScalarConditionalMoveCmpObj {
 
     @Test
     @IR(failOn = {IRNode.STORE_VECTOR})
-    // @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_P, ">0"},
-    //     applyIf = {"UseCompressedOops", "false"})
-    // @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_N, ">0"},
-    //     applyIf = {"UseCompressedOops", "true"})
+    @SkipIR({2, 3})
+    @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_P, ">0"},
+        applyIf = {"UseCompressedOops", "false"})
+    @IR(counts = {IRNode.CMOVE_L, ">0", IRNode.CMP_N, ">0"},
+        applyIf = {"UseCompressedOops", "true"})
     private static void testCMoveONEforL(Object[] a, Object[] b, long[] c, long[] d, long[] r, long[] r2) {
         for (int i = 0; i < a.length; i++) {
             long cc = c[i];

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -596,7 +596,8 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     // FAILS: adr is CastX2P(dest + 8 * (i + int_con))
     // See: JDK-8331576
     public static void testOffHeapLong1a(long dest, long[] src) {
@@ -607,7 +608,8 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     // FAILS: adr is CastX2P(dest + 8L * (i + int_con))
     // See: JDK-8331576
     public static void testOffHeapLong1b(long dest, long[] src) {
@@ -624,7 +626,8 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     // FAILS: adr is CastX2P
     // See: JDK-8331576
     public static void testOffHeapLong2a(long dest, long[] src) {
@@ -635,7 +638,8 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     // FAILS: adr is CastX2P
     // See: JDK-8331576
     public static void testOffHeapLong2b(long dest, long[] src) {
@@ -652,7 +656,8 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     // FAILS: adr is CastX2P
     // See: JDK-8331576
     public static void testOffHeapLong3a(long dest, long[] src) {
@@ -663,7 +668,8 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     // FAILS: adr is CastX2P
     // See: JDK-8331576
     public static void testOffHeapLong3b(long dest, long[] src) {
@@ -680,8 +686,9 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
-    //     applyIf = {"AlignVector", "false"})
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
+        applyIf = {"AlignVector", "false"})
     // FAILS: adr is CastX2P
     // See: JDK-8331576
     // AlignVector cannot guarantee that invar is aligned.
@@ -693,8 +700,9 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, "=0", IRNode.STORE_VECTOR, "=0" }) // temporary
-    // @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
-    //     applyIf = {"AlignVector", "false"})
+    @SkipIR(2)
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
+        applyIf = {"AlignVector", "false"})
     // FAILS: adr is CastX2P
     // See: JDK-8331576
     // AlignVector cannot guarantee that invar is aligned.

--- a/test/hotspot/jtreg/compiler/igvn/IntegerDivValueTests.java
+++ b/test/hotspot/jtreg/compiler/igvn/IntegerDivValueTests.java
@@ -282,7 +282,8 @@ public class IntegerDivValueTests {
     private static final long LONG_CONST_2 = LONGS.next();
 
     @Test
-    //@IR(failOn = {IRNode.DIV, IRNode.URSHIFT, IRNode.RSHIFT, IRNode.MUL, IRNode.ADD, IRNode.SUB, IRNode.AND})
+    @SkipIR(1)
+    @IR(failOn = {IRNode.DIV, IRNode.URSHIFT, IRNode.RSHIFT, IRNode.MUL, IRNode.ADD, IRNode.SUB, IRNode.AND})
     // This results in a series of nodes due to DivLNode::Ideal and in particular transform_long_divide, which operates on non-constant divisors.
     // transform_long_divide splits up the division into multiple other nodes, such as MulHiLNode, which does not have a good Value() implemantion.
     // When JDK-8366815 is fixed, these rules should be reenabled
@@ -300,7 +301,8 @@ public class IntegerDivValueTests {
     }
 
     @Test
-    //@IR(failOn = {IRNode.DIV, IRNode.URSHIFT, IRNode.RSHIFT, IRNode.MUL, IRNode.ADD, IRNode.SUB, IRNode.AND})
+    @SkipIR(1)
+    @IR(failOn = {IRNode.DIV, IRNode.URSHIFT, IRNode.RSHIFT, IRNode.MUL, IRNode.ADD, IRNode.SUB, IRNode.AND})
     // This results in a series of nodes due to DivLNode::Ideal and in particular transform_long_divide, which operates on non-constant divisors.
     // transform_long_divide splits up the division into multiple other nodes, such as MulHiLNode, which does not have a good Value() implemantion.
     // When JDK-8366815 is fixed, these rules should be reenabled

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -60,6 +60,9 @@ A custom run test gives full control over the invocation of the `@Test` annotate
 
 More information on checked tests with a precise definition can be found in the Javadocs of [Run](./Run.java). Concrete examples on how to specify a custom run test can be found in [CustomRunTestsExample](../../../testlibrary_tests/ir_framework/examples/CustomRunTestExample.java).
 
+#### Skipping a Test Completely When Encountering Problems
+When a test execution is failing due to a VM problem (crash, wrong execution etc.) without having an immediate fix, it is preferred to specify [@Skip](./Skip.java) at the `@Test`-method to disable the test over commenting the test out. This allows to still execute the skipped test by passing the property flag `-DIgnoreSkip=true`. This can be useful when trying to quickly verify if a disabled test is still failing or not.
+
 ### 2.2 IR Verification
 The main feature of this framework is to perform a simple but yet powerful regex-based C2 IR matching on the output of `-XX:+PrintIdeal`, `-XX:+PrintOptoAssembly` and/or on specific compile phases emitted by the compile command `-XX:CompileCommand=PrintIdealPhase` which supports the same set of compile phases as the Ideal Graph Visualizer (IGV).
 
@@ -133,6 +136,11 @@ If a `@Test` annotated method has multiple preconditions (for example `applyIf` 
 
 Platform attributes are evaluated as a logical conjunction, and take precedence over VM Flag attributes. An example with both `applyIfPlatformXXX` and `applyIfXXX` can be found in [TestPreconditions](../../../testlibrary_tests/ir_framework/tests/TestPreconditions.java) (internal framework test).
 
+#### Disable IR Rules Due to Compiler Problems
+If an IR rule is failing due to compiler problems (e.g. not emitting the expected shape, compile phase wrongly skipped etc.) without having an immediate fix, it is preferred to additionally specify [@SkipIR](./SkipIR.java) together with the `@IR` annotations to disable IR matching for specific rules over commenting the IR rule out. This allows to still perform IR matching for the skipped IR rules by passing the property flag `-DIgnoreSkipIR=true`. This can be useful when trying to quickly verify if a disabled IR rule is still failing or not.
+
+One (e.g. `@SkipIR(2)`) or multiple (e.g. `@SkipIR({3, 4})`) IR rules can be disabled by specifying the IR rule number(s) as paremeter (note that the first IR rule is rule 1).
+
 #### Implicitly Skipping IR Verification
 An IR verification cannot always be performed. Certain VM flags explicitly disable IR verification, change the IR shape in unexpected ways letting IR rules fail or even make IR verification impossible:
 
@@ -189,6 +197,8 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DWaitForCompilationTimeout=20`: Change the default waiting time (default: 10s) for a compilation of a `@Test` annotated method with compilation level [WAIT\_FOR\_COMPILATION](./CompLevel.java).
 - `-DIgnoreCompilerControls=true`: Ignore all compiler controls applied in the framework. This includes any compiler control annotations (`@DontCompile`, `@DontInline`, `@ForceCompile`, `@ForceInline`, `@ForceCompileStaticInitializer`), the exclusion of `@Run` and `@Check` methods from compilation, and the directive to not inline `@Test` annotated methods.
 - `-DPreferCommandLineFlags=true`: Prefer flags set via the command line over flags specified by the tests.
+- `-DIgnoreSkip=True`: Run all skipped tests (i.e. tests with a `@Skip` annotation).
+- `-DIgnoreSkipIR=True`: Perform IR matching for all skipped IR rules (i.e. tests with a `@SkipIR` annotation).
 
 ## 3. Test Framework Execution
 This section gives an overview of how the framework is executing a JTreg test that calls the framework from within its `main()` method.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/Skip.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/Skip.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation skips the execution of a {@link Test @Test}-annotated method completely. This is useful when the
+ * {@link Test @Test}-method causes the VM to misbehave (crash, wrong execution etc.) with no immediately available fix.
+ *
+ * <p>
+ * It is preferable to use {@link Skip @Skip} over commenting a test out because one can still execute the skipped
+ * test by passing the property flag {@code -DIgnoreSkip=true}. This can be useful when trying to quickly
+ * verify if a disabled test is still failing or not.
+ *
+ * <p>
+ * The {@link Skip @Skip} annotation can only be used at {@link Test @Test}-annotated methods. If the
+ * {@link Test @Test}-method is part of a custom run test, then the {@link Run @Run}-method is also not executed.
+ * A special case is a {@link Run @Run}-annotated method with multiple associated {@link Test @Test}-methods. In this
+ * case, you should either skip all or none to limit the impact. When only needing to disable one of them, consider
+ * moving it to a separate custom run test with a 1-to-1 {@link Run @Run}-{@link Test @Test}-relation for minimum impact.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Skip {
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/SkipIR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/SkipIR.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation skips the IR matching of an individual {@link Test @IR}-rule found at a {@link Test @Test}-method.
+ * This is useful when the {@link Test @Test}-method causes the VM to emit an unexpected graph shape with no immediately
+ * available fix. Note that this only restricts the IR matching and not the execution of the {@link Test @Test}-method
+ * itself. To skip the entire execution, use the {@link Skip @Skip} annotation instead.
+ *
+ * <p>
+ * It is preferable to use {@link SkipIR @SkipIR} over commenting an IR rule out because one can enable IR matching
+ * of the skipped IR rule by passing the property flag {@code -DIgnoreSkip=true}. This can be useful when trying to
+ * quickly verify if a disabled IR rule is still failing or not.
+ *
+ * <p>
+ * The {@link SkipIR @SkipIR} annotation can only be used in combination with at least one {@link Test @IR}-rule at
+ * a {@link Test @Test}-method. The {@link SkipIR#value()} parameter defines which IR rules should be disabled.
+ * One (e.g. {@code @SkipIR(2)}) or multiple (e.g. {@code @SkipIR({3, 4})}) IR rules can be disabled by specifying the IR
+ * rule number(s) as paremeter (note that the first IR rule is rule 1).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SkipIR {
+    int[] value();
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -199,7 +199,8 @@ public class TestVMProcess {
             throw new TestFormatException(System.lineSeparator() + System.lineSeparator() + matcher.group());
         } else if (stdErr.contains("NoTestsRunException")) {
             throw new NoTestsRunException(">>> No tests run due to empty set specified with -DTest and/or -DExclude. " +
-                                          "Make sure to define a set of at least one @Test method");
+                                          "Make sure to define a set of at least one @Test method that is not " +
+                                          "skipped with @Skip");
         } else {
             throw new TestVMException(getExceptionInfo());
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
@@ -25,6 +25,7 @@ package compiler.lib.ir_framework.driver.irmatching.irmethod;
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.SkipIR;
 import compiler.lib.ir_framework.Test;
 import compiler.lib.ir_framework.driver.irmatching.Compilation;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
@@ -38,7 +39,10 @@ import compiler.lib.ir_framework.shared.TestFormatException;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static compiler.lib.ir_framework.TestFramework.PRINT_RULE_MATCHING_TIME;
 
@@ -51,25 +55,69 @@ import static compiler.lib.ir_framework.TestFramework.PRINT_RULE_MATCHING_TIME;
  * @see IRMethodMatchResult
  */
 public class IRMethod implements IRMethodMatchable {
+    private static final boolean IGNORE_SKIP_IR = Boolean.parseBoolean(System.getProperty("IgnoreSkipIR", "false"));
+
     private final Method method;
+    private final Set<Integer> skippedIRRules;
     private final MatchableMatcher matcher;
 
     public IRMethod(Method method, IRRuleIds irRuleIds, IR[] irAnnos, Compilation compilation, VMInfo vmInfo) {
         this.method = method;
+        this.skippedIRRules = createSkippedIRRules(irAnnos.length);
         this.matcher = new MatchableMatcher(createIRRules(method, irRuleIds, irAnnos, compilation, vmInfo));
+    }
+
+    private Set<Integer> createSkippedIRRules(int irAnnoCount) {
+        SkipIR skipIR = method.getAnnotation(SkipIR.class);
+        if (skipIR == null) {
+            return Set.of();
+        }
+
+        if (IGNORE_SKIP_IR) {
+            System.out.println("Matching @SkipIR-annotated method \"" + method.getName() + "\"");
+            return Set.of();
+        }
+
+        int[] skipIRIndicesArray = skipIR.value();
+        Set<Integer> skippedIRRules = createValidatedSkippedIRRules(irAnnoCount, skipIRIndicesArray);
+        TestFormat.checkNoThrow(!skippedIRRules.isEmpty(), "Cannot specify empty @SkipIR annotation at " + method);
+        TestFormat.checkNoThrow(skippedIRRules.size() == skipIRIndicesArray.length, "Found duplicated IR rule index in @SkipIR at " + method);
+        return skippedIRRules;
+    }
+
+    private Set<Integer> createValidatedSkippedIRRules(int irAnnoCount, int[] skipIRIndicesArray) {
+        return Arrays.stream(skipIRIndicesArray)
+                .peek(skippedIndex -> checkValidRuleIndex(skippedIndex, irAnnoCount))
+                .boxed()
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private void checkValidRuleIndex(int skippedIndex, int irAnnoCount) {
+        TestFormat.checkNoThrow(skippedIndex > 0 && skippedIndex <= irAnnoCount, "Specified invalid IR rule index " + skippedIndex + " at " + method);
     }
 
     private List<Matchable> createIRRules(Method method, IRRuleIds irRuleIds, IR[] irAnnos, Compilation compilation, VMInfo vmInfo) {
         List<Matchable> irRules = new ArrayList<>();
         for (int ruleId : irRuleIds) {
             try {
-                irRules.add(new IRRule(ruleId, irAnnos[ruleId - 1], compilation, vmInfo));
+                createIRRule(irAnnos, compilation, vmInfo, ruleId, irRules);
             } catch (TestFormatException e) {
                 String postfixErrorMsg = " for IR rule " + ruleId + " at " + method + ".";
                 TestFormat.failNoThrow(e.getMessage() + postfixErrorMsg);
             }
         }
         return irRules;
+    }
+
+    private void createIRRule(IR[] irAnnos, Compilation compilation, VMInfo vmInfo, int ruleId, List<Matchable> irRules) {
+        if (shouldSkipIRRule(ruleId)) {
+            return;
+        }
+        irRules.add(new IRRule(ruleId, irAnnos[ruleId - 1], compilation, vmInfo));
+    }
+
+    private boolean shouldSkipIRRule(int ruleId) {
+        return skippedIRRules.contains(ruleId);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -95,8 +95,9 @@ public class TestVM {
     private static final boolean PRINT_TIMES = Boolean.getBoolean("PrintTimes") || VERBOSE;
     public static final boolean USE_COMPILER = WHITE_BOX.getBooleanVMFlag("UseCompiler");
     static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
-    private static final String TESTLIST = System.getProperty("Test", "");
-    private static final String EXCLUDELIST = System.getProperty("Exclude", "");
+    private static final String TEST_LIST = System.getProperty("Test", "");
+    private static final String EXCLUDE_LIST = System.getProperty("Exclude", "");
+    private static final boolean IGNORE_SKIP = Boolean.parseBoolean(System.getProperty("IgnoreSkip", "false"));
     private static final boolean DUMP_REPLAY = Boolean.getBoolean("DumpReplay");
     private static final boolean GC_AFTER = Boolean.getBoolean("GCAfter");
     private static final boolean SHUFFLE_TESTS = Boolean.parseBoolean(System.getProperty("ShuffleTests", "true"));
@@ -121,8 +122,8 @@ public class TestVM {
     private TestVM(Class<?> testClass) {
         TestRun.check(testClass != null, "Test class cannot be null");
         this.testClass = testClass;
-        this.testList = createTestFilterList(TESTLIST, testClass);
-        this.excludeList = createTestFilterList(EXCLUDELIST, testClass);
+        this.testList = createTestFilterList(TEST_LIST, testClass);
+        this.excludeList = createTestFilterList(EXCLUDE_LIST, testClass);
 
         if (PRINT_VALID_IR_RULES) {
             irMatchRulePrinter = new ApplicableIRRulesPrinter();
@@ -135,19 +136,20 @@ public class TestVM {
      * Parse "test1,test2,test3" into a list.
      */
     private static List<String> createTestFilterList(String list, Class<?> testClass) {
-        List<String> filterList = null;
-        if (!list.isEmpty()) {
-            String classPrefix = testClass.getSimpleName() + ".";
-            filterList = new ArrayList<>(Arrays.asList(list.split(",")));
-            for (int i = filterList.size() - 1; i >= 0; i--) {
-                String test = filterList.get(i);
-                if (test.indexOf(".") > 0) {
-                    if (test.startsWith(classPrefix)) {
-                        test = test.substring(classPrefix.length());
-                        filterList.set(i, test);
-                    } else {
-                        filterList.remove(i);
-                    }
+        if (list.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        String classPrefix = testClass.getSimpleName() + ".";
+        List<String> filterList = new ArrayList<>(Arrays.asList(list.split(",")));
+        for (int i = filterList.size() - 1; i >= 0; i--) {
+            String test = filterList.get(i);
+            if (test.indexOf(".") > 0) {
+                if (test.startsWith(classPrefix)) {
+                    test = test.substring(classPrefix.length());
+                    filterList.set(i, test);
+                } else {
+                    filterList.remove(i);
                 }
             }
         }
@@ -291,7 +293,7 @@ public class TestVM {
                 try {
                     Arguments argumentsAnno = getAnnotation(m, Arguments.class);
                     TestFormat.check(argumentsAnno != null || m.getParameterCount() == 0, "Missing @Arguments annotation to define arguments of " + m);
-                    BaseTest baseTest = new BaseTest(test, shouldExcludeTest(m.getName()));
+                    BaseTest baseTest = new BaseTest(test, shouldExcludeTest(m));
                     allTests.add(baseTest);
                     if (PRINT_VALID_IR_RULES) {
                         irMatchRulePrinter.emitApplicableIRRules(m, baseTest.isSkipped());
@@ -304,17 +306,34 @@ public class TestVM {
     }
 
     /**
-     * Check if user wants to exclude this test by checking the -DTest and -DExclude lists.
+     * A test is excluded from execution if:
+     * - -DTest does not list the method
+     * - -DExclude lists the method
+     * - The method specifies a (temporary) @Skip annotation.
      */
-    private boolean shouldExcludeTest(String testName) {
-        boolean hasTestList = testList != null;
-        boolean hasExcludeList = excludeList != null;
-        if (hasTestList) {
-            return !testList.contains(testName) || (hasExcludeList && excludeList.contains(testName));
-        } else if (hasExcludeList) {
-            return excludeList.contains(testName);
+    private boolean shouldExcludeTest(Method testMethod) {
+        String testName = testMethod.getName();
+        return isNotOnTestList(testName) ||
+               isOnExcludeList(testName) ||
+               hasSkipAnnotation(testMethod);
+    }
+
+    private boolean isNotOnTestList(String testName) {
+        return !testList.isEmpty() && !testList.contains(testName);
+    }
+
+    private boolean isOnExcludeList(String testName) {
+        return excludeList.contains(testName);
+    }
+
+    private boolean hasSkipAnnotation(Method testMethod) {
+        boolean shouldSkip = getAnnotation(testMethod, Skip.class) != null;
+        if (shouldSkip && IGNORE_SKIP) {
+            TestVmSocket.send("Running @Skip-annotated method \"" + testMethod.getName() + "\"");
+            return false;
         }
-        return false;
+        return shouldSkip;
+
     }
 
     /**
@@ -537,7 +556,7 @@ public class TestVM {
     }
 
     /**
-     * Setup @Test annotated method an add them to the declaredTests map to have a convenient way of accessing them
+     * Setup @Test annotated method and add them to the declaredTests map to have a convenient way of accessing them
      * once setting up a framework test (base  checked, or custom run test).
      */
     private void setupDeclaredTests() {
@@ -551,6 +570,10 @@ public class TestVM {
                                             "Found @IR annotation on non-@Test method " + m);
                     TestFormat.checkNoThrow(!m.isAnnotationPresent(Warmup.class) || getAnnotation(m, Run.class) != null,
                                             "Found @Warmup annotation on non-@Test or non-@Run method " + m);
+                    TestFormat.checkNoThrow(!m.isAnnotationPresent(Skip.class) ,
+                                            "Found @Skip annotation on non-@Test method " + m);
+                    TestFormat.checkNoThrow(!m.isAnnotationPresent(SkipIR.class) ,
+                                            "Found @SkipIR annotation on non-@Test method " + m);
                 }
             } catch (TestFormatException e) {
                 // Failure logged. Continue and report later.
@@ -569,6 +592,13 @@ public class TestVM {
             TestFormat.checkNoThrow(warmupIterations >= 0, "Cannot have negative value for @Warmup at " + m);
         }
 
+        TestFormat.checkNoThrow(!m.isAnnotationPresent(Skip.class) ||
+                                !m.isAnnotationPresent(SkipIR.class),
+                                "@SkipIR is useless when @Skip is present at " + m);
+
+        TestFormat.checkNoThrow(!m.isAnnotationPresent(SkipIR.class) ||
+                                m.getAnnotationsByType(IR.class).length > 0,
+                                "@SkipIR cannot be used without @IR at " + m);
         if (!IGNORE_COMPILER_CONTROLS) {
             // Don't inline test methods by default. Do not apply this when -DIgnoreCompilerControls=true is set.
             WHITE_BOX.testSetDontInlineMethod(m, true);
@@ -689,7 +719,7 @@ public class TestVM {
                          + "checked test " + m);
         CheckedTest.Parameter parameter = getCheckedTestParameter(m, testMethod);
         dontCompileAndDontInlineMethod(m);
-        CheckedTest checkedTest = new CheckedTest(test, m, checkAnno, parameter, shouldExcludeTest(testMethod.getName()));
+        CheckedTest checkedTest = new CheckedTest(test, m, checkAnno, parameter, shouldExcludeTest(testMethod));
         allTests.add(checkedTest);
         if (PRINT_VALID_IR_RULES) {
             // Only need to emit IR verification information if IR verification is actually performed.
@@ -741,6 +771,7 @@ public class TestVM {
         checkRunMethod(m, runAnno);
         List<DeclaredTest> tests = new ArrayList<>();
         boolean shouldExcludeTest = true;
+        boolean shouldExcludeAtLeastOneTest = false;
         for (String testName : runAnno.test()) {
             try {
                 Method testMethod = testMethodMap.get(testName);
@@ -748,12 +779,18 @@ public class TestVM {
                 checkCustomRunTest(m, testName, testMethod, test, runAnno.mode());
                 test.setAttachedMethod(m);
                 tests.add(test);
-                // Only exclude custom run test if all test methods excluded
-                shouldExcludeTest &= shouldExcludeTest(testMethod.getName());
+                boolean shouldExclude = shouldExcludeTest(testMethod);
+                // Only exclude custom run test if all its associated test methods are excluded
+                shouldExcludeTest &= shouldExclude;
+                shouldExcludeAtLeastOneTest |= shouldExclude;
             } catch (TestFormatException e) {
                 // Logged, continue.
             }
         }
+        if (shouldExcludeAtLeastOneTest) {
+            checkAllWithSkipAnnotationOrNone(m, runAnno);
+        }
+
         if (tests.isEmpty()) {
             return; // There was a format violation. Return.
         }
@@ -797,6 +834,44 @@ public class TestVM {
         Warmup warmupAnno = getAnnotation(m, Warmup.class);
         TestFormat.checkNoThrow(warmupAnno == null || runAnno.mode() != RunMode.STANDALONE,
                                 "Cannot set @Warmup at @Run method " + m + " when used with RunMode.STANDALONE. The @Run method is only invoked once.");
+    }
+
+    private void checkAllWithSkipAnnotationOrNone(Method runMethod, Run runAnno) {
+        List<Method> testMethodsWithoutSkip = testMethodsWithoutSkipAnnotation(runAnno);
+        if (testMethodsWithoutSkip.isEmpty()) {
+            // All with @Skip
+            return;
+        }
+
+        if (testMethodsWithoutSkip.size() == runAnno.test().length) {
+            // No method with @Skip -> must be using -DTest/-DExclude
+            TestFramework.check(testFilterPresent(), "must be present in this case");
+            return;
+        }
+
+        reportNotAllTestsWithSkipAnnotation(runMethod, testMethodsWithoutSkip);
+    }
+
+    private List<Method> testMethodsWithoutSkipAnnotation(Run runAnno) {
+        List<Method> methodsWithoutSkip = new ArrayList<>();
+        String[] tests = runAnno.test();
+        for (String testName : tests) {
+            Method testMethod = testMethodMap.get(testName);
+            if (!hasSkipAnnotation(testMethod)) {
+                methodsWithoutSkip.add(testMethod);
+            }
+        }
+        return methodsWithoutSkip;
+    }
+
+    private void reportNotAllTestsWithSkipAnnotation(Method runMethod, List<Method> testMethodsWithoutSkip) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("@Run-methods with multiple tests can only skip either all or none methods with @Skip:")
+               .append(System.lineSeparator())
+               .append("   - @Run-method: ").append(runMethod);
+        testMethodsWithoutSkip.forEach(method -> builder.append(System.lineSeparator())
+                                                        .append("   - @Test without @Skip: ").append(method));
+        TestFormat.failNoThrow(builder.toString());
     }
 
     private static <T extends Annotation> T getAnnotation(AnnotatedElement element, Class<T> c) {
@@ -900,7 +975,7 @@ public class TestVM {
     }
 
     private boolean testFilterPresent() {
-        return testList != null || excludeList != null;
+        return !testList.isEmpty() || !excludeList.isEmpty();
     }
 
     enum TriState {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentAliasing.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentAliasing.java
@@ -747,12 +747,13 @@ class TestMemorySegmentAliasingImpl {
     }
 
     @Test
-    // @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
-    //               ".*multiversion.*",   "> 0"}, // AutoVectorization Predicate FAILS
-    //     phase = CompilePhase.PRINT_IDEAL,
-    //     applyIfPlatform = {"64-bit", "true"},
-    //     applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
-    //     applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    @SkipIR(1)
+    @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
+                  ".*multiversion.*",   "> 0"}, // AutoVectorization Predicate FAILS
+        phase = CompilePhase.PRINT_IDEAL,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     //
     // FAILS: but only on "native" and "byte-buffer-direct"
     //        The issue is that one of the VPointers is invalid.
@@ -772,12 +773,13 @@ class TestMemorySegmentAliasingImpl {
     }
 
     @Test
-    // @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
-    //               ".*multiversion.*",   "= 0"}, // AutoVectorization Predicate SUFFICES
-    //     phase = CompilePhase.PRINT_IDEAL,
-    //     applyIfPlatform = {"64-bit", "true"},
-    //     applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
-    //     applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    @SkipIR(1)
+    @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
+                  ".*multiversion.*",   "= 0"}, // AutoVectorization Predicate SUFFICES
+        phase = CompilePhase.PRINT_IDEAL,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     //
     // FAILS: but only on "native" and "byte-buffer-direct"
     //        The issue is that one of the VPointers is invalid.
@@ -804,11 +806,12 @@ class TestMemorySegmentAliasingImpl {
     }
 
     @Test
-    // @IR(counts = {IRNode.STORE_VECTOR,  "> 0"},
-    //     phase = CompilePhase.PRINT_IDEAL,
-    //     applyIfPlatform = {"64-bit", "true"},
-    //     applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
-    //     applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    @SkipIR(1)
+    @IR(counts = {IRNode.STORE_VECTOR,  "> 0"},
+        phase = CompilePhase.PRINT_IDEAL,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     //
     // FAILS: but only on "native" and "byte-buffer-direct"
     //        The issue is that one of the VPointers is invalid.
@@ -830,12 +833,13 @@ class TestMemorySegmentAliasingImpl {
     }
 
     @Test
-    // @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
-    //               ".*multiversion.*",   "> 0"}, // AutoVectorization Predicate FAILS
-    //     phase = CompilePhase.PRINT_IDEAL,
-    //     applyIfPlatform = {"64-bit", "true"},
-    //     applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
-    //     applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    @SkipIR(1)
+    @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
+                  ".*multiversion.*",   "> 0"}, // AutoVectorization Predicate FAILS
+        phase = CompilePhase.PRINT_IDEAL,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     //
     // FAILS: but only on "native" and "byte-buffer-direct"
     //        The issue is that one of the VPointers is invalid.
@@ -855,12 +859,13 @@ class TestMemorySegmentAliasingImpl {
     }
 
     @Test
-    // @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
-    //               ".*multiversion.*",   "= 0"}, // AutoVectorization Predicate SUFFICES
-    //     phase = CompilePhase.PRINT_IDEAL,
-    //     applyIfPlatform = {"64-bit", "true"},
-    //     applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
-    //     applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    @SkipIR(1)
+    @IR(counts = {IRNode.STORE_VECTOR,  "> 0",
+                  ".*multiversion.*",   "= 0"}, // AutoVectorization Predicate SUFFICES
+        phase = CompilePhase.PRINT_IDEAL,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     //
     // FAILS: but only on "native" and "byte-buffer-direct"
     //        The issue is that one of the VPointers is invalid.
@@ -887,11 +892,12 @@ class TestMemorySegmentAliasingImpl {
     }
 
     @Test
-    // @IR(counts = {IRNode.STORE_VECTOR,  "> 0"},
-    //     phase = CompilePhase.PRINT_IDEAL,
-    //     applyIfPlatform = {"64-bit", "true"},
-    //     applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
-    //     applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+    @SkipIR(1)
+    @IR(counts = {IRNode.STORE_VECTOR,  "> 0"},
+        phase = CompilePhase.PRINT_IDEAL,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfAnd = {"AlignVector", "false", "UseAutoVectorizationSpeculativeAliasingChecks", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     //
     // FAILS: but only on "native" and "byte-buffer-direct"
     //        The issue is that one of the VPointers is invalid.

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -58,6 +58,9 @@ public class TestBadFormat {
         expectTestFormatException(BadRunTests.class);
         expectTestFormatException(BadSetupTest.class);
         expectTestFormatException(BadCheckTest.class);
+        expectTestFormatException(BadSkip.class);
+        expectTestFormatException(BadSkipIR.class);
+        expectTestFormatException(BadSkipIRAtIRMatching.class);
         expectTestFormatException(BadIRAnnotationBeforeFlagVM.class);
         expectTestFormatException(BadIRAnnotations.class);
         expectTestFormatException(BadIRAnnotationsAfterTestVM.class);
@@ -777,6 +780,115 @@ class BadCheckTest {
     public void invalidRunWithArgAnnotation(TestInfo info) {}
 }
 
+class BadSkip {
+    @NoFail
+    @Test
+    public void test() {}
+
+    @NoFail
+    @Test
+    public void test2() {}
+
+    @Skip
+    public void noTest() {}
+
+    @Run(test = "test")
+    @Skip
+    public void noTest2() {}
+
+    @Check(test = "test2")
+    @Skip
+    public void noTest3() {}
+
+    @Setup
+    @Skip
+    public void noTest4() {}
+
+    @NoFail
+    @Test
+    @Skip
+    public static void testSkipOnlyOneTestWithRunMultiple1() {}
+
+    @FailCount(0) // Combined with runTestSkipOnlyOneTestWithRunMultiple() below
+    @Test
+    public static void testSkipOnlyOneTestWithRunMultiple2() {}
+
+    @Run(test = {"testSkipOnlyOneTestWithRunMultiple1",
+                 "testSkipOnlyOneTestWithRunMultiple2"})
+    public static void runTestSkipOnlyOneTestWithRunMultiple() {}
+}
+
+
+class BadSkipIR {
+    @NoFail
+    @Test
+    public void test() {}
+
+    @NoFail
+    @Test
+    public void test2() {}
+
+    @SkipIR(1)
+    public void noTest() {}
+
+    @Run(test = "test")
+    @SkipIR(1)
+    public void noTest2() {}
+
+    @Check(test = "test2")
+    @SkipIR(1)
+    public void noTest3() {}
+
+    @Setup
+    @SkipIR(1)
+    public void noTest4() {}
+
+    @Test
+    @SkipIR(1)
+    public void noIR() {}
+
+    @Test
+    @Skip
+    @SkipIR(1)
+    @IR(failOn = IRNode.CALL)
+    public void noSkipAndSkipIR() {}
+}
+
+class BadSkipIRAtIRMatching {
+    @Test
+    @SkipIR(2)
+    @IR(failOn = IRNode.CALL)
+    public void invalidIndex() {}
+
+    @Test
+    @SkipIR(-1)
+    @IR(failOn = IRNode.CALL)
+    public void invalidIndex2() {}
+
+    @Test
+    @SkipIR({1, 1})
+    @IR(failOn = IRNode.CALL)
+    public void duplicatedIndex1() {}
+
+    @Test
+    @SkipIR({1, 1})
+    @IR(failOn = IRNode.CALL)
+    @IR(failOn = IRNode.CALL)
+    public void duplicatedIndex2() {}
+
+    @Test
+    @SkipIR({1, 2, 1})
+    @IR(failOn = IRNode.CALL)
+    @IR(failOn = IRNode.CALL)
+    public void duplicatedIndex3() {}
+
+    @FailCount(3)
+    @Test
+    @SkipIR({-1, 2, -1})
+    @IR(failOn = IRNode.CALL)
+    @IR(failOn = IRNode.CALL)
+    public void duplicatedIndexWrongIndex() {}
+}
 
 class BadIRAnnotationBeforeFlagVM {
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestSkip.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestSkip.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package testlibrary_tests.ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.driver.TestVMException;
+import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
+import jdk.test.lib.Asserts;
+
+import java.util.regex.Pattern;
+
+/*
+ * @test
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
+ * @summary Test different custom run tests.
+ * @library /test/lib /testlibrary_tests /
+ * @run driver ${test.main.class}
+ * @run main/othervm -DIgnoreSkipIR=true ${test.main.class} IgnoreSkipIR
+ */
+
+public class TestSkip {
+    public static void main(String[] args) {
+        boolean isSkipIR = args.length == 1;
+        try {
+            TestFramework.run();
+            Asserts.assertFalse(isSkipIR);
+        } catch (IRViolationException e) {
+            String message = e.getExceptionInfo();
+            Asserts.assertTrue(message.contains("testSkipIR1\" - [Failed IR rules: 1]"));
+            Asserts.assertTrue(message.contains("testSkipIR2\" - [Failed IR rules: 1]"));
+            Asserts.assertTrue(message.contains("testSkipIR3\" - [Failed IR rules: 2]"));
+            assertIrRuleCount(message, 1, 3);
+            assertIrRuleCount(message, 3, 1);
+        }
+
+        try {
+            TestFramework.runWithFlags("-DIgnoreSkip=true");
+            Asserts.fail("should not reach");
+        } catch (TestVMException e) {
+            String message = e.getExceptionInfo();
+            Asserts.assertTrue(message.contains("testSkip() should not be executed"), "should find");
+            Asserts.assertTrue(message.contains("testSkipWithIR() should not be executed"), "should find");
+            Asserts.assertTrue(message.contains("testSkipWithRunMultipleTests1() should not be executed"), "should find");
+        }
+    }
+
+    private static void assertIrRuleCount(String message, int ruleIndex, int expectedCount) {
+        Asserts.assertEQ(expectedCount,  message.split(Pattern.quote("IR rule " + ruleIndex), -1).length - 1);
+    }
+
+    @Test
+    @Skip
+    public static void testSkip() {
+        throw new RuntimeException("testSkip() should not be executed");
+    }
+
+    @Test
+    @Skip
+    public static void testSkipWithRun() {
+        throw new RuntimeException("testSkipWithRun() should not be executed");
+    }
+
+    @Run(test = "testSkipWithRun")
+    public static void runTestSkipWithRun() {
+        testSkipWithRun();
+    }
+
+    @Test
+    @Skip
+    public static void testSkipWithRunMultipleTests1() {
+        throw new RuntimeException("testSkipWithRunMultipleTests1() should not be executed");
+    }
+
+    @Test
+    @Skip
+    public static void testSkipWithRunMultipleTests2() {
+        throw new RuntimeException("testSkipWithRunMultipleTests2() should not be executed");
+    }
+
+    @Run(test = {"testSkipWithRunMultipleTests1",
+                 "testSkipWithRunMultipleTests2"})
+    public static void runTestSkipWithRunMultipleTests1() {
+        testSkipWithRunMultipleTests1();
+        testSkipWithRunMultipleTests2();
+    }
+
+    @Test
+    @Skip
+    @IR(counts = {IRNode.CALL, "2"}) // normally fails
+    public static void testSkipWithIR() {
+        throw new RuntimeException("testSkipWithIR() should not be executed");
+    }
+
+    @Test
+    @SkipIR(1)
+    @IR(counts = {IRNode.CALL, "2"}) // normally fails
+    public static void testSkipIR1() {}
+
+    @Test
+    @SkipIR(1)
+    @IR(counts = {IRNode.CALL, "2"}) // normally fails
+    @IR(failOn = IRNode.CALL)
+    public static void testSkipIR2() {}
+
+    @Test
+    @SkipIR({1, 3})
+    @IR(counts = {IRNode.CALL, "2"}) // normally fails
+    @IR(failOn = IRNode.CALL)
+    @IR(counts = {IRNode.CALL, "1"}) // normally fails
+    public static void testSkipIR3() {}
+}


### PR DESCRIPTION
This patch adds `@Skip` and `@SkipIR` annotations to the IR Framework which can be used at `@Test`-annotated methods. The goal is to skip either complete tests with `@Skip` in case of a VM misbehavior (e.g. crash, wrong execution etc.) or individual IR rules with `@SkipIR` in case of a compiler problem (e.g. emitting a wrong IR shape, wrongly skipping compile phases etc.).

This is an improvement over commenting failing tests or IR rules out because we could still run these tests on demand by passing the new property flags `-DIgnoreSkip=true` and/or `-DIgnoreSkipIR=true`. This is useful when trying to check if some skipped tests or IR rules are still failing. These property flags could also be used at ATR where problemlisted tests are executed.

In summary, this patch includes:
- New `@Skip` annotation + format violations for misuse (see tests at `TestBadFormat.java`). More explanations at the Javadocs of `Skip.java` and in `README.md`.
- New `@SkipIR` annotation + format violations for misuse (see tests at `TestBadFormat.java`). More explanations at the Javadocs of `SkipIR.java` and in `README.md`.
- New `IgnoreSkip` property flag for ignoring any `@Skip` annotation.
- New `IgnoreSkipIR` property flag for ignoring any `@Skip` annotation.
- Changing some currently commented out IR rules to use `@SkipIR` instead.
- Some small clean-ups (see PR comments for more explanations).
- Added tests for the new features in `TestSkip.java`.

Thanks,
Christian

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8343659](https://bugs.openjdk.org/browse/JDK-8343659)

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-BoldItalic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Italic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif.woff)

### Issue
 * [JDK-8343659](https://bugs.openjdk.org/browse/JDK-8343659): [IR Framework] Add a way to skip/disable individual IR tests and IR rules instead of commenting them out (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30982/head:pull/30982` \
`$ git checkout pull/30982`

Update a local copy of the PR: \
`$ git checkout pull/30982` \
`$ git pull https://git.openjdk.org/jdk.git pull/30982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30982`

View PR using the GUI difftool: \
`$ git pr show -t 30982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30982.diff">https://git.openjdk.org/jdk/pull/30982.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30982#issuecomment-4341920990)
</details>
