### PR TITLE
8379512: C2: Remove macro node flag once a node is removed from Compile::_macro_nodes

### DIFF
--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -428,7 +428,6 @@ public:
 class MaxLNode : public MinMaxNode {
 public:
   MaxLNode(Compile* C, Node* in1, Node* in2) : MinMaxNode(in1, in2) {
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
   virtual int Opcode() const;
@@ -447,7 +446,6 @@ public:
 class MinLNode : public MinMaxNode {
 public:
   MinLNode(Compile* C, Node* in1, Node* in2) : MinMaxNode(in1, in2) {
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
   virtual int Opcode() const;

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -41,7 +41,6 @@ ArrayCopyNode::ArrayCopyNode(Compile* C, bool alloc_tightly_coupled, bool has_ne
     _src_type(TypeOopPtr::BOTTOM),
     _dest_type(TypeOopPtr::BOTTOM) {
   init_class_id(Class_ArrayCopy);
-  init_flags(Flag_is_macro);
   C->add_macro_node(this);
 }
 

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1759,7 +1759,6 @@ AllocateNode::AllocateNode(Compile* C, const TypeFunc *atype,
   : CallNode(atype, nullptr, TypeRawPtr::BOTTOM)
 {
   init_class_id(Class_Allocate);
-  init_flags(Flag_is_macro);
   _is_scalar_replaceable = false;
   _is_non_escaping = false;
   _is_allocation_MemBar_redundant = false;
@@ -2494,7 +2493,6 @@ PowDNode::PowDNode(Compile* C, Node* base, Node* exp)
         OptoRuntime::Math_DD_D_Type(),
         StubRoutines::dpow() != nullptr ? StubRoutines::dpow() : CAST_FROM_FN_PTR(address, SharedRuntime::dpow),
         "pow") {
-  add_flag(Flag_is_macro);
   C->add_macro_node(this);
 
   init_req(TypeFunc::Parms + 0, base);

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -882,19 +882,20 @@ class CallStaticJavaNode : public CallJavaNode {
   // If this is an uncommon trap guarded by some condition, is it safe to change the condition to a narrower condition?
   // See comment in PhaseIdealLoop::do_split_if()
   bool _safe_for_fold_compare;
+  bool _is_boxing_method;
   virtual bool cmp( const Node &n ) const;
   virtual uint size_of() const; // Size is bigger
 public:
   CallStaticJavaNode(Compile* C, const TypeFunc* tf, address addr, ciMethod* method)
-    : CallJavaNode(tf, addr, method), _safe_for_fold_compare(true) {
+    : CallJavaNode(tf, addr, method), _safe_for_fold_compare(true),
+      _is_boxing_method(C->eliminate_boxing() && (method != nullptr) && method->is_boxing_method()) {
     init_class_id(Class_CallStaticJava);
-    if (C->eliminate_boxing() && (method != nullptr) && method->is_boxing_method()) {
-      init_flags(Flag_is_macro);
+    if (_is_boxing_method) {
       C->add_macro_node(this);
     }
   }
   CallStaticJavaNode(const TypeFunc* tf, address addr, const char* name, const TypePtr* adr_type)
-    : CallJavaNode(tf, addr, nullptr), _safe_for_fold_compare(true) {
+    : CallJavaNode(tf, addr, nullptr), _safe_for_fold_compare(true), _is_boxing_method(false) {
     init_class_id(Class_CallStaticJava);
     // This node calls a runtime stub, which often has narrow memory effects.
     _adr_type = adr_type;
@@ -907,7 +908,7 @@ public:
   static int extract_uncommon_trap_request(const Node* call);
 
   bool is_boxing_method() const {
-    return is_macro() && (method() != nullptr) && method()->is_boxing_method();
+    return _is_boxing_method;
   }
   // Late inlining modifies the JVMState, so we need to deep clone it
   // when the call node is cloned (because it is macro node).
@@ -1331,7 +1332,6 @@ public:
   virtual uint size_of() const; // Size is bigger
   LockNode(Compile* C, const TypeFunc *tf) : AbstractLockNode( tf ) {
     init_class_id(Class_Lock);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
   virtual bool        guaranteed_safepoint()  { return false; }
@@ -1360,7 +1360,6 @@ public:
 #endif
   {
     init_class_id(Class_Unlock);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4738,6 +4738,8 @@ void Compile::add_macro_node(Node* n) {
 }
 
 void Compile::remove_macro_node(Node* n) {
+  // This function may be called twice for a node so we can only remove it
+  // if it's still existing.
   _macro_nodes.remove_if_existing(n);
   n->remove_flag(Node::Flag_is_macro);
   // Remove from coarsened locks list if present

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4731,6 +4731,21 @@ void Compile::cleanup_expensive_nodes(PhaseIterGVN &igvn) {
   }
 }
 
+void Compile::add_macro_node(Node* n) {
+  assert(!_macro_nodes.contains(n), "duplicate entry in expand list");
+  n->add_flag(Node::Flag_is_macro);
+  _macro_nodes.append(n);
+}
+
+void Compile::remove_macro_node(Node* n) {
+  _macro_nodes.remove_if_existing(n);
+  n->remove_flag(Node::Flag_is_macro);
+  // Remove from coarsened locks list if present
+  if (coarsened_count() > 0) {
+    remove_coarsened_lock(n);
+  }
+}
+
 void Compile::add_expensive_node(Node * n) {
   assert(!_expensive_nodes.contains(n), "duplicate entry in expensive list");
   assert(n->is_expensive(), "expensive nodes with non-null control here only");

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -729,20 +729,8 @@ public:
 
   ConnectionGraph* congraph()                   { return _congraph;}
   void set_congraph(ConnectionGraph* congraph)  { _congraph = congraph;}
-  void add_macro_node(Node * n) {
-    //assert(n->is_macro(), "must be a macro node");
-    assert(!_macro_nodes.contains(n), "duplicate entry in expand list");
-    _macro_nodes.append(n);
-  }
-  void remove_macro_node(Node* n) {
-    // this function may be called twice for a node so we can only remove it
-    // if it's still existing.
-    _macro_nodes.remove_if_existing(n);
-    // Remove from coarsened locks list if present
-    if (coarsened_count() > 0) {
-      remove_coarsened_lock(n);
-    }
-  }
+  void add_macro_node(Node* n);
+  void remove_macro_node(Node* n);
   void add_expensive_node(Node* n);
   void remove_expensive_node(Node* n) {
     _expensive_nodes.remove_if_existing(n);

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -43,7 +43,6 @@
 #include <math.h>
 
 ModFloatingNode::ModFloatingNode(Compile* C, const TypeFunc* tf, address addr, const char* name) : CallLeafPureNode(tf, addr, name) {
-  add_flag(Flag_is_macro);
   C->add_macro_node(this);
 }
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -570,7 +570,6 @@ class LoopLimitNode : public Node {
  public:
   LoopLimitNode( Compile* C, Node *init, Node *limit, Node *stride ) : Node(nullptr,init,limit,stride) {
     // Put it on the Macro nodes list to optimize during macro nodes expansion.
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
   virtual int Opcode() const;
@@ -591,7 +590,6 @@ public:
   OuterStripMinedLoopNode(Compile* C, Node *entry, Node *backedge)
     : LoopNode(entry, backedge) {
     init_class_id(Class_OuterStripMinedLoop);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -40,7 +40,6 @@ class Opaque1Node : public Node {
   public:
   Opaque1Node(Compile* C, Node *n) : Node(nullptr, n) {
     // Put it on the Macro nodes list to removed during macro nodes expansion.
-    init_flags(Flag_is_macro);
     init_class_id(Class_Opaque1);
     C->add_macro_node(this);
   }
@@ -48,7 +47,6 @@ class Opaque1Node : public Node {
   // which is consumed by range check elimination.
   Opaque1Node(Compile* C, Node *n, Node* orig_limit) : Node(nullptr, n, orig_limit) {
     // Put it on the Macro nodes list to removed during macro nodes expansion.
-    init_flags(Flag_is_macro);
     init_class_id(Class_Opaque1);
     C->add_macro_node(this);
   }
@@ -150,7 +148,6 @@ class OpaqueConstantBoolNode : public Node {
   OpaqueConstantBoolNode(Compile* C, Node* tst, bool constant) : Node(nullptr, tst), _constant(constant) {
     assert(tst->is_Bool() || tst->is_Con(), "Test node must be a BoolNode or a constant");
     init_class_id(Class_OpaqueConstantBool);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 
@@ -241,7 +238,6 @@ class OpaqueInitializedAssertionPredicateNode : public Node {
   OpaqueInitializedAssertionPredicateNode(BoolNode* bol, Compile* C) : Node(nullptr, bol),
       _useless(false) {
     init_class_id(Class_OpaqueInitializedAssertionPredicate);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 

--- a/src/hotspot/share/opto/subtypenode.hpp
+++ b/src/hotspot/share/opto/subtypenode.hpp
@@ -38,7 +38,6 @@ public:
   SubTypeCheckNode(Compile* C, Node* obj_or_subklass, Node* superklass, ciMethod* method, int bci)
     : CmpNode(obj_or_subklass, superklass), _method(method), _bci(bci) {
     init_class_id(Class_SubTypeCheck);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -2093,7 +2093,6 @@ class VectorBoxNode : public Node {
   VectorBoxNode(Compile* C, Node* box, Node* val,
                 const TypeInstPtr* box_type, const TypeVect* vt)
     : Node(nullptr, box, val), _box_type(box_type), _vec_type(vt) {
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 
@@ -2114,7 +2113,6 @@ class VectorBoxAllocateNode : public CallStaticJavaNode {
  public:
   VectorBoxAllocateNode(Compile* C, const TypeInstPtr* vbox_type)
     : CallStaticJavaNode(C, VectorBoxNode::vec_box_type(vbox_type), nullptr, nullptr) {
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 
@@ -2134,7 +2132,6 @@ class VectorUnboxNode : public VectorNode {
   VectorUnboxNode(Compile* C, const TypeVect* vec_type, Node* obj, Node* mem)
     : VectorNode(mem, obj, vec_type) {
     init_class_id(Class_VectorUnbox);
-    init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 


### PR DESCRIPTION
## Changes
- Move `add_macro_node()` / `remove_macro_node()` from inline (compile.hpp) to compile.cpp, and set/clear `Flag_is_macro` centrally in these methods.
- Decouple `CallStaticJavaNode::is_boxing_method()` from `is_macro()` by introducing a `_is_boxing_method` member, so it remains correct after `remove_macro_node()` clears the flag.

## Test
- Verified that `make images` completes without errors.
- Confirmed that `Tier1` tests pass successfully.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379512](https://bugs.openjdk.org/browse/JDK-8379512): C2: Remove macro node flag once a node is removed from Compile::_macro_nodes (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) 🔄 Re-review required (review applies to [7e7c8f94](https://git.openjdk.org/jdk/pull/31110/files/7e7c8f94a69db6e6205b5e92fb845126f812cdde))
 * [Anton Seoane Ampudia](https://openjdk.org/census#aseoane) (@anton-seoane - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31110/head:pull/31110` \
`$ git checkout pull/31110`

Update a local copy of the PR: \
`$ git checkout pull/31110` \
`$ git pull https://git.openjdk.org/jdk.git pull/31110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31110`

View PR using the GUI difftool: \
`$ git pr show -t 31110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31110.diff">https://git.openjdk.org/jdk/pull/31110.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31110#issuecomment-4415677876)
</details>
