### PR TITLE
8383623: (fs) Update Windows file system provider to use GetFileInformationByName where possible

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -96,6 +96,7 @@ class WindowsConstants {
     public static final int ERROR_NOT_SAME_DEVICE       = 17;
     public static final int ERROR_NOT_READY             = 21;
     public static final int ERROR_SHARING_VIOLATION     = 32;
+    public static final int ERROR_NOT_SUPPORTED         = 50;
     public static final int ERROR_NETWORK_ACCESS_DENIED = 65;
     public static final int ERROR_FILE_EXISTS           = 80;
     public static final int ERROR_INVALID_PARAMETER     = 87;
@@ -114,6 +115,12 @@ class WindowsConstants {
     public static final int ERROR_CANT_RESOLVE_FILENAME = 1921;
     public static final int ERROR_NOT_A_REPARSE_POINT   = 4390;
     public static final int ERROR_INVALID_REPARSE_DATA  = 4392;
+
+    // FILE_INFO_BY_NAME_CLASS enum values for GetFileInformationByName()
+    public static final int FileStatByNameInfo          = 0;
+    public static final int FileStatLxByNameInfo        = 1;
+    public static final int FileCaseSensitiveByNameInfo = 2;
+    public static final int FileStatBasicByNameInfo     = 3;
 
     // notify filters
     public static final int FILE_NOTIFY_CHANGE_FILE_NAME   = 0x00000001;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -96,7 +96,6 @@ class WindowsConstants {
     public static final int ERROR_NOT_SAME_DEVICE       = 17;
     public static final int ERROR_NOT_READY             = 21;
     public static final int ERROR_SHARING_VIOLATION     = 32;
-    public static final int ERROR_NOT_SUPPORTED         = 50;
     public static final int ERROR_NETWORK_ACCESS_DENIED = 65;
     public static final int ERROR_FILE_EXISTS           = 80;
     public static final int ERROR_INVALID_PARAMETER     = 87;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -107,6 +107,35 @@ class WindowsFileAttributes
     private static final short OFFSETOF_FIND_DATA_SIZELOW = 32;
     private static final short OFFSETOF_FIND_DATA_RESERVED0 = 36;
 
+    /*
+     * typedef struct _FILE_STAT_BASIC_INFORMATION {
+     *     LARGE_INTEGER FileId;                // offset = 0
+     *     LARGE_INTEGER CreationTime;          // offset = 8
+     *     LARGE_INTEGER LastAccessTime;        // offset = 16
+     *     LARGE_INTEGER LastWriteTime;         // offset = 24
+     *     LARGE_INTEGER ChangeTime;            // offset = 32
+     *     LARGE_INTEGER AllocationSize;        // offset = 40
+     *     LARGE_INTEGER EndOfFile;             // offset = 48
+     *     ULONG         FileAttributes;        // offset = 56
+     *     ULONG         ReparseTag;            // offset = 60
+     *     ULONG         NumberOfLinks;         // offset = 64
+     *     ULONG         DeviceType;            // offset = 68
+     *     ULONG         DeviceCharacteristics; // offset = 72
+     *     ULONG         Reserved;              // offset = 76
+     *     LARGE_INTEGER VolumeSerialNumber;    // offset = 80
+     *     FILE_ID_128   FileId128;             // offset = 88
+     * } FILE_STAT_BASIC_INFORMATION;
+     */
+    static final short SIZEOF_STAT_BASIC_INFO = 104;
+    private static final short OFFSETOF_STAT_BASIC_INFO_CREATETIME      = 8;
+    private static final short OFFSETOF_STAT_BASIC_INFO_LASTACCESSTIME  = 16;
+    private static final short OFFSETOF_STAT_BASIC_INFO_LASTWRITETIME   = 24;
+    private static final short OFFSETOF_STAT_BASIC_INFO_ENDOFFILE       = 48;
+    private static final short OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES      = 56;
+    private static final short OFFSETOF_STAT_BASIC_INFO_REPARSETAG      = 60;
+    private static final short OFFSETOF_STAT_BASIC_INFO_VOLSERIAL       = 80;
+    private static final short OFFSETOF_STAT_BASIC_INFO_FILEID128       = 88;
+
     // used to adjust values between Windows and java epochs
     private static final long WINDOWS_EPOCH_IN_MICROS = -11644473600000000L;
     private static final long WINDOWS_EPOCH_IN_100NS  = -116444736000000000L;
@@ -227,6 +256,32 @@ class WindowsFileAttributes
 
 
     /**
+     * Create a WindowsFileAttributes from a FILE_STAT_BASIC_INFORMATION structure
+     */
+    static WindowsFileAttributes fromStatBasicInfo(long address) {
+        int fileAttrs = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
+        long creationTime = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_CREATETIME);
+        long lastAccessTime = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_LASTACCESSTIME);
+        long lastWriteTime = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_LASTWRITETIME);
+        long size = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_ENDOFFILE);
+        int reparseTag = isReparsePoint(fileAttrs) ?
+            unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_REPARSETAG) : 0;
+        int volSerialNumber = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_VOLSERIAL);
+        int fileIndexLow = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID128);
+        int fileIndexHigh = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID128 + 4);
+
+        return new WindowsFileAttributes(fileAttrs,
+                                         creationTime,
+                                         lastAccessTime,
+                                         lastWriteTime,
+                                         size,
+                                         reparseTag,
+                                         volSerialNumber,
+                                         fileIndexHigh,
+                                         fileIndexLow);
+    }
+
+    /**
      * Allocates a native buffer for a WIN32_FIND_DATA structure
      */
     static NativeBuffer getBufferForFindData() {
@@ -329,6 +384,26 @@ class WindowsFileAttributes
                 } catch (WindowsException ignore) {
                     throw firstException;
                 }
+            }
+        }
+
+        try (NativeBuffer buffer =
+            NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
+            long addr = buffer.address();
+            GetFileInformationByName(path.getPathForWin32Calls(),
+                                        FileStatBasicByNameInfo, addr,
+                                        SIZEOF_STAT_BASIC_INFO);
+
+            // GetFileInformationByName() doesn't follow reparse points so if
+            // we discover that this is a reparse point and if we're being asked
+            // to follow links, then drop to the slow path.
+            int fileAttrs = unsafe.getInt(addr + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
+            if (!isReparsePoint(fileAttrs) || !followLinks) {
+                return fromStatBasicInfo(addr);
+            }
+        } catch (WindowsException exc) {
+            if (exc.lastError() != ERROR_NOT_SUPPORTED) {
+                throw exc;
             }
         }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -127,6 +127,7 @@ class WindowsFileAttributes
      * } FILE_STAT_BASIC_INFORMATION;
      */
     static final short SIZEOF_STAT_BASIC_INFO = 104;
+    private static final short OFFSETOF_STAT_BASIC_INFO_FILEID          = 0;
     private static final short OFFSETOF_STAT_BASIC_INFO_CREATETIME      = 8;
     private static final short OFFSETOF_STAT_BASIC_INFO_LASTACCESSTIME  = 16;
     private static final short OFFSETOF_STAT_BASIC_INFO_LASTWRITETIME   = 24;
@@ -134,7 +135,6 @@ class WindowsFileAttributes
     private static final short OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES      = 56;
     private static final short OFFSETOF_STAT_BASIC_INFO_REPARSETAG      = 60;
     private static final short OFFSETOF_STAT_BASIC_INFO_VOLSERIAL       = 80;
-    private static final short OFFSETOF_STAT_BASIC_INFO_FILEID128       = 88;
 
     // used to adjust values between Windows and java epochs
     private static final long WINDOWS_EPOCH_IN_MICROS = -11644473600000000L;
@@ -267,8 +267,8 @@ class WindowsFileAttributes
         int reparseTag = isReparsePoint(fileAttrs) ?
             unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_REPARSETAG) : 0;
         int volSerialNumber = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_VOLSERIAL);
-        int fileIndexLow = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID128);
-        int fileIndexHigh = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID128 + 4);
+        int fileIndexLow = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID);
+        int fileIndexHigh = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID + 4);
 
         return new WindowsFileAttributes(fileAttrs,
                                          creationTime,
@@ -387,23 +387,21 @@ class WindowsFileAttributes
             }
         }
 
-        try (NativeBuffer buffer =
-            NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
-            long addr = buffer.address();
-            GetFileInformationByName(path.getPathForWin32Calls(),
-                                        FileStatBasicByNameInfo, addr,
-                                        SIZEOF_STAT_BASIC_INFO);
+        if (supportsGetFileInformationByName()) {
+            try (NativeBuffer buffer =
+                NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
+                long addr = buffer.address();
+                GetFileInformationByName(path.getPathForWin32Calls(),
+                                            FileStatBasicByNameInfo, addr,
+                                            SIZEOF_STAT_BASIC_INFO);
 
-            // GetFileInformationByName() doesn't follow reparse points so if
-            // we discover that this is a reparse point and if we're being asked
-            // to follow links, then drop to the slow path.
-            int fileAttrs = unsafe.getInt(addr + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
-            if (!isReparsePoint(fileAttrs) || !followLinks) {
-                return fromStatBasicInfo(addr);
-            }
-        } catch (WindowsException exc) {
-            if (exc.lastError() != ERROR_NOT_SUPPORTED) {
-                throw exc;
+                // GetFileInformationByName() doesn't follow reparse points so if
+                // we discover that this is a reparse point and if we're being asked
+                // to follow links, then drop to the slow path.
+                int fileAttrs = unsafe.getInt(addr + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
+                if (!isReparsePoint(fileAttrs) || !followLinks) {
+                    return fromStatBasicInfo(addr);
+                }
             }
         }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -126,7 +126,7 @@ class WindowsFileAttributes
      *     FILE_ID_128   FileId128;             // offset = 88
      * } FILE_STAT_BASIC_INFORMATION;
      */
-    static final short SIZEOF_STAT_BASIC_INFO = 104;
+    private static final short SIZEOF_STAT_BASIC_INFO = 104;
     private static final short OFFSETOF_STAT_BASIC_INFO_FILEID          = 0;
     private static final short OFFSETOF_STAT_BASIC_INFO_CREATETIME      = 8;
     private static final short OFFSETOF_STAT_BASIC_INFO_LASTACCESSTIME  = 16;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -388,8 +388,7 @@ class WindowsFileAttributes
         }
 
         if (supportsGetFileInformationByName()) {
-            try (NativeBuffer buffer =
-                NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
+            try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
                 long addr = buffer.address();
                 GetFileInformationByName(path.getPathForWin32Calls(),
                                             FileStatBasicByNameInfo, addr,

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -368,6 +368,24 @@ class WindowsNativeDispatcher {
         throws WindowsException;
 
     /**
+     * GetFileInformationByName(
+     *   PCWSTR                  FileName,
+     *   FILE_INFO_BY_NAME_CLASS FileInformationClass,
+     *   PVOID                   FileInfoBuffer,
+     *   ULONG                   FileInfoBufferSize
+     * )
+     */
+    static void GetFileInformationByName(String path, int infoClass, long address, int size)
+        throws WindowsException
+    {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
+            GetFileInformationByName0(buffer.address(), infoClass, address, size);
+        }
+    }
+    private static native void GetFileInformationByName0(long pathAddress,
+        int infoClass, long infoAddress, int infoSize) throws WindowsException;
+
+    /**
      * SetFileTime(
      *   HANDLE hFile,
      *   CONST FILETIME *lpCreationTime,

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -386,6 +386,14 @@ class WindowsNativeDispatcher {
         int infoClass, long infoAddress, int infoSize) throws WindowsException;
 
     /**
+     * Indicates whether GetFileInformationByName is supported on this OS version.
+     */
+    static boolean supportsGetFileInformationByName() {
+        return supportsGetFileInformationByName0();
+    }
+    private static native boolean supportsGetFileInformationByName0();
+
+    /**
      * SetFileTime(
      *   HANDLE hFile,
      *   CONST FILETIME *lpCreationTime,

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -386,14 +386,6 @@ class WindowsNativeDispatcher {
         int infoClass, long infoAddress, int infoSize) throws WindowsException;
 
     /**
-     * Indicates whether GetFileInformationByName is supported on this OS version.
-     */
-    static boolean supportsGetFileInformationByName() {
-        return supportsGetFileInformationByName0();
-    }
-    private static native boolean supportsGetFileInformationByName0();
-
-    /**
      * SetFileTime(
      *   HANDLE hFile,
      *   CONST FILETIME *lpCreationTime,
@@ -1116,15 +1108,23 @@ class WindowsNativeDispatcher {
         return buffer;
     }
 
+    // -- capabilities --
+    private static final int SUPPORTS_GETFILEINFORMATIONBYNAME = 1 << 1;
+    private static final int capabilities;
+
+    static boolean supportsGetFileInformationByName() {
+        return (capabilities & SUPPORTS_GETFILEINFORMATIONBYNAME) != 0;
+    }
+
     // -- native library initialization --
 
-    private static native void initIDs();
+    private static native int init();
 
     static {
         // nio.dll has dependency on net.dll
         jdk.internal.loader.BootLoader.loadLibrary("net");
         jdk.internal.loader.BootLoader.loadLibrary("nio");
-        initIDs();
+        capabilities = init();
     }
 
 }

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -565,7 +565,7 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
     PVOID pInfo = jlong_to_ptr(infoAddress);
 
     if (pGetFileInformationByName == NULL) {
-        throwWindowsException(env, ERROR_NOT_SUPPORTED);
+        JNU_ThrowInternalError(env, "should not reach here");
         return;
     }
 

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -544,16 +544,20 @@ typedef enum _FILE_INFO_BY_NAME_CLASS {
 typedef BOOL (WINAPI *PGetFileInformationByName)(
     PCWSTR, FILE_INFO_BY_NAME_CLASS, PVOID, ULONG);
 
-static INIT_ONCE fileInfoByNameInitOnce = INIT_ONCE_STATIC_INIT;
 static PGetFileInformationByName pGetFileInformationByName = NULL;
 
-static BOOL CALLBACK initFileInfoByName(PINIT_ONCE initOnce, PVOID param, PVOID *context) {
-    HMODULE hMod = GetModuleHandleW(L"kernel32.dll");
-    if (hMod != NULL) {
-        pGetFileInformationByName =
-            (PGetFileInformationByName)GetProcAddress(hMod, "GetFileInformationByName");
+static void initGetFileInformationByName(void) {
+    // Use a static initializer so that we don't probe kernel32.dll every time
+    // this function is called.
+    static int initialized = 0;
+    if (!initialized) {
+        HMODULE hMod = GetModuleHandleW(L"kernel32.dll");
+        if (hMod != NULL) {
+            pGetFileInformationByName =
+                (PGetFileInformationByName)GetProcAddress(hMod, "GetFileInformationByName");
+        }
+        initialized = 1;
     }
-    return TRUE;
 }
 
 JNIEXPORT void JNICALL
@@ -563,7 +567,12 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
     LPCWSTR lpFileName = jlong_to_ptr(pathAddress);
     PVOID pInfo = jlong_to_ptr(infoAddress);
 
-    InitOnceExecuteOnce(&fileInfoByNameInitOnce, initFileInfoByName, NULL, NULL);
+    // In case the caller didn't invoke `supportsGetFileInformationByName()`
+    // prior to calling `GetFileInformationByName()`, we call the init function
+    // to set the pointer to the Win32 API function.  The init function is
+    // cheap because it uses a static initializer, so we pay the cost of probing
+    // kernel32.dll only once instead of once per function call.
+    initGetFileInformationByName();
 
     if (pGetFileInformationByName == NULL) {
         throwWindowsException(env, ERROR_NOT_SUPPORTED);
@@ -574,6 +583,14 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
                                    pInfo, (ULONG)infoSize)) {
         throwWindowsException(env, GetLastError());
     }
+}
+
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_supportsGetFileInformationByName0(JNIEnv* env,
+    jclass this)
+{
+    initGetFileInformationByName();
+    return pGetFileInformationByName != NULL;
 }
 
 JNIEXPORT void JNICALL

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -511,6 +511,71 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileAttributesEx0(JNIEnv* env, jclass
 }
 
 
+#if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
+
+typedef struct _FILE_STAT_BASIC_INFORMATION {
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    ULONG         FileAttributes;
+    ULONG         ReparseTag;
+    ULONG         NumberOfLinks;
+    ULONG         DeviceType;
+    ULONG         DeviceCharacteristics;
+    ULONG         Reserved;
+    LARGE_INTEGER VolumeSerialNumber;
+    FILE_ID_128   FileId128;
+} FILE_STAT_BASIC_INFORMATION;
+
+typedef enum _FILE_INFO_BY_NAME_CLASS {
+    FileStatByNameInfo,
+    FileStatLxByNameInfo,
+    FileCaseSensitiveByNameInfo,
+    FileStatBasicByNameInfo,
+    MaximumFileInfoByNameClass
+} FILE_INFO_BY_NAME_CLASS;
+
+#endif /* !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI) */
+
+typedef BOOL (WINAPI *PGetFileInformationByName)(
+    PCWSTR, FILE_INFO_BY_NAME_CLASS, PVOID, ULONG);
+
+static INIT_ONCE fileInfoByNameInitOnce = INIT_ONCE_STATIC_INIT;
+static PGetFileInformationByName pGetFileInformationByName = NULL;
+
+static BOOL CALLBACK initFileInfoByName(PINIT_ONCE initOnce, PVOID param, PVOID *context) {
+    HMODULE hMod = GetModuleHandleW(L"kernel32.dll");
+    if (hMod != NULL) {
+        pGetFileInformationByName =
+            (PGetFileInformationByName)GetProcAddress(hMod, "GetFileInformationByName");
+    }
+    return TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
+    jclass this, jlong pathAddress, jint infoClass, jlong infoAddress, jint infoSize)
+{
+    LPCWSTR lpFileName = jlong_to_ptr(pathAddress);
+    PVOID pInfo = jlong_to_ptr(infoAddress);
+
+    InitOnceExecuteOnce(&fileInfoByNameInitOnce, initFileInfoByName, NULL, NULL);
+
+    if (pGetFileInformationByName == NULL) {
+        throwWindowsException(env, ERROR_NOT_SUPPORTED);
+        return;
+    }
+
+    if (!pGetFileInformationByName(lpFileName, (FILE_INFO_BY_NAME_CLASS)infoClass,
+                                   pInfo, (ULONG)infoSize)) {
+        throwWindowsException(env, GetLastError());
+    }
+}
+
 JNIEXPORT void JNICALL
 Java_sun_nio_fs_WindowsNativeDispatcher_SetFileTime0(JNIEnv* env, jclass this,
     jlong handle, jlong createTime, jlong lastAccessTime, jlong lastWriteTime)

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -79,75 +79,122 @@ static void throwWindowsException(JNIEnv* env, DWORD lastError) {
     }
 }
 
+#if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
+
+typedef struct _FILE_STAT_BASIC_INFORMATION {
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    ULONG         FileAttributes;
+    ULONG         ReparseTag;
+    ULONG         NumberOfLinks;
+    ULONG         DeviceType;
+    ULONG         DeviceCharacteristics;
+    ULONG         Reserved;
+    LARGE_INTEGER VolumeSerialNumber;
+    FILE_ID_128   FileId128;
+} FILE_STAT_BASIC_INFORMATION;
+
+typedef enum _FILE_INFO_BY_NAME_CLASS {
+    FileStatByNameInfo,
+    FileStatLxByNameInfo,
+    FileCaseSensitiveByNameInfo,
+    FileStatBasicByNameInfo,
+    MaximumFileInfoByNameClass
+} FILE_INFO_BY_NAME_CLASS;
+
+#endif /* !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI) */
+
+typedef BOOL (WINAPI *PGetFileInformationByName)(
+    PCWSTR, FILE_INFO_BY_NAME_CLASS, PVOID, ULONG);
+
+static PGetFileInformationByName pGetFileInformationByName = NULL;
+
 /**
  * Initializes jfieldIDs and get address of Win32 calls that are located
  * at runtime.
  */
-JNIEXPORT void JNICALL
-Java_sun_nio_fs_WindowsNativeDispatcher_initIDs(JNIEnv* env, jclass this)
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_init(JNIEnv* env, jclass this)
 {
     jclass clazz;
+    jint capabilities = 0;
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$FirstFile");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     findFirst_handle = (*env)->GetFieldID(env, clazz, "handle", "J");
-    CHECK_NULL(findFirst_handle);
+    CHECK_NULL_RETURN(findFirst_handle, 0);
     findFirst_name = (*env)->GetFieldID(env, clazz, "name", "Ljava/lang/String;");
-    CHECK_NULL(findFirst_name);
+    CHECK_NULL_RETURN(findFirst_name, 0);
     findFirst_attributes = (*env)->GetFieldID(env, clazz, "attributes", "I");
-    CHECK_NULL(findFirst_attributes);
+    CHECK_NULL_RETURN(findFirst_attributes, 0);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$FirstStream");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     findStream_handle = (*env)->GetFieldID(env, clazz, "handle", "J");
-    CHECK_NULL(findStream_handle);
+    CHECK_NULL_RETURN(findStream_handle, 0);
     findStream_name = (*env)->GetFieldID(env, clazz, "name", "Ljava/lang/String;");
-    CHECK_NULL(findStream_name);
+    CHECK_NULL_RETURN(findStream_name, 0);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$VolumeInformation");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     volumeInfo_fsName = (*env)->GetFieldID(env, clazz, "fileSystemName", "Ljava/lang/String;");
-    CHECK_NULL(volumeInfo_fsName);
+    CHECK_NULL_RETURN(volumeInfo_fsName, 0);
     volumeInfo_volName = (*env)->GetFieldID(env, clazz, "volumeName", "Ljava/lang/String;");
-    CHECK_NULL(volumeInfo_volName);
+    CHECK_NULL_RETURN(volumeInfo_volName, 0);
     volumeInfo_volSN = (*env)->GetFieldID(env, clazz, "volumeSerialNumber", "I");
-    CHECK_NULL(volumeInfo_volSN);
+    CHECK_NULL_RETURN(volumeInfo_volSN, 0);
     volumeInfo_flags = (*env)->GetFieldID(env, clazz, "flags", "I");
-    CHECK_NULL(volumeInfo_flags);
+    CHECK_NULL_RETURN(volumeInfo_flags, 0);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$DiskFreeSpace");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     diskSpace_bytesAvailable = (*env)->GetFieldID(env, clazz, "freeBytesAvailable", "J");
-    CHECK_NULL(diskSpace_bytesAvailable);
+    CHECK_NULL_RETURN(diskSpace_bytesAvailable, 0);
     diskSpace_totalBytes = (*env)->GetFieldID(env, clazz, "totalNumberOfBytes", "J");
-    CHECK_NULL(diskSpace_totalBytes);
+    CHECK_NULL_RETURN(diskSpace_totalBytes, 0);
     diskSpace_totalFree = (*env)->GetFieldID(env, clazz, "totalNumberOfFreeBytes", "J");
-    CHECK_NULL(diskSpace_totalFree);
+    CHECK_NULL_RETURN(diskSpace_totalFree, 0);
     diskSpace_bytesPerSector = (*env)->GetFieldID(env, clazz, "bytesPerSector", "J");
-    CHECK_NULL(diskSpace_bytesPerSector);
+    CHECK_NULL_RETURN(diskSpace_bytesPerSector, 0);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$Account");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     account_domain = (*env)->GetFieldID(env, clazz, "domain", "Ljava/lang/String;");
-    CHECK_NULL(account_domain);
+    CHECK_NULL_RETURN(account_domain, 0);
     account_name = (*env)->GetFieldID(env, clazz, "name", "Ljava/lang/String;");
-    CHECK_NULL(account_name);
+    CHECK_NULL_RETURN(account_name, 0);
     account_use = (*env)->GetFieldID(env, clazz, "use", "I");
-    CHECK_NULL(account_use);
+    CHECK_NULL_RETURN(account_use, 0);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$AclInformation");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     aclInfo_aceCount = (*env)->GetFieldID(env, clazz, "aceCount", "I");
-    CHECK_NULL(aclInfo_aceCount);
+    CHECK_NULL_RETURN(aclInfo_aceCount, 0);
 
     clazz = (*env)->FindClass(env, "sun/nio/fs/WindowsNativeDispatcher$CompletionStatus");
-    CHECK_NULL(clazz);
+    CHECK_NULL_RETURN(clazz, 0);
     completionStatus_error = (*env)->GetFieldID(env, clazz, "error", "I");
-    CHECK_NULL(completionStatus_error);
+    CHECK_NULL_RETURN(completionStatus_error, 0);
     completionStatus_bytesTransferred = (*env)->GetFieldID(env, clazz, "bytesTransferred", "I");
-    CHECK_NULL(completionStatus_bytesTransferred);
+    CHECK_NULL_RETURN(completionStatus_bytesTransferred, 0);
     completionStatus_completionKey = (*env)->GetFieldID(env, clazz, "completionKey", "J");
-    CHECK_NULL(completionStatus_completionKey);
+    CHECK_NULL_RETURN(completionStatus_completionKey, 0);
+
+    HMODULE hMod = GetModuleHandleW(L"kernel32.dll");
+    if (hMod != NULL) {
+        pGetFileInformationByName =
+            (PGetFileInformationByName)GetProcAddress(hMod, "GetFileInformationByName");
+        if (pGetFileInformationByName != NULL) {
+            capabilities |= sun_nio_fs_WindowsNativeDispatcher_SUPPORTS_GETFILEINFORMATIONBYNAME;
+        }
+    }
+
+    return capabilities;
 }
 
 JNIEXPORT jlong JNICALL
@@ -510,69 +557,12 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileAttributesEx0(JNIEnv* env, jclass
         throwWindowsException(env, GetLastError());
 }
 
-
-#if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
-
-typedef struct _FILE_STAT_BASIC_INFORMATION {
-    LARGE_INTEGER FileId;
-    LARGE_INTEGER CreationTime;
-    LARGE_INTEGER LastAccessTime;
-    LARGE_INTEGER LastWriteTime;
-    LARGE_INTEGER ChangeTime;
-    LARGE_INTEGER AllocationSize;
-    LARGE_INTEGER EndOfFile;
-    ULONG         FileAttributes;
-    ULONG         ReparseTag;
-    ULONG         NumberOfLinks;
-    ULONG         DeviceType;
-    ULONG         DeviceCharacteristics;
-    ULONG         Reserved;
-    LARGE_INTEGER VolumeSerialNumber;
-    FILE_ID_128   FileId128;
-} FILE_STAT_BASIC_INFORMATION;
-
-typedef enum _FILE_INFO_BY_NAME_CLASS {
-    FileStatByNameInfo,
-    FileStatLxByNameInfo,
-    FileCaseSensitiveByNameInfo,
-    FileStatBasicByNameInfo,
-    MaximumFileInfoByNameClass
-} FILE_INFO_BY_NAME_CLASS;
-
-#endif /* !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI) */
-
-typedef BOOL (WINAPI *PGetFileInformationByName)(
-    PCWSTR, FILE_INFO_BY_NAME_CLASS, PVOID, ULONG);
-
-static PGetFileInformationByName pGetFileInformationByName = NULL;
-
-static void initGetFileInformationByName(void) {
-    // Use a static initializer so that we don't probe kernel32.dll every time
-    // this function is called.
-    static int initialized = 0;
-    if (!initialized) {
-        HMODULE hMod = GetModuleHandleW(L"kernel32.dll");
-        if (hMod != NULL) {
-            pGetFileInformationByName =
-                (PGetFileInformationByName)GetProcAddress(hMod, "GetFileInformationByName");
-        }
-        initialized = 1;
-    }
-}
-
 JNIEXPORT void JNICALL
 Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
     jclass this, jlong pathAddress, jint infoClass, jlong infoAddress, jint infoSize)
 {
     LPCWSTR lpFileName = jlong_to_ptr(pathAddress);
     PVOID pInfo = jlong_to_ptr(infoAddress);
-
-    // In case the caller didn't invoke `supportsGetFileInformationByName()`
-    // prior to calling `GetFileInformationByName()`, we call the init function
-    // to set the pointer to the Win32 API function.  The init function is
-    // cheap because it uses a static initializer, so we pay the cost of probing
-    // kernel32.dll only once instead of once per function call.
-    initGetFileInformationByName();
 
     if (pGetFileInformationByName == NULL) {
         throwWindowsException(env, ERROR_NOT_SUPPORTED);
@@ -583,14 +573,6 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
                                    pInfo, (ULONG)infoSize)) {
         throwWindowsException(env, GetLastError());
     }
-}
-
-JNIEXPORT jboolean JNICALL
-Java_sun_nio_fs_WindowsNativeDispatcher_supportsGetFileInformationByName0(JNIEnv* env,
-    jclass this)
-{
-    initGetFileInformationByName();
-    return pGetFileInformationByName != NULL;
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
On Linux, various `stat()` calls allow probing information about files
without opening them, but until recently, there wasn't an equivalent API
available on Windows.  Now that `GetFileInformationByName()` exists,
we can use it instead of `GetFileInformationByHandle()`, which required
first opening the file to create a file handle, then reading the file
attributes, and finally closing the file handle.

Since `GetFileInformationByName()` is available on only newer versions
of Windows, this patch uses conditional compilation and function address
lookup using `GetProcAddress()` to dynamically set the pointer to the
API function. If the dynamic loading fails, we fall back to the old API.
To avoid problems with race conditions, we use Windows' `INIT_ONCE` and
`InitOnceExecuteOnce()` to initialize the function pointer exactly once.

The rest of the patch is similar to the addition of any new JNI function
call.  WindowsConstants.java adds the relevant flags and error codes,
WindowsFileAttributes.java adds the Java entry point,
WindowsNativeDispatcher.java links the Java function with the C
function, and WindowsNativeDispatcher.c calls the Win32 API function.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383623](https://bugs.openjdk.org/browse/JDK-8383623): (fs) Update Windows file system provider to use GetFileInformationByName where possible (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31081/head:pull/31081` \
`$ git checkout pull/31081`

Update a local copy of the PR: \
`$ git checkout pull/31081` \
`$ git pull https://git.openjdk.org/jdk.git pull/31081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31081`

View PR using the GUI difftool: \
`$ git pr show -t 31081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31081.diff">https://git.openjdk.org/jdk/pull/31081.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31081#issuecomment-4400352983)
</details>
