### PR TITLE
8383914: [PPC] cleanup dtrace leftovers

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -210,7 +210,7 @@ int LIR_Assembler::emit_unwind_handler() {
   _masm->block_comment("Unwind handler");
 
   int offset = code_offset();
-  bool preserve_exception = method()->is_synchronized() || compilation()->env()->dtrace_method_probes();
+  bool preserve_exception = method()->is_synchronized();
   const Register Rexception = R3 /*LIRGenerator::exceptionOopOpr()*/, Rexception_save = R31;
 
   // Fetch the exception from TLS and clear out exception related thread state.
@@ -230,10 +230,6 @@ int LIR_Assembler::emit_unwind_handler() {
     stub = new MonitorExitStub(FrameMap::R4_opr, 0);
     __ unlock_object(R5, R6, R4, *stub->entry());
     __ bind(*stub->continuation());
-  }
-
-  if (compilation()->env()->dtrace_method_probes()) {
-    Unimplemented();
   }
 
   // Dispatch to the unwind logic.

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -232,13 +232,6 @@ void C1_MacroAssembler::initialize_object(
     initialize_body(obj, t1, t2, con_size_in_bytes, hdr_size_in_bytes);
   }
 
-  if (CURRENT_ENV->dtrace_alloc_probes()) {
-    Unimplemented();
-//    assert(obj == O0, "must be");
-//    call(CAST_FROM_FN_PTR(address, Runtime1::entry_for(StubId::c1_dtrace_object_alloc_id)),
-//         relocInfo::runtime_call_type);
-  }
-
   verify_oop(obj, FILE_AND_LINE);
 }
 
@@ -306,13 +299,6 @@ void C1_MacroAssembler::allocate_array(
     }
 
     initialize_body(base, index);
-  }
-
-  if (CURRENT_ENV->dtrace_alloc_probes()) {
-    Unimplemented();
-    //assert(obj == O0, "must be");
-    //call(CAST_FROM_FN_PTR(address, Runtime1::entry_for(StubId::c1_dtrace_object_alloc_id)),
-    //     relocInfo::runtime_call_type);
   }
 
   verify_oop(obj, FILE_AND_LINE);

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3852,13 +3852,6 @@ void TemplateTable::_new() {
       __ store_klass(RallocatedObject, RinstanceKlass, Rscratch);
     }
 
-    // Check and trigger dtrace event.
-    if (DTraceAllocProbes) {
-      __ push(atos);
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)));
-      __ pop(atos);
-    }
-
     __ b(Ldone);
   }
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -47,8 +47,8 @@ compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 
-compiler/runtime/Test8168712.java#with-dtrace 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
-compiler/runtime/Test8168712.java#without-dtrace 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
+compiler/runtime/Test8168712.java#with-dtrace 8211771 linux-s390x
+compiler/runtime/Test8168712.java#without-dtrace 8211771 linux-s390x
 compiler/runtime/Test7196199.java 8365196 windows-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all


### PR DESCRIPTION
Removes a test from the problemlist.txt and removes unused PPC code regarding dtrace. Dtrace support is excluded from Power builds.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383914](https://bugs.openjdk.org/browse/JDK-8383914): [PPC] cleanup dtrace leftovers (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31057/head:pull/31057` \
`$ git checkout pull/31057`

Update a local copy of the PR: \
`$ git checkout pull/31057` \
`$ git pull https://git.openjdk.org/jdk.git pull/31057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31057`

View PR using the GUI difftool: \
`$ git pr show -t 31057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31057.diff">https://git.openjdk.org/jdk/pull/31057.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31057#issuecomment-4386907419)
</details>
