### PR TITLE
8384631: SwitchBoostraps.typeSwitch method Javadoc still mentions target of a reference type

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -180,7 +180,7 @@ public final class SwitchBootstraps {
      *
      * @throws NullPointerException     if any argument is {@code null}, unless noted otherwise
      * @throws IllegalArgumentException if any element in the labels array is null
-     * @throws IllegalArgumentException if the invocation type is not a method type of first parameter of a reference type,
+     * @throws IllegalArgumentException if the invocation type is not a method type of first parameter of a target type,
      *                                  second parameter of type {@code int} and with {@code int} as its return type
      * @throws IllegalArgumentException if {@code labels} contains an element that is not of type {@code String},
      *                                  {@code Integer}, {@code Long}, {@code Float}, {@code Double}, {@code Boolean},


### PR DESCRIPTION
While fixing the issue https://bugs.openjdk.org/browse/JDK-8376162, a change to the `SwitchBoostraps.typeSwitch` method Javadoc was made reflecting the fact that the switch target no longer needs to be of a reference type. All mentions of the "reference type" in the documentation have been changed to the “target type” with one omission:
```
@throws IllegalArgumentException if the invocation type is not a method type of first parameter of a reference type, …
```

The proposal here is to fix this omission.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8385029](https://bugs.openjdk.org/browse/JDK-8385029) to be approved

### Issues
 * [JDK-8384631](https://bugs.openjdk.org/browse/JDK-8384631): SwitchBoostraps.typeSwitch method Javadoc still mentions target of a reference type (**Bug** - P3)
 * [JDK-8385029](https://bugs.openjdk.org/browse/JDK-8385029): SwitchBoostraps.typeSwitch method Javadoc still mentions target of a reference type (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31174/head:pull/31174` \
`$ git checkout pull/31174`

Update a local copy of the PR: \
`$ git checkout pull/31174` \
`$ git pull https://git.openjdk.org/jdk.git pull/31174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31174`

View PR using the GUI difftool: \
`$ git pr show -t 31174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31174.diff">https://git.openjdk.org/jdk/pull/31174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31174#issuecomment-4458177253)
</details>
