### PR TITLE
8291470: Description change for mouseMoved method in java.awt.event.MouseMotionAdapter

### DIFF
--- a/src/java.desktop/share/classes/java/awt/event/MouseMotionAdapter.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseMotionAdapter.java
@@ -63,10 +63,12 @@ public abstract class MouseMotionAdapter implements MouseMotionListener {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void mouseDragged(MouseEvent e) {}
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public void mouseMoved(MouseEvent e) {}
 }

--- a/src/java.desktop/share/classes/java/awt/event/MouseMotionAdapter.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseMotionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,13 @@ package java.awt.event;
  * <P>
  * Mouse motion events occur when a mouse is moved or dragged.
  * (Many such events will be generated in a normal program.
- * To track clicks and other mouse events, use the MouseAdapter.)
+ * To track clicks and other mouse events, use the {@link MouseAdapter}.)
  * <P>
  * Extend this class to create a {@code MouseEvent} listener
  * and override the methods for the events of interest. (If you implement the
  * {@code MouseMotionListener} interface, you have to define all of
  * the methods in it. This abstract class defines null methods for them
- * all, so you can only have to define methods for events you care about.)
+ * all, so you have to define only methods for events you care about.)
  * <P>
  * Create a listener object using the extended class and then register it with
  * a component using the component's {@code addMouseMotionListener}
@@ -61,17 +61,12 @@ public abstract class MouseMotionAdapter implements MouseMotionListener {
     protected MouseMotionAdapter() {}
 
     /**
-     * Invoked when a mouse button is pressed on a component and then
-     * dragged.  Mouse drag events will continue to be delivered to
-     * the component where the first originated until the mouse button is
-     * released (regardless of whether the mouse position is within the
-     * bounds of the component).
+     * {@inheritDoc}
      */
     public void mouseDragged(MouseEvent e) {}
 
     /**
-     * Invoked when the mouse button has been moved on a component
-     * (with no buttons no down).
+     * {@inheritDoc}
      */
     public void mouseMoved(MouseEvent e) {}
 }


### PR DESCRIPTION
Change the description of `mouseDragged` and `mouseMoved` in the [`MouseMotionAdapter` class](https://docs.oracle.com/en/java/javase/26/docs/api/java.desktop/java/awt/event/MouseMotionAdapter.html) to `{@inheritDoc}`. The custom description didn't provide additional information about the methods and repeated the description from the [`MouseMotionListener` interface](https://docs.oracle.com/en/java/javase/26/docs/api/java.desktop/java/awt/event/MouseMotionListener.html).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8291470](https://bugs.openjdk.org/browse/JDK-8291470): Description change for mouseMoved method in java.awt.event.MouseMotionAdapter (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31161/head:pull/31161` \
`$ git checkout pull/31161`

Update a local copy of the PR: \
`$ git checkout pull/31161` \
`$ git pull https://git.openjdk.org/jdk.git pull/31161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31161`

View PR using the GUI difftool: \
`$ git pr show -t 31161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31161.diff">https://git.openjdk.org/jdk/pull/31161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31161#issuecomment-4450797139)
</details>
