### PR TITLE
8383910: klass_or_null_acquire asserts on null when using compact object headers

### DIFF
--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -119,7 +119,7 @@ Klass* oopDesc::klass_or_null() const {
 Klass* oopDesc::klass_or_null_acquire() const {
   switch (ObjLayout::klass_mode()) {
     case ObjLayout::Compact:
-      return mark_acquire().klass();
+      return mark_acquire().klass_or_null();
     case ObjLayout::Compressed: {
       narrowKlass narrow_klass = AtomicAccess::load_acquire(&_compressed_klass);
       return CompressedKlassPointers::decode(narrow_klass);


### PR DESCRIPTION
While looking into our klass-fetching code I saw that we are calling `markWord::klass()` instead of `markWord::klass_or_null()` from `klass_or_null_acquire`:

```
Klass* oopDesc::klass_or_null_acquire() const {
  switch (ObjLayout::klass_mode()) {
    case ObjLayout::Compact:
      return mark_acquire().klass();
    case ObjLayout::Compressed: {
      narrowKlass narrow_klass = AtomicAccess::load_acquire(&_compressed_klass);
      return CompressedKlassPointers::decode(narrow_klass);
    }
    default:
      ShouldNotReachHere();
  }
}
```

`klass()` ends up calling `CompressedKlassPointers::decode_not_null`, which will assert in debug builds or do something wrong in release builds.

Currently the only usage of this function is `G1HeapRegion::do_oops_on_memregion_in_humongous`. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383910](https://bugs.openjdk.org/browse/JDK-8383910): klass_or_null_acquire asserts on null when using compact object headers (**Bug** - P3)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31053/head:pull/31053` \
`$ git checkout pull/31053`

Update a local copy of the PR: \
`$ git checkout pull/31053` \
`$ git pull https://git.openjdk.org/jdk.git pull/31053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31053`

View PR using the GUI difftool: \
`$ git pr show -t 31053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31053.diff">https://git.openjdk.org/jdk/pull/31053.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31053#issuecomment-4386716470)
</details>
