### PR TITLE
8383873: SNIWildcardMatching test logs an error instead of failing

### DIFF
--- a/test/jdk/javax/net/ssl/ServerName/SNIWildcardMatching.java
+++ b/test/jdk/javax/net/ssl/ServerName/SNIWildcardMatching.java
@@ -22,6 +22,7 @@
  */
 
 import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.fail;
 import static jdk.test.lib.Utils.runAndCheckException;
 
 import java.io.IOException;
@@ -118,7 +119,7 @@ public final class SNIWildcardMatching extends SSLSocketTemplate {
                 try {
                     new SNIWildcardMatching(v[0], v[1], protocol).run();
                 } catch (Exception e) {
-                    System.err.println("Error running "
+                    fail("Error running "
                             + Arrays.toString(v) + ": " + e.getMessage());
                 }
             }

--- a/test/jdk/javax/net/ssl/ServerName/SNIWildcardMatching.java
+++ b/test/jdk/javax/net/ssl/ServerName/SNIWildcardMatching.java
@@ -120,7 +120,7 @@ public final class SNIWildcardMatching extends SSLSocketTemplate {
                     new SNIWildcardMatching(v[0], v[1], protocol).run();
                 } catch (Exception e) {
                     fail("Error running "
-                            + Arrays.toString(v) + ": " + e.getMessage());
+                            + Arrays.toString(v) + ": " + e);
                 }
             }
 


### PR DESCRIPTION
SNIWildcardMatching test logs an error instead of failing when testing valid values.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383873](https://bugs.openjdk.org/browse/JDK-8383873): SNIWildcardMatching test logs an error instead of failing (**Bug** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31042/head:pull/31042` \
`$ git checkout pull/31042`

Update a local copy of the PR: \
`$ git checkout pull/31042` \
`$ git pull https://git.openjdk.org/jdk.git pull/31042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31042`

View PR using the GUI difftool: \
`$ git pr show -t 31042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31042.diff">https://git.openjdk.org/jdk/pull/31042.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31042#issuecomment-4381355330)
</details>
