### PR TITLE
8383830: Vector API: internal AbstractVector helper methods exposed in public Javadoc

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -184,7 +184,7 @@ abstract sealed class AbstractVector<E> extends Vector<E>
     }
 
     @ForceInline
-    protected static <T> VectorShuffle<T> normalizeSubLanesForSpecies(AbstractSpecies<T> targetSpecies, int subLanesPerSrc) {
+    static <T> VectorShuffle<T> normalizeSubLanesForSpecies(AbstractSpecies<T> targetSpecies, int subLanesPerSrc) {
         final int lanes = targetSpecies.laneCount();
 
         if ((lanes % subLanesPerSrc) != 0) {
@@ -205,7 +205,7 @@ abstract sealed class AbstractVector<E> extends Vector<E>
     }
 
     @ForceInline
-    protected final int subLanesToSwap(AbstractSpecies<?> srcSpecies) {
+    final int subLanesToSwap(AbstractSpecies<?> srcSpecies) {
         if (java.nio.ByteOrder.nativeOrder() != ByteOrder.BIG_ENDIAN) {
             return -1;
         }


### PR DESCRIPTION
Two internal helper methods recently added to AbstractVector are currently showing up in the public javadoc of concrete vector classes:

- ByteVector
- ShortVector
- IntVector
- LongVector
- FloatVector
- DoubleVector

The methods are:

- protected final int subLanesToSwap(AbstractSpecies<?> srcSpecies)
- protected static <T> VectorShuffle<T> normalizeSubLanesForSpecies(...)

These methods appear to be implementation helpers for the Big Endian lane/sub-lane normalization path (JDK-8371187/PR #28425) and are not intended to be part of the Vector API surface.

Since the generated vector classes are in the same jdk.incubator.vector package, "protected" does not seem necessary for access. Making these helpers package-private should keep the implementation access intact while preventing them from appearing as inherited protected API in public Javadoc.

The PR removes "protected" from these 2 methods, making them package private to keep them out of the public api surface.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383830](https://bugs.openjdk.org/browse/JDK-8383830): Vector API: internal AbstractVector helper methods exposed in public Javadoc (**Bug** - P3)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31034/head:pull/31034` \
`$ git checkout pull/31034`

Update a local copy of the PR: \
`$ git checkout pull/31034` \
`$ git pull https://git.openjdk.org/jdk.git pull/31034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31034`

View PR using the GUI difftool: \
`$ git pr show -t 31034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31034.diff">https://git.openjdk.org/jdk/pull/31034.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31034#issuecomment-4377013819)
</details>
