### PR TITLE
8383861: Shenandoah: Use int[] as filling class for compressed oop array allocation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -74,9 +74,19 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
-    filling_klass = UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass();
+    DEBUG_ONLY(size_t filling_element_byte_size;)
+#ifdef LP64
+    if (!CompressedOops) {
+      filling_klass = Universe::longArrayKlass();
+      filling_element_byte_size = T_LONG_aelem_bytes;
+    } else
+#endif
+    {
+      filling_klass = Universe::intArrayKlass();
+      filling_element_byte_size = T_INT_aelem_bytes;
+    }
+
 #ifdef ASSERT
-    const size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
     const int max_filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
     assert(max_filling_array_length == _length || max_filling_array_length - _length == 1,
            "max filling array length must match or exceed by at most 1 due to alignment padding");

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -72,12 +72,11 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   // For obj array, the header will be corrected to object array after clearing the memory.
   Klass* filling_klass = _klass;
   int filling_array_length = _length;
-  const bool is_ref_type = is_reference_type(element_type, true);
+  const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
-    const bool is_narrow_oop = element_type == T_NARROWOOP;
-    size_t filling_element_byte_size = is_narrow_oop ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
-    filling_klass = is_narrow_oop ? Universe::intArrayKlass() : Universe::longArrayKlass();
+    size_t filling_element_byte_size = UseCompactObjectHeaders ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
+    filling_klass = UseCompactObjectHeaders ? Universe::intArrayKlass() : Universe::longArrayKlass();
     filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
   }
   ObjArrayAllocator filling_array_allocator(filling_klass, _word_size,  filling_array_length , /* do_zero */ false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -75,8 +75,8 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
-    size_t filling_element_byte_size = UseCompactObjectHeaders ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
-    filling_klass = UseCompactObjectHeaders ? Universe::intArrayKlass() : Universe::longArrayKlass();
+    size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
+    filling_klass = UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass();
     filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
   }
   ObjArrayAllocator filling_array_allocator(filling_klass, _word_size,  filling_array_length , /* do_zero */ false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -74,14 +74,7 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
-#ifdef _LP64
-    if (!UseCompressedOops) {
-      filling_klass = Universe::longArrayKlass();
-    } else
-#endif
-    {
-      filling_klass = Universe::intArrayKlass();
-    }
+    filling_klass = LP64_ONLY(UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass()) NOT_LP64(Universe::intArrayKlass());
 
 #ifdef ASSERT
     const int filling_element_byte_size = type2aelembytes(ArrayKlass::cast(filling_klass)->element_type());

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -75,9 +75,10 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
-    size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
     filling_klass = UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass();
+    size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
     filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
+    LP64_ONLY(assert(filling_array_length == _length, "Must match");)
   }
   ObjArrayAllocator filling_array_allocator(filling_klass, _word_size,  filling_array_length , /* do_zero */ false);
   filling_array_allocator.initialize(mem);

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -75,14 +75,7 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
 
   if (is_ref_type) {
     filling_klass = LP64_ONLY(UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass()) NOT_LP64(Universe::intArrayKlass());
-
-#ifdef ASSERT
-    const int filling_element_byte_size = type2aelembytes(ArrayKlass::cast(filling_klass)->element_type());
-    assert(filling_element_byte_size == type2aelembytes(element_type), "filling element size must match ref size");
-    const int max_filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
-    assert(max_filling_array_length == _length || max_filling_array_length - _length < ObjectAlignmentInBytes / filling_element_byte_size,
-           "max filling array length must match or exceed by less than alignment padding elements");
-#endif
+    assert(type2aelembytes(ArrayKlass::cast(filling_klass)->element_type()) == type2aelembytes(element_type), "filling element size must match ref size");
   }
   // Use _length directly: it matches the ref count, and the filling element size equals the ref size.
   ObjArrayAllocator filling_array_allocator(filling_klass, _word_size, _length, /* do_zero */ false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -111,7 +111,6 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
 
   // reference array, header need to be overridden to its own.
   if (is_ref_type) {
-    arrayOopDesc::set_length(mem, _length);
     finish(mem);
     // zap paddings after setting correct klass
     mem_zap_start_padding(mem);

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -71,16 +71,18 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   // Always initialize the mem with primitive array first so GC won't look into the elements in the array.
   // For obj array, the header will be corrected to object array after clearing the memory.
   Klass* filling_klass = _klass;
-  int filling_array_length = _length;
   const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
     filling_klass = UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass();
+#ifdef ASSERT
     size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
-    filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
+    int filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
+    // Should always pass given that 32bit architecture is not supported.
     assert(filling_array_length == _length, "Must match");
+#endif
   }
-  ObjArrayAllocator filling_array_allocator(filling_klass, _word_size,  filling_array_length , /* do_zero */ false);
+  ObjArrayAllocator filling_array_allocator(filling_klass, _word_size, _length, /* do_zero */ false);
   filling_array_allocator.initialize(mem);
 
   // Invisible roots will be scanned and marked at the end of marking.

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -78,7 +78,7 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
     filling_klass = UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass();
     size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
     filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
-    LP64_ONLY(assert(filling_array_length == _length, "Must match");)
+    assert(filling_array_length == _length, "Must match");
   }
   ObjArrayAllocator filling_array_allocator(filling_klass, _word_size,  filling_array_length , /* do_zero */ false);
   filling_array_allocator.initialize(mem);

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -76,12 +76,13 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   if (is_ref_type) {
     filling_klass = UseCompressedOops ? Universe::intArrayKlass() : Universe::longArrayKlass();
 #ifdef ASSERT
-    size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
-    int filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
-    // Should always pass given that 32bit architecture is not supported.
-    assert(filling_array_length == _length, "Must match");
+    const size_t filling_element_byte_size = UseCompressedOops ? T_INT_aelem_bytes : T_LONG_aelem_bytes;
+    const int max_filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
+    assert(max_filling_array_length == _length || max_filling_array_length - _length == 1,
+           "max filling array length must match or exceed by at most 1 due to alignment padding");
 #endif
   }
+  // Use _length directly: it matches the ref count, and the filling element size equals the ref size.
   ObjArrayAllocator filling_array_allocator(filling_klass, _word_size, _length, /* do_zero */ false);
   filling_array_allocator.initialize(mem);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -85,6 +85,7 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
 
 #ifdef ASSERT
     const int filling_element_byte_size = type2aelembytes(ArrayKlass::cast(filling_klass)->element_type());
+    assert(filling_element_byte_size == type2aelembytes(element_type), "filling element size must match ref size");
     const int max_filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
     assert(max_filling_array_length == _length || max_filling_array_length - _length == 1,
            "max filling array length must match or exceed by at most 1 due to alignment padding");

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -80,8 +80,8 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
     const int filling_element_byte_size = type2aelembytes(ArrayKlass::cast(filling_klass)->element_type());
     assert(filling_element_byte_size == type2aelembytes(element_type), "filling element size must match ref size");
     const int max_filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
-    assert(max_filling_array_length == _length || max_filling_array_length - _length == 1,
-           "max filling array length must match or exceed by at most 1 due to alignment padding");
+    assert(max_filling_array_length == _length || max_filling_array_length - _length < ObjectAlignmentInBytes / filling_element_byte_size,
+           "max filling array length must match or exceed by less than alignment padding elements");
 #endif
   }
   // Use _length directly: it matches the ref count, and the filling element size equals the ref size.

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjArrayAllocator.cpp
@@ -74,19 +74,17 @@ oop ShenandoahObjArrayAllocator::initialize(HeapWord* mem) const {
   const bool is_ref_type = is_reference_type(element_type);
 
   if (is_ref_type) {
-    DEBUG_ONLY(size_t filling_element_byte_size;)
-#ifdef LP64
-    if (!CompressedOops) {
+#ifdef _LP64
+    if (!UseCompressedOops) {
       filling_klass = Universe::longArrayKlass();
-      filling_element_byte_size = T_LONG_aelem_bytes;
     } else
 #endif
     {
       filling_klass = Universe::intArrayKlass();
-      filling_element_byte_size = T_INT_aelem_bytes;
     }
 
 #ifdef ASSERT
+    const int filling_element_byte_size = type2aelembytes(ArrayKlass::cast(filling_klass)->element_type());
     const int max_filling_array_length = (int) ((process_size << LogBytesPerWord) / filling_element_byte_size);
     assert(max_filling_array_length == _length || max_filling_array_length - _length == 1,
            "max filling array length must match or exceed by at most 1 due to alignment padding");

--- a/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInit.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInit.java
@@ -72,7 +72,6 @@
  * @test id=compressed-oops-off
  * @summary Verify zero-initialization completeness for large arrays with compressed oops disabled
  * @requires vm.gc.Shenandoah
- * @requires vm.bits == 64
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx512m -Xms512m

--- a/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInit.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInit.java
@@ -68,6 +68,19 @@
  *      TestLargeArrayInit
  */
 
+/*
+ * @test id=compressed-oops-off
+ * @summary Verify zero-initialization completeness for large arrays with compressed oops disabled
+ * @requires vm.gc.Shenandoah
+ * @requires vm.bits == 64
+ * @library /test/lib
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx512m -Xms512m
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
+ *      -XX:-UseCompressedOops
+ *      TestLargeArrayInit
+ */
+
 /**
  *
  * Allocates large byte[], int[], long[], and Object[] arrays whose sizes span

--- a/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInitGCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInitGCStress.java
@@ -69,6 +69,19 @@
  *      TestLargeArrayInitGCStress
  */
 
+/*
+ * @test id=compressed-oops-off
+ * @summary Verify correct object metadata for large arrays with compressed oops disabled under GC stress
+ * @requires vm.gc.Shenandoah
+ * @requires vm.bits == 64
+ * @library /test/lib
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx256m -Xms256m
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:-UseCompressedOops
+ *      TestLargeArrayInitGCStress
+ */
+
 /**
  *
  * Allocates large arrays of various types under GC stress (aggressive heuristics,

--- a/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInitGCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLargeArrayInitGCStress.java
@@ -73,7 +73,6 @@
  * @test id=compressed-oops-off
  * @summary Verify correct object metadata for large arrays with compressed oops disabled under GC stress
  * @requires vm.gc.Shenandoah
- * @requires vm.bits == 64
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx256m -Xms256m


### PR DESCRIPTION
See the details of the issue in the JBS ticket, it is not crucial bug, but the code I am trying to fix doesn't work as designed because it assumes element type can be T_NARROWOOP(false assumption).

Test
- [x] jtreg test hotspot_gc_shenandoah 
- [x] GHA 
- [x] Internal perf CI(jtreg + stress + perf test) 
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383861](https://bugs.openjdk.org/browse/JDK-8383861): Shenandoah: Use int[] as filling class for compressed oop array allocation (**Bug** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31041/head:pull/31041` \
`$ git checkout pull/31041`

Update a local copy of the PR: \
`$ git checkout pull/31041` \
`$ git pull https://git.openjdk.org/jdk.git pull/31041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31041`

View PR using the GUI difftool: \
`$ git pr show -t 31041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31041.diff">https://git.openjdk.org/jdk/pull/31041.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31041#issuecomment-4382829983)
</details>
