### PR TITLE
8382273: Update nsk/jvmti/unit tests to use ThreadWrapper

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretfp.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretfp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.ForceEarlyReturn;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -75,7 +76,7 @@ public class earlyretfp {
     }
 
     // Tested thread class
-    static class earlyretThread extends Thread {
+    static class earlyretThread extends ThreadWrapper {
         public void run() {
             double val0 = 0.0;    // an arbitrary value
             /* Start a chain of recursive calls with NESTING_DEPTH.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretint.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.ForceEarlyReturn;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -79,7 +80,7 @@ public class earlyretint {
     }
 
     // Tested thread class
-    static class earlyretThread extends Thread {
+    static class earlyretThread extends ThreadWrapper {
         public void run() {
             long val0 = 9009; // an arbitrary value
             /* Start a chain of recursive calls with NESTING_DEPTH.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretlong.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretlong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.ForceEarlyReturn;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -75,7 +76,7 @@ public class earlyretlong {
     }
 
     // Tested thread class
-    static class earlyretThread extends Thread {
+    static class earlyretThread extends ThreadWrapper {
         public void run() {
             long val0 = 9000009; // arbitrary value
             /* Start a chain of recursive calls with NESTING_DEPTH.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretobj.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretobj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.ForceEarlyReturn;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -87,7 +88,7 @@ public class earlyretobj {
     }
 
     // Tested thread class
-    static class earlyretThread extends Thread {
+    static class earlyretThread extends ThreadWrapper {
         public void run() {
             /* Start a chain of recursive calls with NESTING_DEPTH.
              * Then ForceEarlyReturn will be called in the JVMTI native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretstr.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretstr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.ForceEarlyReturn;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -73,7 +74,7 @@ public class earlyretstr {
     }
 
     // Tested thread class
-    static class earlyretThread extends Thread {
+    static class earlyretThread extends ThreadWrapper {
         public void run() {
             System.out.println("earlyretThread.run() Begin");
             /* Start a chain of recursive calls with NESTING_DEPTH.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretvoid.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretvoid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.ForceEarlyReturn;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -76,7 +77,7 @@ public class earlyretvoid {
 
 
     // Tested thread class
-    static class earlyretThread extends Thread {
+    static class earlyretThread extends ThreadWrapper {
         Monitor mntr = null;
 
         public void run() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.GetAllStackTraces;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -74,7 +75,7 @@ public class getallstktr001 {
             try { Thread.sleep(500); } catch ( InterruptedException e ) {}
 
             boolean allThreadsReady = true;
-            for ( Thread t : thr ) {
+            for ( TestThread t : thr ) {
                 StackTraceElement[] stack = t.getStackTrace();
                 if ( stack.length == 0 ) {
                     System.out.println("Thread " + t.getName() + " has an empty stack. Seems strange.");
@@ -118,7 +119,7 @@ public class getallstktr001 {
         return GetResult();
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         static int counter=0;
         int ind;
         public TestThread(String name) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetConstantPool/getcpool001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetConstantPool/getcpool001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.GetConstantPool;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -74,7 +75,7 @@ public class getcpool001 {
         return check();
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         // Some constants to fill in the class constant pool
         boolean    bl = true;
         byte       bt = 127;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/MethodBind/JvmtiTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/MethodBind/JvmtiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.MethodBind;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 
 public class JvmtiTest {
@@ -48,8 +49,8 @@ public class JvmtiTest {
     native static void RawMonitorEnter(int i);
     native static void RawMonitorExit(int i);
     native static void RawMonitorWait(int i);
-    native static void GetStackTrace(TestThread t);
-    native static int GetFrameCount(TestThread t);
+    native static void GetStackTrace(Thread t);
+    native static int GetFrameCount(Thread t);
 
 
     static volatile int thrCount = 0;
@@ -75,8 +76,8 @@ public class JvmtiTest {
 
 
         for (int i=0; i < THREADS_LIMIT-1; i++) {
-            GetStackTrace(t[i]);
-            GetFrameCount(t[i]);
+            GetStackTrace(t[i].getThread());
+            GetFrameCount(t[i].getThread());
         }
 
         RawMonitorExit(4);
@@ -92,7 +93,7 @@ public class JvmtiTest {
         return GetResult() + fail_id;
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         static int counter=0;
         int ind;
         public TestThread(String name) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/StackTrace/JvmtiTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/StackTrace/JvmtiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.StackTrace;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 
 public class JvmtiTest {
@@ -37,8 +38,8 @@ public class JvmtiTest {
     native static void RawMonitorEnter(int i);
     native static void RawMonitorExit(int i);
     native static void RawMonitorWait(int i);
-    native static void GetStackTrace(TestThread t);
-    native static int GetFrameCount(TestThread t);
+    native static void GetStackTrace(Thread t);
+    native static int GetFrameCount(Thread t);
 
 
     static volatile int thrCount = 0;
@@ -64,8 +65,8 @@ public class JvmtiTest {
 
 
         for (int i=0; i < THREADS_LIMIT-1; i++) {
-            GetStackTrace(t[i]);
-            GetFrameCount(t[i]);
+            GetStackTrace(t[i].getThread());
+            GetFrameCount(t[i].getThread());
         }
 
         RawMonitorExit(4);
@@ -81,7 +82,7 @@ public class JvmtiTest {
         return GetResult() + fail_id;
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         static int counter=0;
         int ind;
         public TestThread(String name) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendMonitorInfo/JvmtiTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendMonitorInfo/JvmtiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.functions.nosuspendMonitorInfo;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 
 public class JvmtiTest {
@@ -74,14 +75,14 @@ public class JvmtiTest {
             runn.start();
             try {
                 CheckMonitorInfo(thr,lock1, 1);
-                CheckMonitorInfo(runn,lock1, 0);
+                CheckMonitorInfo(runn.getThread(),lock1, 0);
                 lock1.wait();
             } catch (Throwable e) {
                 out.println(e);
                 return 2;
             }
             CheckMonitorInfo(thr,lock1,1);
-            CheckMonitorInfo(runn,lock1,0);
+            CheckMonitorInfo(runn.getThread(),lock1,0);
         }
 
         while (!lock1held) {
@@ -93,7 +94,7 @@ public class JvmtiTest {
             CheckMonitorInfo(thr,lock2,1);
             lock2.notifyAll();
             CheckMonitorInfo(thr,lock2,1);
-            CheckMonitorInfo(runn,lock2,0);
+            CheckMonitorInfo(runn.getThread(),lock2,0);
         }
 
         while (!lock1held) {
@@ -103,11 +104,11 @@ public class JvmtiTest {
         synchronized (lock2) {
             lock1held = false;
             CheckMonitorInfo(thr,lock2,1);
-            CheckMonitorInfo(runn,lock2,1);
-            CheckMonitorInfo(runn,lock1,1);
+            CheckMonitorInfo(runn.getThread(),lock2,1);
+            CheckMonitorInfo(runn.getThread(),lock1,1);
             lock2.notifyAll();
             CheckMonitorInfo(thr,lock2,1);
-            CheckMonitorInfo(runn,lock2,0);
+            CheckMonitorInfo(runn.getThread(),lock2,0);
         }
 
         try {
@@ -120,7 +121,7 @@ public class JvmtiTest {
     }
 }
 
-class JvmtiTesta extends Thread {
+class JvmtiTesta extends ThreadWrapper {
     public void run() {
         synchronized (JvmtiTest.lock1) {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendStackTrace/JvmtiTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendStackTrace/JvmtiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.functions.nosuspendStackTrace;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 
 public class JvmtiTest {
@@ -48,8 +49,8 @@ public class JvmtiTest {
     native static void RawMonitorEnter(int i);
     native static void RawMonitorExit(int i);
     native static void RawMonitorWait(int i);
-    native static void GetStackTrace(TestThread t);
-    native static int GetFrameCount(TestThread t);
+    native static void GetStackTrace(Thread t);
+    native static int GetFrameCount(Thread t);
 
 
     static volatile int thrCount = 0;
@@ -75,8 +76,8 @@ public class JvmtiTest {
 
 
         for (int i=0; i < THREADS_LIMIT-1; i++) {
-            GetStackTrace(t[i]);
-            GetFrameCount(t[i]);
+            GetStackTrace(t[i].getThread());
+            GetFrameCount(t[i].getThread());
         }
 
         RawMonitorExit(4);
@@ -92,7 +93,7 @@ public class JvmtiTest {
         return GetResult() + fail_id;
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         static int counter=0;
         int ind;
         public TestThread(String name) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.functions;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 
 public class rawmonitor {
@@ -77,7 +78,7 @@ public class rawmonitor {
         return GetResult() + fail_id;
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         static int counter=0;
         public TestThread(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/timers/JvmtiTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/timers/JvmtiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jvmti.unit.timers;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import java.util.*;
 
@@ -109,7 +110,7 @@ public class JvmtiTest {
         }
     }
 
-    static class TestThread extends Thread {
+    static class TestThread extends ThreadWrapper {
         int threadNumber;
         int iterations;
 
@@ -127,7 +128,7 @@ public class JvmtiTest {
                 }
                 Collections.sort(list);
             }
-            JvmtiTest.RegisterCompletedThread(this, threadNumber, iterations);
+            JvmtiTest.RegisterCompletedThread(this.getThread(), threadNumber, iterations);
             JvmtiTest.completeThread();
         }
     }


### PR DESCRIPTION
Converted 14 nsk/jvmti/unit tests from extends Thread to extends ThreadWrapper so they can run with both platform and virtual threads

For tests with native methods expecting a Thread (GetStackTrace, GetFrameCount, CheckMonitorInfo, RegisterCompletedThread), changed the native signatures to take Thread and pass  .getThread() at the call sites

earlyretbase is left unconverted its native code does GetObjectClass on the thread to find activeMethod(), so it needs the wrapper class for method lookup but the real Thread for JVMTI operations. That one probably needs a separate approach.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382273](https://bugs.openjdk.org/browse/JDK-8382273): Update nsk/jvmti/unit tests to use ThreadWrapper (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31043/head:pull/31043` \
`$ git checkout pull/31043`

Update a local copy of the PR: \
`$ git checkout pull/31043` \
`$ git pull https://git.openjdk.org/jdk.git pull/31043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31043`

View PR using the GUI difftool: \
`$ git pr show -t 31043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31043.diff">https://git.openjdk.org/jdk/pull/31043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31043#issuecomment-4444667391)
</details>
