### PR TITLE
8384507: Incorrect vector reassociation for signed saturating addition

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1182,8 +1182,6 @@ bool VectorNode::is_associative_and_commutative_vector_operation() {
     case Op_OrVMask:
     case Op_XorVMask:
       return true;
-    case Op_SaturatingAddV:
-      return is_SaturatingVector() && as_SaturatingVector()->is_unsigned();
     default:
       return false;
   }

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1161,14 +1161,32 @@ static bool is_commutative_vector_operation(int opcode) {
   }
 }
 
-bool VectorNode::is_associative_vector_operation() {
-  if (!is_commutative_vector_operation(Opcode())) {
-    return false;
+bool VectorNode::is_associative_and_commutative_vector_operation() {
+  switch (Opcode()) {
+    case Op_AddVB:
+    case Op_AddVS:
+    case Op_AddVI:
+    case Op_AddVL:
+    case Op_MulVB:
+    case Op_MulVS:
+    case Op_MulVI:
+    case Op_MulVL:
+    case Op_MaxV:
+    case Op_MinV:
+    case Op_UMinV:
+    case Op_UMaxV:
+    case Op_XorV:
+    case Op_OrV:
+    case Op_AndV:
+    case Op_AndVMask:
+    case Op_OrVMask:
+    case Op_XorVMask:
+      return true;
+    case Op_SaturatingAddV:
+      return is_SaturatingVector() && as_SaturatingVector()->is_unsigned();
+    default:
+      return false;
   }
-  if (is_SaturatingVector() && !as_SaturatingVector()->is_unsigned()) {
-    return false;
-  }
-  return true;
 }
 
 bool VectorNode::should_swap_inputs_to_help_global_value_numbering() {
@@ -1315,8 +1333,8 @@ Node* VectorNode::reassociate_vector_operation(PhaseGVN* phase) {
     return nullptr;
   }
 
-  // Enable re-association only for associative vector operations.
-  if (!is_associative_vector_operation()) {
+  // Enable re-association only for associative and commutative vector operations.
+  if (!is_associative_and_commutative_vector_operation()) {
     return nullptr;
   }
 

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1161,6 +1161,16 @@ static bool is_commutative_vector_operation(int opcode) {
   }
 }
 
+bool VectorNode::is_associative_vector_operation() {
+  if (!is_commutative_vector_operation(Opcode())) {
+    return false;
+  }
+  if (is_SaturatingVector() && !as_SaturatingVector()->is_unsigned()) {
+    return false;
+  }
+  return true;
+}
+
 bool VectorNode::should_swap_inputs_to_help_global_value_numbering() {
   // Predicated vector operations are sensitive to ordering of inputs.
   // When the mask corresponding to a vector lane is false then
@@ -1292,7 +1302,7 @@ Node* VectorNode::create_reassociated_node(Node* parent, Node* child, Node* cinp
   return cloned_parent;
 }
 
-// Try to reassociate commutative vector operations using the following ideal transformation,
+// Try to reassociate associative vector operations using the following ideal transformation,
 // this will facilitate strength reducing a vector operation with all replicated inputs to
 // a scalar operation.
 //
@@ -1305,8 +1315,8 @@ Node* VectorNode::reassociate_vector_operation(PhaseGVN* phase) {
     return nullptr;
   }
 
-  // Enable re-association for commutative vector operations.
-  if (!is_commutative_vector_operation(Opcode())) {
+  // Enable re-association only for associative vector operations.
+  if (!is_associative_vector_operation()) {
     return nullptr;
   }
 

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1161,8 +1161,8 @@ static bool is_commutative_vector_operation(int opcode) {
   }
 }
 
-bool VectorNode::is_associative_and_commutative_vector_operation() {
-  switch (Opcode()) {
+static bool is_associative_and_commutative_vector_operation(int opcode) {
+  switch (opcode) {
     case Op_AddVB:
     case Op_AddVS:
     case Op_AddVI:
@@ -1332,7 +1332,7 @@ Node* VectorNode::reassociate_vector_operation(PhaseGVN* phase) {
   }
 
   // Enable re-association only for associative and commutative vector operations.
-  if (!is_associative_and_commutative_vector_operation()) {
+  if (!is_associative_and_commutative_vector_operation(Opcode())) {
     return nullptr;
   }
 

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -146,7 +146,6 @@ class VectorNode : public TypeNode {
   static bool is_minmax_opcode(int opc);
 
   bool should_swap_inputs_to_help_global_value_numbering();
-  bool is_associative_and_commutative_vector_operation();
   Node* reassociate_vector_operation(PhaseGVN* phase);
   static Node* create_reassociated_node(Node* parent, Node* child, Node* cinput1, Node* cinput2,
                                         Node* pinput2, PhaseGVN* phase);

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -146,6 +146,7 @@ class VectorNode : public TypeNode {
   static bool is_minmax_opcode(int opc);
 
   bool should_swap_inputs_to_help_global_value_numbering();
+  bool is_associative_vector_operation();
   Node* reassociate_vector_operation(PhaseGVN* phase);
   static Node* create_reassociated_node(Node* parent, Node* child, Node* cinput1, Node* cinput2,
                                         Node* pinput2, PhaseGVN* phase);

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -146,7 +146,7 @@ class VectorNode : public TypeNode {
   static bool is_minmax_opcode(int opc);
 
   bool should_swap_inputs_to_help_global_value_numbering();
-  bool is_associative_vector_operation();
+  bool is_associative_and_commutative_vector_operation();
   Node* reassociate_vector_operation(PhaseGVN* phase);
   static Node* create_reassociated_node(Node* parent, Node* child, Node* cinput1, Node* cinput2,
                                         Node* pinput2, PhaseGVN* phase);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
@@ -63,7 +63,7 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
-    @IR(counts = {IRNode.SATURATING_ADD_VB, IRNode.VECTOR_SIZE_ANY, " 2 "},
+    @IR(counts = {IRNode.SATURATING_ADD_VB, " 2 "},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_byte_sadd(int index) {
         ByteVector.broadcast(BSP, BA)
@@ -100,7 +100,7 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
-    @IR(counts = {IRNode.SATURATING_ADD_VS, IRNode.VECTOR_SIZE_ANY, " 2 "},
+    @IR(counts = {IRNode.SATURATING_ADD_VS, " 2 "},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_short_sadd(int index) {
         ShortVector.broadcast(SSP, SA)
@@ -137,7 +137,7 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
-    @IR(counts = {IRNode.SATURATING_ADD_VI, IRNode.VECTOR_SIZE_ANY, " 2 "},
+    @IR(counts = {IRNode.SATURATING_ADD_VI, " 2 "},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_int_sadd(int index) {
         IntVector.broadcast(ISP, IA)
@@ -174,7 +174,7 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
-    @IR(counts = {IRNode.SATURATING_ADD_VL, IRNode.VECTOR_SIZE_ANY, " 2 "},
+    @IR(counts = {IRNode.SATURATING_ADD_VL, " 2 "},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_long_sadd(int index) {
         LongVector.broadcast(LSP, LA)
@@ -196,7 +196,7 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
-    @IR(counts = {IRNode.SATURATING_ADD_VI, IRNode.VECTOR_SIZE_ANY, " 2 "},
+    @IR(counts = {IRNode.SATURATING_ADD_VI, " 2 "},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static IntVector test_mixed_sadd_suadd() {
         IntVector v0 = IntVector.broadcast(ISP, 1);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.verify.*;
+import java.util.Arrays;
+import jdk.incubator.vector.*;
+
+/**
+ * @test
+ * @bug 8384507
+ * @library /test/lib /
+ * @summary Incorrect vector reassociation for signed saturating addition
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.TestIncorrectVectorReassociation
+ */
+
+public class TestIncorrectVectorReassociation {
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    /* =======================
+     * BYTE: a=100, b=100, arr[i]=-50
+     *   Correct: sat_add(100, sat_add(100, -50)) = sat_add(100, 50) = 127
+     *   Wrong:   sat_add(sat_add(100, 100), -50) = sat_add(127, -50) = 77
+     * ======================= */
+
+    static final VectorSpecies<Byte> BSP = ByteVector.SPECIES_PREFERRED;
+    static byte[] byteIn  = new byte[BSP.length()];
+    static byte[] byteOut = new byte[BSP.length()];
+    static final byte BA = 100, BB = 100;
+
+    static {
+        Arrays.fill(byteIn, (byte) -50);
+    }
+
+    @Test
+    static void test_byte_sadd(int index) {
+        ByteVector.broadcast(BSP, BA)
+                  .lanewise(VectorOperators.SADD,
+                            ByteVector.broadcast(BSP, BB)
+                                     .lanewise(VectorOperators.SADD,
+                                               ByteVector.fromArray(BSP, byteIn, index)))
+                  .intoArray(byteOut, index);
+    }
+
+    @Run(test = "test_byte_sadd")
+    void run_byte_sadd() {
+        for (int i = 0; i < BSP.loopBound(byteIn.length); i += BSP.length()) {
+            test_byte_sadd(i);
+        }
+        for (int i = 0; i < BSP.loopBound(byteIn.length); i++) {
+            Verify.checkEQ(byteOut[i], VectorMath.addSaturating(BA, VectorMath.addSaturating(BB, byteIn[i])));
+        }
+    }
+
+    /* =======================
+     * SHORT: a=30000, b=30000, arr[i]=-50
+     *   Correct: sat_add(30000, sat_add(30000, -50)) = sat_add(30000, 29950) = 32767
+     *   Wrong:   sat_add(sat_add(30000, 30000), -50) = sat_add(32767, -50) = 32717
+     * ======================= */
+
+    static final VectorSpecies<Short> SSP = ShortVector.SPECIES_PREFERRED;
+    static short[] shortIn  = new short[SSP.length()];
+    static short[] shortOut = new short[SSP.length()];
+    static final short SA = 30000, SB = 30000;
+
+    static {
+        Arrays.fill(shortIn, (short) -50);
+    }
+
+    @Test
+    static void test_short_sadd(int index) {
+        ShortVector.broadcast(SSP, SA)
+                   .lanewise(VectorOperators.SADD,
+                             ShortVector.broadcast(SSP, SB)
+                                      .lanewise(VectorOperators.SADD,
+                                                ShortVector.fromArray(SSP, shortIn, index)))
+                   .intoArray(shortOut, index);
+    }
+
+    @Run(test = "test_short_sadd")
+    void run_short_sadd() {
+        for (int i = 0; i < SSP.loopBound(shortIn.length); i += SSP.length()) {
+            test_short_sadd(i);
+        }
+        for (int i = 0; i < SSP.loopBound(shortIn.length); i++) {
+            Verify.checkEQ(shortOut[i], VectorMath.addSaturating(SA, VectorMath.addSaturating(SB, shortIn[i])));
+        }
+    }
+
+    /* =======================
+     * INT: a=2_000_000_000, b=2_000_000_000, arr[i]=-50
+     *   Correct: sat_add(2B, sat_add(2B, -50)) = sat_add(2B, 1_999_999_950) = MAX
+     *   Wrong:   sat_add(sat_add(2B, 2B), -50) = sat_add(MAX, -50) = MAX-50
+     * ======================= */
+
+    static final VectorSpecies<Integer> ISP = IntVector.SPECIES_PREFERRED;
+    static int[] intIn  = new int[ISP.length()];
+    static int[] intOut = new int[ISP.length()];
+    static final int IA = 2_000_000_000, IB = 2_000_000_000;
+
+    static {
+        Arrays.fill(intIn, -50);
+    }
+
+    @Test
+    static void test_int_sadd(int index) {
+        IntVector.broadcast(ISP, IA)
+                 .lanewise(VectorOperators.SADD,
+                           IntVector.broadcast(ISP, IB)
+                                    .lanewise(VectorOperators.SADD,
+                                              IntVector.fromArray(ISP, intIn, index)))
+                 .intoArray(intOut, index);
+    }
+
+    @Run(test = "test_int_sadd")
+    void run_int_sadd() {
+        for (int i = 0; i < ISP.loopBound(intIn.length); i += ISP.length()) {
+            test_int_sadd(i);
+        }
+        for (int i = 0; i < ISP.loopBound(intIn.length); i++) {
+            Verify.checkEQ(intOut[i], VectorMath.addSaturating(IA, VectorMath.addSaturating(IB, intIn[i])));
+        }
+    }
+
+    /* =======================
+     * LONG: a=8_000_000_000_000_000_000L, b=8_000_000_000_000_000_000L, arr[i]=-50
+     *   Correct: sat_add(8e18, sat_add(8e18, -50)) = sat_add(8e18, 7_999_999_999_999_999_950) = MAX
+     *   Wrong:   sat_add(sat_add(8e18, 8e18), -50) = sat_add(MAX, -50) = MAX-50
+     * ======================= */
+
+    static final VectorSpecies<Long> LSP = LongVector.SPECIES_PREFERRED;
+    static long[] longIn  = new long[LSP.length()];
+    static long[] longOut = new long[LSP.length()];
+    static final long LA = 8_000_000_000_000_000_000L, LB = 8_000_000_000_000_000_000L;
+
+    static {
+        Arrays.fill(longIn, -50L);
+    }
+
+    @Test
+    static void test_long_sadd(int index) {
+        LongVector.broadcast(LSP, LA)
+                  .lanewise(VectorOperators.SADD,
+                            LongVector.broadcast(LSP, LB)
+                                     .lanewise(VectorOperators.SADD,
+                                               LongVector.fromArray(LSP, longIn, index)))
+                  .intoArray(longOut, index);
+    }
+
+    @Run(test = "test_long_sadd")
+    void run_long_sadd() {
+        for (int i = 0; i < LSP.loopBound(longIn.length); i += LSP.length()) {
+            test_long_sadd(i);
+        }
+        for (int i = 0; i < LSP.loopBound(longIn.length); i++) {
+            Verify.checkEQ(longOut[i], VectorMath.addSaturating(LA, VectorMath.addSaturating(LB, longIn[i])));
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
@@ -195,14 +195,12 @@ public class TestIncorrectVectorReassociation {
         }
     }
 
-    static final VectorSpecies<Integer> ISP256 = IntVector.SPECIES_256;
-
     @Test
     @IR(counts = {IRNode.SATURATING_ADD_VI, IRNode.VECTOR_SIZE_ANY, " 2 "},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static IntVector test_mixed_sadd_suadd() {
-        IntVector v0 = IntVector.broadcast(ISP256, 1);
-        IntVector v1 = IntVector.broadcast(ISP256, 0);
+        IntVector v0 = IntVector.broadcast(ISP, 1);
+        IntVector v1 = IntVector.broadcast(ISP, 0);
         IntVector v2 = v0.lanewise(VectorOperators.SADD, v1);
         return v2.lanewise(VectorOperators.SUADD, -1);
     }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIncorrectVectorReassociation.java
@@ -30,7 +30,7 @@ import jdk.incubator.vector.*;
 
 /**
  * @test
- * @bug 8384507
+ * @bug 8384507 8385308
  * @library /test/lib /
  * @summary Incorrect vector reassociation for signed saturating addition
  * @modules jdk.incubator.vector
@@ -41,7 +41,10 @@ import jdk.incubator.vector.*;
 public class TestIncorrectVectorReassociation {
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+        TestFramework testFramework = new TestFramework();
+        testFramework.setDefaultWarmup(10000)
+                     .addFlags("--add-modules=jdk.incubator.vector")
+                     .start();
     }
 
     /* =======================
@@ -60,6 +63,8 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
+    @IR(counts = {IRNode.SATURATING_ADD_VB, IRNode.VECTOR_SIZE_ANY, " 2 "},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_byte_sadd(int index) {
         ByteVector.broadcast(BSP, BA)
                   .lanewise(VectorOperators.SADD,
@@ -95,6 +100,8 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
+    @IR(counts = {IRNode.SATURATING_ADD_VS, IRNode.VECTOR_SIZE_ANY, " 2 "},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_short_sadd(int index) {
         ShortVector.broadcast(SSP, SA)
                    .lanewise(VectorOperators.SADD,
@@ -130,6 +137,8 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
+    @IR(counts = {IRNode.SATURATING_ADD_VI, IRNode.VECTOR_SIZE_ANY, " 2 "},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_int_sadd(int index) {
         IntVector.broadcast(ISP, IA)
                  .lanewise(VectorOperators.SADD,
@@ -165,6 +174,8 @@ public class TestIncorrectVectorReassociation {
     }
 
     @Test
+    @IR(counts = {IRNode.SATURATING_ADD_VL, IRNode.VECTOR_SIZE_ANY, " 2 "},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test_long_sadd(int index) {
         LongVector.broadcast(LSP, LA)
                   .lanewise(VectorOperators.SADD,
@@ -181,6 +192,29 @@ public class TestIncorrectVectorReassociation {
         }
         for (int i = 0; i < LSP.loopBound(longIn.length); i++) {
             Verify.checkEQ(longOut[i], VectorMath.addSaturating(LA, VectorMath.addSaturating(LB, longIn[i])));
+        }
+    }
+
+    static final VectorSpecies<Integer> ISP256 = IntVector.SPECIES_256;
+
+    @Test
+    @IR(counts = {IRNode.SATURATING_ADD_VI, IRNode.VECTOR_SIZE_ANY, " 2 "},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
+    static IntVector test_mixed_sadd_suadd() {
+        IntVector v0 = IntVector.broadcast(ISP256, 1);
+        IntVector v1 = IntVector.broadcast(ISP256, 0);
+        IntVector v2 = v0.lanewise(VectorOperators.SADD, v1);
+        return v2.lanewise(VectorOperators.SUADD, -1);
+    }
+
+    @Run(test = "test_mixed_sadd_suadd")
+    void run_mixed_sadd_suadd() {
+        IntVector result = test_mixed_sadd_suadd();
+        int expected = VectorMath.addSaturatingUnsigned(
+                           VectorMath.addSaturating(1, 0), -1);
+        int[] res = result.toArray();
+        for (int i = 0; i < res.length; i++) {
+            Verify.checkEQ(res[i], expected);
         }
     }
 }


### PR DESCRIPTION
Reassociating vector broadcasts expects the vector operation to be associative, since we perform the following transformation:

```
VectorOp(ReplicateA, VectorOp(ReplicateB, Operand3))
  => VectorOp(Operand3, VectorOp(ReplicateA, ReplicateB))
```

Signed saturating addition is not an associative operation, i.e. sat_add(a, sat_add(b, c)) != sat_add(sat_add(a, b), c) because intermediate clamping can change the final result. This patch introduces is_associative_vector_operation() which skips the reassociation transformation for signed saturating addition while continuing to allow it for unsigned saturating addition (which is associative).

Please review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384507](https://bugs.openjdk.org/browse/JDK-8384507): Incorrect vector reassociation for signed saturating addition (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31172/head:pull/31172` \
`$ git checkout pull/31172`

Update a local copy of the PR: \
`$ git checkout pull/31172` \
`$ git pull https://git.openjdk.org/jdk.git pull/31172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31172`

View PR using the GUI difftool: \
`$ git pr show -t 31172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31172.diff">https://git.openjdk.org/jdk/pull/31172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31172#issuecomment-4457275168)
</details>
