### PR TITLE
8383631: Test vmTestbase/nsk/jdb/kill/kill003/kill003.java failed - possible NullPointerException

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
@@ -76,7 +76,7 @@ public class kill003 extends JdbTest {
         // after creating all the threads. Get the list of debuggee threads.
         threads = jdb.getThreadIdsByName("main");
 
-        // Make sure we stop in jdb when the NPE is thrown
+        // Make sure we stop in jdb when the NPE is thrown or rethrown.
         reply = jdb.receiveReplyFor(JdbCommand._catch + "all java.lang.NullPointerException");
 
         // Stopped at kill003a.main(), so step into synchronized block

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
@@ -97,7 +97,7 @@ public class kill003 extends JdbTest {
         // Continue the debuggee - the async exception will be delivered to the debuggee.
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        // jdb got notified of the NPE for the kill command. continue and jdb will get
+        // jdb got notified of the NPE for the kill command. Continue and jdb will get
         // notified again when it is rethrown from the synchronized block's implicit
         // exception handler, which is where we want to execute the locals command from.
         reply = jdb.receiveReplyFor(JdbCommand.cont);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
@@ -76,7 +76,10 @@ public class kill003 extends JdbTest {
         // after creating all the threads. Get the list of debuggee threads.
         threads = jdb.getThreadIdsByName("main");
 
-        // Stopped at kill.main, so step into synchronized block
+        // Make sure we stop in jdb when the NPE is thrown
+        reply = jdb.receiveReplyFor(JdbCommand._catch + "all java.lang.NullPointerException");
+
+        // Stopped at kill003a.main(), so step into synchronized block
         reply = jdb.receiveReplyFor(JdbCommand.next);
 
         if (threads.length != 1) {
@@ -85,24 +88,28 @@ public class kill003 extends JdbTest {
             success = false;
         }
 
-        // Execution is at a bytecode that is not expected to handle an async exception.  Throw one here
-        // to make sure it gets handled without crashing.  The exception will be delivered at the next
-        // bytecode that can handle the async exception.
+        // Execution is at a bytecode that is not expected to handle an async exception.
+        // Throw one here to make sure it gets handled without crashing. The exception
+        // will be delivered at the next bytecode that can handle the async exception.
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[0] + " " + DEBUGGEE_EXCEPTION,
                                                    "killed");
 
         // Continue the debuggee - the async exception will be delivered to the debuggee.
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        // Ask the debuggee for its local variables at the bytecode where the async exception was delivered, which
-        // should be reachable.
+        // jdb got notified of the NPE for the kill command. continue and jdb will get
+        // notified again when it is rethrown from the synchronized block's implicit
+        // exception handler, which is where we want to execute the locals command from.
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        // Ask the debuggee for its local variables at the bytecode where the async
+        // exception was rethrown, which should be reachable.
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.locals, "Local variables");
 
         if (jdb.terminated()) {
             throw new Failure("Debuggee exited");
         }
 
-        // The lack of exception handler in the debuggee should cause it to exit when continued.
         jdb.contToExit(1);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003.java
@@ -55,6 +55,7 @@ public class kill003 extends JdbTest {
     public static void main (String argv[]) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
+        compoundPromptIdent = COMPOUND_PROMPT_IDENT;
         new kill003().runTest(argv);
     }
 
@@ -65,6 +66,7 @@ public class kill003 extends JdbTest {
     static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_EXCEPTION = DEBUGGEE_CLASS + ".exception";
+    static final String COMPOUND_PROMPT_IDENT = "main";
 
     protected void runCases() {
         String[] reply;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill003/kill003a.java
@@ -30,7 +30,10 @@ public class kill003a {
     static NullPointerException exception = new NullPointerException();
 
     public static void main(String args[]) {
-        synchronized (args) {
+        try {
+            synchronized (args) {
+            }
+        } catch (NullPointerException npe) {
         }
         System.out.println("done");
         System.exit(JdbTest.JCK_STATUS_BASE);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -530,7 +530,7 @@ public class Jdb extends LocalProcess {
                 return found;
             }
 
-            // spleep for awhile
+            // sleep for awhile
             synchronized(dummy) {
                 try {
                     dummy.wait(delta);
@@ -614,7 +614,7 @@ public class Jdb extends LocalProcess {
         searching:
         for (int pos = startPos; pos < length; ) {
 
-            // skip each simbol not suitable for prompt begin
+            // skip each symbol not suitable for prompt begin
             if (!Character.isLetterOrDigit(lines.charAt(pos))) {
                 pos++;
                 continue searching;


### PR DESCRIPTION
The test sees the following output and is supposed to detect the "main[1]" prompt to indicate it is done with the "locals" command that was issued, and then issue a "cont" command:

[9:13:15.40] Sending command: locals
[9:13:15.560] reply[0]: Method arguments:
[9:13:15.561] reply[1]: args = instance of java.lang.String[3] (id=669)
[9:13:15.561] reply[2]: Local variables:
[9:13:15.561] reply[3]: main[1]
[9:13:15.561] Sending command: cont 

However, the output instead looks like this:

[21:15:18.114] Sending command: locals
[21:15:18.515] reply[0]: Method arguments:
[21:15:18.515] reply[1]: args = instance of java.lang.String[3] (id=686)
[21:15:18.515] reply[2]: Local variables:
[21:15:18.515] Sending command: cont
[21:15:18.716] reply[0]: main[1] > 

The JdbTest.findPrompt() code looks for a pattern of characters, followed by '[', then a number, then ']'. Unfortunately it matches the String[3] text you see in the output. Because of that the test thought the "locals" command had completed, and issued the "cont" command too soon, which gets the test out of sync.

Apparently some tests have had this same issue before and a solution was already available. You just need to set compoundPromptIdent to the prompt that the test expects (sans the square brackets part).

I also fixed a couple of comment typos I noticed in JdbTest while debugging this.

Tested by running kill003 a couple hundred times on the failing platform and with the failing JVM args.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383631](https://bugs.openjdk.org/browse/JDK-8383631): Test vmTestbase/nsk/jdb/kill/kill003/kill003.java failed - possible NullPointerException (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [8d108623](https://git.openjdk.org/jdk/pull/31048/files/8d108623f1ae371d575f6fe14dbf102299716d80)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [49334c1b](https://git.openjdk.org/jdk/pull/31048/files/49334c1b72514fc48fd53e614436f27662ba6d8b)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31048/head:pull/31048` \
`$ git checkout pull/31048`

Update a local copy of the PR: \
`$ git checkout pull/31048` \
`$ git pull https://git.openjdk.org/jdk.git pull/31048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31048`

View PR using the GUI difftool: \
`$ git pr show -t 31048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31048.diff">https://git.openjdk.org/jdk/pull/31048.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31048#issuecomment-4384761935)
</details>
