### PR TITLE
8383990: Remove exception code filters from Windows AArch64 safefetch handler

### DIFF
--- a/src/hotspot/os/windows/safefetch_static_windows.cpp
+++ b/src/hotspot/os/windows/safefetch_static_windows.cpp
@@ -39,10 +39,8 @@
 extern "C" char _SafeFetch32_continuation[];
 extern "C" char _SafeFetch32_fault[];
 
-#ifdef _LP64
 extern "C" char _SafeFetchN_continuation[];
 extern "C" char _SafeFetchN_fault[];
-#endif // _LP64
 
 bool handle_safefetch(int exception_code, address pc, void* context) {
   CONTEXT* ctx = (CONTEXT*)context;
@@ -51,12 +49,11 @@ bool handle_safefetch(int exception_code, address pc, void* context) {
       os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
       return true;
     }
-#ifdef _LP64
+
     if (pc == (address)_SafeFetchN_fault) {
       os::win32::context_set_pc(ctx, (address)_SafeFetchN_continuation);
       return true;
     }
-#endif
   }
   return false;
 }

--- a/src/hotspot/os/windows/safefetch_static_windows.cpp
+++ b/src/hotspot/os/windows/safefetch_static_windows.cpp
@@ -46,8 +46,7 @@ extern "C" char _SafeFetchN_fault[];
 
 bool handle_safefetch(int exception_code, address pc, void* context) {
   CONTEXT* ctx = (CONTEXT*)context;
-  if ((exception_code == EXCEPTION_ACCESS_VIOLATION ||
-       exception_code == EXCEPTION_GUARD_PAGE) && ctx != nullptr) {
+  if (ctx != nullptr) {
     if (pc == (address)_SafeFetch32_fault) {
       os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
       return true;


### PR DESCRIPTION
[JDK-8383541: Safefetch should return the error value when accessing pages protected with PAGE_GUARD on windows-aarch64](https://bugs.openjdk.org/browse/JDK-8383541) added a handler for guard pages specifically. However, @mo-beck has pointed out that we can actually remove the list of exceptions altogether to future-proof the safefetch implementation since it uses a LDR instruction whose PC is known and checked for by handle_safefetch. The gtests added in JDK-8383541 still pass with this change.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383990](https://bugs.openjdk.org/browse/JDK-8383990): Remove exception code filters from Windows AArch64 safefetch handler (**Bug** - P4)


### Reviewers
 * [Monica Beckwith](https://openjdk.org/census#mbeckwit) (@mo-beck - Author) Review applies to [adec8405](https://git.openjdk.org/jdk/pull/31158/files/adec84058b279693383b84e62053bda4ea58a94f)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31158/head:pull/31158` \
`$ git checkout pull/31158`

Update a local copy of the PR: \
`$ git checkout pull/31158` \
`$ git pull https://git.openjdk.org/jdk.git pull/31158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31158`

View PR using the GUI difftool: \
`$ git pr show -t 31158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31158.diff">https://git.openjdk.org/jdk/pull/31158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31158#issuecomment-4445600493)
</details>
