### PR TITLE
8384486: NTLM tests fail on Windows 11 and Windows Server 2025

### DIFF
--- a/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
+++ b/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,9 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @bug 8270290
- * @requires os.name != "Windows 11" & os.name != "Windows Server 2025"
+ * @requires os.family != "windows"
  * @library /test/lib
  * @run main/othervm NTLMHeadTest SERVER
  * @run main/othervm NTLMHeadTest PROXY
@@ -47,6 +47,17 @@
  *      (to not block on socket read) because HEAD is sent to server and
  *      NTLMSSP_CHALLENGE response includes Content-Length, but does not
  *      include the body.
+ */
+
+/*
+ * @test id=windows
+ * @bug 8270290
+ * @comment Only run on specific Windows OS versions because NTLMv1 is no longer supported starting Windows 11 and Windows Server 2025
+ * @requires os.family == "windows" & (os.name == "Windows 10" | os.name == "Windows Server 2016" | os.name == "Windows Server 2019" | os.name == "Windows Server 2022")
+ * @library /test/lib
+ * @run main/othervm NTLMHeadTest SERVER
+ * @run main/othervm NTLMHeadTest PROXY
+ * @run main/othervm NTLMHeadTest TUNNEL
  */
 
 import java.net.*;

--- a/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
+++ b/test/jdk/sun/net/www/protocol/http/NTLMHeadTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8270290
+ * @requires os.name != "Windows 11" & os.name != "Windows Server 2025"
  * @library /test/lib
  * @run main/othervm NTLMHeadTest SERVER
  * @run main/othervm NTLMHeadTest PROXY

--- a/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
+++ b/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
@@ -26,7 +26,7 @@
  * @bug 8225425
  * @summary Verifies that transparent NTLM (on Windows) is not used by default,
  *          and is used only when the relevant property is set.
- * @requires os.family == "windows"
+ * @requires os.family == "windows" & os.name != "Windows 11" & os.name != "Windows Server 2025"
  * @library /test/lib
  * @run junit/othervm
  *      -Dtest.auth.succeed=false

--- a/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
+++ b/test/jdk/sun/net/www/protocol/http/TestTransparentNTLM.java
@@ -26,7 +26,8 @@
  * @bug 8225425
  * @summary Verifies that transparent NTLM (on Windows) is not used by default,
  *          and is used only when the relevant property is set.
- * @requires os.family == "windows" & os.name != "Windows 11" & os.name != "Windows Server 2025"
+ * @comment Only run on specific Windows OS versions because NTLMv1 is no longer supported starting Windows 11 and Windows Server 2025
+ * @requires os.family == "windows" & (os.name == "Windows 10" | os.name == "Windows Server 2016" | os.name == "Windows Server 2019" | os.name == "Windows Server 2022")
  * @library /test/lib
  * @run junit/othervm
  *      -Dtest.auth.succeed=false


### PR DESCRIPTION
NTLM is removed from Windows 11 24H2 and Windows Server 2025 [1],
causing the NTLMHeadTest and TestTransparentNTLM tests to fail on these
platforms.  This patch adds an annotation to skip these tests on Windows
11 and on Windows Server 2025.

[1] https://support.microsoft.com/en-us/topic/upcoming-changes-to-ntlmv1-in-windows-11-version-24h2-and-windows-server-2025-c0554217-cdbc-420f-b47c-e02b2db49b2e

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384486](https://bugs.openjdk.org/browse/JDK-8384486): NTLM tests fail on Windows 11 and Windows Server 2025 (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31141/head:pull/31141` \
`$ git checkout pull/31141`

Update a local copy of the PR: \
`$ git checkout pull/31141` \
`$ git pull https://git.openjdk.org/jdk.git pull/31141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31141`

View PR using the GUI difftool: \
`$ git pr show -t 31141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31141.diff">https://git.openjdk.org/jdk/pull/31141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31141#issuecomment-4434576316)
</details>
