### PR TITLE
8384043: [REDO] Incorrect handling of Hawaii_Aleutian metazone

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -815,6 +815,13 @@ public class CLDRConverter {
                 data = map.get(TIMEZONE_ID_PREFIX + tzLink);
             }
 
+            String meta = handlerMetaZones.get(tzKey);
+            if (meta == null && tzLink != null) {
+                // Check for tzLink
+                meta = handlerMetaZones.get(tzLink);
+            }
+            String metaKey = meta != null ? METAZONE_ID_PREFIX + meta : null;
+
             if (data instanceof String[] tznames) {
                 // Hack for UTC. UTC is an alias to Etc/UTC in CLDR
                 if (tzid.equals("Etc/UTC") && !map.containsKey(TIMEZONE_ID_PREFIX + "UTC")) {
@@ -826,24 +833,14 @@ public class CLDRConverter {
                     tznames = Arrays.copyOf(tznames, tznames.length);
                     fillTZDBShortNames(tzKey, tznames);
                     names.put(tzid, tznames);
+                    if (meta != null && map.get(metaKey) instanceof String[] metaNames) {
+                        recordMetazone(names, meta, tzKey, metaNames);
+                    }
                 }
             } else {
-                String meta = handlerMetaZones.get(tzKey);
-                if (meta == null && tzLink != null) {
-                    // Check for tzLink
-                    meta = handlerMetaZones.get(tzLink);
-                }
                 if (meta != null) {
-                    String metaKey = METAZONE_ID_PREFIX + meta;
-                    data = map.get(metaKey);
-                    if (data instanceof String[] tznames) {
-                        if (isDefaultZone(meta, tzKey)) {
-                            // Record the metazone names only from the default
-                            // (001) zone, with short names filled from TZDB
-                            tznames = Arrays.copyOf(tznames, tznames.length);
-                            fillTZDBShortNames(tzKey, tznames);
-                            names.put(metaKey, tznames);
-                        }
+                    if (map.get(metaKey) instanceof String[] metaNames) {
+                        recordMetazone(names, meta, tzKey, metaNames);
                         names.put(tzid, meta);
                         if (tzLink != null && availableIds.contains(tzLink)) {
                             names.put(tzLink, meta);
@@ -1508,11 +1505,18 @@ public class CLDRConverter {
         }
     }
 
-    private static boolean isDefaultZone(String meta, String tzid) {
+    private static void recordMetazone(Map<String, Object> names, String meta, String tzid, String[] tznames) {
         String zone001 = handlerMetaZones.zidMap().get(meta);
         var tzLink = getTZDBLink(tzid);
-        return canonicalTZMap.getOrDefault(tzid, tzid).equals(zone001) ||
-            tzLink != null && canonicalTZMap.getOrDefault(tzLink, tzLink).equals(zone001);
+
+        // Record the metazone names only from the default
+        // (001) zone, with short names filled from TZDB
+        if (canonicalTZMap.getOrDefault(tzid, tzid).equals(zone001) ||
+            tzLink != null && canonicalTZMap.getOrDefault(tzLink, tzLink).equals(zone001)) {
+            tznames = Arrays.copyOf(tznames, tznames.length);
+            fillTZDBShortNames(tzid, tznames);
+            names.put(METAZONE_ID_PREFIX + meta, tznames);
+        }
     }
 
     private static String getTZDBLink(String tzid) {

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -24,7 +24,7 @@
  /*
  * @test
  * @bug 8181157 8202537 8234347 8236548 8261279 8322647 8174269 8346948
- *      8354548 8381379 8382020
+ *      8354548 8381379 8382020 8384043
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at
  * either build or runtime
@@ -274,6 +274,27 @@ public class TimeZoneNamesTest {
                 "EDT",
                 "Восточная Америка",
                 "ET"},
+
+            // Hawaii/Aleutian
+            //
+            // Note that CLDR v48 only contains the standard names in "Hawaii"
+            // metazone. Other long names are synthesized, and short names are
+            // from TZDB. "America/Adak" reflects the "Hawaii_Aleutian" metazone
+            // names.
+            {"Pacific/Honolulu", Locale.US,
+                "Hawaii-Aleutian Standard Time",
+                "HST",
+                "Honolulu Daylight Time",
+                "HST",
+                "Honolulu Time",
+                "HST"},
+            {"America/Adak", Locale.US,
+                "Hawaii-Aleutian Standard Time",
+                "HAST",
+                "Hawaii-Aleutian Daylight Time",
+                "HADT",
+                "Hawaii-Aleutian Time",
+                "HAT"},
         };
     }
 


### PR DESCRIPTION
Redoing the previously failed fix. The earlier fix unnecessarily added all metazones to the root bundle, even when the names were empty. The revised fix updates metazone names only when the mapped zone has its own names (which fixes the original backporting issue, and is not applicable to the current mainline). I confirmed that the resource bundles generated by CLDRConverter are identical to those from the baseline build without this fix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384043](https://bugs.openjdk.org/browse/JDK-8384043): [REDO] Incorrect handling of Hawaii_Aleutian metazone (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31084/head:pull/31084` \
`$ git checkout pull/31084`

Update a local copy of the PR: \
`$ git checkout pull/31084` \
`$ git pull https://git.openjdk.org/jdk.git pull/31084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31084`

View PR using the GUI difftool: \
`$ git pr show -t 31084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31084.diff">https://git.openjdk.org/jdk/pull/31084.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31084#issuecomment-4402624535)
</details>
