### PR TITLE
8378583: (process) ProcessBuilder tests that span deeper trees must pass launchMechanism to their children

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -602,9 +602,22 @@ public class Basic {
     private static final String classpath =
         System.getProperty("java.class.path");
 
+    private static String launchMechanismOverride(){
+        if (Unix.is()) {
+            // Propagate any launchMechanism mode specified for the
+            // parent process to spawned java child processes.
+            var launchMechanism = System.getProperty("jdk.lang.Process.launchMechanism");
+            if (launchMechanism != null) {
+               return "-Djdk.lang.Process.launchMechanism=" + launchMechanism;
+            }
+        }
+        return "";
+    }
+
     private static final List<String> javaChildArgs =
         Arrays.asList(javaExe,
                       "-XX:+DisplayVMOutputToStderr",
+                      launchMechanismOverride(),
                       "-classpath", absolutifyPath(classpath),
                       "Basic$JavaChild");
 

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -602,24 +602,22 @@ public class Basic {
     private static final String classpath =
         System.getProperty("java.class.path");
 
-    private static String launchMechanismOverride(){
-        if (Unix.is()) {
-            // Propagate any launchMechanism mode specified for the
-            // parent process to spawned java child processes.
-            var launchMechanism = System.getProperty("jdk.lang.Process.launchMechanism");
-            if (launchMechanism != null) {
-               return "-Djdk.lang.Process.launchMechanism=" + launchMechanism;
-            }
+    private static List<String> prepareJavaChildArgs() {
+        List<String> javaArgs = new ArrayList<>();
+        javaArgs.add(javaExe);
+        javaArgs.add("-XX:+DisplayVMOutputToStderr");
+        // Propagate launchMechanism mode to spawned java processes if specified.
+        var launchMechanism = System.getProperty("jdk.lang.Process.launchMechanism");
+        if (launchMechanism != null) {
+            javaArgs.add("-Djdk.lang.Process.launchMechanism=" + launchMechanism);
         }
-        return "";
+        javaArgs.add("-classpath");
+        javaArgs.add(absolutifyPath(classpath));
+        javaArgs.add("Basic$JavaChild");
+        return javaArgs;
     }
 
-    private static final List<String> javaChildArgs =
-        Arrays.asList(javaExe,
-                      "-XX:+DisplayVMOutputToStderr",
-                      launchMechanismOverride(),
-                      "-classpath", absolutifyPath(classpath),
-                      "Basic$JavaChild");
+    private static final List<String> javaChildArgs = prepareJavaChildArgs();
 
     private static void testEncoding(String encoding, String tested) {
         try {

--- a/test/jdk/java/lang/ProcessBuilder/InvalidWorkDir.java
+++ b/test/jdk/java/lang/ProcessBuilder/InvalidWorkDir.java
@@ -38,7 +38,7 @@
  * @requires (os.family != "windows")
  * @requires vm.flagless
  * @library /test/lib
- * @run main/othervm -Xmx64m -Djdk.lang.Process.launchMechanism=FORK InvalidWorkDir
+ * @run main/othervm -Xmx64m -Djdk.lang.Process.launchMechanism=POSIX_SPAWN InvalidWorkDir
  */
 
 import jdk.test.lib.process.OutputAnalyzer;


### PR DESCRIPTION
I've reviewed the tests in `tests/jdk/java/lang/ProcessBuilder` for issues where a specific `launchMechanism` mode is explicitly requested for running a test, but is not honoured by  other jvm processes spawned by the test runner.

I found two issues:
  - In `Basic.java` where the specified value for `jdk.lang.Process.launchMechanism` isn't propagated to descendant java processes.
  - In `InvalidWorkDir.java`, where the posix_spawn test run incorrectly runs in fork mode.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378583](https://bugs.openjdk.org/browse/JDK-8378583): (process) ProcessBuilder tests that span deeper trees must pass launchMechanism to their children (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31126/head:pull/31126` \
`$ git checkout pull/31126`

Update a local copy of the PR: \
`$ git checkout pull/31126` \
`$ git pull https://git.openjdk.org/jdk.git pull/31126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31126`

View PR using the GUI difftool: \
`$ git pr show -t 31126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31126.diff">https://git.openjdk.org/jdk/pull/31126.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31126#issuecomment-4423320508)
</details>
