### PR TITLE
8383769: compiler/c2/TestDependsOnTestSqrtHFAssertion.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestDependsOnTestSqrtHFAssertion.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDependsOnTestSqrtHFAssertion.java
@@ -27,8 +27,8 @@
  * @summary assertion failure due to missing depends_only_on_test_impl definition in SqrtHFNode
  * @library /test/lib /
  * @modules jdk.incubator.vector
- * @requires vm.debug & vm.compiler2.enabled & vm.cpu.features ~= ".*avx512fp16.*"
- * @run main/othervm --add-modules=jdk.incubator.vector compiler.c2.TestDependsOnTestSqrtHFAssertion
+ * @requires vm.debug & vm.compiler2.enabled
+ * @run main/othervm --add-modules=jdk.incubator.vector -Xbatch compiler.c2.TestDependsOnTestSqrtHFAssertion
  */
 
 package compiler.c2;
@@ -54,15 +54,15 @@ public class TestDependsOnTestSqrtHFAssertion {
                         }
                     }
                 }
-           }
+            }
         }
         return res;
     }
 
     public static void main(String [] args) {
         int res = 0;
-        for (int i = 0 ; i < 100000; i++) {
-            res += micro(x1, x2, y, i);
+        for (int i = 0 ; i < 10000; i++) {
+            res += micro(x1, x2, y, i % 100);
         }
         IO.println("PASS" + res);
     }

--- a/test/hotspot/jtreg/compiler/c2/TestDependsOnTestSqrtHFAssertion.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDependsOnTestSqrtHFAssertion.java
@@ -27,7 +27,7 @@
  * @summary assertion failure due to missing depends_only_on_test_impl definition in SqrtHFNode
  * @library /test/lib /
  * @modules jdk.incubator.vector
- * @requires vm.debug & vm.compiler2.enabled
+ * @requires vm.debug & vm.compiler2.enabled & vm.cpu.features ~= ".*avx512fp16.*"
  * @run main/othervm --add-modules=jdk.incubator.vector compiler.c2.TestDependsOnTestSqrtHFAssertion
  */
 


### PR DESCRIPTION
This PR limits the execution of a occasionally timing out test to the platform context in which it only makes sense to run it.

The regression test for [JDK-8378897](https://bugs.openjdk.org/browse/JDK-8378897) has been found occasionally to be timing out (most recently in the Valhalla CI). This test only makes sense in the context of AVX512-FP16-enabled x86 CPUs, and should therefore only be executed when such features are available.

**Testing:** test is now skipped if the CPU does not support AVX512-FP16

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383769](https://bugs.openjdk.org/browse/JDK-8383769): compiler/c2/TestDependsOnTestSqrtHFAssertion.java timed out (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**) Review applies to [c2e3bb4b](https://git.openjdk.org/jdk/pull/31072/files/c2e3bb4b82967a4d57ac60a380c5ade7154f3009)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31072/head:pull/31072` \
`$ git checkout pull/31072`

Update a local copy of the PR: \
`$ git checkout pull/31072` \
`$ git pull https://git.openjdk.org/jdk.git pull/31072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31072`

View PR using the GUI difftool: \
`$ git pr show -t 31072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31072.diff">https://git.openjdk.org/jdk/pull/31072.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31072#issuecomment-4397410964)
</details>
