### PR TITLE
8384808: Remove AppContext-based Window Activation time map from SunToolkit

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1787,34 +1787,20 @@ public abstract class SunToolkit extends Toolkit
 
     public void dismissPopupOnFocusLostIfNeededCleanUp(Window invoker) {}
 
-
-    private static final Object DEACTIVATION_TIMES_MAP_KEY = new Object();
+    private static WeakHashMap<Window, Long> activationMap = null;
 
     public synchronized void setWindowDeactivationTime(Window w, long time) {
-        AppContext ctx = getAppContext(w);
-        if (ctx == null) {
-            return;
+        if (activationMap == null) {
+            activationMap = new WeakHashMap<Window, Long>();
         }
-        @SuppressWarnings("unchecked")
-        WeakHashMap<Window, Long> map = (WeakHashMap<Window, Long>)ctx.get(DEACTIVATION_TIMES_MAP_KEY);
-        if (map == null) {
-            map = new WeakHashMap<Window, Long>();
-            ctx.put(DEACTIVATION_TIMES_MAP_KEY, map);
-        }
-        map.put(w, time);
+        activationMap.put(w, time);
     }
 
     public synchronized long getWindowDeactivationTime(Window w) {
-        AppContext ctx = getAppContext(w);
-        if (ctx == null) {
+        if (activationMap == null) {
             return -1;
         }
-        @SuppressWarnings("unchecked")
-        WeakHashMap<Window, Long> map = (WeakHashMap<Window, Long>)ctx.get(DEACTIVATION_TIMES_MAP_KEY);
-        if (map == null) {
-            return -1;
-        }
-        Long time = map.get(w);
+        Long time = activationMap.get(w);
         return time == null ? -1 : time;
     }
 


### PR DESCRIPTION
This removes a per-AppContext window activation map I'd not noticed until now.
No tests failed as a result of this change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384808](https://bugs.openjdk.org/browse/JDK-8384808): Remove AppContext-based Window Activation time map from SunToolkit (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31180/head:pull/31180` \
`$ git checkout pull/31180`

Update a local copy of the PR: \
`$ git checkout pull/31180` \
`$ git pull https://git.openjdk.org/jdk.git pull/31180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31180`

View PR using the GUI difftool: \
`$ git pr show -t 31180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31180.diff">https://git.openjdk.org/jdk/pull/31180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31180#issuecomment-4467614563)
</details>
