### PR TITLE
8383729: Shenandoah: limit ShenandoahGCHeuristics=aggressive GC frequency

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
@@ -31,7 +31,7 @@
 #include "runtime/os.hpp"
 
 ShenandoahAggressiveHeuristics::ShenandoahAggressiveHeuristics(ShenandoahSpaceInfo* space_info) :
-  ShenandoahHeuristics(space_info) {
+  ShenandoahStaticHeuristics(space_info) {
   // Do not shortcut evacuation
   SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahImmediateThreshold, 100);
 
@@ -51,9 +51,14 @@ void ShenandoahAggressiveHeuristics::choose_collection_set_from_regiondata(Shena
 }
 
 bool ShenandoahAggressiveHeuristics::should_start_gc() {
-  log_trigger("Start next cycle immediately");
-  accept_trigger();
-  return true;
+  double last_time_ms = (os::elapsedTime() - _last_cycle_end) * 1000;
+  if (last_time_ms > ShenandoahAggressiveGCInterval) {
+    log_trigger("Time since last GC (%.0f ms) is larger than agressive interval (%zu ms)",
+                  last_time_ms, ShenandoahAggressiveGCInterval);
+    accept_trigger();
+    return true;
+  }
+  return ShenandoahStaticHeuristics::should_start_gc();
 }
 
 bool ShenandoahAggressiveHeuristics::should_unload_classes() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
@@ -53,7 +53,7 @@ void ShenandoahAggressiveHeuristics::choose_collection_set_from_regiondata(Shena
 bool ShenandoahAggressiveHeuristics::should_start_gc() {
   double last_time_ms = (os::elapsedTime() - _last_cycle_end) * 1000;
   if (last_time_ms > ShenandoahAggressiveGCInterval) {
-    log_trigger("Time since last GC (%.0f ms) is larger than agressive interval (%zu ms)",
+    log_trigger("Time since last GC (%.0f ms) is larger than aggressive interval (%zu ms)",
                   last_time_ms, ShenandoahAggressiveGCInterval);
     accept_trigger();
     return true;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.hpp
@@ -26,12 +26,13 @@
 #define SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHAGGRESSIVEHEURISTICS_HPP
 
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
+#include "gc/shenandoah/heuristics/shenandoahStaticHeuristics.hpp"
 
 /*
  * This is a diagnostic heuristic that continuously runs collections
  * cycles and adds every region with any garbage to the collection set.
  */
-class ShenandoahAggressiveHeuristics : public ShenandoahHeuristics {
+class ShenandoahAggressiveHeuristics : public ShenandoahStaticHeuristics {
 public:
   ShenandoahAggressiveHeuristics(ShenandoahSpaceInfo* space_info);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -213,7 +213,9 @@
           "at all times, even during the GC cycle;"                         \
           " static - trigger GC when free heap falls below a specified "    \
           "threshold;"                                                      \
-          " aggressive - run GC continuously, try to evacuate everything;"  \
+          " aggressive - run GC very frequently (controlled by "           \
+          "ShenandoahAggressiveGCInterval), try to evacuate everything "    \
+          "(recommended only for testing);"                                 \
           " compact - run GC more frequently and with deeper targets to "   \
           "free up more memory.")                                           \
                                                                             \
@@ -335,6 +337,10 @@
           "Run a collection of the young generation at least this often. "  \
           "Heuristics may trigger collections more frequently. Time is in " \
           "milliseconds. Setting this to 0 disables the feature.")          \
+                                                                            \
+  product(uintx, ShenandoahAggressiveGCInterval, 50, EXPERIMENTAL,          \
+          "If using ShenandoahHeuristics=aggressive, run GC at least "      \
+          "this often. Time is in milliseconds.")                           \
                                                                             \
   product(bool, ShenandoahAlwaysClearSoftRefs, false, EXPERIMENTAL,         \
           "Unconditionally clear soft references, instead of using any "    \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -213,7 +213,7 @@
           "at all times, even during the GC cycle;"                         \
           " static - trigger GC when free heap falls below a specified "    \
           "threshold;"                                                      \
-          " aggressive - run GC very frequently (controlled by "           \
+          " aggressive - run GC very frequently (controlled by "            \
           "ShenandoahAggressiveGCInterval), try to evacuate everything "    \
           "(recommended only for testing);"                                 \
           " compact - run GC more frequently and with deeper targets to "   \


### PR DESCRIPTION
`-XX:ShenandoahGCHeuristics=aggressive` is useful for testing, but 100% back-to-back GC can tank performance, especially with things like `-XX:+ShenandoahVerify`.

Add `ShenandoahAggressiveGCInterval` (default 50ms) to limit the frequency of aggressive GC triggers. Fall back to the existing static heuristic so we can still trigger if we're running out of space. You can set `ShenandoahAggressiveGCInterval=0` to get the old behaviour (always trigger).

```
# Before
[0.656s][info][gc] Trigger: Start next cycle immediately
[0.663s][info][gc] Trigger: Start next cycle immediately
[0.671s][info][gc] Trigger: Start next cycle immediately
[0.678s][info][gc] Trigger: Start next cycle immediately
[0.685s][info][gc] Trigger: Start next cycle immediately

# After
[0.757s][info][gc] Trigger: Time since last GC (51 ms) is larger than agressive interval (50 ms)
[0.816s][info][gc] Trigger: Time since last GC (51 ms) is larger than agressive interval (50 ms)
[0.874s][info][gc] Trigger: Time since last GC (51 ms) is larger than agressive interval (50 ms)
```


```
make test TEST="test/hotspot/jtreg/gc/shenandoah/TestResizeTLAB.java#aggressive"

# before
82.10s user 6.49s system 304% cpu 29.055 total

# after
41.39s user 6.33s system 292% cpu 16.299 total
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383729](https://bugs.openjdk.org/browse/JDK-8383729): Shenandoah: limit ShenandoahGCHeuristics=aggressive GC frequency (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31009/head:pull/31009` \
`$ git checkout pull/31009`

Update a local copy of the PR: \
`$ git checkout pull/31009` \
`$ git pull https://git.openjdk.org/jdk.git pull/31009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31009`

View PR using the GUI difftool: \
`$ git pr show -t 31009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31009.diff">https://git.openjdk.org/jdk/pull/31009.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31009#issuecomment-4359375861)
</details>
