### PR TITLE
Permit the usage of `std::invoke` in Hotspot

### DIFF
--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1579,6 +1579,9 @@ single-argument form are permitted.
 barely used (if at all) in HotSpot, but there's no reason to artificially
 forbid this syntactic regularization in any such uses.
 
+* `std::invoke<>()`
+([n4169](http://wg21.link/n4169))
+
 ## Forbidden Features
 
 ### Structured Bindings
@@ -1957,9 +1960,6 @@ because pack manipulation without this can be complicated.
 Prefer named access to class objects, rather than indexed access
 to anonymous heterogeneous sequences.  In particular, a standard-layout
 class is preferred to a tuple.
-
-* `std::invoke<>()`
-([n4169](http://wg21.link/n4169))
 
 * [`<chrono>`](https://en.cppreference.com/w/cpp/header/chrono.html) &mdash;
 The argument for chrono is that our existing APIs aren't serving us well.

--- a/src/hotspot/share/cppstdlib/functional.hpp
+++ b/src/hotspot/share/cppstdlib/functional.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_CPPSTDLIB_FUNCTIONAL_HPP
+#define SHARE_CPPSTDLIB_FUNCTIONAL_HPP
+
+#include "utilities/compilerWarnings.hpp"
+
+// HotSpot usage for <functional>:
+// * Do not use std::function as it may heap allocate.
+BEGIN_ALLOW_FORBIDDEN_FUNCTIONS
+#include "utilities/vmassert_uninstall.hpp"
+
+#include <functional>
+
+#include "utilities/vmassert_reinstall.hpp" // don't reorder
+END_ALLOW_FORBIDDEN_FUNCTIONS
+
+#endif // SHARE_CPPSTDLIB_FUNCTIONAL_HPP


### PR DESCRIPTION
Hi all,

`std::invoke` is a C++ feature which provides uniform call syntax for methods, functions, lambdas, and field accesses. This is useful when accessing data from an object whose type is provided by a template and whose accessor is provided separately.

I propose that we permit this in Hotspot, as it's useful when writing generic data structures. This PR adds the required `cppstdlib/functional.hpp` as well as moving `std::invoke` from undecided to accepted in the style docs.

## Cost

`std::invoke` has no runtime cost when optimizations are enabled. It does have an increased compilation CPU and memory usage as compared to plain calls.

## Reading

https://devblogs.microsoft.com/oldnewthing/20220401-00/?p=106426
https://eggs-cpp.github.io/invoke/benchmark.html

## Motivating and pedagogical example
Let's say that we have `Person`s:

```c++
struct Person {
  string name;
  string phone_no;
};
```

We want O(1) access when looking these up, so we decide to store `Person`s in a hashtable. However, we don't want to copy the `string name` key unnecessarily, instead we would like `Person` to act as the key-value container. So, we set out to implement a generic hashtable that will serve our needs, and we whip this up:

```
template<typename KV, auto Key>
struct Hashtable {
    // Pretend this is filled with the regular Hashtable stuff :-)
    void get(KV& kv) {
        decltype(auto) key_value = Key(kv);
        // and the rest of the code
    }
};

using PersonTable = Hashtable<Person, &Person::name>
PersonTable my_table;
Person& get_person(string& name) {
   return my_table.get(name);
}
```

Unfortunately, this will fail to compile. Our accessor is a reference to a field, not a callable method. In swoops `std::invoke`, allowing us to fix it:

```
template<typename KV, auto Key>
struct Hashtable {
    // Pretend this is filled with the regular Hashtable stuff :-)
    void get(KV& kv) {
        decltype(auto) key_value = std::invoke(Key, kv);
        // and the rest of the code
    }
};
```

The nifty thing is that we have a second user that wants to use a public accessor for its key, then `std::invoke` will work for that case as well:

```
class Foo {
  int _x;
public:
  int& get_x() { return _x; }
};
using FooTable = Hashtable<Foo, &Foo::get_x>;
```

Here's a full Godbolt to play around with: https://godbolt.org/z/51eex7T8c

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31153/head:pull/31153` \
`$ git checkout pull/31153`

Update a local copy of the PR: \
`$ git checkout pull/31153` \
`$ git pull https://git.openjdk.org/jdk.git pull/31153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31153`

View PR using the GUI difftool: \
`$ git pr show -t 31153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31153.diff">https://git.openjdk.org/jdk/pull/31153.diff</a>

</details>
