### PR TITLE
8384229: Previously accepted code is rejected after JDK-8378102

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2358,7 +2358,8 @@ public class Resolve {
                 bestSoFar != sym) {
                 return new AmbiguityError(bestSoFar, sym);
             } else if (env.toplevel.namedImportScope == scope &&
-                    (sym == typeNotFound || (sym.kind == ERR && s.kind == ERR))) {
+                    ((sym == typeNotFound && s.kind.matches(KindSelector.TYP)) ||
+                    (sym.kind == ERR && s.kind == ERR))) {
                 bestSoFar = bestOf(bestSoFar, new UnresolvableGobalSymbolError(s));
             } else
                 bestSoFar = bestOf(bestSoFar, sym);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2360,7 +2360,7 @@ public class Resolve {
             } else if (env.toplevel.namedImportScope == scope &&
                     ((sym == typeNotFound && s.kind.matches(KindSelector.TYP)) ||
                     (sym.kind == ERR && s.kind == ERR))) {
-                bestSoFar = bestOf(bestSoFar, new UnresolvableGobalSymbolError(s));
+                bestSoFar = bestOf(bestSoFar, new UnresolvableGlobalSymbolError(s));
             } else
                 bestSoFar = bestOf(bestSoFar, sym);
         }
@@ -4158,9 +4158,9 @@ public class Resolve {
                 List<Type> typeargtypes);
     }
 
-    class UnresolvableGobalSymbolError extends InvalidSymbolError {
+    class UnresolvableGlobalSymbolError extends InvalidSymbolError {
 
-        UnresolvableGobalSymbolError(Symbol sym) {
+        UnresolvableGlobalSymbolError(Symbol sym) {
             super(HIDDEN, sym, "unresolvable class error");
             this.name = sym.name;
         }

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8301580 8322159 8333107 8332230 8338678 8351260 8366196 8372336 8373094
+ * @bug 8301580 8322159 8333107 8332230 8338678 8351260 8366196 8372336 8373094 8384229
  * @summary Verify error recovery w.r.t. Attr
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -798,6 +798,66 @@ public class AttrRecovery {
         );
 
         assertEquals(expected, actual);
+    }
+
+    @Test //JDK-8384229
+    public void testStaticFieldTypeLookup() throws Exception {
+        Path out = base.resolve("out");
+
+        Files.createDirectories(out);
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDdev")
+                .sources("""
+                         package test;
+                         import static test.A.Object;
+                         enum A {
+                             Object;
+                         }
+                         class Test {
+                             void foo() {
+                                 Object f = "";
+                             }
+                         }
+                         """)
+                .outdir(out)
+                .run()
+                .writeAll();
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDdev")
+                .sources("""
+                         package test;
+                         import static test.A.Object;
+                         enum A {
+                             Object;
+                         }
+                         class Test {
+                             private static final Object f = "";
+                         }
+                         """)
+                .outdir(out)
+                .run()
+                .writeAll();
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics",
+                         "-XDdev")
+                .sources("""
+                         package test;
+                         import static test.A.Object;
+                         class A {
+                             public static java.lang.Object Object() { return null; }
+                         }
+                         class Test {
+                             private static final Object f = Object();
+                         }
+                         """)
+                .outdir(out)
+                .run()
+                .writeAll();
     }
 
     @BeforeEach


### PR DESCRIPTION
Under https://bugs.openjdk.org/browse/JDK-8378102, if the named import scope contains a Symbol that cannot be loaded as a class, a new (nicer) error symbol is create for it. This was meant for TYP-like symbols, but unintentionally is also applied for statically imported fields and methods, which means such statically imported symbols are not usable.

The proposal in this PR is to restrict the new handling only to TYP (and ERR) symbols.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384229](https://bugs.openjdk.org/browse/JDK-8384229): Previously accepted code is rejected after JDK-8378102 (**Bug** - P2)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31143/head:pull/31143` \
`$ git checkout pull/31143`

Update a local copy of the PR: \
`$ git checkout pull/31143` \
`$ git pull https://git.openjdk.org/jdk.git pull/31143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31143`

View PR using the GUI difftool: \
`$ git pr show -t 31143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31143.diff">https://git.openjdk.org/jdk/pull/31143.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31143#issuecomment-4437931020)
</details>
