### PR TITLE
8384164: JFR: Omit command-line arguments for jdk.SystemProcess

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -256,10 +256,7 @@ TRACE_REQUEST_FUNC(SystemProcess) {
     // feature is implemented, write real event
     while (processes != nullptr) {
       SystemProcess* tmp = processes;
-      const char* info = processes->command_line();
-      if (info == nullptr) {
-         info = processes->path();
-      }
+      const char* info = processes->path();
       if (info == nullptr) {
          info = processes->name();
       }


### PR DESCRIPTION
Could I have a review of a PR that prevents command-line arguments from being emitted for the jdk.SystemProcess event. I didn't remove the supporting code to simplify potential backports.

Testing: jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384164](https://bugs.openjdk.org/browse/JDK-8384164): JFR: Omit command-line arguments for jdk.SystemProcess (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31095/head:pull/31095` \
`$ git checkout pull/31095`

Update a local copy of the PR: \
`$ git checkout pull/31095` \
`$ git pull https://git.openjdk.org/jdk.git pull/31095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31095`

View PR using the GUI difftool: \
`$ git pr show -t 31095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31095.diff">https://git.openjdk.org/jdk/pull/31095.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31095#issuecomment-4407800465)
</details>
