### PR TITLE
8330128: Problemlist failing vmTestbase/nsk/sysdict tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -175,6 +175,9 @@ vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 807
 vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t006/TestDescription.java 8372206 generic-all
 vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-all
 
+vmTestbase/nsk/sysdict/vm/stress/btree/btree010/btree010.java 8298991 generic-all
+vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 generic-all
+
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening002.java 8208259 generic-all
 


### PR DESCRIPTION
 Added btree010 and chain007 to ProblemList.txt. both fail intermittently with OOME during scalar replacement

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8330128](https://bugs.openjdk.org/browse/JDK-8330128): Problemlist failing vmTestbase/nsk/sysdict tests (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31170/head:pull/31170` \
`$ git checkout pull/31170`

Update a local copy of the PR: \
`$ git checkout pull/31170` \
`$ git pull https://git.openjdk.org/jdk.git pull/31170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31170`

View PR using the GUI difftool: \
`$ git pr show -t 31170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31170.diff">https://git.openjdk.org/jdk/pull/31170.diff</a>

</details>
