### PR TITLE
8384228: Cleanup compiler/arguments/TestCompilerCounts.java

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCompilerCounts.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompilerCounts.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
  */
 
 /*
- * @test
- * @library /test/lib /
+ * @test id=debug
+ * @library /test/lib
  * @bug 8356000
  * @requires vm.flagless
  * @requires vm.bits == "64"
@@ -33,8 +33,8 @@
  */
 
 /*
- * @test
- * @library /test/lib /
+ * @test id=product
+ * @library /test/lib
  * @bug 8356000
  * @requires vm.flagless
  * @requires vm.bits == "64"
@@ -44,15 +44,10 @@
 
 package compiler.arguments;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.function.Function;
 import jdk.test.lib.Asserts;
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.cli.CommandLineOptionTest;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class TestCompilerCounts {
 


### PR DESCRIPTION
Hi all,

This PR cleanup test compiler/arguments/TestCompilerCounts.java

1. Unuse import
2. Unuse @libary path
3. Use debug/product test id instead of default number test id

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384228](https://bugs.openjdk.org/browse/JDK-8384228): Cleanup compiler/arguments/TestCompilerCounts.java (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31107/head:pull/31107` \
`$ git checkout pull/31107`

Update a local copy of the PR: \
`$ git checkout pull/31107` \
`$ git pull https://git.openjdk.org/jdk.git pull/31107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31107`

View PR using the GUI difftool: \
`$ git pr show -t 31107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31107.diff">https://git.openjdk.org/jdk/pull/31107.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31107#issuecomment-4487590827)
</details>
