### PR TITLE
8382928: Add documentation to java.net.URI.normalize about empty segments

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -175,11 +175,11 @@ import static jdk.internal.util.Exceptions.formatMsg;
  * The key operations supported by this class are those of
  * <i>normalization</i>, <i>resolution</i>, and <i>relativization</i>.
  *
- * <p> <i>Normalization</i> is the process of removing unnecessary {@code "."},
- * {@code ".."}, and {@code "//"} (empty) segments from the path component of a
- * hierarchical URI. Each {@code "."} and empty segment is simply removed. A
- * {@code ".."} segment is removed only if it is preceded by a non-{@code ".."}
- * segment. Normalization has no effect upon opaque URIs.
+ * <p> <i>Normalization</i> is the process of removing unnecessary {@code "."}
+ * and {@code ".."} segments, and redundant {@code "/"} (empty segments) from
+ * the path component of a hierarchical URI. Each {@code "."} and empty segment
+ * is simply removed. A {@code ".."} segment is removed only if it is preceded
+ * by a non-{@code ".."} segment. Normalization has no effect upon opaque URIs.
  *
  * <p> <i>Resolution</i> is the process of resolving one URI against another,
  * <i>base</i> URI.  The resulting URI is constructed from components of both
@@ -1030,7 +1030,7 @@ public final class URI
      *   scheme of {@code "a"} and a scheme-specific part of {@code "b/c/d"}.
      *   <b><i>(Deviation from RFC&nbsp;2396)</i></b> </p></li>
      *
-     *   <li><p> All {@code "//"} empty segments are removed.
+     *   <li><p> All redundant {@code "/"} (empty segments) are removed.
      *   <b><i>(Deviation from RFC&nbsp;2396)</i></b> </p></li>
      *
      * </ol>

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -177,9 +177,9 @@ import static jdk.internal.util.Exceptions.formatMsg;
  *
  * <p> <i>Normalization</i> is the process of removing unnecessary {@code "."},
  * {@code ".."}, and {@code "//"} (empty) segments from the path component of a
- * hierarchical URI. Each {@code "."} and {@code "//"} segment is simply
- * removed. A {@code ".."} segment is removed only if it is preceded by a
- * non-{@code ".."} segment. Normalization has no effect upon opaque URIs.
+ * hierarchical URI. Each {@code "."} and empty segment is simply removed. A
+ * {@code ".."} segment is removed only if it is preceded by a non-{@code ".."}
+ * segment. Normalization has no effect upon opaque URIs.
  *
  * <p> <i>Resolution</i> is the process of resolving one URI against another,
  * <i>base</i> URI.  The resulting URI is constructed from components of both

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -1030,7 +1030,7 @@ public final class URI
      *   scheme of {@code "a"} and a scheme-specific part of {@code "b/c/d"}.
      *   <b><i>(Deviation from RFC&nbsp;2396)</i></b> </p></li>
      *
-     *   <li><p> All {@code "//"} empty path segments are removed.
+     *   <li><p> All {@code "//"} empty segments are removed.
      *   <b><i>(Deviation from RFC&nbsp;2396)</i></b> </p></li>
      *
      * </ol>

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,11 +175,11 @@ import static jdk.internal.util.Exceptions.formatMsg;
  * The key operations supported by this class are those of
  * <i>normalization</i>, <i>resolution</i>, and <i>relativization</i>.
  *
- * <p> <i>Normalization</i> is the process of removing unnecessary {@code "."}
- * and {@code ".."} segments from the path component of a hierarchical URI.
- * Each {@code "."} segment is simply removed.  A {@code ".."} segment is
- * removed only if it is preceded by a non-{@code ".."} segment.
- * Normalization has no effect upon opaque URIs.
+ * <p> <i>Normalization</i> is the process of removing unnecessary {@code "."},
+ * {@code ".."}, and {@code "//"} (empty) segments from the path component of a
+ * hierarchical URI. Each {@code "."} and {@code "//"} segment is simply
+ * removed. A {@code ".."} segment is removed only if it is preceded by a
+ * non-{@code ".."} segment. Normalization has no effect upon opaque URIs.
  *
  * <p> <i>Resolution</i> is the process of resolving one URI against another,
  * <i>base</i> URI.  The resulting URI is constructed from components of both
@@ -1028,6 +1028,9 @@ public final class URI
      *   prepended.  This prevents a relative URI with a path such as
      *   {@code "a:b/c/d"} from later being re-parsed as an opaque URI with a
      *   scheme of {@code "a"} and a scheme-specific part of {@code "b/c/d"}.
+     *   <b><i>(Deviation from RFC&nbsp;2396)</i></b> </p></li>
+     *
+     *   <li><p> All {@code "//"} empty path segments are removed.
      *   <b><i>(Deviation from RFC&nbsp;2396)</i></b> </p></li>
      *
      * </ol>

--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1137,6 +1137,37 @@ public class Test {
             norm().p("b");
         test("a/../b:c").p("a/../b:c").z()
             .norm().p("./b:c").z();
+
+        // Relative URI empty path segment normalization
+        String[] slashes = {"/", "//", "///", "////"};
+        for (var s1 : slashes) {
+            test("/1" + s1).p("/1" + s1).z()
+                    .norm().p("/1/").z();
+            test("/1" + s1 + "2").p("/1" + s1 + "2").z()
+                    .norm().p("/1/2").z();
+            for (var s2 : slashes) {
+                test("/1" + s1 + "2" + s2).p("/1" + s1 + "2" + s2).z()
+                        .norm().p("/1/2/").z();
+            }
+        }
+
+        // Absolute URI empty path segment normalization
+        for (var s1 : slashes) {
+            test("s://a" + s1).s("s").h("a").p(s1).z()
+                    .norm().s("s").h("a").p("/").z();
+            test("s://a" + s1 + "1").s("s").h("a").p(s1 + "1").z()
+                    .norm().s("s").h("a").p("/1").z();
+            for (var s2 : slashes) {
+                test("s://a" + s1 + "1" + s2).s("s").h("a").p(s1 + "1" + s2).z()
+                        .norm().s("s").h("a").p("/1/").z();
+                test("s://a" + s1 + "1" + s2 + "2").s("s").h("a").p(s1 + "1" + s2 + "2").z()
+                        .norm().s("s").h("a").p("/1/2").z();
+                for (var s3 : slashes) {
+                    test("s://a" + s1 + "1" + s2 + "2" + s3).s("s").h("a").p(s1 + "1" + s2 + "2" + s3).z()
+                            .norm().s("s").h("a").p("/1/2/").z();
+                }
+            }
+        }
 
         // Normalization of already normalized URI should yield the
         // same URI

--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -1145,24 +1145,40 @@ public class Test {
                     .norm().p("/1/").z();
             test("/1" + s1 + "2").p("/1" + s1 + "2").z()
                     .norm().p("/1/2").z();
+            test("///1" + s1).p("/1" + s1).z()
+                    .norm().p("/1/").z();
+            test("///1" + s1 + "2").p("/1" + s1 + "2").z()
+                    .norm().p("/1/2").z();
             for (var s2 : slashes) {
                 test("/1" + s1 + "2" + s2).p("/1" + s1 + "2" + s2).z()
+                        .norm().p("/1/2/").z();
+                test("///1" + s1 + "2" + s2).p("/1" + s1 + "2" + s2).z()
                         .norm().p("/1/2/").z();
             }
         }
 
         // Absolute URI empty path segment normalization
         for (var s1 : slashes) {
+            test("//a" + s1).h("a").p(s1).z()
+                    .norm().h("a").p("/").z();
+            test("//a" + s1 + "1").h("a").p(s1 + "1").z()
+                    .norm().h("a").p("/1").z();
             test("s://a" + s1).s("s").h("a").p(s1).z()
                     .norm().s("s").h("a").p("/").z();
             test("s://a" + s1 + "1").s("s").h("a").p(s1 + "1").z()
                     .norm().s("s").h("a").p("/1").z();
             for (var s2 : slashes) {
+                test("//a" + s1 + "1" + s2).h("a").p(s1 + "1" + s2).z()
+                        .norm().h("a").p("/1/").z();
+                test("//a" + s1 + "1" + s2 + "2").h("a").p(s1 + "1" + s2 + "2").z()
+                        .norm().h("a").p("/1/2").z();
                 test("s://a" + s1 + "1" + s2).s("s").h("a").p(s1 + "1" + s2).z()
                         .norm().s("s").h("a").p("/1/").z();
                 test("s://a" + s1 + "1" + s2 + "2").s("s").h("a").p(s1 + "1" + s2 + "2").z()
                         .norm().s("s").h("a").p("/1/2").z();
                 for (var s3 : slashes) {
+                    test("//a" + s1 + "1" + s2 + "2" + s3).h("a").p(s1 + "1" + s2 + "2" + s3).z()
+                            .norm().h("a").p("/1/2/").z();
                     test("s://a" + s1 + "1" + s2 + "2" + s3).s("s").h("a").p(s1 + "1" + s2 + "2" + s3).z()
                             .norm().s("s").h("a").p("/1/2/").z();
                 }


### PR DESCRIPTION
Document and test empty path segment normalization in `java.net.URI`.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8384899](https://bugs.openjdk.org/browse/JDK-8384899) to be approved

### Issues
 * [JDK-8382928](https://bugs.openjdk.org/browse/JDK-8382928): Add documentation to java.net.URI.normalize about empty segments (**Bug** - P4)
 * [JDK-8384899](https://bugs.openjdk.org/browse/JDK-8384899): Add documentation to java.net.URI.normalize about empty segments (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31150/head:pull/31150` \
`$ git checkout pull/31150`

Update a local copy of the PR: \
`$ git checkout pull/31150` \
`$ git pull https://git.openjdk.org/jdk.git pull/31150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31150`

View PR using the GUI difftool: \
`$ git pr show -t 31150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31150.diff">https://git.openjdk.org/jdk/pull/31150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31150#issuecomment-4440144522)
</details>
