### PR TITLE
8384163: (so) SocketChannel.connect and finishConnect() exception messages could be improved

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -929,13 +929,13 @@ Java_sun_nio_ch_Net_pollConnect(JNIEnv *env, jobject this, jobject fdo, jlong ti
         errno = 0;
         result = getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &n);
         if (result < 0) {
-            handleSocketError(env, errno);
+            handleSocketErrorWithMessage(env, errno, "getsockopt return value indicates error");
             return JNI_FALSE;
         } else if (error) {
-            handleSocketError(env, error);
+            handleSocketErrorWithMessage(env, error, "getsockopt error parameter indicates error");
             return JNI_FALSE;
         } else if ((poller.revents & POLLHUP) != 0) {
-            handleSocketError(env, ENOTCONN);
+            handleSocketErrorWithMessage(env, ENOTCONN, "connection was hung up");
             return JNI_FALSE;
         }
         // connected

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -929,13 +929,13 @@ Java_sun_nio_ch_Net_pollConnect(JNIEnv *env, jobject this, jobject fdo, jlong ti
         errno = 0;
         result = getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &n);
         if (result < 0) {
-            handleSocketErrorWithMessage(env, errno, "getsockopt return value indicates error");
+            handleSocketErrorWithMessage(env, errno, "getsockopt failed");
             return JNI_FALSE;
         } else if (error) {
-            handleSocketErrorWithMessage(env, error, "getsockopt error parameter indicates error");
+            handleSocketErrorWithMessage(env, error, "connect failed");
             return JNI_FALSE;
         } else if ((poller.revents & POLLHUP) != 0) {
-            handleSocketErrorWithMessage(env, ENOTCONN, "connection was hung up");
+            handleSocketErrorWithMessage(env, ENOTCONN, "peer closed connection after accepting");
             return JNI_FALSE;
         }
         // connected

--- a/test/jdk/java/nio/channels/SocketChannel/ConnectionRefusedMessage.java
+++ b/test/jdk/java/nio/channels/SocketChannel/ConnectionRefusedMessage.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *          with an interest in CONNECT operation, then SocketChannel.finishConnect()
  *          throws the correct exception message, if the connect() fails
  * @run junit/othervm -Djdk.includeInExceptions=hostInfoExclSocket ${test.main.class}
- * @run junit/othervm -Djdk.includeInExceptions=hostInfo -Dcheck.relaxed=true ${test.main.class}
+ * @run junit/othervm -Djdk.includeInExceptions=hostInfo ${test.main.class}
  */
 class ConnectionRefusedMessage {
 
@@ -109,7 +109,6 @@ class ConnectionRefusedMessage {
     }
 
     private static void assertExceptionMessage(final ConnectException ce) {
-        // relax the check
         if (ce.getMessage() != null && ce.getMessage().startsWith("Connection refused")) {
             return;
         }

--- a/test/jdk/java/nio/channels/SocketChannel/ConnectionRefusedMessage.java
+++ b/test/jdk/java/nio/channels/SocketChannel/ConnectionRefusedMessage.java
@@ -109,10 +109,8 @@ class ConnectionRefusedMessage {
     }
 
     private static void assertExceptionMessage(final ConnectException ce) {
-        if ("Connection refused".equals(ce.getMessage())) {
-            return;
-        }
-        if (Boolean.getBoolean("check.relaxed") && ce.getMessage() != null && ce.getMessage().startsWith("Connection refused")) {
+        // relax the check
+        if (ce.getMessage() != null && ce.getMessage().startsWith("Connection refused")) {
             return;
         }
         // propagate the original exception


### PR DESCRIPTION
Java_sun_nio_ch_Net_pollConnect has a couple of calls to handleSocketError, but we do not pass over a specific message.
So it can be hard to detect which was the exact code location causing the error message.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384163](https://bugs.openjdk.org/browse/JDK-8384163): (so) SocketChannel.connect and finishConnect() exception messages could be improved (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [3ecffcd1](https://git.openjdk.org/jdk/pull/31094/files/3ecffcd1b84610783a83820984dbe4388df9db38)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31094/head:pull/31094` \
`$ git checkout pull/31094`

Update a local copy of the PR: \
`$ git checkout pull/31094` \
`$ git pull https://git.openjdk.org/jdk.git pull/31094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31094`

View PR using the GUI difftool: \
`$ git pr show -t 31094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31094.diff">https://git.openjdk.org/jdk/pull/31094.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31094#issuecomment-4407431770)
</details>
