### PR TITLE
8377042: [IGV] compiler.unsafe.TestUnsafeLoadWithZeroAddress crashes when trying to dump the graph

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1780,8 +1780,9 @@ bool Compile::have_alias_type(const TypePtr* adr_type) {
   }
 
   // Handle special cases.
-  if (adr_type == nullptr)             return true;
+  if (adr_type == nullptr)          return true;
   if (adr_type == TypePtr::BOTTOM)  return true;
+  if (adr_type->base() == Type::AnyPtr && adr_type->is_ptr()->ptr() == TypePtr::Null) return false;
 
   return find_alias_type(adr_type, true, nullptr) != nullptr;
 }


### PR DESCRIPTION
**Description** 
TestUnsafeLoadWithZeroAddress.java implements `UNSAFE.getInt(0)` and 
`UNSAFE.putInt(0, 0)` which generates memory access to null which is `TypePtr[AnyPtr, Null]`. When run with  `-XX:CompileCommand=IGVPrintLevel,*::*,6`, while printing the fields the method `IdealGraphPrinter::get_field` calls` Compile::have_alias_type` which does not have a guard for` TypePtr[AnyPtr, Null] ` leading it to call `find_alias_type` which collapses this to `TypePtr::BOTTOM` and triggers  the assertion `assert(flat != TypePtr::BOTTOM) failed: cannot alias-analyze an untyped ptr: adr_type = ptr:null+0`. 

The simple fix proposed in this PR has the method `have_alias_type` return false when it encounters `TypePtr[AnyPtr, Null]`.

**Testing**
Tier1-3 and Github actions

**Question to reviewers**
Please let me know if this fix looks reasonable.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8377042](https://bugs.openjdk.org/browse/JDK-8377042): [IGV] compiler.unsafe.TestUnsafeLoadWithZeroAddress crashes when trying to dump the graph (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31147/head:pull/31147` \
`$ git checkout pull/31147`

Update a local copy of the PR: \
`$ git checkout pull/31147` \
`$ git pull https://git.openjdk.org/jdk.git pull/31147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31147`

View PR using the GUI difftool: \
`$ git pr show -t 31147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31147.diff">https://git.openjdk.org/jdk/pull/31147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31147#issuecomment-4464164656)
</details>
