### PR TITLE
8384274: Shenandoah: GC checks in C1 LRB clobber fastpath result

### DIFF
--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
@@ -893,13 +893,11 @@ void ShenandoahBarrierSetAssembler::gen_load_reference_barrier_stub(LIR_Assemble
   Register tmp2 = stub->tmp2()->as_register();
   assert_different_registers(addr, res, tmp1, tmp2);
 
-#ifdef ASSERT
-  // Ensure that 'res' is 'R3_ARG1' and contains the same value as 'obj' to reduce the number of required
-  // copy instructions.
   assert(R3_RET == res, "res must be r3");
-  __ cmpd(CR0, res, obj);
-  __ asm_assert_eq("result register must contain the reference stored in obj");
-#endif
+
+  if (res != obj) {
+    __ mr(res, obj);
+  }
 
   DecoratorSet decorators = stub->decorators();
 
@@ -1034,7 +1032,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_load_reference_barrier_runtime_s
   __ save_volatile_gprs(R1_SP, -nbytes_save, true, false);
 
   // Load arguments from stack.
-  // No load required, as assured by assertions in 'ShenandoahBarrierSetAssembler::gen_load_reference_barrier_stub'.
+  // No load required, as caller has already loaded obj into R3.
   Register R3_obj = R3_ARG1;
   Register R4_load_addr = R4_ARG2;
   __ ld(R4_load_addr, -8, R1_SP);

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
@@ -133,7 +133,6 @@ LIR_Opr ShenandoahBarrierSetC1::load_reference_barrier_impl(LIRGenerator* gen, L
   addr = ensure_in_register(gen, addr, T_ADDRESS);
   assert(addr->is_register(), "must be a register at this point");
   LIR_Opr result = gen->result_register_for(obj->value_type());
-  __ move(obj, result);
   LIR_Opr tmp1 = gen->new_register(T_ADDRESS);
   LIR_Opr tmp2 = gen->new_register(T_ADDRESS);
 
@@ -164,6 +163,11 @@ LIR_Opr ShenandoahBarrierSetC1::load_reference_barrier_impl(LIRGenerator* gen, L
 
   CodeStub* slow = new ShenandoahLoadReferenceBarrierStub(obj, addr, result, tmp1, tmp2, decorators);
   __ branch(lir_cond_notEqual, slow);
+
+  // No barrier is needed, move obj to result now.
+  __ move(obj, result);
+
+  // Slow-path re-enters here with result set.
   __ branch_destination(slow->continuation());
 
   return result;

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.hpp
@@ -127,6 +127,7 @@ public:
     visitor->do_input(_addr);
     visitor->do_temp(_addr);
     visitor->do_temp(_result);
+    visitor->do_output(_result);
     visitor->do_temp(_tmp1);
     visitor->do_temp(_tmp2);
   }


### PR DESCRIPTION
See the bug for investigation.

The fix is to move `result` to fast-path branch, let slow-path re-enter with `result` properly set. This also amends PPC64 implementation to match other architectures: do the result move in the stub itself.

Additional testing:
 - [x] Linux PPC64 server fastdebug reproducer does not fail now
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules` with `-XX:+UseShenandoahGC`
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x]  Regular testing pipelines

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384274](https://bugs.openjdk.org/browse/JDK-8384274): Shenandoah: GC checks in C1 LRB clobber fastpath result (**Bug** - P3)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31114/head:pull/31114` \
`$ git checkout pull/31114`

Update a local copy of the PR: \
`$ git checkout pull/31114` \
`$ git pull https://git.openjdk.org/jdk.git pull/31114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31114`

View PR using the GUI difftool: \
`$ git pr show -t 31114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31114.diff">https://git.openjdk.org/jdk/pull/31114.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31114#issuecomment-4420283350)
</details>
