### PR TITLE
8383824: TestCopyFiles.java fails after JDK-8347112

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -93,9 +93,9 @@ public class TestCopyFiles extends JavadocTester {
                     <a href="../../../../index-all.html">Index</a>""",
                 "phi-HEADER-phi",
                 """
-                    <a href="../../../module-summary.html">acme.mdle</a>""",
+                    <a href="../../../module-summary.html" title="Module acme.mdle">acme.mdle</a>""",
                 """
-                    <a href="../../package-summary.html" class="current-selection">p</a>""",
+                    <a href="../../package-summary.html" title="Package p" class="current-selection">p</a>""",
                 """
                    SubReadme.html at second level of doc-file directory for acme.module.""",
                 // check footer
@@ -115,9 +115,9 @@ public class TestCopyFiles extends JavadocTester {
                     <a href="../../../../../index-all.html">Index</a>""",
                 "phi-HEADER-phi",
                 """
-                    <a href="../../../../module-summary.html">acme.mdle</a>""",
+                    <a href="../../../../module-summary.html" title="Module acme.mdle">acme.mdle</a>""",
                 """
-                    <a href="../../../package-summary.html" class="current-selection">p</a>""",
+                    <a href="../../../package-summary.html" title="Package p" class="current-selection">p</a>""",
                 """
                    SubSubReadme.html at third level of doc-file directory.""",
                 // check bottom


### PR DESCRIPTION
Please review a change to fix a failing javadoc test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383824](https://bugs.openjdk.org/browse/JDK-8383824): TestCopyFiles.java fails after JDK-8347112 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31030/head:pull/31030` \
`$ git checkout pull/31030`

Update a local copy of the PR: \
`$ git checkout pull/31030` \
`$ git pull https://git.openjdk.org/jdk.git pull/31030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31030`

View PR using the GUI difftool: \
`$ git pr show -t 31030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31030.diff">https://git.openjdk.org/jdk/pull/31030.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31030#issuecomment-4374466358)
</details>
