### PR TITLE
8384636: Parallel: Remove redundant PSAdjustTask claim counter initialization loop

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1378,11 +1378,9 @@ public:
     _weak_proc_task(nworkers),
     _oop_storage_iter(),
     _nworkers(nworkers),
-    _code_cache_claimed(false) {
+    _code_cache_claimed(false),
+    _claim_counters{} {
 
-    for (unsigned int i = PSParallelCompact::old_space_id; i < PSParallelCompact::last_space_id; ++i) {
-      ::new (&_claim_counters[i]) Atomic<uint>{};
-    }
     ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_adjust);
   }
 


### PR DESCRIPTION
PSAdjustTask currently initializes `_claim_counters` with a placement-new loop in the constructor body. The array elements are already constructed before the constructor body runs, and this is sufficient because the default constructor of `Atomic<uint>` initializes the value to zero.

This trivial patch removes the redundant loop and adds an explicit `_claim_counters{}` member initializer.

The generated release assembly is not byte-identical: the new form uses a vector zero store for the counter array instead of separate scalar stores. The effective initialization is the same.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384636](https://bugs.openjdk.org/browse/JDK-8384636): Parallel: Remove redundant PSAdjustTask claim counter initialization loop (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31175/head:pull/31175` \
`$ git checkout pull/31175`

Update a local copy of the PR: \
`$ git checkout pull/31175` \
`$ git pull https://git.openjdk.org/jdk.git pull/31175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31175`

View PR using the GUI difftool: \
`$ git pr show -t 31175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31175.diff">https://git.openjdk.org/jdk/pull/31175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31175#issuecomment-4458620792)
</details>
