### PR TITLE
8383503: Test runtime/cds/MetaspaceAllocGaps.java failed

### DIFF
--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -416,13 +416,22 @@ void DumpRegion::report_gaps(DumpAllocStats* stats) {
         stats->record_gap(checked_cast<int>(node->key().gap_bytes()));
         return true;
       });
+
+  double unfilled_percent = 0.0;
   if (_gap_tree.size() > 0) {
-    log_warning(aot)("Unexpected %zu gaps (%zu bytes) for Klass alignment",
-                     _gap_tree.size(), _total_gap_bytes);
+    unfilled_percent = percent_of(_total_gap_bytes, _total_gap_allocs);
+    if (unfilled_percent > 5.0) {
+      // We have a limited number of small objects, so some small gaps may remain
+      // unfilled. If more than 5% of the gaps are unfilled, this likely indicates
+      // a systematic error that should be investigated. Otherwise, do not warn to
+      // avoid noise.
+      log_warning(aot)("Unexpected %zu gaps (%zu bytes) for Klass alignment",
+                       _gap_tree.size(), _total_gap_bytes);
+    }
   }
   if (_total_gap_allocs > 0) {
-    log_info(aot)("Allocated %zu objects of %zu bytes in gaps (remain = %zu bytes)",
-                  _total_gap_allocs, _total_gap_bytes_used, _total_gap_bytes);
+    log_info(aot)("Allocated %zu objects of %zu bytes in gaps (remain = %zu bytes, %.2f%%)",
+                  _total_gap_allocs, _total_gap_bytes_used, _total_gap_bytes, unfilled_percent);
   }
 }
 


### PR DESCRIPTION
We have a limited number of small objects, so some small gaps may remain unfilled. If more than 5% of the gaps are unfilled, this likely indicates a systematic error that should be investigated. Otherwise, do not warn to avoid noise.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383503](https://bugs.openjdk.org/browse/JDK-8383503): Test runtime/cds/MetaspaceAllocGaps.java failed (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31012/head:pull/31012` \
`$ git checkout pull/31012`

Update a local copy of the PR: \
`$ git checkout pull/31012` \
`$ git pull https://git.openjdk.org/jdk.git pull/31012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31012`

View PR using the GUI difftool: \
`$ git pr show -t 31012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31012.diff">https://git.openjdk.org/jdk/pull/31012.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31012#issuecomment-4360919497)
</details>
