### PR TITLE
8383794: G1: Rename refinement sweep duration helper to reflect SwapGlobalCT start

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
@@ -145,14 +145,16 @@ void G1ConcurrentRefineSweepState::enter_state(State state, Ticks timestamp) {
   _state = state;
 }
 
-Tickspan G1ConcurrentRefineSweepState::get_duration(State start, State end) const {
-  assert(end >= start, "precondition");
-  return _state_start[static_cast<uint>(end)] - _state_start[static_cast<uint>(start)];
-}
-
 Tickspan G1ConcurrentRefineSweepState::time_since_start(Ticks completion_time) const {
   assert(_state >= State::SwapGlobalCT, "precondition");
   return completion_time - _state_start[static_cast<uint>(State::SwapGlobalCT)];
+}
+
+Tickspan G1ConcurrentRefineSweepState::time_until_state(State state) const {
+  assert(_state >= State::SwapGlobalCT, "precondition");
+  assert(state >= State::SwapGlobalCT, "precondition");
+  assert(state <= _state, "precondition");
+  return _state_start[static_cast<uint>(state)] - _state_start[static_cast<uint>(State::SwapGlobalCT)];
 }
 
 void G1ConcurrentRefineSweepState::reset_stats() {
@@ -333,7 +335,7 @@ void G1ConcurrentRefineSweepState::handle_ongoing_refinement_at_safepoint() {
   const Ticks completion_time = Ticks::now();
 
   const Tickspan total_duration = time_since_start(completion_time);
-  const Tickspan pre_sweep_duration = get_duration(State::SwapGlobalCT, MIN2(_state, State::SweepRT));
+  const Tickspan pre_sweep_duration = time_until_state(MIN2(_state, State::SweepRT));
 
   print_refinement_stats(total_duration, pre_sweep_duration, &_stats);
 
@@ -370,7 +372,7 @@ void G1ConcurrentRefineSweepState::complete_refinement(jlong total_yield_during_
   const Ticks completion_time = Ticks::now();
 
   const Tickspan total_duration = time_since_start(completion_time);
-  const Tickspan pre_sweep_duration = get_duration(State::SwapGlobalCT, State::SweepRT);
+  const Tickspan pre_sweep_duration = time_until_state(State::SweepRT);
 
   print_refinement_stats(total_duration, pre_sweep_duration, &_stats);
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentRefine.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefine.hpp
@@ -146,8 +146,8 @@ class G1ConcurrentRefineSweepState {
   Ticks _state_start[static_cast<uint>(State::Last)];
 
   void enter_state(State state, Ticks timestamp);
-  Tickspan get_duration(State start, State end) const;
   Tickspan time_since_start(Ticks completion_time) const;
+  Tickspan time_until_state(State state) const;
 
   G1ConcurrentRefineStats _stats;
 


### PR DESCRIPTION
Refactoring `G1ConcurrentRefineSweepState::get_duration` to remove the redundancy -- all callers of this api uses the same first arg.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383794](https://bugs.openjdk.org/browse/JDK-8383794): G1: Rename refinement sweep duration helper to reflect SwapGlobalCT start (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31021/head:pull/31021` \
`$ git checkout pull/31021`

Update a local copy of the PR: \
`$ git checkout pull/31021` \
`$ git pull https://git.openjdk.org/jdk.git pull/31021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31021`

View PR using the GUI difftool: \
`$ git pr show -t 31021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31021.diff">https://git.openjdk.org/jdk/pull/31021.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31021#issuecomment-4370619405)
</details>
