### PR TITLE
8384277: Internal error happened when building fastdebug with LTO

### DIFF
--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -81,7 +81,7 @@
 #define SPELL_REG_SP "rsp"
 #define SPELL_REG_FP "rbp"
 
-address os::current_stack_pointer() {
+NOINLINE address os::current_stack_pointer() {
   return (address)__builtin_frame_address(0);
 }
 


### PR DESCRIPTION
I saw following internal error (see attached hs_err log for details) when I tried to build fastdebug JDK with LTO (`--enable-debug --enable-jvm-feature-link-time-opt`).

```
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (/home/yasuenag/github-forked/jdk/src/hotspot/share/runtime/handles.inline.hpp:76), pid=51951, tid=51954
# assert(_thread->is_in_live_stack((address)this)) failed: not on stack?
#
# JRE version: (27.0) (fastdebug build )
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 27-internal-adhoc.yasuenag.jdk, mixed mode, tiered, compressed oops, g1 gc, linux-amd64)
# Problematic frame:
# V [libjvm.so+0xb7545c] InstanceKlass::link_methods(JavaThread*)+0x43c
```

I saw this error on GCC 11, 15, and 16.

`os::current_stack_pointer()` is implemented as following:
```c++
address os::current_stack_pointer() {
  return (address)__builtin_frame_address(0);
}
```

It would return current FP - if this function is inlined, FP might be less than the address for local variables on stack.
Ideally it is better to compare with SP, but it seems to be difficult because we have to implement `os::current_stack_pointer()` as inlined function on all of platforms. Thus I've proposed not to be inlined function. It is not a valid for knowing SP in precise because `current_stack_pointer()` returns FP of that function, but I think it could be allowed it is not so different from caller SP (SP + return address + saved FP). Actually os_linux_aarch64.cpp has `current_stack_pointer()` with `NOINLINE` like this PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384277](https://bugs.openjdk.org/browse/JDK-8384277): Internal error happened when building fastdebug with LTO (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31116/head:pull/31116` \
`$ git checkout pull/31116`

Update a local copy of the PR: \
`$ git checkout pull/31116` \
`$ git pull https://git.openjdk.org/jdk.git pull/31116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31116`

View PR using the GUI difftool: \
`$ git pr show -t 31116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31116.diff">https://git.openjdk.org/jdk/pull/31116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31116#issuecomment-4420291676)
</details>
