### PR TITLE
8384132: javac: Cannot read field "sym" because "this.lvar[1]" is null

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/CaptureScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/CaptureScanner.java
@@ -66,7 +66,7 @@ public class CaptureScanner extends TreeScanner {
     @Override
     public void visitIdent(JCTree.JCIdent tree) {
         Symbol sym = tree.sym;
-        if (sym.kind == VAR && sym.owner.kind == MTH) {
+        if (sym.kind == VAR && (sym.owner.kind == MTH || sym.owner.kind == VAR)) {
             Symbol.VarSymbol vsym = (Symbol.VarSymbol) sym;
             if (vsym.getConstValue() == null && !seenVars.contains(vsym)) {
                 addFreeVar(vsym);
@@ -83,7 +83,7 @@ public class CaptureScanner extends TreeScanner {
 
     @Override
     public void visitVarDef(JCTree.JCVariableDecl tree) {
-        if (tree.sym.owner.kind == MTH) {
+        if (tree.sym.owner.kind == MTH || tree.sym.owner.kind == VAR) {
             seenVars.add(tree.sym);
         }
         super.visitVarDef(tree);

--- a/test/langtools/tools/javac/switchexpr/LambdaCaptureInStaticInit.java
+++ b/test/langtools/tools/javac/switchexpr/LambdaCaptureInStaticInit.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384132
+ * @summary Check that captured local variables in lambdas inside switch expression
+ *          static field initialization are passed correctly.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.JavaTask;
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.Task;
+
+public class LambdaCaptureInStaticInit {
+
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testCompilerDoesNotCrash() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         import java.util.function.Function;;
+
+                         class Test {
+                             static boolean b = switch ("test") {
+                                 case "test" -> {
+                                     String s = "yes";
+                                     Function<Integer, String> f = a -> s;
+                                     yield f.apply(1) == s;
+                                 }
+                                 default -> false;
+                             };
+
+                             static final Object o;
+
+                             static {
+                                 o = null;
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+    }
+
+    @Test
+    void testSemanticsIsPreserved() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         import java.util.function.Function;;
+
+                         class Test {
+                             static boolean b = switch ("test") {
+                                 case "test" -> {
+                                     String s = "yes";
+                                     Function<Integer, String> f = a -> s;
+                                     yield f.apply(1) == s;
+                                 }
+                                 default -> false;
+                             };
+
+                             public static void main(String[] args) {
+                                 if (!b) System.exit(1);
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+        new JavaTask(tb)
+                .className("Test")
+                .classpath(classes.toString())
+                .run(Task.Expect.SUCCESS);
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Consider the following source code:
```
import java.util.function.Function;;

class Test {
   static boolean b = switch ("test") {
       case "test" -> {
           String s = "yes";
           Function<Integer, String> f = a -> s;
           yield f.apply(1) == s;
       }
       default -> false;
   };
}
```
When compiled using the current `javac`, the generated class file is invalid. As can be seen from the `javap` output:
```
  private static java.lang.String lambda$static$0(java.lang.Integer);
    descriptor: (Ljava/lang/Integer;)Ljava/lang/String;
    flags: (0x100a) ACC_PRIVATE, ACC_STATIC, ACC_SYNTHETIC
    Code:
      stack=1, locals=1, args_size=1
         0: aload_0
         1: areturn
      LineNumberTable:
        line 7: 0
```
generated lambda method is missing a parameter for the captured local variable `s`. Moreover the method incorrectly returns the value of the lambda parameter `a` instead of `s` which significantly changes the semantics of the code.

If we add another static field initialized in the static initializer to the `Test` class e.g.:
```
    static final Object o;
    static {
        o = null;
    }
```
the compiler crashes with the `NullPointerException: Cannot read field "sym" because "this.lvar[1]" is null` exception thrown from the `Code.emitop0(...)` method.

The problem is in the `CaptureScanner.visitIdent(...)` method that filters out the local variable symbols with non method symbol owners when collecting the set of local variables "captured" by the given lambda (note that the owner of the `VarSymbol` representing the local variable `s` is the `VarSymbol` representing the field `b`).

The proposal here is:
Modify the `CaptureScanner` to accept also `VarSymbol` owners when collecting the set of captured local variables.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384132](https://bugs.openjdk.org/browse/JDK-8384132): javac: Cannot read field "sym" because "this.lvar[1]" is null (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31160/head:pull/31160` \
`$ git checkout pull/31160`

Update a local copy of the PR: \
`$ git checkout pull/31160` \
`$ git pull https://git.openjdk.org/jdk.git pull/31160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31160`

View PR using the GUI difftool: \
`$ git pr show -t 31160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31160.diff">https://git.openjdk.org/jdk/pull/31160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31160#issuecomment-4449117290)
</details>
