### PR TITLE
8383792: Simplify internal DocFinder API

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/InheritDocTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,12 +121,8 @@ public class InheritDocTaglet extends BaseTaglet {
         if (holderTag.getKind() == DocTree.Kind.DOC_COMMENT) {
             try {
                 var docFinder = utils.docFinder();
-                Result<Documentation> d;
-                if (src == null) {
-                    d = docFinder.find(method, m -> extractMainDescription(m, isFirstSentence, utils));
-                } else {
-                    d = docFinder.search(src, m -> extractMainDescription(m, isFirstSentence, utils));
-                }
+                Result<Documentation> d = docFinder.searchInherited(
+                        method, src, m -> extractMainDescription(m, isFirstSentence, utils));
                 if (d instanceof Result.Conclude<Documentation> doc) {
                     replacement = writer.commentTagsToOutput(doc.value().method, inheritDoc,
                             doc.value().mainDescription, isFirstSentence);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ParamTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,16 +95,9 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
         try {
             var docFinder = utils.docFinder();
 
-            Optional<Documentation> r;
-            if (src != null){
-                r = docFinder.search((ExecutableElement) src,
-                                m -> DocFinder.Result.fromOptional(extract(utils, m, position, param.isTypeParameter())))
-                        .toOptional();
-            } else {
-                r = docFinder.find((ExecutableElement) dst,
-                                m -> DocFinder.Result.fromOptional(extract(utils, m, position, param.isTypeParameter())))
-                        .toOptional();
-            }
+            Optional<Documentation> r = docFinder.searchInherited(method, (ExecutableElement) src,
+                            m -> DocFinder.Result.fromOptional(extract(utils, m, position, param.isTypeParameter())))
+                    .toOptional();
             return r.map(result -> new Output(result.paramTree, result.method, result.paramTree.getDescription(), true))
                     .orElseGet(() -> new Output(null, null, List.of(), true));
         } catch (DocFinder.NoOverriddenMethodFound e) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ReturnTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ReturnTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,12 +67,8 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
     public Output inherit(Element dst, Element src, DocTree tag, boolean isFirstSentence) {
         try {
             var docFinder = utils.docFinder();
-            Optional<Documentation> r;
-            if (src == null) {
-                r = docFinder.find((ExecutableElement) dst, m -> DocFinder.Result.fromOptional(extract(utils, m))).toOptional();
-            } else {
-                r = docFinder.search((ExecutableElement) src, m -> DocFinder.Result.fromOptional(extract(utils, m))).toOptional();
-            }
+            Optional<Documentation> r = docFinder.searchInherited((ExecutableElement) dst, (ExecutableElement) src,
+                    m -> DocFinder.Result.fromOptional(extract(utils, m))).toOptional();
             return r.map(result -> new Output(result.returnTree, result.method, result.returnTree.getDescription(), true))
                     .orElseGet(() -> new Output(null, null, List.of(), true));
         } catch (DocFinder.NoOverriddenMethodFound e) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SimpleTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SimpleTaglet.java
@@ -162,14 +162,8 @@ public class SimpleTaglet extends BaseTaglet implements InheritableTaglet {
         assert !isFirstSentence;
         try {
             var docFinder = utils.docFinder();
-            Optional<Documentation> r;
-            if (src == null) {
-                r = docFinder.find((ExecutableElement) dst,
-                        m -> DocFinder.Result.fromOptional(extractFirst(m))).toOptional();
-            } else {
-                r = docFinder.search((ExecutableElement) src,
-                        m -> DocFinder.Result.fromOptional(extractFirst(m))).toOptional();
-            }
+            Optional<Documentation> r = docFinder.searchInherited((ExecutableElement) dst, (ExecutableElement) src,
+                    m -> DocFinder.Result.fromOptional(extractFirst(m))).toOptional();
             return r.map(result -> new Output(result.tag, result.method, result.description, true))
                     .orElseGet(()->new Output(null, null, List.of(), true));
         } catch (DocFinder.NoOverriddenMethodFound e) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ThrowsTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -634,11 +634,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         }
         DocFinder.Result<Map<ThrowsTree, ExecutableElement>> result;
         try {
-            if (src.isPresent()) {
-                result = utils.docFinder().search(src.get(), criterion);
-            } else {
-                result = utils.docFinder().find(holder, criterion);
-            }
+            result = utils.docFinder().searchInherited(holder, src.orElse(null), criterion);
         } catch (Failure.NotExceptionType
                  | Failure.ExceptionTypeNotFound
                  | Failure.UnsupportedTypeParameter x) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DocFinder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DocFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,23 +57,55 @@ public class DocFinder {
         private NoOverriddenMethodFound() { }
     }
 
+    /**
+     * Search for documentation beginning at {@code method}, then iterating through
+     * the list of methods it overrides, until {@code criterion} returns a valid result,
+     * throws an exception or the end of the hierarchy is reached.
+     *
+     * @param method the method where to start searching
+     * @param criterion function to compute the result
+     * @return the result
+     * @param <T> result type
+     * @param <X> exception type
+     * @throws X thrown by {@code criterion}
+     */
     public <T, X extends Throwable> Result<T> search(ExecutableElement method,
                                                      Criterion<T, X> criterion)
             throws X
     {
         try {
-            return search0(method, true, false, criterion);
+            return search0(method, false, criterion);
         } catch (NoOverriddenMethodFound e) {
             // should not happen because the exception flag is unset
             throw new AssertionError(e);
         }
     }
 
-    public <T, X extends Throwable> Result<T> find(ExecutableElement method,
-                                                   Criterion<T, X> criterion)
+    /**
+     * Search for documentation in methods overridden by {@code method}.
+     * If {@code src} is not null, it is the overridden method where to begin searching.
+     * If {@code src} is null, all methods overridden by {@code method} are searched.
+     * If {@code src} is null and {@code method} does not override any methods,
+     * {@code NoOverriddenMethodFound} is thrown.
+     *
+     * @param method the overriding method
+     * @param src the method where to start searching, or null to search in all overridden methods
+     * @param criterion function to compute the result
+     * @return the result
+     * @param <T> result type
+     * @param <X> exception type
+     * @throws NoOverriddenMethodFound if {@code src} is null and {@code method} does not
+     *         override any methods.
+     * @throws X thrown by {@code criterion}
+     */
+    public <T, X extends Throwable> Result<T> searchInherited(ExecutableElement method,
+                                                     ExecutableElement src,
+                                                     Criterion<T, X> criterion)
             throws NoOverriddenMethodFound, X
     {
-        return search0(method, false, true, criterion);
+        return src == null
+                ? search0(method, true, criterion)
+                : search0(src, false, criterion);
     }
 
     /*
@@ -93,22 +125,20 @@ public class DocFinder {
      * recent call to Criterion::apply.
      *
      * If the given method overrides no methods (i.e. hierarchy consists of the
-     * given method only) and the search is instructed to detect that, the
-     * search terminates with an exception.
+     * given method only) and the search is instructed to search overridden
+     * methods only, the search terminates with an exception.
      */
     private <T, X extends Throwable> Result<T> search0(ExecutableElement method,
-                                                       boolean includeMethodInSearch,
-                                                       boolean throwExceptionIfDoesNotOverride,
+                                                       boolean overriddenMethodsOnly,
                                                        Criterion<T, X> criterion)
             throws NoOverriddenMethodFound, X
     {
-        // if the "overrides" check is requested and does not pass, throw the exception
-        // first so that it trumps the result that the search would otherwise had
+        // Throw exception if overriddenMethodsOnly is true and method does not override any methods.
         Iterator<? extends ExecutableElement> methods = overriddenMethodLookup.apply(method).iterator();
-        if (throwExceptionIfDoesNotOverride && !methods.hasNext() ) {
+        if (overriddenMethodsOnly && !methods.hasNext() ) {
             throw new NoOverriddenMethodFound();
         }
-        Result<T> r = includeMethodInSearch ? criterion.apply(method) : Result.CONTINUE();
+        Result<T> r = overriddenMethodsOnly ? Result.CONTINUE() : criterion.apply(method);
         if (!(r instanceof Result.Continue<T>)) {
             return r;
         }


### PR DESCRIPTION
Please review a refactoring to simplify use of the internal `DocFinder` class. Previously, users of the class had to call the `search` or `find` method when looking up documentation in an overridden method, depending on whether an explicit orverridden source method was provided. 

The `find` method is updated to handle both cases (which are always used together). Passing `null` as `src` argument implements the old behavior of the `find` method, while passing a non-null reference implements the old `search` call. Additionally, `find` is renamed to `searchInherited` to make its relation to the `search` method clearer (`searchInherited` searches in overridden methods only while `search` starts in the method itself).

The internal `search0` method loses a redundant boolean parameter, the new `overriddenMethodsOnly` parameter is the same as `not(includeMethodInSearch)` and `throwExceptionIfDoesNotOverride`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8383792](https://bugs.openjdk.org/browse/JDK-8383792): Simplify internal DocFinder API (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31022/head:pull/31022` \
`$ git checkout pull/31022`

Update a local copy of the PR: \
`$ git checkout pull/31022` \
`$ git pull https://git.openjdk.org/jdk.git pull/31022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31022`

View PR using the GUI difftool: \
`$ git pr show -t 31022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31022.diff">https://git.openjdk.org/jdk/pull/31022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31022#issuecomment-4370981382)
</details>
