### PR TITLE
8384553: ProblemList runtime/jni/critical/SuspendInCritical.java for virtual threads

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -24,6 +24,7 @@
 ####
 # Bugs
 
+runtime/jni/critical/SuspendInCritical.java 8384369 generic-all
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all
@@ -92,4 +93,3 @@ vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.ja
 # implementation or test code.
 
 #############################################################################
-


### PR DESCRIPTION
Temporary exclusion whilst the proper fix is polished.

Thanks.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384553](https://bugs.openjdk.org/browse/JDK-8384553): ProblemList runtime/jni/critical/SuspendInCritical.java for virtual threads (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31159/head:pull/31159` \
`$ git checkout pull/31159`

Update a local copy of the PR: \
`$ git checkout pull/31159` \
`$ git pull https://git.openjdk.org/jdk.git pull/31159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31159`

View PR using the GUI difftool: \
`$ git pr show -t 31159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31159.diff">https://git.openjdk.org/jdk/pull/31159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31159#issuecomment-4447539186)
</details>
