### PR TITLE
8248122: java launcher should launch normally if JavaFX modules not found

### DIFF
--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -768,8 +768,9 @@ public final class LauncherHelper {
          * the main class may or may not have a main method, so do this before
          * validating the main class.
          */
-        if (JAVAFX_FXHELPER_CLASS_NAME_SUFFIX.equals(mainClass.getName()) ||
-            doesExtendFXApplication(mainClass)) {
+        if ((JAVAFX_FXHELPER_CLASS_NAME_SUFFIX.equals(mainClass.getName()) ||
+                doesExtendFXApplication(mainClass)) &&
+                ModuleLayer.boot().findModule(FXHelper.JAVAFX_GRAPHICS_MODULE_NAME).isPresent()) {
             // Will abort() if there are problems with FX runtime
             FXHelper.setFXLaunchParameters(what, mode);
             mainClass = FXHelper.class;
@@ -1125,13 +1126,12 @@ public final class LauncherHelper {
         private static void setFXLaunchParameters(String what, int mode) {
 
             // find the module with the FX launcher
-            Optional<Module> om = ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME);
-            if (om.isEmpty()) {
-                abort(null, "java.launcher.cls.error3");
-            }
+            // this method is only called if we can find the module
+            // in the first place, so it will always be present
+            Module om = ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME).orElseThrow();
 
             // load the FX launcher class
-            fxLauncherClass = Class.forName(om.get(), JAVAFX_LAUNCHER_CLASS_NAME);
+            fxLauncherClass = Class.forName(om, JAVAFX_LAUNCHER_CLASS_NAME);
             if (fxLauncherClass == null) {
                 abort(null, "java.launcher.cls.error3");
             }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -98,6 +98,8 @@ public final class LauncherHelper {
             "javafx.application.Application";
     private static final String JAVAFX_FXHELPER_CLASS_NAME_SUFFIX =
             "sun.launcher.LauncherHelper$FXHelper";
+    private static final String JAVAFX_GRAPHICS_MODULE_NAME =
+            "javafx.graphics";
     private static final String LAUNCHER_AGENT_CLASS = "Launcher-Agent-Class";
     private static final String MAIN_CLASS = "Main-Class";
     private static final String ADD_EXPORTS = "Add-Exports";
@@ -770,7 +772,7 @@ public final class LauncherHelper {
          */
         if ((JAVAFX_FXHELPER_CLASS_NAME_SUFFIX.equals(mainClass.getName()) ||
                 doesExtendFXApplication(mainClass)) &&
-                ModuleLayer.boot().findModule(FXHelper.JAVAFX_GRAPHICS_MODULE_NAME).isPresent()) {
+                ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME).isPresent()) {
             // Will abort() if there are problems with FX runtime
             FXHelper.setFXLaunchParameters(what, mode);
             mainClass = FXHelper.class;
@@ -1083,9 +1085,6 @@ public final class LauncherHelper {
 
     static final class FXHelper {
 
-        private static final String JAVAFX_GRAPHICS_MODULE_NAME =
-                "javafx.graphics";
-
         private static final String JAVAFX_LAUNCHER_CLASS_NAME =
                 "com.sun.javafx.application.LauncherImpl";
 
@@ -1128,10 +1127,13 @@ public final class LauncherHelper {
             // find the module with the FX launcher
             // this method is only called if we can find the module
             // in the first place, so it will always be present
-            Module om = ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME).orElseThrow();
+            Optional<Module> om = ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME);
+            if (om.isEmpty()) {
+                abort(null, "java.launcher.cls.error3");
+            }
 
             // load the FX launcher class
-            fxLauncherClass = Class.forName(om, JAVAFX_LAUNCHER_CLASS_NAME);
+            fxLauncherClass = Class.forName(om.get(), JAVAFX_LAUNCHER_CLASS_NAME);
             if (fxLauncherClass == null) {
                 abort(null, "java.launcher.cls.error3");
             }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -1125,8 +1125,6 @@ public final class LauncherHelper {
         private static void setFXLaunchParameters(String what, int mode) {
 
             // find the module with the FX launcher
-            // this method is only called if we can find the module
-            // in the first place, so it will always be present
             Optional<Module> om = ModuleLayer.boot().findModule(JAVAFX_GRAPHICS_MODULE_NAME);
             if (om.isEmpty()) {
                 abort(null, "java.launcher.cls.error3");


### PR DESCRIPTION
This PR allows Main classes to be launched if they extend the Application class, even when only having the JavaFX dependencies on the classpath instead of the module path. This issue has been there for a long time and was quite annoying for a lot of people: https://stackoverflow.com/questions/78501081/how-do-i-fix-error-javafx-runtime-components-are-missing-and-are-required-to-r. It is also a common use case for JavaFX developers when testing some PR to create a quick reproducer class without setting up the module path properly.

While it is true that launching modern JavaFX via the classpath is unuspported, it still launches and prints its own warnings, which is better than the previous behavior. The old launcher error message in this case is misleading as the runtime components aren't really missing, they are just not in the module path.

This change should not have any change in behavior for any other case.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8248122: java launcher should launch normally if JavaFX modules not found`

### Issue
 * [JDK-8248122](https://bugs.openjdk.org/browse/JDK-8248122): java launcher should launch normally if JavaFX modules not found (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31016/head:pull/31016` \
`$ git checkout pull/31016`

Update a local copy of the PR: \
`$ git checkout pull/31016` \
`$ git pull https://git.openjdk.org/jdk.git pull/31016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31016`

View PR using the GUI difftool: \
`$ git pr show -t 31016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31016.diff">https://git.openjdk.org/jdk/pull/31016.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31016#issuecomment-4362712685)
</details>
