### PR TITLE
8384138: Linux container CPU hierarchy adjustment can ignore stricter leaf CPU quotas

### DIFF
--- a/src/hotspot/os/linux/cgroupUtil_linux.cpp
+++ b/src/hotspot/os/linux/cgroupUtil_linux.cpp
@@ -101,9 +101,8 @@ void CgroupUtil::adjust_controller(CgroupMemoryController* mem, physical_memory_
   assert(cg_path[0] == '/', "cgroup path must start with '/'");
   char* limit_cg_path = nullptr;
   physical_memory_size_type limit = value_unlimited;
-  physical_memory_size_type lowest_limit = upper_bound;
-  lowest_limit = get_updated_mem_limit(mem, lowest_limit, upper_bound);
-  physical_memory_size_type orig_limit = lowest_limit != upper_bound ? lowest_limit : upper_bound;
+  physical_memory_size_type lowest_limit = get_updated_mem_limit(mem, upper_bound, upper_bound);
+  const physical_memory_size_type orig_limit = lowest_limit;
   while ((last_slash = strrchr(cg_path, '/')) != cg_path) {
     *last_slash = '\0'; // strip path
     // update to shortened path and try again
@@ -163,10 +162,9 @@ void CgroupUtil::adjust_controller(CgroupCpuController* cpu, double upper_bound)
   char* cg_path = os::strdup(orig);
   char* last_slash;
   assert(cg_path[0] == '/', "cgroup path must start with '/'");
-  double lowest_limit = upper_bound;
-  lowest_limit = get_updated_cpu_limit(cpu, lowest_limit, upper_bound);
+  double lowest_limit = get_updated_cpu_limit(cpu, upper_bound, upper_bound);
   double cpus = lowest_limit;
-  double orig_limit = lowest_limit != upper_bound ? lowest_limit : upper_bound;
+  const double orig_limit = lowest_limit;
   char* limit_cg_path = nullptr;
   while ((last_slash = strrchr(cg_path, '/')) != cg_path) {
     *last_slash = '\0'; // strip path

--- a/src/hotspot/os/linux/cgroupUtil_linux.cpp
+++ b/src/hotspot/os/linux/cgroupUtil_linux.cpp
@@ -164,7 +164,8 @@ void CgroupUtil::adjust_controller(CgroupCpuController* cpu, double upper_bound)
   char* last_slash;
   assert(cg_path[0] == '/', "cgroup path must start with '/'");
   double lowest_limit = upper_bound;
-  double cpus = get_updated_cpu_limit(cpu, lowest_limit, upper_bound);
+  lowest_limit = get_updated_cpu_limit(cpu, lowest_limit, upper_bound);
+  double cpus = lowest_limit;
   double orig_limit = lowest_limit != upper_bound ? lowest_limit : upper_bound;
   char* limit_cg_path = nullptr;
   while ((last_slash = strrchr(cg_path, '/')) != cg_path) {

--- a/test/hotspot/jtreg/containers/docker/TestCPUWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUWithSubgroups.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key cgroups
+ * @summary Test that a stricter leaf CPU quota is not replaced by a looser parent quota
+ * @requires container.support
+ * @requires !vm.asan
+ * @library /test/lib
+ * @modules java.base/jdk.internal.platform
+ * @run driver TestCPUWithSubgroups
+ */
+
+import jdk.internal.platform.Metrics;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+
+import jtreg.SkippedException;
+
+public class TestCPUWithSubgroups {
+    private static final String imageName = Common.imageName("cpu-subgroup");
+
+    public static void main(String[] args) throws Exception {
+        Metrics metrics = Metrics.systemMetrics();
+        if (metrics == null) {
+            System.out.println("Cgroup not configured.");
+            return;
+        }
+
+        DockerTestUtils.checkCanTestDocker();
+        String provider = metrics.getProvider();
+        if (!"cgroupv1".equals(provider) && !"cgroupv2".equals(provider)) {
+            throw new SkippedException("Metrics are from neither cgroup v1 nor v2, skipped for now.");
+        }
+        if ("cgroupv1".equals(provider) && DockerTestUtils.isRootless()) {
+            throw new SkippedException("Test skipped in cgroup v1 rootless mode");
+        }
+        if (Runtime.getRuntime().availableProcessors() < 2) {
+            throw new SkippedException("Test requires at least two CPUs.");
+        }
+
+        DockerTestUtils.buildJdkContainerImage(imageName);
+        try {
+            testCpuLimitSubgroup(provider);
+        } finally {
+            DockerTestUtils.removeDockerImage(imageName);
+        }
+    }
+
+    private static void testCpuLimitSubgroup(String cgroupVersion) throws Exception {
+        final String upperVersion = "cgroupv1".equals(cgroupVersion) ? "V1" : "V2";
+        Common.logNewTestCase("Cgroup " + upperVersion + " subgroup CPU limit");
+
+        DockerRunOptions opts = new DockerRunOptions(imageName, "sh", "-c");
+        opts.javaOpts.clear();
+        opts.appendTestJavaOptions = false;
+        opts.addDockerOpts("--privileged")
+            .addDockerOpts("--user", "root");
+        if ("cgroupv1".equals(cgroupVersion)) {
+            opts.addClassOptions(
+                "CG=/sys/fs/cgroup/cpu; if [ ! -d $CG ]; then CG=/sys/fs/cgroup/cpu,cpuacct; fi; " +
+                "CG=$CG/jdk-cpu-hierarchy-test; mkdir -p $CG/leaf; " +
+                "echo 100000 > $CG/cpu.cfs_period_us; " +
+                "echo 200000 > $CG/cpu.cfs_quota_us; " +
+                "echo 100000 > $CG/leaf/cpu.cfs_period_us; " +
+                "echo 100000 > $CG/leaf/cpu.cfs_quota_us; " +
+                "echo $$ > $CG/leaf/cgroup.procs; " +
+                "/jdk/bin/java -Xlog:os+container=trace -Xlog:os=trace -version");
+        } else {
+            opts.addClassOptions(
+                "CG=/sys/fs/cgroup/jdk-cpu-hierarchy-test; mkdir -p $CG/leaf; " +
+                "echo $$ > $CG/leaf/cgroup.procs; " +
+                "echo '+cpu' > /sys/fs/cgroup/cgroup.subtree_control; " +
+                "echo '+cpu' > $CG/cgroup.subtree_control; " +
+                "echo '200000 100000' > $CG/cpu.max; " +
+                "echo '100000 100000' > $CG/leaf/cpu.max; " +
+                "/jdk/bin/java -Xlog:os+container=trace -Xlog:os=trace -version");
+        }
+
+        Common.run(opts)
+            .shouldContain("active_processor_count: determined by OSContainer: 1");
+    }
+}


### PR DESCRIPTION
Hi everyone,

When traversing the cgroup hierarchy while adjusting the controller for CPU limits in `CgroupUtil::adjust_controller`, we do not fold the initial (leaf) quota as `lowest_limit`. As a result, a stricter leaf quota can be skipped in favor of a less restrictive quota from a parent cgroup.

This change fixes that by updating `lowest_limit` with the leaf value before walking the parent hiererchy, similar to what is already done for the memory controller hierarchy adjustment.

I have also added a new test `TestCPUWithSubgroups.java`, inspired from `TestMemoryWithSubgroups.java`, which sets up a nested CPU hierarchy and verifies that the leaf CPU limit is used as expected.

Testing:
- TestCPUWithSubgroups.java` locally on both cgroup v1 and cgroup v2
- Oracle tiers 1-5

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384138](https://bugs.openjdk.org/browse/JDK-8384138): Linux container CPU hierarchy adjustment can ignore stricter leaf CPU quotas (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31091/head:pull/31091` \
`$ git checkout pull/31091`

Update a local copy of the PR: \
`$ git checkout pull/31091` \
`$ git pull https://git.openjdk.org/jdk.git pull/31091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31091`

View PR using the GUI difftool: \
`$ git pr show -t 31091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31091.diff">https://git.openjdk.org/jdk/pull/31091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31091#issuecomment-4406579267)
</details>
