### PR TITLE
8384505: Account for all jtreg-based frames in stack walk test

### DIFF
--- a/test/jdk/java/lang/StackWalker/StackWalkTest.java
+++ b/test/jdk/java/lang/StackWalker/StackWalkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,11 +56,11 @@ public class StackWalkTest {
     static final Set<String> infrastructureClasses = new TreeSet<>(Arrays.asList(
             "jdk.internal.reflect.DirectMethodHandleAccessor",
             "java.lang.reflect.Method",
-            "com.sun.javatest.regtest.MainWrapper$MainThread",
-            "com.sun.javatest.regtest.agent.MainWrapper$MainThread",
-            "com.sun.javatest.regtest.agent.MainWrapper$MainTask",
             "java.lang.Thread"
     ));
+    static final List<String> infrastructurePackages = List.of(
+            "com.sun.javatest.regtest."
+    );
     static final List<Class<?>> streamPipelines = Arrays.asList(
         classForName("java.util.stream.AbstractPipeline"),
         classForName("java.util.stream.TerminalOp")
@@ -128,6 +128,11 @@ public class StackWalkTest {
         if (count >= recorder.frameCount()) {
             // We've gone past main()...
             if (infrastructureClasses.contains(sf.getClassName())) {
+                // safe to ignore
+                return;
+            }
+            for (var prefix : infrastructurePackages) {
+                if (sf.getClassName().startsWith(prefix))
                 // safe to ignore
                 return;
             }

--- a/test/jdk/java/lang/StackWalker/StackWalkTest.java
+++ b/test/jdk/java/lang/StackWalker/StackWalkTest.java
@@ -131,10 +131,11 @@ public class StackWalkTest {
                 // safe to ignore
                 return;
             }
-            for (var prefix : infrastructurePackages) {
-                if (sf.getClassName().startsWith(prefix))
-                // safe to ignore
-                return;
+            for (String prefix : infrastructurePackages) {
+                if (sf.getClassName().startsWith(prefix)) {
+                    // safe to ignore
+                    return;
+                }
             }
         }
         try {


### PR DESCRIPTION
Please review this test-only change to account for all jtreg-based frames in `StackWalkTest.java`

The change replaces a set of explicit class names with a package name-based logic to filter out stackframe elements originating from jtreg.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384505](https://bugs.openjdk.org/browse/JDK-8384505): Account for all jtreg-based frames in stack walk test (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31144/head:pull/31144` \
`$ git checkout pull/31144`

Update a local copy of the PR: \
`$ git checkout pull/31144` \
`$ git pull https://git.openjdk.org/jdk.git pull/31144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31144`

View PR using the GUI difftool: \
`$ git pr show -t 31144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31144.diff">https://git.openjdk.org/jdk/pull/31144.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31144#issuecomment-4438330602)
</details>
