### PR TITLE
8384215: Remove AppContext from unix/classes/sun/awt/X11/XWindow.java

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -128,7 +128,6 @@ import javax.swing.LookAndFeel;
 import javax.swing.UIDefaults;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AppContext;
 import sun.awt.DisplayChangedListener;
 import sun.awt.LightweightFrame;
 import sun.awt.SunToolkit;

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Cursor;
+import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
@@ -425,7 +426,7 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
         if (focusLog.isLoggable(PlatformLogger.Level.FINER) && (e instanceof FocusEvent)) {
             focusLog.finer("Sending " + e);
         }
-        XToolkit.postEvent(XToolkit.targetToAppContext(e.getSource()), pe);
+        XToolkit.postEvent(pe);
     }
 
 
@@ -435,11 +436,11 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
 // NOTE: This method may be called by privileged threads.
 //       DO NOT INVOKE CLIENT CODE ON THIS THREAD!
     void postEvent(AWTEvent event) {
-        XToolkit.postEvent(XToolkit.targetToAppContext(event.getSource()), event);
+        XToolkit.postEvent(event);
     }
 
     static void postEventStatic(AWTEvent event) {
-        XToolkit.postEvent(XToolkit.targetToAppContext(event.getSource()), event);
+        XToolkit.postEvent(event);
     }
 
     public void postEventToEventQueue(final AWTEvent event) {
@@ -514,7 +515,7 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
         if (g != null) {
             try {
                 g.setClip(x, y, width, height);
-                if (SunToolkit.isDispatchThreadForAppContext(getTarget())) {
+                if (EventQueue.isDispatchThread()) {
                     paint(g); // The native and target will be painted in place.
                 } else {
                     paintPeer(g);

--- a/test/jdk/java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java
+++ b/test/jdk/java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,19 +27,17 @@
  * @key headful
  * @summary Checks that an Error which propogates up to the EventDispatch
  * loop does not crash AWT.
- * @author Andrei Dmitriev: area=awt.event
- * @library ../../regtesthelpers
- * @modules java.desktop/sun.awt
- * @build Util
  * @run main LoopRobustness
  */
 
-import java.awt.*;
-import java.awt.event.*;
-
-import sun.awt.SunToolkit;
-
-import test.java.awt.regtesthelpers.Util;
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 
 public class LoopRobustness {
 
@@ -50,15 +48,15 @@ public class LoopRobustness {
     public static volatile boolean notifyOccured = false;
     public static volatile boolean otherExceptionsCaught = false;
 
-    public static void main(String [] args) throws Exception {
-        SunToolkit.createNewAppContext();
+    public static void main(String[] args) throws Exception {
 
         ThreadGroup mainThreadGroup = Thread.currentThread().getThreadGroup();
 
+        Impl impl = new Impl();
         long at;
         //wait for a TIMEOUT giving a chance to a new Thread above to accomplish its stuff.
         synchronized (LoopRobustness.LOCK) {
-            new Thread(new TestThreadGroup(mainThreadGroup, "TestGroup"), new Impl()).start();
+            new Thread(new TestThreadGroup(mainThreadGroup, "TestGroup"), impl).start();
             at = System.currentTimeMillis();
             try {
                 while (!notifyOccured && (System.currentTimeMillis() - at < TIMEOUT)) {
@@ -76,7 +74,7 @@ public class LoopRobustness {
 
         //now wait for two clicks
         at = System.currentTimeMillis();
-        while(System.currentTimeMillis() - at < TIMEOUT && clicks < 2) {
+        while (System.currentTimeMillis() - at < TIMEOUT && clicks < 2) {
             try {
                 Thread.sleep(100);
             } catch(InterruptedException e) {
@@ -89,16 +87,26 @@ public class LoopRobustness {
         if (otherExceptionsCaught) {
             throw new RuntimeException("Test FAILED: unexpected exceptions caught");
         }
+        Frame f = impl.getFrame();
+        if (f != null) {
+            EventQueue.invokeAndWait(() -> f.dispose());
+        }
     }
 }
 
-class Impl implements Runnable{
+class Impl implements Runnable {
     static Robot robot;
-    public void run() {
-        SunToolkit.createNewAppContext();
+    volatile Button b;
+    volatile Frame lr;
 
-        Button b = new Button("Press me to test the AWT-Event Queue thread");
-        Frame lr = new Frame("ROBUST FRAME");
+    public Frame getFrame() {
+        return lr;
+    }
+
+    void createUI() {
+
+        b = new Button("Press me to test the AWT-Event Queue thread");
+        lr = new Frame("ROBUST FRAME");
         lr.setBounds(100, 100, 300, 100);
         b.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
@@ -109,13 +117,19 @@ class Impl implements Runnable{
             });
         lr.add(b);
         lr.setVisible(true);
+    }
+
+    public void run() {
 
         try {
+            EventQueue.invokeAndWait(() -> createUI());
             robot = new Robot();
         } catch (AWTException e) {
             throw new RuntimeException("Test interrupted.", e);
+        } catch (Exception e) {
+            throw new RuntimeException("UI creation failed.", e);
         }
-        Util.waitForIdle(robot);
+        robot.waitForIdle();
 
         synchronized (LoopRobustness.LOCK){
             LoopRobustness.LOCK.notify();
@@ -126,11 +140,11 @@ class Impl implements Runnable{
         while (i < 2) {
             robot.mouseMove(b.getLocationOnScreen().x + b.getWidth()/2,
                             b.getLocationOnScreen().y + b.getHeight()/2);
-            Util.waitForIdle(robot);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            Util.waitForIdle(robot);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
-            Util.waitForIdle(robot);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
             i++;
         }
     }


### PR DESCRIPTION
Remove AppContext from the X11 XWindow implementation class.
Also removed a remaining import in XToolkit.

A test that uses AppContext started to fail on Linux.
It looks like it still proves something useful even without an AppContext, so I did some minimal updating to remove AppContext and clean it up, and it passes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384215](https://bugs.openjdk.org/browse/JDK-8384215): Remove AppContext from unix/classes/sun/awt/X11/XWindow.java (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31104/head:pull/31104` \
`$ git checkout pull/31104`

Update a local copy of the PR: \
`$ git checkout pull/31104` \
`$ git pull https://git.openjdk.org/jdk.git pull/31104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31104`

View PR using the GUI difftool: \
`$ git pr show -t 31104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31104.diff">https://git.openjdk.org/jdk/pull/31104.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31104#issuecomment-4409944729)
</details>
