### PR TITLE
8385564: Replace VMA linked list with hashtable in MemBaseline

### DIFF
--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -138,7 +138,6 @@ bool MemBaseline::baseline_allocation_sites() {
   if (!aggregate_virtual_memory_allocation_sites()) {
     return false;
   }
-  sort_virtual_memory_sites(by_address);
 
   return true;
 }
@@ -159,11 +158,6 @@ void MemBaseline::baseline(bool summaryOnly) {
     baseline_allocation_sites();
     _baseline_type = Detail_baselined;
   }
-}
-
-int compare_allocation_site(const VirtualMemoryAllocationSite& s1,
-  const VirtualMemoryAllocationSite& s2) {
-  return s1.call_stack()->compare(*s2.call_stack());
 }
 
 bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
@@ -196,7 +190,11 @@ bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
     return false;
   }
   _virtual_memory_sites = vht.detach(&_virtual_memory_sites_length);
-  return _virtual_memory_sites != nullptr;
+  if (_virtual_memory_sites == nullptr) {
+    return false;
+  }
+  sort_virtual_memory_sites(by_site);
+  return true;
 }
 
 MallocSiteIterator MemBaseline::malloc_sites(SortingOrder order) {

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -209,7 +209,6 @@ MallocSiteIterator MemBaseline::malloc_sites(SortingOrder order) {
     case by_site_and_tag:
       malloc_sites_to_allocation_site_and_tag_order();
       break;
-    case by_address:
     default:
       ShouldNotReachHere();
   }
@@ -225,7 +224,6 @@ void MemBaseline::sort_virtual_memory_sites(SortingOrder order) {
     case by_site:
       virtual_memory_sites_to_reservation_site_order();
       break;
-    case by_address:
     default:
       ShouldNotReachHere();
   }

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -196,7 +196,7 @@ bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
     return false;
   }
   _virtual_memory_sites = vht.detach(&_virtual_memory_sites_length);
-  return true;
+  return _virtual_memory_sites != nullptr;
 }
 
 MallocSiteIterator MemBaseline::malloc_sites(SortingOrder order) {
@@ -281,12 +281,12 @@ void MemBaseline::virtual_memory_sites_to_size_order() {
 }
 
 void MemBaseline::virtual_memory_sites_to_reservation_site_order() {
-  if (_virtual_memory_sites_order != by_size) {
+  if (_virtual_memory_sites_order != by_site) {
     ::qsort(_virtual_memory_sites, _virtual_memory_sites_length, sizeof(VirtualMemoryAllocationSite),
             [](const void* a, const void* b) -> int {
               return compare_virtual_memory_site(*static_cast<const VirtualMemoryAllocationSite*>(a),
                                                  *static_cast<const VirtualMemoryAllocationSite*>(b));
             });
-    _virtual_memory_sites_order = by_size;
+    _virtual_memory_sites_order = by_site;
   }
 }

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -28,6 +28,7 @@
 #include "nmt/memBaseline.hpp"
 #include "nmt/memTracker.hpp"
 #include "nmt/regionsTree.inline.hpp"
+#include "nmt/virtualMemoryTracker.hpp"
 
 /*
  * Sizes are sorted in descenting order for reporting
@@ -41,7 +42,6 @@ int compare_malloc_size(const MallocSite& s1, const MallocSite& s2) {
     return 1;
   }
 }
-
 
 int compare_virtual_memory_size(const VirtualMemoryAllocationSite& s1,
   const VirtualMemoryAllocationSite& s2) {
@@ -138,8 +138,7 @@ bool MemBaseline::baseline_allocation_sites() {
   if (!aggregate_virtual_memory_allocation_sites()) {
     return false;
   }
-  // Virtual memory allocation sites are aggregrated in call stack order
-  _virtual_memory_sites_order = by_address;
+  sort_virtual_memory_sites(by_address);
 
   return true;
 }
@@ -168,25 +167,27 @@ int compare_allocation_site(const VirtualMemoryAllocationSite& s1,
 }
 
 bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
-
-  SortedLinkedList<VirtualMemoryAllocationSite, compare_allocation_site> allocation_sites;
-
+  auto stack = [](const VirtualMemoryAllocationSite& vmas) -> const NativeCallStack& { return *vmas.call_stack(); };
+  auto hash = [](const NativeCallStack& ncs) { return ncs.calculate_hash(); };
+  auto equals = [](const NativeCallStack& a, const NativeCallStack& b) { return a.equals(b); };
+  using VirtualMemorySiteTable = OpenAddressedHashTable<VirtualMemoryAllocationSite,
+                                                        decltype(stack),
+                                                        decltype(hash),
+                                                        decltype(equals),
+                                                        mtNMT, AllocFailStrategy::RETURN_NULL,
+                                                        75>;
+  VirtualMemorySiteTable vht(stack, hash, equals);
   VirtualMemoryAllocationSite* site;
   bool failed_oom = false;
   _vma_allocations->visit_reserved_regions([&](VirtualMemoryRegion& rgn) {
     VirtualMemoryAllocationSite tmp(*rgn.reserved_call_stack(), rgn.mem_tag());
-    site = allocation_sites.find(tmp);
+    bool found;
+    site = vht.put_if_absent(tmp, &found);
     if (site == nullptr) {
-      LinkedListNode<VirtualMemoryAllocationSite>* node =
-        allocation_sites.add(tmp);
-      if (node == nullptr) {
-        failed_oom = true;
-        return false;
-      }
-      site = node->data();
+      failed_oom = true;
+      return false;
     }
     site->reserve_memory(rgn.size());
-
     site->commit_memory(_vma_allocations->committed_size(rgn));
     return true;
   });
@@ -194,8 +195,7 @@ bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
   if (failed_oom) {
     return false;
   }
-
-  _virtual_memory_sites.move(&allocation_sites);
+  _virtual_memory_sites = vht.detach(&_virtual_memory_sites_length);
   return true;
 }
 
@@ -218,8 +218,8 @@ MallocSiteIterator MemBaseline::malloc_sites(SortingOrder order) {
   return MallocSiteIterator(_malloc_sites.head());
 }
 
-VirtualMemorySiteIterator MemBaseline::virtual_memory_sites(SortingOrder order) {
-  assert(!_virtual_memory_sites.is_empty(), "Not detail baseline");
+void MemBaseline::sort_virtual_memory_sites(SortingOrder order) {
+  assert(_virtual_memory_sites_length != 0, "Not detail baseline");
   switch(order) {
     case by_size:
       virtual_memory_sites_to_size_order();
@@ -231,7 +231,6 @@ VirtualMemorySiteIterator MemBaseline::virtual_memory_sites(SortingOrder order) 
     default:
       ShouldNotReachHere();
   }
-  return VirtualMemorySiteIterator(_virtual_memory_sites.head());
 }
 
 
@@ -272,26 +271,22 @@ void MemBaseline::malloc_sites_to_allocation_site_and_tag_order() {
 
 void MemBaseline::virtual_memory_sites_to_size_order() {
   if (_virtual_memory_sites_order != by_size) {
-    SortedLinkedList<VirtualMemoryAllocationSite, compare_virtual_memory_size> tmp;
-
-    tmp.move(&_virtual_memory_sites);
-
-    _virtual_memory_sites.set_head(tmp.head());
-    tmp.set_head(nullptr);
+    ::qsort(_virtual_memory_sites, _virtual_memory_sites_length, sizeof(VirtualMemoryAllocationSite),
+          [](const void* a, const void* b) -> int {
+            return compare_virtual_memory_size(*static_cast<const VirtualMemoryAllocationSite*>(a),
+                                               *static_cast<const VirtualMemoryAllocationSite*>(b));
+          });
     _virtual_memory_sites_order = by_size;
   }
 }
 
 void MemBaseline::virtual_memory_sites_to_reservation_site_order() {
   if (_virtual_memory_sites_order != by_size) {
-    SortedLinkedList<VirtualMemoryAllocationSite, compare_virtual_memory_site> tmp;
-
-    tmp.move(&_virtual_memory_sites);
-
-    _virtual_memory_sites.set_head(tmp.head());
-    tmp.set_head(nullptr);
-
+    ::qsort(_virtual_memory_sites, _virtual_memory_sites_length, sizeof(VirtualMemoryAllocationSite),
+            [](const void* a, const void* b) -> int {
+              return compare_virtual_memory_site(*static_cast<const VirtualMemoryAllocationSite*>(a),
+                                                 *static_cast<const VirtualMemoryAllocationSite*>(b));
+            });
     _virtual_memory_sites_order = by_size;
   }
 }
-

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -161,16 +161,14 @@ void MemBaseline::baseline(bool summaryOnly) {
 }
 
 bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
-  auto stack = [](const VirtualMemoryAllocationSite& vmas) -> const NativeCallStack& { return *vmas.call_stack(); };
-  auto hash = [](const NativeCallStack& ncs) { return ncs.calculate_hash(); };
-  auto equals = [](const NativeCallStack& a, const NativeCallStack& b) { return a.equals(b); };
+  auto hash = [](const VirtualMemoryAllocationSite& vmas) { return vmas.call_stack()->calculate_hash(); };
+  auto equals = [](const VirtualMemoryAllocationSite& a, const VirtualMemoryAllocationSite& b) { return a.equals(b); };
   using VirtualMemorySiteTable = OpenAddressedHashTable<VirtualMemoryAllocationSite,
-                                                        decltype(stack),
                                                         decltype(hash),
                                                         decltype(equals),
                                                         mtNMT, AllocFailStrategy::RETURN_NULL,
                                                         75>;
-  VirtualMemorySiteTable vht(stack, hash, equals);
+  VirtualMemorySiteTable vht(hash, equals);
   VirtualMemoryAllocationSite* site;
   bool failed_oom = false;
   _vma_allocations->visit_reserved_regions([&](VirtualMemoryRegion& rgn) {
@@ -268,7 +266,7 @@ void MemBaseline::malloc_sites_to_allocation_site_and_tag_order() {
 void MemBaseline::virtual_memory_sites_to_size_order() {
   if (_virtual_memory_sites_order != by_size) {
     ::qsort(_virtual_memory_sites, _virtual_memory_sites_length, sizeof(VirtualMemoryAllocationSite),
-          [](const void* a, const void* b) -> int {
+          [](const void* a, const void* b) {
             return compare_virtual_memory_size(*static_cast<const VirtualMemoryAllocationSite*>(a),
                                                *static_cast<const VirtualMemoryAllocationSite*>(b));
           });
@@ -279,7 +277,7 @@ void MemBaseline::virtual_memory_sites_to_size_order() {
 void MemBaseline::virtual_memory_sites_to_reservation_site_order() {
   if (_virtual_memory_sites_order != by_site) {
     ::qsort(_virtual_memory_sites, _virtual_memory_sites_length, sizeof(VirtualMemoryAllocationSite),
-            [](const void* a, const void* b) -> int {
+            [](const void* a, const void* b) {
               return compare_virtual_memory_site(*static_cast<const VirtualMemoryAllocationSite*>(a),
                                                  *static_cast<const VirtualMemoryAllocationSite*>(b));
             });

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -95,7 +95,7 @@ class MemBaseline {
   }
 
   ~MemBaseline() {
-    delete _vma_allocations;
+    reset();
   }
 
   void baseline(bool summaryOnly = true);
@@ -198,6 +198,7 @@ class MemBaseline {
     _malloc_sites.clear();
     os::free(_virtual_memory_sites);
     _virtual_memory_sites_length = 0;
+    _virtual_memory_sites = nullptr;
     delete _vma_allocations;
     _vma_allocations = nullptr;
   }

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -198,6 +198,7 @@ class MemBaseline {
     os::free(_virtual_memory_sites);
     _virtual_memory_sites_length = 0;
     _virtual_memory_sites = nullptr;
+    _virtual_memory_sites_order = invalid;
     delete _vma_allocations;
     _vma_allocations = nullptr;
   }

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -49,7 +49,6 @@ class MemBaseline {
   };
 
   enum SortingOrder {
-    by_address,       // by memory address
     by_size,          // by memory size
     by_site,          // by call site where the memory is allocated from
     by_site_and_tag,  // by call site and memory tag
@@ -73,7 +72,7 @@ class MemBaseline {
   // All virtual memory allocations
   RegionsTree* _vma_allocations;
 
-  // Virtual memory allocations by allocation sites, always in by_address
+  // Virtual memory allocations by allocation sites, always in by_site
   // order
   VirtualMemoryAllocationSite* _virtual_memory_sites;
   int                          _virtual_memory_sites_length;

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -29,12 +29,12 @@
 #include "nmt/mallocSiteTable.hpp"
 #include "nmt/mallocTracker.hpp"
 #include "nmt/nmtCommon.hpp"
+#include "nmt/nmtHashTable.hpp"
 #include "nmt/virtualMemoryTracker.hpp"
 #include "runtime/mutex.hpp"
 #include "utilities/linkedlist.hpp"
 
 typedef LinkedListIterator<MallocSite>                   MallocSiteIterator;
-typedef LinkedListIterator<VirtualMemoryAllocationSite>  VirtualMemorySiteIterator;
 
 /*
  * Baseline a memory snapshot
@@ -49,10 +49,11 @@ class MemBaseline {
   };
 
   enum SortingOrder {
-    by_address,      // by memory address
-    by_size,         // by memory size
-    by_site,         // by call site where the memory is allocated from
-    by_site_and_tag  // by call site and memory tag
+    by_address,       // by memory address
+    by_size,          // by memory size
+    by_site,          // by call site where the memory is allocated from
+    by_site_and_tag,  // by call site and memory tag
+    invalid
   };
 
  private:
@@ -74,7 +75,8 @@ class MemBaseline {
 
   // Virtual memory allocations by allocation sites, always in by_address
   // order
-  LinkedListImpl<VirtualMemoryAllocationSite> _virtual_memory_sites;
+  VirtualMemoryAllocationSite* _virtual_memory_sites;
+  int                          _virtual_memory_sites_length;
 
   SortingOrder         _malloc_sites_order;
   SortingOrder         _virtual_memory_sites_order;
@@ -86,6 +88,9 @@ class MemBaseline {
   MemBaseline():
     _instance_class_count(0), _array_class_count(0), _thread_count(0),
     _vma_allocations(nullptr),
+    _virtual_memory_sites(nullptr), _virtual_memory_sites_length(0),
+    _malloc_sites_order(invalid),
+    _virtual_memory_sites_order(invalid),
     _baseline_type(Not_baselined) {
   }
 
@@ -110,7 +115,10 @@ class MemBaseline {
   }
 
   MallocSiteIterator malloc_sites(SortingOrder order);
-  VirtualMemorySiteIterator virtual_memory_sites(SortingOrder order);
+  void sort_virtual_memory_sites(SortingOrder order);
+
+  VirtualMemoryAllocationSite* virtual_memory_sites()        { return _virtual_memory_sites; }
+  int                          virtual_memory_sites_length() { return _virtual_memory_sites_length; }
 
   // Virtual memory allocation iterator always returns in virtual memory
   // base address order.
@@ -188,7 +196,8 @@ class MemBaseline {
     _thread_count = 0;
 
     _malloc_sites.clear();
-    _virtual_memory_sites.clear();
+    os::free(_virtual_memory_sites);
+    _virtual_memory_sites_length = 0;
     delete _vma_allocations;
     _vma_allocations = nullptr;
   }

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -352,33 +352,30 @@ int MemDetailReporter::report_malloc_sites() {
 }
 
 int MemDetailReporter::report_virtual_memory_allocation_sites()  {
-  VirtualMemorySiteIterator  virtual_memory_itr =
-    _baseline.virtual_memory_sites(MemBaseline::by_size);
-
-  if (virtual_memory_itr.is_empty()) return 0;
+  _baseline.sort_virtual_memory_sites(MemBaseline::by_size);
 
   outputStream* out = output();
 
-  const VirtualMemoryAllocationSite*  virtual_memory_site;
   int num_omitted = 0;
-  while ((virtual_memory_site = virtual_memory_itr.next()) != nullptr) {
+  for (int i = 0; i < _baseline.virtual_memory_sites_length(); i++) {
+    const VirtualMemoryAllocationSite& virtual_memory_site = _baseline.virtual_memory_sites()[i];
     // Don't report free sites; does not count toward omitted count.
-    if (virtual_memory_site->reserved() == 0) {
+    if (virtual_memory_site.reserved() == 0) {
       continue;
     }
     // Omit printing if the current value and the historic peak value both fall below the
     // reporting scale threshold
-    if (amount_in_current_scale(MAX2(virtual_memory_site->reserved(),
-                                     virtual_memory_site->peak_size())) == 0) {
+    if (amount_in_current_scale(MAX2(virtual_memory_site.reserved(),
+                                     virtual_memory_site.peak_size())) == 0) {
       num_omitted++;
       continue;
     }
-    const NativeCallStack* stack = virtual_memory_site->call_stack();
+    const NativeCallStack* stack = virtual_memory_site.call_stack();
     _stackprinter.print_stack(stack);
     INDENT_BY(29,
       out->print("(");
-      print_total(virtual_memory_site->reserved(), virtual_memory_site->committed());
-      const MemTag mem_tag = virtual_memory_site->mem_tag();
+      print_total(virtual_memory_site.reserved(), virtual_memory_site.committed());
+      const MemTag mem_tag = virtual_memory_site.mem_tag();
       if (mem_tag != mtNone) {
         out->print(" Tag=%s", NMTUtil::tag_to_name(mem_tag));
       }
@@ -835,38 +832,58 @@ void MemDetailDiffReporter::diff_malloc_sites() const {
 }
 
 void MemDetailDiffReporter::diff_virtual_memory_sites() const {
-  VirtualMemorySiteIterator early_itr = _early_baseline.virtual_memory_sites(MemBaseline::by_site);
-  VirtualMemorySiteIterator current_itr = _current_baseline.virtual_memory_sites(MemBaseline::by_site);
+  _early_baseline.sort_virtual_memory_sites(MemBaseline::by_site);
+  _current_baseline.sort_virtual_memory_sites(MemBaseline::by_site);
 
-  const VirtualMemoryAllocationSite* early_site   = early_itr.next();
-  const VirtualMemoryAllocationSite* current_site = current_itr.next();
+  const VirtualMemoryAllocationSite* early_site = nullptr;
+  const VirtualMemoryAllocationSite* current_site = nullptr;
+  int early_i = 0;
+  int current_i = 0;
+  auto early_next = [&]() -> const VirtualMemoryAllocationSite* {
+    if (early_i < _early_baseline.virtual_memory_sites_length()) {
+      const VirtualMemoryAllocationSite* e = &_early_baseline.virtual_memory_sites()[early_i];
+      early_i++;
+      return e;
+    } else {
+      return nullptr;
+    }
+  };
+  auto current_next = [&]() -> const VirtualMemoryAllocationSite* {
+    if (current_i < _current_baseline.virtual_memory_sites_length()) {
+      const VirtualMemoryAllocationSite* e = &_current_baseline.virtual_memory_sites()[current_i];
+      current_i++;
+      return e;
+    } else {
+      return nullptr;
+    }
+  };
 
   while (early_site != nullptr || current_site != nullptr) {
     if (early_site == nullptr) {
       new_virtual_memory_site(current_site);
-      current_site = current_itr.next();
+      current_site = current_next();
     } else if (current_site == nullptr) {
       old_virtual_memory_site(early_site);
-      early_site = early_itr.next();
+      early_site = early_next();
     } else {
       int compVal = current_site->call_stack()->compare(*early_site->call_stack());
       if (compVal < 0) {
         new_virtual_memory_site(current_site);
-        current_site = current_itr.next();
+        current_site = current_next();
       } else if (compVal > 0) {
         old_virtual_memory_site(early_site);
-        early_site = early_itr.next();
+        early_site = early_next();
       } else if (early_site->mem_tag() != current_site->mem_tag()) {
         // This site was originally allocated with one memory tag, then released,
         // then re-allocated at the same site (as far as we can tell) with a different memory tag.
         old_virtual_memory_site(early_site);
-        early_site = early_itr.next();
+        early_site = early_next();
         new_virtual_memory_site(current_site);
-        current_site = current_itr.next();
+        current_site = current_next();
       } else {
         diff_virtual_memory_site(early_site, current_site);
-        early_site   = early_itr.next();
-        current_site = current_itr.next();
+        early_site   = early_next();
+        current_site = current_next();
       }
     }
   }

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -858,6 +858,9 @@ void MemDetailDiffReporter::diff_virtual_memory_sites() const {
     }
   };
 
+  early_site = early_next();
+  current_site = current_next();
+
   while (early_site != nullptr || current_site != nullptr) {
     if (early_site == nullptr) {
       new_virtual_memory_site(current_site);

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -271,13 +271,28 @@ private:
       return nullptr;
     }
 
+    KVElement* resulting_array = nullptr;
+    if (_members == small()) {
+      // Can't return the _small array, need to allocate one.
+      resulting_array = allocate_kvelement_array(_occupied);
+      if (resulting_array == nullptr) {
+        *length = 0;
+        return nullptr;
+      }
+      for (int i = 0; i < _occupied; i++) {
+        ::new (&resulting_array[i]) KVElement(small()[i]);
+      }
+    } else {
+      resulting_array = _members;
+    }
+
     // Remove all empty spaces in the array, making it dense.
     int result_index = 0;
     int index = 0;
     while (result_index < _occupied) {
       if (is_occupied(index)) {
         if (result_index != index) {
-          ::new (&_members[result_index]) KVElement(_members[index]);
+          ::new (&resulting_array[result_index]) KVElement(resulting_array[index]);
         }
         result_index++;
       }
@@ -285,20 +300,6 @@ private:
     }
     assert(result_index == _occupied, "must be");
 
-    KVElement* result = nullptr;
-    if (_members == small()) {
-      // Can't return the _small array, need to allocate one.
-      result = allocate_kvelement_array(_occupied);
-      if (result == nullptr) {
-        *length = 0;
-        return nullptr;
-      }
-      for (int i = 0; i < _occupied; i++) {
-        ::new (&result[i]) KVElement(small()[i]);
-      }
-    } else {
-      result = _members;
-    }
     *length = _occupied;
 
     if (_members == small()) {
@@ -311,7 +312,7 @@ private:
       clear_occupied_map();
     }
 
-    return result;
+    return resulting_array;
   }
 };
 

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -86,7 +86,7 @@ private:
   }
 
   static KVElement* allocate_kvelement_array(int length) {
-    if (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
+    if constexpr (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
       return NEW_C_HEAP_ARRAY_RETURN_NULL(KVElement, length, MT);
     }
     return NEW_C_HEAP_ARRAY(KVElement, length, MT);
@@ -155,7 +155,7 @@ private:
 
     KVElement* new_members = allocate_kvelement_array(new_length);
     if (new_members == nullptr) {
-      if (alloc_failmode == AllocFailStrategy::EXIT_OOM) {
+      if constexpr (alloc_failmode == AllocFailStrategy::EXIT_OOM) {
         vm_exit_out_of_memory(new_length, OOM_MALLOC_ERROR, "Hashtable resize failed, out of memory");
       }
       return false;

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -186,7 +186,7 @@ private:
     _members = new_members;
     _length = new_length;
     _occupied = new_occupied;
-    _occupied_map.swap(new_occupied_map);
+    _occupied_map.move(new_occupied_map);
 
     if (old_members_on_c_heap) {
       FREE_C_HEAP_ARRAY(old_members);

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -104,7 +104,8 @@ private:
       _occupied_map.reinitialize(_length);
     }
   }
-
+  // We can't discern whether keys and values should be pointers, references or passed by-value.
+  // So we use decltype(auto) to automatically follow the implementation for us.
   KVElement& insert_into(KVElement* members,
                          int length,
                          OccupancyBitMap& occupied_map,

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_NMT_NMTHASHTABLE_HPP
+#define SHARE_NMT_NMTHASHTABLE_HPP
+
+#include "cppstdlib/new.hpp"
+#include "cppstdlib/type_traits.hpp"
+#include "memory/allocation.hpp"
+#include "utilities/bitMap.hpp"
+#include "utilities/bitMap.inline.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/powerOfTwo.hpp"
+
+// This is an open adressed hashtable which stores trivial key-value pairs.
+// It is backed by a CHeap allocated array which it reallocates, causing underlying pointers to be invalidated.
+// Membership is stored in an occupancy bitmap, so the memory overhead of this hashtable is fairly low.
+// The KVElement is a container for your key and value. Key, Hash, and Equals are function object types.
+// Key is an accessor to the key of a KVElement, Hash returns an int as the hash of the key, and
+// Equals is a comparison function returning a boolean.
+// Instances are supplied via the constructor.
+// Lookups, and not only insertions, may resize the array, causing all previously acquired pointers to become invalidated.
+// For example, this is unsafe code:
+// OAHT<...> ht;
+// auto A = {a_key, ...};
+// auto B = {b_key, ...};
+// auto a_lookup = ht.put_if_absent(A);
+// auto b_lookup = ht.put_if_absent(B);
+// do_thing(a_lookup, b_lookup);
+// Here, a_lookup may have been invalidated at the point of b_lookup.
+template <typename KVElement,
+          typename Key, typename Hash, typename Equals,
+          MemTag MT = mtNMT,
+          AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM,
+          int LoadFactorPercentage = 75> // Load factor until resizing
+class OpenAddressedHashTable : public StackObj {
+  static_assert(std::is_trivially_copyable<KVElement>::value &&
+                std::is_trivially_destructible<KVElement>::value,
+                "These are required for the hashtable to function correctly");
+  static_assert(LoadFactorPercentage <= 1, "Load factor cannot be higher than one in an open addressed hashtable");
+
+private:
+  // Load factor before resize is necessary
+  static constexpr double load_factor = LoadFactorPercentage * 0.01;
+  static constexpr int small_size = 4;
+  using OccupancyBitMap = CHeapBitMap;
+
+  Key _key;
+  Hash _hash;
+  Equals _equals;
+  alignas(KVElement) char _small[small_size * sizeof(KVElement)];
+  KVElement* small() { return reinterpret_cast<KVElement*>(_small); };
+  KVElement* _members;
+  int _length;
+  int _occupied;
+  OccupancyBitMap _occupied_map;
+
+  NONCOPYABLE(OpenAddressedHashTable);
+
+  static void clear_members(KVElement* members, int length) {
+    // Uninitialize all memory. KVElement is trivially destructible,
+    // so this is correct.
+    memset(static_cast<void*>(members), 0, sizeof(KVElement) * length);
+  }
+
+  static KVElement* allocate_kvelement_array(int length) {
+    if (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
+      return NEW_C_HEAP_ARRAY_RETURN_NULL(KVElement, length, MT);
+    }
+    return NEW_C_HEAP_ARRAY(KVElement, length, MT);
+  }
+
+  bool is_occupied(int index) const {
+    assert(_occupied_map.size() == (size_t)_length, "must be");
+    return _occupied_map.at(index);
+  }
+
+  void clear_occupied_map() {
+    if (_occupied_map.size() == (size_t)_length) {
+      _occupied_map.clear_range(0, _length);
+    } else {
+      _occupied_map.reinitialize(_length);
+    }
+  }
+
+  KVElement& insert_into(KVElement* members,
+                         int length,
+                         OccupancyBitMap& occupied_map,
+                         int* occupied,
+                         const KVElement& kv,
+                         bool* found) const {
+    assert(is_power_of_2(length), "must be");
+    assert(*occupied < length, "must still have room for insertion");
+    decltype(auto) key_value = _key(kv);
+    int index = _hash(key_value) & (length - 1);
+    for (int probes = 0; probes < length; probes++) {
+      KVElement& element = members[index];
+      if (!occupied_map.at(index)) {
+        *found = false;
+        ::new (&element) KVElement(kv);
+        occupied_map.set_bit(index);
+        (*occupied)++;
+        return element;
+      }
+      decltype(auto) element_key = _key(element);
+      if (_equals(element_key, key_value)) {
+        *found = true;
+        return element;
+      }
+      // index = (index + 1) % length but for POW2
+      index = (index + 1) & (length - 1);
+    }
+    ShouldNotReachHere();
+  }
+
+  bool rehash_to_length(int new_length, bool c_heap) {
+    assert(is_power_of_2(new_length), "must be");
+    assert(new_length >= small_size, "must be");
+
+    if (new_length < _length) {
+      new_length = _length;
+    }
+    guarantee(_occupied <= new_length / 2, "must have enough room");
+
+    if (_members != small() && new_length == _length) {
+      return true;
+    }
+
+    if (!c_heap && _members == small() && new_length == small_size) {
+      clear_occupied_map();
+      return true;
+    }
+
+    KVElement* new_members = allocate_kvelement_array(new_length);
+    if (new_members == nullptr) {
+      if (alloc_failmode == AllocFailStrategy::EXIT_OOM) {
+        vm_exit_out_of_memory(new_length, OOM_MALLOC_ERROR, "Hashtable resize failed, out of memory");
+      }
+      return false;
+    }
+    clear_members(new_members, new_length);
+    OccupancyBitMap new_occupied_map(MT);
+    new_occupied_map.initialize(new_length);
+
+    KVElement* const old_members = _members;
+    const int old_length = _length;
+    const bool old_members_on_c_heap = old_members != small();
+
+    int new_occupied = 0;
+
+    if (_occupied > 0) {
+      assert(_occupied_map.size() == (size_t)old_length, "must be");
+      for (int index = 0; index < old_length; index++) {
+        if (is_occupied(index)) {
+          bool found = false;
+          KVElement& result = insert_into(new_members, new_length, new_occupied_map,
+                                          &new_occupied, old_members[index],  &found);
+          assert(!found, "must be");
+        }
+      }
+    }
+    assert(new_occupied == _occupied, "must preserve all entries");
+
+    _members = new_members;
+    _length = new_length;
+    _occupied = new_occupied;
+    _occupied_map.swap(new_occupied_map);
+
+    if (old_members_on_c_heap) {
+      FREE_C_HEAP_ARRAY(old_members);
+    }
+    return true;
+  }
+
+  bool grow_and_rehash() {
+    return rehash_to_length(_length * 2, true);
+  }
+
+  bool has_capacity_for_insert() const {
+    return (_occupied + 1) / double(_length) < load_factor;
+  }
+
+ public:
+  OpenAddressedHashTable(Key key, Hash hash, Equals equals) :
+    _key(key), _hash(hash), _equals(equals),
+    _small(), _members(small()), _length(small_size), _occupied(0),
+    _occupied_map(small_size, MT) {
+    clear_members(small(), small_size);
+  }
+
+  ~OpenAddressedHashTable() {
+    if (_members != small()) {
+      FREE_C_HEAP_ARRAY(_members);
+    }
+  }
+
+  int occupied() const {
+    return _occupied;
+  }
+
+  KVElement* put_if_absent(const KVElement& kv, bool* found) {
+    assert(_occupied_map.size() == (size_t)_length, "must be");
+    if (!has_capacity_for_insert()) {
+      if (!grow_and_rehash()) {
+        return nullptr;
+      }
+    }
+    KVElement& result = insert_into(_members, _length, _occupied_map, &_occupied, kv, found);
+    return &result;
+  }
+
+  template<typename F>
+  void visit(F f) const {
+    if (_occupied == 0) {
+      return;
+    }
+    int hits = 0;
+    for (int index = 0; index < _length; index++) {
+      if (is_occupied(index)) {
+        const KVElement& element = _members[index];
+        f(element);
+        hits++;
+      }
+      if (hits == _occupied) {
+        return;
+      }
+    }
+  }
+
+  void clear() {
+    if (_members != small()) {
+      FREE_C_HEAP_ARRAY(_members);
+      _members = small();
+      _length = small_size;
+    }
+    _occupied = 0;
+    clear_members(small(), small_size);
+    clear_occupied_map();
+  }
+
+  KVElement* detach(int* length) {
+    assert(length != nullptr, "must be");
+
+    if (_occupied == 0) {
+      *length = 0;
+      return nullptr;
+    }
+
+    // Remove all empty spaces in the array, making it dense.
+    int result_index = 0;
+    int index = 0;
+    while (result_index < _occupied) {
+      if (is_occupied(index)) {
+        if (result_index != index) {
+          ::new (&_members[result_index]) KVElement(_members[index]);
+        }
+        result_index++;
+      }
+      index++;
+    }
+    assert(result_index == _occupied, "must be");
+
+    KVElement* result = nullptr;
+    if (_members == small()) {
+      // Can't return the _small array, need to allocate one.
+      result = allocate_kvelement_array(_occupied);
+      if (result == nullptr) {
+        *length = 0;
+        return nullptr;
+      }
+      for (int i = 0; i < _occupied; i++) {
+        ::new (&result[i]) KVElement(small()[i]);
+      }
+    } else {
+      result = _members;
+    }
+    *length = _occupied;
+
+    if (_members == small()) {
+      clear();
+    } else {
+      _members = small();
+      _length = small_size;
+      _occupied = 0;
+      clear_members(small(), small_size);
+      clear_occupied_map();
+    }
+
+    return result;
+  }
+};
+
+#endif // SHARE_NMT_NMTHASHTABLE_HPP

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -34,7 +34,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
 
-// This is an open adressed hashtable which stores trivial key-value pairs.
+// This is an open-addressed hashtable which stores trivial key-value pairs.
 // It is backed by a CHeap allocated array which it reallocates, causing underlying pointers to be invalidated.
 // Membership is stored in an occupancy bitmap, so the memory overhead of this hashtable is fairly low.
 // The KVElement is a container for your key and value. Key, Hash, and Equals are function object types.
@@ -80,7 +80,7 @@ private:
   NONCOPYABLE(OpenAddressedHashTable);
 
   static void clear_members(KVElement* members, int length) {
-    // Uninitialize all memory. KVElement is trivially destructible,
+    // Zap all memory. KVElement is trivially destructible,
     // so this is correct.
     memset(static_cast<void*>(members), 0, sizeof(KVElement) * length);
   }
@@ -221,9 +221,11 @@ private:
   }
 
   KVElement* put_if_absent(const KVElement& kv, bool* found) {
+    assert(found != nullptr, "must be");
     assert(_occupied_map.size() == (size_t)_length, "must be");
     if (!has_capacity_for_insert()) {
       if (!grow_and_rehash()) {
+        *found = false;
         return nullptr;
       }
     }

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -59,7 +59,7 @@ class OpenAddressedHashTable : public StackObj {
   static_assert(std::is_trivially_copyable<KVElement>::value &&
                 std::is_trivially_destructible<KVElement>::value,
                 "These are required for the hashtable to function correctly");
-  static_assert(LoadFactorPercentage <= 1, "Load factor cannot be higher than one in an open addressed hashtable");
+  static_assert(LoadFactorPercentage <= 100, "Load factor cannot be higher than 100% in an open addressed hashtable");
 
 private:
   // Load factor before resize is necessary

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -37,9 +37,9 @@
 // This is an open-addressed hashtable which stores trivial key-value pairs.
 // It is backed by a CHeap allocated array which it reallocates, causing underlying pointers to be invalidated.
 // Membership is stored in an occupancy bitmap, so the memory overhead of this hashtable is fairly low.
-// The KVElement is a container for your key and value. Key, Hash, and Equals are function object types.
-// Key is an accessor to the key of a KVElement, Hash returns an int as the hash of the key, and
-// Equals is a comparison function returning a boolean.
+// The KVElement is a container for your key and value. HashFun, and EqualsFun are function object types.
+// HashFun returns an int as the hash of the KVElement, and
+// Equals returns a boolean and is a comparison function of the KVElement.
 // Instances are supplied via the constructor.
 // Lookups, and not only insertions, may resize the array, causing all previously acquired pointers to become invalidated.
 // For example, this is unsafe code:
@@ -51,7 +51,7 @@
 // do_thing(a_lookup, b_lookup);
 // Here, a_lookup may have been invalidated at the point of b_lookup.
 template <typename KVElement,
-          typename Key, typename Hash, typename Equals,
+          typename HashFun, typename EqualsFun,
           MemTag MT = mtNMT,
           AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM,
           int LoadFactorPercentage = 75> // Load factor until resizing
@@ -67,9 +67,8 @@ private:
   static constexpr int small_size = 4;
   using OccupancyBitMap = CHeapBitMap;
 
-  Key _key;
-  Hash _hash;
-  Equals _equals;
+  HashFun _hash;
+  EqualsFun _equals;
   alignas(KVElement) char _small[small_size * sizeof(KVElement)];
   KVElement* small() { return reinterpret_cast<KVElement*>(_small); };
   KVElement* _members;
@@ -114,8 +113,7 @@ private:
                          bool* found) const {
     assert(is_power_of_2(length), "must be");
     assert(*occupied < length, "must still have room for insertion");
-    decltype(auto) key_value = _key(kv);
-    int index = _hash(key_value) & (length - 1);
+    int index = _hash(kv) & (length - 1);
     for (int probes = 0; probes < length; probes++) {
       KVElement& element = members[index];
       if (!occupied_map.at(index)) {
@@ -125,8 +123,7 @@ private:
         (*occupied)++;
         return element;
       }
-      decltype(auto) element_key = _key(element);
-      if (_equals(element_key, key_value)) {
+      if (_equals(element, kv)) {
         *found = true;
         return element;
       }
@@ -204,8 +201,8 @@ private:
   }
 
  public:
-  OpenAddressedHashTable(Key key, Hash hash, Equals equals) :
-    _key(key), _hash(hash), _equals(equals),
+  OpenAddressedHashTable(HashFun hash, EqualsFun equals) :
+    _hash(hash), _equals(equals),
     _small(), _members(small()), _length(small_size), _occupied(0),
     _occupied_map(small_size, MT) {
     clear_members(small(), small_size);

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -60,6 +60,7 @@ class OpenAddressedHashTable : public StackObj {
                 std::is_trivially_destructible<KVElement>::value,
                 "These are required for the hashtable to function correctly");
   static_assert(LoadFactorPercentage <= 100, "Load factor cannot be higher than 100% in an open addressed hashtable");
+  static_assert(LoadFactorPercentage > 0, "Load factor must be at least 1%");
 
 private:
   // Load factor before resize is necessary
@@ -133,7 +134,7 @@ private:
     ShouldNotReachHere();
   }
 
-  bool rehash_to_length(int new_length, bool c_heap) {
+  bool rehash_to_length(int new_length) {
     assert(is_power_of_2(new_length), "must be");
     assert(new_length >= small_size, "must be");
 
@@ -146,7 +147,7 @@ private:
       return true;
     }
 
-    if (!c_heap && _members == small() && new_length == small_size) {
+    if (_members == small() && new_length == small_size) {
       clear_occupied_map();
       return true;
     }
@@ -193,7 +194,7 @@ private:
   }
 
   bool grow_and_rehash() {
-    return rehash_to_length(_length * 2, true);
+    return rehash_to_length(_length * 2);
   }
 
   bool has_capacity_for_insert() const {
@@ -269,6 +270,7 @@ private:
     }
 
     KVElement* resulting_array = nullptr;
+    int result_index = 0;
     if (_members == small()) {
       // Can't return the _small array, need to allocate one.
       resulting_array = allocate_kvelement_array(_occupied);
@@ -276,39 +278,32 @@ private:
         *length = 0;
         return nullptr;
       }
-      for (int i = 0; i < _occupied; i++) {
-        ::new (&resulting_array[i]) KVElement(small()[i]);
+      // Remove all empty spaces in the array, making it dense.
+      for (int i = 0; i < _length; i++) {
+        if (is_occupied(i)) {
+          ::new (&resulting_array[result_index]) KVElement(small()[i]);
+          result_index++;
+        }
       }
     } else {
       resulting_array = _members;
-    }
-
-    // Remove all empty spaces in the array, making it dense.
-    int result_index = 0;
-    int index = 0;
-    while (result_index < _occupied) {
-      if (is_occupied(index)) {
-        if (result_index != index) {
-          ::new (&resulting_array[result_index]) KVElement(resulting_array[index]);
+      // Remove all empty spaces in the array, making it dense.
+      int index = 0;
+      while (result_index < _occupied) {
+        if (is_occupied(index)) {
+          if (result_index != index) {
+            ::new (&resulting_array[result_index]) KVElement(resulting_array[index]);
+          }
+          result_index++;
         }
-        result_index++;
+        index++;
       }
-      index++;
     }
     assert(result_index == _occupied, "must be");
-
     *length = _occupied;
-
-    if (_members == small()) {
-      clear();
-    } else {
-      _members = small();
-      _length = small_size;
-      _occupied = 0;
-      clear_members(small(), small_size);
-      clear_occupied_map();
-    }
-
+    _members = small();
+    _length = small_size;
+    clear();
     return resulting_array;
   }
 };

--- a/src/hotspot/share/nmt/nmtHashTable.hpp
+++ b/src/hotspot/share/nmt/nmtHashTable.hpp
@@ -134,23 +134,8 @@ private:
     ShouldNotReachHere();
   }
 
-  bool rehash_to_length(int new_length) {
-    assert(is_power_of_2(new_length), "must be");
-    assert(new_length >= small_size, "must be");
-
-    if (new_length < _length) {
-      new_length = _length;
-    }
-    guarantee(_occupied <= new_length / 2, "must have enough room");
-
-    if (_members != small() && new_length == _length) {
-      return true;
-    }
-
-    if (_members == small() && new_length == small_size) {
-      clear_occupied_map();
-      return true;
-    }
+  bool grow_and_rehash() {
+    int new_length = _length * 2;
 
     KVElement* new_members = allocate_kvelement_array(new_length);
     if (new_members == nullptr) {
@@ -168,7 +153,6 @@ private:
     const bool old_members_on_c_heap = old_members != small();
 
     int new_occupied = 0;
-
     if (_occupied > 0) {
       assert(_occupied_map.size() == (size_t)old_length, "must be");
       for (int index = 0; index < old_length; index++) {
@@ -191,10 +175,6 @@ private:
       FREE_C_HEAP_ARRAY(old_members);
     }
     return true;
-  }
-
-  bool grow_and_rehash() {
-    return rehash_to_length(_length * 2);
   }
 
   bool has_capacity_for_insert() const {

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -93,6 +93,8 @@ class VirtualMemoryAllocationSite : public AllocationSite {
   VirtualMemoryAllocationSite(const NativeCallStack& stack, MemTag mem_tag) :
     AllocationSite(stack, mem_tag) { }
 
+  VirtualMemoryAllocationSite(const VirtualMemoryAllocationSite& other) = default;
+
   inline void reserve_memory(size_t sz)  { _c.reserve_memory(sz);  }
   inline void commit_memory (size_t sz)  { _c.commit_memory(sz);   }
   inline size_t reserved() const  { return _c.reserved(); }

--- a/src/hotspot/share/nmt/vmatree.cpp
+++ b/src/hotspot/share/nmt/vmatree.cpp
@@ -193,13 +193,17 @@ void VMATree::compute_summary_diff(const SingleDiff::delta region_size,
                                         {0,a,  0,a, -a,a },    // op == Commit
                                         {0,0,  0,0, -a,0 }     // op == Uncommit
                                      };
-  SingleDiff& from_rescom = diff.tag(current_tag);
-  SingleDiff&   to_rescom = diff.tag(operation_tag);
   int st = state_to_index(ex);
-  from_rescom.reserve += reserve[op][st * 2    ];
+  {
+    SingleDiff& from_rescom = diff.tag(current_tag);
+    from_rescom.reserve += reserve[op][st * 2    ];
+    from_rescom.commit  +=  commit[op][st * 2    ];
+  }
+  {
+    SingleDiff& to_rescom = diff.tag(operation_tag);
     to_rescom.reserve += reserve[op][st * 2 + 1];
-  from_rescom.commit  +=  commit[op][st * 2    ];
     to_rescom.commit  +=  commit[op][st * 2 + 1];
+  }
 
 }
 // update the region state between n1 and n2. Since n1 and n2 are pointers, any update of them will be visible from tree.
@@ -748,85 +752,11 @@ bool VMATree::is_empty() {
   return _tree.size() == 0;
 }
 
-VMATree::SummaryDiff::KVEntry&
-VMATree::SummaryDiff::hash_insert_or_get(const KVEntry& kv, bool* found) {
-  DEBUG_ONLY(int counter = 0);
-  // If the length is large (picked as 32)
-  // then we apply a load-factor check and rehash if it exceeds it.
-  // When the length is small we're OK with a full linear search for an empty space
-  // to avoid a grow and rehash.
-  constexpr float load_factor = 0.5;
-  constexpr int load_factor_cutoff_length = 32;
-  if (_length > load_factor_cutoff_length &&
-      (float)_occupied / _length > load_factor) {
-    grow_and_rehash();
-  }
-  while (true) {
-    DEBUG_ONLY(counter++);
-    assert(counter < 8, "Infinite loop?");
-    int i = hash_to_bucket(kv.mem_tag);
-    while (i < _length && _members[i].marker == Marker::Occupied) {
-      if (_members[i].mem_tag == kv.mem_tag) {
-        // Found previous
-        *found = true;
-        return _members[i];
-      }
-      i++;
-    }
-    *found = false;
-    // We didn't find it but ran out of space, grow and rehash
-    // Then look at again
-    if (i >= _length) {
-      assert(_length < std::numeric_limits<std::underlying_type_t<MemTag>>::max(), "");
-      grow_and_rehash();
-      continue;
-    }
-    // We didn't find it, but _members[i] is empty, allocate a new one
-    assert(_members[i].marker == Marker::Empty, "must be");
-    _members[i] = kv;
-    _occupied++;
-    return _members[i];
-  }
-}
-
-void VMATree::SummaryDiff::grow_and_rehash() {
-  assert(is_power_of_2(_length), "must be");
-  constexpr int length_limit = std::numeric_limits<std::underlying_type_t<MemTag>>::max() + 1;
-  assert(is_power_of_2(length_limit), "must be");
-  if (_length == length_limit) {
-    // If we are at MemTag's maximum size, then just continue with the current size.
-    return;
-  }
-
-  int new_len = _length * 2;
-  // Save old entries (can't use ResourceMark, too early)
-  GrowableArrayCHeap<KVEntry, mtNMT> tmp(_length);
-  for (int i = 0; i < _length; i++) {
-    tmp.push(_members[i]);
-  }
-
-  // Clear previous -- if applicable
-  if (_members != _small) {
-    FREE_C_HEAP_ARRAY(_members);
-  }
-
-  _members = NEW_C_HEAP_ARRAY(KVEntry, new_len, mtNMT);
-  // Clear new array
-  memset(_members, 0, sizeof(KVEntry) * new_len);
-  _length = new_len;
-  _occupied = 0;
-
-  for (int i = 0; i < tmp.length(); i++) {
-    bool _found = false;
-    hash_insert_or_get(tmp.at(i), &_found);
-  }
-}
-
 VMATree::SingleDiff& VMATree::SummaryDiff::tag(MemTag tag) {
-  KVEntry kv{Marker::Occupied, tag, {}};
-  bool _found = false;
-  KVEntry& inserted = hash_insert_or_get(kv, &_found);
-  return inserted.single_diff;
+  KVEntry kv{tag, {0,0}};
+  bool found = false;
+  KVEntry* inserted = _table.put_if_absent(kv, &found);
+  return inserted->single_diff;
 }
 
 VMATree::SingleDiff& VMATree::SummaryDiff::tag(int mt_index) {
@@ -836,24 +766,15 @@ VMATree::SingleDiff& VMATree::SummaryDiff::tag(int mt_index) {
 void VMATree::SummaryDiff::add(const SummaryDiff& other) {
   other.visit([&](MemTag mt, const SingleDiff& single_diff) {
     bool found = false;
-    KVEntry other_kv = {Marker::Occupied, mt, single_diff};
-    KVEntry& this_kv = hash_insert_or_get(other_kv, &found);
+    KVEntry other_kv{mt, single_diff};
+    KVEntry* this_kv = _table.put_if_absent(other_kv, &found);
     if (found) {
-      this_kv.single_diff.reserve += other_kv.single_diff.reserve;
-      this_kv.single_diff.commit += other_kv.single_diff.commit;
+      this_kv->single_diff.reserve += other_kv.single_diff.reserve;
+      this_kv->single_diff.commit += other_kv.single_diff.commit;
     }
   });
 }
 
 void VMATree::SummaryDiff::clear() {
-  if (_members != _small) {
-    FREE_C_HEAP_ARRAY(_members);
-  }
-  memset(_small, 0, sizeof(_small));
-}
-
-uint32_t VMATree::SummaryDiff::hash_to_bucket(MemTag mt) {
-  uint32_t hash = primitive_hash<uint32_t>((uint32_t)mt);
-  assert(is_power_of_2(_length), "must be");
-  return hash & ((uint32_t)_length - 1);
+  _table.clear();
 }

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -28,6 +28,7 @@
 
 #include "memory/resourceArea.hpp"
 #include "nmt/memTag.hpp"
+#include "nmt/nmtHashTable.hpp"
 #include "nmt/nmtNativeCallStackStorage.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
@@ -240,32 +241,25 @@ public:
   };
 
   class SummaryDiff {
-    enum class Marker { Empty, Occupied };
-    static_assert((int)Marker::Empty == 0, "We memset the array to 0, so this must be true");
-
     struct KVEntry {
-      Marker marker;
-      MemTag mem_tag;
+      MemTag mt;
       SingleDiff single_diff;
+      static MemTag key(const KVEntry& entry) { return entry.mt; }
+      static int hash(MemTag mt) { return (int)mt; }
+      static bool equals(MemTag mt1, MemTag mt2) { return mt1 == mt2; }
+      KVEntry(const KVEntry&) = default;
+      KVEntry() = default;
+      KVEntry(MemTag mt, SingleDiff sd) : mt(mt), single_diff(sd) {}
     };
 
-    static constexpr const int _init_size = 4;
-    KVEntry _small[_init_size];
-    KVEntry* _members;
-    int _length;
-    int _occupied;
-    KVEntry& hash_insert_or_get(const KVEntry& kv, bool* found);
-    void grow_and_rehash();
-    uint32_t hash_to_bucket(MemTag mt);
-
+    using Table = OpenAddressedHashTable<KVEntry,
+                                         decltype(&KVEntry::key),
+                                         decltype(&KVEntry::hash),
+                                         decltype(&KVEntry::equals),
+                                         mtNMT, AllocFailStrategy::EXIT_OOM, 100>;
+    Table _table;
   public:
-    SummaryDiff() : _small(), _members(_small), _length(_init_size), _occupied(0) {
-      clear();
-    }
-    ~SummaryDiff() {
-      if (_members != _small) {
-        FREE_C_HEAP_ARRAY(_members);
-      }
+    SummaryDiff() : _table(&KVEntry::key, &KVEntry::hash, &KVEntry::equals) {
     }
 
     SingleDiff& tag(MemTag tag);
@@ -273,18 +267,9 @@ public:
 
     template<typename F>
     void visit(F f) const {
-      int hits = 0;
-      for (int i = 0; i < _length; i++) {
-        const KVEntry& kv = _members[i];
-        if (kv.marker == Marker::Occupied) {
-          f(kv.mem_tag, kv.single_diff);
-          hits++;
-        }
-        if (hits == _occupied) {
-          // Early exit
-          return;
-        }
-      }
+      _table.visit([&](const KVEntry& entry) {
+        f(entry.mt, entry.single_diff);
+      });
     }
 
     void add(const SummaryDiff& other);

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -244,22 +244,20 @@ public:
     struct KVEntry {
       MemTag mt;
       SingleDiff single_diff;
-      static MemTag key(const KVEntry& entry) { return entry.mt; }
-      static int hash(MemTag mt) { return (int)mt; }
-      static bool equals(MemTag mt1, MemTag mt2) { return mt1 == mt2; }
+      static int hash(const KVEntry& kv) { return (int)kv.mt; }
+      static bool equals(const KVEntry& a, const KVEntry& b) { return a.mt == b.mt; }
       KVEntry(const KVEntry&) = default;
       KVEntry() = default;
       KVEntry(MemTag mt, SingleDiff sd) : mt(mt), single_diff(sd) {}
     };
 
     using Table = OpenAddressedHashTable<KVEntry,
-                                         decltype(&KVEntry::key),
                                          decltype(&KVEntry::hash),
                                          decltype(&KVEntry::equals),
                                          mtNMT, AllocFailStrategy::EXIT_OOM, 100>;
     Table _table;
   public:
-    SummaryDiff() : _table(&KVEntry::key, &KVEntry::hash, &KVEntry::equals) {
+    SummaryDiff() : _table(&KVEntry::hash, &KVEntry::equals) {
     }
 
     SingleDiff& tag(MemTag tag);

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -195,6 +195,13 @@ bm_word_t* CHeapBitMap::reallocate(bm_word_t* map, size_t old_size_in_words, siz
   return MallocArrayAllocator<bm_word_t>::reallocate(map, new_size_in_words, _mem_tag);
 }
 
+void CHeapBitMap::swap(CHeapBitMap &other) {
+  free(map(), size_in_words());
+  update(other.map(), other.size());
+  other.update(nullptr, 0);
+}
+
+
 #ifdef ASSERT
 void BitMap::verify_index(idx_t bit) const {
   assert(bit < _size,

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -195,7 +195,7 @@ bm_word_t* CHeapBitMap::reallocate(bm_word_t* map, size_t old_size_in_words, siz
   return MallocArrayAllocator<bm_word_t>::reallocate(map, new_size_in_words, _mem_tag);
 }
 
-void CHeapBitMap::swap(CHeapBitMap &other) {
+void CHeapBitMap::move(CHeapBitMap &other) {
   free(map(), size_in_words());
   update(other.map(), other.size());
   other.update(nullptr, 0);

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -654,6 +654,9 @@ class CHeapBitMap : public GrowableBitMap<CHeapBitMap> {
   bm_word_t* allocate(idx_t size_in_words) const;
   bm_word_t* reallocate(bm_word_t* old_map, size_t old_size_in_words, size_t new_size_in_words) const;
   void free(bm_word_t* map, idx_t size_in_words) const;
+
+  // Move other's map into this, invalidating other.
+  void swap(CHeapBitMap &other);
 };
 
 // Convenience class wrapping BitMap which provides multiple bits per slot.

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -656,7 +656,7 @@ class CHeapBitMap : public GrowableBitMap<CHeapBitMap> {
   void free(bm_word_t* map, idx_t size_in_words) const;
 
   // Move other's map into this, invalidating other.
-  void swap(CHeapBitMap &other);
+  void move(CHeapBitMap& other);
 };
 
 // Convenience class wrapping BitMap which provides multiple bits per slot.

--- a/test/hotspot/gtest/nmt/test_nmt_ht.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_ht.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "nmt/nmtHashTable.hpp"
+#include "unittest.hpp"
+
+
+struct KVElement {
+  int k;
+  int v;
+  static size_t hash(int x) {
+    return x & 0xFF;
+  }
+  static bool equals(int v1, int v2) {
+    return v1 == v2;
+  }
+};
+
+TEST(NMTOAHTTest, Basic) {
+  auto key = [](const KVElement& kv) { return kv.k; };
+  auto hash = [](int x) { return KVElement::hash(x); };
+  auto equals = [](int v1, int v2) { return KVElement::equals(v1, v2); };
+  using BasicHT = OpenAddressedHashTable<KVElement,
+                                         decltype(key),
+                                         decltype(hash),
+                                         decltype(equals)>;
+
+  BasicHT ht(key, hash, equals);
+  KVElement kv{1, 1};
+  bool found = false;
+  ht.put_if_absent(kv, &found);
+  assert(found == false, "");
+  assert(ht.occupied() == 1, "");
+  kv.v = 0;
+  KVElement* found_kv = ht.put_if_absent(kv, &found);
+  assert(found == true, "");
+  assert(found_kv->v == 1, "");
+}
+
+struct PointerKey {
+  int value;
+
+  unsigned int hash() const {
+    return value;
+  }
+
+  bool equals(const PointerKey& other) const {
+    return value == other.value;
+  }
+};
+
+struct PointerKeyElement {
+  PointerKey _key;
+  int _v;
+
+  const PointerKey* key() const {
+    return &_key;
+  }
+};
+
+TEST(NMTOAHTTest, PointerKeyAccessor) {
+  auto key = [](const PointerKeyElement& kv) -> const PointerKey& {
+    return *kv.key();
+  };
+  auto hash = [](const PointerKey& key) { return key.hash(); };
+  auto equals = [](const PointerKey& v1, const PointerKey& v2) {
+    return v1.equals(v2);
+  };
+  using PointerKeyHT = OpenAddressedHashTable<PointerKeyElement,
+                                             decltype(key),
+                                             decltype(hash),
+                                             decltype(equals)>;
+
+  PointerKeyHT ht(key, hash, equals);
+  PointerKeyElement kv{{1}, 1};
+  bool found = false;
+  ht.put_if_absent(kv, &found);
+  assert(found == false, "");
+  assert(ht.occupied() == 1, "");
+  kv._v = 0;
+  PointerKeyElement* found_kv = ht.put_if_absent(kv, &found);
+  assert(found == true, "");
+  assert(found_kv->_v == 1, "");
+}

--- a/test/hotspot/gtest/nmt/test_nmt_ht.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_ht.cpp
@@ -29,7 +29,7 @@
 struct KVElement {
   int k;
   int v;
-  static size_t hash(int x) {
+  static int hash(int x) {
     return x & 0xFF;
   }
   static bool equals(int v1, int v2) {

--- a/test/hotspot/gtest/nmt/test_nmt_ht.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_ht.cpp
@@ -50,12 +50,12 @@ TEST(NMTOAHTTest, Basic) {
   KVElement kv{1, 1};
   bool found = false;
   ht.put_if_absent(kv, &found);
-  assert(found == false, "");
-  assert(ht.occupied() == 1, "");
+  EXPECT_FALSE(found);
+  EXPECT_EQ(1, ht.occupied());
   kv.v = 0;
   KVElement* found_kv = ht.put_if_absent(kv, &found);
-  assert(found == true, "");
-  assert(found_kv->v == 1, "");
+  EXPECT_TRUE(found);
+  EXPECT_EQ(1, found_kv->v);
 }
 
 struct PointerKey {
@@ -96,10 +96,10 @@ TEST(NMTOAHTTest, PointerKeyAccessor) {
   PointerKeyElement kv{{1}, 1};
   bool found = false;
   ht.put_if_absent(kv, &found);
-  assert(found == false, "");
-  assert(ht.occupied() == 1, "");
+  EXPECT_FALSE(found);
+  EXPECT_EQ(1, ht.occupied());
   kv._v = 0;
   PointerKeyElement* found_kv = ht.put_if_absent(kv, &found);
-  assert(found == true, "");
-  assert(found_kv->_v == 1, "");
+  EXPECT_TRUE(found);
+  EXPECT_EQ(1, found_kv->_v);
 }

--- a/test/hotspot/gtest/nmt/test_nmt_ht.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_ht.cpp
@@ -95,3 +95,43 @@ TEST(NMTOAHTTest, PointerKeyAccessor) {
   EXPECT_TRUE(found);
   EXPECT_EQ(1, found_kv->_v);
 }
+
+TEST(NMTOAHTTest, Detach) {
+  auto hash = [](const PointerKeyElement& kv) { return kv.key()->hash(); };
+  auto equals = [](const PointerKeyElement& a, const PointerKeyElement& b) {
+    return a.key()->equals(*b.key());
+  };
+  using PointerKeyHT = OpenAddressedHashTable<PointerKeyElement,
+                                              decltype(hash),
+                                              decltype(equals)>;
+  PointerKeyHT ht(hash, equals);
+  bool found = false;
+  PointerKeyElement kv{{1}, 1};
+  ht.put_if_absent(kv, &found);
+  PointerKeyElement kv2{{2}, 1};
+  ht.put_if_absent(kv2, &found);
+
+  // Check state of returned array
+  int len = 0;
+  PointerKeyElement* array = ht.detach(&len);
+  EXPECT_EQ(2, len);
+  // Check both elements are inserted
+  bool found_elts[2] = {false, false};
+  for (int i = 0; i < len; i++) {
+    PointerKeyElement x = array[i];
+    found_elts[0] = found_elts[0] || x.key()->equals(*kv.key());
+    found_elts[1] = found_elts[1] || x.key()->equals(*kv2.key());
+  }
+  EXPECT_TRUE(found_elts[0]);
+  EXPECT_TRUE(found_elts[1]);
+
+  // Check state of the hashtable
+  EXPECT_EQ(0, ht.occupied());
+  found = false;
+  EXPECT_NE(nullptr, ht.put_if_absent(kv, &found));
+  EXPECT_FALSE(found);
+  EXPECT_NE(nullptr, ht.put_if_absent(kv2, &found));
+  EXPECT_FALSE(found);
+
+  FREE_C_HEAP_ARRAY(array);
+}

--- a/test/hotspot/gtest/nmt/test_nmt_ht.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_ht.cpp
@@ -29,24 +29,20 @@
 struct KVElement {
   int k;
   int v;
-  static int hash(int x) {
-    return x & 0xFF;
+  static int hash(const KVElement& a) {
+    return a.k & 0xFF;
   }
-  static bool equals(int v1, int v2) {
-    return v1 == v2;
+  static bool equals(const KVElement& a, const KVElement& b) {
+    return a.k == b.k;
   }
 };
 
 TEST(NMTOAHTTest, Basic) {
-  auto key = [](const KVElement& kv) { return kv.k; };
-  auto hash = [](int x) { return KVElement::hash(x); };
-  auto equals = [](int v1, int v2) { return KVElement::equals(v1, v2); };
   using BasicHT = OpenAddressedHashTable<KVElement,
-                                         decltype(key),
-                                         decltype(hash),
-                                         decltype(equals)>;
+                                         decltype(&KVElement::hash),
+                                         decltype(&KVElement::equals)>;
 
-  BasicHT ht(key, hash, equals);
+  BasicHT ht(&KVElement::hash, &KVElement::equals);
   KVElement kv{1, 1};
   bool found = false;
   ht.put_if_absent(kv, &found);
@@ -80,19 +76,15 @@ struct PointerKeyElement {
 };
 
 TEST(NMTOAHTTest, PointerKeyAccessor) {
-  auto key = [](const PointerKeyElement& kv) -> const PointerKey& {
-    return *kv.key();
-  };
-  auto hash = [](const PointerKey& key) { return key.hash(); };
-  auto equals = [](const PointerKey& v1, const PointerKey& v2) {
-    return v1.equals(v2);
+  auto hash = [](const PointerKeyElement& kv) { return kv.key()->hash(); };
+  auto equals = [](const PointerKeyElement& a, const PointerKeyElement& b) {
+    return a.key()->equals(*b.key());
   };
   using PointerKeyHT = OpenAddressedHashTable<PointerKeyElement,
-                                             decltype(key),
                                              decltype(hash),
                                              decltype(equals)>;
 
-  PointerKeyHT ht(key, hash, equals);
+  PointerKeyHT ht(hash, equals);
   PointerKeyElement kv{{1}, 1};
   bool found = false;
   ht.put_if_absent(kv, &found);


### PR DESCRIPTION
Hi,

This PR rewrites the NMT SummaryDiff hashtable and moves it into a separate file and finally uses it to store the VirtualMemoryAllocationSites.

The hashtable is still open-addressed, as in, all of its entries are stored in an array. I've changed it so that membership is stored in a growable bitmap. This allows the key value container to be user-defined, and for the backing array to be extracted when the usage of the hashtable is over.

So we can do this:

```c++
struct MyKV {
  int key; int count;
}
MyHT ht;
// Fill the ht with stuff, incrementing the count when the same key is inserted
// Now, we want to print the sorted results, with descending keys, so we detach the array.
int length;
MyKV* myA = ht.detach(&length); // Detach makes the sparse array dense, without reallocating
qsort(myA, ....);
for i = 0; i < length; i++
  ...
// Done
os::free(myA);
```
This feature turns out to be exactly what we need in MemBaseline, as then we avoid a costly linked list implementation, and a linear search for each insertion when iterating over the virtual tree's reserved regions.

I also fixed a bug in the VMATree, where we accessed potentially stale data.

**NOTE**: This new hashtable does support returning null on OOM, but it will only do so if the array allocation fails, not if the occupancy bitmap needs to be resized and that fails, then we exit on oom. I believe that this is an OK trade-off (the risk of running out of occupancy bytes is very, very low), and we could extend the growable bitmap to support OOM behavior, if the reviewers disagree.
---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385564](https://bugs.openjdk.org/browse/JDK-8385564): Replace VMA linked list with hashtable in MemBaseline (**Enhancement** - P4)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31133/head:pull/31133` \
`$ git checkout pull/31133`

Update a local copy of the PR: \
`$ git checkout pull/31133` \
`$ git pull https://git.openjdk.org/jdk.git pull/31133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31133`

View PR using the GUI difftool: \
`$ git pr show -t 31133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31133.diff">https://git.openjdk.org/jdk/pull/31133.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31133#issuecomment-5397482108)
</details>
