### PR TITLE
8383564: Avoid reloading klass when transforming stack chunks

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -444,7 +444,7 @@ void G1ParScanThreadState::do_iterate_object(oop const obj,
       return;
     }
 
-    ContinuationGCSupport::transform_stack_chunk(obj);
+    ContinuationGCSupport::transform_stack_chunk(obj, klass);
 
     // Check for deduplicating young Strings.
     if (G1StringDedup::is_candidate_from_evacuation(klass,

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -292,7 +292,7 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
       assert(young_space()->contains(new_obj), "Attempt to push non-promoted obj");
     }
 
-    ContinuationGCSupport::transform_stack_chunk(new_obj);
+    ContinuationGCSupport::transform_stack_chunk(new_obj, klass);
 
     // Do the size comparison first with new_obj_size, which we
     // already have. Hopefully, only a few objects are larger than

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -698,7 +698,8 @@ void DefNewGeneration::handle_promotion_failure(oop old) {
 oop DefNewGeneration::copy_to_survivor_space(oop old) {
   assert(is_in_reserved(old) && !old->is_forwarded(),
          "shouldn't be scavenging this oop");
-  size_t s = old->size();
+  Klass* klass = old->klass();
+  size_t s = old->size_given_klass(klass);
   oop obj = nullptr;
 
   // Try allocating obj in to-space (unless too old)
@@ -725,7 +726,7 @@ oop DefNewGeneration::copy_to_survivor_space(oop old) {
   // Copy obj
   Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(old), cast_from_oop<HeapWord*>(obj), s);
 
-  ContinuationGCSupport::transform_stack_chunk(obj);
+  ContinuationGCSupport::transform_stack_chunk(obj, klass);
 
   if (!new_obj_is_tenured) {
     // Increment age if obj still in new generation

--- a/src/hotspot/share/gc/shared/continuationGCSupport.hpp
+++ b/src/hotspot/share/gc/shared/continuationGCSupport.hpp
@@ -28,6 +28,8 @@
 #include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 
+class Klass;
+
 class ContinuationGCSupport : public AllStatic {
 public:
   // Relativize the given oop if it is a stack chunk.
@@ -35,6 +37,7 @@ public:
   // Relativize and transform to use a bitmap for future oop iteration for the
   // given oop if it is a stack chunk.
   static void transform_stack_chunk(oop obj);
+  static void transform_stack_chunk(oop obj, Klass* klass);
 };
 
 #endif // SHARE_GC_SHARED_CONTINUATIONGCSUPPORT_HPP

--- a/src/hotspot/share/gc/shared/continuationGCSupport.inline.hpp
+++ b/src/hotspot/share/gc/shared/continuationGCSupport.inline.hpp
@@ -43,7 +43,11 @@ inline bool ContinuationGCSupport::relativize_stack_chunk(oop obj) {
 }
 
 inline void ContinuationGCSupport::transform_stack_chunk(oop obj) {
-  if (!obj->is_stackChunk()) {
+  transform_stack_chunk(obj, obj->klass());
+}
+
+inline void ContinuationGCSupport::transform_stack_chunk(oop obj, Klass* klass) {
+  if (!klass->is_stack_chunk_instance_klass()) {
     return;
   }
 


### PR DESCRIPTION
Add a new `transform_stack_chunk` with `klass` so that callers who has `klass` loaded already to avoid reloading it. Release build asm shows the stack-chunk check uses the existing `Klass*` instead of reloading it from the object header.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383564](https://bugs.openjdk.org/browse/JDK-8383564): Avoid reloading klass when transforming stack chunks (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30987/head:pull/30987` \
`$ git checkout pull/30987`

Update a local copy of the PR: \
`$ git checkout pull/30987` \
`$ git pull https://git.openjdk.org/jdk.git pull/30987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30987`

View PR using the GUI difftool: \
`$ git pr show -t 30987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30987.diff">https://git.openjdk.org/jdk/pull/30987.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30987#issuecomment-4342905522)
</details>
