### PR TITLE
8382118: Refactor open/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java test

### DIFF
--- a/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
+++ b/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
@@ -32,7 +32,6 @@
  */
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
@@ -45,43 +44,35 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class DirPermissionDenied {
     private static final Path TEST_DIR = Paths.get(
             "DirPermissionDeniedDirectory");
+    private static URL url;
 
     @Test
-    public void doTest() throws MalformedURLException {
-        URL url = new URL(TEST_DIR.toUri().toString());
-        try {
-            URLConnection uc = url.openConnection();
-            uc.connect();
-        } catch (IOException e) {
-            // OK
-        } catch (Exception e) {
-            throw new RuntimeException("Failed " + e);
-        }
+    public void connectTest() {
+        assertThrows(IOException.class, ()-> {URLConnection uc = url.openConnection();
+        uc.connect();});
+    }
 
-        try {
-            URLConnection uc = url.openConnection();
-            uc.getInputStream();
-        } catch (IOException e) {
-            // OK
-        } catch (Exception e) {
-            throw new RuntimeException("Failed " + e);
-        }
+    @Test
+    public void getInputStreamTest() {
+        assertThrows(IOException.class, ()-> {URLConnection uc = url.openConnection();
+            uc.getInputStream();});
+    }
 
-        try {
-            URLConnection uc = url.openConnection();
-            uc.getContentLengthLong();
-        } catch (IOException e) {
-            // OK
-        } catch (Exception e) {
-            throw new RuntimeException("Failed " + e);
-        }
+    @Test
+    public void getContentLengthLongTest() {
+        assertDoesNotThrow(() -> {URLConnection uc = url.openConnection();
+        uc.getContentLengthLong();});
     }
 
     @BeforeAll
     public static void setup() throws Throwable {
+        url = new URL(TEST_DIR.toUri().toString());
         // mkdir and chmod "333"
         Files.createDirectories(TEST_DIR);
         ProcessTools.executeCommand("chmod", "333", TEST_DIR.toString())

--- a/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
+++ b/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
@@ -53,21 +53,21 @@ public class DirPermissionDenied {
     private static URL url;
 
     @Test
-    public void connectTest() {
-        assertThrows(IOException.class, ()-> {URLConnection uc = url.openConnection();
-        uc.connect();});
+    public void connectTest() throws IOException {
+        URLConnection uc = url.openConnection();
+        assertThrows(IOException.class, ()-> uc.connect());
     }
 
     @Test
-    public void getInputStreamTest() {
-        assertThrows(IOException.class, ()-> {URLConnection uc = url.openConnection();
-            uc.getInputStream();});
+    public void getInputStreamTest() throws IOException {
+        URLConnection uc = url.openConnection();
+        assertThrows(IOException.class, ()-> uc.getInputStream());
     }
 
     @Test
-    public void getContentLengthLongTest() {
-        assertDoesNotThrow(() -> {URLConnection uc = url.openConnection();
-        uc.getContentLengthLong();});
+    public void getContentLengthLongTest() throws IOException {
+        URLConnection uc = url.openConnection();
+        assertDoesNotThrow(() -> uc.getContentLengthLong());
     }
 
     @BeforeAll


### PR DESCRIPTION
Breakdown one test tomultiple test each for one method.




---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382118](https://bugs.openjdk.org/browse/JDK-8382118): Refactor open/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java test (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31163/head:pull/31163` \
`$ git checkout pull/31163`

Update a local copy of the PR: \
`$ git checkout pull/31163` \
`$ git pull https://git.openjdk.org/jdk.git pull/31163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31163`

View PR using the GUI difftool: \
`$ git pr show -t 31163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31163.diff">https://git.openjdk.org/jdk/pull/31163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31163#issuecomment-4453367164)
</details>
