### PR TITLE
8357381: C2: assert(false) failed: should not be here

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4343,7 +4343,7 @@ Node* ConnectionGraph::find_inst_mem(Node *orig_mem, int alias_idx, GrowableArra
   return result;
 }
 
-Node* ConnectionGraph::find_inst_mem_assert_no_new_node(Node *orig_mem, int alias_idx, GrowableArray<PhiNode *> & orig_phis) {
+Node* ConnectionGraph::find_inst_mem_assert_no_new_node(Node* orig_mem, int alias_idx, GrowableArray<PhiNode*>& orig_phis) {
   uint orig_uniq = _compile->unique();
   Node* result = find_inst_mem(orig_mem, alias_idx, orig_phis);
   assert(orig_uniq == _compile->unique(), "no new nodes");

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4343,7 +4343,7 @@ Node* ConnectionGraph::find_inst_mem(Node *orig_mem, int alias_idx, GrowableArra
   return result;
 }
 
-Node* ConnectionGraph::find_inst_mem_assert_no_new_node(Node *orig_mem, int alias_idx, GrowableArray<PhiNode *>  &orig_phis) {
+Node* ConnectionGraph::find_inst_mem_assert_no_new_node(Node *orig_mem, int alias_idx, GrowableArray<PhiNode *> & orig_phis) {
   uint orig_uniq = _compile->unique();
   Node* result = find_inst_mem(orig_mem, alias_idx, orig_phis);
   assert(orig_uniq == _compile->unique(), "no new nodes");

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4149,6 +4149,20 @@ void ConnectionGraph::move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phi
       igvn->hash_insert(use);
       record_for_optimizer(use);
       --i;
+    } else if (use->Opcode() == Op_AryEq || use->Opcode() == Op_StrComp || use->Opcode() == Op_CountPositives ||
+          use->Opcode() == Op_StrEquals || use->Opcode() == Op_StrIndexOf || use->Opcode() == Op_StrIndexOfChar) {
+      if (alias_idx == general_idx)
+        continue;
+      if (use->in(MemNode::Memory) == n) {
+        uint orig_uniq = C->unique();
+        Node* m = find_inst_mem(n, general_idx, orig_phis);
+        assert(orig_uniq == C->unique(), "no new nodes");
+        igvn->hash_delete(use);
+        imax -= use->replace_edge(n, m, igvn);
+        igvn->hash_insert(use);
+        record_for_optimizer(use);
+        --i;
+      }
 #ifdef ASSERT
     } else if (use->is_Mem()) {
       // Memory nodes should have new memory input.

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4120,10 +4120,8 @@ void ConnectionGraph::move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phi
       if (n != mmem->memory_at(general_idx) || alias_idx == general_idx) {
         continue; // Nothing to do
       }
-      // Replace previous general reference to mem node.
-      uint orig_uniq = C->unique();
-      Node* m = find_inst_mem(n, general_idx, orig_phis);
-      assert(orig_uniq == C->unique(), "no new nodes");
+      // Replace previous general reference to mem node and assert no new node is created.
+      Node* m = find_inst_mem_assert_no_new_node(n, general_idx, orig_phis);
       mmem->set_memory_at(general_idx, m);
       --imax;
       --i;
@@ -4140,23 +4138,19 @@ void ConnectionGraph::move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phi
           alias_idx == general_idx) {
         continue; // Nothing to do
       }
-      // Move to general memory slice.
-      uint orig_uniq = C->unique();
-      Node* m = find_inst_mem(n, general_idx, orig_phis);
-      assert(orig_uniq == C->unique(), "no new nodes");
+      // Move to general memory slice and assert no new node is created.
+      Node* m = find_inst_mem_assert_no_new_node(n, general_idx, orig_phis);
       igvn->hash_delete(use);
       imax -= use->replace_edge(n, m, igvn);
       igvn->hash_insert(use);
       record_for_optimizer(use);
       --i;
-    } else if (use->Opcode() == Op_AryEq || use->Opcode() == Op_StrComp || use->Opcode() == Op_CountPositives ||
-          use->Opcode() == Op_StrEquals || use->Opcode() == Op_StrIndexOf || use->Opcode() == Op_StrIndexOfChar) {
+    } else if (is_mem_read_only_string_intrinsic(use)) {
       if (alias_idx == general_idx)
         continue;
       if (use->in(MemNode::Memory) == n) {
-        uint orig_uniq = C->unique();
-        Node* m = find_inst_mem(n, general_idx, orig_phis);
-        assert(orig_uniq == C->unique(), "no new nodes");
+        // Move to general memory slice and assert no new node is created.
+        Node* m = find_inst_mem_assert_no_new_node(n, general_idx, orig_phis);
         igvn->hash_delete(use);
         imax -= use->replace_edge(n, m, igvn);
         igvn->hash_insert(use);
@@ -4346,6 +4340,23 @@ Node* ConnectionGraph::find_inst_mem(Node *orig_mem, int alias_idx, GrowableArra
   }
   // the result is either MemNode, PhiNode, InitializeNode.
   return result;
+}
+
+Node* ConnectionGraph::find_inst_mem_assert_no_new_node(Node *orig_mem, int alias_idx, GrowableArray<PhiNode *>  &orig_phis) {
+  uint orig_uniq = _compile->unique();
+  Node* result = find_inst_mem(orig_mem, alias_idx, orig_phis);
+  assert(orig_uniq == _compile->unique(), "no new nodes");
+  return result;
+}
+
+bool ConnectionGraph::is_mem_read_only_string_intrinsic(Node* n) {
+  uint op = n->Opcode();
+  if (op == Op_AryEq || op == Op_CountPositives ||
+    op == Op_StrComp || op == Op_StrEquals ||
+    op == Op_StrIndexOf || op == Op_StrIndexOfChar) {
+      return true;
+    }
+  return false;
 }
 
 //
@@ -4925,9 +4936,8 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           // They overwrite memory edge corresponding to destination array,
           memnode_worklist.append_if_missing(use);
         } else if (!(BarrierSet::barrier_set()->barrier_set_c2()->is_gc_barrier_node(use) ||
-              op == Op_AryEq || op == Op_StrComp || op == Op_CountPositives ||
-              op == Op_StrCompressedCopy || op == Op_StrInflatedCopy || op == Op_VectorizedHashCode ||
-              op == Op_StrEquals || op == Op_StrIndexOf || op == Op_StrIndexOfChar)) {
+              is_mem_read_only_string_intrinsic(use) || op == Op_VectorizedHashCode ||
+              op == Op_StrCompressedCopy || op == Op_StrInflatedCopy)) {
           n->dump();
           use->dump();
           assert(false, "EA: missing memory path");

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4146,8 +4146,9 @@ void ConnectionGraph::move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phi
       record_for_optimizer(use);
       --i;
     } else if (is_mem_read_only_string_intrinsic(use)) {
-      if (alias_idx == general_idx)
+      if (alias_idx == general_idx) {
         continue;
+      }
       if (use->in(MemNode::Memory) == n) {
         // Move to general memory slice and assert no new node is created.
         Node* m = find_inst_mem_assert_no_new_node(n, general_idx, orig_phis);

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -562,7 +562,7 @@ private:
 
   void  move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phis);
   Node* find_inst_mem(Node* mem, int alias_idx,GrowableArray<PhiNode *>  &orig_phi_worklist, uint rec_depth = 0);
-  Node* find_inst_mem_assert_no_new_node(Node* mem, int alias_idx, GrowableArray<PhiNode *>& orig_phi_worklist);
+  Node* find_inst_mem_assert_no_new_node(Node* mem, int alias_idx, GrowableArray<PhiNode*>& orig_phi_worklist);
   Node* step_through_mergemem(MergeMemNode *mmem, int alias_idx, const TypeOopPtr *toop);
 
   Node_Array _node_map; // used for bookkeeping during type splitting

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -546,6 +546,7 @@ private:
   int address_offset(Node* adr, PhaseValues* phase);
 
   bool is_captured_store_address(Node* addp);
+  bool is_mem_read_only_string_intrinsic(Node* n);
 
   // Propagate unique types created for non-escaped allocated objects through the graph
   void split_unique_types(GrowableArray<Node *>  &alloc_worklist,
@@ -561,6 +562,7 @@ private:
 
   void  move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phis);
   Node* find_inst_mem(Node* mem, int alias_idx,GrowableArray<PhiNode *>  &orig_phi_worklist, uint rec_depth = 0);
+  Node* find_inst_mem_assert_no_new_node(Node* mem, int alias_idx,GrowableArray<PhiNode *>  &orig_phi_worklist);
   Node* step_through_mergemem(MergeMemNode *mmem, int alias_idx, const TypeOopPtr *toop);
 
   Node_Array _node_map; // used for bookkeeping during type splitting

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -562,7 +562,7 @@ private:
 
   void  move_inst_mem(Node* n, GrowableArray<PhiNode *>  &orig_phis);
   Node* find_inst_mem(Node* mem, int alias_idx,GrowableArray<PhiNode *>  &orig_phi_worklist, uint rec_depth = 0);
-  Node* find_inst_mem_assert_no_new_node(Node* mem, int alias_idx,GrowableArray<PhiNode *>  &orig_phi_worklist);
+  Node* find_inst_mem_assert_no_new_node(Node* mem, int alias_idx, GrowableArray<PhiNode *>& orig_phi_worklist);
   Node* step_through_mergemem(MergeMemNode *mmem, int alias_idx, const TypeOopPtr *toop);
 
   Node_Array _node_map; // used for bookkeeping during type splitting

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
@@ -21,11 +21,14 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8357381
  * @summary C2 compilation fails with C2: assert(false) failed: should not be here
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch -XX:CompileCommand=compileonly,compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA::main
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:CompileThreshold=1000 -XX:CompileCommand=compileonly,compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA::test1
+ *                   compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA
+ * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:CompileThreshold=1000 -XX:CompileCommand=compileonly,compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA::test2
  *                   compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA
  */
 
@@ -57,7 +60,7 @@ public class TestReadOnlyStringIntrinsicDuringEA extends c159.HelperBase {
     }
 
     public static void main(String[] strArr) {
-        for (int t = 0; t < 10_000; t++) {
+        for (int t = 0; t < 100_000; t++) {
             test1("123456abc", "123456abc");
             test2("X");
         }

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
@@ -25,24 +25,14 @@
  * @test
  * @bug 8357381
  * @summary C2 compilation fails with C2: assert(false) failed: should not be here
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch -XX:CompileCommand=compileonly,compiler.escapeAnalysis.Ce::cem
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch -XX:CompileCommand=compileonly,compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA::main
  *                   compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA
  */
 
 package compiler.escapeAnalysis;
 
 public class TestReadOnlyStringIntrinsicDuringEA extends c159.HelperBase {
-    public static void main(String[] strArr) {
-        for (int var16 = 0; var16 < 100000; var16++) {
-            Ce.VALUE2.cem("123456abc", "123456abc");
-        }
-    }
-}
-
-enum Ce {
-    VALUE2;
-
-    int cem(String id, String nameKey) {
+    static int test1(String id, String nameKey) {
         try {
             java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
             java.math.BigInteger num = java.math.BigInteger.valueOf(123);
@@ -55,9 +45,22 @@ enum Ce {
             ;
         return 0;
     }
-}
 
-class c159 {
-    static class HelperBase {
+    static boolean test2(String b) {
+        String t1 = "";
+        var s1 = new StringBuffer();
+        var s2 = s1.append(String.valueOf(t1));
+        var s3 = s2.append(7);
+        var s4 = String.valueOf("AB");
+        var s5 = s4.equals(String.valueOf(b));
+        return s5;
+    }
+
+    public static void main(String[] strArr) {
+        for (int t = 0; t < 10_000; t++) {
+            test1("123456abc", "123456abc");
+            test2("X");
+        }
     }
 }
+

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8357381
+ * @summary C2 compilation fails with C2: assert(false) failed: should not be here
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch -XX:CompileCommand=compileonly,compiler.escapeAnalysis.Ce::cem
+ *                   compiler.escapeAnalysis.TestReadOnlyStringIntrinsicDuringEA
+ */
+
+package compiler.escapeAnalysis;
+
+public class TestReadOnlyStringIntrinsicDuringEA extends c159.HelperBase {
+    public static void main(String[] strArr) {
+        for (int var16 = 0; var16 < 100000; var16++) {
+            Ce.VALUE2.cem("123456abc", "123456abc");
+        }
+    }
+}
+
+enum Ce {
+    VALUE2;
+
+    int cem(String id, String nameKey) {
+        try {
+            java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
+            java.math.BigInteger num = java.math.BigInteger.valueOf(123);
+            int length = num.toByteArray().length;
+            stream.write(num.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        if ("UTC".equals(id) && id.equals(nameKey))
+            ;
+        return 0;
+    }
+}
+
+class c159 {
+    static class HelperBase {
+    }
+}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReadOnlyStringIntrinsicDuringEA.java
@@ -34,7 +34,7 @@
 
 package compiler.escapeAnalysis;
 
-public class TestReadOnlyStringIntrinsicDuringEA extends c159.HelperBase {
+public class TestReadOnlyStringIntrinsicDuringEA {
     static int test1(String id, String nameKey) {
         try {
             java.io.ByteArrayOutputStream stream = new java.io.ByteArrayOutputStream();
@@ -60,7 +60,7 @@ public class TestReadOnlyStringIntrinsicDuringEA extends c159.HelperBase {
     }
 
     public static void main(String[] strArr) {
-        for (int t = 0; t < 100_000; t++) {
+        for (int t = 0; t < 10_000; t++) {
             test1("123456abc", "123456abc");
             test2("X");
         }


### PR DESCRIPTION
**Issue**
The assertion `assert(false, "should not be here")` in `ConnectionGraph::move_inst_mem` fires because a `StoreB` node has `StrEquals` as a memory user. 

**Analysis**
The main issues starts after the first iteration of iterative escape analysis. As mentioned in [JDK-8357381](https://bugs.openjdk.org/browse/JDK-8357381), EA#0 does lock removal. During IGVN after EA#0, the string intrinsic node `StrEqual` undergoes an ideal transformation (`StrIntrinsicNode::Ideal()`) which peels its `MergeMem` input node. At this point `StoreB` becomes a direct input  of `StrEquals`.  

Now EA#1 runs on the transformed graph. Phase 2 of `split_unique_types` explicitly allows `StrEquals` as a user of `StoreB`.  In Phase 4, `split_unique_types` then calls `move_inst_mem` which is responsible for moving memory users to their memory slices. However, `move_inst_mem` only handles `MergeMem`, `MemBar`, `Mem`, and `Phi` as memory user. Since, `StrEquals` is not handled in `move_inst_mem` even though it is allowed in Phase 2 of `split_unique_types` it fires the assertion `assert(false, "should not be here")`.

**Solution**
In the proposed fix, I have extended `move_inst_mem` to move string intrinsic nodes that are explicitly allowed in Phase 2 of `split_unique_type` to their appropriate memory slices. 

**Testing**
Tier1-3 and Github actions

**Question to reviewers**
Please let me know if this fix looks reasonable.

Thank you @danielogh for the initial analysis.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357381](https://bugs.openjdk.org/browse/JDK-8357381): C2: assert(false) failed: should not be here (**Bug** - P3)(⚠️ The fixVersion in this issue is [28] but the fixVersion in .jcheck/conf is 27, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31037/head:pull/31037` \
`$ git checkout pull/31037`

Update a local copy of the PR: \
`$ git checkout pull/31037` \
`$ git pull https://git.openjdk.org/jdk.git pull/31037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31037`

View PR using the GUI difftool: \
`$ git pr show -t 31037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31037.diff">https://git.openjdk.org/jdk/pull/31037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31037#issuecomment-4381755413)
</details>
