### PR TITLE
8383630: Fix iteration in tests doing class redefinition

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
@@ -193,7 +193,7 @@ public class DefineClass {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - needle.length(); i++) {
+        for (int i = offset; i <= buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }

--- a/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
@@ -193,7 +193,7 @@ public class DefineClass {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - offset - needle.length(); i++) {
+        for (int i = offset; i < buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }

--- a/test/hotspot/jtreg/runtime/vthread/RedefineClass.java
+++ b/test/hotspot/jtreg/runtime/vthread/RedefineClass.java
@@ -120,7 +120,7 @@ public class RedefineClass {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - offset - needle.length(); i++) {
+        for (int i = offset; i < buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }

--- a/test/hotspot/jtreg/runtime/vthread/RedefineClass.java
+++ b/test/hotspot/jtreg/runtime/vthread/RedefineClass.java
@@ -120,7 +120,7 @@ public class RedefineClass {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - needle.length(); i++) {
+        for (int i = offset; i <= buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }


### PR DESCRIPTION
This fixes the search of a needle in a buffer.  The buffer was not searched to the end.

Two tests use the very same coding including the same issue.

Ran the tests locally and in our nightly CI successfully.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383630](https://bugs.openjdk.org/browse/JDK-8383630): Fix iteration in tests doing class redefinition (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31054/head:pull/31054` \
`$ git checkout pull/31054`

Update a local copy of the PR: \
`$ git checkout pull/31054` \
`$ git pull https://git.openjdk.org/jdk.git pull/31054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31054`

View PR using the GUI difftool: \
`$ git pr show -t 31054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31054.diff">https://git.openjdk.org/jdk/pull/31054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31054#issuecomment-4386787570)
</details>
