### PR TITLE
8384091: Some coding from Region.c seems to be unnecessary in the headless build

### DIFF
--- a/src/java.desktop/share/native/libawt/java2d/pipe/Region.c
+++ b/src/java.desktop/share/native/libawt/java2d/pipe/Region.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,7 @@ Region_StartIteration(JNIEnv *env, RegionData *pRgnInfo)
     pRgnInfo->numrects = 0;
 }
 
+#ifndef HEADLESS
 JNIEXPORT jint JNICALL
 Region_CountIterationRects(RegionData *pRgnInfo)
 {
@@ -144,6 +145,7 @@ Region_CountIterationRects(RegionData *pRgnInfo)
     }
     return totalrects;
 }
+#endif
 
 JNIEXPORT jint JNICALL
 Region_NextIteration(RegionData *pRgnInfo, SurfaceDataBounds *pSpan)
@@ -222,6 +224,8 @@ Region_EndIteration(JNIEnv *env, RegionData *pRgnInfo)
     }
 }
 
+
+#ifndef HEADLESS
 /*
  * The code was extracted from
  * src/solaris/native/sun/java2d/x11/X11SurfaceData.c
@@ -282,3 +286,4 @@ RegionToYXBandedRectangles(JNIEnv *env,
 
     return numrects;
 }
+#endif


### PR DESCRIPTION
Some coding from Region.c seems to be unnecessary in the headless build, e.g. RegionToYXBandedRectangles .


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384091](https://bugs.openjdk.org/browse/JDK-8384091): Some coding from Region.c seems to be unnecessary in the headless build (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31088/head:pull/31088` \
`$ git checkout pull/31088`

Update a local copy of the PR: \
`$ git checkout pull/31088` \
`$ git pull https://git.openjdk.org/jdk.git pull/31088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31088`

View PR using the GUI difftool: \
`$ git pr show -t 31088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31088.diff">https://git.openjdk.org/jdk/pull/31088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31088#issuecomment-4404869358)
</details>
