### PR TITLE
8384097: G1: G1ConcurrentMarkThread::total_mark_cpu_time_s adds together nanoseconds and seconds

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
@@ -32,7 +32,7 @@
 
   // Total virtual time so far.
 inline double G1ConcurrentMarkThread::total_mark_cpu_time_s() {
-  return static_cast<double>(os::thread_cpu_time(this)) + worker_threads_cpu_time_s();
+  return static_cast<double>(os::thread_cpu_time(this)) / NANOSECS_PER_SEC + worker_threads_cpu_time_s();
 }
 
 // Marking virtual time so far


### PR DESCRIPTION
Hi all,

  please review this fix for a time unit mismatch when calculating "marking" time.

This only affects some log message.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384097](https://bugs.openjdk.org/browse/JDK-8384097): G1: G1ConcurrentMarkThread::total_mark_cpu_time_s adds together nanoseconds and seconds (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31074/head:pull/31074` \
`$ git checkout pull/31074`

Update a local copy of the PR: \
`$ git checkout pull/31074` \
`$ git pull https://git.openjdk.org/jdk.git pull/31074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31074`

View PR using the GUI difftool: \
`$ git pr show -t 31074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31074.diff">https://git.openjdk.org/jdk/pull/31074.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31074#issuecomment-4397963283)
</details>
