### PR TITLE
8384804: JMX remote bootstrap tests fail on Windows

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -44,15 +44,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.UserPrincipal;
 import java.nio.channels.SocketChannel;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.Map;
@@ -1031,25 +1034,18 @@ public final class Utils {
         } else if (attr.contains("acl")) {
             AclFileAttributeView view =
                     Files.getFileAttributeView(file, AclFileAttributeView.class);
+            UserPrincipal everyone = file.getFileSystem()
+                    .getUserPrincipalLookupService()
+                    .lookupPrincipalByName("Everyone");
+            UserPrincipal principal = userOnly ? view.getOwner() : everyone;
+            EnumSet<AclEntryPermission> allPermissions = EnumSet.allOf(AclEntryPermission.class);
+
             List<AclEntry> acl = new ArrayList<>();
-            for (AclEntry thisEntry : view.getAcl()) {
-                if (userOnly) {
-                    if (thisEntry.principal().getName()
-                            .equals(view.getOwner().getName())) {
-                        acl.add(allowAccess(thisEntry));
-                    } else if (thisEntry.type() == AclEntryType.ALLOW) {
-                        acl.add(revokeAccess(thisEntry));
-                    } else {
-                        acl.add(thisEntry);
-                    }
-                } else {
-                    if (thisEntry.type() != AclEntryType.ALLOW) {
-                        acl.add(allowAccess(thisEntry));
-                    } else {
-                        acl.add(thisEntry);
-                    }
-                }
-            }
+            acl.add(AclEntry.newBuilder()
+                    .setType(AclEntryType.ALLOW)
+                    .setPrincipal(principal)
+                    .setPermissions(allPermissions)
+                    .build());
             view.setAcl(acl);
         } else {
             throw new RuntimeException("Unsupported file attributes: " + attr);


### PR DESCRIPTION
Prior to this patch, when `userOnly` was true, the conflicting "allow"
entry (for the owner) and "deny" entry (for groups that the owner is a
member of) resulted in the owner being denied access since the "deny"
entry takes precedence.  This resulted in RmiBootstrapTest and
RmiSslNoKeyStoreTest tests failing with an "Access Denied" error.

In reality, the "deny" entry is not required, since Windows grants
access only when an explicit "allow" entry matches the requesting
principal.  So this patch fixes the ACLs so that when `userOnly` is
true, only the owner has "allow" access.  Principals without a matching
"allow" entry are denied access, thus restricting access without risking
a group "deny" entry overriding the owner's access.

This patch also fixes the case when `userOnly` is false so that it
doesn't inadvertently deny access when a principal didn't already have
an ACL entry for the file.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384804](https://bugs.openjdk.org/browse/JDK-8384804): JMX remote bootstrap tests fail on Windows (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mat Carter](https://openjdk.org/census#macarte) (@macarte - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31179/head:pull/31179` \
`$ git checkout pull/31179`

Update a local copy of the PR: \
`$ git checkout pull/31179` \
`$ git pull https://git.openjdk.org/jdk.git pull/31179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31179`

View PR using the GUI difftool: \
`$ git pr show -t 31179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31179.diff">https://git.openjdk.org/jdk/pull/31179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31179#issuecomment-4464726125)
</details>
