### PR TITLE
8382035: [ubsan] Under UBSAN builds, disable tests that rely on simulated JVM crashes

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -29,6 +29,7 @@
  *          in the same directory as the libjvm.so file, in a subdirectory called .debug, or in the path specified
  *          by the environment variable _JVM_DWARF_PATH, then no verification of the hs_err_file is done for libjvm.so.
  * @requires vm.debug == true & vm.flagless & vm.compMode != "Xint" & os.family == "linux" & !vm.graal.enabled & vm.gc.G1
+ * @requires !vm.ubsan
  * @modules java.base/jdk.internal.misc
  * @run main/native/othervm -Xbootclasspath/a:. -XX:-CreateCoredumpOnCrash TestDwarf
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022 SAP. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026 SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -30,6 +30,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @requires vm.flagless
+ * @requires !vm.ubsan
  * @requires (vm.debug == true)
  * @requires os.family == "linux"
  * @run driver VeryEarlyAssertTest

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -26,6 +26,7 @@
  * @bug 8174994 8200613
  * @summary Test the clhsdb commands 'printall', 'jstack' on a CDS enabled corefile.
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires vm.cds
  * @requires vm.flavor == "server"

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -36,7 +36,6 @@ import jtreg.SkippedException;
  * @bug 8193124
  * @summary Test the clhsdb 'findpc' command with Xcomp on live process
  * @requires vm.hasSA
- * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires vm.compMode != "Xcomp"
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
@@ -51,6 +50,7 @@ import jtreg.SkippedException;
  * @bug 8193124
  * @summary Test the clhsdb 'findpc' command with Xcomp on core file
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires vm.compMode != "Xcomp"
  * @requires vm.compiler1.enabled
@@ -76,6 +76,7 @@ import jtreg.SkippedException;
  * @bug 8193124
  * @summary Test the clhsdb 'findpc' command w/o Xcomp on core file
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires vm.compiler1.enabled
  * @library /test/lib

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -36,6 +36,7 @@ import jtreg.SkippedException;
  * @bug 8193124
  * @summary Test the clhsdb 'findpc' command with Xcomp on live process
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires vm.compMode != "Xcomp"
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -35,6 +35,7 @@ import jtreg.SkippedException;
  * @bug 8190198
  * @summary Test clhsdb pmap command on a live process
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
  * @library /test/lib

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -35,7 +35,6 @@ import jtreg.SkippedException;
  * @bug 8190198
  * @summary Test clhsdb pmap command on a live process
  * @requires vm.hasSA
- * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
  * @library /test/lib
@@ -47,6 +46,7 @@ import jtreg.SkippedException;
  * @bug 8190198
  * @summary Test clhsdb pmap command on a core file
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @run main/othervm/timeout=480 ClhsdbPmap true

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -35,7 +35,6 @@ import jtreg.SkippedException;
  * @bug 8190198
  * @summary Test clhsdb pstack command on a live process
  * @requires vm.hasSA
- * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
  * @library /test/lib
@@ -47,6 +46,7 @@ import jtreg.SkippedException;
  * @bug 8190198
  * @summary Test clhsdb pstack command on a core file
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @run main/othervm/timeout=480 ClhsdbPstack true

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -35,6 +35,7 @@ import jtreg.SkippedException;
  * @bug 8190198
  * @summary Test clhsdb pstack command on a live process
  * @requires vm.hasSA
+ * @requires !vm.ubsan
  * @requires vm.gc != "Z"
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
  * @library /test/lib


### PR DESCRIPTION
There are a couple of tests that do not work well with ubsan - enabled binaries.
Thoe have been identified by Afshin

runtime/ErrorHandling/TestDwarf.java uses artificial division by zero
runtime/ErrorHandling/VeryEarlyAssertTest.java uses artificial env var to crash early in jvm load
serviceability/sa/ClhsdbFindPC.java
serviceability/sa/ClhsdbCDSCore.java
serviceability/sa/ClhsdbPstack.java
serviceability/sa/ClhsdbPmap.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382035](https://bugs.openjdk.org/browse/JDK-8382035): [ubsan] Under UBSAN builds, disable tests that rely on simulated JVM crashes (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31035/head:pull/31035` \
`$ git checkout pull/31035`

Update a local copy of the PR: \
`$ git checkout pull/31035` \
`$ git pull https://git.openjdk.org/jdk.git pull/31035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31035`

View PR using the GUI difftool: \
`$ git pr show -t 31035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31035.diff">https://git.openjdk.org/jdk/pull/31035.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31035#issuecomment-4377714301)
</details>
