### PR TITLE
8382888: [asan] ASAN crashes with high heap base addresses during startup

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestFromCardCacheIndex.java
+++ b/test/hotspot/jtreg/gc/g1/TestFromCardCacheIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * @summary Ensure that G1 does not miss a remembered set entry due to from card cache default value indices.
  * @requires vm.gc.G1
  * @requires vm.debug
+ * @comment VM heap and shadow memory of ASan overlap
+ * @requires !vm.asan
  * @requires vm.bits != "32"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java
@@ -29,6 +29,8 @@
  *          java.management
  * @requires vm.bits == 64
  * @requires vm.flagless
+ * @comment With larger ObjectAlignmentInBytes, the VM heap and shadow memory of ASan overlap
+ * @requires !vm.asan
  * @run driver CompressedKlassPointerAndOops
  */
 

--- a/test/hotspot/jtreg/runtime/CompressedOops/ObjectAlignment.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/ObjectAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 8022865
  * @summary Tests for the -XX:ObjectAlignmentInBytes command line option
  * @requires vm.flagless
+ * @comment With larger ObjectAlignmentInBytes, the VM heap and shadow memory of ASan overlap
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
The tests here in this PR use higher values of object alignments that causes the heap area selected at memory addresses that overlaps with ASan shadow/internal memories. 
The tests are excluded from the ASan builds.
Local tests all passed.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382888](https://bugs.openjdk.org/browse/JDK-8382888): [asan] ASAN crashes with high heap base addresses during startup (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Author)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31080/head:pull/31080` \
`$ git checkout pull/31080`

Update a local copy of the PR: \
`$ git checkout pull/31080` \
`$ git pull https://git.openjdk.org/jdk.git pull/31080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31080`

View PR using the GUI difftool: \
`$ git pr show -t 31080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31080.diff">https://git.openjdk.org/jdk/pull/31080.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31080#issuecomment-4400302171)
</details>
