### PR TITLE
8369455: XAWT: List.getSelectedItem may throw ArrayIndexOutOfBoundsException

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XListPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XListPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1233,10 +1233,12 @@ final class XListPeer extends XComponentPeer implements ListPeer, XScrollbarClie
      */
     @Override
     public void select(int index) {
-        // Programmatic select() should also set the focus index
-        setFocusIndex(index);
-        repaint(PAINT_FOCUS);
-        selectItem(index);
+        if (index >= 0 && index < items.size()) {
+            // Programmatic select() should also set the focus index
+            setFocusIndex(index);
+            repaint(PAINT_FOCUS);
+            selectItem(index);
+        }
     }
 
     /**

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -151,7 +151,6 @@ java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java 7080150 macosx-all
 java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java 8168646 generic-all
 java/awt/List/KeyEventsTest/KeyEventsTest.java 8201307 linux-all
 java/awt/List/NoEvents/ProgrammaticChange.java 8201307 linux-all
-java/awt/List/ListSelection/SelectInvalidTest.java 8369455 linux-all
 java/awt/Paint/ListRepaint.java 8201307 linux-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
 java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java 6986109 windows-all

--- a/test/jdk/java/awt/List/ListSelection/SelectInvalidTest.java
+++ b/test/jdk/java/awt/List/ListSelection/SelectInvalidTest.java
@@ -32,7 +32,7 @@ import static jdk.test.lib.Asserts.assertTrue;
 
 /**
  * @test
- * @bug 8369327
+ * @bug 8369327 8369455
  * @summary Test awt list selection of invalid indexes
  * @key headful
  * @library /test/lib


### PR DESCRIPTION
This fixes a bug in XAWT that prevents selecting non existent element in the List.
It was extracted from the https://github.com/openjdk/jdk/pull/27682, see "Description of how invalid indexes are handled on other platforms:" section in that PR description.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8369455](https://bugs.openjdk.org/browse/JDK-8369455): XAWT: List.getSelectedItem may throw ArrayIndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30992/head:pull/30992` \
`$ git checkout pull/30992`

Update a local copy of the PR: \
`$ git checkout pull/30992` \
`$ git pull https://git.openjdk.org/jdk.git pull/30992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30992`

View PR using the GUI difftool: \
`$ git pr show -t 30992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30992.diff">https://git.openjdk.org/jdk/pull/30992.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30992#issuecomment-4356119367)
</details>
