### PR TITLE
8384223: RISC-V: entry_barrier_offset should consider UseZtso

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -228,7 +228,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   Assembler::IncompressibleScope scope(masm); // Fixed length: see entry_barrier_offset()
 
-  Label local_guard;
+  Label local_guard, skip_barrier;
   NMethodPatchingType patching_type = nmethod_patching_type();
 
   if (slow_path == nullptr) {
@@ -290,24 +290,26 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
       ShouldNotReachHere();
   }
 
+  Label& barrier_target = slow_path == nullptr ? skip_barrier : *slow_path;
   if (slow_path == nullptr) {
-    Label skip_barrier;
-    __ beq(t0, t1, skip_barrier);
+    __ beq(t0, t1, barrier_target, true /* is_far */);
+  } else {
+    __ bne(t0, t1, barrier_target, true /* is_far */);
+  }
 
+  if (slow_path == nullptr) {
     __ rt_call(StubRoutines::method_entry_barrier());
-
     __ j(skip_barrier);
 
     __ bind(local_guard);
 
     MacroAssembler::assert_alignment(__ pc());
     __ emit_int32(0); // nmethod guard value. Skipped over in common case.
-    __ bind(skip_barrier);
   } else {
-    __ beq(t0, t1, *continuation);
-    __ j(*slow_path);
     __ bind(*continuation);
   }
+
+  __ bind(skip_barrier);
 }
 
 void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler* masm) {

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,17 +41,16 @@
 
 static int slow_path_size(nmethod* nm) {
   // The slow path code is out of line with C2.
-  // Leave a jal to the stub in the fast path.
-  return nm->is_compiled_by_c2() ? 1 : 8;
+  return nm->is_compiled_by_c2() ? 0 : 4;
 }
 
 static int entry_barrier_offset(nmethod* nm) {
   BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
   switch (bs_asm->nmethod_patching_type()) {
     case NMethodPatchingType::stw_instruction_and_data_patch:
-      return -4 * (4 + slow_path_size(nm));
+      return -4 * (5 + slow_path_size(nm));
     case NMethodPatchingType::conc_instruction_and_data_patch:
-      return -4 * (15 + slow_path_size(nm));
+      return -4 * ((UseZtso ? 14 : 16) + slow_path_size(nm));
   }
   ShouldNotReachHere();
   return 0;
@@ -103,6 +102,10 @@ public:
         }
         _guard_addr = reinterpret_cast<int*>(instruction_address() + local_guard_offset(nm));
       }
+
+      // Perform the checking as verification.
+      err_msg msg("%s", "");
+      assert(check_barrier(msg), "%s", msg.buffer());
   }
 
   int get_value() {
@@ -128,10 +131,6 @@ public:
   }
 
   bool check_barrier(err_msg& msg) const;
-  void verify() const {
-    err_msg msg("%s", "");
-    assert(check_barrier(msg), "%s", msg.buffer());
-  }
 };
 
 // Store the instruction bitmask, bits and name for checking the barrier.
@@ -142,8 +141,8 @@ struct CheckInsn {
 };
 
 static const struct CheckInsn barrierInsn[] = {
-  { 0x00000fff, 0x00000297, "auipc  t0, 0                     "},
-  { 0x000fffff, 0x0002e283, "lwu    t0, guard_offset(t0)      "},
+  { 0x00000fff, 0x00000297, "auipc  t0, 0               " },
+  { 0x000fffff, 0x0002e283, "lwu    t0, guard_offset(t0)" },
   /* ...... */
   /* ...... */
   /* guard: */
@@ -155,10 +154,11 @@ static const struct CheckInsn barrierInsn[] = {
 // register numbers and immediate values in the encoding.
 bool NativeNMethodBarrier::check_barrier(err_msg& msg) const {
   address addr = instruction_address();
-  for(unsigned int i = 0; i < sizeof(barrierInsn)/sizeof(struct CheckInsn); i++ ) {
+  for (unsigned int i = 0; i < sizeof(barrierInsn) / sizeof(struct CheckInsn); i++) {
     uint32_t inst = Assembler::ld_instr(addr);
     if ((inst & barrierInsn[i].mask) != barrierInsn[i].bits) {
-      msg.print("Addr: " INTPTR_FORMAT " Code: 0x%x not an %s instruction", p2i(addr), inst, barrierInsn[i].name);
+      msg.print("Nmethod entry barrier did not start with auipc & lwu as expected. "
+                "Addr: " INTPTR_FORMAT " Code: 0x%x not an %s instruction.", p2i(addr), inst, barrierInsn[i].name);
       return false;
     }
     addr += 4;


### PR DESCRIPTION
Hi, please consider.

`BarrierSetAssembler::nmethod_entry_barrier` emits two less instructions under UseZtso for `NMethodPatchingType::conc_instruction_and_data_patch`.
But that is not reflected in `entry_barrier_offset`. This doesn't seem to affect basic functionality for now because currently we rely on
`entry_guard_Relocation` relocation to find where the guard is.

But it should be fixed so that we can locate the start of the barrier instructions accurately. This also fixes the size of slow path code
in `slow_path_size` using 4 instead of 8 for non-c2-compiled methods and cleans up code in `BarrierSetAssembler::nmethod_entry_barrier`
making it more readable.

Testing: `hotspot:tier1` - `hotspot:tier2` using fastdebug build on linux-riscv64.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384223](https://bugs.openjdk.org/browse/JDK-8384223): RISC-V: entry_barrier_offset should consider UseZtso (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31106/head:pull/31106` \
`$ git checkout pull/31106`

Update a local copy of the PR: \
`$ git checkout pull/31106` \
`$ git pull https://git.openjdk.org/jdk.git pull/31106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31106`

View PR using the GUI difftool: \
`$ git pr show -t 31106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31106.diff">https://git.openjdk.org/jdk/pull/31106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31106#issuecomment-4411255602)
</details>
