### PR TITLE
JEP 468: Initial javac support for derived record creation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -214,7 +214,7 @@ public class Preview {
      */
     public boolean isPreview(Feature feature) {
         return switch (feature) {
-            case PRIMITIVE_PATTERNS -> true;
+            case PRIMITIVE_PATTERNS, DERIVED_RECORD_CREATION -> true;
             //Note: this is a backdoor which allows to optionally treat all features as 'preview' (for testing).
             //When real preview features will be added, this method can be implemented to return 'true'
             //for those selected features, and 'false' for all the others.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -285,6 +285,7 @@ public enum Source {
         PRIVATE_MEMBERS_IN_PERMITS_CLAUSE(JDK19),
         ERASE_POLY_SIG_RETURN_TYPE(JDK24),
         CAPTURE_MREF_RETURN_TYPE(JDK26),
+        DERIVED_RECORD_CREATION(JDK26, Fragments.FeatureDerivedRecordCreation, DiagKind.PLURAL),
         ;
 
         enum DiagKind {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3155,6 +3155,44 @@ public class Attr extends JCTree.Visitor {
         result = check(tree, owntype, KindSelector.VAL, resultInfo);
     }
 
+    public void visitDerivedRecord(JCDerivedRecord tree) {
+        Type baseType = attribExpr(tree.base, env);
+        if (!(baseType.tsym instanceof ClassSymbol cs && cs.isRecord())) {
+            log.error(tree.base.pos(), Errors.NotARecordType(baseType));
+            result = tree.type = types.createErrorType(baseType);
+            return;
+        }
+        Map<Name, RecordComponent> componentMap = new LinkedHashMap<>();
+        for (RecordComponent rc : cs.getRecordComponents()) {
+            componentMap.put(rc.name, rc);
+        }
+        Set<Name> seen = new HashSet<>();
+        for (JCTree s : tree.block.stats) {
+            if (!(s instanceof JCExpressionStatement es && es.expr instanceof JCAssign assign)) {
+                log.error(s.pos(), Errors.InvalidWithStatement);
+                continue;
+            }
+            if (!(assign.lhs instanceof JCIdent lhs)) {
+                log.error(assign.lhs.pos(), Errors.InvalidWithStatement);
+                continue;
+            }
+            RecordComponent rc = componentMap.get(lhs.name);
+            if (rc == null) {
+                log.error(lhs.pos(), Errors.NotARecordComponent(lhs.name, baseType));
+                continue;
+            }
+            if (!seen.add(lhs.name)) {
+                log.error(lhs.pos(), Errors.DuplicateComponentInWith(lhs.name));
+                continue;
+            }
+            lhs.sym = rc;
+            lhs.type = rc.type;
+            assign.type = rc.type;
+            attribExpr(assign.rhs, env, rc.type);
+        }
+        result = check(tree, baseType, KindSelector.VAL, resultInfo);
+    }
+
     /*
      * A lambda expression can only be attributed when a target-type is available.
      * In addition, if the target-type is that of a functional interface whose

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2649,6 +2649,15 @@ public class Flow {
             scanExprs(tree.elems);
         }
 
+        public void visitDerivedRecord(JCDerivedRecord tree) {
+            scanExpr(tree.base);
+            for (JCTree s : tree.block.stats) {
+                if (s instanceof JCExpressionStatement es && es.expr instanceof JCAssign assign) {
+                    scanExpr(assign.rhs);
+                }
+            }
+        }
+
         public void visitAssert(JCAssert tree) {
             final Bits initsExit = new Bits(inits);
             final Bits uninitsExit = new Bits(uninits);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -4265,6 +4265,34 @@ public class Lower extends TreeTranslator {
         result = tree;
     }
 
+    public void visitDerivedRecord(JCDerivedRecord tree) {
+        // Collect the override expressions from the with-block (already translated)
+        Map<Name, JCExpression> overrides = new LinkedHashMap<>();
+        for (JCTree s : tree.block.stats) {
+            if (s instanceof JCExpressionStatement es
+                    && es.expr instanceof JCAssign assign
+                    && assign.lhs instanceof JCIdent lhs) {
+                overrides.put(lhs.name, translate(assign.rhs));
+            }
+        }
+        ClassSymbol cs = (ClassSymbol) tree.type.tsym;
+        JCExpression translatedBase = translate(tree.base);
+        // Evaluate base exactly once; build new Record(override-or-accessor, ...)
+        result = abstractRval(translatedBase, tree.base.type, baseVar -> {
+            ListBuffer<JCExpression> args = new ListBuffer<>();
+            for (RecordComponent rc : cs.getRecordComponents()) {
+                JCExpression overrideExpr = overrides.get(rc.name);
+                if (overrideExpr != null) {
+                    args.append(overrideExpr);
+                } else {
+                    JCExpression call = make.App(make.Select(baseVar, rc.accessor));
+                    args.append(call);
+                }
+            }
+            return makeNewClass(tree.type, args.toList());
+        });
+    }
+
     public void visitSelect(JCFieldAccess tree) {
         // need to special case-access of the form C.super.x
         // these will always need an access method, unless C

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -1883,6 +1883,13 @@ public class JavacParser implements Parser {
                 if (typeArgs != null) return illegal();
                 accept(COLCOL);
                 t = memberReferenceSuffix(pos1, t);
+            } else if (isMode(EXPR) && token.kind == IDENTIFIER && token.name() == names.with
+                       && peekToken(tk -> tk == LBRACE)) {
+                checkSourceLevel(token.pos, Feature.DERIVED_RECORD_CREATION);
+                selectExprMode();
+                nextToken();
+                JCBlock blk = block();
+                t = toP(F.at(pos1).DerivedRecord(t, blk));
             } else {
                 if (!annos.isEmpty()) {
                     if (permitTypeAnnotationsPushBack)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3429,6 +3429,9 @@ compiler.misc.feature.primitive.patterns=\
 compiler.misc.feature.records=\
     records
 
+compiler.misc.feature.derived.record.creation=\
+    derived record creation
+
 compiler.misc.feature.sealed.classes=\
     sealed classes
 
@@ -4179,6 +4182,22 @@ compiler.misc.canonical.must.not.have.stronger.access=\
 compiler.err.record.cannot.declare.instance.fields=\
     field declaration must be static\n\
     (consider replacing field with record component)
+
+# with expressions (JEP 468)
+# 0: type
+compiler.err.not.a.record.type=\
+    {0} is not a record type
+
+# 0: name, 1: type
+compiler.err.not.a.record.component=\
+    {0} is not a component of record type {1}
+
+# 0: name
+compiler.err.duplicate.component.in.with=\
+    component {0} appears more than once in with block
+
+compiler.err.invalid.with.statement=\
+    with block may only contain simple component assignments of the form ''name = expression''
 
 # 0: symbol
 compiler.err.invalid.supertype.record=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -221,6 +221,10 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
          */
         NEWARRAY,
 
+        /** Derived record creation expressions, of type DerivedRecord.
+         */
+        DERIVEDRECORD,
+
         /** Lambda expression, of type Lambda.
          */
         LAMBDA,
@@ -2028,6 +2032,37 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     }
 
     /**
+     * A derived record creation expression: {@code expr with { ... }}
+     */
+    public static class JCDerivedRecord extends JCPolyExpression {
+        /** The base record expression. */
+        public JCExpression base;
+        /** The block of field overrides. */
+        public JCBlock block;
+
+        protected JCDerivedRecord(JCExpression base, JCBlock block) {
+            this.base = base;
+            this.block = block;
+        }
+
+        @Override
+        public void accept(Visitor v) { v.visitDerivedRecord(this); }
+
+        @DefinedBy(Api.COMPILER_TREE)
+        public Kind getKind() {
+            throw new AssertionError("JCDerivedRecord is not part of a public API");
+        }
+
+        @Override @DefinedBy(Api.COMPILER_TREE)
+        public <R,D> R accept(TreeVisitor<R,D> v, D d) {
+            throw new AssertionError("JCDerivedRecord is not part of a public API");
+        }
+
+        @Override
+        public Tag getTag() { return DERIVEDRECORD; }
+    }
+
+    /**
      * A lambda expression.
      */
     public static class JCLambda extends JCFunctionalExpression implements LambdaExpressionTree {
@@ -3642,6 +3677,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public void visitRequires(JCRequires that)           { visitTree(that); }
         public void visitUses(JCUses that)                   { visitTree(that); }
         public void visitLetExpr(LetExpr that)               { visitTree(that); }
+        public void visitDerivedRecord(JCDerivedRecord that) { visitTree(that); }
 
         public void visitTree(JCTree that)                   { Assert.error(); }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -1746,6 +1746,16 @@ public class Pretty extends JCTree.Visitor {
         }
     }
 
+    public void visitDerivedRecord(JCDerivedRecord tree) {
+        try {
+            printExpr(tree.base);
+            print(" with ");
+            printStat(tree.block);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     public void visitModifiers(JCModifiers mods) {
         try {
             printAnnotations(mods.annotations);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -628,6 +628,10 @@ public class TreeInfo {
                 JCBindingPattern node = (JCBindingPattern)tree;
                 return getStartPos(node.var);
             }
+            case DERIVEDRECORD: {
+                JCDerivedRecord node = (JCDerivedRecord)tree;
+                return getStartPos(node.base);
+            }
             case ERRONEOUS: {
                 JCErroneous node = (JCErroneous)tree;
                 if (node.errs != null && node.errs.nonEmpty()) {
@@ -721,7 +725,10 @@ public class TreeInfo {
                 JCErroneous node = (JCErroneous)tree;
                 if (node.errs != null && node.errs.nonEmpty())
                     return getEndPos(node.errs.last());
+                break;
             }
+            case DERIVEDRECORD:
+                return getEndPos(((JCDerivedRecord) tree).block);
         }
         return Position.NOPOS;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -443,6 +443,12 @@ public class TreeMaker implements JCTree.Factory {
         return tree;
     }
 
+    public JCDerivedRecord DerivedRecord(JCExpression base, JCBlock block) {
+        JCDerivedRecord tree = new JCDerivedRecord(base, block);
+        tree.pos = pos;
+        return tree;
+    }
+
     public JCLambda Lambda(List<JCVariableDecl> params,
                            JCTree body)
     {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeScanner.java
@@ -419,6 +419,11 @@ public class TreeScanner extends Visitor {
         scan(tree.expr);
     }
 
+    public void visitDerivedRecord(JCDerivedRecord tree) {
+        scan(tree.base);
+        scan(tree.block);
+    }
+
     public void visitTree(JCTree tree) {
         Assert.error();
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
@@ -471,6 +471,12 @@ public class TreeTranslator extends JCTree.Visitor {
         result = tree;
     }
 
+    public void visitDerivedRecord(JCDerivedRecord tree) {
+        tree.base = translate(tree.base);
+        tree.block = translate(tree.block);
+        result = tree;
+    }
+
     public void visitModifiers(JCModifiers tree) {
         tree.annotations = translateAnnotations(tree.annotations);
         result = tree;


### PR DESCRIPTION
Implements the compiler for JEP 468 (Derived Record Creation),
  the `expr with { field = value; ... }` syntax.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31167/head:pull/31167` \
`$ git checkout pull/31167`

Update a local copy of the PR: \
`$ git checkout pull/31167` \
`$ git pull https://git.openjdk.org/jdk.git pull/31167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31167`

View PR using the GUI difftool: \
`$ git pr show -t 31167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31167.diff">https://git.openjdk.org/jdk/pull/31167.diff</a>

</details>
