### PR TITLE
8384076: Make TableStatistics non-static

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -239,7 +239,7 @@ void Dictionary::verify() {
 }
 
 void Dictionary::print_table_statistics(outputStream* st, const char* table_name) {
-  static TableStatistics ts;
+  TableStatistics ts;
   auto sz = [&] (InstanceKlass** val) {
     return sizeof(**val);
   };

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -728,7 +728,7 @@ struct SizeFunc : StackObj {
 };
 
 TableStatistics StringTable::get_table_statistics() {
-  static TableStatistics ts;
+  TableStatistics ts;
   SizeFunc sz;
 
   Thread* jt = Thread::current();

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -563,7 +563,7 @@ Symbol* SymbolTable::new_permanent_symbol(const char* name) {
 }
 
 TableStatistics SymbolTable::get_table_statistics() {
-  static TableStatistics ts;
+  TableStatistics ts;
   auto sz = [&](Symbol* value) {
     assert(value != nullptr, "expected valid value");
     return (value)->size() * HeapWordSize;

--- a/src/hotspot/share/utilities/tableStatistics.cpp
+++ b/src/hotspot/share/utilities/tableStatistics.cpp
@@ -127,8 +127,6 @@ TableStatistics::TableStatistics(TableRateStatistics& rate_stats,
 #endif
 }
 
-TableStatistics::~TableStatistics() { }
-
 void TableStatistics::print(outputStream* st, const char *table_name) {
   st->print_cr("%s statistics:", table_name);
   st->print_cr("Number of buckets       : %9" PRIuPTR " = %9" PRIuPTR

--- a/src/hotspot/share/utilities/tableStatistics.hpp
+++ b/src/hotspot/share/utilities/tableStatistics.hpp
@@ -59,7 +59,7 @@ protected:
   float get_remove_rate();
 };
 
-class TableStatistics : CHeapObj<mtStatistics> {
+class TableStatistics {
 
 public:
   size_t _literal_bytes;
@@ -85,7 +85,6 @@ public:
   TableStatistics();
   TableStatistics(NumberSeq summary, size_t literal_bytes, size_t bucket_bytes, size_t node_bytes);
   TableStatistics(TableRateStatistics& rate_stats, NumberSeq summary, size_t literal_bytes, size_t bucket_bytes, size_t node_bytes);
-  ~TableStatistics();
 
   void print(outputStream* st, const char *table_name);
 };


### PR DESCRIPTION
Remove the `static` allocation of the `TableStatistics`. A TS is 96 bytes, surely we can afford to allocate that directly on the stack? I'm making this change because JEP-528 ( https://github.com/openjdk/jdk/pull/31011 ) added platform specific non-staticness of this code on Windows, I think it's preferable if it's the same on all platforms. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384076](https://bugs.openjdk.org/browse/JDK-8384076): Make TableStatistics non-static (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31039/head:pull/31039` \
`$ git checkout pull/31039`

Update a local copy of the PR: \
`$ git checkout pull/31039` \
`$ git pull https://git.openjdk.org/jdk.git pull/31039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31039`

View PR using the GUI difftool: \
`$ git pr show -t 31039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31039.diff">https://git.openjdk.org/jdk/pull/31039.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31039#issuecomment-4395426163)
</details>
