### PR TITLE
8383605: Incomplete input validation on the bands parameters in j.a.i.Raster

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -200,7 +200,7 @@ public class Raster {
      * @throws IllegalArgumentException if {@code bands} is less than 1
      * @throws IllegalArgumentException if {@code w} and {@code h} are not
      *         both > 0
-     * @throws IllegalArgumentException if the product of {@code w}
+     * @throws IllegalArgumentException if the product of {@code w},
      *         {@code h} and {@code bands} is greater than {@code Integer.MAX_VALUE}
      * @throws RasterFormatException if computing either
      *         {@code location.x + w} or

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -201,7 +201,7 @@ public class Raster {
      * @throws IllegalArgumentException if {@code w} and {@code h} are not
      *         both > 0
      * @throws IllegalArgumentException if the product of {@code w}
-     *         and {@code h} is greater than {@code Integer.MAX_VALUE}
+     *         {@code h} and {@code bands} is greater than {@code Integer.MAX_VALUE}
      * @throws RasterFormatException if computing either
      *         {@code location.x + w} or
      *         {@code location.y + h} results in integer overflow
@@ -217,6 +217,14 @@ public class Raster {
         if (lsz > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Dimensions (width="+w+
                                                " height="+h+") are too large");
+        }
+        if (bands < 1) {
+            throw new IllegalArgumentException("Number of bands ("+
+                                               bands+") must be greater than 0");
+        }
+        long slsz = (long)w * bands;
+        if (slsz > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("width * bands is too large");
         }
         int[] bandOffsets = new int[bands];
         for (int i = 0; i < bands; i++) {

--- a/test/jdk/java/awt/image/Raster/InterleavedRasterTest.java
+++ b/test/jdk/java/awt/image/Raster/InterleavedRasterTest.java
@@ -32,27 +32,29 @@ import java.awt.image.Raster;
 
 public class InterleavedRasterTest {
 
-   public static void main(String[] args) {
-     int w = 1;
-     int h = 1;
-     int b = -1;
-      try {
-          Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
-      } catch (IllegalArgumentException e) {
-      }
-      w = 100_000;
-      h = 1;
-      b = 100_000;
-      try {
-          Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
-      } catch (IllegalArgumentException e) {
-      }
-      w = 10_000;
-      h = 10_000;
-      b = 10_000;
-      try {
-          Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
-      } catch (IllegalArgumentException e) {
-      }
-   }
+    public static void main(String[] args) {
+
+        int w = 1;
+        int h = 1;
+        int b = -1;
+        test(w, h, b);
+
+        w = 100_000;
+        h = 1;
+        b = 100_000;
+        test(w, h, b);
+
+        w = 10_000;
+        h = 10_000;
+        b = 10_000;
+        test(w, h, b);
+    }
+
+    static void test(int w, int h, int b) {
+        try {
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
+            throw new RuntimeException("No IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+        }
+    }
 }

--- a/test/jdk/java/awt/image/Raster/InterleavedRasterTest.java
+++ b/test/jdk/java/awt/image/Raster/InterleavedRasterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8383605
+ * @summary test some out of bounds parameters for createInterleavedRaster()
+ */
+
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+
+public class InterleavedRasterTest {
+
+   public static void main(String[] args) {
+     int w = 1;
+     int h = 1;
+     int b = -1;
+      try {
+          Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
+      } catch (IllegalArgumentException e) {
+      }
+      w = 100_000;
+      h = 1;
+      b = 100_000;
+      try {
+          Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
+      } catch (IllegalArgumentException e) {
+      }
+      w = 10_000;
+      h = 10_000;
+      b = 10_000;
+      try {
+          Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, w, h, b, null);
+      } catch (IllegalArgumentException e) {
+      }
+   }
+}


### PR DESCRIPTION
Better up-front validation of some out of bounds parameters.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383605](https://bugs.openjdk.org/browse/JDK-8383605): Incomplete input validation on the bands parameters in j.a.i.Raster (**Bug** - P4)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer) Review applies to [6c7ccf3e](https://git.openjdk.org/jdk/pull/31014/files/6c7ccf3e20fca7c887e5dde29208b8c4672210c0)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31014/head:pull/31014` \
`$ git checkout pull/31014`

Update a local copy of the PR: \
`$ git checkout pull/31014` \
`$ git pull https://git.openjdk.org/jdk.git pull/31014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31014`

View PR using the GUI difftool: \
`$ git pr show -t 31014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31014.diff">https://git.openjdk.org/jdk/pull/31014.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31014#issuecomment-4361790290)
</details>
