### PR TITLE
 8383414: Exhaustiveness rejects a type pattern that covers all permitted subtypes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ExhaustivenessComputer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ExhaustivenessComputer.java
@@ -223,12 +223,28 @@ public class ExhaustivenessComputer {
 
     private boolean checkCovered(Type seltype, Iterable<PatternDescription> patterns) {
         for (Type seltypeComponent : components(seltype)) {
-            for (PatternDescription pd : patterns) {
-                if(isBpCovered(seltypeComponent, pd)) {
-                    return true;
-                }
+            if (isCoveredBy(seltypeComponent, patterns)) {
+                return true;
             }
         }
+        return false;
+    }
+
+    private boolean isCoveredBy(Type seltype, Iterable<PatternDescription> patterns) {
+        for (PatternDescription pd : patterns) {
+            if(isBpCovered(seltype, pd)) {
+                return true;
+            }
+            if (seltype.tsym.isSealed() && seltype.tsym.isAbstract()) {
+                boolean allDirectPermittedSubtypesPermitted =
+                        directPermittedSubTypes(seltype)
+                                 .map(csym -> instantiatePatternType(seltype, csym))
+                                 .allMatch(currentPermitted -> isCoveredBy(currentPermitted, patterns));
+
+                return allDirectPermittedSubtypesPermitted;
+            }
+        }
+
         return false;
     }
 
@@ -694,20 +710,9 @@ public class ExhaustivenessComputer {
             Type seltype = types.erasure(componentType);
             Type pattype = types.erasure(bp.type);
 
-            if (seltype.isPrimitive() ?
-                types.isUnconditionallyExactTypeBased(seltype, pattype) :
-                (bp.type.isPrimitive() && types.isUnconditionallyExactTypeBased(types.unboxedType(seltype), bp.type)) || types.isSubtype(seltype, pattype)) {
-                return true;
-            }
-
-            if (componentType.tsym.isSealed() && componentType.tsym.isAbstract()) {
-                boolean allDirectPermittedSubtypesPermitted =
-                        directPermittedSubTypes(componentType)
-                                 .map(csym -> instantiatePatternType(componentType, csym))
-                                 .allMatch(currentPermitted -> isBpCovered(currentPermitted, newNested));
-
-                return allDirectPermittedSubtypesPermitted;
-            }
+            return seltype.isPrimitive() ?
+                    types.isUnconditionallyExactTypeBased(seltype, pattype) :
+                    (bp.type.isPrimitive() && types.isUnconditionallyExactTypeBased(types.unboxedType(seltype), bp.type)) || types.isSubtype(seltype, pattype);
         }
         return false;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ExhaustivenessComputer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ExhaustivenessComputer.java
@@ -700,8 +700,7 @@ public class ExhaustivenessComputer {
                 return true;
             }
 
-            if (componentType.tsym.isSealed()) {
-                List<Type> permitted = ((ClassSymbol) componentType.tsym).getPermittedSubclasses();
+            if (componentType.tsym.isSealed() && componentType.tsym.isAbstract()) {
                 boolean allDirectPermittedSubtypesPermitted =
                         directPermittedSubTypes(componentType)
                                  .map(csym -> instantiatePatternType(componentType, csym))

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ExhaustivenessComputer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ExhaustivenessComputer.java
@@ -244,10 +244,10 @@ public class ExhaustivenessComputer {
                     }
                     yield List.nil();
                 }
-                yield List.of(types.erasure(seltype));
+                yield List.of(seltype);
             }
             case TYPEVAR -> components(((TypeVar) seltype).getUpperBound());
-            default -> List.of(types.erasure(seltype));
+            default -> List.of(seltype);
         };
     }
 
@@ -369,6 +369,14 @@ public class ExhaustivenessComputer {
         } else {
             return infer.instantiatePatternType(targetType, csym);
         }
+    }
+
+    private Stream<TypeSymbol> directPermittedSubTypes(Type type) {
+        List<Type> permitted = ((ClassSymbol) type.tsym).getPermittedSubclasses();
+
+        return permitted.stream()
+                        .map(permittedType -> permittedType.tsym)
+                        .filter(isApplicableSubtypePredicate(type));
     }
 
     private Set<ClassSymbol> leafPermittedSubTypes(TypeSymbol root, Predicate<ClassSymbol> accept) {
@@ -686,9 +694,21 @@ public class ExhaustivenessComputer {
             Type seltype = types.erasure(componentType);
             Type pattype = types.erasure(bp.type);
 
-            return seltype.isPrimitive() ?
-                    types.isUnconditionallyExactTypeBased(seltype, pattype) :
-                    (bp.type.isPrimitive() && types.isUnconditionallyExactTypeBased(types.unboxedType(seltype), bp.type)) || types.isSubtype(seltype, pattype);
+            if (seltype.isPrimitive() ?
+                types.isUnconditionallyExactTypeBased(seltype, pattype) :
+                (bp.type.isPrimitive() && types.isUnconditionallyExactTypeBased(types.unboxedType(seltype), bp.type)) || types.isSubtype(seltype, pattype)) {
+                return true;
+            }
+
+            if (componentType.tsym.isSealed()) {
+                List<Type> permitted = ((ClassSymbol) componentType.tsym).getPermittedSubclasses();
+                boolean allDirectPermittedSubtypesPermitted =
+                        directPermittedSubTypes(componentType)
+                                 .map(csym -> instantiatePatternType(componentType, csym))
+                                 .allMatch(currentPermitted -> isBpCovered(currentPermitted, newNested));
+
+                return allDirectPermittedSubtypesPermitted;
+            }
         }
         return false;
     }
@@ -877,11 +897,8 @@ public class ExhaustivenessComputer {
         if (toExpand instanceof BindingPattern bp) {
             if (bp.type.tsym.isSealed()) {
                 //try to replace binding patterns for sealed types with all their immediate permitted applicable types:
-                List<Type> permitted = ((ClassSymbol) bp.type.tsym).getPermittedSubclasses();
                 Set<PatternDescription> applicableDirectPermittedPatterns =
-                        permitted.stream()
-                                 .map(type -> type.tsym)
-                                 .filter(isApplicableSubtypePredicate(targetType))
+                        directPermittedSubTypes(bp.type)
                                  .map(csym -> new BindingPattern(types.erasure(csym.type)))
                                  .collect(Collectors.toCollection(LinkedHashSet::new));
 

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -1486,9 +1486,7 @@ public class Exhaustiveness extends TestRunner {
                        }
                    }
                }
-               """,
-               "Test.java:11:9: compiler.err.not.exhaustive.statement",
-               "1 error");
+               """);
     }
 
     @Test
@@ -2554,6 +2552,23 @@ public class Exhaustiveness extends TestRunner {
                    static void f(II<Long> i) {
                        switch (i) {
                            case J j -> {}
+                       }
+                   }
+               }
+               """);
+        doTest(base,
+               new String[0],
+               """
+               class Test {
+                   interface J1 {}
+                   interface J2 {}
+                   static sealed interface II<T> permits A2, B2 {}
+                   static final class A2 implements II<Long>, J1 {}
+                   static final class B2 implements II<Long>, J2 {}
+                   static void f(II<Long> i) {
+                       switch (i) {
+                           case J1 j -> {}
+                           case J2 j -> {}
                        }
                    }
                }

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215 8333169 8327368 8366968 8364991
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215 8333169 8327368 8366968 8364991 8383414
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2485,6 +2485,79 @@ public class Exhaustiveness extends TestRunner {
                """,
                "Test.java:4:16: compiler.err.not.exhaustive",
                "1 error");
+    }
+
+    @Test //JDK-8383414
+    public void testVerifyCoverageCheckWithApplicablePermittedSubTypes(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               class Test {
+                   interface J {}
+                   static sealed interface II<T> permits A2, B2 {}
+                   static final class A2 implements II<Long>, J {}
+                   static final class B2 implements II<Long>, J {}
+                   static void f(II<Long> i) {
+                       switch (i) {
+                           case J j -> {}
+                       }
+                   }
+               }
+               """);
+        //deeper hierarchy:
+        doTest(base,
+               new String[0],
+               """
+               class Test {
+                   interface J {}
+                   static sealed interface II<T> permits Med, B2 {}
+                   static sealed interface Med extends II<Long> {}
+                   static final class A2 implements Med, J {}
+                   static final class B2 implements II<Long>, J {}
+                   static void f(II<Long> i) {
+                       switch (i) {
+                           case J j -> {}
+                       }
+                   }
+               }
+               """);
+        //even deeper hierarchy:
+        doTest(base,
+               new String[0],
+               """
+               class Test {
+                   interface J {}
+                   static sealed interface II<T> permits Med1, B2 {}
+                   static sealed interface Med1 extends II<Long> {}
+                   static sealed interface Med2 extends Med1 {}
+                   static sealed interface Med3 extends Med2 {}
+                   static sealed interface Med4 extends Med3 {}
+                   static sealed interface Med5 extends Med4 {}
+                   static final class A2 implements Med5, J {}
+                   static final class B2 implements II<Long>, J {}
+                   static void f(II<Long> i) {
+                       switch (i) {
+                           case J j -> {}
+                       }
+                   }
+               }
+               """);
+        //a class that does not implement J, but is not applicable:
+        doTest(base,
+               new String[0],
+               """
+               class Test {
+                   interface J {}
+                   static sealed interface II<T> permits A2, B2 {}
+                   static final class A2 implements II<String> {}
+                   static final class B2 implements II<Long>, J {}
+                   static void f(II<Long> i) {
+                       switch (i) {
+                           case J j -> {}
+                       }
+                   }
+               }
+               """);
     }
 
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {


### PR DESCRIPTION
Consider:
```
class Test {
    interface J {}
    static sealed interface II<T> permits A2, B2 {}
    static final class A2 implements II<Long>, J {}
    static final class B2 implements II<Long>, J {}
    static void f(II<Long> i) {
        switch (i) {
            case J j -> {}
        }
    }
}

$ jdk-26/bin/javac /tmp/Test.java 
/tmp/Test.java:7: error: the switch statement does not cover all possible input values
        switch (i) {
        ^
1 error
```

The JLS (14.11.1.1. Exhaustive Switch Blocks) says that:
- the switch is exhaustive if (among others) the set of patterns based on the cases covers the selector type
- a set of patterns covers a type if (among others) for an abstract sealed class or interface, all applicable permitted subtypes of the given type are covered
- a set of patterns covers a type if (among other) it contains a pattern that is unconditional for the given type

In the example above, `J` is obviously not unconditional for `II<Long>`, but `II<Long>` is an interface and has two applicable permitted subtypes: `A2` and `B2`, and `J` is unconditional for both of them, and hence they are both covered. And hence `II<Long>` should be covered. But `ExhaustivenessComputer` does not check permitted subtypes on this specific place.

This PR is enhancing the coverage check with permitted subtypes handling.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383414](https://bugs.openjdk.org/browse/JDK-8383414): Exhaustiveness rejects a type pattern that covers all permitted subtypes (**Bug** - P4)


### Reviewers
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30986/head:pull/30986` \
`$ git checkout pull/30986`

Update a local copy of the PR: \
`$ git checkout pull/30986` \
`$ git pull https://git.openjdk.org/jdk.git pull/30986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30986`

View PR using the GUI difftool: \
`$ git pr show -t 30986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30986.diff">https://git.openjdk.org/jdk/pull/30986.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30986#issuecomment-4342725759)
</details>
