### PR TITLE
8384235: javac crashes with AssertionError: Cannot add metadata to a void type when annotating void as a generic bound

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -705,7 +705,7 @@ public class TypeAnnotations {
 
                 @Override
                 public Type visitType(Type t, List<TypeCompound> s) {
-                    return t.annotatedType(s);
+                    return t.hasTag(TypeTag.VOID) ? t : t.annotatedType(s);
                 }
             };
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5273,7 +5273,7 @@ public class Attr extends JCTree.Visitor {
     public void visitAnnotatedType(JCAnnotatedType tree) {
         attribAnnotationTypes(tree.annotations, env);
         Type underlyingType = attribTree(tree.underlyingType, env, resultInfo);
-        if (underlyingType.getTag() == PACKAGE) {
+        if (underlyingType.getTag() == PACKAGE || underlyingType.getTag() == VOID) {
             result = tree.type = underlyingType;
         } else {
             Type annotatedType = underlyingType.preannotatedType();

--- a/test/langtools/tools/javac/annotations/typeAnnotations/CrashOnVoidType.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/CrashOnVoidType.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384235
+ * @summary Check that javac does not creash when annotating void.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class CrashOnVoidType {
+
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testVoidParam() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         public class Test {
+                             public void op(@Ann void p) {}
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:5:25: compiler.err.void.not.allowed.here",
+                "1 error"));
+    }
+
+    @Test
+    void testVoidLocalVarType() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         public class Test {
+                             public void op() {
+                                 @Ann void l;
+                             }
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:6:14: compiler.err.void.not.allowed.here",
+                "1 error"));
+    }
+
+    @Test
+    void testVoidRecordComponent() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         public record R(@Ann void v) {}
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "R.java:4:22: compiler.err.void.not.allowed.here",
+                "1 error"));
+    }
+
+    @Test
+    void testVoidExceptionParam() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         public class Test {
+                             public void op() {
+                                 try {
+                                 } catch (@Ann void e) {}
+                             }
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:7:23: compiler.err.void.not.allowed.here",
+                "1 error"));
+    }
+
+    @Test
+    void testVoidUnion() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         public class Test {
+                             public void op() {
+                                 try {
+                                 } catch (Exception | @Ann void e) {}
+                             }
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:7:30: compiler.err.illegal.start.of.type",
+                "1 error"));
+    }
+
+    @Test
+    void testVoidTypeParam() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+                         import java.util.List;
+
+                         public class Test {
+                             public List<@Ann void> l;
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:6:17: compiler.err.illegal.start.of.type",
+                "Test.java:6:22: compiler.err.void.not.allowed.here",
+                "2 errors"));
+    }
+
+    @Test
+    void testVoidWildcardBound() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+                         import java.util.List;
+
+                         public class Test {
+                             public List<? extends @Ann void> l;
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:6:17: compiler.err.illegal.start.of.type",
+                "Test.java:6:32: compiler.err.void.not.allowed.here",
+                "2 errors"));
+    }
+
+    @Test
+    void testVoidTypeParamBound() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics")
+                .sources("""
+                         import java.lang.annotation.ElementType;
+                         import java.lang.annotation.Target;
+
+                         public class Test {
+                             public <T extends @Ann void> void op() {}
+                         }
+
+                         @Target(ElementType.TYPE_USE)
+                         @interface Ann {}
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:5:23: compiler.err.illegal.start.of.type",
+                "Test.java:5:28: compiler.err.void.not.allowed.here",
+                "2 errors"));
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Consider the following code snippet:
```
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;

 public class Test {
     public <T extends @Ann void> void op() {}
 }

 @Target(ElementType.TYPE_USE)
 @interface Ann {}
```
Compilation of this source code crashes with the `AssertionError: Cannot add metadata to this type: void` thrown by the `javac` instead of producing the usual `illegal start of type` or `'void' type not allowed here` compilation errors. The same problem arises also in other contexts whenever a `void` type is by mistake annotated with a type annotation.

The proposal here is:
Avoid calling the `preannotatedType()` and `annotatedType(...)` methods on `JCVoidType` instances, thereby preventing type annotations from being added to the `void` type.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8384235: javac crashes with AssertionError: Cannot add metadata to a void type when annotating void as a generic bound`

### Issue
 * [JDK-8384235](https://bugs.openjdk.org/browse/JDK-8384235): javac crashes with AssertionError: Cannot add metadata to a void type when annotating void as a generic bound (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31115/head:pull/31115` \
`$ git checkout pull/31115`

Update a local copy of the PR: \
`$ git checkout pull/31115` \
`$ git pull https://git.openjdk.org/jdk.git pull/31115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31115`

View PR using the GUI difftool: \
`$ git pr show -t 31115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31115.diff">https://git.openjdk.org/jdk/pull/31115.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31115#issuecomment-4420293760)
</details>
