### PR TITLE
8376885: StressGetTotalGcCpuTimeDuringShutdown.java intermittently timed out

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java
@@ -79,6 +79,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.ThreadMXBean;
 
+import jtreg.SkippedException;
+
 public class StressGetTotalGcCpuTimeDuringShutdown {
     static final ThreadMXBean mxThreadBean = ManagementFactory.getThreadMXBean();
     static final MemoryMXBean mxMemoryBean = ManagementFactory.getMemoryMXBean();
@@ -86,7 +88,7 @@ public class StressGetTotalGcCpuTimeDuringShutdown {
     public static void main(String[] args) throws Exception {
         try {
             if (!mxThreadBean.isThreadCpuTimeEnabled()) {
-                return;
+                throw new SkippedException("Thread CPU time is not enabled");
             }
         } catch (UnsupportedOperationException e) {
             if (mxMemoryBean.getTotalGcCpuTime() != -1) {
@@ -95,7 +97,8 @@ public class StressGetTotalGcCpuTimeDuringShutdown {
             return;
         }
 
-        final int numberOfThreads = Runtime.getRuntime().availableProcessors() * 8;
+        final int cpuCount = Runtime.getRuntime().availableProcessors() * 8;
+        final int numberOfThreads = Math.min(cpuCount, 128);
         for (int i = 0; i < numberOfThreads; i++) {
             Thread t = new Thread(() -> {
                 while (true) {
@@ -103,6 +106,7 @@ public class StressGetTotalGcCpuTimeDuringShutdown {
                     if (gcCpuTimeFromThread < -1) {
                         throw new RuntimeException("GC CPU time should never be less than -1 but was " + gcCpuTimeFromThread);
                     }
+                    Thread.onSpinWait();
                 }
             });
             t.setDaemon(true);


### PR DESCRIPTION
Hi all,

Test test/jdk/java/lang/management/MemoryMXBean/StressGetTotalGcCpuTimeDuringShutdown.java observed intermittently timed out, both with ZGC and Shenandoah GC. This test create number of $(nproc)*8 daemon theads, and all these threads invoke ManagementFactory.getMemoryMXBean()getTotalGcCpuTime() in the while(true) loop. If the tested machine has many cpu cores, this test will create too many threads and cause too huge stress, thus test intermittently timed out.

This PR limited the max thread number to 128, this will reduce the thread number pressure. And add `Thread.onSpinWait()` in the while(true) loop will make loop less busy, this change do not change the original test intention.

Before this change, test failure probability about 5/1000. After this change test run 1000 times and all passed on linux-x64/linux-aarch64.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376885](https://bugs.openjdk.org/browse/JDK-8376885): StressGetTotalGcCpuTimeDuringShutdown.java intermittently timed out (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30983/head:pull/30983` \
`$ git checkout pull/30983`

Update a local copy of the PR: \
`$ git checkout pull/30983` \
`$ git pull https://git.openjdk.org/jdk.git pull/30983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30983`

View PR using the GUI difftool: \
`$ git pr show -t 30983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30983.diff">https://git.openjdk.org/jdk/pull/30983.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30983#issuecomment-4341949109)
</details>
