### PR TITLE
8374397: test/hotspot/jtreg/gc/shenandoah/options/TestPassiveModeWithCardBarrier.java fails with -Xcomp after JDK-8369013

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -990,19 +990,23 @@ void ShenandoahBarrierSetC2::eliminate_gc_barrier(PhaseMacroExpand* macro, Node*
     shenandoah_eliminate_wb_pre(node, &macro->igvn());
   }
   if (ShenandoahCardBarrier && node->Opcode() == Op_CastP2X) {
-    Node* shift = node->unique_out();
-    Node* addp = shift->unique_out();
-    for (DUIterator_Last jmin, j = addp->last_outs(jmin); j >= jmin; --j) {
-      Node* mem = addp->last_out(j);
-      if (UseCondCardMark && mem->is_Load()) {
-        assert(mem->Opcode() == Op_LoadB, "unexpected code shape");
-        // The load is checking if the card has been written so
-        // replace it with zero to fold the test.
-        macro->replace_node(mem, macro->intcon(0));
-        continue;
+    for (DUIterator_Last imin, i = node->last_outs(imin); i >= imin; --i) {
+      Node* shift = node->last_out(i);
+      for (DUIterator_Last kmin, k = shift->last_outs(kmin); k >= kmin; --k) {
+        Node* addp = shift->last_out(k);
+        for (DUIterator_Last jmin, j = addp->last_outs(jmin); j >= jmin; --j) {
+          Node* mem = addp->last_out(j);
+          if (UseCondCardMark && mem->is_Load()) {
+            assert(mem->Opcode() == Op_LoadB, "unexpected code shape");
+            // The load is checking if the card has been written so
+            // replace it with zero to fold the test.
+            macro->replace_node(mem, macro->intcon(0));
+            continue;
+          }
+          assert(mem->is_Store(), "store required");
+          macro->replace_node(mem, mem->in(MemNode::Memory));
+        }
       }
-      assert(mem->is_Store(), "store required");
-      macro->replace_node(mem, mem->in(MemNode::Memory));
     }
   }
 }


### PR DESCRIPTION
**Context and root cause**

In `ShenandoahBarrierSetC2::eliminate_gc_barrier`, it assumes each node only has one consumer and uses `unique_out`, [code](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp#L993-L994). However, it is possible that a node can have multiple consumers, in which case, jvm would crash at `unique_out` when C2 kicks in (or `-Xcomp` turned on) and debug builds are used. The test was originally for passive mode, but I ran it with satb mode and it still failed at the same place.

**Fix**

Iterate all consumers of a node instead of assuming it only has a single consumer. 

**Note**

The crash happened at `shift->unique_out()`. I also iterate all the consumers of `node` just for safety.

**Testing**

Ran  the test with fastdebug and slowdebug build with `-Xcomp`. They can pass now. Internal test pipeline and GHA passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8374397](https://bugs.openjdk.org/browse/JDK-8374397): test/hotspot/jtreg/gc/shenandoah/options/TestPassiveModeWithCardBarrier.java fails with -Xcomp after JDK-8369013 (**Bug** - P2)


### Reviewers
 * [Cesar Soares Lucas](https://openjdk.org/census#cslucas) (@JohnTortugo - Committer)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31103/head:pull/31103` \
`$ git checkout pull/31103`

Update a local copy of the PR: \
`$ git checkout pull/31103` \
`$ git pull https://git.openjdk.org/jdk.git pull/31103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31103`

View PR using the GUI difftool: \
`$ git pr show -t 31103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31103.diff">https://git.openjdk.org/jdk/pull/31103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31103#issuecomment-4425692772)
</details>
