### PR TITLE
8384428: C2: compiler/vectorapi/TestVectorLongToMaskNodeIdealization.java fails with AVX2

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -62,8 +62,6 @@ compiler/vectorization/TestVectorAlgorithms.java#noSuperWord 8376803 aix-ppc64,l
 compiler/vectorization/TestVectorAlgorithms.java#vanilla 8376803 aix-ppc64,linux-s390x
 compiler/vectorization/TestVectorAlgorithms.java#noOptimizeFill 8376803 aix-ppc64,linux-s390x
 
-compiler/vectorapi/TestVectorLongToMaskNodeIdealization.java 8384428 generic-x64
-
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java 8331704 linux-riscv64
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java 8331704 linux-riscv64

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorLongToMaskNodeIdealization.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorLongToMaskNodeIdealization.java
@@ -95,7 +95,6 @@ public class TestVectorLongToMaskNodeIdealization {
                   IRNode.VECTOR_MASK_TO_LONG,                   "= 0", // Optimized away
                   IRNode.VECTOR_MASK_CAST,                      "= 0", // Optimized away
                   IRNode.VECTOR_BLEND_I,  IRNode.VECTOR_SIZE_4, "> 0",
-                  IRNode.XOR_VI,          IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR,                          "> 0"},
                   applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     @IR(counts = {IRNode.REPLICATE_L,     IRNode.VECTOR_SIZE_4, "> 0",
@@ -170,7 +169,6 @@ public class TestVectorLongToMaskNodeIdealization {
                   IRNode.VECTOR_MASK_TO_LONG,                   "= 0", // Optimized away
                   IRNode.VECTOR_MASK_CAST,                      "= 0", // Optimized away
                   IRNode.VECTOR_BLEND_I,  IRNode.VECTOR_SIZE_4, "> 0",
-                  IRNode.XOR_VI,          IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR,                          "> 0"},
                   applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     @IR(counts = {IRNode.REPLICATE_L,     IRNode.VECTOR_SIZE_4, "> 0",
@@ -221,7 +219,6 @@ public class TestVectorLongToMaskNodeIdealization {
                   IRNode.VECTOR_MASK_TO_LONG,                   "= 0", // Optimized away
                   IRNode.VECTOR_MASK_CAST,                      "= 0", // Optimized away
                   IRNode.VECTOR_BLEND_I,  IRNode.VECTOR_SIZE_4, "> 0",
-                  IRNode.XOR_VI,          IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR,                          "> 0"},
                   applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     @IR(counts = {IRNode.REPLICATE_L,     IRNode.VECTOR_SIZE_4, "= 0",


### PR DESCRIPTION
All the failing tests contains following source fragment 

  Java Source:
```
    var trues_I128 = VectorMask.fromLong(IntVector.SPECIES_128, trues_L256.toLong());
    var zeros = IntVector.zero(IntVector.SPECIES_128);
    var m1s = zeros.lanewise(VectorOperators.NOT, trues_I128);
```

  On AVX2 `VectorMask.fromLong` generates a `NVectMask,` `IntVector.zero` results into `Replicate` IR and `VectorOperators.NOT` generates `[XorV (zeros Replicate -1)].` Thus both the inputs of `XorV `are` Replicate` nodes which triggers `VectorNode::push_through_replicate` thereby replacing `XorV` with replicated constant folded scalar -1.

Removed XorV nodes from @IR rules of failing tests.

Kindly review and share your feedback.

Thanks
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384428](https://bugs.openjdk.org/browse/JDK-8384428): C2: compiler/vectorapi/TestVectorLongToMaskNodeIdealization.java fails with AVX2 (**Bug** - P3)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31145/head:pull/31145` \
`$ git checkout pull/31145`

Update a local copy of the PR: \
`$ git checkout pull/31145` \
`$ git pull https://git.openjdk.org/jdk.git pull/31145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31145`

View PR using the GUI difftool: \
`$ git pr show -t 31145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31145.diff">https://git.openjdk.org/jdk/pull/31145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31145#issuecomment-4438536788)
</details>
