### PR TITLE
8383825: Incorrect handling of Hawaii_Aleutian metazone

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -815,6 +815,28 @@ public class CLDRConverter {
                 data = map.get(TIMEZONE_ID_PREFIX + tzLink);
             }
 
+            // Process metazones first, if any
+            String meta = handlerMetaZones.get(tzKey);
+            String[] metaNames = null;
+            if (meta == null && tzLink != null) {
+                // Check for tzLink
+                meta = handlerMetaZones.get(tzLink);
+            }
+            if (meta != null) {
+                var metaKey = METAZONE_ID_PREFIX + meta;
+                if (map.get(metaKey) instanceof String[] mn) {
+                    metaNames = mn;
+                }
+                if (metaNames != null && isDefaultZone(meta, tzKey)) {
+                    // Record the metazone names only from the default
+                    // (001) zone, with short names filled from TZDB
+                    metaNames = Arrays.copyOf(metaNames, metaNames.length);
+                    fillTZDBShortNames(tzKey, metaNames);
+                    names.put(metaKey, metaNames);
+                }
+            }
+
+            // Put regular time zones
             if (data instanceof String[] tznames) {
                 // Hack for UTC. UTC is an alias to Etc/UTC in CLDR
                 if (tzid.equals("Etc/UTC") && !map.containsKey(TIMEZONE_ID_PREFIX + "UTC")) {
@@ -828,26 +850,10 @@ public class CLDRConverter {
                     names.put(tzid, tznames);
                 }
             } else {
-                String meta = handlerMetaZones.get(tzKey);
-                if (meta == null && tzLink != null) {
-                    // Check for tzLink
-                    meta = handlerMetaZones.get(tzLink);
-                }
-                if (meta != null) {
-                    String metaKey = METAZONE_ID_PREFIX + meta;
-                    data = map.get(metaKey);
-                    if (data instanceof String[] tznames) {
-                        if (isDefaultZone(meta, tzKey)) {
-                            // Record the metazone names only from the default
-                            // (001) zone, with short names filled from TZDB
-                            tznames = Arrays.copyOf(tznames, tznames.length);
-                            fillTZDBShortNames(tzKey, tznames);
-                            names.put(metaKey, tznames);
-                        }
-                        names.put(tzid, meta);
-                        if (tzLink != null && availableIds.contains(tzLink)) {
-                            names.put(tzLink, meta);
-                        }
+                if (metaNames != null) {
+                    names.put(tzid, meta);
+                    if (tzLink != null && availableIds.contains(tzLink)) {
+                        names.put(tzLink, meta);
                     }
                 } else if (id.equals("root")) {
                     // supply TZDB short names if available


### PR DESCRIPTION
This fixes a regression found while backporting the fix for JDK-8382020.

The previous fix records metazone names only when processing the default (001) time zone for the metazone. However, it did not handle the case where that default time zone also has its own zone-specific names.

This does not show up in mainline for `Hawaii_Aleutian` metazone, because the metazone's default time zone is `America/Adak`, which maps back to the `Hawaii_Aleutian` metazone. In JDK 25, however, the default time zone for `Hawaii_Aleutian` is `Pacific/Honolulu`, which has its own zone-specific names so that Hawaii can use short names such as `HST`/`HDT` instead of `HAST`/`HADT`.

As a result, when the JDK-8382020 fix is backported to JDK 25, the `Hawaii_Aleutian` metazone names are not generated during the build. This change processes metazone names before zone-specific names, so the default-zone metazone entry is still recorded even when the default zone has its own names.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383825](https://bugs.openjdk.org/browse/JDK-8383825): Incorrect handling of Hawaii_Aleutian metazone (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31046/head:pull/31046` \
`$ git checkout pull/31046`

Update a local copy of the PR: \
`$ git checkout pull/31046` \
`$ git pull https://git.openjdk.org/jdk.git pull/31046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31046`

View PR using the GUI difftool: \
`$ git pr show -t 31046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31046.diff">https://git.openjdk.org/jdk/pull/31046.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31046#issuecomment-4383376938)
</details>
