### PR TITLE
8383525: DateTimeFormatterBuilder.getLocalizedDateTimePattern() concurrency issue

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -657,6 +657,8 @@ public class LocaleResources {
         // "preferred"/"allowed" input skeleton maps
         var inputSkeletons = new HashMap<String, Map<String, String>>();
         Pattern p = Pattern.compile("([^:]+):([^;]+);");
+
+        // CLDR is guaranteed to implement ResourceBundleBasedAdapter
         if (LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR) instanceof ResourceBundleBasedAdapter rbba) {
             var r = rbba.getLocaleData().getDateFormatData(Locale.ROOT);
             Stream.of("preferred", "allowed").forEach(type -> {

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,11 +130,12 @@ public class LocaleResources {
 
     // Input Skeleton map for "preferred" and "allowed"
     // Map<"preferred"/"allowed", Map<"region", "skeleton">>
-    private static Map<String, Map<String, String>> inputSkeletons;
+    private static final LazyConstant<Map<String, Map<String, String>>> INPUT_SKELETONS =
+        LazyConstant.of(LocaleResources::initSkeletons);
 
     // Skeletons for "j" and "C" input skeleton symbols for this locale
-    private String jPattern;
-    private String CPattern;
+    private final LazyConstant<String> jPattern = LazyConstant.of(() -> resolveInputSkeleton("preferred"));
+    private final LazyConstant<String> CPattern = LazyConstant.of(this::initCPattern);
 
     LocaleResources(ResourceBundleBasedAdapter adapter, Locale locale) {
         this.locale = locale;
@@ -604,8 +605,6 @@ public class LocaleResources {
     }
 
     private String getLocalizedPatternImpl(String requestedTemplate, String calType) {
-        initSkeletonIfNeeded();
-
         // input skeleton substitution
         var skeleton = substituteInputSkeletons(requestedTemplate);
 
@@ -654,12 +653,12 @@ public class LocaleResources {
             .orElse(null);
     }
 
-    private void initSkeletonIfNeeded() {
+    private static Map<String, Map<String, String>> initSkeletons() {
         // "preferred"/"allowed" input skeleton maps
-        if (inputSkeletons == null) {
-            inputSkeletons = new HashMap<>();
-            Pattern p = Pattern.compile("([^:]+):([^;]+);");
-            ResourceBundle r = localeData.getDateFormatData(Locale.ROOT);
+        var inputSkeletons = new HashMap<String, Map<String, String>>();
+        Pattern p = Pattern.compile("([^:]+):([^;]+);");
+        if (LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR) instanceof ResourceBundleBasedAdapter rbba) {
+            var r = rbba.getLocaleData().getDateFormatData(Locale.ROOT);
             Stream.of("preferred", "allowed").forEach(type -> {
                 var inputRegionsKey = SKELETON_INPUT_REGIONS_KEY + "." + type;
                 Map<String, String> typeMap = new HashMap<>();
@@ -673,19 +672,17 @@ public class LocaleResources {
                 inputSkeletons.put(type, typeMap);
             });
         }
+        return inputSkeletons;
+    }
 
-        // j/C patterns for this locale
-        if (jPattern == null) {
-            jPattern = resolveInputSkeleton("preferred");
-            CPattern = resolveInputSkeleton("allowed");
-            // hack: "allowed" contains reversed order for hour/period, e.g, "hB" which should be "Bh" as a skeleton
-            if (CPattern.length() == 2) {
-                var ba = new byte[2];
-                ba[0] = (byte)CPattern.charAt(1);
-                ba[1] = (byte)CPattern.charAt(0);
-                CPattern = new String(ba);
-            }
+    private String initCPattern() {
+        // C patterns for this locale
+        var cp = resolveInputSkeleton("allowed");
+        // hack: "allowed" contains reversed order for hour/period, e.g, "hB" which should be "Bh" as a skeleton
+        if (cp.length() == 2) {
+            cp = "" + cp.charAt(1) + cp.charAt(0);
         }
+        return cp;
     }
 
     /**
@@ -695,11 +692,13 @@ public class LocaleResources {
      * @return resolved skeletons for this locale, defaults to "h" if none found.
      */
     private String resolveInputSkeleton(String type) {
-        var regionToSkeletonMap = inputSkeletons.get(type);
-        return regionToSkeletonMap.getOrDefault(locale.getLanguage() + "-" + locale.getCountry(),
-            regionToSkeletonMap.getOrDefault(locale.getCountry(),
-                regionToSkeletonMap.getOrDefault(locale.getLanguage() + "-001",
-                    regionToSkeletonMap.getOrDefault("001", "h"))));
+        var regionToSkeletonMap = INPUT_SKELETONS.get().get(type);
+        return regionToSkeletonMap != null ?
+            regionToSkeletonMap.getOrDefault(locale.getLanguage() + "-" + locale.getCountry(),
+                regionToSkeletonMap.getOrDefault(locale.getCountry(),
+                    regionToSkeletonMap.getOrDefault(locale.getLanguage() + "-001",
+                        regionToSkeletonMap.getOrDefault("001", "h")))) :
+            "h";
     }
 
     /**
@@ -711,8 +710,8 @@ public class LocaleResources {
      */
     private String substituteInputSkeletons(String requestedTemplate) {
         var cCount = requestedTemplate.chars().filter(c -> c == 'C').count();
-        return requestedTemplate.replaceAll("j", jPattern)
-                .replaceFirst("C+", CPattern.replaceAll("([hkHK])", "$1".repeat((int)cCount)));
+        return requestedTemplate.replaceAll("j", jPattern.get())
+                .replaceFirst("C+", CPattern.get().replaceAll("([hkHK])", "$1".repeat((int)cCount)));
     }
 
     /**

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -695,7 +695,6 @@ public class LocaleResources {
      */
     private String resolveInputSkeleton(String type) {
         var regionToSkeletonMap = INPUT_SKELETONS.get().get(type);
-        var hour = "h";
 
         if (regionToSkeletonMap != null) {
             for (var region: new String[] {
@@ -703,14 +702,14 @@ public class LocaleResources {
                 locale.getCountry(),
                 locale.getLanguage() + "-001",
                 "001"}) {
-                hour = regionToSkeletonMap.get(region);
+                var hour = regionToSkeletonMap.get(region);
                 if (hour != null) {
-                    break;
+                    return hour;
                 }
             }
         }
 
-        return hour;
+        return "h";
     }
 
     /**

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -693,12 +693,22 @@ public class LocaleResources {
      */
     private String resolveInputSkeleton(String type) {
         var regionToSkeletonMap = INPUT_SKELETONS.get().get(type);
-        return regionToSkeletonMap != null ?
-            regionToSkeletonMap.getOrDefault(locale.getLanguage() + "-" + locale.getCountry(),
-                regionToSkeletonMap.getOrDefault(locale.getCountry(),
-                    regionToSkeletonMap.getOrDefault(locale.getLanguage() + "-001",
-                        regionToSkeletonMap.getOrDefault("001", "h")))) :
-            "h";
+        var hour = "h";
+
+        if (regionToSkeletonMap != null) {
+            for (var region: new String[] {
+                locale.getLanguage() + "-" + locale.getCountry(),
+                locale.getCountry(),
+                locale.getLanguage() + "-001",
+                "001"}) {
+                hour = regionToSkeletonMap.get(region);
+                if (hour != null) {
+                    break;
+                }
+            }
+        }
+
+        return hour;
     }
 
     /**

--- a/test/jdk/sun/util/locale/provider/SkeletonRaceTest.java
+++ b/test/jdk/sun/util/locale/provider/SkeletonRaceTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class SkeletonRaceTest {
     @Test
-    void testSkeletonRace() throws InterruptedException, ExecutionException {
+    void testSkeletonRace() {
         // Without the fix, LocaleResources throws an NPE
         assertDoesNotThrow(this::doRaceTest);
     }

--- a/test/jdk/sun/util/locale/provider/SkeletonRaceTest.java
+++ b/test/jdk/sun/util/locale/provider/SkeletonRaceTest.java
@@ -47,31 +47,34 @@ public class SkeletonRaceTest {
     @Test
     void testSkeletonRace() {
         // Without the fix, LocaleResources throws an NPE
-        assertDoesNotThrow(this::doRaceTest);
+        for (int run = 0; run < 10; run++) {
+            assertDoesNotThrow(this::doRaceTest);
+        }
     }
 
     private void doRaceTest() throws InterruptedException, ExecutionException {
         Locale[] locales = Locale.getAvailableLocales();
         int threads = 50;
-        ExecutorService pool = Executors.newFixedThreadPool(threads);
-        CountDownLatch ready = new CountDownLatch(threads);
-        CountDownLatch go = new CountDownLatch(1);
-        List<Future<?>> futures = new ArrayList<>();
 
-        for (int i = 0; i < threads; i++) {
-            Locale locale = locales[i % locales.length];
-            futures.add(pool.submit(() -> {
-                ready.countDown();
-                go.await();
-                DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-                    "yMd", IsoChronology.INSTANCE, locale);
-                return null;
-            }));
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            CountDownLatch ready = new CountDownLatch(threads);
+            CountDownLatch go = new CountDownLatch(1);
+            List<Future<?>> futures = new ArrayList<>();
+
+            for (int i = 0; i < threads; i++) {
+                Locale locale = locales[i % locales.length];
+                futures.add(pool.submit(() -> {
+                    ready.countDown();
+                    go.await();
+                    DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+                        "yMd", IsoChronology.INSTANCE, locale);
+                    return null;
+                }));
+            }
+
+            ready.await();
+            go.countDown();
+            for (Future<?> f : futures) f.get();
         }
-
-        ready.await();
-        go.countDown();
-        pool.shutdown();
-        for (Future<?> f : futures) f.get();
     }
 }

--- a/test/jdk/sun/util/locale/provider/SkeletonRaceTest.java
+++ b/test/jdk/sun/util/locale/provider/SkeletonRaceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8383525
+ * @modules jdk.localedata
+ * @summary Make sure that input skeleton init code is thread safe
+ * @run junit SkeletonRaceTest
+ */
+
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class SkeletonRaceTest {
+    @Test
+    void testSkeletonRace() throws InterruptedException, ExecutionException {
+        // Without the fix, LocaleResources throws an NPE
+        assertDoesNotThrow(this::doRaceTest);
+    }
+
+    private void doRaceTest() throws InterruptedException, ExecutionException {
+        Locale[] locales = Locale.getAvailableLocales();
+        int threads = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch go = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            Locale locale = locales[i % locales.length];
+            futures.add(pool.submit(() -> {
+                ready.countDown();
+                go.await();
+                DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+                    "yMd", IsoChronology.INSTANCE, locale);
+                return null;
+            }));
+        }
+
+        ready.await();
+        go.countDown();
+        pool.shutdown();
+        for (Future<?> f : futures) f.get();
+    }
+}


### PR DESCRIPTION
Fixing the race condition during the initialization of the skeleton map. The root cause was that the map could be accessed while it was still being initialized, leading to an NPE. Although the NPE could be avoided by returning a default value, the map initialization itself should be made thread safe.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383525](https://bugs.openjdk.org/browse/JDK-8383525): DateTimeFormatterBuilder.getLocalizedDateTimePattern() concurrency issue (**Bug** - P3)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31006/head:pull/31006` \
`$ git checkout pull/31006`

Update a local copy of the PR: \
`$ git checkout pull/31006` \
`$ git pull https://git.openjdk.org/jdk.git pull/31006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31006`

View PR using the GUI difftool: \
`$ git pr show -t 31006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31006.diff">https://git.openjdk.org/jdk/pull/31006.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31006#issuecomment-4355828406)
</details>
