### PR TITLE
8384158: GHA: Downgrade Windows GHA runners to windows-2022 temporarily

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,9 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
       extra-conf-options:
         required: false
         type: string
@@ -67,7 +70,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2025
+    runs-on: ${{ inputs.runs-on }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,6 +353,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
+      runs-on: windows-2025-vs2026
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
@@ -366,6 +367,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
+      runs-on: windows-2025-vs2026
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
@@ -446,6 +448,6 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
-      runs-on: windows-2025
+      runs-on: windows-2025-vs2026
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       debug-suffix: -debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,7 +353,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
-      runs-on: windows-2025-vs2026
+      runs-on: windows-2022
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
@@ -367,7 +367,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
-      runs-on: windows-2025-vs2026
+      runs-on: windows-2022
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
@@ -448,6 +448,6 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
-      runs-on: windows-2025-vs2026
+      runs-on: windows-2022
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       debug-suffix: -debug


### PR DESCRIPTION
See the bug for more details. 

There is a little infrastructural mess in GHA infra now:
https://github.com/actions/runner-images/issues/14004

...and there is a looming MSVC upgrade in `windows-2025` anyway. So our current GHA builds are intermittently broken. With this PR, I suggest we temporarily move back to `windows-2022` which ships the same MSVC version we use now. This would be easy to backport to fix the current (due to `windows-2025` leak) and future (due to `windows-2025` roll-out in June) breakages in JDK Update releases.

I am posting this PR now and seeing if GHA is really fine with it.

Additional testing:
 - [x] GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158): GHA: Downgrade Windows GHA runners to windows-2022 temporarily (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31093/head:pull/31093` \
`$ git checkout pull/31093`

Update a local copy of the PR: \
`$ git checkout pull/31093` \
`$ git pull https://git.openjdk.org/jdk.git pull/31093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31093`

View PR using the GUI difftool: \
`$ git pr show -t 31093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31093.diff">https://git.openjdk.org/jdk/pull/31093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31093#issuecomment-4407282741)
</details>
