### PR TITLE
8383906: Target highlight in member details is too aggressive

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -192,7 +192,7 @@ body {
     width:100%;
 }
 main [id] {
-    scroll-margin-top: calc(var(--nav-height) + 6px);
+    scroll-margin-top: calc(var(--nav-height) + 14px);
 }
 div.main-grid {
     max-width: var(--max-content-width);
@@ -1774,6 +1774,9 @@ table.striped > tbody > tr > th {
     }
     main {
         padding: 10px 12px;
+    }
+    main [id] {
+        scroll-margin-top: calc(var(--nav-height) + 10px);
     }
     body {
         -webkit-text-size-adjust: none;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -486,12 +486,7 @@ body.class-declaration-page .details h3 {
 }
 body.class-declaration-page section.detail:target > h3,
 body.class-declaration-page section.detail > h3:target {
-    background-color: var(--navbar-background-color);
-    color: var(--navbar-text-color);
-}
-body.class-declaration-page section.detail:target > h3 > a.anchor-link > img,
-body.class-declaration-page section.detail > h3:target > a.anchor-link > img {
-    filter: invert(100%) brightness(160%);
+    box-shadow: -4px 0 0 rgb(from var(--link-color) r g b / 0.7);
 }
 h1 > sup {
     font-size: small;


### PR DESCRIPTION
Please review a change to improve the target highlight for javadoc member details sections.

Instead of highlighting the member header by changing its background color, we now add a subtle accent bar to the left side of the header. The bar is implemented as `box-shadow`, is just outside the header element and does not cause a layout shift. It uses the theme's link color with an alpha of 70%, which seems to work well in both themes. 

The accent bar is wide enough to be noticeable, but nowhere near as distractive as the old highlight, and brings our documentation more in line with modern documentation/UI patterns.

I also slightly increased the `scroll-margin-top` property of elements to position them a bit further from the navigation bar when targeted by id.

Sample docs for the `java.lang` package are [available here](https://cr.openjdk.org/~hannesw/8383906/api.00/java.base/java/lang/Object.html#hashCode()).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8383906](https://bugs.openjdk.org/browse/JDK-8383906): Target highlight in member details is too aggressive (**Enhancement** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31052/head:pull/31052` \
`$ git checkout pull/31052`

Update a local copy of the PR: \
`$ git checkout pull/31052` \
`$ git pull https://git.openjdk.org/jdk.git pull/31052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31052`

View PR using the GUI difftool: \
`$ git pr show -t 31052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31052.diff">https://git.openjdk.org/jdk/pull/31052.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31052#issuecomment-4386454669)
</details>
