### PR TITLE
8377991: TestLimitsUpdating.java fails with runtime exception even after JDK-8370492 is fixed

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -49,8 +49,12 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
 
 public class TestLimitsUpdating {
+    private static final int CPU_PERIOD = 100_000;
+    private static final int INITIAL_CPU_COUNT = 1;
+    private static final int UPDATED_CPU_COUNT = 2;
     private static final String TARGET_CONTAINER = "limitsUpdatingHS_" + Runtime.getRuntime().version().major();
     private static final String imageName = Common.imageName("limitsUpdating");
 
@@ -68,6 +72,10 @@ public class TestLimitsUpdating {
     }
 
     private static void testLimitUpdates() throws Exception {
+        if (Runtime.getRuntime().availableProcessors() < UPDATED_CPU_COUNT) {
+            throw new SkippedException("Need at least " + UPDATED_CPU_COUNT
+                    + " available CPUs to test CPU limit updates");
+        }
         File sharedtmpdir = new File("test-sharedtmp");
         File flag = new File(sharedtmpdir, "limitsUpdated"); // shared with LimitUpdateChecker
         File started = new File(sharedtmpdir, "started"); // shared with LimitUpdateChecker
@@ -77,8 +85,8 @@ public class TestLimitsUpdating {
         DockerRunOptions opts = new DockerRunOptions(imageName, "/jdk/bin/java", "LimitUpdateChecker");
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         opts.addDockerOpts("--volume", sharedtmpdir.getAbsolutePath() + ":/tmp");
-        opts.addDockerOpts("--cpu-period", "100000");
-        opts.addDockerOpts("--cpu-quota", "200000");
+        opts.addDockerOpts("--cpu-period", Integer.toString(CPU_PERIOD));
+        opts.addDockerOpts("--cpu-quota", Integer.toString(INITIAL_CPU_COUNT * CPU_PERIOD));
         opts.addDockerOpts("--memory", "500m");
         opts.addDockerOpts("--memory-swap", "500m");
         opts.addDockerOpts("--name", TARGET_CONTAINER);
@@ -103,7 +111,7 @@ public class TestLimitsUpdating {
             Thread.sleep(100);
         }
 
-        final List<String> containerCommand = getContainerUpdate(300_000, 100_000, "300m");
+        final List<String> containerCommand = getContainerUpdate(UPDATED_CPU_COUNT * CPU_PERIOD, CPU_PERIOD, "300m");
         // Run the update command so as to increase resources once the container signaled it has started.
         Thread t2 = new Thread() {
                 public void run() {
@@ -126,8 +134,8 @@ public class TestLimitsUpdating {
 
         // Do assertions based on the output in target container
         OutputAnalyzer targetOut = out[0];
-        DockerTestUtils.shouldMatchWithValue(targetOut, "active_processor_count", "2"); // initial value
-        DockerTestUtils.shouldMatchWithValue(targetOut, "active_processor_count", "3"); // updated value
+        DockerTestUtils.shouldMatchWithValue(targetOut, "active_processor_count", "1"); // initial value
+        DockerTestUtils.shouldMatchWithValue(targetOut, "active_processor_count", "2"); // updated value
         DockerTestUtils.shouldMatchWithValue(targetOut, "memory_limit", "512000 kB"); // initial value
         DockerTestUtils.shouldMatchWithValue(targetOut, "memory_and_swap_limit", "512000 kB"); // initial value
         DockerTestUtils.shouldMatchWithValue(targetOut, "memory_limit", "307200 kB"); // updated value

--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -48,9 +48,13 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
 
 public class TestLimitsUpdating {
     private static final long M = 1024 * 1024;
+    private static final int CPU_PERIOD = 100_000;
+    private static final int INITIAL_CPU_COUNT = 1;
+    private static final int UPDATED_CPU_COUNT = 2;
     private static final String TARGET_CONTAINER = "limitsUpdatingJDK_" + Runtime.getRuntime().version().major();
     private static final String imageName = Common.imageName("limitsUpdatingJDK");
 
@@ -67,6 +71,10 @@ public class TestLimitsUpdating {
     }
 
     private static void testLimitUpdates() throws Exception {
+        if (Runtime.getRuntime().availableProcessors() < UPDATED_CPU_COUNT) {
+            throw new SkippedException("Need at least " + UPDATED_CPU_COUNT
+                    + " available CPUs to test CPU limit updates");
+        }
         File sharedtmpdir = new File("jdk-sharedtmp");
         File flag = new File(sharedtmpdir, "limitsUpdated"); // shared with LimitUpdateChecker
         File started = new File(sharedtmpdir, "started"); // shared with LimitUpdateChecker
@@ -76,8 +84,8 @@ public class TestLimitsUpdating {
         DockerRunOptions opts = new DockerRunOptions(imageName, "/jdk/bin/java", "LimitUpdateChecker");
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         opts.addDockerOpts("--volume", sharedtmpdir.getAbsolutePath() + ":/tmp");
-        opts.addDockerOpts("--cpu-period", "100000");
-        opts.addDockerOpts("--cpu-quota", "200000");
+        opts.addDockerOpts("--cpu-period", Integer.toString(CPU_PERIOD));
+        opts.addDockerOpts("--cpu-quota", Integer.toString(INITIAL_CPU_COUNT * CPU_PERIOD));
         opts.addDockerOpts("--memory", "500m");
         opts.addDockerOpts("--memory-swap", "500m");
         opts.addDockerOpts("--name", TARGET_CONTAINER);
@@ -106,7 +114,7 @@ public class TestLimitsUpdating {
             Thread.sleep(100);
         }
 
-        final List<String> containerCommand = getContainerUpdate(300_000, 100_000, "300m");
+        final List<String> containerCommand = getContainerUpdate(UPDATED_CPU_COUNT * CPU_PERIOD, CPU_PERIOD, "300m");
         // Run the update command so as to increase resources once the container signaled it has started.
         Thread t2 = new Thread() {
                 public void run() {
@@ -129,10 +137,10 @@ public class TestLimitsUpdating {
 
         // Do assertions based on the output in target container
         OutputAnalyzer targetOut = out[0];
-        targetOut.shouldContain("Runtime.availableProcessors: 2");                  // initial value
-        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 2"); // initial value
-        targetOut.shouldContain("Runtime.availableProcessors: 3");                  // updated value
-        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 3"); // updated value
+        targetOut.shouldContain("Runtime.availableProcessors: 1");                  // initial value
+        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 1"); // initial value
+        targetOut.shouldContain("Runtime.availableProcessors: 2");                  // updated value
+        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 2"); // updated value
         long memoryInBytes = 500 * M;
         targetOut.shouldContain("Metrics.getMemoryLimit() == " + memoryInBytes);    // initial value
         targetOut.shouldContain("OperatingSystemMXBean.getTotalMemorySize: " + memoryInBytes); // initial value

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
Hi everyone,

`TestLimitsUpdating.java` tests updating container limits live during a JVMs runtime. One of these updates is to the number of CPUs available, from 2 to 3. However, if there are only 2 CPUs visible to the JVM (total available, or restricted by other means), this update is ignored, and we are bounded to 2 CPUs. The tests expects the new limit to be 3, and thus fails.

I propose we lower the number from 2/3 -> 1/2 to allow more configurations to run this tests. If we only have 1 CPU available, we should instead skip the test as we can't update the number of CPUs in a meaningful way.

Testing:
- Local testing with both low and high number of CPUs available
- Oracle tiers 1-5

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8377991](https://bugs.openjdk.org/browse/JDK-8377991): TestLimitsUpdating.java fails with runtime exception even after JDK-8370492 is fixed (**Bug** - P3)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30985/head:pull/30985` \
`$ git checkout pull/30985`

Update a local copy of the PR: \
`$ git checkout pull/30985` \
`$ git pull https://git.openjdk.org/jdk.git pull/30985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30985`

View PR using the GUI difftool: \
`$ git pr show -t 30985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30985.diff">https://git.openjdk.org/jdk/pull/30985.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30985#issuecomment-4342271430)
</details>
