### PR TITLE
8383999: javax/swing/AbstractButton/bug4133768.java failing on macosx due to color mismatch

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/bug4133768.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4133768.java
@@ -59,6 +59,7 @@ public class bug4133768 {
     private static volatile int buttonHeight;
     private static Robot robot;
     private static int ROLLOVER_Y_OFFSET = 4;
+    private static int COLOR_TOLERANCE = 5;
     private static CountDownLatch frameGainedFocusLatch =
         new CountDownLatch(1);
 
@@ -87,6 +88,12 @@ public class bug4133768 {
                 }
             });
         }
+    }
+
+    private static boolean checkColor(Color actual, Color expected) {
+        return Math.abs(actual.getRed() - expected.getRed()) <= COLOR_TOLERANCE
+            && Math.abs(actual.getGreen() - expected.getGreen()) <= COLOR_TOLERANCE
+            && Math.abs(actual.getBlue() - expected.getBlue()) <= COLOR_TOLERANCE;
     }
 
     private static void createTestImages() {
@@ -153,7 +160,7 @@ public class bug4133768 {
         robot.delay(1000);
         Color buttonColor = robot.getPixelColor(buttonLocation.x +
             buttonWidth / 2, buttonLocation.y + buttonHeight / 2);
-        if (!buttonColor.equals(Color.GREEN)) {
+        if (!checkColor(buttonColor, Color.GREEN)) {
             throw new RuntimeException("Button roll over color is : " +
                 buttonColor + " but it should be : " + Color.GREEN);
         }
@@ -170,8 +177,8 @@ public class bug4133768 {
         robot.delay(200);
         Color buttonColor = robot.getPixelColor(buttonLocation.x +
             buttonWidth / 2, buttonLocation.y + buttonHeight / 2);
-        if (buttonColor.equals(Color.GREEN) ||
-            buttonColor.equals(Color.RED)) {
+        if (checkColor(buttonColor, Color.GREEN) ||
+            checkColor(buttonColor, Color.RED)) {
             throw new RuntimeException("Disabled button color should not be : "
                 + buttonColor);
         }


### PR DESCRIPTION
This PR fixes a failure of bug4133768.java on macOS aarch64 by adding an RGB tolerance of 5.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/AbstractButton/bug4133768.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27487190/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27487191/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27487192/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27487193/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383999](https://bugs.openjdk.org/browse/JDK-8383999): javax/swing/AbstractButton/bug4133768.java failing on macosx due to color mismatch (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31061/head:pull/31061` \
`$ git checkout pull/31061`

Update a local copy of the PR: \
`$ git checkout pull/31061` \
`$ git pull https://git.openjdk.org/jdk.git pull/31061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31061`

View PR using the GUI difftool: \
`$ git pr show -t 31061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31061.diff">https://git.openjdk.org/jdk/pull/31061.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31061#issuecomment-4390581446)
</details>
