### PR TITLE
8384065: Improve wrapping of link labels in the table of contents

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -138,6 +138,26 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     }
 
     /**
+     * Returns a label for the given element to be used the table of contents sidebar.
+     *
+     * @param executableElement method or constructor
+     * @return the link label
+     */
+    protected Content getTOCLabel(ExecutableElement executableElement) {
+        var signature = utils.makeSignature(executableElement, typeElement, false, true);
+        var label = new ContentBuilder(Text.of(utils.getSimpleName(executableElement)));
+        // Insert line break opportunity before first parameter.
+        if (signature.length() > 2) {
+            label.add(Text.of(signature.substring(0, 1)))
+                    .add(HtmlTree.WBR())
+                    .add(Text.of(signature.substring(1)));
+        } else {
+            label.add(signature);
+        }
+        return label;
+    }
+
+    /**
      * Adds the generic type parameters.
      *
      * @param member the member to add the generic type parameters for

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
@@ -119,9 +119,7 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
                 constructorContent.add(div);
                 memberList.add(getMemberListItem(constructorContent));
                 writer.tableOfContents.addLink(htmlIds.forMember(currentConstructor).getFirst(),
-                        Text.of(utils.getSimpleName(constructor)
-                                + utils.makeSignature(currentConstructor, typeElement, false, true)),
-                        TableOfContents.Level.SECOND);
+                        getTOCLabel(currentConstructor), TableOfContents.Level.SECOND);
             }
             Content constructorDetails = getConstructorDetails(constructorDetailsHeader, memberList);
             target.add(constructorDetails);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
@@ -118,9 +118,7 @@ public class MethodWriter extends AbstractExecutableMemberWriter {
                 methodContent.add(div);
                 memberList.add(writer.getMemberListItem(methodContent));
                 writer.tableOfContents.addLink(htmlIds.forMember(currentMethod).getFirst(),
-                        Text.of(utils.getSimpleName(method)
-                                + utils.makeSignature(currentMethod, typeElement, false, true)),
-                        TableOfContents.Level.SECOND);
+                        getTOCLabel(currentMethod), TableOfContents.Level.SECOND);
             }
             Content methodDetails = getMethodDetails(methodDetailsHeader, memberList);
             detailsList.add(methodDetails);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -665,7 +665,7 @@ nav.toc a {
     overflow: hidden;
     text-overflow: ellipsis;
     text-wrap: balance;
-    text-indent: 0.9em hanging;
+    text-indent: 0.5em hanging;
     line-height: 1.35;
 }
 nav.toc ol.toc-list ol.toc-list a {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -943,6 +943,9 @@ div.checkboxes > label > input {
 .col-first, .col-second, .col-constructor-name {
     overflow: auto;
 }
+.col-constructor-name, .method-summary .col-second {
+    text-indent: 0.5em hanging;
+}
 body:not(.class-declaration-page) .col-first a:link,
 .col-summary-item-name a:link {
     font-weight:bold;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -661,9 +661,12 @@ a.current-selection {
 }
 nav.toc a {
     display: block;
-    padding: 8px;
+    padding: 7px 8px;
     overflow: hidden;
     text-overflow: ellipsis;
+    text-wrap: balance;
+    text-indent: 0.9em hanging;
+    line-height: 1.35;
 }
 nav.toc ol.toc-list ol.toc-list a {
     padding-left: 24px;

--- a/test/langtools/jdk/javadoc/doclet/testErasure/TestErasure.java
+++ b/test/langtools/jdk/javadoc/doclet/testErasure/TestErasure.java
@@ -103,9 +103,9 @@ public class TestErasure extends JavadocTester {
         checkOutput("Foo.html", true, """
                 <li><a href="#constructor-detail" tabindex="0">Constructor Details</a>
                 <ol class="toc-list">
-                <li><a href="#%3Cinit%3E(T)" tabindex="0">Foo(T)</a></li>
-                <li><a href="#%3Cinit%3E(X)" tabindex="0">Foo(T)</a></li>
-                <li><a href="#%3Cinit%3E(Y)" tabindex="0">Foo(T)</a></li>
+                <li><a href="#%3Cinit%3E(T)" tabindex="0">Foo(<wbr>T)</a></li>
+                <li><a href="#%3Cinit%3E(X)" tabindex="0">Foo(<wbr>T)</a></li>
+                <li><a href="#%3Cinit%3E(Y)" tabindex="0">Foo(<wbr>T)</a></li>
                 </ol>
                 </li>""");
         checkOutput("index-all.html", true, """
@@ -145,9 +145,9 @@ public class TestErasure extends JavadocTester {
         checkOutput("Foo.html", true, """
                 <li><a href="#method-detail" tabindex="0">Method Details</a>
                 <ol class="toc-list">
-                <li><a href="#m(T)" tabindex="0">m(T)</a></li>
-                <li><a href="#m(X)" tabindex="0">m(T)</a></li>
-                <li><a href="#m(Y)" tabindex="0">m(T)</a></li>
+                <li><a href="#m(T)" tabindex="0">m(<wbr>T)</a></li>
+                <li><a href="#m(X)" tabindex="0">m(<wbr>T)</a></li>
+                <li><a href="#m(Y)" tabindex="0">m(<wbr>T)</a></li>
                 </ol>
                 </li>""");
         checkOutput("index-all.html", true, """
@@ -210,8 +210,8 @@ public class TestErasure extends JavadocTester {
         checkOutput("Foo.html", true, """
                 <li><a href="#constructor-detail" tabindex="0">Constructor Details</a>
                 <ol class="toc-list">
-                <li><a href="#%3Cinit%3E(T)" tabindex="0">Foo(T)</a></li>
-                <li><a href="#%3Cinit%3E(X)" tabindex="0">Foo(T)</a></li>
+                <li><a href="#%3Cinit%3E(T)" tabindex="0">Foo(<wbr>T)</a></li>
+                <li><a href="#%3Cinit%3E(X)" tabindex="0">Foo(<wbr>T)</a></li>
                 </ol>
                 </li>""");
         checkOutput("index-all.html", true, """
@@ -242,8 +242,8 @@ public class TestErasure extends JavadocTester {
         checkOutput("Foo.html", true, """
                 <li><a href="#method-detail" tabindex="0">Method Details</a>
                 <ol class="toc-list">
-                <li><a href="#m(T)" tabindex="0">m(T)</a></li>
-                <li><a href="#m(X)" tabindex="0">m(T)</a></li>
+                <li><a href="#m(T)" tabindex="0">m(<wbr>T)</a></li>
+                <li><a href="#m(X)" tabindex="0">m(<wbr>T)</a></li>
                 </ol>
                 </li>""");
         checkOutput("index-all.html", true, """

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
@@ -25,7 +25,7 @@
  * @test
  * @bug      7025314 8023700 7198273 8025633 8026567 8081854 8196027 8182765
  *           8196200 8196202 8223378 8258659 8261976 8320458 8329537 8350638
- *           8342705 8371021 8373526
+ *           8342705 8371021 8373526 8384065
  * @summary  Make sure the Next/Prev Class links iterate through all types.
  *           Make sure the navagation is 2 columns, not 3.
  * @library  /tools/lib ../../lib
@@ -173,6 +173,36 @@ public class TestNavigation extends JavadocTester {
                 """
                     package pkg1; public class A {
                         /**
+                         * Empty ctor
+                         */
+                        public A() {}
+
+                        /**
+                         * Single param ctor
+                         */
+                        public A(int i) {}
+
+                        /**
+                         * A ctor with many params
+                         */
+                        public A(int i, int j, int x, int y, String s, boolean b) {}
+
+                        /**
+                         * A method without parameters
+                         */
+                        public void noParams() {}
+
+                        /**
+                         * A method with a single parameter
+                         */
+                        public void oneParam(String s) {}
+
+                        /**
+                         * A method with lots of parameters
+                         */
+                        public void manyParams(String s, int i, int j, boolean b, double d, double e) {}
+
+                        /**
                          * Class with members.
                          */
                         public static class X {
@@ -216,6 +246,29 @@ public class TestNavigation extends JavadocTester {
                 "-sourcepath", src.toString(),
                 "pkg1");
         checkExit(Exit.OK);
+
+        checkOrder("pkg1/A.html",
+                """
+                    <ol class="toc-list" tabindex="-1">
+                    <li><a href="#" tabindex="0">Description</a></li>
+                    <li><a href="#nested-class-summary" tabindex="0">Nested Class Summary</a></li>
+                    <li><a href="#constructor-summary" tabindex="0">Constructor Summary</a></li>
+                    <li><a href="#method-summary" tabindex="0">Method Summary</a></li>
+                    <li><a href="#constructor-detail" tabindex="0">Constructor Details</a>
+                    <ol class="toc-list">
+                    <li><a href="#%3Cinit%3E()" tabindex="0">A()</a></li>
+                    <li><a href="#%3Cinit%3E(int)" tabindex="0">A(<wbr>int)</a></li>
+                    <li><a href="#%3Cinit%3E(int,int,int,int,java.lang.String,boolean)" tabindex="0">A(<wbr>int, int, int, int, String, boolean)</a></li>
+                    </ol>
+                    </li>
+                    <li><a href="#method-detail" tabindex="0">Method Details</a>
+                    <ol class="toc-list">
+                    <li><a href="#noParams()" tabindex="0">noParams()</a></li>
+                    <li><a href="#oneParam(java.lang.String)" tabindex="0">oneParam(<wbr>String)</a></li>
+                    <li><a href="#manyParams(java.lang.String,int,int,boolean,double,double)" tabindex="0">manyParams(<wbr>String, int, int, boolean, double, double)</a></li>
+                    </ol>
+                    </li>
+                    </ol>""");
 
         checkOrder("pkg1/A.X.html",
                 """

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -288,7 +288,6 @@ public class TestStylesheet extends JavadocTester {
                 "field-summary",
                 "member-details",
                 "method-details",
-                "method-summary",
                 // the following provide the ability to optionally override components of the
                 // memberSignature structure
                 "name",


### PR DESCRIPTION
Please review a change to improve wrapping of long labels in tables of contents generated by JavaDoc. 

A description of changes and screenshots are available [in the JBS issue](https://bugs.openjdk.org/browse/JDK-8384065).

Up-to-date sample documentation [can be browsed here](https://cr.openjdk.org/~hannesw/8384065/api.01/java.base/java/lang/invoke/MethodHandles.html#method-summary).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384065](https://bugs.openjdk.org/browse/JDK-8384065): Improve wrapping of link labels in the table of contents (**Enhancement** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31066/head:pull/31066` \
`$ git checkout pull/31066`

Update a local copy of the PR: \
`$ git checkout pull/31066` \
`$ git pull https://git.openjdk.org/jdk.git pull/31066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31066`

View PR using the GUI difftool: \
`$ git pr show -t 31066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31066.diff">https://git.openjdk.org/jdk/pull/31066.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31066#issuecomment-4395542504)
</details>
