### PR TITLE
8384131: Lowering of array enhanced for loop misses a synthetic cast

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3568,7 +3568,7 @@ public class Lower extends TreeTranslator {
          *             int #len = array.length;
          *             int #i = 0; };
          *           #i < #len; i$++ ) {
-         *         T v = arr$[#i];
+         *         T v = (T) arr$[#i];
          *         stmt;
          *     }
          * }</pre>
@@ -3604,6 +3604,7 @@ public class Lower extends TreeTranslator {
             Type elemtype = types.elemtype(tree.expr.type);
             JCExpression loopvarinit = make.Indexed(make.Ident(arraycache),
                                                     make.Ident(index)).setType(elemtype);
+            loopvarinit = transTypes.coerce(attrEnv, loopvarinit, tree.var.type);
             JCVariableDecl loopvardef = (JCVariableDecl)make.VarDef(tree.var.mods,
                                                   tree.var.name,
                                                   tree.var.vartype,

--- a/test/langtools/tools/javac/foreach/T8384131.java
+++ b/test/langtools/tools/javac/foreach/T8384131.java
@@ -52,12 +52,6 @@ public class T8384131 {
             }
         }
 
-        void testArrayEagerCCE(Z[] arr) {
-            for (I i : arr) {
-                throw new AssertionError("reached beyond for-header");
-            }
-        }
-
         void testList(List<Z> l) {
             for (I i : l) {
                 i.f();
@@ -70,11 +64,11 @@ public class T8384131 {
     public static void main(String[] args) throws Exception {
         // neg tests
         expectCCE(() -> new Test().testArray(new C[] { new C() }));
-        expectCCE(() -> new Test().testArrayEagerCCE(new C[] { new C() }));
         expectCCE(() -> new Test().testList(List.of(new C())));
 
         // pos tests
         new Test<CI>().testArray(new CI[] { new CI() });
+        checkPrimitiveConversionsResults();
         checkPrimitiveConversionsBytecode();
     }
 
@@ -90,34 +84,65 @@ public class T8384131 {
     }
 
     // <editor-fold defaultstate="collapsed" desc="Conversions to Inspect">
-    static <T extends Integer> void integerTypeVariableArrayToIntWideningReferenceAndUnboxing(T[] values) {
-        for (int i : values) { }
+    static <T extends Integer> int integerTypeVariableArrayToIntWideningReferenceAndUnboxing(T[] values) {
+        for (int i : values) {
+            return i;
+        }
+        return 0;
     }
 
-    static <T extends Short> void shortTypeVariableArrayToIntWideningReferenceAndUnboxingAndPrimitiveWidening(T[] values) {
-        for (int i : values) { }
+    static <T extends Short> int shortTypeVariableArrayToIntWideningReferenceAndUnboxingAndPrimitiveWidening(T[] values) {
+        for (int i : values) {
+            return i;
+        }
+        return 0;
     }
 
-    static void intArrayToLongPrimitiveWidening() {
-        for (long l : new int[] { 1 }) { }
+    static long intArrayToLongPrimitiveWidening(int[] values) {
+        for (long l : values) {
+            return l;
+        }
+        return 0L;
     }
 
-    static void integerArrayToIntUnboxing() {
-        for (int i : new Integer[] { 1 }) { }
+    static int integerArrayToIntUnboxing(Integer[] values) {
+        for (int i : values) {
+            return i;
+        }
+        return 0;
     }
 
-    static void integerArrayToLongUnboxingAndPrimitiveWidening() {
-        for (long l : new Integer[] { 1 }) { }
+    static long integerArrayToLongUnboxingAndPrimitiveWidening(Integer[] values) {
+        for (long l : values) {
+            return l;
+        }
+        return 0L;
     }
 
-    static void intArrayToIntegerBoxing() {
-        for (Integer i : new int[] { 1 }) { }
+    static Integer intArrayToIntegerBoxing(int[] values) {
+        for (Integer i : values) {
+            return i;
+        }
+        return null;
     }
 
-    static void intArrayToObjectBoxingAndWideningReference() {
-        for (Object o : new int[] { 1 }) { }
+    static Object intArrayToObjectBoxingAndWideningReference(int[] values) {
+        for (Object o : values) {
+            return o;
+        }
+        return null;
     }
     // </editor-fold>
+
+    static void checkPrimitiveConversionsResults() {
+        expectEquals(1, integerTypeVariableArrayToIntWideningReferenceAndUnboxing(new Integer[] { 1 }));
+        expectEquals(1, shortTypeVariableArrayToIntWideningReferenceAndUnboxingAndPrimitiveWidening(new Short[] { 1 }));
+        expectEquals(1L, intArrayToLongPrimitiveWidening(new int[] { 1 }));
+        expectEquals(1, integerArrayToIntUnboxing(new Integer[] { 1 }));
+        expectEquals(1L, integerArrayToLongUnboxingAndPrimitiveWidening(new Integer[] { 1 }));
+        expectEquals(Integer.valueOf(1), intArrayToIntegerBoxing(new int[] { 1 }));
+        expectEquals(Integer.valueOf(1), intArrayToObjectBoxingAndWideningReference(new int[] { 1 }));
+    }
 
     static void checkPrimitiveConversionsBytecode() throws Exception {
         String out = new JavapTask(new ToolBox())
@@ -131,33 +156,48 @@ public class T8384131 {
 
         expect(out, "intArrayToLongPrimitiveWidening",
                 """
-                        20: iaload
-                        21: i2l
+                    descriptor: ([I)J
+                """,
+                """
+                        14: iaload
+                        15: i2l
                 """);
         expect(out, "integerArrayToIntUnboxing",
                 """
-                        24: aaload
-                        25: invokevirtual # // Method java/lang/Integer.intValue:()I
+                    descriptor: ([Ljava/lang/Integer;)I
+                """,
+                """
+                        14: aaload
+                        15: invokevirtual # // Method java/lang/Integer.intValue:()I
                 """);
         expect(out, "integerArrayToLongUnboxingAndPrimitiveWidening",
                 """
-                        24: aaload
-                        25: invokevirtual # // Method java/lang/Integer.intValue:()I
-                        28: i2l
+                    descriptor: ([Ljava/lang/Integer;)J
+                """,
+                """
+                        14: aaload
+                        15: invokevirtual # // Method java/lang/Integer.intValue:()I
+                        18: i2l
                 """);
         expect(out, "intArrayToIntegerBoxing",
                 """
-                        20: iaload
-                        21: invokestatic  # // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+                    descriptor: ([I)Ljava/lang/Integer;
+                """,
+                """
+                        14: iaload
+                        15: invokestatic  # // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
                 """);
         expect(out, "intArrayToObjectBoxingAndWideningReference",
                 """
-                        20: iaload
-                        21: invokestatic  # // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+                    descriptor: ([I)Ljava/lang/Object;
+                """,
+                """
+                        14: iaload
+                        15: invokestatic  # // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
                 """);
         expect(out, "integerTypeVariableArrayToIntWideningReferenceAndUnboxing",
                 """
-                    descriptor: ([Ljava/lang/Integer;)V
+                    descriptor: ([Ljava/lang/Integer;)I
                 """,
                 """
                         14: aaload
@@ -165,7 +205,7 @@ public class T8384131 {
                 """);
         expect(out, "shortTypeVariableArrayToIntWideningReferenceAndUnboxingAndPrimitiveWidening",
                 """
-                    descriptor: ([Ljava/lang/Short;)V
+                    descriptor: ([Ljava/lang/Short;)I
                 """,
                 """
                         14: aaload
@@ -184,6 +224,12 @@ public class T8384131 {
             if (!method.contains(fragment)) {
                 throw new AssertionError("Expected:\n" + fragment + "\nin " + methodName + ":\n" + method);
             }
+        }
+    }
+
+    static void expectEquals(Object expected, Object actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError("Expected: " + expected + ", actual: " + actual);
         }
     }
 }

--- a/test/langtools/tools/javac/foreach/T8384131.java
+++ b/test/langtools/tools/javac/foreach/T8384131.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384131
+ * @summary Lowering of array enhanced for loop misses a synthetic cast
+ * @library /tools/lib
+ * @modules java.compiler
+ *          jdk.jdeps/com.sun.tools.javap
+ * @build toolbox.JavapTask
+ * @run main T8384131
+ */
+import java.util.List;
+import java.util.stream.Collectors;
+
+import toolbox.JavapTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class T8384131 {
+
+    static class C { }
+    interface I {
+        default void f() {}
+    }
+
+    static class Test<Z extends C & I> {
+        void testArray(Z[] arr) {
+            for (I i : arr) {
+                i.f();
+            }
+        }
+
+        void testArrayEagerCCE(Z[] arr) {
+            for (I i : arr) {
+                throw new AssertionError("reached beyond for-header");
+            }
+        }
+
+        void testList(List<Z> l) {
+            for (I i : l) {
+                i.f();
+            }
+        }
+    }
+
+    static class CI extends C implements I { }
+
+    public static void main(String[] args) throws Exception {
+        // neg tests
+        expectCCE(() -> new Test().testArray(new C[] { new C() }));
+        expectCCE(() -> new Test().testArrayEagerCCE(new C[] { new C() }));
+        expectCCE(() -> new Test().testList(List.of(new C())));
+
+        // pos tests
+        new Test<CI>().testArray(new CI[] { new CI() });
+        checkPrimitiveConversionsBytecode();
+    }
+
+    static void expectCCE(Runnable action) {
+        try {
+            action.run();
+            throw new AssertionError("expected CCE");
+        } catch (ClassCastException expected) {
+            // expected
+        } catch (IncompatibleClassChangeError wrong) {
+            throw new AssertionError("got ICCE", wrong);
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="Conversions to Inspect">
+    static <T extends Integer> void integerTypeVariableArrayToIntWideningReferenceAndUnboxing(T[] values) {
+        for (int i : values) { }
+    }
+
+    static <T extends Short> void shortTypeVariableArrayToIntWideningReferenceAndUnboxingAndPrimitiveWidening(T[] values) {
+        for (int i : values) { }
+    }
+
+    static void intArrayToLongPrimitiveWidening() {
+        for (long l : new int[] { 1 }) { }
+    }
+
+    static void integerArrayToIntUnboxing() {
+        for (int i : new Integer[] { 1 }) { }
+    }
+
+    static void integerArrayToLongUnboxingAndPrimitiveWidening() {
+        for (long l : new Integer[] { 1 }) { }
+    }
+
+    static void intArrayToIntegerBoxing() {
+        for (Integer i : new int[] { 1 }) { }
+    }
+
+    static void intArrayToObjectBoxingAndWideningReference() {
+        for (Object o : new int[] { 1 }) { }
+    }
+    // </editor-fold>
+
+    static void checkPrimitiveConversionsBytecode() throws Exception {
+        String out = new JavapTask(new ToolBox())
+                .options("-c", "-private", "-s")
+                .classpath(System.getProperty("test.classes"))
+                .classes("T8384131")
+                .run()
+                .getOutputLines(Task.OutputKind.DIRECT)
+                .stream()
+                .collect(Collectors.joining("\n"));
+
+        expect(out, "intArrayToLongPrimitiveWidening",
+                """
+                        20: iaload
+                        21: i2l
+                """);
+        expect(out, "integerArrayToIntUnboxing",
+                """
+                        24: aaload
+                        25: invokevirtual # // Method java/lang/Integer.intValue:()I
+                """);
+        expect(out, "integerArrayToLongUnboxingAndPrimitiveWidening",
+                """
+                        24: aaload
+                        25: invokevirtual # // Method java/lang/Integer.intValue:()I
+                        28: i2l
+                """);
+        expect(out, "intArrayToIntegerBoxing",
+                """
+                        20: iaload
+                        21: invokestatic  # // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+                """);
+        expect(out, "intArrayToObjectBoxingAndWideningReference",
+                """
+                        20: iaload
+                        21: invokestatic  # // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
+                """);
+        expect(out, "integerTypeVariableArrayToIntWideningReferenceAndUnboxing",
+                """
+                    descriptor: ([Ljava/lang/Integer;)V
+                """,
+                """
+                        14: aaload
+                        15: invokevirtual # // Method java/lang/Integer.intValue:()I
+                """);
+        expect(out, "shortTypeVariableArrayToIntWideningReferenceAndUnboxingAndPrimitiveWidening",
+                """
+                    descriptor: ([Ljava/lang/Short;)V
+                """,
+                """
+                        14: aaload
+                        15: invokevirtual # // Method java/lang/Short.shortValue:()S
+                """);
+    }
+
+    static void expect(String out, String methodName, String... expectedFragments) {
+        int start = out.indexOf(methodName + "(");
+        int end = out.indexOf("\n\n", start);
+        String method = out
+                .substring(start, end == -1 ? out.length() : end)
+                .replaceAll("#\\d+\\s+//", "# //");
+        for (String expected : expectedFragments) {
+            String fragment = expected.stripTrailing();
+            if (!method.contains(fragment)) {
+                throw new AssertionError("Expected:\n" + fragment + "\nin " + methodName + ":\n" + method);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR aligns the translation of the element access in an array-based enhanced-for loop (`#a[#i]`) by applying `transTypes.coerce` to the array element expression produced by `#a[#i]` before it is used to initialise the enhanced-for loop variable. That effectively preserves the type of the element in the case of reference-to-reference assignment. The rest of the conversions are preserved in the assignment context and should be reflected in the bytecode. The regression test checks both the failing case with the intersection types (the reference-to-reference case) and the primitive-related array conversions. In the latter, I try to discover the observable behavior at the bytecode level (for example, no `checkcast`). For the generic methods, the appearance of the descriptor suffices I think.

(note: the array lowering does not need to replicate the `Iterable` lowering’s primitive/reference `if`. In the array case, there is no erased `Object next()` call. The bytecode operation should be `aaload` from an `Integer[]`, `Short[]`, `C[]`, etc., or `iaload` from an `int[]`)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384131](https://bugs.openjdk.org/browse/JDK-8384131): Lowering of array enhanced for loop misses a synthetic cast (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31129/head:pull/31129` \
`$ git checkout pull/31129`

Update a local copy of the PR: \
`$ git checkout pull/31129` \
`$ git pull https://git.openjdk.org/jdk.git pull/31129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31129`

View PR using the GUI difftool: \
`$ git pr show -t 31129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31129.diff">https://git.openjdk.org/jdk/pull/31129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31129#issuecomment-4429473714)
</details>
