### PR TITLE
8384278: Potential deadlock after JDK-8373839

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -718,7 +718,8 @@ HandshakeState::ProcessResult HandshakeState::try_process(HandshakeOperation* ma
   // It is possible that since we claimed the handshake the op has
   // transitioned to a disabled state and so won't be returned by get_op.
   if (op == nullptr) {
-      return HandshakeState::_no_operation;
+    _lock.unlock();
+    return HandshakeState::_no_operation;
   }
 
   assert(op->is_enabled(), "Should not reach here with a disabled op");


### PR DESCRIPTION
Please review this simple fix where I forgot to unlock the mutex before returning.

Testing:
 - tiers 1-3 (sanity)

Thanks @shipilev  for pointing this out.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384278](https://bugs.openjdk.org/browse/JDK-8384278): Potential deadlock after JDK-8373839 (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31117/head:pull/31117` \
`$ git checkout pull/31117`

Update a local copy of the PR: \
`$ git checkout pull/31117` \
`$ git pull https://git.openjdk.org/jdk.git pull/31117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31117`

View PR using the GUI difftool: \
`$ git pr show -t 31117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31117.diff">https://git.openjdk.org/jdk/pull/31117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31117#issuecomment-4420622742)
</details>
