### PR TITLE
8373645: Test vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/TestDescription.java failed: Unexpected event JVMTI_EVENT_COMPILED_METHOD_LOAD

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -465,26 +465,24 @@ static bool setCallBacks(int step) {
             break;
 
         case 2:
-            for (i = 0; i < JVMTI_EVENT_COUNT; i++) {
-                newEventCount[i] = 0;
-            }
-
             eventCallbacks.CompiledMethodLoad   = cbNewCompiledMethodLoad;
             eventCallbacks.CompiledMethodUnload = cbNewCompiledMethodUnload;
             break;
 
         case 3:
-
-            for (i = 0; i < JVMTI_EVENT_COUNT; i++) {
-                newEventCount[i] = 0;
-            }
-
             eventCallbacks.VMDeath                   = cbVMDeath;
             break;
 
     }
     if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return false;
+
+    /* Give some time to complete already started cbNew* events without additional synchronization. */
+    nsk_jvmti_sleep(100);
+    for (i = 0; i < JVMTI_EVENT_COUNT; i++) {
+        newEventCount[i] = 0;
+    }
+
 
     return true;
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
@@ -477,7 +477,7 @@ static bool setCallBacks(int step) {
     if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return false;
 
-    /* Give some time to complete already started cbNew* events without additional synchronization. */
+    /* Give some time to complete already processing cbNew* events. */
     nsk_jvmti_sleep(100);
     for (i = 0; i < JVMTI_EVENT_COUNT; i++) {
         newEventCount[i] = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
@@ -325,8 +325,9 @@ cbVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     changeCount(JVMTI_EVENT_VM_OBJECT_ALLOC, &eventCount[0]);
 }
 
+/* Sanity check of method id. */
 void
-handlerMC2(jvmtiEvent event, jvmtiEnv* jvmti, jmethodID method) {
+handlerMC2(jvmtiEnv* jvmti, jmethodID method) {
 
     char *name;
     char *sign;
@@ -338,7 +339,6 @@ handlerMC2(jvmtiEvent event, jvmtiEnv* jvmti, jmethodID method) {
     }
 
     NSK_DISPLAY2("\tMethod: %s, signature: %s\n", name, sign);
-    changeCount(event, &newEventCount[0]);
 
     if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
@@ -358,7 +358,9 @@ cbNewCompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
                 const jvmtiAddrLocationMap* map, const void* compile_info) {
 
     loadEvents++;
-    handlerMC2(JVMTI_EVENT_COMPILED_METHOD_LOAD, jvmti_env, method);
+    changeCount(JVMTI_EVENT_COMPILED_METHOD_LOAD, &newEventCount[0]);
+    NSK_DISPLAY0(">>>JVMTI_EVENT_COMPILED_METHOD_LOAD received for\n");
+    handlerMC2(jvmti_env, method);
 }
 
 void JNICALL
@@ -366,8 +368,8 @@ cbNewCompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
                 const void* code_addr) {
 
     unloadEvents++;
-    NSK_DISPLAY0(">>>JVMTI_EVENT_COMPILED_METHOD_UNLOAD received for\n");
     changeCount(JVMTI_EVENT_COMPILED_METHOD_UNLOAD, &newEventCount[0]);
+    NSK_DISPLAY0(">>>JVMTI_EVENT_COMPILED_METHOD_UNLOAD received for\n");
 }
 
 /* ============================================================================= */
@@ -477,7 +479,7 @@ static bool setCallBacks(int step) {
     if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return false;
 
-    /* Give some time to complete already processing cbNew* events. */
+    /* Give some time to complete already processing cbNewCompiledMethodLoad/Unload events. */
     nsk_jvmti_sleep(100);
     for (i = 0; i < JVMTI_EVENT_COUNT; i++) {
         newEventCount[i] = 0;


### PR DESCRIPTION
Please review following test fix that improve synchronization of compiled method load/unload events.

The CompiledMethodLoad/CompiledMethodUnload might be already executing while SetEventCallbacks removed their callbacks.
Thus they hit 'newEventCount' after setting it to zero and cause test to fail.

The simple monitor inside event doesn't help, because race might happen while callback is calling in VM or before it obtain lock.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373645](https://bugs.openjdk.org/browse/JDK-8373645): Test vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/TestDescription.java failed: Unexpected event JVMTI_EVENT_COMPILED_METHOD_LOAD (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31128/head:pull/31128` \
`$ git checkout pull/31128`

Update a local copy of the PR: \
`$ git checkout pull/31128` \
`$ git pull https://git.openjdk.org/jdk.git pull/31128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31128`

View PR using the GUI difftool: \
`$ git pr show -t 31128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31128.diff">https://git.openjdk.org/jdk/pull/31128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31128#issuecomment-4425678849)
</details>
