### PR TITLE
8330363: JDI ThreadDeathEvent/thread/thread001 timed out with UT enabled

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadDeathEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadDeathEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,6 +205,18 @@ public class thread001 {
 
                     log.display("Disabling event request");
                     checkedRequest.disable();
+
+                    // Make sure we drain the event queue after disabling the request.
+                    try {
+                        while ((eventSet = vm.eventQueue().remove(1000)) != null) {
+                            eventSet.resume();
+                        }
+                    } catch (InterruptedException ie) {
+                        log.complain("FAILURE: draining event queue failed");
+                        testFailed = true;
+                    }
+                    // And do a vm.resume() for good measure.
+                    vm.resume();
 
                     log.display("eventHandler completed");
 


### PR DESCRIPTION
After receiving the expected 4 ThreadDeathEvents, the test disables the ThreadDeathRequest and stops processing events. However, there is already another ThreadDeathEvent in flight for the UsageTracker thread. That results in suspending all debuggee threads, with the expectation that the debugger will eventually process the event and do an eventSet.resume(). That never happens, leaving the debuggee suspended while the debugger waits for the debuggee to send a DONE command, which it can't because it is suspended.

After disabling the ThreadDeathRequest, the debuggee needs to make sure all pending events get processed.

Tested by running thread001 about 600 times with JTREG_USAGE_TRACKER=true

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330363](https://bugs.openjdk.org/browse/JDK-8330363): JDI ThreadDeathEvent/thread/thread001 timed out with UT enabled (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31156/head:pull/31156` \
`$ git checkout pull/31156`

Update a local copy of the PR: \
`$ git checkout pull/31156` \
`$ git pull https://git.openjdk.org/jdk.git pull/31156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31156`

View PR using the GUI difftool: \
`$ git pr show -t 31156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31156.diff">https://git.openjdk.org/jdk/pull/31156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31156#issuecomment-4443779431)
</details>
