### PR TITLE
8384801: Shenandoah: ShouldNotReachHere() in shenandoahSupport.cpp with AllocatePrefetchStyle=3

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1617,7 +1617,7 @@ void MemoryGraphFixer::collect_memory_nodes() {
         } else if (mem->is_MergeMem()) {
           MergeMemNode* mm = mem->as_MergeMem();
           mem = mm->memory_at(_alias);
-        } else if (mem->is_Store() || mem->is_LoadStore() || mem->is_ClearArray()) {
+        } else if (mem->is_Store() || mem->is_LoadStore() || mem->is_ClearArray() || mem->Opcode() == Op_PrefetchAllocation) {
           assert(_alias == Compile::AliasIdxRaw, "");
           stack.push(mem, mem->req());
           mem = mem->in(MemNode::Memory);


### PR DESCRIPTION
I believe [a recent change](https://bugs.openjdk.org/browse/JDK-8374397) exposed a latent bug that had Shenandoah ignoring prefetch nodes in the IR graph.

Note that this issue does NOT exist in the imminent [late barrier expansion for Shenandoah pull request](https://github.com/openjdk/jdk/pull/31140), but in the interest of backporting to earlier releases I'm opening a fix on tip.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384801](https://bugs.openjdk.org/browse/JDK-8384801): Shenandoah: ShouldNotReachHere() in shenandoahSupport.cpp with AllocatePrefetchStyle=3 (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31178/head:pull/31178` \
`$ git checkout pull/31178`

Update a local copy of the PR: \
`$ git checkout pull/31178` \
`$ git pull https://git.openjdk.org/jdk.git pull/31178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31178`

View PR using the GUI difftool: \
`$ git pr show -t 31178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31178.diff">https://git.openjdk.org/jdk/pull/31178.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31178#issuecomment-4464329949)
</details>
