### PR TITLE
8380025: C2: Missed Value() optimization opportunity in CCP with LoadUB

### DIFF
--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -236,6 +236,9 @@ private:
     ciInstanceKlass* declared_holder = get_instance_klass_for_declared_method_holder(holder);
     return _factory->get_unloaded_method(declared_holder, name, signature, accessor);
   }
+  InstanceKlass::ClassState get_shared_init_state(uint id) {
+    return (InstanceKlass::ClassState)_factory->shared_init_state(id);
+  }
 
   // Get a ciKlass representing an unloaded klass.
   // Ensures uniqueness of the result.

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -236,8 +236,8 @@ private:
     ciInstanceKlass* declared_holder = get_instance_klass_for_declared_method_holder(holder);
     return _factory->get_unloaded_method(declared_holder, name, signature, accessor);
   }
-  InstanceKlass::ClassState get_shared_init_state(uint id) {
-    return (InstanceKlass::ClassState)_factory->shared_init_state(id);
+  InstanceKlass::ClassState get_cached_init_state(uint id) {
+    return (InstanceKlass::ClassState)_factory->cached_init_state(id);
   }
 
   // Get a ciKlass representing an unloaded klass.

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -137,10 +137,17 @@ ciInstanceKlass::ciInstanceKlass(ciSymbol* name,
 
 // ------------------------------------------------------------------
 // ciInstanceKlass::compute_shared_is_initialized
-void ciInstanceKlass::compute_shared_init_state() {
+InstanceKlass::ClassState ciInstanceKlass::compute_shared_init_state() {
   GUARDED_VM_ENTRY(
     InstanceKlass* ik = get_instanceKlass();
+    // Update state of shared instance to be used by next compilation
     _init_state = ik->init_state();
+    // But return its cached state for current compilation
+    ciEnv* env = CURRENT_ENV;
+    if (env != nullptr && env->task() != nullptr) {
+      return env->get_shared_init_state(ident());
+    }
+    return _init_state;
   )
 }
 
@@ -319,11 +326,11 @@ void ciInstanceKlass::print_impl(outputStream* st) {
               bool_to_str(has_subklass()),
               layout_helper());
 
-    _flags.print_klass_flags();
+    _flags.print_klass_flags(st);
 
     if (_super) {
       st->print(" super=");
-      _super->print_name();
+      _super->print_name_on(st);
     }
     if (_java_mirror) {
       st->print(" mirror=PRESENT");

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,14 +140,8 @@ InstanceKlass::ClassState ciInstanceKlass::compute_init_state() {
   if (_is_shared && is_loaded()) {
     // Return cached init state of shared klass
     ciEnv* env = CURRENT_ENV;
-    if (env != nullptr && env->task() != nullptr) {
-      return env->get_cached_init_state(ident());
-    } else {
-      GUARDED_VM_ENTRY(
-        InstanceKlass* ik = get_instanceKlass();
-        _init_state = ik->init_state();
-      )
-    }
+    precond(env != nullptr && env->task() != nullptr);
+    return env->get_cached_init_state(ident());
   }
   return _init_state;
 }

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -136,19 +136,15 @@ ciInstanceKlass::ciInstanceKlass(ciSymbol* name,
 
 
 // ------------------------------------------------------------------
-// ciInstanceKlass::compute_shared_is_initialized
-InstanceKlass::ClassState ciInstanceKlass::compute_shared_init_state() {
-  GUARDED_VM_ENTRY(
-    InstanceKlass* ik = get_instanceKlass();
-    // Update state of shared instance to be used by next compilation
-    _init_state = ik->init_state();
-    // But return its cached state for current compilation
+InstanceKlass::ClassState ciInstanceKlass::compute_init_state() {
+  if (_is_shared && is_loaded()) {
+    // Return cached init state of shared klass
     ciEnv* env = CURRENT_ENV;
     if (env != nullptr && env->task() != nullptr) {
       return env->get_shared_init_state(ident());
     }
-    return _init_state;
-  )
+  }
+  return _init_state;
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -141,7 +141,7 @@ InstanceKlass::ClassState ciInstanceKlass::compute_init_state() {
     // Return cached init state of shared klass
     ciEnv* env = CURRENT_ENV;
     if (env != nullptr && env->task() != nullptr) {
-      return env->get_shared_init_state(ident());
+      return env->get_cached_init_state(ident());
     }
   }
   return _init_state;

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -142,6 +142,11 @@ InstanceKlass::ClassState ciInstanceKlass::compute_init_state() {
     ciEnv* env = CURRENT_ENV;
     if (env != nullptr && env->task() != nullptr) {
       return env->get_cached_init_state(ident());
+    } else {
+      GUARDED_VM_ENTRY(
+        InstanceKlass* ik = get_instanceKlass();
+        _init_state = ik->init_state();
+      )
     }
   }
   return _init_state;

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -140,7 +140,7 @@ InstanceKlass::ClassState ciInstanceKlass::compute_init_state() {
   if (_is_shared && is_loaded()) {
     // Return cached init state of shared klass
     ciEnv* env = CURRENT_ENV;
-    precond(env != nullptr && env->task() != nullptr);
+    assert(env->task() != nullptr, "only calls from compilation are expected here");
     return env->get_cached_init_state(ident());
   }
   return _init_state;

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -106,43 +106,44 @@ protected:
 
   bool is_shared() { return _is_shared; }
 
-  void compute_shared_init_state();
+  InstanceKlass::ClassState compute_shared_init_state();
   bool compute_shared_has_subklass();
   int  compute_nonstatic_fields();
   GrowableArray<ciField*>* compute_nonstatic_fields_impl(GrowableArray<ciField*>* super_fields);
   bool compute_has_trusted_loader();
 
   // Update the init_state for shared klasses
-  void update_if_shared(InstanceKlass::ClassState expected) {
-    if (_is_shared && _init_state != expected) {
-      if (is_loaded()) compute_shared_init_state();
+  InstanceKlass::ClassState update_if_shared() {
+    if (_is_shared && is_loaded()) {
+      return compute_shared_init_state();
     }
+    return _init_state;
   }
 
 public:
   // Has this klass been initialized?
   bool                   is_initialized() {
-    update_if_shared(InstanceKlass::fully_initialized);
-    return _init_state == InstanceKlass::fully_initialized;
+    InstanceKlass::ClassState state = update_if_shared();
+    return state == InstanceKlass::fully_initialized;
   }
   bool                   is_not_initialized() {
-    update_if_shared(InstanceKlass::fully_initialized);
-    return _init_state < InstanceKlass::being_initialized;
+    InstanceKlass::ClassState state = update_if_shared();
+    return state < InstanceKlass::being_initialized;
   }
   // Is this klass being initialized?
   bool                   is_being_initialized() {
-    update_if_shared(InstanceKlass::being_initialized);
-    return _init_state == InstanceKlass::being_initialized;
+    InstanceKlass::ClassState state = update_if_shared();
+    return state == InstanceKlass::being_initialized;
   }
   // Has this klass been linked?
   bool                   is_linked() {
-    update_if_shared(InstanceKlass::linked);
-    return _init_state >= InstanceKlass::linked;
+    InstanceKlass::ClassState state = update_if_shared();
+    return state >= InstanceKlass::linked;
   }
   // Is this klass in error state?
   bool                   is_in_error_state() {
-    update_if_shared(InstanceKlass::initialization_error);
-    return _init_state == InstanceKlass::initialization_error;
+    InstanceKlass::ClassState state = update_if_shared();
+    return state == InstanceKlass::initialization_error;
   }
 
   // General klass information.

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -106,43 +106,35 @@ protected:
 
   bool is_shared() { return _is_shared; }
 
-  InstanceKlass::ClassState compute_shared_init_state();
+  InstanceKlass::ClassState compute_init_state();
   bool compute_shared_has_subklass();
   int  compute_nonstatic_fields();
   GrowableArray<ciField*>* compute_nonstatic_fields_impl(GrowableArray<ciField*>* super_fields);
   bool compute_has_trusted_loader();
 
-  // Update the init_state for shared klasses
-  InstanceKlass::ClassState update_if_shared() {
-    if (_is_shared && is_loaded()) {
-      return compute_shared_init_state();
-    }
-    return _init_state;
-  }
-
 public:
   // Has this klass been initialized?
   bool                   is_initialized() {
-    InstanceKlass::ClassState state = update_if_shared();
+    InstanceKlass::ClassState state = compute_init_state();
     return state == InstanceKlass::fully_initialized;
   }
   bool                   is_not_initialized() {
-    InstanceKlass::ClassState state = update_if_shared();
+    InstanceKlass::ClassState state = compute_init_state();
     return state < InstanceKlass::being_initialized;
   }
   // Is this klass being initialized?
   bool                   is_being_initialized() {
-    InstanceKlass::ClassState state = update_if_shared();
+    InstanceKlass::ClassState state = compute_init_state();
     return state == InstanceKlass::being_initialized;
   }
   // Has this klass been linked?
   bool                   is_linked() {
-    InstanceKlass::ClassState state = update_if_shared();
+    InstanceKlass::ClassState state = compute_init_state();
     return state >= InstanceKlass::linked;
   }
   // Is this klass in error state?
   bool                   is_in_error_state() {
-    InstanceKlass::ClassState state = update_if_shared();
+    InstanceKlass::ClassState state = compute_init_state();
     return state == InstanceKlass::initialization_error;
   }
 

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -48,6 +48,7 @@
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/universe.hpp"
+#include "oops/instanceKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/trainingData.hpp"
 #include "runtime/handles.inline.hpp"
@@ -83,6 +84,7 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
                                  int expected_size)
                                  : _arena(arena),
                                    _ci_metadata(arena, expected_size, 0, nullptr),
+                                   _shared_init_state(arena, expected_size, 0, (u1)0),
                                    _unloaded_methods(arena, 4, 0, nullptr),
                                    _unloaded_klasses(arena, 8, 0, nullptr),
                                    _unloaded_instances(arena, 4, 0, nullptr),
@@ -97,6 +99,22 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
   // If the shared ci objects exist append them to this factory's objects
   if (_shared_ci_metadata != nullptr) {
     _ci_metadata.appendAll(_shared_ci_metadata);
+    // ciInstanceKlass for well-known class is shared by all
+    // compiler threads and can be updated concurrently by
+    // other compiler threads during compilation.
+    // Make local copy of class state to avoid state change
+    // during compilation.
+    int len = _ci_metadata.length();
+    for (int i = 0; i < len; i++) {
+      ciMetadata* obj = _ci_metadata.at(i);
+      if (obj->is_loaded() && obj->is_instance_klass() &&
+          obj->as_instance_klass()->is_shared()) {
+        ciInstanceKlass* cik = obj->as_instance_klass();
+        u1 state = 0;
+        GUARDED_VM_ENTRY( state = (u1)cik->get_instanceKlass()->init_state(); )
+        _shared_init_state.at_put_grow(cik->ident(), state, 0);
+      }
+    }
   }
 }
 

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -110,9 +110,15 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
       if (obj->is_loaded() && obj->is_instance_klass() &&
           obj->as_instance_klass()->is_shared()) {
         ciInstanceKlass* cik = obj->as_instance_klass();
-        u1 state = 0;
-        GUARDED_VM_ENTRY( state = (u1)cik->get_instanceKlass()->init_state(); )
-        _shared_init_state.at_put_grow(cik->ident(), state, 0);
+        InstanceKlass::ClassState current_state = cik->_init_state;
+        InstanceKlass::ClassState state = InstanceKlass::fully_initialized;
+        if (current_state != state) {
+          GUARDED_VM_ENTRY( state = cik->get_instanceKlass()->init_state(); )
+          // Update state of shared ciInstanceKlass
+          cik->_init_state = state;
+        }
+        // Cache state for current compilation
+        _shared_init_state.at_put_grow(cik->ident(), (u1)state, 0);
       }
     }
   }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -84,7 +84,7 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
                                  int expected_size)
                                  : _arena(arena),
                                    _ci_metadata(arena, expected_size, 0, nullptr),
-                                   _shared_init_state(arena, expected_size, 0, (u1)0),
+                                   _cached_init_state(arena, _shared_ident_limit, 0, (u1)0),
                                    _unloaded_methods(arena, 4, 0, nullptr),
                                    _unloaded_klasses(arena, 8, 0, nullptr),
                                    _unloaded_instances(arena, 4, 0, nullptr),
@@ -118,7 +118,7 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
           cik->_init_state = state;
         }
         // Cache state for current compilation
-        _shared_init_state.at_put_grow(cik->ident(), (u1)state, 0);
+        _cached_init_state.at_put_grow(cik->ident(), (u1)state, 0);
       }
     }
   }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -107,9 +107,9 @@ ciObjectFactory::ciObjectFactory(Arena* arena,
     int len = _ci_metadata.length();
     for (int i = 0; i < len; i++) {
       ciMetadata* obj = _ci_metadata.at(i);
-      if (obj->is_loaded() && obj->is_instance_klass() &&
-          obj->as_instance_klass()->is_shared()) {
+      if (obj->is_loaded() && obj->is_instance_klass()) {
         ciInstanceKlass* cik = obj->as_instance_klass();
+        precond(cik->is_shared());
         InstanceKlass::ClassState current_state = cik->_init_state;
         InstanceKlass::ClassState state = InstanceKlass::fully_initialized;
         if (current_state != state) {

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -47,6 +47,8 @@ private:
 
   Arena*                           _arena;
   GrowableArray<ciMetadata*>       _ci_metadata;
+  // Local copy of shared ciInstanceKlass init state for current compilation
+  GrowableArray<u1>                _shared_init_state;
   GrowableArray<ciMethod*>         _unloaded_methods;
   GrowableArray<ciKlass*>          _unloaded_klasses;
   GrowableArray<ciInstance*>       _unloaded_instances;
@@ -102,6 +104,11 @@ public:
   ciMetadata* get_metadata(Metadata* key);
   ciMetadata* cached_metadata(Metadata* key);
   ciSymbol* get_symbol(Symbol* key);
+
+  // Get cached init state of shared ciInstanceKlass
+  u1 shared_init_state(uint id) {
+    return _shared_init_state.at(id);
+  }
 
   // Get the ciSymbol corresponding to one of the vmSymbols.
   static ciSymbol* vm_symbol_at(vmSymbolID index);

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -48,7 +48,7 @@ private:
   Arena*                           _arena;
   GrowableArray<ciMetadata*>       _ci_metadata;
   // Local copy of shared ciInstanceKlass init state for current compilation
-  GrowableArray<u1>                _shared_init_state;
+  GrowableArray<u1>                _cached_init_state;
   GrowableArray<ciMethod*>         _unloaded_methods;
   GrowableArray<ciKlass*>          _unloaded_klasses;
   GrowableArray<ciInstance*>       _unloaded_instances;
@@ -106,8 +106,8 @@ public:
   ciSymbol* get_symbol(Symbol* key);
 
   // Get cached init state of shared ciInstanceKlass
-  u1 shared_init_state(uint id) {
-    return _shared_init_state.at(id);
+  u1 cached_init_state(uint id) {
+    return _cached_init_state.at(id);
   }
 
   // Get the ciSymbol corresponding to one of the vmSymbols.


### PR DESCRIPTION
Running  JCK testing with AOT code caching and `-ea -esa -XX:CompileThreshold=100 -XX:-TieredCompilation -XX:+AlwaysIncrementalInline` flags found this issue. It reproduced about 1 in 50 iterations. I wasn't able to reproduce this issue with mainline JDK except what @TheRealMDoerr reported for this bug.

The code in  `MethodHandleNatives::refKindIsGetter()` is loading from static final field from class which is not fully initialized (it is being initialized):
```
<ciField name=java/lang/invoke/MethodHandleNatives.$assertionsDisabled signature=Z offset=120 type=boolean flags=1018 is_constant=true constant_value=<ciConstant type=*illegal* value=ILLEGAL>>

<ciInstanceKlass name=java/lang/invoke/MethodHandleNatives loaded=true loader=0x0000000000000000 initialized=false finalized=false subklass=false size=16 flags=DEFAULT_ACCESS,super super=java/lang/Object ident=1287 address=0x00007ffff08311f8>
```
Note, `refKindIsGetter()` is static method and it is allowed to compile with C2 when its holder is **being** initialized. We do it for long time.

During PhaseCCP we can't treat the field as constant until class is fully initialized. As result we keep `LoadUB` node and its `TypeInt::BOOL` default type and set C2 types table to this type for this node. Now types in both places match.

Because it is `Load `node we put it on `worklist_revisit` to revisit it again later. See `PhaseCCP::analyze()`.

Now is the issue. `ciInstanceKlass` is suppose to cache value for current compilation and don't change. Except we have shared `ciInstanceKlass` for "well know" classes. And `MethodHandleNatives` is such class - see `classfile/vmClassMacros.hpp`.

For such classes the set of `ciInstanceKlass` is created during Compiler initialization - see `ciObjectFactory::init_shared_objects()`. And they are `SHARED` by all compilations and also can be `UPDATED` concurrently by one of compiler threads. See `ciInstanceKlass::update_if_shared()`.

While a compiler thread which compiles `java.lang.invoke.MethodHandleNatives::refKindIsGetter()` is suspended by OS's scheduler the `MethodHandleNatives` class could be fully initialized. Then an other compiler thread can update its `ciInstanceKlass::_init_state` by calling `ciInstanceKlass::update_if_shared()`.

After first compiler thread resumes the compilation and start processing `LoadUB` again from `worklist_revisit` list it will see that field's holder class is initialized and it can treat the field as constant and use field's value (0). After that it hit the assert because we got new type which does not match corresponding type in C2 types table.

The fix is to create local copy of shared `ciInstanceKlass::_init_state` for each compilation and use it instead of state recorded in shared `ciInstanceKlass::_init_state`. But keep updating `ciInstanceKlass::_init_state` to be used by next compilation.

I also fixed few print instructions which missed output stream parameter.

Tested: tier1-4,comp-stress and JCK testing with AOT code (I ran 500 iterations with fix)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380025](https://bugs.openjdk.org/browse/JDK-8380025): C2: Missed Value() optimization opportunity in CCP with LoadUB (**Bug** - P3)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - **Reviewer**) Review applies to [75e7147d](https://git.openjdk.org/jdk/pull/31019/files/75e7147d806df82abdf5761c32f396cd7b546d8a)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31019/head:pull/31019` \
`$ git checkout pull/31019`

Update a local copy of the PR: \
`$ git checkout pull/31019` \
`$ git pull https://git.openjdk.org/jdk.git pull/31019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31019`

View PR using the GUI difftool: \
`$ git pr show -t 31019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31019.diff">https://git.openjdk.org/jdk/pull/31019.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31019#issuecomment-4365095411)
</details>
