### PR TITLE
8383868: Separate resourcehogs tests from hotspot_misc

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -73,7 +73,8 @@ hotspot_misc = \
  -:hotspot_gc \
  -:hotspot_runtime \
  -:hotspot_serviceability \
- -:hotspot_containers
+ -:hotspot_containers \
+ -:hotspot_resourcehogs
 
 hotspot_native_sanity = \
   native_sanity


### PR DESCRIPTION
Hello,

While working on [JDK-8383850](https://bugs.openjdk.org/browse/JDK-8383850) I looked into how resourcehog tests are being run and noticed that we run them both in the `hotspot_resourcehogs` and `hotspot_misc` test groups.

To make it more intuitive when resourcehogs are being run, I suggest we be explicit when wanting to do so, by not including them in `hotspot_misc` and using `hotspot_resourcehogs` directly instead.

This might impact CI pipelines running `hotspot_misc` but not `hotspot_resourcehogs` in similar configurations. That will require a follow up after this if resourcehogs is still desirable to run.

The folders part of the `hotspot_misc` group are:
```bash
# Before
$ jtreg -showGroups test/hotspot/jtreg/:hotspot_misc
hotspot_misc: gtest/ native_sanity/ resourcehogs/ sanity/ sources/ testlibrary/ testlibrary_tests/

# After
$ jtreg -showGroups test/hotspot/jtreg/:hotspot_misc
hotspot_misc: gtest/ native_sanity/ sanity/ sources/ testlibrary/ testlibrary_tests/

``` 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383868](https://bugs.openjdk.org/browse/JDK-8383868): Separate resourcehogs tests from hotspot_misc (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31051/head:pull/31051` \
`$ git checkout pull/31051`

Update a local copy of the PR: \
`$ git checkout pull/31051` \
`$ git pull https://git.openjdk.org/jdk.git pull/31051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31051`

View PR using the GUI difftool: \
`$ git pr show -t 31051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31051.diff">https://git.openjdk.org/jdk/pull/31051.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31051#issuecomment-4386315440)
</details>
