### PR TITLE
8384810: sun/security/ssl/X509KeyManager/PreferredKey.java fails Failed to get the preferable key aliases

### DIFF
--- a/test/jdk/sun/security/ssl/X509KeyManager/PreferredKey.java
+++ b/test/jdk/sun/security/ssl/X509KeyManager/PreferredKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,28 +32,54 @@
  * @bug 6302644
  * @summary X509KeyManager implementation for NewSunX509 doesn't return most
  *          preferable key
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.util
+ * @library /test/lib
  * @run main/othervm PreferredKey
  */
-import java.io.*;
-import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
+
+import static jdk.test.lib.Asserts.assertEquals;
+import static jdk.test.lib.Asserts.assertNotNull;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import jdk.test.lib.security.CertificateBuilder;
+import sun.security.x509.AuthorityKeyIdentifierExtension;
+import sun.security.x509.GeneralName;
+import sun.security.x509.GeneralNames;
+import sun.security.x509.KeyIdentifier;
+import sun.security.x509.SerialNumber;
+import sun.security.x509.X500Name;
 
 public class PreferredKey {
 
-    /*
-     * =============================================================
-     * Set the various variables needed for the tests, then
-     * specify what tests to run on each side.
-     */
+    private static final String RSA_ALIAS = "rsa-alias";
+    private static final String DSA_ALIAS = "dsa-alias";
+    private static final char[] PASSPHRASE = "passphrase".toCharArray();
 
-    /*
-     * Where do we find the keystores?
-     */
-    static String pathToStores = "../../../../javax/net/ssl/etc";
-    static String keyStoreFile = "keystore";
-    static String passwd = "passphrase";
+    private static final String CA_KEY_TYPE = "RSA";
+    private static final String CERT_SIG_ALG = "SHA256withRSA";
+    private static final String CA_ISSUER_STRING =
+            "O=TrustedCert, L=Some-City, ST=Some-State, C=US";
+    private static final String EE_ISSUER_STRING =
+            "O=EndpointCert, L=Some-City, ST=Some-State, C=US";
 
+    private static final boolean[] DEFAULT_KEY_USAGES =
+            new boolean[]{true, true, true, true, true, true};
 
     public static void main(String[] args) throws Exception {
         // MD5 is used in this test case, don't disable MD5 algorithm.
@@ -62,48 +88,102 @@ public class PreferredKey {
         Security.setProperty("jdk.tls.disabledAlgorithms",
                 "SSLv3, RC4, DH keySize < 768");
 
-        KeyStore ks;
-        KeyManagerFactory kmf;
-        X509KeyManager km;
+        X509KeyManager km = getKeyManager();
 
-        String keyFilename =
-            System.getProperty("test.src", ".") + "/" + pathToStores +
-                "/" + keyStoreFile;
-        char [] password = passwd.toCharArray();
+        checkPreferredKey(km, "RSA", new String[] {"RSA", "DSA"});
+        checkPreferredKey(km, "DSA", new String[] {"DSA", "RSA"});
+    }
 
-        ks = KeyStore.getInstance(new File(keyFilename), password);
-        kmf = KeyManagerFactory.getInstance("NewSunX509");
-        kmf.init(ks, password);
-        km = (X509KeyManager) kmf.getKeyManagers()[0];
+    private static void checkPreferredKey(X509KeyManager km, String keyType,
+            String[] keyTypes) throws Exception {
+        String[] aliases = km.getClientAliases(keyType, null);
+        String alias = km.chooseClientAlias(keyTypes, null, null);
 
-        /*
-         * There should be both an rsa and a dsa entry in the
-         * keystore, otherwise the test will no work.
-         */
-        String[] aliases = km.getClientAliases("RSA", null);
-        String alias = km.chooseClientAlias(new String[] {"RSA", "DSA"},
-                                     null, null);
+        assertNotNull(aliases, "Expected client aliases for " + keyType);
+        assertNotNull(alias, "Expected chosen alias for " + keyTypes[0]);
 
-        // there're should both be null or nonnull
-        if (aliases != null || alias != null) {
-            String algorithm = km.getPrivateKey(alias).getAlgorithm();
-            if (!algorithm.equals("RSA") || !algorithm.equals(
-                        km.getPrivateKey(aliases[0]).getAlgorithm())) {
-                throw new Exception("Failed to get the preferable key aliases");
-            }
-        }
+        String algorithm = km.getPrivateKey(alias).getAlgorithm();
+        String firstAliasAlgorithm =
+                km.getPrivateKey(aliases[0]).getAlgorithm();
 
-        aliases = km.getClientAliases("DSA", null);
-        alias = km.chooseClientAlias(new String[] {"DSA", "RSA"},
-                                     null, null);
+        assertEquals(keyType, algorithm,
+                "chooseClientAlias did not return preferable " + keyType
+                        + " key");
+        assertEquals(keyType, firstAliasAlgorithm,
+                "getClientAliases did not list preferable " + keyType
+                        + " key first");
+        assertEquals(algorithm, firstAliasAlgorithm,
+                "chosen key algorithm does not match first alias");
+    }
 
-        // there're should both be null or nonnull
-        if (aliases != null || alias != null) {
-            String algorithm = km.getPrivateKey(alias).getAlgorithm();
-            if (!algorithm.equals("DSA") || !algorithm.equals(
-                        km.getPrivateKey(aliases[0]).getAlgorithm())) {
-                throw new Exception("Failed to get the preferable key aliases");
-            }
-        }
+    private static X509KeyManager getKeyManager() throws Exception {
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+
+        KeyPair caKeys = KeyPairGenerator.getInstance(CA_KEY_TYPE)
+                .generateKeyPair();
+        X509Certificate trustedCert = createTrustedCert(caKeys);
+        ks.setCertificateEntry("ca", trustedCert);
+
+        addKeyEntry(ks, RSA_ALIAS, "RSA", caKeys, trustedCert);
+        addKeyEntry(ks, DSA_ALIAS, "DSA", caKeys, trustedCert);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509");
+        kmf.init(ks, PASSPHRASE);
+        return (X509KeyManager) kmf.getKeyManagers()[0];
+    }
+
+    private static void addKeyEntry(KeyStore ks, String alias, String keyAlg,
+            KeyPair caKeys, X509Certificate trustedCert) throws Exception {
+        KeyPair endpointKeys = KeyPairGenerator.getInstance(keyAlg)
+                .generateKeyPair();
+
+        X509Certificate endpointCert = certificateBuilder(
+                EE_ISSUER_STRING,
+                endpointKeys.getPublic(), caKeys.getPublic())
+                .addBasicConstraintsExt(false, false, -1)
+                .build(trustedCert, caKeys.getPrivate(), CERT_SIG_ALG);
+
+        Certificate[] chain = {endpointCert, trustedCert};
+        ks.setKeyEntry(alias, endpointKeys.getPrivate(), PASSPHRASE, chain);
+    }
+
+    private static X509Certificate createTrustedCert(KeyPair caKeys)
+            throws Exception {
+        SecureRandom random = new SecureRandom();
+
+        KeyIdentifier kid = new KeyIdentifier(caKeys.getPublic());
+        GeneralNames gns = new GeneralNames();
+        GeneralName name = new GeneralName(new X500Name(
+                "O=Some-Org, L=Some-City, ST=Some-State, C=US"));
+        gns.add(name);
+        BigInteger serialNumber =
+                BigInteger.valueOf(random.nextLong(1_000_000) + 1);
+        return certificateBuilder(
+                CA_ISSUER_STRING,
+                caKeys.getPublic(), caKeys.getPublic())
+                .setSerialNumber(serialNumber)
+                .addExtension(new AuthorityKeyIdentifierExtension(kid, gns,
+                        new SerialNumber(serialNumber)))
+                .addBasicConstraintsExt(true, true, -1)
+                .build(null, caKeys.getPrivate(), CERT_SIG_ALG);
+    }
+
+    private static CertificateBuilder certificateBuilder(
+            String subjectName, PublicKey publicKey, PublicKey caKey)
+            throws CertificateException, IOException {
+        SecureRandom random = new SecureRandom();
+        Instant now = Instant.now();
+
+        return new CertificateBuilder()
+                .setSubjectName(subjectName)
+                .setPublicKey(publicKey)
+                .setNotBefore(Date.from(now.minus(1, ChronoUnit.DAYS)))
+                .setNotAfter(Date.from(now.plus(3650, ChronoUnit.DAYS)))
+                .setSerialNumber(
+                        BigInteger.valueOf(random.nextLong(1_000_000) + 1))
+                .addSubjectKeyIdExt(publicKey)
+                .addAuthorityKeyIdExt(caKey)
+                .addKeyUsageExt(DEFAULT_KEY_USAGES);
     }
 }

--- a/test/jdk/sun/security/ssl/X509KeyManager/SelectOneKeyOutOfMany.java
+++ b/test/jdk/sun/security/ssl/X509KeyManager/SelectOneKeyOutOfMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,87 +34,99 @@
  *      passing in a single keytype parameter to chooseServerAlias method.
  *
  * @author Brad Wetmore
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.util
+ * @library /test/lib
+ * @run main SelectOneKeyOutOfMany
  */
 
-import java.io.*;
-import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import jdk.test.lib.security.CertificateBuilder;
+import sun.security.x509.AuthorityKeyIdentifierExtension;
+import sun.security.x509.GeneralName;
+import sun.security.x509.GeneralNames;
+import sun.security.x509.KeyIdentifier;
+import sun.security.x509.SerialNumber;
+import sun.security.x509.X500Name;
 
 public class SelectOneKeyOutOfMany {
 
-    /*
-     * =============================================================
-     * Set the various variables needed for the tests, then
-     * specify what tests to run on each side.
-     */
+    private static final String RSA_ALIAS = "rsa-alias";
+    private static final String DSA_ALIAS = "dsa-alias";
+    private static final char[] PASSPHRASE = "passphrase".toCharArray();
 
-    /*
-     * Where do we find the keystores?
-     */
-    static String pathToStores = "../../../../javax/net/ssl/etc";
-    static String keyStoreFile = "keystore";
-    static String passwd = "passphrase";
+    private static final String CA_KEY_TYPE = "RSA";
+    private static final String CERT_SIG_ALG = "SHA256withRSA";
+    private static final String CA_ISSUER_STRING =
+            "O=TrustedCert, L=Some-City, ST=Some-State, C=US";
+    private static final String EE_ISSUER_STRING =
+            "O=EndpointCert, L=Some-City, ST=Some-State, C=US";
+
+    private static final boolean[] DEFAULT_KEY_USAGES =
+            new boolean[]{true, true, true, true, true, true};
 
     public static void main(String[] args) throws Exception {
-        KeyStore ks;
-        KeyManagerFactory kmf;
-        X509KeyManager km;
-
-        char[] passphrase = passwd.toCharArray();
-
-        String keyFilename =
-            System.getProperty("test.src", ".") + "/" + pathToStores +
-                "/" + keyStoreFile;
-        /*
-         * Setup the tests.
-         */
-        kmf = KeyManagerFactory.getInstance("SunX509");
-        ks = KeyStore.getInstance(new File(keyFilename), passphrase);
-        kmf.init(ks, passphrase);
-        km = (X509KeyManager) kmf.getKeyManagers()[0];
+        X509KeyManager km = getKeyManager();
 
         /*
          * There should be one of each key type here.
          */
-        String [] nothing = new String [] { "nothing" };
-        String [] rsa = new String [] { "RSA" };
-        String [] dsa = new String [] { "DSA" };
-        String [] rsaDsa = new String [] { "RSA", "DSA" };
-        String [] dsaRsa = new String [] { "DSA", "RSA" };
+        String[] nothing = new String[] { "nothing" };
+        String[] rsa = new String[] { "RSA" };
+        String[] dsa = new String[] { "DSA" };
+        String[] rsaDsa = new String[] { "RSA", "DSA" };
+        String[] dsaRsa = new String[] { "DSA", "RSA" };
 
         String resultsRsaDsa, resultsDsaRsa;
         String resultsRsa, resultsDsa;
         String resultsNone;
 
-        String [] resultArrayRSA;
-        String [] resultArrayDSA;
+        String[] resultArrayRSA;
+        String[] resultArrayDSA;
 
         /*
          * Check get*Aliases for null returns
          */
-        if (km.getClientAliases("nothing", null) != null)
+        if (km.getClientAliases("nothing", null) != null) {
             throw new Exception("km.getClientAliases(nothing) != null");
+        }
         System.out.println("km.getClientAlias(nothing) returning nulls");
 
-        if (km.getServerAliases("nothing", null) != null)
+        if (km.getServerAliases("nothing", null) != null) {
             throw new Exception("km.getServerAliases(nothing) != null");
+        }
         System.out.println("km.getServerAlias(nothing) returning nulls");
         System.out.println("=====");
 
         System.out.println("Dumping Certs...");
-        if ((resultArrayRSA = km.getServerAliases("RSA", null)) == null)
+        if ((resultArrayRSA = km.getServerAliases("RSA", null)) == null) {
             throw new Exception("km.getServerAliases(RSA) == null");
+        }
         for (int i = 0; i < resultArrayRSA.length; i++) {
-            System.out.println("        resultArrayRSA#" + i + ": " +
-                resultArrayRSA[i]);
+            System.out.println("        resultArrayRSA#" + i + ": "
+                    + resultArrayRSA[i]);
         }
 
-        if ((resultArrayDSA = km.getServerAliases("DSA", null)) == null)
+        if ((resultArrayDSA = km.getServerAliases("DSA", null)) == null) {
             throw new Exception("km.getServerAliases(DSA) == null");
+        }
         for (int i = 0; i < resultArrayDSA.length; i++) {
-            System.out.println("        resultArrayDSA#" + i + ": " +
-                resultArrayDSA[i]);
+            System.out.println("        resultArrayDSA#" + i + ": "
+                    + resultArrayDSA[i]);
         }
         System.out.println("=====");
 
@@ -131,9 +143,9 @@ public class SelectOneKeyOutOfMany {
          * Check chooseClientAlias for RSA keys.
          */
         resultsRsa = km.chooseClientAlias(rsa, null, null);
-        if (resultsRsa == null)  {
+        if (resultsRsa == null) {
             throw new Exception(
-                "km.chooseClientAlias(rsa, null, null) != null");
+                    "km.chooseClientAlias(rsa, null, null) != null");
         }
         System.out.println("km.chooseClientAlias(rsa) passed");
 
@@ -143,7 +155,7 @@ public class SelectOneKeyOutOfMany {
         resultsDsa = km.chooseClientAlias(dsa, null, null);
         if (resultsDsa == null) {
             throw new Exception(
-                "km.chooseClientAlias(dsa, null, null) != null");
+                    "km.chooseClientAlias(dsa, null, null) != null");
         }
         System.out.println("km.chooseClientAlias(dsa) passed");
 
@@ -181,9 +193,9 @@ public class SelectOneKeyOutOfMany {
          * Check chooseServerAlias for RSA keys.
          */
         resultsRsa = km.chooseServerAlias("RSA", null, null);
-        if (resultsRsa == null)  {
+        if (resultsRsa == null) {
             throw new Exception(
-                "km.chooseServerAlias(\"RSA\", null, null) != null");
+                    "km.chooseServerAlias(\"RSA\", null, null) != null");
         }
         System.out.println("km.chooseServerAlias(\"RSA\") passed");
 
@@ -193,9 +205,79 @@ public class SelectOneKeyOutOfMany {
         resultsDsa = km.chooseServerAlias("DSA", null, null);
         if (resultsDsa == null) {
             throw new Exception(
-                "km.chooseServerAlias(\"DSA\", null, null) != null");
+                    "km.chooseServerAlias(\"DSA\", null, null) != null");
         }
         System.out.println("km.chooseServerAlias(\"DSA\") passed");
+    }
 
+    private static X509KeyManager getKeyManager() throws Exception {
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+
+        KeyPair caKeys = KeyPairGenerator.getInstance(CA_KEY_TYPE)
+                .generateKeyPair();
+        X509Certificate trustedCert = createTrustedCert(caKeys);
+        ks.setCertificateEntry("ca", trustedCert);
+
+        addKeyEntry(ks, RSA_ALIAS, "RSA", caKeys, trustedCert);
+        addKeyEntry(ks, DSA_ALIAS, "DSA", caKeys, trustedCert);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, PASSPHRASE);
+        return (X509KeyManager) kmf.getKeyManagers()[0];
+    }
+
+    private static void addKeyEntry(KeyStore ks, String alias, String keyAlg,
+            KeyPair caKeys, X509Certificate trustedCert) throws Exception {
+        KeyPair endpointKeys = KeyPairGenerator.getInstance(keyAlg)
+                .generateKeyPair();
+
+        X509Certificate endpointCert = certificateBuilder(
+                EE_ISSUER_STRING,
+                endpointKeys.getPublic(), caKeys.getPublic())
+                .addBasicConstraintsExt(false, false, -1)
+                .build(trustedCert, caKeys.getPrivate(), CERT_SIG_ALG);
+
+        Certificate[] chain = {endpointCert, trustedCert};
+        ks.setKeyEntry(alias, endpointKeys.getPrivate(), PASSPHRASE, chain);
+    }
+
+    private static X509Certificate createTrustedCert(KeyPair caKeys)
+            throws Exception {
+        SecureRandom random = new SecureRandom();
+
+        KeyIdentifier kid = new KeyIdentifier(caKeys.getPublic());
+        GeneralNames gns = new GeneralNames();
+        GeneralName name = new GeneralName(new X500Name(
+                "O=Some-Org, L=Some-City, ST=Some-State, C=US"));
+        gns.add(name);
+        BigInteger serialNumber =
+                BigInteger.valueOf(random.nextLong(1_000_000) + 1);
+        return certificateBuilder(
+                CA_ISSUER_STRING,
+                caKeys.getPublic(), caKeys.getPublic())
+                .setSerialNumber(serialNumber)
+                .addExtension(new AuthorityKeyIdentifierExtension(kid, gns,
+                        new SerialNumber(serialNumber)))
+                .addBasicConstraintsExt(true, true, -1)
+                .build(null, caKeys.getPrivate(), CERT_SIG_ALG);
+    }
+
+    private static CertificateBuilder certificateBuilder(
+            String subjectName, PublicKey publicKey, PublicKey caKey)
+            throws CertificateException, IOException {
+        SecureRandom random = new SecureRandom();
+        Instant now = Instant.now();
+
+        return new CertificateBuilder()
+                .setSubjectName(subjectName)
+                .setPublicKey(publicKey)
+                .setNotBefore(Date.from(now.minus(1, ChronoUnit.DAYS)))
+                .setNotAfter(Date.from(now.plus(3650, ChronoUnit.DAYS)))
+                .setSerialNumber(
+                        BigInteger.valueOf(random.nextLong(1_000_000) + 1))
+                .addSubjectKeyIdExt(publicKey)
+                .addAuthorityKeyIdExt(caKey)
+                .addKeyUsageExt(DEFAULT_KEY_USAGES);
     }
 }


### PR DESCRIPTION
Hi all,

Two regression tests under test/jdk/sun/security/ssl/X509KeyManager/ failed because they relied on the shared javax/net/ssl/etc/keystore, whose RSA entry (dummy) expired on 2026-05-16. With certificate checking enabled in the SunJSSE key managers (X509KeyManagerCertChecking), valid keys are preferred over expired ones when multiple key types are offered. That broke tests that expect selection based on keyTypes order alone.

This change updates both tests to build an in-memory PKCS12 keystore at runtime using CertificateBuilder, following the pattern in CertChecking.java. Each test gets separate RSA and DSA private-key entries with certificates valid for 10 years (notAfter = now + 3650 days), removing dependence on fixed-expiry shared test data.

This PR generate RSA/DSA key entries and certificate chains in-process instead of loading etc/keystore. The keymanager in PreferredKey.java is 'NewSunX509 (X509KeyManagerImpl)', the keymanager in SelectOneKeyOutOfMany.java is SunX509 (SunX509KeyManagerImpl).



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384810](https://bugs.openjdk.org/browse/JDK-8384810): sun/security/ssl/X509KeyManager/PreferredKey.java fails Failed to get the preferable key aliases (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31182/head:pull/31182` \
`$ git checkout pull/31182`

Update a local copy of the PR: \
`$ git checkout pull/31182` \
`$ git pull https://git.openjdk.org/jdk.git pull/31182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31182`

View PR using the GUI difftool: \
`$ git pr show -t 31182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31182.diff">https://git.openjdk.org/jdk/pull/31182.diff</a>

</details>
