### PR TITLE
8383639: JConsole unnecessary classloading for MBean types

### DIFF
--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/Utils.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,10 @@ public class Utils {
         if ((c = primitiveMap.get(className)) != null) {
             return c;
         }
-        return Class.forName(className);
+        if (editableTypes.contains(className)) {
+            return Class.forName(className);
+        }
+        return Object.class; // No need to load class.
     }
 
     /**
@@ -216,7 +219,7 @@ public class Utils {
                 className = className.substring(2, className.length() - 1);
             } else {
                 try {
-                    Class<?> c = Class.forName(className);
+                    Class<?> c = Utils.getClass(className);
                     className = c.getComponentType().getName();
                 } catch (ClassNotFoundException e) {
                     // Should not happen


### PR DESCRIPTION
JConsole attempts unnecessary classloading by using Class.forName when creating the graphical interface, including the components for MBeans.

JConosole does not implement MBean operations on types other than the standard types.  It already has a set of types which it can check against, so can check if a type is in "editableTypes" before resolving and returning a Class.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383639](https://bugs.openjdk.org/browse/JDK-8383639): JConsole unnecessary classloading for MBean types (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/30999/head:pull/30999` \
`$ git checkout pull/30999`

Update a local copy of the PR: \
`$ git checkout pull/30999` \
`$ git pull https://git.openjdk.org/jdk.git pull/30999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30999`

View PR using the GUI difftool: \
`$ git pr show -t 30999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/30999.diff">https://git.openjdk.org/jdk/pull/30999.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/30999#issuecomment-4351968268)
</details>
