### PR TITLE
8375645: C2: NPE in compiled method does not occur with interpreter

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -24,6 +24,7 @@
 
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
+#include "libadt/vectset.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/objArrayKlass.hpp"
@@ -34,9 +35,11 @@
 #include "opto/convertnode.hpp"
 #include "opto/loopnode.hpp"
 #include "opto/machnode.hpp"
+#include "opto/memnode.hpp"
 #include "opto/movenode.hpp"
 #include "opto/mulnode.hpp"
 #include "opto/narrowptrnode.hpp"
+#include "opto/node.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/regalloc.hpp"
 #include "opto/regmask.hpp"
@@ -1105,23 +1108,30 @@ PhiNode* PhiNode::split_out_instance(const TypePtr* at, PhaseIterGVN *igvn) cons
   const TypeOopPtr *t_oop = at->isa_oopptr();
   assert(t_oop != nullptr && t_oop->is_known_instance(), "expecting instance oopptr");
 
-  // Check if an appropriate node already exists.
-  Node *region = in(0);
-  for (DUIterator_Fast kmax, k = region->fast_outs(kmax); k < kmax; k++) {
-    Node* use = region->fast_out(k);
-    if( use->is_Phi()) {
-      PhiNode *phi2 = use->as_Phi();
-      if (phi2->type() == Type::MEMORY && phi2->adr_type() == at) {
-        return phi2;
+  auto find_existing = [&](const PhiNode* bot_phi) -> PhiNode* {
+    Node* region = bot_phi->in(0);
+    for (DUIterator_Fast imax, i = region->fast_outs(imax); i < imax; i++) {
+      Node* use = region->fast_out(i);
+      if (use->is_Phi() && use->bottom_type() == Type::MEMORY && use->adr_type() == at) {
+        return use->as_Phi();
       }
     }
+
+    return nullptr;
+  };
+
+  PhiNode* nphi = find_existing(this);
+  if (nphi != nullptr) {
+    return nphi;
   }
+
   Compile *C = igvn->C;
   ResourceMark rm;
   Node_Array node_map;
   Node_Stack stack(C->live_nodes() >> 4);
-  PhiNode *nphi = slice_memory(at);
-  igvn->register_new_node_with_optimizer( nphi );
+
+  nphi = slice_memory(at);
+  igvn->register_new_node_with_optimizer(nphi);
   node_map.map(_idx, nphi);
   stack.push((Node *)this, 1);
   while(!stack.is_empty()) {
@@ -1138,6 +1148,14 @@ PhiNode* PhiNode::split_out_instance(const TypePtr* at, PhaseIterGVN *igvn) cons
       PhiNode *optphi = opt->is_Phi() ? opt->as_Phi() : nullptr;
       if (optphi != nullptr && optphi->adr_type() == TypePtr::BOTTOM) {
         opt = node_map[optphi->_idx];
+        if (opt == nullptr) {
+          // Phis that are created previously can be elided during IGVN. As a result, even if there
+          // is no corresponding Phi at the same Region as this, there can still be one here, and
+          // we must look for it to avoid generating multiple memory Phis of the same adr_type.
+          opt = find_existing(optphi);
+          node_map.map(optphi->_idx, opt);
+        }
+
         if (opt == nullptr) {
           stack.push(ophi, i);
           nphi = optphi->slice_memory(at);
@@ -2151,6 +2169,68 @@ bool PhiNode::is_split_through_mergemem_terminating() const {
   return true;
 }
 
+// Phi(...MergeMem(m0, m1:AT1, m2:AT2)...) into
+//     MergeMem(Phi(...m0...), Phi:AT1(...m1...), Phi:AT2(...m2...))
+MergeMemNode* PhiNode::push_mergemems_down_through_phi(PhaseIterGVN* igvn) {
+  assert(igvn != nullptr, "only during IGVN");
+  PhiNode* new_base = (PhiNode*) clone();
+  // Must eagerly register phis, since they participate in loops.
+  igvn->register_new_node_with_optimizer(new_base);
+  MergeMemNode* result = MergeMemNode::make(new_base);
+
+  // Record the existing memory Phis to avoid creating multiple Phis of the same memory at the same
+  // RegionNode
+  ResourceMark rm;
+  VectorSet existing_phis;
+  RegionNode* region = this->region();
+  for (DUIterator_Fast imax, i = region->fast_outs(imax); i < imax; i++) {
+    Node* mem_phi = region->fast_out(i);
+    if (mem_phi->is_memory_phi() && mem_phi->adr_type() != TypePtr::BOTTOM) {
+      int alias_idx = igvn->C->get_alias_index(mem_phi->adr_type());
+      existing_phis.set(alias_idx);
+      result->set_memory_at(alias_idx, mem_phi);
+    }
+  }
+
+  for (uint phi_in_idx = 1; phi_in_idx < req(); phi_in_idx++) {
+    MergeMemNode* phi_in = in(phi_in_idx)->isa_MergeMem();
+    if (phi_in == nullptr) {
+      continue;
+    }
+
+    for (MergeMemStream mms(result, phi_in); mms.next_non_empty2(); ) {
+      if (existing_phis.test(mms.alias_idx())) {
+        continue;
+      }
+
+      // If we have not seen this slice yet, make a phi for it.
+      bool made_new_phi = false;
+      if (mms.is_empty()) {
+        Node* new_phi = new_base->slice_memory(mms.adr_type(igvn->C));
+        made_new_phi = true;
+        igvn->register_new_node_with_optimizer(new_phi);
+        mms.set_memory(new_phi);
+      }
+
+      Node* phi = mms.memory();
+      assert(made_new_phi || phi->in(phi_in_idx) == phi_in, "replace the i-th merge by a slice");
+      phi->set_req_X(phi_in_idx, mms.memory2(), igvn);
+    }
+  }
+
+  // Distribute all self-loops
+  for (MergeMemStream mms(result); mms.next_non_empty(); ) {
+    Node* phi = mms.memory();
+    for (uint i = 1; i < req(); ++i) {
+      if (phi->in(i) == this) {
+        phi->set_req_X(i, phi, igvn);
+      }
+    }
+  }
+
+  return result;
+}
+
 // Is one of the inputs a Cast that has not been processed by igvn yet?
 bool PhiNode::wait_for_cast_input_igvn(const PhaseIterGVN* igvn) const {
   for (uint i = 1, cnt = req(); i < cnt; ++i) {
@@ -2619,53 +2699,11 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           return top;
         }
 
-        // Phi(...MergeMem(m0, m1:AT1, m2:AT2)...) into
-        //     MergeMem(Phi(...m0...), Phi:AT1(...m1...), Phi:AT2(...m2...))
-        PhaseIterGVN* igvn = phase->is_IterGVN();
-        assert(igvn != nullptr, "sanity check");
-        PhiNode* new_base = (PhiNode*) clone();
-        // Must eagerly register phis, since they participate in loops.
-        igvn->register_new_node_with_optimizer(new_base);
-
-        MergeMemNode* result = MergeMemNode::make(new_base);
-        for (uint i = 1; i < req(); ++i) {
-          Node *ii = in(i);
-          if (ii->is_MergeMem()) {
-            MergeMemNode* n = ii->as_MergeMem();
-            for (MergeMemStream mms(result, n); mms.next_non_empty2(); ) {
-              // If we have not seen this slice yet, make a phi for it.
-              bool made_new_phi = false;
-              if (mms.is_empty()) {
-                Node* new_phi = new_base->slice_memory(mms.adr_type(phase->C));
-                made_new_phi = true;
-                igvn->register_new_node_with_optimizer(new_phi);
-                mms.set_memory(new_phi);
-              }
-              Node* phi = mms.memory();
-              assert(made_new_phi || phi->in(i) == n, "replace the i-th merge by a slice");
-              phi->set_req_X(i, mms.memory2(), phase);
-            }
-          }
-        }
-        // Distribute all self-loops.
-        { // (Extra braces to hide mms.)
-          for (MergeMemStream mms(result); mms.next_non_empty(); ) {
-            Node* phi = mms.memory();
-            for (uint i = 1; i < req(); ++i) {
-              if (phi->in(i) == this) {
-                phi->set_req_X(i, phi, phase);
-              }
-            }
-          }
-        }
-
         // We could immediately transform the new Phi nodes here, but that can
         // result in creating an excessive number of new nodes within a single
         // IGVN iteration. We have put the Phi nodes on the IGVN worklist, so
         // they are transformed later on in any case.
-
-        // Replace self with the result.
-        return result;
+        return push_mergemems_down_through_phi(phase->is_IterGVN());
       }
     }
     //

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -180,6 +180,7 @@ class PhiNode : public TypeNode {
   bool must_wait_for_region_in_irreducible_loop(PhaseGVN* phase) const;
 
   bool is_split_through_mergemem_terminating() const;
+  MergeMemNode* push_mergemems_down_through_phi(PhaseIterGVN* igvn);
 
   void verify_type_stability(const PhaseGVN* phase, const Type* union_of_input_types, const Type* new_type) const NOT_DEBUG_RETURN;
   bool wait_for_cast_input_igvn(const PhaseIterGVN* igvn) const;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -396,8 +396,8 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
     base = address->in(AddPNode::Base);
   }
   if (base != nullptr && phase->type(base)->higher_equal(TypePtr::NULL_PTR) &&
-      !t_adr->isa_rawptr()) {
-    // Note: raw address has TOP base and top->higher_equal(TypePtr::NULL_PTR) is true.
+      !t_adr->isa_rawptr() && !t_adr->isa_klassptr()) {
+    // Note: non-oop address has TOP base and top->higher_equal(TypePtr::NULL_PTR) is true.
     // Skip this node optimization if its address has TOP base.
     return NodeSentinel; // caller will return null
   }
@@ -5971,6 +5971,36 @@ void MergeMemNode::set_base_memory(Node *new_base) {
       if (in(i) == new_base)  set_req(i, empty_mem);
     }
   }
+}
+
+// The base_memory of this is a MergeMemNode, collapse it into this, effectively looking through
+// the MergeMem base input of this node
+void MergeMemNode::collapse_mergemem_base(PhaseGVN* phase) {
+  MergeMemNode* base = base_memory()->isa_MergeMem();
+  assert(base != nullptr, "unexpected base_memory %s", base_memory()->Name());
+
+  grow_to_match(base);
+  Node* empty_mem = empty_memory();
+  assert(base->is_empty_memory(empty_mem), "must be compatible");
+
+  Node* base_base = base->base_memory();
+  assert(!is_empty_memory(base_base), "must not be an empty memory");
+  assert(base_base != this, "invalid cycle");
+  assert(!base_base->is_MergeMem(), "should not chain");
+  set_req_X(Compile::AliasIdxBot, base_base, phase);
+
+  for (uint i = Compile::AliasIdxRaw; i < req(); i++) {
+    Node* current_mem = in(i);
+    if (current_mem == base_base) {
+      set_req_X(i, empty_mem, phase);
+    } else if (is_empty_memory(current_mem)) {
+      Node* new_mem = i < base->req() ? base->in(i) : empty_mem;
+      assert(new_mem != this, "invalid cycle");
+      set_req_X(i, new_mem, phase);
+    }
+  }
+
+  assert(verify_sparse(), "MergeMem invariant");
 }
 
 //------------------------------out_RegMask------------------------------------

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1542,6 +1542,9 @@ public:
   void iteration_setup(const MergeMemNode* other = nullptr);
   // push sentinels until I am at least as long as the other (semantic no-op)
   void grow_to_match(const MergeMemNode* other);
+
+  void collapse_mergemem_base(PhaseGVN* phase);
+
   bool verify_sparse() const PRODUCT_RETURN0;
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -24,6 +24,7 @@
 
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
+#include "libadt/vectset.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "opto/addnode.hpp"
@@ -35,11 +36,15 @@
 #include "opto/idealGraphPrinter.hpp"
 #include "opto/loopnode.hpp"
 #include "opto/machnode.hpp"
+#include "opto/memnode.hpp"
+#include "opto/node.hpp"
 #include "opto/opcodes.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/regalloc.hpp"
 #include "opto/rootnode.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/ostream.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 //=============================================================================
@@ -1201,6 +1206,11 @@ void PhaseIterGVN::optimize(bool deep) {
     return;
   }
 
+  split_memory_phis();
+  if (drain_worklist()) {
+    return;
+  }
+
   if (deep && UseDeepIGVNRevisit) {
     deep_revisit_converged = deep_revisit();
     if (C->failing()) {
@@ -1210,6 +1220,291 @@ void PhaseIterGVN::optimize(bool deep) {
 
   NOT_PRODUCT(verify_PhaseIterGVN(deep_revisit_converged);)
   C->print_method(PHASE_AFTER_ITER_GVN, 3);
+}
+
+// Bottom memory Phis are peculiar. Consider a bottom memory Phi bot_phi and an arbitrary alias
+// class mem.
+//
+// 1. Sometimes, bot_phi does not contain the memory state corresponding to mem, and there is
+// another memory Phi mem_phi at the same region representing the memory state corresponding to
+// mem.
+//
+// if (b) {
+//   Call1();
+//   MemProj1(Call1);
+// } else {
+//   Call2();
+//   MemProj2(Call2);
+//   Store1(_, MemProj2, p, v): mem;
+// }
+// bot_phi = Phi(MemProj1, MemProj2);
+// mem_phi = Phi(MemProj1, Store1);
+//
+// In this example, bot_phi cannot contain the memory state corresponding to mem, because MemProj2
+// does not capture the store into that memory.
+//
+// 2. Sometimes, bot_phi contains the memory state corresponding to mem, even if there is another
+// memory Phi at the same region representing the memory state corresponding to mem.
+//
+// Call1();
+// MemProj1(Call1);
+// Store1(_, MemProj1, p1, v): mem;
+// MergeMem1(MemProj1, Top, Store1);
+// Load1(_, Store1, p2): mem;
+// Load2(_, MergeMem, p3): mem;
+//
+// We somehow want to multiversion some statements:
+//
+// Call1();
+// MemProj1(Call1);
+// if (b) {
+//   Store11(_, MemProj1, p1, v): mem;
+//   MergeMem11(MemProj1, Top, Store11);
+// } else {
+//   Store12(_, MemProj1, p1, v): mem;
+//   MergeMem12(MemProj1, Top, Store12);
+// }
+// bot_phi = Phi(MergeMem11, MergeMem12);
+// mem_phi = Phi(Store11, Store12);
+// Load1(_, mem_phi, p2): mem;
+// Load2(_, bot_phi, p3): mem;
+//
+// In this example, bot_phi must contain the memory state corresponding to mem, because there is a
+// load corresponding to mem from it. This pattern can be eventually simplified after IGVN, but
+// until then, the existence of mem_phi does not mean that bot_phi does not contain the memory
+// state corresponding to mem.
+//
+// 3. Sometimes, bot_phi does not contain the memory state corresponding to mem, even if there is
+// not any memory Phi at the same region representing the memory state corresponding to mem.
+//
+// Call1();
+// MemProj1(Call1);
+// Store1(_, MemProj1, p, v);
+// if (b) {
+//   MergeMem1(MemProj1, Top, Store1);
+// }
+// bot_phi = Phi(MergeMem1, MemProj1);
+//
+// In this case, bot_phi does not contain the memory state corresponding to mem, because in one
+// branch, its input is MemProj1, which does not capture the latest store Store1 of the alias class
+// mem. This situation can be removed if we push the MergeMem down through the Phi, but this
+// transformation is not universally applicable during IGVN because it can lead to infinite loop.
+//
+// This funtion solves the issue above by pushing all MergeMem inputs of bottom memory Phis down
+// through the Phi in a controlled manner. The notable property of the transformation is that,
+// the push effectively splits the bottom memory Phi, so we know for certain the new bottom memory
+// Phi does not contain the memory states corresponding to the other Phis.
+// For example:
+//
+//   Proj1       Store
+//      \       /
+//       MergeMem        Proj2
+//             \       /
+//                Phi
+//                 |
+//                ...
+//
+// Into:
+//
+//   Proj1     Proj2    Store     Proj2(this is the same node as the other Proj2)
+//       \     /            \     /
+//         Phi1              Phi2
+//             \            /
+//                MergeMem
+//                   |
+//                  ...
+//
+// While it is uncertain which memory state the original Phi contains, it is certain that Phi1 (the
+// new bottom memory Phi) does not contain the memory state corresponding to Phi2, because all uses
+// of Phi1 are uses of the new MergeMem, and that MergeMem does not read the memory state
+// corresponding to Phi2 from Phi1.
+//
+// As a result, if we record which alias classes have been split from each bottom memory Phi, it is
+// certain that the transformation will terminate, because if a MergeMem input of a bottom memory
+// Phi has all its non-top inputs being known to be excluded from that Phi, then the Phi does not
+// have to be split anymore (i.e. it can simply skip the MergeMem and is rewired to the MergeMem's
+// base input instead of having the MergeMem pushed through it).
+void PhaseIterGVN::split_memory_phis() {
+  ResourceMark rm;
+  Unique_Node_List control_graph;
+  Unique_Node_List bottom_mem_phis;
+
+  // Visit the graph in BFS order, this is an optimization that makes it so that a control is
+  // often processed after its inputs, which may help the algorithm converge faster
+  control_graph.push(C->root());
+  for (uint i = 0; i < control_graph.size(); i++) {
+    Node* n = control_graph.at(i);
+    for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+      Node* out = n->fast_out(i);
+      if (out->is_CFG()) {
+        control_graph.push(out);
+      } else if (out->is_memory_phi() && out->adr_type() == TypePtr::BOTTOM) {
+        bottom_mem_phis.push(out);
+      }
+    }
+  }
+
+  // Map the Phi idx to the VectorSet representing the alias indices that have been split from that
+  // Phi
+  GrowableArray<VectorSet*> excluded_idx_map;
+  VectorSet tmp;
+  bool progress = true;;
+  for (int iter = 0; progress; iter++) {
+    constexpr int iter_limit = 100;
+    assert(iter < iter_limit, "infinite loop");
+
+    progress = false;
+    for (uint phi_idx = 0; phi_idx < bottom_mem_phis.size(); phi_idx++) {
+      PhiNode* phi = bottom_mem_phis.at(phi_idx)->as_Phi();
+      int phi_key = phi->_idx;
+      VectorSet* excluded_idx = phi_key < excluded_idx_map.length() ? excluded_idx_map.at(phi_key) : nullptr;
+      MergeMemNode* transformed_phi = try_push_mergemems_down_through_phi(phi, excluded_idx, tmp);
+      if (transformed_phi == nullptr) {
+        continue;
+      }
+
+      // Record progress
+      C->print_method(PHASE_AFTER_SPLIT_MEMORY_PHI, 5, phi);
+      progress = true;
+      if (excluded_idx == nullptr) {
+        excluded_idx = new VectorSet();
+        excluded_idx_map.at_put_grow(phi_key, excluded_idx);
+      }
+
+      for (MergeMemStream mms(transformed_phi); mms.next_non_empty();) {
+        if (!mms.at_base_memory()) {
+          excluded_idx->set(mms.alias_idx());
+        }
+      }
+    }
+  }
+}
+
+// Try to push MergeMem inputs of a bottom memory Phi through that Phi. This function is somewhat
+// similar to what PhiNode::Ideal does, but it is used exclusively for this transformation in that
+// it reuses the old Phi as the new Phi, it rewires all uses of phi to the new MergeMemNode, and it
+// eagerly collapses chained MergeMem if the push results in a MergeMem being the base of another
+// MergeMem.
+// If phi has no MergeMem input, or for each of them, all non-top input of the MergeMem has been
+// split from phi before (recorded in excluded_idx), then this function rewires the input of phi as
+// necessary without pushing the MergeMem inputs down.
+MergeMemNode* PhaseIterGVN::try_push_mergemems_down_through_phi(PhiNode* phi, const VectorSet* excluded_idx, VectorSet& tmp) {
+  assert(phi->is_memory_phi(), "must be a memory Phi");
+  assert(phi->adr_type() == TypePtr::BOTTOM, "must be a bottom memory Phi");
+
+  // Record existing Phis to avoid creating multiple Phis of the same memory at the same Region
+  VectorSet& existing_phis = tmp;
+  existing_phis.clear();
+  MergeMemNode* result = nullptr;
+  bool progress = false;
+  for (uint phi_in_idx = 1; phi_in_idx < phi->req(); phi_in_idx++) {
+    MergeMemNode* phi_in = phi->in(phi_in_idx)->isa_MergeMem();
+    if (phi_in == nullptr) {
+      continue;
+    }
+
+    if (result == nullptr) {
+      result = MergeMemNode::make(phi);
+      register_new_node_with_optimizer(result);
+
+      RegionNode* region = phi->region();
+      for (DUIterator_Fast imax, i = region->fast_outs(imax); i < imax; i++) {
+        Node* mem_phi = region->fast_out(i);
+        if (mem_phi->is_memory_phi() && mem_phi->adr_type() != TypePtr::BOTTOM) {
+          int alias_idx = C->get_alias_index(mem_phi->adr_type());
+          existing_phis.set(alias_idx);
+          result->set_memory_at(alias_idx, mem_phi);
+        }
+      }
+    }
+
+    result->grow_to_match(phi_in);
+    for (MergeMemStream mms(phi_in); mms.next_non_empty();) {
+      if (mms.at_base_memory()) {
+        continue;
+      }
+
+      int alias_idx = mms.alias_idx();
+      if (excluded_idx != nullptr && excluded_idx->test(alias_idx)) {
+        continue;
+      }
+
+      progress = true;
+      if (existing_phis.test(alias_idx)) {
+        continue;
+      }
+
+      Node* current_mem = result->in(alias_idx);
+      if (result->is_empty_memory(current_mem)) {
+        current_mem = phi->slice_memory(C->get_adr_type(alias_idx));
+        register_new_node_with_optimizer(current_mem);
+        result->set_req(alias_idx, current_mem);
+      }
+      current_mem->set_req(phi_in_idx, mms.memory());
+    }
+
+    Node* phi_in_base = phi_in->base_memory();
+    assert(!phi_in_base->is_MergeMem(), "should not chain");
+    replace_input_of(phi, phi_in_idx, phi_in_base);
+  }
+
+  if (!progress) {
+    if (result != nullptr) {
+      remove_dead_node(result, PhaseIterGVN::NodeOrigin::Speculative);
+    }
+
+    return nullptr;
+  }
+
+  // Self-edges of the original Phi also become self-edges of the split Phis
+  assert(result != nullptr, "must have created new node");
+  for (MergeMemStream mms(result); mms.next_non_empty(); ) {
+    Node* current_mem = mms.memory();
+    assert(current_mem->is_Phi(), "unexpected result input %s", current_mem->Name());
+    assert(current_mem->req() == phi->req(), "unexpected number of input %d - %d", phi->req(), current_mem->req());
+    if (mms.at_base_memory()) {
+      assert(current_mem == phi, "unexpected modification of base memory");
+      continue;
+    }
+
+    for (uint i = 1; i < current_mem->req(); i++) {
+      if (current_mem->in(i) == phi) {
+        current_mem->set_req(i, current_mem);
+      }
+    }
+  }
+
+  // Replace the old Phi with result in the graph
+  for (DUIterator_Fast phi_out_max, phi_out_idx = phi->fast_outs(phi_out_max); phi_out_idx < phi_out_max; phi_out_idx++) {
+    Node* phi_out = phi->fast_out(phi_out_idx);
+    if (phi_out == phi || phi_out == result) {
+      continue;
+    }
+
+    uint del_cnt = 0;
+    for (uint i = 0; i < phi_out->len(); i++) {
+      Node* phi_out_in = phi_out->in(i);
+      if (phi_out_in == phi) {
+        replace_input_of(phi_out, i, result);
+        del_cnt++;
+      }
+    }
+
+    --phi_out_idx;
+    phi_out_max -= del_cnt;
+  }
+
+  // Eagerly collapse MergeMem chains at base_memory
+  for (DUIterator_Fast imax, i = result->fast_outs(imax); i < imax; i++) {
+    Node* out = result->fast_out(i);
+    if (MergeMemNode* mm = out->isa_MergeMem(); mm != nullptr && mm->base_memory() == result) {
+      mm->collapse_mergemem_base(this);
+      --i;
+      --imax;
+    }
+  }
+
+  return result;
 }
 
 #ifdef ASSERT
@@ -2163,6 +2458,35 @@ void PhaseIterGVN::verify_node_invariants_for(const Node* n) {
       tty->print_cr("%s", ss.as_string());
 
       assert(false, "Broken node invariant for %s", n->Name());
+    }
+  } else if (n->is_Region()) {
+    ResourceMark rm;
+    VectorSet visited_idx;
+    for (DUIterator_Fast n_out_max, n_out_idx = n->fast_outs(n_out_max); n_out_idx < n_out_max; n_out_idx++) {
+      Node* out = n->fast_out(n_out_idx);
+      if (out->is_memory_phi()) {
+        if (out->adr_type() == TypePtr::BOTTOM) {
+          for (uint i = 1; i < out->req(); i++) {
+            if (out->in(i)->is_MergeMem()) {
+              stringStream ss;
+              ss.cr();
+              ss.print_cr("Bottom memory Phi with a MergeMem input");
+              out->dump_bfs(2, nullptr, "", &ss);
+              tty->print_cr("%s", ss.as_string());
+              assert(false, "Broken node invariant for %s", n->Name());
+            }
+          }
+        } else {
+          if (visited_idx.test_set(C->get_alias_index(out->adr_type()))) {
+            stringStream ss;
+            ss.cr();
+            ss.print_cr("Ambiguous memory Phi at %s", n->Name());
+            n->dump_bfs(2, nullptr, "-m", &ss);
+            tty->print_cr("%s", ss.as_string());
+            assert(false, "Broken node invariant for %s", n->Name());
+          }
+        }
+      }
     }
   }
 }

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -489,6 +489,9 @@ private:
   // changes happen far away.
   bool needs_deep_revisit(const Node* n) const;
 
+  void split_memory_phis();
+  MergeMemNode* try_push_mergemems_down_through_phi(PhiNode* phi, const VectorSet* excluded_idx, VectorSet& tmp);
+
   // Subsume users of node 'old' into node 'nn'
   void subsume_node( Node *old, Node *nn );
 

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -37,6 +37,7 @@
   flags(BEFORE_ITER_GVN,                "Before Iter GVN") \
   flags(ITER_GVN1,                      "Iter GVN 1") \
   flags(AFTER_ITER_GVN_STEP,            "After Iter GVN Step") \
+  flags(AFTER_SPLIT_MEMORY_PHI,         "After Splitting Memory Phi") \
   flags(AFTER_ITER_GVN,                 "After Iter GVN") \
   flags(INCREMENTAL_INLINE_STEP,        "Incremental Inline Step") \
   flags(INCREMENTAL_INLINE_CLEANUP,     "Incremental Inline Cleanup") \


### PR DESCRIPTION
Hi,

The underlying issue is the existence of multiple `Phi`s corresponding to the same memory at the same region, which is unexpected and can confuse other components of the compiler regarding which `Phi` does represent the memory state of a particular alias class.

The first issue is the peculiarity of bottom memory `Phi`s, please see the comment above `PhaseIterGVN::split_memory_phis` in this PR for more details.

The second issue is that a `Phi` is a merge point, which allows them to participate in a data loop. This means that the IGVN may have a hard time collecting dead `Phi`s, as well as value numbering identical `Phi`s. As a result, each time we split a bottom memory `Phi`, we need to check for existing `Phi`s at that region.

There are likely more issue, such as when a load is sunk below a loop even if its memory input is not the exit state of the loop, and if we unswitch the loop, the input of the load becomes an incorrect `Phi`. These issues can be observed by running some tests with `-XX:VerifyIterativeGVN=10000`.

The test case provided in the JBS issue does not fail anymore, so it is not included in this PR. However, without the fix and with addition verification in `PhaseIterGVN::verify_node_invariants_for`, we have multiple tier1 failures. With this fix, I only see a few failures in tier3 and tier4, the other failures happen in tier 5 or higher. Running the PR without `-XX:VerifyIterativeGVN` seems clean tier1-7, hs-comp-stress. As a result, I think the PR is ready for review.

Testing:

- [ ] tier1-7,hs-comp-stress
- [x] tier1-6,hs-comp-stress - Linux-x64-fastdebug - `-XX:VerifyIterativeGVN=10000`

Please take a look and share your thoughts, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8375645](https://bugs.openjdk.org/browse/JDK-8375645): C2: NPE in compiled method does not occur with interpreter (**Bug** - P3)(⚠️ The fixVersion in this issue is [28] but the fixVersion in .jcheck/conf is 27, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31146/head:pull/31146` \
`$ git checkout pull/31146`

Update a local copy of the PR: \
`$ git checkout pull/31146` \
`$ git pull https://git.openjdk.org/jdk.git pull/31146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31146`

View PR using the GUI difftool: \
`$ git pr show -t 31146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31146.diff">https://git.openjdk.org/jdk/pull/31146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31146#issuecomment-4439220488)
</details>
