### PR TITLE
8383767: C2: assert(curr_ctrl->in(0)->Opcode() == Op_If) failed: unexpected node MemBarStoreStore

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -623,7 +623,7 @@ bool ConnectionGraph::can_reduce_phi_at_castpp(Node* phi, Node* castpp, bool tra
     bool can_reduce = iff->Opcode() == Op_If &&
                       iff->in(1)->is_Bool() &&
                       iff->in(1)->in(1)->is_Cmp() &&
-                      (iff->in(1)->in(1)->Opcode() == Op_CmpP || iff->in(1)->in(1)->Opcode() == Op_CmpP) &&
+                      (iff->in(1)->in(1)->Opcode() == Op_CmpP || iff->in(1)->in(1)->Opcode() == Op_CmpN) &&
                       can_reduce_cmp(phi, iff->in(1)->in(1));
     if (can_reduce) {
       return true;

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -603,6 +603,10 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
   return true;
 }
 
+// Returns true if the CastPP's control is simple enough to reduce the Phi; i.e.:
+//  1) no control,
+//  2) the same region as the phi, or
+//  3) an IfTrue/IfFalse coming from an CmpP/N between the phi and a constant.
 bool ConnectionGraph::can_reduce_phi_at_castpp(Node* phi, Node* castpp, bool trace) const {
   bool is_trivial_control = castpp->in(0) == nullptr || castpp->in(0) == phi->in(0);
 

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -582,30 +582,8 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
         return false;
       }
 
-      bool is_trivial_control = use->in(0) == nullptr || use->in(0) == n->in(0);
-      if (!is_trivial_control) {
-        // If it's not a trivial control then we check if we can reduce the
-        // CmpP/N used by the If controlling the cast.
-        if (use->in(0)->is_IfTrue() || use->in(0)->is_IfFalse()) {
-          Node* iff = use->in(0)->in(0);
-          // We may have an OpaqueConstantBool node between If and Bool nodes. But we could also have a sub class of IfNode,
-          // for example, an OuterStripMinedLoopEnd or a Parse Predicate. Bail out in all these cases.
-          bool can_reduce = (iff->Opcode() == Op_If) && iff->in(1)->is_Bool() && iff->in(1)->in(1)->is_Cmp();
-          if (can_reduce) {
-            Node* iff_cmp = iff->in(1)->in(1);
-            int opc = iff_cmp->Opcode();
-            can_reduce = (opc == Op_CmpP || opc == Op_CmpN) && can_reduce_cmp(n, iff_cmp);
-          }
-          if (!can_reduce) {
-#ifndef PRODUCT
-            if (TraceReduceAllocationMerges) {
-              tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
-              n->dump(5);
-            }
-#endif
-            return false;
-          }
-        }
+      if (!can_reduce_phi_at_castpp(n, use)) {
+        return false;
       }
 
       if (!can_reduce_check_users(use, nesting+1)) {
@@ -623,6 +601,38 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
   }
 
   return true;
+}
+
+bool ConnectionGraph::can_reduce_phi_at_castpp(Node* phi, Node* castpp, bool trace) const {
+  bool is_trivial_control = castpp->in(0) == nullptr || castpp->in(0) == phi->in(0);
+
+  if (is_trivial_control) {
+    return true;
+  }
+
+  // If it's not a trivial control then we check if we can reduce the
+  // CmpP/N used by the If controlling the cast.
+  if (castpp->in(0)->is_IfTrue() || castpp->in(0)->is_IfFalse()) {
+    Node* iff = castpp->in(0)->in(0);
+    // We may have an OpaqueConstantBool node between If and Bool nodes. But we could also have a sub class of IfNode,
+    // for example, an OuterStripMinedLoopEnd or a Parse Predicate. Bail out in all these cases.
+    bool can_reduce = iff->Opcode() == Op_If &&
+                      iff->in(1)->is_Bool() &&
+                      iff->in(1)->in(1)->is_Cmp() &&
+                      (iff->in(1)->in(1)->Opcode() == Op_CmpP || iff->in(1)->in(1)->Opcode() == Op_CmpP) &&
+                      can_reduce_cmp(phi, iff->in(1)->in(1));
+    if (can_reduce) {
+      return true;
+    }
+  }
+
+#ifndef PRODUCT
+  if (TraceReduceAllocationMerges && trace) {
+    tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", phi->_idx, _invocation, castpp->_idx);
+    phi->dump(5);
+  }
+#endif
+  return false;
 }
 
 // Returns true if: 1) It's profitable to reduce the merge, and 2) The Phi is
@@ -881,6 +891,7 @@ Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr
 void ConnectionGraph::reduce_phi_on_castpp_field_load(Node* curr_castpp, GrowableArray<Node*> &alloc_worklist) {
   Node* ophi = curr_castpp->in(1);
   assert(ophi->is_Phi(), "Expected this to be a Phi node.");
+  assert(can_reduce_phi_at_castpp(ophi, curr_castpp, false), "precondition");
 
   // Identify which base should be used for AddP->Load later when spliting the
   // CastPP->Loads through ophi. Three kind of values may be stored in this

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,6 +614,7 @@ private:
   bool can_reduce_phi(PhiNode* ophi) const;
   bool can_reduce_check_users(Node* n, uint nesting) const;
   bool can_reduce_phi_check_inputs(PhiNode* ophi) const;
+  bool can_reduce_phi_at_castpp(Node* phi, Node* castpp, bool trace = true) const;
 
   void reduce_phi_on_field_access(Node* previous_addp, GrowableArray<Node *>  &alloc_worklist);
   void reduce_phi_on_castpp_field_load(Node* castpp, GrowableArray<Node*> &alloc_worklist);


### PR DESCRIPTION


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383767](https://bugs.openjdk.org/browse/JDK-8383767): C2: assert(curr_ctrl-&gt;in(0)-&gt;Opcode() == Op_If) failed: unexpected node MemBarStoreStore (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31119/head:pull/31119` \
`$ git checkout pull/31119`

Update a local copy of the PR: \
`$ git checkout pull/31119` \
`$ git pull https://git.openjdk.org/jdk.git pull/31119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31119`

View PR using the GUI difftool: \
`$ git pr show -t 31119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31119.diff">https://git.openjdk.org/jdk/pull/31119.diff</a>

</details>
