### PR TITLE
8384099: C2: assert(_base == Long) failed on 32-bit systems

### DIFF
--- a/src/hotspot/share/opto/mempointer.cpp
+++ b/src/hotspot/share/opto/mempointer.cpp
@@ -273,14 +273,6 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
       case Op_CastLL:
       case Op_ConvI2L:
 #endif
-        // On 32bit systems we can also look through ConvL2I, since the final result will always
-        // be truncated back with ConvL2I. On 64bit systems we cannot decompose ConvL2I because
-        // such int values will eventually be expanded to long with a ConvI2L:
-        //
-        //   valL = max_jint + 1
-        //   ConvI2L(ConvL2I(valL)) = ConvI2L(min_jint) = min_jint != max_jint + 1 = valL
-        //
-        NOT_LP64( case Op_ConvL2I: )
         {
           // Decompose: look through.
           Node* a = n->in(1);

--- a/src/hotspot/share/opto/mempointer.cpp
+++ b/src/hotspot/share/opto/mempointer.cpp
@@ -103,6 +103,10 @@ void MemPointerParser::canonicalize_raw_summands() {
            _raw_summands.at(pos_get).int_group() == int_group &&
            _raw_summands.at(pos_get).variable() == variable) {
       MemPointerRawSummand s = _raw_summands.at(pos_get++);
+#ifndef _LP64
+      assert(scaleL.value() == 1 && s.scaleL().value() == 1, "scaleL must be 1");
+      scaleI = scaleI + s.scaleI();
+#else
       if (int_group == 0) {
         assert(scaleI.is_one() && s.scaleI().is_one(), "no ConvI2L");
         scaleL = scaleL + s.scaleL();
@@ -110,6 +114,7 @@ void MemPointerParser::canonicalize_raw_summands() {
         assert(scaleL.value() == s.scaleL().value(), "same ConvI2L, same scaleL");
         scaleI = scaleI + s.scaleI();
       }
+#endif
     }
     // Keep summands with non-zero scale.
     if (!scaleI.is_zero() && !scaleL.is_zero()) {
@@ -170,6 +175,7 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
 
   int opc = n->Opcode();
   if (is_safe_to_decompose_op(opc, scaleI * scaleL)) {
+    const bool is_long = (int_group == 0) && (MemPointer::TYPE == T_LONG);
     switch (opc) {
       case Op_ConI:
       case Op_ConL:
@@ -177,8 +183,8 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
         // Terminal summand.
         NoOverflowInt con = (opc == Op_ConI) ? NoOverflowInt(n->get_int())
                                              : NoOverflowInt(n->get_long());
-        NoOverflowInt conI = (int_group == 0) ? scaleI : scaleI * con;
-        NoOverflowInt conL = (int_group == 0) ? scaleL * con : scaleL;
+        NoOverflowInt conI = (is_long) ? scaleI : scaleI * con;
+        NoOverflowInt conL = (is_long) ? scaleL * con : scaleL;
         _raw_summands.push(MemPointerRawSummand::make_con(conI, conL, int_group));
         return;
       }
@@ -205,8 +211,8 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
         // 2L * (x - y)      0          1         2         1         -2
         // ConvI2L(x - y)    1          1         1         -1        1
 
-        NoOverflowInt sub_scaleI = (int_group == 0) ? scaleI : scaleI * NoOverflowInt(-1);
-        NoOverflowInt sub_scaleL = (int_group == 0) ? scaleL * NoOverflowInt(-1) : scaleL;
+        NoOverflowInt sub_scaleI = (is_long) ? scaleI : scaleI * NoOverflowInt(-1);
+        NoOverflowInt sub_scaleL = (is_long) ? scaleL * NoOverflowInt(-1) : scaleL;
 
         _worklist.push(MemPointerRawSummand(a,     scaleI,     scaleL, int_group));
         _worklist.push(MemPointerRawSummand(b, sub_scaleI, sub_scaleL, int_group));
@@ -245,8 +251,8 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
         // 2L * (4L * x)           0          1         8
         // 2L * ConvI2L(4 * x)     1          4         2
 
-        NoOverflowInt mul_scaleI = (int_group == 0) ? scaleI : scaleI * factor;
-        NoOverflowInt mul_scaleL = (int_group == 0) ? scaleL * factor : scaleL;
+        NoOverflowInt mul_scaleI = (is_long) ? scaleI : scaleI * factor;
+        NoOverflowInt mul_scaleL = (is_long) ? scaleL * factor : scaleL;
 
         _worklist.push(MemPointerRawSummand(variable, mul_scaleI, mul_scaleL, int_group));
         callback.callback(n);
@@ -263,8 +269,10 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
         // Fall-through: we can find a more precise native-memory "base". We further decompose
         // the CastX2P to find this "base" and any other offsets from it.
       case Op_CastII:
+#ifdef _LP64
       case Op_CastLL:
       case Op_ConvI2L:
+#endif
         // On 32bit systems we can also look through ConvL2I, since the final result will always
         // be truncated back with ConvL2I. On 64bit systems we cannot decompose ConvL2I because
         // such int values will eventually be expanded to long with a ConvI2L:
@@ -276,7 +284,6 @@ void MemPointerParser::parse_sub_expression(const MemPointerRawSummand& summand,
         {
           // Decompose: look through.
           Node* a = n->in(1);
-
           int cast_int_group = int_group;
 #ifdef _LP64
           if (opc == Op_ConvI2L) {

--- a/src/hotspot/share/opto/mempointer.hpp
+++ b/src/hotspot/share/opto/mempointer.hpp
@@ -862,6 +862,12 @@ public:
   static const int RAW_SUMMANDS_SIZE = 16;
   static const int SUMMANDS_SIZE = 10;
 
+#ifndef _LP64
+  static const BasicType TYPE = T_INT;
+#else
+  static const BasicType TYPE = T_LONG;
+#endif
+
   // A base can be:
   // - Known:
   //   - On-heap: Object

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1345,12 +1345,16 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
         variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);
       }
-      NOT_LP64( // On 32-bit CastP2X produces TypeInt
-        if (variable->bottom_type()->isa_int()) {
-          variable = new ConvI2LNode(variable);
-          phase->register_new_node(variable, ctrl);
-        }
-      )
+#ifndef _LP64 // On 32-bit CastP2X produces TypeInt
+      if (variable->bottom_type()->isa_int()) {
+        // adding zero-extended I2L conversion
+        variable = new ConvI2LNode(variable);
+        phase->register_new_node(variable, ctrl);
+        // avoid sign extension
+        variable = new AndLNode(variable, igvn.longcon(0xFFFFFFFFL));
+        phase->register_new_node(variable, ctrl);
+      }
+#endif
       node = new MulLNode(scaleL, variable);
       phase->register_new_node(node, ctrl);
     }

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1345,6 +1345,12 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
         variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);
       }
+      NOT_LP64( // On 32-bit CastP2X produces TypeInt
+        if (variable->bottom_type()->isa_int()) {
+          variable = new ConvI2LNode(variable);
+          phase->register_new_node(variable, ctrl);
+        }
+      )
       node = new MulLNode(scaleL, variable);
       phase->register_new_node(node, ctrl);
     }

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1345,16 +1345,6 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
         variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);
       }
-#ifndef _LP64 // On 32-bit CastP2X produces TypeInt
-      if (variable->bottom_type()->isa_int()) {
-        // adding zero-extended I2L conversion
-        variable = new ConvI2LNode(variable);
-        phase->register_new_node(variable, ctrl);
-        // avoid sign extension
-        variable = new AndLNode(variable, igvn.longcon(0xFFFFFFFFL));
-        phase->register_new_node(variable, ctrl);
-      }
-#endif
       node = new MulLNode(scaleL, variable);
       phase->register_new_node(node, ctrl);
     }

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1328,16 +1328,21 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
   };
 
   Node* expression = nullptr;
+  BasicType bt = MemPointer::TYPE;
+
   mem_pointer().for_each_raw_summand_of_int_group(0, [&] (const MemPointerRawSummand& s) {
     Node* node = nullptr;
+#ifndef _LP64
+    assert (s.scaleL().is_one(), "must be int");
+#else
+    assert (s.scaleI().is_one(), "must be long");
+#endif
     if (s.is_con()) {
-      // Long constant.
+      // Constant.
       NoOverflowInt con = s.scaleI() * s.scaleL();
-      node = igvn.longcon(con.value());
+      node = igvn.integercon(con.value(), bt);
     } else {
-      // Long variable.
-      assert(s.scaleI().is_one(), "must be long variable");
-      Node* scaleL = igvn.longcon(s.scaleL().value());
+      Node* scale = igvn.integercon(s.scaleL().value() * s.scaleI().value(), bt);
       Node* variable = (s.variable() == iv) ? iv_value : s.variable();
       if (variable->bottom_type()->isa_ptr() != nullptr) {
         // Use a ctrl that is late enough, so that we do not
@@ -1345,10 +1350,10 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
         variable = new CastP2XNode(ctrl, variable);
         phase->register_new_node(variable, ctrl);
       }
-      node = new MulLNode(scaleL, variable);
+      node = MulNode::make(scale, variable, bt);
       phase->register_new_node(node, ctrl);
     }
-    expression = maybe_add(expression, node, T_LONG);
+    expression = maybe_add(expression, node, bt);
   });
 
   int max_int_group = mem_pointer().max_int_group();
@@ -1377,6 +1382,10 @@ Node* VPointer::make_pointer_expression(Node* iv_value, Node* ctrl) const {
     expression = maybe_add(expression, int_expression, T_LONG);
   }
 
+#ifndef _LP64
+  expression = new ConvI2LNode(expression);
+  phase->register_new_node(expression, ctrl);
+#endif
   return expression;
 }
 


### PR DESCRIPTION
On 32-bit systems, CastP2X returns TypeInt instead of TypeLong, triggering assert(_base == Long) in MulLNode. Added ConvI2LNode (guarded by NOT_LP64) to fix the type mismatch:
`MulLNode(CastP2XNode)` -> `MulLNode(ConvI2LNode(CastP2XNode))`


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384099](https://bugs.openjdk.org/browse/JDK-8384099): C2: assert(_base == Long) failed on 32-bit systems (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31076/head:pull/31076` \
`$ git checkout pull/31076`

Update a local copy of the PR: \
`$ git checkout pull/31076` \
`$ git pull https://git.openjdk.org/jdk.git pull/31076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31076`

View PR using the GUI difftool: \
`$ git pr show -t 31076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31076.diff">https://git.openjdk.org/jdk/pull/31076.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31076#issuecomment-4398282136)
</details>
