### PR TITLE
8334403: Unify behavior of os::committed_in_range across OSes

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -167,11 +167,11 @@ void os::check_core_dump_prerequisites(char* buffer, size_t bufferSize, bool che
   }
 }
 
-bool os::committed_in_range(address start, size_t size, address& committed_start, size_t& committed_size) {
+bool os::live_in_range(address start, size_t size, address& live_start, size_t& live_size) {
 
 #ifdef _AIX
-  committed_start = start;
-  committed_size = size;
+  live_start = start;
+  live_size = size;
   return true;
 #else
 
@@ -188,10 +188,10 @@ bool os::committed_in_range(address start, size_t size, address& committed_start
   assert(is_aligned(start, page_sz), "Start address must be page aligned");
   assert(is_aligned(size, page_sz), "Size must be page aligned");
 
-  committed_start = nullptr;
+  live_start = nullptr;
 
   int loops = checked_cast<int>((pages + stripe - 1) / stripe);
-  int committed_pages = 0;
+  int live_pages = 0;
   address loop_base = start;
   bool found_range = false;
 
@@ -226,30 +226,30 @@ bool os::committed_in_range(address start, size_t size, address& committed_start
     for (uintx vecIdx = 0; vecIdx < pages_to_query; vecIdx ++) {
       if ((vec[vecIdx] & 0x01) == 0) { // not committed
         // End of current contiguous region
-        if (committed_start != nullptr) {
+        if (live_start != nullptr) {
           found_range = true;
           break;
         }
       } else { // committed
         // Start of region
-        if (committed_start == nullptr) {
-          committed_start = loop_base + page_sz * vecIdx;
+        if (live_start == nullptr) {
+          live_start = loop_base + page_sz * vecIdx;
         }
-        committed_pages ++;
+        live_pages ++;
       }
     }
 
     loop_base += pages_to_query * page_sz;
   }
 
-  if (committed_start != nullptr) {
-    assert(committed_pages > 0, "Must have committed region");
-    assert(committed_pages <= int(size / page_sz), "Can not commit more than it has");
-    assert(committed_start >= start && committed_start < start + size, "Out of range");
-    committed_size = page_sz * committed_pages;
+  if (live_start != nullptr) {
+    assert(live_pages > 0, "Must have live region");
+    assert(live_pages <= int(size / page_sz), "Region cannot be smaller than size of live pages");
+    assert(live_start >= start && live_start < start + size, "Out of range");
+    live_size = page_sz * live_pages;
     return true;
   } else {
-    assert(committed_pages == 0, "Should not have committed region");
+    assert(live_pages == 0, "Should not have live region");
     return false;
   }
 #endif

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -167,11 +167,11 @@ void os::check_core_dump_prerequisites(char* buffer, size_t bufferSize, bool che
   }
 }
 
-bool os::live_in_range(address start, size_t size, address& live_start, size_t& live_size) {
+bool os::resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size) {
 
 #ifdef _AIX
-  live_start = start;
-  live_size = size;
+  resident_start = start;
+  resident_size = size;
   return true;
 #else
 
@@ -188,10 +188,10 @@ bool os::live_in_range(address start, size_t size, address& live_start, size_t& 
   assert(is_aligned(start, page_sz), "Start address must be page aligned");
   assert(is_aligned(size, page_sz), "Size must be page aligned");
 
-  live_start = nullptr;
+  resident_start = nullptr;
 
   int loops = checked_cast<int>((pages + stripe - 1) / stripe);
-  int live_pages = 0;
+  int resident_pages = 0;
   address loop_base = start;
   bool found_range = false;
 
@@ -210,7 +210,7 @@ bool os::live_in_range(address start, size_t size, address& live_start, size_t& 
 
     // During shutdown, some memory goes away without properly notifying NMT,
     // E.g. ConcurrentGCThread/WatcherThread can exit without deleting thread object.
-    // Bailout and return as not committed for now.
+    // Bailout and return as not resident for now.
     if (mincore_return_value == -1 && errno == ENOMEM) {
       return false;
     }
@@ -224,32 +224,32 @@ bool os::live_in_range(address start, size_t size, address& live_start, size_t& 
     assert(mincore_return_value == 0, "Range must be valid");
     // Process this stripe
     for (uintx vecIdx = 0; vecIdx < pages_to_query; vecIdx ++) {
-      if ((vec[vecIdx] & 0x01) == 0) { // not committed
+      if ((vec[vecIdx] & 0x01) == 0) { // not resident
         // End of current contiguous region
-        if (live_start != nullptr) {
+        if (resident_start != nullptr) {
           found_range = true;
           break;
         }
-      } else { // committed
+      } else { // resident
         // Start of region
-        if (live_start == nullptr) {
-          live_start = loop_base + page_sz * vecIdx;
+        if (resident_start == nullptr) {
+          resident_start = loop_base + page_sz * vecIdx;
         }
-        live_pages ++;
+        resident_pages ++;
       }
     }
 
     loop_base += pages_to_query * page_sz;
   }
 
-  if (live_start != nullptr) {
-    assert(live_pages > 0, "Must have live region");
-    assert(live_pages <= int(size / page_sz), "Region cannot be smaller than size of live pages");
-    assert(live_start >= start && live_start < start + size, "Out of range");
-    live_size = page_sz * live_pages;
+  if (resident_start != nullptr) {
+    assert(resident_pages > 0, "Must have a resident region");
+    assert(resident_pages <= int(size / page_sz), "Resident size exceeds region size");
+    assert(resident_start >= start && resident_start < start + size, "Out of range");
+    resident_size = page_sz * resident_pages;
     return true;
   } else {
-    assert(live_pages == 0, "Should not have live region");
+    assert(resident_pages == 0, "Should not have a resident region");
     return false;
   }
 #endif

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -167,7 +167,7 @@ void os::check_core_dump_prerequisites(char* buffer, size_t bufferSize, bool che
   }
 }
 
-bool os::resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size) {
+bool os::first_resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size) {
 
 #ifdef _AIX
   resident_start = start;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -465,7 +465,7 @@ void os::current_stack_base_and_size(address* stack_base, size_t* stack_size) {
   *stack_size = size;
 }
 
-bool os::live_in_range(address start, size_t size, address& live_start, size_t& live_size) {
+bool os::resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size) {
   constexpr size_t stripe = 1024;  // query this many pages each time
   PSAPI_WORKING_SET_EX_INFORMATION wsinfo[stripe];
 
@@ -475,10 +475,10 @@ bool os::live_in_range(address start, size_t size, address& live_start, size_t& 
   assert(is_aligned(start, page_sz), "Start address must be page aligned");
   assert(is_aligned(size, page_sz), "Size must be page aligned");
 
-  live_start = nullptr;
+  resident_start = nullptr;
 
   uintx loops = (pages_left + stripe - 1) / stripe;
-  uintx live_pages = 0;
+  uintx resident_pages = 0;
   address pos = start;
   bool found_range = false;
 
@@ -487,7 +487,7 @@ bool os::live_in_range(address start, size_t size, address& live_start, size_t& 
     uintx pages_to_query = MIN2(pages_left, stripe);
     pages_left -= pages_to_query;
 
-    for (int i = 0; i < pages_to_query; i++) {
+    for (uintx i = 0; i < pages_to_query; i++) {
       wsinfo[i].VirtualAddress = (PVOID)(pos + i * page_sz);
     }
 
@@ -496,31 +496,31 @@ bool os::live_in_range(address start, size_t size, address& live_start, size_t& 
       return false;
     }
 
-    for (int i = 0; i < pages_to_query; i++) {
+    for (uintx i = 0; i < pages_to_query; i++) {
       if (wsinfo[i].VirtualAttributes.Valid == 0) {
-        if (live_start != nullptr) {
+        if (resident_start != nullptr) {
           found_range = true;
           break;
         }
-        // Still searching for start of live region
+        // Still searching for start of resident region
       } else {
-        if (live_start == nullptr) {
-          // Found first live page in region
-          live_start = pos + i * page_sz;
+        if (resident_start == nullptr) {
+          // Found first resident page in region
+          resident_start = pos + i * page_sz;
         }
-        live_pages++;
+        resident_pages++;
       }
     }
     pos += pages_to_query * page_sz;
   }
-  if (live_start != nullptr) {
-    assert(live_pages > 0, "Must have live region");
-    assert(live_pages <= size / page_sz, "Region cannot be smaller than size of live pages");
-    assert(live_start >= start && live_start < start + size, "Out of range");
-    live_size = page_sz * live_pages;
+  if (resident_start != nullptr) {
+    assert(resident_pages > 0, "Must have a resident region");
+    assert(resident_pages <= size / page_sz, "Resident size exceeds region size");
+    assert(resident_start >= start && resident_start < start + size, "Out of range");
+    resident_size = page_sz * resident_pages;
     return true;
   } else {
-    assert(live_pages == 0, "Should not have live region");
+    assert(resident_pages == 0, "Should not have a resident region");
     return false;
   }
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -465,36 +465,63 @@ void os::current_stack_base_and_size(address* stack_base, size_t* stack_size) {
   *stack_size = size;
 }
 
-bool os::committed_in_range(address start, size_t size, address& committed_start, size_t& committed_size) {
-  MEMORY_BASIC_INFORMATION minfo;
-  committed_start = nullptr;
-  committed_size = 0;
-  address top = start + size;
-  const address start_addr = start;
-  while (start < top) {
-    VirtualQuery(start, &minfo, sizeof(minfo));
-    if ((minfo.State & MEM_COMMIT) == 0) {  // not committed
-      if (committed_start != nullptr) {
-        break;
-      }
-    } else {  // committed
-      if (committed_start == nullptr) {
-        committed_start = start;
-      }
-      size_t offset = start - (address)minfo.BaseAddress;
-      committed_size += minfo.RegionSize - offset;
-    }
-    start = (address)minfo.BaseAddress + minfo.RegionSize;
-  }
+bool os::live_in_range(address start, size_t size, address& live_start, size_t& live_size) {
+  constexpr size_t stripe = 1024;  // query this many pages each time
+  PSAPI_WORKING_SET_EX_INFORMATION wsinfo[stripe];
 
-  if (committed_start == nullptr) {
-    assert(committed_size == 0, "Sanity");
-    return false;
-  } else {
-    assert(committed_start >= start_addr && committed_start < top, "Out of range");
-    // current region may go beyond the limit, trim to the limit
-    committed_size = MIN2(committed_size, size_t(top - committed_start));
+  size_t page_sz = os::vm_page_size();
+  uintx pages_left = size / page_sz;
+
+  assert(is_aligned(start, page_sz), "Start address must be page aligned");
+  assert(is_aligned(size, page_sz), "Size must be page aligned");
+
+  live_start = nullptr;
+
+  uintx loops = (pages_left + stripe - 1) / stripe;
+  uintx live_pages = 0;
+  address pos = start;
+  bool found_range = false;
+
+  for (uintx index = 0; index < loops && !found_range; index++) {
+    assert(pages_left > 0, "Nothing to do");
+    uintx pages_to_query = MIN2(pages_left, stripe);
+    pages_left -= pages_to_query;
+
+    for (int i = 0; i < pages_to_query; i++) {
+      wsinfo[i].VirtualAddress = (PVOID)(pos + i * page_sz);
+    }
+
+    BOOL success = QueryWorkingSetEx(GetCurrentProcess(), wsinfo, pages_to_query * sizeof(PSAPI_WORKING_SET_EX_INFORMATION));
+    if (!success) {
+      return false;
+    }
+
+    for (int i = 0; i < pages_to_query; i++) {
+      if (wsinfo[i].VirtualAttributes.Valid == 0) {
+        if (live_start != nullptr) {
+          found_range = true;
+          break;
+        }
+        // Still searching for start of live region
+      } else {
+        if (live_start == nullptr) {
+          // Found first live page in region
+          live_start = pos + i * page_sz;
+        }
+        live_pages++;
+      }
+    }
+    pos += pages_to_query * page_sz;
+  }
+  if (live_start != nullptr) {
+    assert(live_pages > 0, "Must have live region");
+    assert(live_pages <= size / page_sz, "Region cannot be smaller than size of live pages");
+    assert(live_start >= start && live_start < start + size, "Out of range");
+    live_size = page_sz * live_pages;
     return true;
+  } else {
+    assert(live_pages == 0, "Should not have live region");
+    return false;
   }
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -465,7 +465,7 @@ void os::current_stack_base_and_size(address* stack_base, size_t* stack_size) {
   *stack_size = size;
 }
 
-bool os::resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size) {
+bool os::first_resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size) {
   constexpr size_t stripe = 1024;  // query this many pages each time
   PSAPI_WORKING_SET_EX_INFORMATION wsinfo[stripe];
 

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -272,29 +272,29 @@ public:
     _start(start), _size(size), _current_start(start) {
   }
 
-  // return true if committed region is found
-  bool next_committed(address& start, size_t& size);
+  // return true if resident region is found
+  bool next_resident(address& start, size_t& size);
 private:
   address end() const { return _start + _size; }
 };
 
-bool RegionIterator::next_committed(address& committed_start, size_t& committed_size) {
+bool RegionIterator::next_resident(address& resident_start, size_t& resident_size) {
   if (end() <= _current_start) return false;
 
   const size_t page_sz = os::vm_page_size();
   const size_t current_size = end() - _current_start;
-  if (os::resident_in_range(_current_start, current_size, committed_start, committed_size)) {
-    assert(committed_start != nullptr, "Must be");
-    assert(committed_size > 0 && is_aligned(committed_size, os::vm_page_size()), "Must be");
+  if (os::resident_in_range(_current_start, current_size, resident_start, resident_size)) {
+    assert(resident_start != nullptr, "Must be");
+    assert(resident_size > 0 && is_aligned(resident_size, os::vm_page_size()), "Must be");
 
-    _current_start = committed_start + committed_size;
+    _current_start = resident_start + resident_size;
     return true;
   } else {
     return false;
   }
 }
 
-// Walk all known thread stacks, snapshot their committed ranges.
+// Walk all known thread stacks, snapshot their resident ranges.
 class SnapshotThreadStackWalker : public VirtualMemoryWalker {
 public:
   SnapshotThreadStackWalker() {}

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -283,7 +283,7 @@ bool RegionIterator::next_committed(address& committed_start, size_t& committed_
 
   const size_t page_sz = os::vm_page_size();
   const size_t current_size = end() - _current_start;
-  if (os::resident_in_range(_current_start, current_size, committed_start, committed_size)) {
+  if (os::first_resident_in_range(_current_start, current_size, committed_start, committed_size)) {
     assert(committed_start != nullptr, "Must be");
     assert(committed_size > 0 && is_aligned(committed_size, os::vm_page_size()), "Must be");
 

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -283,7 +283,7 @@ bool RegionIterator::next_committed(address& committed_start, size_t& committed_
 
   const size_t page_sz = os::vm_page_size();
   const size_t current_size = end() - _current_start;
-  if (os::committed_in_range(_current_start, current_size, committed_start, committed_size)) {
+  if (os::live_in_range(_current_start, current_size, committed_start, committed_size)) {
     assert(committed_start != nullptr, "Must be");
     assert(committed_size > 0 && is_aligned(committed_size, os::vm_page_size()), "Must be");
 

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -272,29 +272,29 @@ public:
     _start(start), _size(size), _current_start(start) {
   }
 
-  // return true if resident region is found
-  bool next_resident(address& start, size_t& size);
+  // return true if committed region is found
+  bool next_committed(address& start, size_t& size);
 private:
   address end() const { return _start + _size; }
 };
 
-bool RegionIterator::next_resident(address& resident_start, size_t& resident_size) {
+bool RegionIterator::next_committed(address& committed_start, size_t& committed_size) {
   if (end() <= _current_start) return false;
 
   const size_t page_sz = os::vm_page_size();
   const size_t current_size = end() - _current_start;
-  if (os::resident_in_range(_current_start, current_size, resident_start, resident_size)) {
-    assert(resident_start != nullptr, "Must be");
-    assert(resident_size > 0 && is_aligned(resident_size, os::vm_page_size()), "Must be");
+  if (os::resident_in_range(_current_start, current_size, committed_start, committed_size)) {
+    assert(committed_start != nullptr, "Must be");
+    assert(committed_size > 0 && is_aligned(committed_size, os::vm_page_size()), "Must be");
 
-    _current_start = resident_start + resident_size;
+    _current_start = committed_start + committed_size;
     return true;
   } else {
     return false;
   }
 }
 
-// Walk all known thread stacks, snapshot their resident ranges.
+// Walk all known thread stacks, snapshot their committed ranges.
 class SnapshotThreadStackWalker : public VirtualMemoryWalker {
 public:
   SnapshotThreadStackWalker() {}

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -283,7 +283,7 @@ bool RegionIterator::next_committed(address& committed_start, size_t& committed_
 
   const size_t page_sz = os::vm_page_size();
   const size_t current_size = end() - _current_start;
-  if (os::live_in_range(_current_start, current_size, committed_start, committed_size)) {
+  if (os::resident_in_range(_current_start, current_size, committed_start, committed_size)) {
     assert(committed_start != nullptr, "Must be");
     assert(committed_size > 0 && is_aligned(committed_size, os::vm_page_size()), "Must be");
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -441,9 +441,10 @@ class os: AllStatic {
  public:
   // get allowed minimum java stack size
   static jlong get_minimum_java_stack_size();
-  // Find committed memory region within specified range (start, start + size),
-  // return true if found any
-  static bool committed_in_range(address start, size_t size, address& committed_start, size_t& committed_size);
+  // Find a live memory region within specified range (start, start + size).
+  // The search begins at the provided start address.
+  // Returns true after the first contiguous live region is found, otherwise false if none found.
+  static bool live_in_range(address start, size_t size, address& committed_start, size_t& committed_size);
 
   // OS interface to Virtual Memory
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -441,10 +441,10 @@ class os: AllStatic {
  public:
   // get allowed minimum java stack size
   static jlong get_minimum_java_stack_size();
-  // Find a live memory region within specified range (start, start + size).
+  // Find a resident memory region within specified range (start, start + size).
   // The search begins at the provided start address.
-  // Returns true after the first contiguous live region is found, otherwise false if none found.
-  static bool live_in_range(address start, size_t size, address& committed_start, size_t& committed_size);
+  // Returns true after the first contiguous resident region is found, otherwise false if none found.
+  static bool resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size);
 
   // OS interface to Virtual Memory
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -441,9 +441,8 @@ class os: AllStatic {
  public:
   // get allowed minimum java stack size
   static jlong get_minimum_java_stack_size();
-  // Find the first resident memory region within specified range (start, start + size).
-  // The search begins at the provided start address.
-  // Returns true after the first contiguous resident region is found, otherwise false if none found.
+  // Find the first resident memory region within the specified range (start, start + size) beginning at the start address.
+  // Returns true if successful or false if none are found.
   static bool first_resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size);
 
   // OS interface to Virtual Memory

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -441,10 +441,10 @@ class os: AllStatic {
  public:
   // get allowed minimum java stack size
   static jlong get_minimum_java_stack_size();
-  // Find a resident memory region within specified range (start, start + size).
+  // Find the first resident memory region within specified range (start, start + size).
   // The search begins at the provided start address.
   // Returns true after the first contiguous resident region is found, otherwise false if none found.
-  static bool resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size);
+  static bool first_resident_in_range(address start, size_t size, address& resident_start, size_t& resident_size);
 
   // OS interface to Virtual Memory
 

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -169,8 +169,8 @@ public:
 
   static void test_partial_region() {
     bool   result;
-    size_t committed_size;
-    address committed_start;
+    size_t resident_size;
+    address resident_start;
     size_t index;
 
     const size_t page_sz = os::vm_page_size();
@@ -187,36 +187,36 @@ public:
     }
 
     // Test whole range
-    result = os::live_in_range((address)base, size, committed_start, committed_size);
+    result = os::resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_TRUE(result);
-    ASSERT_EQ(num_pages * page_sz, committed_size);
-    ASSERT_EQ(committed_start, (address)base);
+    ASSERT_EQ(num_pages * page_sz, resident_size);
+    ASSERT_EQ(resident_start, (address)base);
 
     // Test beginning of the range
-    result = os::live_in_range((address)base, 2 * page_sz, committed_start, committed_size);
+    result = os::resident_in_range((address)base, 2 * page_sz, resident_start, resident_size);
     ASSERT_TRUE(result);
-    ASSERT_EQ(2 * page_sz, committed_size);
-    ASSERT_EQ(committed_start, (address)base);
+    ASSERT_EQ(2 * page_sz, resident_size);
+    ASSERT_EQ(resident_start, (address)base);
 
     // Test end of the range
-    result = os::live_in_range((address)(base + page_sz), 3 * page_sz, committed_start, committed_size);
+    result = os::resident_in_range((address)(base + page_sz), 3 * page_sz, resident_start, resident_size);
     ASSERT_TRUE(result);
-    ASSERT_EQ(3 * page_sz, committed_size);
-    ASSERT_EQ(committed_start, (address)(base + page_sz));
+    ASSERT_EQ(3 * page_sz, resident_size);
+    ASSERT_EQ(resident_start, (address)(base + page_sz));
 
     // Test middle of the range
-    result = os::live_in_range((address)(base + page_sz), 2 * page_sz, committed_start, committed_size);
+    result = os::resident_in_range((address)(base + page_sz), 2 * page_sz, resident_start, resident_size);
     ASSERT_TRUE(result);
-    ASSERT_EQ(2 * page_sz, committed_size);
-    ASSERT_EQ(committed_start, (address)(base + page_sz));
+    ASSERT_EQ(2 * page_sz, resident_size);
+    ASSERT_EQ(resident_start, (address)(base + page_sz));
 
     os::release_memory(base, size);
   }
 
-  static void test_live_in_range(size_t num_pages, size_t pages_to_touch) {
+  static void test_resident_in_range(size_t num_pages, size_t pages_to_touch) {
     bool result;
-    size_t live_size;
-    address live_start;
+    size_t resident_size;
+    address resident_start;
     size_t index;
 
     const size_t page_sz = os::vm_page_size();
@@ -228,7 +228,7 @@ public:
     result = os::commit_memory(base, size, !ExecMem);
     ASSERT_TRUE(result);
 
-    result = os::live_in_range((address)base, size, live_start, live_size);
+    result = os::resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_FALSE(result);
 
     // Touch pages
@@ -236,14 +236,14 @@ public:
       base[index * page_sz] = 'a';
     }
 
-    result = os::live_in_range((address)base, size, live_start, live_size);
+    result = os::resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_TRUE(result);
-    ASSERT_EQ(pages_to_touch * page_sz, live_size);
-    ASSERT_EQ(live_start, (address)base);
+    ASSERT_EQ(pages_to_touch * page_sz, resident_size);
+    ASSERT_EQ(resident_start, (address)base);
 
     os::uncommit_memory(base, size, false);
 
-    result = os::live_in_range((address)base, size, live_start, live_size);
+    result = os::resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_FALSE(result);
 
     os::release_memory(base, size);
@@ -267,8 +267,8 @@ TEST_VM(NMTCommittedVirtualMemoryTracker, test_committed_virtualmemory_region) {
 }
 
 #if !defined(_AIX)
-TEST_VM(NMTCommittedVirtualMemory, test_live_in_range){
-  CommittedVirtualMemoryTest::test_live_in_range(1024, 1024);
-  CommittedVirtualMemoryTest::test_live_in_range(2, 1);
+TEST_VM(NMTCommittedVirtualMemory, test_resident_in_range){
+  CommittedVirtualMemoryTest::test_resident_in_range(1024, 1024);
+  CommittedVirtualMemoryTest::test_resident_in_range(2, 1);
 }
 #endif

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -187,25 +187,25 @@ public:
     }
 
     // Test whole range
-    result = os::resident_in_range((address)base, size, resident_start, resident_size);
+    result = os::first_resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(num_pages * page_sz, resident_size);
     ASSERT_EQ(resident_start, (address)base);
 
     // Test beginning of the range
-    result = os::resident_in_range((address)base, 2 * page_sz, resident_start, resident_size);
+    result = os::first_resident_in_range((address)base, 2 * page_sz, resident_start, resident_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(2 * page_sz, resident_size);
     ASSERT_EQ(resident_start, (address)base);
 
     // Test end of the range
-    result = os::resident_in_range((address)(base + page_sz), 3 * page_sz, resident_start, resident_size);
+    result = os::first_resident_in_range((address)(base + page_sz), 3 * page_sz, resident_start, resident_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(3 * page_sz, resident_size);
     ASSERT_EQ(resident_start, (address)(base + page_sz));
 
     // Test middle of the range
-    result = os::resident_in_range((address)(base + page_sz), 2 * page_sz, resident_start, resident_size);
+    result = os::first_resident_in_range((address)(base + page_sz), 2 * page_sz, resident_start, resident_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(2 * page_sz, resident_size);
     ASSERT_EQ(resident_start, (address)(base + page_sz));
@@ -213,7 +213,7 @@ public:
     os::release_memory(base, size);
   }
 
-  static void test_resident_in_range(size_t num_pages, size_t pages_to_touch) {
+  static void test_first_resident_in_range(size_t num_pages, size_t pages_to_touch) {
     bool result;
     size_t resident_size;
     address resident_start;
@@ -228,7 +228,7 @@ public:
     result = os::commit_memory(base, size, !ExecMem);
     ASSERT_TRUE(result);
 
-    result = os::resident_in_range((address)base, size, resident_start, resident_size);
+    result = os::first_resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_FALSE(result);
 
     // Touch pages
@@ -236,14 +236,14 @@ public:
       base[index * page_sz] = 'a';
     }
 
-    result = os::resident_in_range((address)base, size, resident_start, resident_size);
+    result = os::first_resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(pages_to_touch * page_sz, resident_size);
     ASSERT_EQ(resident_start, (address)base);
 
     os::uncommit_memory(base, size, false);
 
-    result = os::resident_in_range((address)base, size, resident_start, resident_size);
+    result = os::first_resident_in_range((address)base, size, resident_start, resident_size);
     ASSERT_FALSE(result);
 
     os::release_memory(base, size);
@@ -267,8 +267,8 @@ TEST_VM(NMTCommittedVirtualMemoryTracker, test_committed_virtualmemory_region) {
 }
 
 #if !defined(_AIX)
-TEST_VM(NMTCommittedVirtualMemory, test_resident_in_range){
-  CommittedVirtualMemoryTest::test_resident_in_range(1024, 1024);
-  CommittedVirtualMemoryTest::test_resident_in_range(2, 1);
+TEST_VM(NMTCommittedVirtualMemory, test_first_resident_in_range){
+  CommittedVirtualMemoryTest::test_first_resident_in_range(1024, 1024);
+  CommittedVirtualMemoryTest::test_first_resident_in_range(2, 1);
 }
 #endif

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -187,25 +187,25 @@ public:
     }
 
     // Test whole range
-    result = os::committed_in_range((address)base, size, committed_start, committed_size);
+    result = os::live_in_range((address)base, size, committed_start, committed_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(num_pages * page_sz, committed_size);
     ASSERT_EQ(committed_start, (address)base);
 
     // Test beginning of the range
-    result = os::committed_in_range((address)base, 2 * page_sz, committed_start, committed_size);
+    result = os::live_in_range((address)base, 2 * page_sz, committed_start, committed_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(2 * page_sz, committed_size);
     ASSERT_EQ(committed_start, (address)base);
 
     // Test end of the range
-    result = os::committed_in_range((address)(base + page_sz), 3 * page_sz, committed_start, committed_size);
+    result = os::live_in_range((address)(base + page_sz), 3 * page_sz, committed_start, committed_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(3 * page_sz, committed_size);
     ASSERT_EQ(committed_start, (address)(base + page_sz));
 
     // Test middle of the range
-    result = os::committed_in_range((address)(base + page_sz), 2 * page_sz, committed_start, committed_size);
+    result = os::live_in_range((address)(base + page_sz), 2 * page_sz, committed_start, committed_size);
     ASSERT_TRUE(result);
     ASSERT_EQ(2 * page_sz, committed_size);
     ASSERT_EQ(committed_start, (address)(base + page_sz));
@@ -213,10 +213,10 @@ public:
     os::release_memory(base, size);
   }
 
-  static void test_committed_in_range(size_t num_pages, size_t pages_to_touch) {
+  static void test_live_in_range(size_t num_pages, size_t pages_to_touch) {
     bool result;
-    size_t committed_size;
-    address committed_start;
+    size_t live_size;
+    address live_start;
     size_t index;
 
     const size_t page_sz = os::vm_page_size();
@@ -228,7 +228,7 @@ public:
     result = os::commit_memory(base, size, !ExecMem);
     ASSERT_TRUE(result);
 
-    result = os::committed_in_range((address)base, size, committed_start, committed_size);
+    result = os::live_in_range((address)base, size, live_start, live_size);
     ASSERT_FALSE(result);
 
     // Touch pages
@@ -236,14 +236,14 @@ public:
       base[index * page_sz] = 'a';
     }
 
-    result = os::committed_in_range((address)base, size, committed_start, committed_size);
+    result = os::live_in_range((address)base, size, live_start, live_size);
     ASSERT_TRUE(result);
-    ASSERT_EQ(pages_to_touch * page_sz, committed_size);
-    ASSERT_EQ(committed_start, (address)base);
+    ASSERT_EQ(pages_to_touch * page_sz, live_size);
+    ASSERT_EQ(live_start, (address)base);
 
     os::uncommit_memory(base, size, false);
 
-    result = os::committed_in_range((address)base, size, committed_start, committed_size);
+    result = os::live_in_range((address)base, size, live_start, live_size);
     ASSERT_FALSE(result);
 
     os::release_memory(base, size);
@@ -266,9 +266,9 @@ TEST_VM(NMTCommittedVirtualMemoryTracker, test_committed_virtualmemory_region) {
 
 }
 
-#if !defined(_WINDOWS) && !defined(_AIX)
-TEST_VM(NMTCommittedVirtualMemory, test_committed_in_range){
-  CommittedVirtualMemoryTest::test_committed_in_range(1024, 1024);
-  CommittedVirtualMemoryTest::test_committed_in_range(2, 1);
+#if !defined(_AIX)
+TEST_VM(NMTCommittedVirtualMemory, test_live_in_range){
+  CommittedVirtualMemoryTest::test_live_in_range(1024, 1024);
+  CommittedVirtualMemoryTest::test_live_in_range(2, 1);
 }
 #endif


### PR DESCRIPTION
### Summary
`os::committed_in_range` is used by NMT to account for thread stacks. The name is misleading, it actually is meant to find **live** pages not just **committed** pages.  On POSIX (except AIX) this works correctly using `mincore`. On Windows this worked incorrectly using `VirtualQuery` (only finds committed, not live regions). This means that the values reported on Windows were inaccurate.

This PR fixes the Windows implementation by using `QueryWorkingSetEx` instead of `VirtualQuery`. This properly identifies pages that are truly live in the working set, not just committed.  I also renamed `committed_in_range` to `resident_in_range` so that the intention is clearer. I have tried to structure the Windows implementation as similarly to Posix as possible to help with maintainability. 

### Testing
- Tested on windows and linux and64
- `make test TEST=gtest:NMTCommittedVirtualMemory`  (this tests `live_in_range` directly)
- `make test TEST=test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java` (this tests `resident_in_range` indirectly through NMT thread stack accounting)
- `make test TEST=gtest:os`
- `make test TEST=hotspot_nmt`
- tier 1
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334403](https://bugs.openjdk.org/browse/JDK-8334403): Unify behavior of os::committed_in_range across OSes (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31124/head:pull/31124` \
`$ git checkout pull/31124`

Update a local copy of the PR: \
`$ git checkout pull/31124` \
`$ git pull https://git.openjdk.org/jdk.git pull/31124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31124`

View PR using the GUI difftool: \
`$ git pr show -t 31124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31124.diff">https://git.openjdk.org/jdk/pull/31124.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31124#issuecomment-4425657259)
</details>
