### PR TITLE
8326547: StrictMath.pow returns results outside of a 1 ulp error bound.

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntimeTrans.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrans.cpp
@@ -442,8 +442,8 @@ bp[] = {1.0, 1.5,},
         cp_h  =  9.61796700954437255859e-01, /* 0x3FEEC709, 0xE0000000 =(float)cp */
         cp_l  = -7.02846165095275826516e-09, /* 0xBE3E2FE0, 0x145B01F5 =tail of cp_h*/
         ivln2    =  1.44269504088896338700e+00, /* 0x3FF71547, 0x652B82FE =1/ln2 */
-        ivln2_h  =  1.44269502162933349609e+00, /* 0x3FF71547, 0x60000000 =24b 1/ln2*/
-        ivln2_l  =  1.92596299112661746887e-08; /* 0x3E54AE0B, 0xF85DDF44 =1/ln2 tail*/
+        ivln2_h  =  1.4426946640014648438, /* 0x3FF71547, 0x00000000 =21b 1/ln2*/
+        ivln2_l  =  3.7688749856360991145e-07; /* 0x3E994AE0, 0xBF85DDF4 =1/ln2 tail*/
 
 ATTRIBUTE_NO_UBSAN
 static double __ieee754_pow(double x, double y) {

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -2207,8 +2207,8 @@ final class FdLibm {
             // |y| is huge
             if (y_abs > 0x1.00000_ffff_ffffp31) { // if |y| > ~2**31
                 final double INV_LN2   =  0x1.7154_7652_b82fep0;   //  1.44269504088896338700e+00 = 1/ln2
-                final double INV_LN2_H =  0x1.715476p0;            //  1.44269502162933349609e+00 = 24 bits of 1/ln2
-                final double INV_LN2_L =  0x1.4ae0_bf85_ddf44p-26; //  1.92596299112661746887e-08 = 1/ln2 tail
+                final double INV_LN2_H =  0x1.7154_7p+0;           //  1.4426946640014648438      = 21 bits of 1/ln2
+                final double INV_LN2_L =  0x1.94ae_0bf8_5ddf4p-22; //  3.7688749856360991145e-07  = 1/ln2 tail
 
                 // Over/underflow if x is not close to one
                 if (x_abs < 0x1.fffff_0000_0000p-1) // |x| < ~0.9999995231628418

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -66,8 +66,9 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * </ul>
  *
  * <p>The Java math library is defined with respect to
- * {@code fdlibm} version 5.3 with a fix to pow. Where {@code fdlibm} provides
- * more than one definition for a function (such as
+ * {@code fdlibm} version 5.3 with a fix to {@code pow} so that its error bounds
+ * conform to the quality of implementation criteria for {@code pow}.
+ * Where {@code fdlibm} provides more than one definition for a function (such as
  * {@code acos}), use the "IEEE 754 core function" version
  * (residing in a file whose name begins with the letter
  * {@code e}).  The methods which require {@code fdlibm}

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -66,7 +66,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * </ul>
  *
  * <p>The Java math library is defined with respect to
- * {@code fdlibm} version 5.3. Where {@code fdlibm} provides
+ * {@code fdlibm} version 5.3 with a fix to pow. Where {@code fdlibm} provides
  * more than one definition for a function (such as
  * {@code acos}), use the "IEEE 754 core function" version
  * (residing in a file whose name begins with the letter

--- a/test/hotspot/jtreg/compiler/intrinsics/math/PowDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/PowDNodeTests.java
@@ -45,6 +45,14 @@ public class PowDNodeTests {
     public static final double B = UNIFORMS.next() * 1000.0d;
     public static final double E = UNIFORMS.next() * 1000.0d + 3.0d; // e >= 3 to avoid strength reduction code
 
+    private static final double REG1_B = 0x1.000002c5e2e99p+0;
+    private static final double REG1_E = 0x1.c9eee35374af6p+31;
+    private static final double REG1_R = 0x1.ffffe0bc9e399p+915;
+
+    private static final double REG2_B = 0x1.fffff4e900013p-1;
+    private static final double REG2_E = 0x1.0000100000001p+31;
+    private static final double REG2_R = 0x0.421378008b246p-1022;
+
     public static void main(String[] args) {
         TestFramework.run();
 
@@ -164,6 +172,20 @@ public class PowDNodeTests {
         return Math.pow(base, exp);
     }
 
+    // Test 12: pow(REG1_B, REG1_E) -> REG1_R
+    @Test
+    @IR(failOn = {IRNode.POW_D})
+    public static double regressionHugeExpAboveOne() {
+        return Math.pow(REG1_B, REG1_E);
+    }
+
+    // Test 13: pow(REG2_B, REG2_E) -> REG2_R
+    @Test
+    @IR(failOn = {IRNode.POW_D})
+    public static double regressionHugeExpBelowOne() {
+        return Math.pow(REG2_B, REG2_E);
+    }
+
     private static void assertEQWithinOneUlp(double expected, double observed) {
         if (Double.isNaN(expected) && Double.isNaN(observed)) return;
 
@@ -214,5 +236,8 @@ public class PowDNodeTests {
                 assertEQWithinOneUlp(StrictMath.pow(b, e), nonConstant(b, e));
             }
         }
+
+        assertEQWithinOneUlp(REG1_R, regressionHugeExpAboveOne());
+        assertEQWithinOneUlp(REG2_R, regressionHugeExpBelowOne());
     }
 }

--- a/test/jdk/java/lang/StrictMath/PowTests.java
+++ b/test/jdk/java/lang/StrictMath/PowTests.java
@@ -301,6 +301,18 @@ public class PowTests {
              5.0,
              55.901699437494756
             },
+
+            {
+                0x1.000002c5e2e99p+0,   // |x| > 1
+                0x1.c9eee35374af6p+31,  // |y| huge
+                0x1.ffffe0bc9e399p+915
+            },
+
+            {
+                0x1.fffff4e900013p-1,   // |x| < 1
+                0x1.0000100000001p+31,  // |y| huge
+                0x0.421378008b246p-1022
+            },
         };
 
         for (double[] testCase: testCases)


### PR DESCRIPTION
Hi, please consider the following changes:

This is a fix for the `StrictMath.pow()` method, which corrects its numerical behavior in certain cases. 

It was recently reported by [Gladman et al](https://members.loria.fr/PZimmermann/papers/accuracy.pdf) that the `pow()` method in the original FDLIBM returns with error of 636 ulps in certain cases. `StrictMath.pow()` is a direct port of FDLIBM `pow()`.

It turned out that `ivln2` constant split into high  and low parts (`ivln2_h` and `ivln2_l` respectively) in the original method is not sufficient to compute `u = ivln2_h * t` exactly in certain cases, namely when the span of non-zero bits in `t` is wide. 

By the default split, the high part `ivln2_h` contains 24 high bits of `ivln2`, and by changing the split so that `ivln2_h` contains only 21 bits of `ivln2` we ensure that `u = ivln2_h * t` is computed exactly in all cases when pow(x,y) does no overflow.

New testcases added.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345546](https://bugs.openjdk.org/browse/JDK-8345546) to be approved
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8326547: StrictMath.pow returns results outside of a 1 ulp error bound.`

### Issues
 * [JDK-8326547](https://bugs.openjdk.org/browse/JDK-8326547): StrictMath.pow returns results outside of a 1 ulp error bound. (**Bug** - P4)
 * [JDK-8345546](https://bugs.openjdk.org/browse/JDK-8345546): StrictMath.pow returns results outside of a 1 ulp error bound. (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30984/head:pull/30984` \
`$ git checkout pull/30984`

Update a local copy of the PR: \
`$ git checkout pull/30984` \
`$ git pull https://git.openjdk.org/jdk.git pull/30984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30984`

View PR using the GUI difftool: \
`$ git pr show -t 30984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30984.diff">https://git.openjdk.org/jdk/pull/30984.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30984#issuecomment-4369466564)
</details>
