### PR TITLE
8384072: Problem list runtime/Thread/TestAlwaysPreTouchStacks.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -115,6 +115,7 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x
+runtime/Thread/TestAlwaysPreTouchStacks.java 8383372 macosx-aarch64
 
 applications/ctw/modules/jdk_jfr.java 8286300 linux-s390x
 applications/jcstress/copy.java 8229852 linux-all


### PR DESCRIPTION
Hi all,

This is a trivial PR to reduce the noise of a failing test on AArch64 Macs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384072](https://bugs.openjdk.org/browse/JDK-8384072): Problem list runtime/Thread/TestAlwaysPreTouchStacks.java (**Sub-task** - P4)


### Reviewers
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31065/head:pull/31065` \
`$ git checkout pull/31065`

Update a local copy of the PR: \
`$ git checkout pull/31065` \
`$ git pull https://git.openjdk.org/jdk.git pull/31065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31065`

View PR using the GUI difftool: \
`$ git pr show -t 31065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31065.diff">https://git.openjdk.org/jdk/pull/31065.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31065#issuecomment-4395329732)
</details>
