### PR TITLE
8384602: Remove AppContext from java.awt.Component

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -88,7 +88,6 @@ import javax.swing.JComponent;
 import javax.swing.JRootPane;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AppContext;
 import sun.awt.ComponentFactory;
 import sun.awt.ConstrainableGraphics;
 import sun.awt.EmbeddedFrame;
@@ -234,11 +233,6 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @see #getParent
      */
     transient Container parent;
-
-    /**
-     * The {@code AppContext} of the component.
-     */
-    transient AppContext appContext;
 
     /**
      * The x position of the component in the parent's coordinate system.
@@ -877,12 +871,6 @@ public abstract class Component implements ImageObserver, MenuContainer,
             {
                  Component.setRequestFocusController(requestController);
             }
-            public AppContext getAppContext(Component comp) {
-                 return comp.appContext;
-            }
-            public void setAppContext(Component comp, AppContext appContext) {
-                 comp.appContext = appContext;
-            }
             public Container getParent(Component comp) {
                 return comp.getParent_NoClientCode();
             }
@@ -975,7 +963,6 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * tree (for example, by a {@code Frame} object).
      */
     protected Component() {
-        appContext = AppContext.getAppContext();
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -3452,7 +3439,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
                 (width > 0) && (height > 0)) {
                 PaintEvent e = new PaintEvent(this, PaintEvent.UPDATE,
                                               new Rectangle(x, y, width, height));
-                SunToolkit.postEvent(SunToolkit.targetToAppContext(this), e);
+                SunToolkit.postEvent(e);
             }
         }
     }
@@ -4786,14 +4773,6 @@ public abstract class Component implements ImageObserver, MenuContainer,
     @SuppressWarnings("deprecation")
     void dispatchEventImpl(AWTEvent e) {
         int id = e.getID();
-
-        // Check that this component belongs to this app-context
-        AppContext compContext = appContext;
-        if (compContext != null && !compContext.equals(AppContext.getAppContext())) {
-            if (eventLog.isLoggable(PlatformLogger.Level.FINE)) {
-                eventLog.fine("Event " + e + " is being dispatched on the wrong AppContext");
-            }
-        }
 
         if (eventLog.isLoggable(PlatformLogger.Level.FINEST)) {
             eventLog.finest("{0}", e);
@@ -8936,7 +8915,6 @@ public abstract class Component implements ImageObserver, MenuContainer,
 
         s.defaultReadObject();
 
-        appContext = AppContext.getAppContext();
         coalescingEnabled = checkCoalescing();
         if (componentSerializedDataVersion < 4) {
             // These fields are non-transient and rely on default

--- a/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
@@ -128,16 +128,6 @@ public final class AWTAccessor {
         void setRequestFocusController(RequestFocusController requestController);
 
         /**
-         * Returns the appContext of the component.
-         */
-        AppContext getAppContext(Component comp);
-
-        /**
-         * Sets the appContext of the component.
-         */
-        void setAppContext(Component comp, AppContext appContext);
-
-        /**
          * Returns the parent of the component.
          */
         Container getParent(Component comp);

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -322,13 +322,7 @@ public abstract class SunToolkit extends Toolkit
      */
     private static boolean setAppContext(Object target,
                                          AppContext context) {
-        if (target instanceof Component) {
-            AWTAccessor.getComponentAccessor().
-                setAppContext((Component)target, context);
-        } else {
-            return false;
-        }
-        return true;
+        return (target instanceof Component);
     }
 
     /**
@@ -336,10 +330,8 @@ public abstract class SunToolkit extends Toolkit
      * Component or MenuComponent this returns null.
      */
     private static AppContext getAppContext(Object target) {
-        if (target instanceof Component) {
-            return AWTAccessor.getComponentAccessor().
-                       getAppContext((Component)target);
-        } else if (target instanceof MenuComponent) {
+        if ((target instanceof Component) ||
+            (target instanceof MenuComponent)) {
             return AppContext.getAppContext();
         } else {
             return null;


### PR DESCRIPTION
Remove AppContext from java.awt.Component.
This allowed me to also remove the accessor for it and therefore the few remaining uses of the Accessor
No tests failed as a result of this change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384602](https://bugs.openjdk.org/browse/JDK-8384602): Remove AppContext from java.awt.Component (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31164/head:pull/31164` \
`$ git checkout pull/31164`

Update a local copy of the PR: \
`$ git checkout pull/31164` \
`$ git pull https://git.openjdk.org/jdk.git pull/31164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31164`

View PR using the GUI difftool: \
`$ git pr show -t 31164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31164.diff">https://git.openjdk.org/jdk/pull/31164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31164#issuecomment-4453624054)
</details>
