### PR TITLE
8384182: Incorrect assertion eq4a_state in vectorization AlignmentSolver::solve

### DIFF
--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -1744,8 +1744,8 @@ AlignmentSolution* AlignmentSolver::solve() const {
   // And since abs(C_pre) < aw, the solutions of (4a, b, c) can now only be constrained or empty.
   // But since we already handled the empty case, the solutions are now all constrained.
   assert(eq4a_state == EQ4::State::CONSTRAINED &&
-         eq4a_state == EQ4::State::CONSTRAINED &&
-         eq4a_state == EQ4::State::CONSTRAINED, "all must be constrained now");
+         eq4b_state == EQ4::State::CONSTRAINED &&
+         eq4c_state == EQ4::State::CONSTRAINED, "all must be constrained now");
 
   // And since they are all constrained, we must have:
   //


### PR DESCRIPTION
Assert on eq4b and eq4c as well, as the explained in the comment "the solutions are now all constrained.".

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384182](https://bugs.openjdk.org/browse/JDK-8384182): Incorrect assertion eq4a_state in vectorization AlignmentSolver::solve (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Saranya Natarajan](https://openjdk.org/census#snatarajan) (@sarannat - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31096/head:pull/31096` \
`$ git checkout pull/31096`

Update a local copy of the PR: \
`$ git checkout pull/31096` \
`$ git pull https://git.openjdk.org/jdk.git pull/31096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31096`

View PR using the GUI difftool: \
`$ git pr show -t 31096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31096.diff">https://git.openjdk.org/jdk/pull/31096.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31096#issuecomment-4407773209)
</details>
