### PR TITLE
8384100: UNSIGNED5::Reader::try_skip() is missing a terminating condition

### DIFF
--- a/src/hotspot/share/utilities/unsigned5.hpp
+++ b/src/hotspot/share/utilities/unsigned5.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/unsigned5.hpp
+++ b/src/hotspot/share/utilities/unsigned5.hpp
@@ -280,6 +280,7 @@ class UNSIGNED5 : AllStatic {
         int len = next_length();  // 0 or length in [1..5]
         if (len == 0)  break;
         _position += len;
+        ++actual;
       }
       return actual;
     }

--- a/test/hotspot/gtest/utilities/test_unsigned5.cpp
+++ b/test/hotspot/gtest/utilities/test_unsigned5.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,10 +178,25 @@ inline void init_ints(int len, int* ints) {
   }
 }
 
+// Knuth multiplicative hashing
+static uint32_t hash_function(int value) {
+  const uint32_t k = static_cast<uint32_t>(value);
+  return k * UINT32_C(2654435761);
+}
+
 struct MyReaderHelper {
   uint8_t operator()(char* a, int i) const { return a[i]; }
 };
 using MyReader = UNSIGNED5::Reader<char*, int, MyReaderHelper>;
+
+static void test_try_skip(int* array, int idx, MyReader& r) {
+  const int skipped = r.try_skip(idx);
+  ASSERT_EQ(idx, skipped);
+  const int x = r.next_uint();
+  const int y = array[idx];
+  ASSERT_EQ(x, y) << idx;
+  r.set_position(0);
+}
 
 TEST_VM(unsigned5, reader) {
   const int LEN = 100;
@@ -221,6 +236,25 @@ TEST_VM(unsigned5, reader) {
     ASSERT_EQ(x, y) << i;
   }
   ASSERT_TRUE(i < LEN);
+
+  { // Begin try_skip() test.
+    r1.set_position(0);
+    i = 0;
+    for (; i < LEN; i++) {
+      // Serial access.
+      test_try_skip(ints, i, r1);
+      // Random access.
+      const int idx = hash_function(i) % LEN;
+      test_try_skip(ints, idx, r1);
+    }
+    // Underflow.
+    int skipped = r1.try_skip(-1);
+    ASSERT_EQ(skipped, 0);
+    // Overflow.
+    skipped = r1.try_skip(LEN + 1);
+    ASSERT_EQ(skipped, LEN);
+  } // End try_skip() test.
+
   // copy from reader to writer
   UNSIGNED5::Reader<char*,int> r3(buf);
   int array_limit = 1;

--- a/test/hotspot/gtest/utilities/test_unsigned5.cpp
+++ b/test/hotspot/gtest/utilities/test_unsigned5.cpp
@@ -178,25 +178,10 @@ inline void init_ints(int len, int* ints) {
   }
 }
 
-// Knuth multiplicative hashing
-static uint32_t hash_function(int value) {
-  const uint32_t k = static_cast<uint32_t>(value);
-  return k * UINT32_C(2654435761);
-}
-
 struct MyReaderHelper {
   uint8_t operator()(char* a, int i) const { return a[i]; }
 };
 using MyReader = UNSIGNED5::Reader<char*, int, MyReaderHelper>;
-
-static void test_try_skip(int* array, int idx, MyReader& r) {
-  const int skipped = r.try_skip(idx);
-  ASSERT_EQ(idx, skipped);
-  const int x = r.next_uint();
-  const int y = array[idx];
-  ASSERT_EQ(x, y) << idx;
-  r.set_position(0);
-}
 
 TEST_VM(unsigned5, reader) {
   const int LEN = 100;
@@ -238,17 +223,38 @@ TEST_VM(unsigned5, reader) {
   ASSERT_TRUE(i < LEN);
 
   { // Begin try_skip() test.
-    r1.set_position(0);
     i = 0;
+    int skipped = 0;
+    r1.set_position(0);
+    // Skip from beginning to ith position.
     for (; i < LEN; i++) {
-      // Serial access.
-      test_try_skip(ints, i, r1);
-      // Random access.
-      const int idx = hash_function(i) % LEN;
-      test_try_skip(ints, idx, r1);
+      skipped = r1.try_skip(i);
+      ASSERT_EQ(i, skipped);
+      const int x = r1.next_uint();
+      const int y = ints[i];
+      ASSERT_EQ(x, y) << i;
+      r1.set_position(0);
+    }
+    // Perform incremental skips.
+    int skipped_total = 0;
+    while (true) {
+      const int skip = skipped_total % 9;
+      skipped = r1.try_skip(skip);
+      skipped_total += skipped;
+      if (skipped_total > LEN - 1) {
+        r1.set_position(0);
+        break;
+      }
+      ASSERT_EQ(skip, skipped);
+      const int x = r1.next_uint();
+      const int y = ints[skipped_total];
+      ASSERT_EQ(x, y) << skipped_total;
+      // Update skipped_total because reader
+      // moved one position when reading x.
+      ++skipped_total;
     }
     // Underflow.
-    int skipped = r1.try_skip(-1);
+    skipped = r1.try_skip(-1);
     ASSERT_EQ(0, skipped) << skipped;
     // Overflow.
     skipped = r1.try_skip(LEN + 1);

--- a/test/hotspot/gtest/utilities/test_unsigned5.cpp
+++ b/test/hotspot/gtest/utilities/test_unsigned5.cpp
@@ -249,10 +249,10 @@ TEST_VM(unsigned5, reader) {
     }
     // Underflow.
     int skipped = r1.try_skip(-1);
-    ASSERT_EQ(skipped, 0);
+    ASSERT_EQ(0, skipped) << skipped;
     // Overflow.
     skipped = r1.try_skip(LEN + 1);
-    ASSERT_EQ(skipped, LEN);
+    ASSERT_EQ(LEN, skipped) << skipped;
   } // End try_skip() test.
 
   // copy from reader to writer


### PR DESCRIPTION
Greetings,

Tiny fix for try_skip().

Found when fixing [JDK-8382332](https://bugs.openjdk.org/browse/JDK-8382332)

Thanks
Markus

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384100](https://bugs.openjdk.org/browse/JDK-8384100): UNSIGNED5::Reader::try_skip() is missing a terminating condition (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31077/head:pull/31077` \
`$ git checkout pull/31077`

Update a local copy of the PR: \
`$ git checkout pull/31077` \
`$ git pull https://git.openjdk.org/jdk.git pull/31077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31077`

View PR using the GUI difftool: \
`$ git pr show -t 31077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31077.diff">https://git.openjdk.org/jdk/pull/31077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31077#issuecomment-4398453631)
</details>
