### PR TITLE
8384209: Remove AppContext from AWT Shutdown implementation

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/AWTAutoShutdown.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAutoShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.awt;
 
 import java.awt.AWTEvent;
+import java.awt.Toolkit;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -317,7 +318,7 @@ public final class AWTAutoShutdown implements Runnable {
             }
         }
         if (!interrupted) {
-            AppContext.stopEventDispatchThreads();
+            Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(getShutdownEvent());
         }
     }
 

--- a/src/java.desktop/share/classes/sun/awt/AppContext.java
+++ b/src/java.desktop/share/classes/sun/awt/AppContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -478,44 +478,6 @@ public final class AppContext {
         numAppContexts.decrementAndGet();
 
         mostRecentKeyValue = null;
-    }
-
-    static final class PostShutdownEventRunnable implements Runnable {
-        private final AppContext appContext;
-
-        PostShutdownEventRunnable(AppContext ac) {
-            appContext = ac;
-        }
-
-        public void run() {
-            final EventQueue eq = (EventQueue)appContext.get(EVENT_QUEUE_KEY);
-            if (eq != null) {
-                eq.postEvent(AWTAutoShutdown.getShutdownEvent());
-            }
-        }
-    }
-
-    static void stopEventDispatchThreads() {
-        for (AppContext appContext: getAppContexts()) {
-            if (appContext.isDisposed()) {
-                continue;
-            }
-            Runnable r = new PostShutdownEventRunnable(appContext);
-            // For security reasons EventQueue.postEvent should only be called
-            // on a thread that belongs to the corresponding thread group.
-            if (appContext != AppContext.getAppContext()) {
-                // Create a thread that belongs to the thread group associated
-                // with the AppContext and invokes EventQueue.postEvent.
-                Thread thread = new Thread(appContext.getThreadGroup(),
-                                           r, "AppContext Disposer", 0, false);
-                thread.setContextClassLoader(appContext.getContextClassLoader());
-                thread.setPriority(Thread.NORM_PRIORITY + 1);
-                thread.setDaemon(true);
-                thread.start();
-            } else {
-                r.run();
-            }
-        }
     }
 
     private MostRecentKeyValue mostRecentKeyValue = null;


### PR DESCRIPTION
Since AppContext is obsolete, we can bypass it and directly post the shutdown event, and remove the now dead code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384209](https://bugs.openjdk.org/browse/JDK-8384209): Remove AppContext from AWT Shutdown implementation (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31101/head:pull/31101` \
`$ git checkout pull/31101`

Update a local copy of the PR: \
`$ git checkout pull/31101` \
`$ git pull https://git.openjdk.org/jdk.git pull/31101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31101`

View PR using the GUI difftool: \
`$ git pr show -t 31101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31101.diff">https://git.openjdk.org/jdk/pull/31101.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31101#issuecomment-4409127421)
</details>
