### PR TITLE
8383642: Additional Shenandoah clone barrier tests

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -22,8 +22,8 @@
  * questions.
  */
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /*
  * @test id=default
@@ -461,131 +461,141 @@ import java.util.List;
 
 public class TestClone {
 
-    private static final List<Object> objects = new ArrayList<>();
-    private static volatile Object sink;
+    private static final int ENTRIES = 10_000;
+    private static final int ITERS = 1_000_000;
+    private static final int ARRAY_MAX_SIZE = 128;
 
     public static void main(String[] args) throws Exception {
-        for (int i = 0; i < 10000; i++) {
-            Object[] src = new Object[i % 512]; // A range of sizes, but limit overhead
-            for (int c = 0; c < src.length; c++) {
-                src[c] = new Object();
-            }
-            testWith(src);
+        SmallObject[] small = new SmallObject[ENTRIES];
+        LargeObject[] large = new LargeObject[ENTRIES];
+        Ref[][] array = new Ref[ENTRIES][];
 
-            testWithObject(new SmallObject());
-            testWithObject(new LargeObject());
+        for (int i = 0; i < ENTRIES; i++) {
+            small[i] = new SmallObject(i);
+            large[i] = new LargeObject(i);
+            array[i] = newArray(i);
         }
-        testOld();
+
+        Random rand = Utils.getRandomInstance();
+        for (int i = 0; i < ITERS; i++) {
+            int r = rand.nextInt(ENTRIES);
+
+            SmallObject s = small[r];
+            small[r] = (SmallObject) s.clone();
+            verify(s, r); // verify *after* clone to avoid LRB healing from-space refs
+
+            LargeObject l = large[r];
+            large[r] = (LargeObject) l.clone();
+            verify(l, r);
+
+            Ref[] a = array[r];
+            array[r] = a.clone();
+            verify(a, r);
+        }
     }
 
-    static void testWith(Object[] src) {
-        Object[] dst = src.clone();
+    static Ref[] newArray(int id) {
+        int size = id % ARRAY_MAX_SIZE;
+        Ref[] arr = new Ref[size];
+        for (int i = 0; i < size; i++) arr[i] = new Ref(id * 1_000 + i);
+        return arr;
+    }
+
+    static void verify(SmallObject src, int id) {
+        int expected = id;
+        if (src.x1.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x1.x);
+        if (src.x2.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x2.x);
+        if (src.x3.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x3.x);
+        if (src.x4.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x4.x);
+    }
+
+    static void verify(LargeObject src, int id) {
+        int expected = id;
+        if (src.x01.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x01.x);
+        if (src.x02.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x02.x);
+        if (src.x03.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x03.x);
+        if (src.x04.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x04.x);
+        if (src.x05.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x05.x);
+        if (src.x06.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x06.x);
+        if (src.x07.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x07.x);
+        if (src.x08.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x08.x);
+        if (src.x09.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x09.x);
+        if (src.x10.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x10.x);
+        if (src.x11.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x11.x);
+        if (src.x12.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x12.x);
+        if (src.x13.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x13.x);
+        if (src.x14.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x14.x);
+        if (src.x15.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x15.x);
+        if (src.x16.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x16.x);
+    }
+
+    static void verify(Ref[] src, int id) {
+        int expectedLen = id % 1000;
         int srcLen = src.length;
-        int dstLen = dst.length;
-        if (srcLen != dstLen) {
-            throw new IllegalStateException("Lengths do not match: " + srcLen + " vs " + dstLen);
+        if (srcLen != expectedLen) {
+            throw new IllegalStateException("Lengths do not match: " + srcLen + " vs " + expectedLen);
         }
-        for (int c = 0; c < src.length; c++) {
-            Object s = src[c];
-            Object d = dst[c];
-            if (s != d) {
-                throw new IllegalStateException("Elements do not match at " + c + ": " + s + " vs " + d + ", len = " + srcLen);
+        for (int i = 0; i < src.length; i++) {
+            int expectedVal = id * 1_000 + i;
+            int val = src[i].x;
+            if (val != expectedVal) {
+                throw new IllegalStateException("Elements do not match at " + i + ": " + val + " vs " + expectedVal + ", len = " + srcLen);
             }
         }
     }
 
-    static void testWithObject(SmallObject src) {
-        SmallObject dst = src.clone();
-        if (dst.x1 != src.x1 ||
-            dst.x2 != src.x2 ||
-            dst.x3 != src.x3 ||
-            dst.x4 != src.x4) {
-            throw new IllegalStateException("Contents do not match");
+    static class Ref {
+        int x;
+
+        Ref(int x) {
+            this.x = x;
         }
     }
 
-    static void testWithObject(LargeObject src) {
-        LargeObject dst = src.clone();
-        if (dst.x01 != src.x01 ||
-            dst.x02 != src.x02 ||
-            dst.x03 != src.x03 ||
-            dst.x04 != src.x04 ||
-            dst.x05 != src.x05 ||
-            dst.x06 != src.x06 ||
-            dst.x07 != src.x07 ||
-            dst.x08 != src.x08 ||
-            dst.x09 != src.x09 ||
-            dst.x10 != src.x10 ||
-            dst.x11 != src.x11 ||
-            dst.x12 != src.x12 ||
-            dst.x13 != src.x13 ||
-            dst.x14 != src.x14 ||
-            dst.x15 != src.x15 ||
-            dst.x16 != src.x16) {
-            throw new IllegalStateException("Contents do not match");
-        }
-    }
-
-    public static void testOld() throws Exception {
-        // Trying to stress the interaction with garbage collection.
-        // Clone old objects while creating garbage. Do *not* read from the cloned
-        // objects as this may trigger LRB to heal a stale from-space reference.
-        // The failure mode here is a ShenandoahVerify observing a bad ref.
-        for (int i = 0; i < 100_000; i++) {
-            objects.add(new SmallObject());
-            objects.add(new LargeObject());
-            objects.add(new Object[i % 100]); // various sizes
-            Object oldObject = objects.get(i % 100);
-            sink = switch (oldObject) {
-                case SmallObject s -> s.clone();
-                case LargeObject l -> l.clone();
-                case Object[] a -> a.clone();
-                default -> throw new IllegalStateException("Impossible");
-            };
-        }
-    }
-
-    static class SmallObject implements Cloneable {
-        Object x1 = new Object();
-        Object x2 = new Object();
-        Object x3 = new Object();
-        Object x4 = new Object();
-
+    static abstract class DefaultClone<T> implements Cloneable {
         @Override
-        public SmallObject clone() {
+        @SuppressWarnings("unchecked")
+        public T clone() {
             try {
-                return (SmallObject) super.clone();
+                return (T) super.clone();
             } catch (CloneNotSupportedException e) {
-                throw new AssertionError();
+                throw new AssertionError(e);
             }
         }
     }
 
-    static class LargeObject implements Cloneable {
-        Object x01 = new Object();
-        Object x02 = new Object();
-        Object x03 = new Object();
-        Object x04 = new Object();
-        Object x05 = new Object();
-        Object x06 = new Object();
-        Object x07 = new Object();
-        Object x08 = new Object();
-        Object x09 = new Object();
-        Object x10 = new Object();
-        Object x11 = new Object();
-        Object x12 = new Object();
-        Object x13 = new Object();
-        Object x14 = new Object();
-        Object x15 = new Object();
-        Object x16 = new Object();
+    static class SmallObject extends DefaultClone {
+        Ref x1,x2,x3,x4;
 
-        @Override
-        public LargeObject clone() {
-            try {
-                return (LargeObject) super.clone();
-            } catch (CloneNotSupportedException e) {
-                throw new AssertionError();
-            }
+        SmallObject(int x) {
+            x1 = new Ref(x++);
+            x2 = new Ref(x++);
+            x3 = new Ref(x++);
+            x4 = new Ref(x++);
+        }
+    }
+
+    static class LargeObject extends DefaultClone {
+        Ref x01,x02,x03,x04,x05,x06,x07,x08;
+        Ref x09,x10,x11,x12,x13,x14,x15,x16;
+
+        LargeObject(int x) {
+            x01 = new Ref(x++);
+            x02 = new Ref(x++);
+            x03 = new Ref(x++);
+            x04 = new Ref(x++);
+            x05 = new Ref(x++);
+            x06 = new Ref(x++);
+            x07 = new Ref(x++);
+            x08 = new Ref(x++);
+            x09 = new Ref(x++);
+            x10 = new Ref(x++);
+            x11 = new Ref(x++);
+            x12 = new Ref(x++);
+            x13 = new Ref(x++);
+            x14 = new Ref(x++);
+            x15 = new Ref(x++);
+            x16 = new Ref(x++);
         }
     }
 }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -521,7 +521,9 @@ public class TestClone {
     static Ref[] newArray(int id) {
         int size = id % ARRAY_MAX_SIZE;
         Ref[] arr = new Ref[size];
-        for (int i = 0; i < size; i++) arr[i] = new Ref(id * 1_000 + i);
+        for (int i = 0; i < size; i++) {
+          arr[i] = new Ref(id * 1_000 + i);
+        }
         return arr;
     }
 
@@ -593,7 +595,7 @@ public class TestClone {
     }
 
     static class SmallObject extends DefaultClone {
-        Ref x1,x2,x3,x4;
+        Ref x1, x2, x3, x4;
 
         SmallObject(int x) {
             x1 = new Ref(x++);
@@ -604,8 +606,8 @@ public class TestClone {
     }
 
     static class LargeObject extends DefaultClone {
-        Ref x01,x02,x03,x04,x05,x06,x07,x08;
-        Ref x09,x10,x11,x12,x13,x14,x15,x16;
+        Ref x01, x02, x03, x04, x05, x06, x07, x08;
+        Ref x09, x10, x11, x12, x13, x14, x15, x16;
 
         LargeObject(int x) {
             x01 = new Ref(x++);

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -216,8 +216,8 @@
  */
 
 /*
- * @key randomness
  * @test id=no-coops
+ * @key randomness
  * @summary Test clone barriers work correctly
  * @library /test/lib
  * @requires vm.gc.Shenandoah
@@ -250,8 +250,8 @@
  */
 
 /*
- * @key randomness
  * @test id=no-coops-verify
+ * @key randomness
  * @summary Test clone barriers work correctly
  * @library /test/lib
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -22,12 +22,11 @@
  * questions.
  */
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /*
  * @test id=default
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -53,7 +52,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=default-verify
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -84,7 +85,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=passive
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -115,7 +118,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=passive-verify
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -151,7 +156,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=aggressive
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -177,7 +184,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=aggressive-verify
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -207,8 +216,10 @@ import jdk.test.lib.Utils;
  */
 
 /*
+ * @key randomness
  * @test id=no-coops
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"
  *
@@ -239,8 +250,10 @@ import jdk.test.lib.Utils;
  */
 
 /*
+ * @key randomness
  * @test id=no-coops-verify
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"
  *
@@ -277,7 +290,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=no-coops-aggressive
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"
  *
@@ -309,7 +324,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=generational
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -335,7 +352,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=generational-small-card-size
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -361,7 +380,9 @@ import jdk.test.lib.Utils;
 
 /*
  * @test id=generational-verify
+ * @key randomness
  * @summary Test clone barriers work correctly
+ * @library /test/lib
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -392,7 +413,9 @@ import jdk.test.lib.Utils;
 
  /*
   * @test id=generational-no-coops
+  * @key randomness
   * @summary Test clone barriers work correctly
+  * @library /test/lib
   * @requires vm.gc.Shenandoah
   * @requires vm.bits == "64"
   *
@@ -424,7 +447,9 @@ import jdk.test.lib.Utils;
 
  /*
   * @test id=generational-no-coops-verify
+  * @key randomness
   * @summary Test clone barriers work correctly
+  * @library /test/lib
   * @requires vm.gc.Shenandoah
   * @requires vm.bits == "64"
   *
@@ -458,6 +483,9 @@ import jdk.test.lib.Utils;
   *                   -XX:TieredStopAtLevel=4
   *                   TestClone
   */
+
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestClone {
 
@@ -530,7 +558,7 @@ public class TestClone {
     }
 
     static void verify(Ref[] src, int id) {
-        int expectedLen = id % 1000;
+        int expectedLen = id % ARRAY_MAX_SIZE;
         int srcLen = src.length;
         if (srcLen != expectedLen) {
             throw new IllegalStateException("Lengths do not match: " + srcLen + " vs " + expectedLen);

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -489,36 +489,39 @@ import jdk.test.lib.Utils;
 
 public class TestClone {
 
-    private static final int ENTRIES = 10_000;
-    private static final int ITERS = 1_000_000;
+    private static final int ENTRIES = 1_000;
+    private static final int ITERS = 50_000;
     private static final int ARRAY_MAX_SIZE = 128;
+    private static final Random RAND = Utils.getRandomInstance();
+    private static final SmallObject[] SMALL = new SmallObject[ENTRIES];
+    private static final LargeObject[] LARGE = new LargeObject[ENTRIES];
+    private static final Ref[][] ARRAY = new Ref[ENTRIES][];
 
     public static void main(String[] args) throws Exception {
-        SmallObject[] small = new SmallObject[ENTRIES];
-        LargeObject[] large = new LargeObject[ENTRIES];
-        Ref[][] array = new Ref[ENTRIES][];
-
         for (int i = 0; i < ENTRIES; i++) {
-            small[i] = new SmallObject(i);
-            large[i] = new LargeObject(i);
-            array[i] = newArray(i);
+            SMALL[i] = new SmallObject(i);
+            LARGE[i] = new LargeObject(i);
+            ARRAY[i] = newArray(i);
         }
 
-        Random rand = Utils.getRandomInstance();
         for (int i = 0; i < ITERS; i++) {
-            int r = rand.nextInt(ENTRIES);
-            small[r] = (SmallObject) small[r].clone();
-            large[r] = (LargeObject) large[r].clone();
-            array[r] = array[r].clone();
-
-            // Verify will trigger LRB.
-            // We don't want LRB to heal refs in the clone source or target,
-            // so we verify a different random location.
-            r = rand.nextInt(ENTRIES);
-            verify(small[r], r);
-            verify(large[r], r);
-            verify(array[r], r);
+            cloneAndVerify();
         }
+    }
+
+    static void cloneAndVerify() {
+        int r = RAND.nextInt(ENTRIES);
+        SMALL[r] = (SmallObject) SMALL[r].clone();
+        LARGE[r] = (LargeObject) LARGE[r].clone();
+        ARRAY[r] = ARRAY[r].clone();
+
+        // Verify will trigger LRB.
+        // We don't want LRB to heal refs in the clone source or target,
+        // so we verify a different random location.
+        r = RAND.nextInt(ENTRIES);
+        verify(SMALL[r], r);
+        verify(LARGE[r], r);
+        verify(ARRAY[r], r);
     }
 
     static Ref[] newArray(int id) {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -511,6 +511,9 @@ public class TestClone {
             large[r] = (LargeObject) large[r].clone();
             array[r] = array[r].clone();
 
+            // Verify will trigger LRB.
+            // We don't want LRB to heal refs in the clone source or target,
+            // so we verify a different random location.
             r = rand.nextInt(ENTRIES);
             verify(small[r], r);
             verify(large[r], r);
@@ -522,7 +525,7 @@ public class TestClone {
         int size = id % ARRAY_MAX_SIZE;
         Ref[] arr = new Ref[size];
         for (int i = 0; i < size; i++) {
-          arr[i] = new Ref(id * 1_000 + i);
+          arr[i] = new Ref(arrayElementValue(id, i));
         }
         return arr;
     }
@@ -566,12 +569,17 @@ public class TestClone {
             throw new IllegalStateException("Lengths do not match: " + srcLen + " vs " + expectedLen);
         }
         for (int i = 0; i < src.length; i++) {
-            int expectedVal = id * 1_000 + i;
+            int expectedVal = arrayElementValue(id, i);
             int val = src[i].x;
             if (val != expectedVal) {
                 throw new IllegalStateException("Elements do not match at " + i + ": " + val + " vs " + expectedVal + ", len = " + srcLen);
             }
         }
+    }
+
+    static int arrayElementValue(int id, int offset) {
+        // Globally unique.
+        return ARRAY_MAX_SIZE * id + offset;
     }
 
     static class Ref {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -411,80 +411,80 @@
  *                   TestClone
  */
 
- /*
-  * @test id=generational-no-coops
-  * @key randomness
-  * @summary Test clone barriers work correctly
-  * @library /test/lib
-  * @requires vm.gc.Shenandoah
-  * @requires vm.bits == "64"
-  *
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -Xint
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:-TieredCompilation
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:TieredStopAtLevel=1
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:TieredStopAtLevel=4
-  *                   TestClone
-  */
-
- /*
-  * @test id=generational-no-coops-verify
-  * @key randomness
-  * @summary Test clone barriers work correctly
-  * @library /test/lib
-  * @requires vm.gc.Shenandoah
-  * @requires vm.bits == "64"
-  *
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:+ShenandoahVerify
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:+ShenandoahVerify
-  *                   -Xint
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:+ShenandoahVerify
-  *                   -XX:-TieredCompilation
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:+ShenandoahVerify
-  *                   -XX:TieredStopAtLevel=1
-  *                   TestClone
-  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
-  *                   -XX:-UseCompressedOops
-  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
-  *                   -XX:+ShenandoahVerify
-  *                   -XX:TieredStopAtLevel=4
-  *                   TestClone
-  */
+/*
+ * @test id=generational-no-coops
+ * @key randomness
+ * @summary Test clone barriers work correctly
+ * @library /test/lib
+ * @requires vm.gc.Shenandoah
+ * @requires vm.bits == "64"
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -Xint
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:-TieredCompilation
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:TieredStopAtLevel=1
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:TieredStopAtLevel=4
+ *                   TestClone
+ */
+/*
+ * @test id=generational-no-coops-verify
+ * @key randomness
+ * @summary Test clone barriers work correctly
+ * @library /test/lib
+ * @requires vm.gc.Shenandoah
+ * @requires vm.bits == "64"
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:+ShenandoahVerify
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:+ShenandoahVerify
+ *                   -Xint
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:+ShenandoahVerify
+ *                   -XX:-TieredCompilation
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:+ShenandoahVerify
+ *                   -XX:TieredStopAtLevel=1
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *                   -XX:+ShenandoahVerify
+ *                   -XX:TieredStopAtLevel=4
+ *                   TestClone
+ */
 
 import java.util.Random;
+
 import jdk.test.lib.Utils;
 
 public class TestClone {
@@ -498,21 +498,30 @@ public class TestClone {
     private static final Ref[][] ARRAY = new Ref[ENTRIES][];
 
     public static void main(String[] args) throws Exception {
+        // Seed
         for (int i = 0; i < ENTRIES; i++) {
             SMALL[i] = new SmallObject(i);
             LARGE[i] = new LargeObject(i);
             ARRAY[i] = newArray(i);
         }
 
+        // Random clone and verify
         for (int i = 0; i < ITERS; i++) {
             cloneAndVerify();
+        }
+
+        // Verify everything
+        for (int i = 0; i < ENTRIES; i++) {
+            verify(SMALL[i], i);
+            verify(LARGE[i], i);
+            verify(ARRAY[i], i);
         }
     }
 
     static void cloneAndVerify() {
         int r = RAND.nextInt(ENTRIES);
-        SMALL[r] = (SmallObject) SMALL[r].clone();
-        LARGE[r] = (LargeObject) LARGE[r].clone();
+        SMALL[r] = SMALL[r].clone();
+        LARGE[r] = LARGE[r].clone();
         ARRAY[r] = ARRAY[r].clone();
 
         // Verify will trigger LRB.
@@ -528,38 +537,38 @@ public class TestClone {
         int size = id % ARRAY_MAX_SIZE;
         Ref[] arr = new Ref[size];
         for (int i = 0; i < size; i++) {
-          arr[i] = new Ref(arrayElementValue(id, i));
+            arr[i] = new Ref(elementValue(id, i));
         }
         return arr;
     }
 
     static void verify(SmallObject src, int id) {
-        assertEquals(src.x1.x, id++);
-        assertEquals(src.x2.x, id++);
-        assertEquals(src.x3.x, id++);
-        assertEquals(src.x4.x, id++);
+        assertEquals(elementValue(id, 0), src.x1.x);
+        assertEquals(elementValue(id, 1), src.x2.x);
+        assertEquals(elementValue(id, 2), src.x3.x);
+        assertEquals(elementValue(id, 3), src.x4.x);
     }
 
     static void verify(LargeObject src, int id) {
-        assertEquals(src.x01.x, id++);
-        assertEquals(src.x02.x, id++);
-        assertEquals(src.x03.x, id++);
-        assertEquals(src.x04.x, id++);
-        assertEquals(src.x05.x, id++);
-        assertEquals(src.x06.x, id++);
-        assertEquals(src.x07.x, id++);
-        assertEquals(src.x08.x, id++);
-        assertEquals(src.x09.x, id++);
-        assertEquals(src.x10.x, id++);
-        assertEquals(src.x11.x, id++);
-        assertEquals(src.x12.x, id++);
-        assertEquals(src.x13.x, id++);
-        assertEquals(src.x14.x, id++);
-        assertEquals(src.x15.x, id++);
-        assertEquals(src.x16.x, id++);
+        assertEquals(elementValue(id, 0), src.x01.x);
+        assertEquals(elementValue(id, 1), src.x02.x);
+        assertEquals(elementValue(id, 2), src.x03.x);
+        assertEquals(elementValue(id, 3), src.x04.x);
+        assertEquals(elementValue(id, 4), src.x05.x);
+        assertEquals(elementValue(id, 5), src.x06.x);
+        assertEquals(elementValue(id, 6), src.x07.x);
+        assertEquals(elementValue(id, 7), src.x08.x);
+        assertEquals(elementValue(id, 8), src.x09.x);
+        assertEquals(elementValue(id, 9), src.x10.x);
+        assertEquals(elementValue(id, 10), src.x11.x);
+        assertEquals(elementValue(id, 11), src.x12.x);
+        assertEquals(elementValue(id, 12), src.x13.x);
+        assertEquals(elementValue(id, 13), src.x14.x);
+        assertEquals(elementValue(id, 14), src.x15.x);
+        assertEquals(elementValue(id, 15), src.x16.x);
     }
 
-    static void assertEquals(int actual, int expected) {
+    static void assertEquals(int expected, int actual) {
         if (actual != expected) {
             throw new IllegalStateException("Mismatch: expected=" + expected + ", actual=" + actual);
         }
@@ -572,7 +581,7 @@ public class TestClone {
             throw new IllegalStateException("Lengths do not match: " + srcLen + " vs " + expectedLen);
         }
         for (int i = 0; i < src.length; i++) {
-            int expectedVal = arrayElementValue(id, i);
+            int expectedVal = elementValue(id, i);
             int val = src[i].x;
             if (val != expectedVal) {
                 throw new IllegalStateException("Elements do not match at " + i + ": " + val + " vs " + expectedVal + ", len = " + srcLen);
@@ -580,9 +589,9 @@ public class TestClone {
         }
     }
 
-    static int arrayElementValue(int id, int offset) {
-        // Globally unique.
-        return ARRAY_MAX_SIZE * id + offset;
+    static int elementValue(int id, int offset) {
+        // Globally unique (per type).
+        return ENTRIES * id + offset;
     }
 
     static class Ref {
@@ -593,7 +602,7 @@ public class TestClone {
         }
     }
 
-    static abstract class DefaultClone<T> implements Cloneable {
+    abstract static class DefaultClone<T> implements Cloneable {
         @Override
         @SuppressWarnings("unchecked")
         public T clone() {
@@ -605,38 +614,38 @@ public class TestClone {
         }
     }
 
-    static class SmallObject extends DefaultClone {
+    static class SmallObject extends DefaultClone<SmallObject> {
         Ref x1, x2, x3, x4;
 
         SmallObject(int x) {
-            x1 = new Ref(x++);
-            x2 = new Ref(x++);
-            x3 = new Ref(x++);
-            x4 = new Ref(x++);
+            x1 = new Ref(elementValue(x, 0));
+            x2 = new Ref(elementValue(x, 1));
+            x3 = new Ref(elementValue(x, 2));
+            x4 = new Ref(elementValue(x, 3));
         }
     }
 
-    static class LargeObject extends DefaultClone {
+    static class LargeObject extends DefaultClone<LargeObject> {
         Ref x01, x02, x03, x04, x05, x06, x07, x08;
         Ref x09, x10, x11, x12, x13, x14, x15, x16;
 
         LargeObject(int x) {
-            x01 = new Ref(x++);
-            x02 = new Ref(x++);
-            x03 = new Ref(x++);
-            x04 = new Ref(x++);
-            x05 = new Ref(x++);
-            x06 = new Ref(x++);
-            x07 = new Ref(x++);
-            x08 = new Ref(x++);
-            x09 = new Ref(x++);
-            x10 = new Ref(x++);
-            x11 = new Ref(x++);
-            x12 = new Ref(x++);
-            x13 = new Ref(x++);
-            x14 = new Ref(x++);
-            x15 = new Ref(x++);
-            x16 = new Ref(x++);
+            x01 = new Ref(elementValue(x, 0));
+            x02 = new Ref(elementValue(x, 1));
+            x03 = new Ref(elementValue(x, 2));
+            x04 = new Ref(elementValue(x, 3));
+            x05 = new Ref(elementValue(x, 4));
+            x06 = new Ref(elementValue(x, 5));
+            x07 = new Ref(elementValue(x, 6));
+            x08 = new Ref(elementValue(x, 7));
+            x09 = new Ref(elementValue(x, 8));
+            x10 = new Ref(elementValue(x, 9));
+            x11 = new Ref(elementValue(x, 10));
+            x12 = new Ref(elementValue(x, 11));
+            x13 = new Ref(elementValue(x, 12));
+            x14 = new Ref(elementValue(x, 13));
+            x15 = new Ref(elementValue(x, 14));
+            x16 = new Ref(elementValue(x, 15));
         }
     }
 }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -507,18 +507,14 @@ public class TestClone {
         Random rand = Utils.getRandomInstance();
         for (int i = 0; i < ITERS; i++) {
             int r = rand.nextInt(ENTRIES);
+            small[r] = (SmallObject) small[r].clone();
+            large[r] = (LargeObject) large[r].clone();
+            array[r] = array[r].clone();
 
-            SmallObject s = small[r];
-            small[r] = (SmallObject) s.clone();
-            verify(s, r); // verify *after* clone to avoid LRB healing from-space refs
-
-            LargeObject l = large[r];
-            large[r] = (LargeObject) l.clone();
-            verify(l, r);
-
-            Ref[] a = array[r];
-            array[r] = a.clone();
-            verify(a, r);
+            r = rand.nextInt(ENTRIES);
+            verify(small[r], r);
+            verify(large[r], r);
+            verify(array[r], r);
         }
     }
 
@@ -530,31 +526,35 @@ public class TestClone {
     }
 
     static void verify(SmallObject src, int id) {
-        int expected = id;
-        if (src.x1.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x1.x);
-        if (src.x2.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x2.x);
-        if (src.x3.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x3.x);
-        if (src.x4.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x4.x);
+        assertEquals(src.x1.x, id++);
+        assertEquals(src.x2.x, id++);
+        assertEquals(src.x3.x, id++);
+        assertEquals(src.x4.x, id++);
     }
 
     static void verify(LargeObject src, int id) {
-        int expected = id;
-        if (src.x01.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x01.x);
-        if (src.x02.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x02.x);
-        if (src.x03.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x03.x);
-        if (src.x04.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x04.x);
-        if (src.x05.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x05.x);
-        if (src.x06.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x06.x);
-        if (src.x07.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x07.x);
-        if (src.x08.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x08.x);
-        if (src.x09.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x09.x);
-        if (src.x10.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x10.x);
-        if (src.x11.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x11.x);
-        if (src.x12.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x12.x);
-        if (src.x13.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x13.x);
-        if (src.x14.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x14.x);
-        if (src.x15.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x15.x);
-        if (src.x16.x != expected++) throw new IllegalStateException("Mismatch: id=" + id + ", expected=" + (expected - 1) + ", actual=" + src.x16.x);
+        assertEquals(src.x01.x, id++);
+        assertEquals(src.x02.x, id++);
+        assertEquals(src.x03.x, id++);
+        assertEquals(src.x04.x, id++);
+        assertEquals(src.x05.x, id++);
+        assertEquals(src.x06.x, id++);
+        assertEquals(src.x07.x, id++);
+        assertEquals(src.x08.x, id++);
+        assertEquals(src.x09.x, id++);
+        assertEquals(src.x10.x, id++);
+        assertEquals(src.x11.x, id++);
+        assertEquals(src.x12.x, id++);
+        assertEquals(src.x13.x, id++);
+        assertEquals(src.x14.x, id++);
+        assertEquals(src.x15.x, id++);
+        assertEquals(src.x16.x, id++);
+    }
+
+    static void assertEquals(int actual, int expected) {
+        if (actual != expected) {
+            throw new IllegalStateException("Mismatch: expected=" + expected + ", actual=" + actual);
+        }
     }
 
     static void verify(Ref[] src, int id) {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -22,6 +22,9 @@
  * questions.
  */
 
+import java.util.ArrayList;
+import java.util.List;
+
 /*
  * @test id=default
  * @summary Test clone barriers work correctly
@@ -168,6 +171,37 @@
  *                   TestClone
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
  *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                   -XX:TieredStopAtLevel=4
+ *                   TestClone
+ */
+
+/*
+ * @test id=aggressive-verify
+ * @summary Test clone barriers work correctly
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                   -XX:+ShenandoahVerify
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                   -XX:+ShenandoahVerify
+ *                   -Xint
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                   -XX:+ShenandoahVerify
+ *                   -XX:-TieredCompilation
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                   -XX:+ShenandoahVerify
+ *                   -XX:TieredStopAtLevel=1
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                   -XX:+ShenandoahVerify
  *                   -XX:TieredStopAtLevel=4
  *                   TestClone
  */
@@ -427,9 +461,12 @@
 
 public class TestClone {
 
+    private static final List<Object> objects = new ArrayList<>();
+    private static volatile Object sink;
+
     public static void main(String[] args) throws Exception {
         for (int i = 0; i < 10000; i++) {
-            Object[] src = new Object[i];
+            Object[] src = new Object[i % 512]; // A range of sizes, but limit overhead
             for (int c = 0; c < src.length; c++) {
                 src[c] = new Object();
             }
@@ -438,6 +475,7 @@ public class TestClone {
             testWithObject(new SmallObject());
             testWithObject(new LargeObject());
         }
+        testOld();
     }
 
     static void testWith(Object[] src) {
@@ -485,6 +523,25 @@ public class TestClone {
             dst.x15 != src.x15 ||
             dst.x16 != src.x16) {
             throw new IllegalStateException("Contents do not match");
+        }
+    }
+
+    public static void testOld() throws Exception {
+        // Trying to stress the interaction with garbage collection.
+        // Clone old objects while creating garbage. Do *not* read from the cloned
+        // objects as this may trigger LRB to heal a stale from-space reference.
+        // The failure mode here is a ShenandoahVerify observing a bad ref.
+        for (int i = 0; i < 100_000; i++) {
+            objects.add(new SmallObject());
+            objects.add(new LargeObject());
+            objects.add(new Object[i % 100]); // various sizes
+            Object oldObject = objects.get(i % 100);
+            sink = switch (oldObject) {
+                case SmallObject s -> s.clone();
+                case LargeObject l -> l.clone();
+                case Object[] a -> a.clone();
+                default -> throw new IllegalStateException("Impossible");
+            };
         }
     }
 


### PR DESCRIPTION
While working on [JDK-8382631](https://bugs.openjdk.org/browse/JDK-8382631) I found that Shenandoah's TestClone.java misses a class of failure - if the clone barrier is entirely missed, the tests won't catch it.

This adds two things:

1. Aggressive *plus* verify.
2. A specific loop targeting GC interactions. We need to clone an object which has a from-space ref, but the clone is above the update-refs watermark, so it doesn't get updated by update-refs. Then, don't access the ref (otherwise we might trigger LRB which will fix the ref), and verify can then find the ref pointing to a trashed region.

aggressive plus verify is slow, plus the new code does more iterations. But I found that this is very reliable in finding issues compared to fewer iterations, and the speed is still manageable.

```
time make test TEST="test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java"

# master
187.48s user 28.50s system 694% cpu 31.080 total

# this PR
651.13s user 26.58s system 1002% cpu 1:07.62 total
```

Example failure if barriers are missed:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (shenandoahVerifier.cpp:105), pid=1558, tid=1565
#  Error: After Updating References, Marked; Object should be in active region

Referenced from:
  interior location: 0x00000000fc380484
  0x00000000fc380480 - nk 3716 klass 0x000000008f3a1000 TestClone$LargeObject

        allocated after mark start
        after update watermark
        marked strong
        marked weak
    not in collection set
    mark:  mark(is_unlocked no_hash age=0)
    region: | 1927|R  |Y|BTE     fc380000,     fc400000,     fc400000|TAMS     fc380000|UWM     fc380000|U   512K|T   512K|G     0B|S     0B|L     0B|CP   0
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383642](https://bugs.openjdk.org/browse/JDK-8383642): Additional Shenandoah clone barrier tests (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**) Review applies to [410e8233](https://git.openjdk.org/jdk/pull/31001/files/410e8233fc2fb27cef7fa92b4ed1ccd03f2fa769)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31001/head:pull/31001` \
`$ git checkout pull/31001`

Update a local copy of the PR: \
`$ git checkout pull/31001` \
`$ git pull https://git.openjdk.org/jdk.git pull/31001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31001`

View PR using the GUI difftool: \
`$ git pr show -t 31001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31001.diff">https://git.openjdk.org/jdk/pull/31001.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31001#issuecomment-4352249319)
</details>
