### PR TITLE
8384143: ZGC: Add minor performance improvment to oop iteration during flip promotion

### DIFF
--- a/src/hotspot/share/gc/z/zIterator.hpp
+++ b/src/hotspot/share/gc/z/zIterator.hpp
@@ -31,11 +31,14 @@ class ZIterator : AllStatic {
 private:
   static bool is_invisible_object(oop obj);
   static bool is_invisible_object_array(oop obj);
+  static bool is_invisible_object_array(oop obj, Klass* klass);
 
 public:
   // This iterator skips invisible roots
   template <typename OopClosureT>
   static void oop_iterate_safe(oop obj, OopClosureT* cl);
+  template <typename OopClosureT>
+  static void oop_iterate_safe(oop obj, Klass* klass, OopClosureT* cl);
 
   template <typename OopClosureT>
   static void oop_iterate(oop obj, OopClosureT* cl);
@@ -46,6 +49,8 @@ public:
   // This function skips invisible roots
   template <typename Function>
   static void basic_oop_iterate_safe(oop obj, Function function);
+  template <typename Function>
+  static void basic_oop_iterate_safe(oop obj, Klass* klass, Function function);
 
   template <typename Function>
   static void basic_oop_iterate(oop obj, Function function);

--- a/src/hotspot/share/gc/z/zIterator.inline.hpp
+++ b/src/hotspot/share/gc/z/zIterator.inline.hpp
@@ -45,17 +45,27 @@ inline bool ZIterator::is_invisible_object(oop obj) {
 }
 
 inline bool ZIterator::is_invisible_object_array(oop obj) {
-  return obj->klass()->is_objArray_klass() && is_invisible_object(obj);
+  return is_invisible_object_array(obj, obj->klass());
 }
 
-// This iterator skips invisible object arrays
+inline bool ZIterator::is_invisible_object_array(oop obj, Klass* klass) {
+  return klass->is_objArray_klass() && is_invisible_object(obj);
+}
+
+// These iterators skips invisible object arrays
+
 template <typename OopClosureT>
 void ZIterator::oop_iterate_safe(oop obj, OopClosureT* cl) {
+  oop_iterate_safe(obj, obj->klass(), cl);
+}
+
+template <typename OopClosureT>
+void ZIterator::oop_iterate_safe(oop obj, Klass* klass, OopClosureT* cl) {
   // Skip invisible object arrays - we only filter out *object* arrays,
   // because that check is arguably faster than the is_invisible_object
   // check, and primitive arrays are cheap to call oop_iterate on.
-  if (!is_invisible_object_array(obj)) {
-    obj->oop_iterate(cl);
+  if (!is_invisible_object_array(obj, klass)) {
+    OopIteratorClosureDispatch::oop_oop_iterate(cl, obj, klass);
   }
 }
 
@@ -89,11 +99,17 @@ public:
   }
 };
 
-// This function skips invisible roots
+// These functions skip invisible roots
+
 template <typename Function>
 void ZIterator::basic_oop_iterate_safe(oop obj, Function function) {
+  basic_oop_iterate_safe(obj, obj->klass(), function);
+}
+
+template <typename Function>
+void ZIterator::basic_oop_iterate_safe(oop obj, Klass* klass, Function function) {
   ZBasicOopIterateClosure<Function> cl(function);
-  oop_iterate_safe(obj, &cl);
+  oop_iterate_safe(obj, klass, &cl);
 }
 
 template <typename Function>

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -1272,7 +1272,7 @@ public:
     for (ZPage* page; _iter.next(&page);) {
       page->object_iterate([&](oop obj) {
         // Remap oops and add remset if needed
-        ZIterator::basic_oop_iterate_safe(obj, remap_and_maybe_add_remset);
+        ZIterator::basic_oop_iterate_safe(obj, obj->klass(), remap_and_maybe_add_remset);
 
         // String dedup
         string_dedup_context.request(obj);


### PR DESCRIPTION
In [JDK-8382041](https://bugs.openjdk.org/browse/JDK-8382041) we found that removing UseCompressedClassPointers caused different inlining in the ZGC code, which caused a significant regression in one of our micro benchmarks (org.openjdk.bench.vm.gc.systemgc.AllLive.gc). A large portion of that regression was fixed with [JDK-8383912](https://bugs.openjdk.org/browse/JDK-8383912). There's still a 1.5% regression that can be fixed by deduplicating calls to oopDesc::klass() during flip promotion. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384143](https://bugs.openjdk.org/browse/JDK-8384143): ZGC: Add minor performance improvment to oop iteration during flip promotion (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31089/head:pull/31089` \
`$ git checkout pull/31089`

Update a local copy of the PR: \
`$ git checkout pull/31089` \
`$ git pull https://git.openjdk.org/jdk.git pull/31089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31089`

View PR using the GUI difftool: \
`$ git pr show -t 31089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31089.diff">https://git.openjdk.org/jdk/pull/31089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31089#issuecomment-4406405241)
</details>
