### PR TITLE
8384088: osThread _thread_id should be an int on all BSD's

### DIFF
--- a/src/hotspot/os/bsd/osThread_bsd.cpp
+++ b/src/hotspot/os/bsd/osThread_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/bsd/osThread_bsd.cpp
+++ b/src/hotspot/os/bsd/osThread_bsd.cpp
@@ -26,6 +26,8 @@
 #include "runtime/mutex.hpp"
 #include "runtime/osThread.hpp"
 
+#include <signal.h>
+
 OSThread::OSThread()
   : _thread_id(0),
     _pthread_id(nullptr),

--- a/src/hotspot/os/bsd/osThread_bsd.cpp
+++ b/src/hotspot/os/bsd/osThread_bsd.cpp
@@ -26,16 +26,8 @@
 #include "runtime/mutex.hpp"
 #include "runtime/osThread.hpp"
 
-#include <signal.h>
-
 OSThread::OSThread()
-  : _thread_id(
-#ifdef __APPLE__
-        0
-#else
-        nullptr
-#endif
-    ),
+  : _thread_id(0),
     _pthread_id(nullptr),
     _unique_thread_id(0),
     _caller_sigmask(),


### PR DESCRIPTION
The initializer for the _thread_id member in hotspot/os/bsd/osThread_bsd.cpp is incorrect for BSD's other than macOS. It should be an integer on all BSD's.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384088](https://bugs.openjdk.org/browse/JDK-8384088): osThread _thread_id should be an int on all BSD's (**Enhancement** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31070/head:pull/31070` \
`$ git checkout pull/31070`

Update a local copy of the PR: \
`$ git checkout pull/31070` \
`$ git pull https://git.openjdk.org/jdk.git pull/31070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31070`

View PR using the GUI difftool: \
`$ git pr show -t 31070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31070.diff">https://git.openjdk.org/jdk/pull/31070.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31070#issuecomment-4396751350)
</details>
