### PR TITLE
8383834: x86_64: Client build fails after JDK-8379706

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -1329,9 +1329,9 @@ void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, 
   __ jmp(slow_continuation);
 }
 
-#undef __
 #endif // COMPILER2
 
+#undef __
 #define __ masm->
 
 void ZBarrierSetAssembler::try_peek_weak_handle_in_nmethod(MacroAssembler* masm, Register weak_handle, Register obj, Label& slow_path) {


### PR DESCRIPTION
[JDK-8379706](https://bugs.openjdk.org/browse/JDK-8379706) / #30816 left the `#undef` guarded by `COMPILER2` rather than pair it up with the new `#define __`

Double checked the other platforms do not also have this issue.

_I was pretty sure I built the original patch with C2 disabled on x64 as well. But must have missed it. Sorry for the noise._

Testing:
* Built `linux-x64` with `--with-debug-level=release --with-jvm-variants=client`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383834](https://bugs.openjdk.org/browse/JDK-8383834): x86_64: Client build fails after JDK-8379706 (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31036/head:pull/31036` \
`$ git checkout pull/31036`

Update a local copy of the PR: \
`$ git checkout pull/31036` \
`$ git pull https://git.openjdk.org/jdk.git pull/31036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31036`

View PR using the GUI difftool: \
`$ git pr show -t 31036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31036.diff">https://git.openjdk.org/jdk/pull/31036.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31036#issuecomment-4378046773)
</details>
