### PR TITLE
8371949: Upcall exception handler crashes with bad oop

### DIFF
--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -130,7 +130,7 @@ void UpcallLinker::on_exit(UpcallStub::FrameData* context) {
   JNIHandleBlock::release_block(context->new_handles, thread);
 }
 
-void UpcallLinker::handle_uncaught_exception(oop exception) {
+void UpcallLinker::handle_uncaught_exception(oopDesc* exception) {
   tty->print_cr("Uncaught exception:");
   Handle exception_h(Thread::current(), exception);
   java_lang_Throwable::print_stack_trace(exception_h, tty);

--- a/src/hotspot/share/prims/upcallLinker.hpp
+++ b/src/hotspot/share/prims/upcallLinker.hpp
@@ -44,7 +44,7 @@ public:
                                   bool needs_return_buffer, int ret_buf_size);
 
   // public for stubGenerator
-  static void handle_uncaught_exception(oop exception);
+  static void handle_uncaught_exception(oopDesc* exception);
 };
 
 #endif // SHARE_VM_PRIMS_UPCALLLINKER_HPP

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @requires jdk.foreign.linker != "FALLBACK"
- * @requires (os.arch == "aarch64" | os.arch=="riscv64") & os.name == "Linux"
+ * @requires (os.arch == "aarch64" | os.arch=="riscv64" | os.arch=="x86_64" | os.arch=="amd64") & os.name == "Linux"
  * @requires os.maxMemory > 4G
  * @requires vm.compMode != "Xcomp"
  * @modules java.base/jdk.internal.foreign


### PR DESCRIPTION
I have a local reproducer for [JDK-8360595](https://bugs.openjdk.org/browse/JDK-8360595), and I only now understood why it crashed badly, without producing a proper error. Because with checked oops, `oop` is really a wrapper class, not a pointer. We are actually passing unwrapped `oopDesc*` from Java/stub code. All of our other entry points declare `oopDesc*`, this one should do the same.

I also extended the platform filter for the test, so reproducer can work on my x86 machines, and it now crashes more reliably:

```
$  CONF=linux-x86_64-server-fastdebug make images test TEST=java/foreign/TestUpcallStress.java TEST_VM_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-ExitOnOutOfMemoryError"
...
[12:37:47.635] test TestUpcallStress.testUpcallsStress(663, "f1_V_SD_DID", VOID, [STRUCT, DOUBLE], [DOUBLE, INT, DOUBLE]): success [25ms]
Uncaught exception:
java.lang.OutOfMemoryError: Java heap space
<<no stack trace available>>
```

Additional testing:
 - [x] Linux x86_64 server fastdebug, reproducer no longer cryptically

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8371949](https://bugs.openjdk.org/browse/JDK-8371949): Upcall exception handler crashes with bad oop (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31151/head:pull/31151` \
`$ git checkout pull/31151`

Update a local copy of the PR: \
`$ git checkout pull/31151` \
`$ git pull https://git.openjdk.org/jdk.git pull/31151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31151`

View PR using the GUI difftool: \
`$ git pr show -t 31151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31151.diff">https://git.openjdk.org/jdk/pull/31151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31151#issuecomment-4440620917)
</details>
