### PR TITLE
8383772: runtime/reflect/ReflectOutOfMemoryError.java can fail intermittently on Shenandoah with small heaps

### DIFF
--- a/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
@@ -38,7 +38,8 @@ public class ReflectOutOfMemoryError {
         try {
             // Repository for objects, which should be allocated:
             int index = 0;
-            for (int size = 1 << 30; size > 0 && pool == null; size >>= 1)
+            // Halving loop starting from max possible size constrained by max heap size
+            for (int size = (int)(Runtime.getRuntime().maxMemory()>>2); size > 0 && pool == null; size >>= 1)
                 try {
                     pool = new Object[size];
                 } catch (OutOfMemoryError oome) {


### PR DESCRIPTION
 runtime/reflect/ReflectOutOfMemoryError.java can fail intermittently on Shenandoah (especially Generational Shenandoah) with a small enough heap. The
  test exits with code 1, stdout contains only Starting test, and stderr shows one or two Exception: java.lang.OutOfMemoryError thrown from the
  UncaughtExceptionHandler lines.
                                                                                                                                                           
  Reproducer on pristine openjdk/master: java -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -Xmx64m
  ReflectOutOfMemoryError. Fails ~30% of runs; passes cleanly at -Xmx128m.


Additional test:
- [x] 360/360 pass across G1 / Parallel / Serial / Shenandoah single / Shenandoah generational / ZGC at both -Xmx128m and -Xmx64m

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383772](https://bugs.openjdk.org/browse/JDK-8383772): runtime/reflect/ReflectOutOfMemoryError.java can fail intermittently on Shenandoah with small heaps (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31015/head:pull/31015` \
`$ git checkout pull/31015`

Update a local copy of the PR: \
`$ git checkout pull/31015` \
`$ git pull https://git.openjdk.org/jdk.git pull/31015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31015`

View PR using the GUI difftool: \
`$ git pr show -t 31015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31015.diff">https://git.openjdk.org/jdk/pull/31015.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31015#issuecomment-4362639288)
</details>
