### PR TITLE
8384089: Correctly catch invalid uses of StubCodeMark

### DIFF
--- a/src/hotspot/share/runtime/stubCodeGenerator.cpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.cpp
@@ -255,8 +255,19 @@ void StubCodeGenerator::print_statistics_on(outputStream* st) {
 }
 
 #ifdef ASSERT
-void StubCodeGenerator::verify_stub(StubId stub_id) {
-  assert(StubRoutines::stub_to_blob(stub_id) == blob_id(), "wrong blob %s for generation of stub %s", StubRoutines::get_blob_name(blob_id()), StubRoutines::get_stub_name(stub_id));
+void StubCodeGenerator::verify_stub(const char* name, StubId stub_id) {
+  if (_stub_data != nullptr) {
+    // we are collecting stub data for the current blob so the stub
+    // code should have been marked using a stub id
+    assert(stub_id != StubId::NO_STUBID, "StubCodeMark for stub %s must be declared with stub id as argument", name);
+  }
+  if (stub_id != StubId::NO_STUBID) {
+    // we may not always be collecting stub data but any stub id that
+    // is provided needs to belong to the current blob id and its name
+    // ought to have been retrieved via a call to StubInfo::name
+    assert(StubRoutines::stub_to_blob(stub_id) == blob_id(), "wrong blob %s for generation of stub %s", StubRoutines::get_blob_name(blob_id()), StubRoutines::get_stub_name(stub_id));
+    assert(name == StubInfo::name(stub_id), "name %s does not match declared stub name %s", name, StubInfo::name(stub_id));
+  }
 }
 #endif
 
@@ -268,15 +279,15 @@ StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, const char* group, const cha
   _cgen->stub_prolog(_cdesc);
   // define the stub's beginning (= entry point) to be after the prolog:
   _cdesc->set_begin(_cgen->assembler()->pc());
+#ifdef ASSERT
+  cgen->verify_stub(name, stub_id);
+#endif
 }
 
 StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, const char* group, const char* name) : StubCodeMark(cgen, group, name, StubId::NO_STUBID) {
 }
 
 StubCodeMark::StubCodeMark(StubCodeGenerator* cgen, StubId stub_id) : StubCodeMark(cgen, "StubRoutines", StubRoutines::get_stub_name(stub_id), stub_id) {
-#ifdef ASSERT
-  cgen->verify_stub(stub_id);
-#endif
 }
 
 StubCodeMark::~StubCodeMark() {

--- a/src/hotspot/share/runtime/stubCodeGenerator.hpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.hpp
@@ -188,7 +188,7 @@ public:
   address load_archive_data(StubId stub_id, GrowableArray<address> *entries = nullptr, GrowableArray<address>* extras = nullptr);
   void store_archive_data(StubId stub_id, address start, address end, GrowableArray<address> *entries = nullptr, GrowableArray<address>* extras = nullptr);
 #ifdef ASSERT
-  void verify_stub(StubId stub_id);
+  void verify_stub(const char* name, StubId stub_id);
 #endif
 
 };


### PR DESCRIPTION
The verify code now detects the case where a StubCodeMark for a managed StubGen stub has been constructed using the wrong constructor and asserts with an error pointing to the misuse. In the case where the usage is correct it ensures that the stub belongs to the current blob and that the stub name is derived from the stub declaration. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384089](https://bugs.openjdk.org/browse/JDK-8384089): Correctly catch invalid uses of StubCodeMark (**Enhancement** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31071/head:pull/31071` \
`$ git checkout pull/31071`

Update a local copy of the PR: \
`$ git checkout pull/31071` \
`$ git pull https://git.openjdk.org/jdk.git pull/31071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31071`

View PR using the GUI difftool: \
`$ git pr show -t 31071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31071.diff">https://git.openjdk.org/jdk/pull/31071.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31071#issuecomment-4396944047)
</details>
