### PR TITLE
8382311: 30% Performance regression in Philosophers benchmark

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1940,7 +1940,7 @@ const int ObjectAlignmentInBytes = 8;
           "Use a table to record inflated monitors rather than the first "  \
           "word of the object.")                                            \
                                                                             \
-  product(int, FastLockingSpins, 13, DIAGNOSTIC,                            \
+  product(int, FastLockingSpins, 8, DIAGNOSTIC,                             \
           "Specifies the number of times fast locking will attempt to "     \
           "CAS the markWord before inflating. Between each CAS it will "    \
           "spin for exponentially more time, resulting in a total number "  \


### PR DESCRIPTION
When turning OMT (Object Monitor Table) on by default there was a 30% regression in the Philosophers benchmark (renaissance suite), which we missed because we normally don't run this test.

Profiling showed that much CPU time was spent executing `SpinPause()` inside of `ObjectSynchronizer::fast_lock_spin_enter()`.

The reason why the spinning was added was the cost of inflating was much higher with the old OMT implementation (a concurrent hash table). So if that high cost could be avoided by some spinning it was considered worth a try.

The amount of spinning can be controlled with the `FastLockingSpins` parameter, and empirical studies came to the conclusion that for the old OMT implementation 13 was a good default value.

Since the new OMT implementation has a much lower cost of infating the old default value of 13 is too high, hence why the philosophers are wasting much CPU time just spinning.

After running lots of performance tests we have decided to lower the default to 8, which removes the regression in the Philosophers benchmark, but also does not seem to harm the performance of other tests.

Passes tier1-3 on supported platforms.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382311](https://bugs.openjdk.org/browse/JDK-8382311): 30% Performance regression in Philosophers benchmark (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Anton Artemov](https://openjdk.org/census#aartemov) (@toxaart - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30988/head:pull/30988` \
`$ git checkout pull/30988`

Update a local copy of the PR: \
`$ git checkout pull/30988` \
`$ git pull https://git.openjdk.org/jdk.git pull/30988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30988`

View PR using the GUI difftool: \
`$ git pr show -t 30988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30988.diff">https://git.openjdk.org/jdk/pull/30988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30988#issuecomment-4349940345)
</details>
