### PR TITLE
Context-sensitive profiling based on inlining decisions

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1303,7 +1303,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
     ciMethod* method = op->profiled_method();
     assert(method != nullptr, "Should have method");
     int bci = op->profiled_bci();
-    md = method->method_data_or_null();
+    md = op->md();
     assert(md != nullptr, "Sanity");
     data = md->bci_to_data(bci);
     assert(data != nullptr,                "need data for type check");
@@ -1422,7 +1422,7 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
       ciMethod* method = op->profiled_method();
       assert(method != nullptr, "Should have method");
       int bci = op->profiled_bci();
-      md = method->method_data_or_null();
+      md = op->md();
       assert(md != nullptr, "Sanity");
       data = md->bci_to_data(bci);
       assert(data != nullptr,                "need data for type check");
@@ -2746,10 +2746,10 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
   ciMethod* method = op->profiled_method();
   int bci          = op->profiled_bci();
   ciMethod* callee = op->profiled_callee();
+  ciMethodData* md = op->md();
   Register tmp_load_klass = rscratch1;
 
   // Update counter for all call types
-  ciMethodData* md = method->method_data_or_null();
   assert(md != nullptr, "Sanity");
   ciProfileData* data = md->bci_to_data(bci);
   assert(data != nullptr && data->is_CounterData(), "need CounterData for calls");

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -261,11 +261,11 @@ void LIRGenerator::store_stack_parameter (LIR_Opr item, ByteSize offset_from_sp)
   __ store(item, new LIR_Address(FrameMap::rsp_opr, in_bytes(offset_from_sp), type));
 }
 
-void LIRGenerator::array_store_check(LIR_Opr value, LIR_Opr array, CodeEmitInfo* store_check_info, ciMethod* profiled_method, int profiled_bci) {
+void LIRGenerator::array_store_check(LIR_Opr value, LIR_Opr array, CodeEmitInfo* store_check_info, ciMethod* profiled_method, ciMethodData* md, int profiled_bci) {
   LIR_Opr tmp1 = new_register(objectType);
   LIR_Opr tmp2 = new_register(objectType);
   LIR_Opr tmp3 = new_register(objectType);
-  __ store_check(value, array, tmp1, tmp2, tmp3, store_check_info, profiled_method, profiled_bci);
+  __ store_check(value, array, tmp1, tmp2, tmp3, store_check_info, profiled_method, md, profiled_bci);
 }
 
 //----------------------------------------------------------------------
@@ -1295,7 +1295,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
   __ checkcast(reg, obj.result(), x->klass(),
                new_register(objectType), new_register(objectType), tmp3,
                x->direct_compare(), info_for_exception, patching_info, stub,
-               x->profiled_method(), x->profiled_bci());
+               x->profiled_method(), x->scope()->method_data(), x->profiled_bci());
 }
 
 
@@ -1314,7 +1314,7 @@ void LIRGenerator::do_InstanceOf(InstanceOf* x) {
   tmp3 = new_register(objectType);
   __ instanceof(reg, obj.result(), x->klass(),
                 new_register(objectType), new_register(objectType), tmp3,
-                x->direct_compare(), patching_info, x->profiled_method(), x->profiled_bci());
+                x->direct_compare(), patching_info, x->profiled_method(), x->scope()->method_data(), x->profiled_bci());
 }
 
 // Intrinsic for Class::isInstance

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -117,7 +117,7 @@ void InterpreterMacroAssembler::profile_arguments_type(Register mdp, Register ca
 
     test_method_data_pointer(mdp, profile_continue);
 
-    int off_to_start = is_virtual ? in_bytes(VirtualCallData::virtual_call_data_size()) : in_bytes(CounterData::counter_data_size());
+    int off_to_start = is_virtual ? in_bytes(VirtualCallData::virtual_call_data_size()) : in_bytes(CallData::call_data_size());
 
     cmpb(Address(mdp, in_bytes(DataLayout::tag_offset()) - off_to_start), is_virtual ? DataLayout::virtual_call_type_data_tag : DataLayout::call_type_data_tag);
     jcc(Assembler::notEqual, profile_continue);
@@ -1366,7 +1366,7 @@ void InterpreterMacroAssembler::profile_call(Register mdp) {
     increment_mdp_data_at(mdp, in_bytes(CounterData::count_offset()));
 
     // The method data pointer needs to be updated to reflect the new target.
-    update_mdp_by_constant(mdp, in_bytes(CounterData::counter_data_size()));
+    update_mdp_by_constant(mdp, in_bytes(CallData::call_data_size()));
     bind(profile_continue);
   }
 }
@@ -1458,7 +1458,7 @@ void InterpreterMacroAssembler::profile_null_seen(Register mdp) {
     // The method data pointer needs to be updated.
     int mdp_delta = in_bytes(BitData::bit_data_size());
     if (TypeProfileCasts) {
-      mdp_delta = in_bytes(VirtualCallData::virtual_call_data_size());
+      mdp_delta = in_bytes(ReceiverTypeData::receiver_type_data_size());
     }
     update_mdp_by_constant(mdp, mdp_delta);
 
@@ -1477,7 +1477,7 @@ void InterpreterMacroAssembler::profile_typecheck(Register mdp, Register klass) 
     // The method data pointer needs to be updated.
     int mdp_delta = in_bytes(BitData::bit_data_size());
     if (TypeProfileCasts) {
-      mdp_delta = in_bytes(VirtualCallData::virtual_call_data_size());
+      mdp_delta = in_bytes(ReceiverTypeData::receiver_type_data_size());
 
       // Record the object type.
       profile_receiver_type(klass, mdp, 0);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1100,6 +1100,7 @@ void GraphBuilder::store_indexed(BasicType type) {
 
     if (profile_checkcasts()) {
       result->set_profiled_method(method());
+      result->set_md(method_data());
       result->set_profiled_bci(bci());
       result->set_should_profile(true);
     }
@@ -1635,7 +1636,8 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
       }
       if (profile_return() && x->type()->is_object_kind()) {
         ciMethod* caller = state()->scope()->method();
-        profile_return_type(x, method(), caller, invoke_bci);
+        ciMethodData* caller_data = state()->scope()->method_data();
+        profile_return_type(x, method(), caller, caller_data, invoke_bci);
       }
     }
     Goto* goto_callee = new Goto(continuation(), false);
@@ -1859,23 +1861,23 @@ Dependencies* GraphBuilder::dependency_recorder() const {
 }
 
 // How many arguments do we want to profile?
-Values* GraphBuilder::args_list_for_profiling(ciMethod* target, int& start, bool may_have_receiver) {
+Values* GraphBuilder::args_list_for_profiling(ciMethodData* target_md, int& start, bool may_have_receiver) {
   int n = 0;
   bool has_receiver = may_have_receiver && Bytecodes::has_receiver(method()->java_code_at_bci(bci()));
   start = has_receiver ? 1 : 0;
   if (profile_arguments()) {
-    ciProfileData* data = method()->method_data()->bci_to_data(bci());
+    ciProfileData* data = method_data()->bci_to_data(bci());
     if (data != nullptr && (data->is_CallTypeData() || data->is_VirtualCallTypeData())) {
       n = data->is_CallTypeData() ? data->as_CallTypeData()->number_of_arguments() : data->as_VirtualCallTypeData()->number_of_arguments();
     }
   }
   // If we are inlining then we need to collect arguments to profile parameters for the target
-  if (profile_parameters() && target != nullptr) {
-    if (target->method_data() != nullptr && target->method_data()->parameters_type_data() != nullptr) {
+  if (profile_parameters() && target_md != nullptr) {
+    if (target_md != nullptr && target_md->parameters_type_data() != nullptr) {
       // The receiver is profiled on method entry so it's included in
       // the number of parameters but here we're only interested in
       // actual arguments.
-      n = MAX2(n, target->method_data()->parameters_type_data()->number_of_parameters() - start);
+      n = MAX2(n, target_md->parameters_type_data()->number_of_parameters() - start);
     }
   }
   if (n > 0) {
@@ -1894,9 +1896,9 @@ void GraphBuilder::check_args_for_profiling(Values* obj_args, int expected) {
 }
 
 // Collect arguments that we want to profile in a list
-Values* GraphBuilder::collect_args_for_profiling(Values* args, ciMethod* target, bool may_have_receiver) {
+Values* GraphBuilder::collect_args_for_profiling(Values* args, ciMethodData* target_md, bool may_have_receiver) {
   int start = 0;
-  Values* obj_args = args_list_for_profiling(target, start, may_have_receiver);
+  Values* obj_args = args_list_for_profiling(target_md, start, may_have_receiver);
   if (obj_args == nullptr) {
     return nullptr;
   }
@@ -2203,7 +2205,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
         } else if (exact_target != nullptr) {
           target_klass = exact_target->holder();
         }
-        profile_call(target, recv, target_klass, collect_args_for_profiling(args, nullptr, false), false);
+        profile_call(target, nullptr, recv, target_klass, collect_args_for_profiling(args, nullptr, false), false);
       }
     }
   }
@@ -3331,7 +3333,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
       }
 
       // Emit the intrinsic node.
-      bool result = try_inline_intrinsics(scope->method());
+      bool result = try_inline_intrinsics(scope->method(), scope->method_data());
       if (!result) BAILOUT("failed to inline intrinsic");
       method_return(dpop());
 
@@ -3374,7 +3376,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
         load_local(objectType, 0);
 
         // Emit the intrinsic node.
-        bool result = try_inline_intrinsics(scope->method());
+        bool result = try_inline_intrinsics(scope->method(), scope->method_data());
         if (!result) BAILOUT("failed to inline intrinsic");
         method_return(apop());
 
@@ -3515,7 +3517,15 @@ bool GraphBuilder::try_inline(ciMethod* callee, bool holder_known, bool ignore_r
   // handle intrinsics
   if (callee->intrinsic_id() != vmIntrinsics::_none &&
       callee->check_intrinsic_candidate()) {
-    if (try_inline_intrinsics(callee, ignore_return)) {
+    ciMethodData* md = callee->method_data();
+    if (is_profiling() &&
+        callee->holder()->is_linked() &&
+        method_data() != nullptr &&
+        compilation()->env()->ensure_specialized_method_data(callee, method_data(), bci())) {
+      md = compilation()->env()->specialized_method_data(callee, method_data(), bci());
+    }
+
+    if (try_inline_intrinsics(callee, md, ignore_return)) {
       print_inlining(callee, "intrinsic");
       set_flags_for_inlined_callee(compilation(), callee);
       return true;
@@ -3563,7 +3573,7 @@ const char* GraphBuilder::should_not_inline(ciMethod* callee) const {
   return nullptr;
 }
 
-void GraphBuilder::build_graph_for_intrinsic(ciMethod* callee, bool ignore_return) {
+void GraphBuilder::build_graph_for_intrinsic(ciMethod* callee, ciMethodData* callee_md, bool ignore_return) {
   vmIntrinsics::ID id = callee->intrinsic_id();
   assert(id != vmIntrinsics::_none, "must be a VM intrinsic");
 
@@ -3650,7 +3660,7 @@ void GraphBuilder::build_graph_for_intrinsic(ciMethod* callee, bool ignore_retur
           recv = args->at(0);
           null_check(recv);
         }
-        profile_call(callee, recv, nullptr, collect_args_for_profiling(args, callee, true), true);
+        profile_call(callee, callee_md, recv, nullptr, collect_args_for_profiling(args, callee_md, true), true);
       }
     }
   }
@@ -3670,7 +3680,7 @@ void GraphBuilder::build_graph_for_intrinsic(ciMethod* callee, bool ignore_retur
   }
 }
 
-bool GraphBuilder::try_inline_intrinsics(ciMethod* callee, bool ignore_return) {
+bool GraphBuilder::try_inline_intrinsics(ciMethod* callee, ciMethodData* callee_md, bool ignore_return) {
   // For calling is_intrinsic_available we need to transition to
   // the '_thread_in_vm' state because is_intrinsic_available()
   // accesses critical VM-internal data.
@@ -3690,7 +3700,7 @@ bool GraphBuilder::try_inline_intrinsics(ciMethod* callee, bool ignore_return) {
       return false;
     }
   }
-  build_graph_for_intrinsic(callee, ignore_return);
+  build_graph_for_intrinsic(callee, callee_md, ignore_return);
   if (_inline_bailout_msg != nullptr) {
     return false;
   }
@@ -3869,8 +3879,19 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   // Proper inlining of methods with jsrs requires a little more work.
   if (callee->has_jsrs()                 ) INLINE_BAILOUT("jsrs not handled properly by inliner yet");
 
-  if (is_profiling() && !callee->ensure_method_data()) {
-    INLINE_BAILOUT("mdo allocation failed");
+  ciMethodData* md = nullptr;
+  if (is_profiling()) {
+    if (method_data() != nullptr) {
+      if (compilation()->env()->ensure_specialized_method_data(callee, method_data(), bci())) {
+        md = compilation()->env()->specialized_method_data(callee, method_data(), bci());
+      }
+    } else if (callee->ensure_method_data()) {
+      md = callee->method_data();
+    }
+
+    if (md == nullptr) {
+      INLINE_BAILOUT("mdo allocation failed");
+    }
   }
 
   const bool is_invokedynamic = (bc == Bytecodes::_invokedynamic);
@@ -3955,7 +3976,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
 
     if (profile_calls()) {
       int start = 0;
-      Values* obj_args = args_list_for_profiling(callee, start, has_receiver);
+      Values* obj_args = args_list_for_profiling(md, start, has_receiver);
       if (obj_args != nullptr) {
         int s = obj_args->capacity();
         // if called through method handle invoke, some arguments may have been popped
@@ -3968,7 +3989,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
         }
         check_args_for_profiling(obj_args, s);
       }
-      profile_call(callee, recv, holder_known ? callee->holder() : nullptr, obj_args, true);
+      profile_call(callee, md, recv, holder_known ? callee->holder() : nullptr, obj_args, true);
     }
   }
 
@@ -3995,7 +4016,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
   int continuation_preds = cont->number_of_preds();
 
   // Push callee scope
-  push_scope(callee, cont);
+  push_scope(callee, md, cont);
 
   // the BlockListBuilder for the callee could have bailed out
   if (bailed_out())
@@ -4264,9 +4285,8 @@ void GraphBuilder::push_root_scope(IRScope* scope, BlockList* bci2block, BlockBe
   _block = start;
 }
 
-
-void GraphBuilder::push_scope(ciMethod* callee, BlockBegin* continuation) {
-  IRScope* callee_scope = new IRScope(compilation(), scope(), bci(), callee, -1, false);
+void GraphBuilder::push_scope(ciMethod* callee, ciMethodData* method_data, BlockBegin* continuation) {
+  IRScope* callee_scope = new IRScope(compilation(), scope(), bci(), callee, method_data, -1, false);
   scope()->add_callee(callee_scope);
 
   BlockListBuilder blb(compilation(), callee_scope, -1);
@@ -4496,7 +4516,7 @@ void GraphBuilder::print_stats() {
 }
 #endif // PRODUCT
 
-void GraphBuilder::profile_call(ciMethod* callee, Value recv, ciKlass* known_holder, Values* obj_args, bool inlined) {
+void GraphBuilder::profile_call(ciMethod* callee, ciMethodData* callee_md, Value recv, ciKlass* known_holder, Values* obj_args, bool inlined) {
   assert(known_holder == nullptr || (known_holder->is_instance_klass() &&
                                   (!known_holder->is_interface() ||
                                    ((ciInstanceKlass*)known_holder)->has_nonstatic_concrete_methods())), "should be non-static concrete method");
@@ -4506,23 +4526,25 @@ void GraphBuilder::profile_call(ciMethod* callee, Value recv, ciKlass* known_hol
     }
   }
 
-  append(new ProfileCall(method(), bci(), callee, recv, known_holder, obj_args, inlined));
+  append(new ProfileCall(method(), bci(), method_data(), callee, callee_md, recv, known_holder, obj_args, inlined));
 }
 
-void GraphBuilder::profile_return_type(Value ret, ciMethod* callee, ciMethod* m, int invoke_bci) {
-  assert((m == nullptr) == (invoke_bci < 0), "invalid method and invalid bci together");
+void GraphBuilder::profile_return_type(Value ret, ciMethod* callee, ciMethod* m, ciMethodData* md, int invoke_bci) {
+  assert(((m == nullptr) == (md == nullptr)) && ((md == nullptr) == (invoke_bci < 0)), "invalid method, method data and bci together");
   if (m == nullptr) {
     m = method();
+  }
+  if (md == nullptr) {
+    md = method_data();
   }
   if (invoke_bci < 0) {
     invoke_bci = bci();
   }
-  ciMethodData* md = m->method_data_or_null();
   ciProfileData* data = md->bci_to_data(invoke_bci);
   if (data != nullptr && (data->is_CallTypeData() || data->is_VirtualCallTypeData())) {
     bool has_return = data->is_CallTypeData() ? ((ciCallTypeData*)data)->has_return() : ((ciVirtualCallTypeData*)data)->has_return();
     if (has_return) {
-      append(new ProfileReturnType(m , invoke_bci, callee, ret));
+      append(new ProfileReturnType(m, md, invoke_bci, callee, ret));
     }
   }
 }

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -204,6 +204,7 @@ class GraphBuilder {
   void              set_state(ValueStack* state) { _state = state; }
   IRScope*          scope() const                { return scope_data()->scope(); }
   ciMethod*         method() const               { return scope()->method(); }
+  ciMethodData*     method_data() const          { return scope()->method_data(); }
   ciBytecodeStream* stream() const               { return scope_data()->stream(); }
   Instruction*      last() const                 { return _last; }
   Bytecodes::Code   code() const                 { return stream()->cur_bc(); }
@@ -346,11 +347,11 @@ class GraphBuilder {
   void inline_sync_entry(Value lock, BlockBegin* sync_handler);
   void fill_sync_handler(Value lock, BlockBegin* sync_handler, bool default_handler = false);
 
-  void build_graph_for_intrinsic(ciMethod* callee, bool ignore_return);
+  void build_graph_for_intrinsic(ciMethod* callee, ciMethodData* callee_md, bool ignore_return);
 
   // inliners
   bool try_inline(           ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc = Bytecodes::_illegal, Value receiver = nullptr);
-  bool try_inline_intrinsics(ciMethod* callee, bool ignore_return = false);
+  bool try_inline_intrinsics(ciMethod* callee, ciMethodData* callee_md, bool ignore_return = false);
   bool try_inline_full(      ciMethod* callee, bool holder_known, bool ignore_return, Bytecodes::Code bc = Bytecodes::_illegal, Value receiver = nullptr);
   bool try_inline_jsr(int jsr_dest_bci);
 
@@ -368,7 +369,7 @@ class GraphBuilder {
   void clear_inline_bailout();
   ValueStack* state_at_entry();
   void push_root_scope(IRScope* scope, BlockList* bci2block, BlockBegin* start);
-  void push_scope(ciMethod* callee, BlockBegin* continuation);
+  void push_scope(ciMethod* callee, ciMethodData* method_data, BlockBegin* continuation);
   void push_scope_for_jsr(BlockBegin* jsr_continuation, int jsr_dest_bci);
   void pop_scope();
   void pop_scope_for_jsr();
@@ -382,8 +383,8 @@ class GraphBuilder {
 
   void print_inlining(ciMethod* callee, const char* msg, bool success = true);
 
-  void profile_call(ciMethod* callee, Value recv, ciKlass* predicted_holder, Values* obj_args, bool inlined);
-  void profile_return_type(Value ret, ciMethod* callee, ciMethod* m = nullptr, int bci = -1);
+  void profile_call(ciMethod* callee, ciMethodData* callee_md, Value recv, ciKlass* predicted_holder, Values* obj_args, bool inlined);
+  void profile_return_type(Value ret, ciMethod* callee, ciMethod* m = nullptr, ciMethodData* md = nullptr, int bci = -1);
   void profile_invocation(ciMethod* inlinee, ValueStack* state);
 
   // Shortcuts to profiling control.
@@ -396,8 +397,8 @@ class GraphBuilder {
   bool profile_arguments()     { return _compilation->profile_arguments();     }
   bool profile_return()        { return _compilation->profile_return();        }
 
-  Values* args_list_for_profiling(ciMethod* target, int& start, bool may_have_receiver);
-  Values* collect_args_for_profiling(Values* args, ciMethod* target, bool may_have_receiver);
+  Values* args_list_for_profiling(ciMethodData* target_md, int& start, bool may_have_receiver);
+  Values* collect_args_for_profiling(Values* args, ciMethodData* target_md, bool may_have_receiver);
   void check_args_for_profiling(Values* obj_args, int expected);
 
  public:

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -131,7 +131,7 @@ BlockBegin* IRScope::build_graph(Compilation* compilation, int osr_bci) {
 }
 
 
-IRScope::IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMethod* method, int osr_bci, bool create_graph)
+IRScope::IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMethod* method, ciMethodData* method_data, int osr_bci, bool create_graph)
 : _compilation(compilation)
 , _callees(2)
 , _requires_phi_function(method->max_locals())
@@ -139,6 +139,7 @@ IRScope::IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMe
   _caller             = caller;
   _level              = caller == nullptr ?  0 : caller->level() + 1;
   _method             = method;
+  _method_data        = method_data;
   _xhandlers          = new XHandlers(method);
   _number_of_locks    = 0;
   _monitor_pairing_ok = method->has_balanced_monitors();
@@ -268,7 +269,7 @@ IR::IR(Compilation* compilation, ciMethod* method, int osr_bci) :
   _num_loops(0) {
   // setup IR fields
   _compilation = compilation;
-  _top_scope   = new IRScope(compilation, nullptr, -1, method, osr_bci, true);
+  _top_scope   = new IRScope(compilation, nullptr, -1, method, method->method_data(), osr_bci, true);
   _code        = nullptr;
 }
 

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -139,6 +139,7 @@ class IRScope: public CompilationResourceObj {
   IRScope*      _caller;                         // the caller scope, or null
   int           _level;                          // the inlining level
   ciMethod*     _method;                         // the corresponding method
+  ciMethodData* _method_data;                    // the corresponding MethodData
   IRScopeList   _callees;                        // the inlined method scopes
 
   // graph
@@ -158,13 +159,14 @@ class IRScope: public CompilationResourceObj {
 
  public:
   // creation
-  IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMethod* method, int osr_bci, bool create_graph = false);
+  IRScope(Compilation* compilation, IRScope* caller, int caller_bci, ciMethod* method, ciMethodData* method_data, int osr_bci, bool create_graph = false);
 
   // accessors
   Compilation*  compilation() const              { return _compilation; }
   IRScope*      caller() const                   { return _caller; }
   int           level() const                    { return _level; }
   ciMethod*     method() const                   { return _method; }
+  ciMethodData* method_data() const              { return _method_data; }
   int           max_stack() const;               // NOTE: expensive
   BitMap&       requires_phi_function()          { return _requires_phi_function; }
 
@@ -247,7 +249,7 @@ class IRScopeDebugInfo: public CompilationResourceObj {
     bool rethrow_exception = false;
     bool has_ea_local_in_scope = false;
     bool arg_escape = false;
-    recorder->describe_scope(pc_offset, methodHandle(), scope()->method(), bci(),
+    recorder->describe_scope(pc_offset, methodHandle(), scope()->method(), scope()->method_data(), bci(),
                              reexecute, rethrow_exception, return_oop,
                              has_ea_local_in_scope, arg_escape, locvals, expvals, monvals);
   }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -29,6 +29,7 @@
 #include "c1/c1_LIR.hpp"
 #include "c1/c1_ValueType.hpp"
 #include "ci/ciField.hpp"
+#include "ci/ciMethodData.hpp"
 
 // Predefined classes
 class ciField;
@@ -955,6 +956,7 @@ LEAF(StoreIndexed, AccessIndexed)
   Value       _value;
 
   ciMethod* _profiled_method;
+  ciMethodData*   _md;
   int       _profiled_bci;
   bool      _check_boolean;
 
@@ -963,7 +965,7 @@ LEAF(StoreIndexed, AccessIndexed)
   StoreIndexed(Value array, Value index, Value length, BasicType elt_type, Value value, ValueStack* state_before,
                bool check_boolean, bool mismatched = false)
   : AccessIndexed(array, index, length, elt_type, state_before, mismatched)
-  , _value(value), _profiled_method(nullptr), _profiled_bci(0), _check_boolean(check_boolean)
+  , _value(value), _profiled_method(nullptr), _md(nullptr), _profiled_bci(0), _check_boolean(check_boolean)
   {
     ASSERT_VALUES
     pin();
@@ -975,9 +977,11 @@ LEAF(StoreIndexed, AccessIndexed)
   // Helpers for MethodData* profiling
   void set_should_profile(bool value)                { set_flag(ProfileMDOFlag, value); }
   void set_profiled_method(ciMethod* method)         { _profiled_method = method;   }
+  void set_md(ciMethodData* md)         { _md = md;   }
   void set_profiled_bci(int bci)                     { _profiled_bci = bci;         }
   bool      should_profile() const                   { return check_flag(ProfileMDOFlag); }
   ciMethod* profiled_method() const                  { return _profiled_method;     }
+  ciMethodData* md() const                  { return _md;     }
   int       profiled_bci() const                     { return _profiled_bci;        }
   // generic
   virtual void input_values_do(ValueVisitor* f)   { AccessIndexed::input_values_do(f); f->visit(&_value); }
@@ -2231,6 +2235,8 @@ LEAF(UnsafeGetAndSet, UnsafeOp)
 LEAF(ProfileCall, Instruction)
  private:
   ciMethod*        _method;
+  ciMethodData*    _md;
+  ciMethodData*    _callee_md;
   int              _bci_of_invoke;
   ciMethod*        _callee;         // the method that is called at the given bci
   Value            _recv;
@@ -2240,9 +2246,11 @@ LEAF(ProfileCall, Instruction)
   bool             _inlined;        // Are we profiling a call that is inlined
 
  public:
-  ProfileCall(ciMethod* method, int bci, ciMethod* callee, Value recv, ciKlass* known_holder, Values* obj_args, bool inlined)
+  ProfileCall(ciMethod* method, int bci, ciMethodData* md, ciMethod* callee, ciMethodData* callee_md, Value recv, ciKlass* known_holder, Values* obj_args, bool inlined)
     : Instruction(voidType)
     , _method(method)
+    , _md(md)
+    , _callee_md(callee_md)
     , _bci_of_invoke(bci)
     , _callee(callee)
     , _recv(recv)
@@ -2257,6 +2265,8 @@ LEAF(ProfileCall, Instruction)
   ciMethod* method()             const { return _method; }
   int bci_of_invoke()            const { return _bci_of_invoke; }
   ciMethod* callee()             const { return _callee; }
+  ciMethodData* md()             const { return _md; }
+  ciMethodData* callee_md()      const { return _callee_md; }
   Value recv()                   const { return _recv; }
   ciKlass* known_holder()        const { return _known_holder; }
   int nb_profiled_args()         const { return _obj_args == nullptr ? 0 : _obj_args->length(); }
@@ -2283,14 +2293,16 @@ LEAF(ProfileCall, Instruction)
 LEAF(ProfileReturnType, Instruction)
  private:
   ciMethod*        _method;
+  ciMethodData*        _md;
   ciMethod*        _callee;
   int              _bci_of_invoke;
   Value            _ret;
 
  public:
-  ProfileReturnType(ciMethod* method, int bci, ciMethod* callee, Value ret)
+  ProfileReturnType(ciMethod* method, ciMethodData* md, int bci, ciMethod* callee, Value ret)
     : Instruction(voidType)
     , _method(method)
+    , _md(md)
     , _callee(callee)
     , _bci_of_invoke(bci)
     , _ret(ret)
@@ -2301,6 +2313,7 @@ LEAF(ProfileReturnType, Instruction)
   }
 
   ciMethod* method()             const { return _method; }
+  ciMethodData* md()             const { return _md; }
   ciMethod* callee()             const { return _callee; }
   int bci_of_invoke()            const { return _bci_of_invoke; }
   Value ret()                    const { return _ret; }

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1420,21 +1420,23 @@ void check_LIR() {
 void LIR_List::checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
                           LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check,
                           CodeEmitInfo* info_for_exception, CodeEmitInfo* info_for_patch, CodeStub* stub,
-                          ciMethod* profiled_method, int profiled_bci) {
+                          ciMethod* profiled_method, ciMethodData* md, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_checkcast, result, object, klass,
                                            tmp1, tmp2, tmp3, fast_check, info_for_exception, info_for_patch, stub);
   if (profiled_method != nullptr && TypeProfileCasts) {
     c->set_profiled_method(profiled_method);
+    c->set_md(md);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
   }
   append(c);
 }
 
-void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, int profiled_bci) {
+void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, ciMethodData* md, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_instanceof, result, object, klass, tmp1, tmp2, tmp3, fast_check, nullptr, info_for_patch, nullptr);
   if (profiled_method != nullptr && TypeProfileCasts) {
     c->set_profiled_method(profiled_method);
+    c->set_md(md);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
   }
@@ -1443,10 +1445,11 @@ void LIR_List::instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Op
 
 
 void LIR_List::store_check(LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3,
-                           CodeEmitInfo* info_for_exception, ciMethod* profiled_method, int profiled_bci) {
+                           CodeEmitInfo* info_for_exception, ciMethod* profiled_method, ciMethodData* md, int profiled_bci) {
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_store_check, object, array, tmp1, tmp2, tmp3, info_for_exception);
   if (profiled_method != nullptr && TypeProfileCasts) {
     c->set_profiled_method(profiled_method);
+    c->set_md(md);
     c->set_profiled_bci(profiled_bci);
     c->set_should_profile(true);
   }

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1511,6 +1511,7 @@ class LIR_OpTypeCheck: public LIR_Op {
   CodeEmitInfo* _info_for_exception;
   CodeStub*     _stub;
   ciMethod*     _profiled_method;
+  ciMethodData*     _md;
   int           _profiled_bci;
   bool          _should_profile;
   bool          _fast_check;
@@ -1535,9 +1536,11 @@ public:
 
   // MethodData* profiling
   void set_profiled_method(ciMethod *method)     { _profiled_method = method; }
+  void set_md(ciMethodData *md)     { _md = md; }
   void set_profiled_bci(int bci)                 { _profiled_bci = bci;       }
   void set_should_profile(bool b)                { _should_profile = b;       }
   ciMethod* profiled_method() const              { return _profiled_method;   }
+  ciMethodData* md() const              { return _md;   }
   int       profiled_bci() const                 { return _profiled_bci;      }
   bool      should_profile() const               { return _should_profile;    }
 
@@ -1936,6 +1939,7 @@ class LIR_OpProfileCall : public LIR_Op {
 
  private:
   ciMethod* _profiled_method;
+  ciMethodData* _md;
   int       _profiled_bci;
   ciMethod* _profiled_callee;
   LIR_Opr   _mdo;
@@ -1945,9 +1949,10 @@ class LIR_OpProfileCall : public LIR_Op {
 
  public:
   // Destroys recv
-  LIR_OpProfileCall(ciMethod* profiled_method, int profiled_bci, ciMethod* profiled_callee, LIR_Opr mdo, LIR_Opr recv, LIR_Opr t1, ciKlass* known_holder)
+  LIR_OpProfileCall(ciMethod* profiled_method, ciMethodData* md, int profiled_bci, ciMethod* profiled_callee, LIR_Opr mdo, LIR_Opr recv, LIR_Opr t1, ciKlass* known_holder)
     : LIR_Op(lir_profile_call, LIR_OprFact::illegalOpr, nullptr)  // no result, no info
     , _profiled_method(profiled_method)
+    , _md(md)
     , _profiled_bci(profiled_bci)
     , _profiled_callee(profiled_callee)
     , _mdo(mdo)
@@ -1956,6 +1961,7 @@ class LIR_OpProfileCall : public LIR_Op {
     , _known_holder(known_holder)                { }
 
   ciMethod* profiled_method() const              { return _profiled_method;  }
+  ciMethodData* md() const              { return _md;  }
   int       profiled_bci()    const              { return _profiled_bci;     }
   ciMethod* profiled_callee() const              { return _profiled_callee;  }
   LIR_Opr   mdo()             const              { return _mdo;              }
@@ -2293,16 +2299,16 @@ class LIR_List: public CompilationResourceObj {
 
   void update_crc32(LIR_Opr crc, LIR_Opr val, LIR_Opr res)  { append(new LIR_OpUpdateCRC32(crc, val, res)); }
 
-  void instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, int profiled_bci);
-  void store_check(LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, CodeEmitInfo* info_for_exception, ciMethod* profiled_method, int profiled_bci);
+  void instanceof(LIR_Opr result, LIR_Opr object, ciKlass* klass, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check, CodeEmitInfo* info_for_patch, ciMethod* profiled_method, ciMethodData* md, int profiled_bci);
+  void store_check(LIR_Opr object, LIR_Opr array, LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, CodeEmitInfo* info_for_exception, ciMethod* profiled_method, ciMethodData* md, int profiled_bci);
 
   void checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
                   LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check,
                   CodeEmitInfo* info_for_exception, CodeEmitInfo* info_for_patch, CodeStub* stub,
-                  ciMethod* profiled_method, int profiled_bci);
+                  ciMethod* profiled_method, ciMethodData* md, int profiled_bci);
   // MethodData* profiling
-  void profile_call(ciMethod* method, int bci, ciMethod* callee, LIR_Opr mdo, LIR_Opr recv, LIR_Opr t1, ciKlass* cha_klass) {
-    append(new LIR_OpProfileCall(method, bci, callee, mdo, recv, t1, cha_klass));
+  void profile_call(ciMethod* method, ciMethodData* md, int bci, ciMethod* callee, LIR_Opr mdo, LIR_Opr recv, LIR_Opr t1, ciKlass* cha_klass) {
+    append(new LIR_OpProfileCall(method, md, bci, callee, mdo, recv, t1, cha_klass));
   }
   void profile_type(LIR_Address* mdp, LIR_Opr obj, ciKlass* exact_klass, intptr_t current_klass, LIR_Opr tmp, bool not_null, bool no_conflict) {
     append(new LIR_OpProfileType(LIR_OprFact::address(mdp), obj, exact_klass, current_klass, tmp, not_null, no_conflict));

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -417,7 +417,7 @@ void LIR_Assembler::record_non_safepoint_debug_info() {
     IRScope* scope = s->scope();
     //Always pass false for reexecute since these ScopeDescs are never used for deopt
     methodHandle null_mh;
-    debug_info->describe_scope(pc_offset, null_mh, scope->method(), s->bci(), false/*reexecute*/);
+    debug_info->describe_scope(pc_offset, null_mh, scope->method(), scope->method_data(), s->bci(), false/*reexecute*/);
   }
 
   debug_info->end_non_safepoint(pc_offset);

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -900,9 +900,7 @@ LIR_Opr LIRGenerator::force_to_spill(LIR_Opr value, BasicType t) {
 
 void LIRGenerator::profile_branch(If* if_instr, If::Condition cond) {
   if (if_instr->should_profile()) {
-    ciMethod* method = if_instr->profiled_method();
-    assert(method != nullptr, "method should be set if branch is profiled");
-    ciMethodData* md = method->method_data_or_null();
+    ciMethodData* md = if_instr->state()->scope()->method_data();
     assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(if_instr->profiled_bci());
     assert(data != nullptr, "must have profiling data");
@@ -1654,7 +1652,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
 
   if (GenerateArrayStoreCheck && needs_store_check) {
     CodeEmitInfo* store_check_info = new CodeEmitInfo(range_check_info);
-    array_store_check(value.result(), array.result(), store_check_info, x->profiled_method(), x->profiled_bci());
+    array_store_check(value.result(), array.result(), store_check_info, x->profiled_method(), x->md(), x->profiled_bci());
   }
 
   DecoratorSet decorators = IN_HEAP | IS_ARRAY;
@@ -2226,8 +2224,7 @@ void LIRGenerator::do_TableSwitch(TableSwitch* x) {
   LIR_Opr value = tag.result();
 
   if (compilation()->env()->comp_level() == CompLevel_full_profile && UseSwitchProfiling) {
-    ciMethod* method = x->state()->scope()->method();
-    ciMethodData* md = method->method_data_or_null();
+    ciMethodData* md = x->state()->scope()->method_data();
     assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(x->state()->bci());
     assert(data != nullptr, "must have profiling data");
@@ -2284,8 +2281,7 @@ void LIRGenerator::do_LookupSwitch(LookupSwitch* x) {
   int len = x->length();
 
   if (compilation()->env()->comp_level() == CompLevel_full_profile && UseSwitchProfiling) {
-    ciMethod* method = x->state()->scope()->method();
-    ciMethodData* md = method->method_data_or_null();
+    ciMethodData* md = x->state()->scope()->method_data();
     assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(x->state()->bci());
     assert(data != nullptr, "must have profiling data");
@@ -2353,9 +2349,7 @@ void LIRGenerator::do_Goto(Goto* x) {
 
   // Gotos can be folded Ifs, handle this case.
   if (x->should_profile()) {
-    ciMethod* method = x->profiled_method();
-    assert(method != nullptr, "method should be set if branch is profiled");
-    ciMethodData* md = method->method_data_or_null();
+    ciMethodData* md = x->state()->scope()->method_data();
     assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(x->profiled_bci());
     assert(data != nullptr, "must have profiling data");
@@ -2924,7 +2918,7 @@ void LIRGenerator::do_Intrinsic(Intrinsic* x) {
 void LIRGenerator::profile_arguments(ProfileCall* x) {
   if (compilation()->profile_arguments()) {
     int bci = x->bci_of_invoke();
-    ciMethodData* md = x->method()->method_data_or_null();
+    ciMethodData* md = x->md();
     assert(md != nullptr, "Sanity");
     ciProfileData* data = md->bci_to_data(bci);
     if (data != nullptr) {
@@ -2980,7 +2974,7 @@ void LIRGenerator::profile_arguments(ProfileCall* x) {
 // profile parameters on entry to an inlined method
 void LIRGenerator::profile_parameters_at_call(ProfileCall* x) {
   if (compilation()->profile_parameters() && x->inlined()) {
-    ciMethodData* md = x->callee()->method_data_or_null();
+    ciMethodData* md = x->callee_md();
     if (md != nullptr) {
       ciParametersTypeData* parameters_type_data = md->parameters_type_data();
       if (parameters_type_data != nullptr) {
@@ -3056,12 +3050,12 @@ void LIRGenerator::do_ProfileCall(ProfileCall* x) {
     recv = new_register(T_OBJECT);
     __ move(value.result(), recv);
   }
-  __ profile_call(x->method(), x->bci_of_invoke(), x->callee(), mdo, recv, tmp, x->known_holder());
+  __ profile_call(x->method(), x->md(), x->bci_of_invoke(), x->callee(), mdo, recv, tmp, x->known_holder());
 }
 
 void LIRGenerator::do_ProfileReturnType(ProfileReturnType* x) {
   int bci = x->bci_of_invoke();
-  ciMethodData* md = x->method()->method_data_or_null();
+  ciMethodData* md = x->md();
   assert(md != nullptr, "Sanity");
   ciProfileData* data = md->bci_to_data(bci);
   if (data != nullptr) {
@@ -3165,7 +3159,7 @@ void LIRGenerator::increment_event_counter_impl(CodeEmitInfo* info,
     counter_holder = new_register(T_METADATA);
     offset = in_bytes(backedge ? MethodData::backedge_counter_offset() :
                                  MethodData::invocation_counter_offset());
-    ciMethodData* md = method->method_data_or_null();
+    ciMethodData* md = info->scope()->method_data();
     assert(md != nullptr, "Sanity");
     __ metadata2reg(md->constant_encoding(), counter_holder);
   } else {

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -317,7 +317,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
 #endif
 
   // specific implementations
-  void array_store_check(LIR_Opr value, LIR_Opr array, CodeEmitInfo* store_check_info, ciMethod* profiled_method, int profiled_bci);
+  void array_store_check(LIR_Opr value, LIR_Opr array, CodeEmitInfo* store_check_info, ciMethod* profiled_method, ciMethodData* md, int profiled_bci);
 
   static LIR_Opr result_register_for(ValueType* type, bool callee = false);
 

--- a/src/hotspot/share/ci/ciClassList.hpp
+++ b/src/hotspot/share/ci/ciClassList.hpp
@@ -58,6 +58,7 @@ class   ciMetadata;
 class   ciMethod;
 class   ciMethodData;
 class     ciReceiverTypeData;  // part of ciMethodData
+class     ciMethodDataEntry;  // part of ciMethodData
 class   ciType;
 class    ciReturnAddress;
 class    ciKlass;
@@ -100,6 +101,7 @@ friend class ciMethod;                 \
 friend class ciMethodData;             \
 friend class ciMethodHandle;           \
 friend class ciMethodType;             \
+friend class ciMethodDataEntry;        \
 friend class ciReceiverTypeData;       \
 friend class ciTypeEntries;            \
 friend class ciSpeculativeTrapData;    \

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -28,6 +28,7 @@
 #include "ci/ciInstance.hpp"
 #include "ci/ciInstanceKlass.hpp"
 #include "ci/ciMethod.hpp"
+#include "ci/ciMethodData.hpp"
 #include "ci/ciNullObject.hpp"
 #include "ci/ciReplay.hpp"
 #include "ci/ciSymbols.hpp"
@@ -1696,4 +1697,72 @@ void ciEnv::dump_inline_data(int compile_id) {
 
 void ciEnv::dump_replay_data_version(outputStream* out) {
   out->print_cr("version %d", REPLAY_VERSION);
+}
+
+bool ciEnv::ensure_specialized_method_data(ciMethod* callee, ciMethodData* caller_md, int bci) {
+  assert(callee != nullptr, "callee should not be null");
+
+  if (!SpecializedMethodData) {
+    return callee->ensure_method_data();
+  }
+
+  return callee->ensure_specialized_method_data(caller_md, bci);
+}
+
+ciMethodData* ciEnv::specialized_method_data(ciMethod* callee, ciMethodData* caller_md, int bci) {
+  assert(callee != nullptr, "callee should not be null");
+
+  if (!SpecializedMethodData) {
+    return callee->method_data();
+  }
+
+  if (callee->specialized_method_data_compatible(caller_md, bci)) {
+    return callee->specialized_method_data(caller_md, bci);
+  }
+  return callee->method_data();
+}
+
+ciMethodData* ciEnv::specialized_method_data(ciMethod* callee, JVMState* caller) {
+  assert(callee != nullptr, "callee should not be null");
+
+  if (!SpecializedMethodData) {
+    return callee->method_data();
+  }
+
+  if (caller == nullptr || !caller->has_method()) {
+    return callee->method_data();
+  }
+
+  GrowableArray<Pair<ciMethod*, int>> call_sites(caller->depth());
+  for (JVMState* jvms = caller; jvms != nullptr && jvms->has_method(); jvms = jvms->caller()) {
+    call_sites.append({jvms->method(), jvms->bci()});
+  }
+
+  for (int spec_depth = call_sites.length(); spec_depth > 0; spec_depth--) {
+    ciMethodData* caller_md = call_sites.at(spec_depth - 1).first->method_data_or_null();
+    int caller_bci = call_sites.at(spec_depth - 1).second;
+
+    if (caller_md == nullptr) {
+      continue;
+    }
+
+    for (int i = spec_depth - 2; i >= 0; i--) {
+      caller_md = call_sites.at(i).first->specialized_method_data_or_null(caller_md, caller_bci);
+      caller_bci = call_sites.at(i).second;
+
+      if (caller_md == nullptr) {
+        break;
+      }
+    }
+    if (caller_md == nullptr) {
+      continue;
+    }
+
+    ciMethodData* md = callee->specialized_method_data_or_null(caller_md, caller_bci);
+    if (md != nullptr && md->is_mature()) {
+      return md;
+    }
+  }
+
+  return callee->method_data();
 }

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -36,9 +36,11 @@
 #include "compiler/compilerThread.hpp"
 #include "oops/methodData.hpp"
 #include "runtime/javaThread.hpp"
+#include "utilities/pair.hpp"
 
 class CompileTask;
 class OopMapSet;
+class JVMState;
 
 // ciEnv
 //
@@ -515,6 +517,19 @@ public:
   void process_invokedynamic(const constantPoolHandle &cp, int index, JavaThread* thread);
   void process_invokehandle(const constantPoolHandle &cp, int index, JavaThread* thread);
   void find_dynamic_call_sites();
+
+  // Creates or returns existing callee`s specialized method data
+  // With SpecializedMethodData disabled acts as callee->ensure_method_data()
+  bool ensure_specialized_method_data(ciMethod* callee, ciMethodData* caller_md, int bci);
+
+  // Returns callee`s specialized method data
+  // With SpecializedMethodData disabled acts as callee->method_data()
+  ciMethodData* specialized_method_data(ciMethod* callee, ciMethodData* caller_md, int bci);
+
+  // Finds most accurate callee`s specialized method data based on inline path
+  // If none exist returns main md
+  // With SpecializedMethodData disabled acts as callee->method_data()
+  ciMethodData* specialized_method_data(ciMethod* callee, JVMState* caller);
 };
 
 #endif // SHARE_CI_CIENV_HPP

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -461,13 +461,13 @@ int ciMethod::check_overflow(int c, Bytecodes::Code code) {
 // ------------------------------------------------------------------
 // ciMethod::call_profile_at_bci
 //
-// Get the ciCallProfile for the invocation of this method.
+// Get the ciCallProfile for the invocation of this method from provided method data.
 // Also reports receiver types for non-call type checks (if TypeProfileCasts).
-ciCallProfile ciMethod::call_profile_at_bci(int bci) {
+ciCallProfile ciMethod::call_profile_at_bci(int bci, ciMethodData* md) {
   ResourceMark rm;
   ciCallProfile result;
-  if (method_data() != nullptr && method_data()->is_mature()) {
-    ciProfileData* data = method_data()->bci_to_data(bci);
+  if (md != nullptr && md->is_mature()) {
+    ciProfileData* data = md->bci_to_data(bci);
     if (data != nullptr && data->is_CounterData()) {
       // Every profiled call site has a counter.
       int count = check_overflow(data->as_CounterData()->count(), java_code_at_bci(bci));
@@ -573,14 +573,15 @@ void ciMethod::assert_call_type_ok(int bci) {
  *
  * @param [in]bci         bci of the call
  * @param [in]i           argument number
+ * @param [in]md          method data of this method
  * @param [out]type       profiled type of argument, null if none
  * @param [out]ptr_kind   whether always null, never null or maybe null
  * @return                true if profiling exists
  *
  */
-bool ciMethod::argument_profiled_type(int bci, int i, ciKlass*& type, ProfilePtrKind& ptr_kind) {
-  if (MethodData::profile_parameters() && method_data() != nullptr && method_data()->is_mature()) {
-    ciProfileData* data = method_data()->bci_to_data(bci);
+bool ciMethod::argument_profiled_type(int bci, int i, ciMethodData* md, ciKlass*& type, ProfilePtrKind& ptr_kind) {
+  if (MethodData::profile_parameters() && md != nullptr && md->is_mature()) {
+    ciProfileData* data = md->bci_to_data(bci);
     if (data != nullptr) {
       if (data->is_VirtualCallTypeData()) {
         assert_virtual_call_type_ok(bci);
@@ -611,14 +612,15 @@ bool ciMethod::argument_profiled_type(int bci, int i, ciKlass*& type, ProfilePtr
  * the call at bci bci
  *
  * @param [in]bci         bci of the call
+ * @param [in]md          method data of this method
  * @param [out]type       profiled type of argument, null if none
  * @param [out]ptr_kind   whether always null, never null or maybe null
  * @return                true if profiling exists
  *
  */
-bool ciMethod::return_profiled_type(int bci, ciKlass*& type, ProfilePtrKind& ptr_kind) {
-  if (MethodData::profile_return() && method_data() != nullptr && method_data()->is_mature()) {
-    ciProfileData* data = method_data()->bci_to_data(bci);
+bool ciMethod::return_profiled_type(int bci, ciMethodData* md, ciKlass*& type, ProfilePtrKind& ptr_kind) {
+  if (MethodData::profile_return() && md != nullptr && md->is_mature()) {
+    ciProfileData* data = md->bci_to_data(bci);
     if (data != nullptr) {
       if (data->is_VirtualCallTypeData()) {
         assert_virtual_call_type_ok(bci);
@@ -646,14 +648,15 @@ bool ciMethod::return_profiled_type(int bci, ciKlass*& type, ProfilePtrKind& ptr
  * Check whether profiling provides a type for the parameter i
  *
  * @param [in]i           parameter number
+ * @param [in]md          method data of this method
  * @param [out]type       profiled type of parameter, null if none
  * @param [out]ptr_kind   whether always null, never null or maybe null
  * @return                true if profiling exists
  *
  */
-bool ciMethod::parameter_profiled_type(int i, ciKlass*& type, ProfilePtrKind& ptr_kind) {
-  if (MethodData::profile_parameters() && method_data() != nullptr && method_data()->is_mature()) {
-    ciParametersTypeData* parameters = method_data()->parameters_type_data();
+bool ciMethod::parameter_profiled_type(int i, ciMethodData* md, ciKlass*& type, ProfilePtrKind& ptr_kind) {
+  if (MethodData::profile_parameters() && md != nullptr && md->is_mature()) {
+    ciParametersTypeData* parameters = md->parameters_type_data();
     if (parameters != nullptr && i < parameters->number_of_parameters()) {
       type = parameters->valid_parameter_type(i);
       ptr_kind = parameters->parameter_ptr_kind(i);

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -47,6 +47,7 @@
 #include "memory/resourceArea.hpp"
 #include "oops/generateOopMap.hpp"
 #include "oops/method.inline.hpp"
+#include "oops/methodData.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/trainingData.hpp"
 #include "prims/methodHandles.hpp"
@@ -1002,7 +1003,7 @@ bool ciMethod::has_member_arg() const {
 // ------------------------------------------------------------------
 // ciMethod::ensure_method_data
 //
-// Generate new MethodData* objects at compile time.
+// Generate new MethodData* objects at compile time for default method profile.
 // Return true if allocation was successful or no MDO is required.
 bool ciMethod::ensure_method_data(const methodHandle& h_m) {
   EXCEPTION_CONTEXT;
@@ -1036,6 +1037,53 @@ bool ciMethod::ensure_method_data() {
   return result;
 }
 
+// ------------------------------------------------------------------
+// ciMethod::ensure_specialized_method_data
+//
+// Generate new MethodData* objects at compile time for specialized profiles at MethodDataEntry.
+// Return true if allocation was successful or no MDO is required.
+bool ciMethod::ensure_specialized_method_data(const methodHandle& h_m, ciMethodDataEntry* entry, MethodDataEntry* mdo_entry) {
+  EXCEPTION_CONTEXT;
+  if (is_native() || is_abstract() || h_m()->is_accessor()) {
+    return true;
+  }
+  if (mdo_entry->method_data() == nullptr) {
+    Method::build_specialized_profiling_method_data(h_m, mdo_entry, THREAD);
+    if (HAS_PENDING_EXCEPTION) {
+      CLEAR_PENDING_EXCEPTION;
+    }
+  }
+  if (mdo_entry->method_data() != nullptr) {
+    entry->translate_method_data_from(mdo_entry);
+    return entry->method_data()->load_data();
+  } else {
+    return false;
+  }
+}
+
+// public, retroactive version
+bool ciMethod::ensure_specialized_method_data(ciMethodData* caller_md, int bci) {
+  assert(caller_md != nullptr, "caller method data should not be null");
+  ciMethodDataEntry* entry = caller_md->bci_to_md_entry(bci);
+  assert(entry != nullptr, "missing specialized method data entry at bci");
+
+  bool result = true;
+  if (entry->method_data()->is_empty()) {
+    GUARDED_VM_ENTRY({
+      MethodDataEntry* mdo_entry = nullptr;
+      {
+        MethodData* caller_mdo = (MethodData*)(caller_md->constant_encoding());
+        MutexLocker ml(caller_mdo->extra_data_lock(), Mutex::_no_safepoint_check_flag);
+        ProfileData* mdo_data = caller_mdo->bci_to_data(bci);
+        mdo_entry = mdo_data->is_CallData() ? ((CallData*)mdo_data)->updatable_callee_md() : ((VirtualCallData*)mdo_data)->updatable_callee_md();
+      }
+
+      methodHandle mh(Thread::current(), get_Method());
+      result = ensure_specialized_method_data(mh, entry, mdo_entry);
+    });
+  }
+  return result;
+}
 
 // ------------------------------------------------------------------
 // ciMethod::method_data
@@ -1065,6 +1113,52 @@ ciMethodData* ciMethod::method_data() {
 // null otherwise.
 ciMethodData* ciMethod::method_data_or_null() {
   ciMethodData *md = method_data();
+  if (md->is_empty()) {
+    return nullptr;
+  }
+  return md;
+}
+
+bool ciMethod::specialized_method_data_compatible(ciMethodData* caller_md, int bci) {
+  ciMethodDataEntry* entry = caller_md->bci_to_md_entry(bci);
+  if (entry == nullptr || entry->method_data()->constant_encoding() == nullptr) {
+    return false;
+  }
+
+  MethodData* mdo = (MethodData*)entry->method_data()->constant_encoding();
+  return mdo->method() == get_Method();
+}
+
+// ------------------------------------------------------------------
+// ciMethod::specialized_method_data
+//
+ciMethodData* ciMethod::specialized_method_data(ciMethodData* caller_md, int bci) {
+  assert(caller_md != nullptr, "caller method data should not be null");
+  assert(specialized_method_data_compatible(caller_md, bci), "specialized method data entry doesn`t exist or incompatible with current method");
+  ciMethodDataEntry* entry = caller_md->bci_to_md_entry(bci);
+  ciMethodData* md = entry->method_data();
+
+  if (!entry->load_required()) {
+    return md;
+  }
+  VM_ENTRY_MARK;
+  ciEnv* env = CURRENT_ENV;
+  Thread* my_thread = JavaThread::current();
+  methodHandle h_m(my_thread, get_Method());
+
+  md->load_data();
+  return md;
+}
+
+// ------------------------------------------------------------------
+// ciMethod::specialized_method_data_or_null
+// Returns a pointer to ciMethodData if specialized MDO exists on the VM side,
+// null otherwise.
+ciMethodData* ciMethod::specialized_method_data_or_null(ciMethodData* caller_md, int bci) {
+  if (!specialized_method_data_compatible(caller_md, bci)) {
+    return nullptr;
+  }
+  ciMethodData *md = specialized_method_data(caller_md, bci);
   if (md->is_empty()) {
     return nullptr;
   }

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -118,6 +118,7 @@ class ciMethod : public ciMetadata {
   void load_code();
 
   bool ensure_method_data(const methodHandle& h_m);
+  bool ensure_specialized_method_data(const methodHandle& h_m, ciMethodDataEntry* entry, MethodDataEntry* mdo_entry);
 
   void code_at_put(int bci, Bytecodes::Code code) {
     Bytecodes::check(code);
@@ -142,6 +143,11 @@ class ciMethod : public ciMetadata {
   ciInstanceKlass* holder() const                { return _holder; }
   ciMethodData* method_data();
   ciMethodData* method_data_or_null();
+
+  // Specialized md access
+  bool specialized_method_data_compatible(ciMethodData* caller_md, int bci);
+  ciMethodData* specialized_method_data(ciMethodData* caller_md, int bci);
+  ciMethodData* specialized_method_data_or_null(ciMethodData* caller_md, int bci);
 
   // Signature information.
   ciSignature* signature() const                 { return _signature; }
@@ -315,6 +321,7 @@ class ciMethod : public ciMetadata {
   bool is_klass_loaded(int refinfo_index, Bytecodes::Code bc, bool must_be_resolved) const;
   bool check_call(int refinfo_index, bool is_static) const;
   bool ensure_method_data();  // make sure it exists in the VM also
+  bool ensure_specialized_method_data(ciMethodData* caller_md, int bci);  // make sure it exists in the VM also
   MethodCounters* ensure_method_counters();
 
   int inline_instructions_size();

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -269,12 +269,12 @@ class ciMethod : public ciMetadata {
 
   ciTypeFlow*   get_flow_analysis();
   ciTypeFlow*   get_osr_flow_analysis(int osr_bci);  // alternate entry point
-  ciCallProfile call_profile_at_bci(int bci);
+  ciCallProfile call_profile_at_bci(int bci, ciMethodData* md);
 
   // Does type profiling provide any useful information at this point?
-  bool          argument_profiled_type(int bci, int i, ciKlass*& type, ProfilePtrKind& ptr_kind);
-  bool          parameter_profiled_type(int i, ciKlass*& type, ProfilePtrKind& ptr_kind);
-  bool          return_profiled_type(int bci, ciKlass*& type, ProfilePtrKind& ptr_kind);
+  bool          argument_profiled_type(int bci, int i, ciMethodData* md, ciKlass*& type, ProfilePtrKind& ptr_kind);
+  bool          parameter_profiled_type(int i, ciMethodData* md, ciKlass*& type, ProfilePtrKind& ptr_kind);
+  bool          return_profiled_type(int bci, ciMethodData* md, ciKlass*& type, ProfilePtrKind& ptr_kind);
 
   ciField*      get_field_at_bci( int bci, bool &will_link);
   ciMethod*     get_method_at_bci(int bci, bool &will_link, ciSignature* *declared_signature);

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -30,6 +30,7 @@
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/methodData.hpp"
 #include "oops/methodData.inline.hpp"
 #include "oops/trainingData.hpp"
 #include "runtime/deoptimization.hpp"
@@ -49,6 +50,7 @@ ciMethodData::ciMethodData(MethodData* md)
   // first_di() may be out of bounds if data_size is 0.
   _hint_di(first_di()),
   _state(empty_state),
+  _specialized(false),
   _saw_free_extra_data(false),
   // Initialize the escape information (to "don't know.");
   _eflags(0), _arg_local(0), _arg_stack(0), _arg_returned(0),
@@ -348,6 +350,23 @@ void ciReturnTypeEntry::translate_type_data_from(const ReturnTypeEntry* ret) {
   }
 }
 
+void ciMethodDataEntry::translate_method_data_from(const MethodDataEntry* entry) {
+  MethodData* mdo = entry->method_data();
+  ciMethodData* method_data;
+  if (mdo != nullptr) {
+    method_data = CURRENT_ENV->get_method_data(mdo);
+  } else {
+    method_data = CURRENT_ENV->get_empty_methodData();
+  }
+  method_data->mark_as_specialized();
+  set_data((intptr_t)method_data);
+}
+
+bool ciMethodDataEntry::load_required() const {
+  ciMethodData* md = method_data();
+  return md->constant_encoding() != nullptr && md->is_empty();
+}
+
 void ciSpeculativeTrapData::translate_from(const ProfileData* data) {
   Method* m = data->as_SpeculativeTrapData()->method();
   ciMethod* ci_m = CURRENT_ENV->get_method(m);
@@ -393,6 +412,8 @@ ciProfileData* ciMethodData::data_from(DataLayout* data_layout) {
     return new ciVirtualCallTypeData(data_layout);
   case DataLayout::parameters_type_data_tag:
     return new ciParametersTypeData(data_layout);
+  case DataLayout::call_data_tag:
+    return new ciCallData(data_layout);
   };
 }
 
@@ -481,6 +502,14 @@ ciProfileData* ciMethodData::bci_to_data(int bci, ciMethod* m) {
     return bci_to_data(bci, nullptr);
   }
   return nullptr;
+}
+
+ciMethodDataEntry* ciMethodData::bci_to_md_entry(int bci) {
+  ciProfileData* data = bci_to_data(bci);
+  if (data == nullptr || (!data->is_CallData() && !data->is_VirtualCallData())) {
+    return nullptr;
+  }
+  return data->is_CallData() ? ((ciCallData*)data)->callee_md() : ((ciVirtualCallData*)data)->callee_md();
 }
 
 ciBitData ciMethodData::exception_handler_bci_to_data(int bci) {
@@ -905,6 +934,20 @@ void ciReturnTypeEntry::print_data_on(outputStream* st) const {
   st->cr();
 }
 
+void ciMethodDataEntry::print_data_on(outputStream* st) const {
+  if (method_data() != nullptr && method_data()->constant_encoding() != nullptr) {
+    _pd->tab(st);
+    st->print("specialized for");
+    ((MethodData*)method_data()->constant_encoding())->method()->print_short_name(st);
+    st->cr();
+  }
+}
+
+void ciCallData::print_data_on(outputStream* st, const char* extra) const {
+  print_shared(st, "ciCallData", extra);
+  callee_md()->print_data_on(st);
+}
+
 void ciCallTypeData::print_data_on(outputStream* st, const char* extra) const {
   print_shared(st, "ciCallTypeData", extra);
   if (has_arguments()) {
@@ -917,6 +960,7 @@ void ciCallTypeData::print_data_on(outputStream* st, const char* extra) const {
     st->print_cr("return type");
     ret()->print_data_on(st);
   }
+  rtd_super()->callee_md()->print_data_on(st);
 }
 
 void ciReceiverTypeData::print_receiver_data_on(outputStream* st) const {
@@ -943,6 +987,7 @@ void ciReceiverTypeData::print_data_on(outputStream* st, const char* extra) cons
 void ciVirtualCallData::print_data_on(outputStream* st, const char* extra) const {
   print_shared(st, "ciVirtualCallData", extra);
   rtd_super()->print_receiver_data_on(st);
+  callee_md()->print_data_on(st);
 }
 
 void ciVirtualCallTypeData::print_data_on(outputStream* st, const char* extra) const {
@@ -958,6 +1003,7 @@ void ciVirtualCallTypeData::print_data_on(outputStream* st, const char* extra) c
     st->print("return type");
     ret()->print_data_on(st);
   }
+  rtd_super()->callee_md()->print_data_on(st);
 }
 
 void ciParametersTypeData::print_data_on(outputStream* st, const char* extra) const {

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -46,6 +46,7 @@ class ciCallTypeData;
 class ciVirtualCallTypeData;
 class ciParametersTypeData;
 class ciSpeculativeTrapData;
+class ciCallData;
 
 typedef ProfileData ciProfileData;
 
@@ -141,14 +142,53 @@ public:
 #endif
 };
 
+class ciMethodDataEntry : public MethodDataEntry {
+public:
+  void translate_method_data_from(const MethodDataEntry* md);
+
+  ciMethodData* method_data() const {
+    return (ciMethodData*)data();
+  }
+
+  bool load_required() const;
+
+#ifndef PRODUCT
+  void print_data_on(outputStream* st) const;
+#endif
+};
+
+class ciCallData : public CallData {
+public:
+  ciCallData(DataLayout* layout) : CallData(layout) {}
+
+  ciMethodDataEntry* callee_md() const { return (ciMethodDataEntry*)CallData::callee_md(); }
+
+  virtual void translate_from(const ProfileData* data) {
+    translate_call_data_from(data);
+  }
+  void translate_call_data_from(const ProfileData* data) {
+    callee_md()->translate_method_data_from(data->as_CallData()->callee_md());
+  }
+
+#ifndef PRODUCT
+  void print_data_on(outputStream* st, const char* extra = nullptr) const;
+#endif
+};
+
 class ciCallTypeData : public CallTypeData {
+  // Fake multiple inheritance...  It's a ciCallData also.
+  ciCallData* rtd_super() const { return (ciCallData*) this; }
+
 public:
   ciCallTypeData(DataLayout* layout) : CallTypeData(layout) {}
+
+  ciMethodDataEntry* callee_md() const { return rtd_super()->callee_md(); }
 
   ciTypeStackSlotEntries* args() const { return (ciTypeStackSlotEntries*)CallTypeData::args(); }
   ciReturnTypeEntry* ret() const { return (ciReturnTypeEntry*)CallTypeData::ret(); }
 
   void translate_from(const ProfileData* data) {
+    rtd_super()->translate_call_data_from(data);
     if (has_arguments()) {
       args()->translate_type_data_from(data->as_CallTypeData()->args());
     }
@@ -233,9 +273,16 @@ public:
     return rtd_super()->receiver(row);
   }
 
+  ciMethodDataEntry* callee_md() const { return (ciMethodDataEntry*)VirtualCallData::callee_md(); }
+
   // Copy & translate from oop based VirtualCallData
   virtual void translate_from(const ProfileData* data) {
+    translate_virtual_call_data_from(data);
+  }
+
+  void translate_virtual_call_data_from(const ProfileData* data) {
     rtd_super()->translate_receiver_data_from(data);
+    callee_md()->translate_method_data_from(data->as_VirtualCallData()->callee_md());
   }
 #ifndef PRODUCT
   void print_data_on(outputStream* st, const char* extra = nullptr) const;
@@ -244,8 +291,8 @@ public:
 
 class ciVirtualCallTypeData : public VirtualCallTypeData {
 private:
-  // Fake multiple inheritance...  It's a ciReceiverTypeData also.
-  ciReceiverTypeData* rtd_super() const { return (ciReceiverTypeData*) this; }
+  // Fake multiple inheritance...  It's a ciVirtualCallData also.
+  ciVirtualCallData* rtd_super() const { return (ciVirtualCallData*) this; }
 public:
   ciVirtualCallTypeData(DataLayout* layout) : VirtualCallTypeData(layout) {}
 
@@ -257,12 +304,14 @@ public:
     return rtd_super()->receiver(row);
   }
 
+  ciMethodDataEntry* callee_md() const { return rtd_super()->callee_md(); }
+
   ciTypeStackSlotEntries* args() const { return (ciTypeStackSlotEntries*)VirtualCallTypeData::args(); }
   ciReturnTypeEntry* ret() const { return (ciReturnTypeEntry*)VirtualCallTypeData::ret(); }
 
   // Copy & translate from oop based VirtualCallData
   virtual void translate_from(const ProfileData* data) {
-    rtd_super()->translate_receiver_data_from(data);
+    rtd_super()->translate_virtual_call_data_from(data);
     if (has_arguments()) {
       args()->translate_type_data_from(data->as_VirtualCallTypeData()->args());
     }
@@ -389,6 +438,9 @@ private:
   // Is data attached?  And is it mature?
   enum { empty_state, immature_state, mature_state };
   u_char _state;
+
+  // Does this snapshot represents mdo at MethodDataEntry
+  bool _specialized;
 
   // Set this true if empty extra_data slots are ever witnessed.
   u_char _saw_free_extra_data;
@@ -526,6 +578,9 @@ public:
   // is not null look for a SpeculativeTrapData if any first.
   ciProfileData* bci_to_data(int bci, ciMethod* m = nullptr);
 
+  // Get the specialized method data entry at an arbitrary bci, or null if there is none.
+  ciMethodDataEntry* bci_to_md_entry(int bci);
+
   ciBitData exception_handler_bci_to_data(int bci);
 
   uint overflow_trap_count() const {
@@ -576,6 +631,14 @@ public:
   // Code generation helper
   ByteSize offset_of_slot(ciProfileData* data, ByteSize slot_offset_in_data);
   int      byte_offset_of_slot(ciProfileData* data, ByteSize slot_offset_in_data) { return in_bytes(offset_of_slot(data, slot_offset_in_data)); }
+
+  bool is_specialized() const {
+    return _specialized;
+  }
+
+  void mark_as_specialized() {
+    _specialized = true;
+  }
 
 #ifndef PRODUCT
   // printing support for method data

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2759,6 +2759,7 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
       DebugInfoReadStream stream(nm, decode_offset);
       decode_offset = stream.read_int();
       method = (Method*)nm->metadata_at(stream.read_int());
+      stream.read_int();
       bci = stream.read_bci();
     } else {
       if (fr.is_first_frame()) break;

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -29,6 +29,7 @@
 #include "code/location.hpp"
 #include "code/nmethod.hpp"
 #include "code/oopRecorder.hpp"
+#include "oops/methodData.hpp"
 #include "runtime/javaThread.hpp"
 #include "utilities/growableArray.hpp"
 
@@ -383,6 +384,12 @@ class DebugInfoReadStream : public CompressedReadStream {
   oop read_oop();
   Method* read_method() {
     Method* o = (Method*)(code()->metadata_at(read_int()));
+    // is_metadata() is a faster check than is_metaspace_object()
+    assert(o == nullptr || o->is_metadata(), "meta data only");
+    return o;
+  }
+  MethodData* read_method_data() {
+    MethodData* o = (MethodData*)(code()->metadata_at(read_int()));
     // is_metadata() is a faster check than is_metaspace_object()
     assert(o == nullptr || o->is_metadata(), "meta data only");
     return o;

--- a/src/hotspot/share/code/debugInfoRec.cpp
+++ b/src/hotspot/share/code/debugInfoRec.cpp
@@ -24,6 +24,7 @@
 
 #include "code/debugInfoRec.hpp"
 #include "code/scopeDesc.hpp"
+#include "ci/ciMethodData.hpp"
 #include "compiler/oopMap.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/globals_extension.hpp"
@@ -280,6 +281,7 @@ int DebugInformationRecorder::find_sharable_decode_offset(int stream_offset) {
 void DebugInformationRecorder::describe_scope(int         pc_offset,
                                               const methodHandle& methodH,
                                               ciMethod*   method,
+                                              ciMethodData*   method_data,
                                               int         bci,
                                               bool        reexecute,
                                               bool        rethrow_exception,
@@ -318,6 +320,14 @@ void DebugInformationRecorder::describe_scope(int         pc_offset,
   }
   int method_enc_index = oop_recorder()->find_index(method_enc);
   stream()->write_int(method_enc_index);
+  Metadata* specialized_mdo_enc;
+  if (method_data != nullptr && method_data->is_specialized()) {
+    specialized_mdo_enc = method_data->constant_encoding();
+  } else {
+    specialized_mdo_enc = nullptr;
+  }
+  int mdo_enc_index = oop_recorder()->find_index(specialized_mdo_enc);
+  stream()->write_int(mdo_enc_index);
   stream()->write_bci(bci);
   assert(method == nullptr ||
          (method->is_native() && bci == 0) ||

--- a/src/hotspot/share/code/debugInfoRec.hpp
+++ b/src/hotspot/share/code/debugInfoRec.hpp
@@ -102,6 +102,7 @@ class DebugInformationRecorder: public ResourceObj {
   void describe_scope(int         pc_offset,
                       const methodHandle& methodH,
                       ciMethod*   method,
+                      ciMethodData* md,
                       int         bci,
                       bool        reexecute,
                       bool        rethrow_exception = false,

--- a/src/hotspot/share/code/scopeDesc.cpp
+++ b/src/hotspot/share/code/scopeDesc.cpp
@@ -72,6 +72,7 @@ void ScopeDesc::decode_body() {
     // approximate queries.  Decode a reasonable frame.
     _sender_decode_offset = DebugInformationRecorder::serialized_null;
     _method = _code->method();
+    _specialized_method_data = nullptr;
     _bci = InvocationEntryBci;
     _locals_decode_offset = DebugInformationRecorder::serialized_null;
     _expressions_decode_offset = DebugInformationRecorder::serialized_null;
@@ -82,6 +83,7 @@ void ScopeDesc::decode_body() {
 
     _sender_decode_offset = stream->read_int();
     _method = stream->read_method();
+    _specialized_method_data = stream->read_method_data();
     _bci    = stream->read_bci();
 
     // decode offsets for body and sender

--- a/src/hotspot/share/code/scopeDesc.hpp
+++ b/src/hotspot/share/code/scopeDesc.hpp
@@ -48,6 +48,7 @@ class SimpleScopeDesc : public StackObj {
     DebugInfoReadStream buffer(code, pc_desc->scope_decode_offset());
     int ignore_sender = buffer.read_int();
     _method           = buffer.read_method();
+    buffer.read_method_data();
     _bci              = buffer.read_bci();
   }
 
@@ -68,6 +69,7 @@ class ScopeDesc : public ResourceObj {
 
   // JVM state
   Method* method()      const { return _method; }
+  MethodData* specialized_method_data()      const { return _specialized_method_data; }
   int          bci()      const { return _bci;    }
   bool should_reexecute() const { return _reexecute; }
   bool rethrow_exception() const { return _rethrow_exception; }
@@ -101,6 +103,7 @@ class ScopeDesc : public ResourceObj {
 
   // JVM state
   Method*       _method;
+  MethodData*   _specialized_method_data;     // Specialized method data or null
   int           _bci;
   bool          _reexecute;
   bool          _rethrow_exception;

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -777,7 +777,9 @@ void CompilationPolicy::reprofile(ScopeDesc* trap_scope, bool is_osr) {
     if (PrintTieredEvents) {
       print_event(REPROFILE, sd->method(), sd->method(), InvocationEntryBci, CompLevel_none);
     }
-    MethodData* mdo = sd->method()->method_data();
+    MethodData* mdo = sd->specialized_method_data() != nullptr ?
+      sd->specialized_method_data() :
+      sd->method()->method_data();
     if (mdo != nullptr) {
       mdo->reset_start_counters();
     }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -657,11 +657,34 @@ void Method::build_profiling_method_data(const methodHandle& method, TRAPS) {
   if (install_training_method_data(method)) {
     return;
   }
+
+  MethodData* method_data = Method::create_profiling_method_data(method, THREAD);
+
+  // Do not profile the method if metaspace has hit an OOM
+  if (method_data == nullptr) {
+    return;   // return the exception (which is cleared)
+  }
+
+  if (!AtomicAccess::replace_if_null(&method->_method_data, method_data)) {
+    MetadataFactory::free_metadata(method->method_holder()->class_loader_data(), method_data);
+    return;
+  }
+
+  if (PrintMethodData && (Verbose || WizardMode)) {
+    ResourceMark rm(THREAD);
+    tty->print("build_profiling_method_data for ");
+    method->print_name(tty);
+    tty->cr();
+    // At the end of the run, the MDO, full of data, will be dumped.
+  }
+}
+
+MethodData* Method::create_profiling_method_data(const methodHandle& method, TRAPS) {
   // Do not profile the method if metaspace has hit an OOM previously
   // allocating profiling data. Callers clear pending exception so don't
   // add one here.
   if (ClassLoaderDataGraph::has_metaspace_oom()) {
-    return;
+    return nullptr;
   }
 
   ClassLoaderData* loader_data = method->method_holder()->class_loader_data();
@@ -669,17 +692,30 @@ void Method::build_profiling_method_data(const methodHandle& method, TRAPS) {
   if (HAS_PENDING_EXCEPTION) {
     CompileBroker::log_metaspace_failure();
     ClassLoaderDataGraph::set_metaspace_oom(true);
+    return nullptr;   // return the exception (which is cleared)
+  }
+
+  return method_data;
+}
+
+// Build a MethodData* object to hold profiling information collected on this
+// method on specific call when requested.
+void Method::build_specialized_profiling_method_data(const methodHandle& method, MethodDataEntry* md_entry, TRAPS) {
+  MethodData* method_data = Method::create_profiling_method_data(method, THREAD);
+
+  // Do not profile the method if metaspace has hit an OOM
+  if (method_data == nullptr) {
     return;   // return the exception (which is cleared)
   }
 
-  if (!AtomicAccess::replace_if_null(&method->_method_data, method_data)) {
-    MetadataFactory::free_metadata(loader_data, method_data);
+  if (!md_entry->set_method_data(method_data)) {
+    MetadataFactory::free_metadata(method->method_holder()->class_loader_data(), method_data);
     return;
   }
 
   if (PrintMethodData && (Verbose || WizardMode)) {
     ResourceMark rm(THREAD);
-    tty->print("build_profiling_method_data for ");
+    tty->print("build_specialized_profiling_method_data for ");
     method->print_name(tty);
     tty->cr();
     // At the end of the run, the MDO, full of data, will be dumped.

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -58,6 +58,7 @@ class CheckedExceptionElement;
 class LocalVariableTableElement;
 class AdapterHandlerEntry;
 class MethodData;
+class MethodDataEntry;
 class MethodCounters;
 class MethodTrainingData;
 class ConstMethod;
@@ -344,7 +345,12 @@ class Method : public Metadata {
   bool was_executed_more_than(int n);
   bool was_never_executed()                     { return !was_executed_more_than(0);  }
 
+private:
+  static MethodData* create_profiling_method_data(const methodHandle& method, TRAPS);
+
+public:
   static void build_profiling_method_data(const methodHandle& method, TRAPS);
+  static void build_specialized_profiling_method_data(const methodHandle& method, MethodDataEntry* md_entry, TRAPS);
   static bool install_training_method_data(const methodHandle& method);
   static MethodCounters* build_method_counters(Thread* current, Method* m);
 

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "oops/methodData.hpp"
 #include "cds/cdsConfig.hpp"
 #include "ci/ciMethodData.hpp"
 #include "classfile/systemDictionaryShared.hpp"
@@ -411,22 +412,43 @@ void ReturnTypeEntry::print_data_on(outputStream* st) const {
   st->cr();
 }
 
-void CallTypeData::print_data_on(outputStream* st, const char* extra) const {
-  CounterData::print_data_on(st, extra);
-  if (has_arguments()) {
-    tab(st, true);
-    st->print("argument types");
-    _args.print_data_on(st);
-  }
-  if (has_return()) {
-    tab(st, true);
-    st->print("return type");
-    _ret.print_data_on(st);
+void MethodDataEntry::clean_weak_klass_links(bool always_clean) {
+  if (method_data() != nullptr) {
+    method_data()->clean_method_data(always_clean);
   }
 }
 
-void VirtualCallTypeData::print_data_on(outputStream* st, const char* extra) const {
-  VirtualCallData::print_data_on(st, extra);
+void MethodDataEntry::metaspace_pointers_do(MetaspaceClosure* it) {
+  MethodData** m = (MethodData**)intptr_at_adr(method_data_entry);
+  it->push(m);
+}
+
+void MethodDataEntry::print_data_on(outputStream* st) const {
+  if (method_data() != nullptr) {
+    _pd->tab(st);
+    st->print("specialized for");
+    method_data()->method()->print_short_name(st);
+    st->cr();
+
+    Thread *thread = Thread::current();
+    ResourceMark rm(thread);
+    methodHandle mh(thread, method_data()->method());
+    StreamIndentor si(st, 4);
+    st->print_cr("<<<<<<<<");
+    method_data()->print_data_on(st);
+    st->print_cr(">>>>>>>>");
+  }
+}
+
+void CallData::print_data_on(outputStream* st, const char* extra) const {
+  print_shared(st, "CallData", extra);
+  st->print_cr("count(%u)", count());
+  print_md_entry_on(st);
+}
+
+void CallTypeData::print_data_on(outputStream* st, const char* extra) const {
+  print_shared(st, "CallTypeData", extra);
+  st->print_cr("count(%u)", count());
   if (has_arguments()) {
     tab(st, true);
     st->print("argument types");
@@ -437,6 +459,23 @@ void VirtualCallTypeData::print_data_on(outputStream* st, const char* extra) con
     st->print("return type");
     _ret.print_data_on(st);
   }
+  print_md_entry_on(st);
+}
+
+void VirtualCallTypeData::print_data_on(outputStream* st, const char* extra) const {
+  print_shared(st, "VirtualCallTypeData", extra);
+  print_receiver_data_on(st);
+  if (has_arguments()) {
+    tab(st, true);
+    st->print("argument types");
+    _args.print_data_on(st);
+  }
+  if (has_return()) {
+    tab(st, true);
+    st->print("return type");
+    _ret.print_data_on(st);
+  }
+  print_md_entry_on(st);
 }
 
 // ==================================================================
@@ -448,7 +487,7 @@ void VirtualCallTypeData::print_data_on(outputStream* st, const char* extra) con
 // which are used to store a type profile for the receiver of the check.
 
 void ReceiverTypeData::clean_weak_klass_links(bool always_clean) {
-    for (uint row = 0; row < row_limit(); row++) {
+  for (uint row = 0; row < row_limit(); row++) {
     Klass* p = receiver(row);
     if (p != nullptr) {
       if (!always_clean && p->is_instance_klass() && InstanceKlass::cast(p)->is_not_initialized()) {
@@ -494,9 +533,20 @@ void ReceiverTypeData::print_data_on(outputStream* st, const char* extra) const 
   print_receiver_data_on(st);
 }
 
+void VirtualCallData::clean_weak_klass_links(bool always_clean) {
+  ReceiverTypeData::clean_weak_klass_links(always_clean);
+  _callee_md.clean_weak_klass_links(always_clean);
+}
+
+void VirtualCallData::metaspace_pointers_do(MetaspaceClosure *it) {
+  ReceiverTypeData::metaspace_pointers_do(it);
+  _callee_md.metaspace_pointers_do(it);
+}
+
 void VirtualCallData::print_data_on(outputStream* st, const char* extra) const {
   print_shared(st, "VirtualCallData", extra);
   print_receiver_data_on(st);
+  print_md_entry_on(st);
 }
 
 // ==================================================================
@@ -737,7 +787,7 @@ int MethodData::bytecode_cell_count(Bytecodes::Code code) {
     if (MethodData::profile_arguments() || MethodData::profile_return()) {
       return variable_cell_count;
     } else {
-      return CounterData::static_cell_count();
+      return CallData::static_cell_count();
     }
   case Bytecodes::_goto:
   case Bytecodes::_goto_w:
@@ -755,7 +805,7 @@ int MethodData::bytecode_cell_count(Bytecodes::Code code) {
     if (MethodData::profile_arguments() || MethodData::profile_return()) {
       return variable_cell_count;
     } else {
-      return CounterData::static_cell_count();
+      return CallData::static_cell_count();
     }
   case Bytecodes::_ret:
     return RetData::static_cell_count();
@@ -805,7 +855,7 @@ int MethodData::compute_data_size(BytecodeStream* stream) {
           profile_return_for_invoke(stream->method(), stream->bci())) {
         cell_count = CallTypeData::compute_cell_count(stream);
       } else {
-        cell_count = CounterData::static_cell_count();
+        cell_count = CallData::static_cell_count();
       }
       break;
     case Bytecodes::_invokevirtual:
@@ -952,17 +1002,17 @@ int MethodData::initialize_data(BytecodeStream* stream,
     break;
   case Bytecodes::_invokespecial:
   case Bytecodes::_invokestatic: {
-    int counter_data_cell_count = CounterData::static_cell_count();
+    int call_data_cell_count = CallData::static_cell_count();
     if (profile_arguments_for_invoke(stream->method(), stream->bci()) ||
         profile_return_for_invoke(stream->method(), stream->bci())) {
       cell_count = CallTypeData::compute_cell_count(stream);
     } else {
-      cell_count = counter_data_cell_count;
+      cell_count = call_data_cell_count;
     }
-    if (cell_count > counter_data_cell_count) {
+    if (cell_count > call_data_cell_count) {
       tag = DataLayout::call_type_data_tag;
     } else {
-      tag = DataLayout::counter_data_tag;
+      tag = DataLayout::call_data_tag;
     }
     break;
   }
@@ -991,17 +1041,17 @@ int MethodData::initialize_data(BytecodeStream* stream,
   }
   case Bytecodes::_invokedynamic: {
     // %%% should make a type profile for any invokedynamic that takes a ref argument
-    int counter_data_cell_count = CounterData::static_cell_count();
+    int call_data_cell_count = CallData::static_cell_count();
     if (profile_arguments_for_invoke(stream->method(), stream->bci()) ||
         profile_return_for_invoke(stream->method(), stream->bci())) {
       cell_count = CallTypeData::compute_cell_count(stream);
     } else {
-      cell_count = counter_data_cell_count;
+      cell_count = call_data_cell_count;
     }
-    if (cell_count > counter_data_cell_count) {
+    if (cell_count > call_data_cell_count) {
       tag = DataLayout::call_type_data_tag;
     } else {
-      tag = DataLayout::counter_data_tag;
+      tag = DataLayout::call_data_tag;
     }
     break;
   }
@@ -1039,7 +1089,7 @@ int MethodData::initialize_data(BytecodeStream* stream,
   assert(tag == DataLayout::multi_branch_data_tag ||
          ((MethodData::profile_arguments() || MethodData::profile_return()) &&
           (tag == DataLayout::call_type_data_tag ||
-           tag == DataLayout::counter_data_tag ||
+           tag == DataLayout::call_data_tag ||
            tag == DataLayout::virtual_call_type_data_tag ||
            tag == DataLayout::virtual_call_data_tag)) ||
          cell_count == bytecode_cell_count(c), "cell counts must agree");
@@ -1095,6 +1145,8 @@ int DataLayout::cell_count() {
     return ((new ParametersTypeData(this))->cell_count());
   case DataLayout::speculative_trap_data_tag:
     return SpeculativeTrapData::static_cell_count();
+  case DataLayout::call_data_tag:
+    return CallData::static_cell_count();
   }
 }
 ProfileData* DataLayout::data_in() {
@@ -1129,6 +1181,8 @@ ProfileData* DataLayout::data_in() {
     return new ParametersTypeData(this);
   case DataLayout::speculative_trap_data_tag:
     return new SpeculativeTrapData(this);
+  case DataLayout::call_data_tag:
+    return new CallData(this);
   }
 }
 
@@ -1289,6 +1343,25 @@ void MethodData::init() {
 
   // Initialize escape flags.
   clear_escape_info();
+}
+
+int MethodData::specialized_size_in_bytes() const {
+  int size = 0;
+  for (ProfileData* data = first_data();
+         is_valid(data);
+         data = next_data(data)) {
+    MethodData* md = nullptr;
+    if (data->is_CallData()) {
+      md = data->as_CallData()->callee_md()->method_data();
+    } else if (data->is_VirtualCallData()) {
+      md = data->as_VirtualCallData()->callee_md()->method_data();
+    }
+
+    if (md != nullptr) {
+      size += md->size_in_bytes() + md->specialized_size_in_bytes();
+    }
+  }
+  return size;
 }
 
 bool MethodData::is_mature() const {
@@ -1811,17 +1884,31 @@ void MethodData::verify_extra_data_clean(CleanExtraDataClosure* cl) {
 
 void MethodData::clean_method_data(bool always_clean) {
   ResourceMark rm;
+  CleanExtraDataKlassClosure cl(always_clean);
+
   for (ProfileData* data = first_data();
        is_valid(data);
        data = next_data(data)) {
     data->clean_weak_klass_links(always_clean);
+
+    if (data->is_CallData()) {
+      CallData* call = data->as_CallData();
+      MethodData* md = call->callee_md()->method_data();
+      if (md != nullptr && !cl.is_live(md->method())) {
+        call->clear_method_data();
+      }
+    } else if (data->is_VirtualCallData()) {
+      VirtualCallData* call = data->as_VirtualCallData();
+      MethodData* md = call->callee_md()->method_data();
+      if (md != nullptr && !cl.is_live(md->method())) {
+        call->clear_method_data();
+      }
+    }
   }
   ParametersTypeData* parameters = parameters_type_data();
   if (parameters != nullptr) {
     parameters->clean_weak_klass_links(always_clean);
   }
-
-  CleanExtraDataKlassClosure cl(always_clean);
 
   // Lock to modify extra data, and prevent Safepoint from breaking the lock
   MutexLocker ml(extra_data_lock(), Mutex::_no_safepoint_check_flag);
@@ -1836,6 +1923,31 @@ void MethodData::clean_weak_method_links() {
   ResourceMark rm;
   CleanExtraDataMethodClosure cl;
 
+  for (ProfileData* data = first_data();
+         is_valid(data);
+         data = next_data(data)) {
+
+    if (data->is_CallData()) {
+      CallData* call = data->as_CallData();
+      MethodData* md = call->callee_md()->method_data();
+      if (md != nullptr) {
+        md->clean_weak_method_links();
+        if (!cl.is_live(md->method())) {
+          call->clear_method_data();
+        }
+      }
+    } else if (data->is_VirtualCallData()) {
+      VirtualCallData* call = data->as_VirtualCallData();
+      MethodData* md = call->callee_md()->method_data();
+      if (md != nullptr) {
+        md->clean_weak_method_links();
+        if (!cl.is_live(md->method())) {
+          call->clear_method_data();
+        }
+      }
+    }
+  }
+
   // Lock to modify extra data, and prevent Safepoint from breaking the lock
   MutexLocker ml(extra_data_lock(), Mutex::_no_safepoint_check_flag);
 
@@ -1844,6 +1956,7 @@ void MethodData::clean_weak_method_links() {
 }
 
 void MethodData::deallocate_contents(ClassLoaderData* loader_data) {
+  free_specialized_method_datas(loader_data);
   release_C_heap_structures();
 }
 
@@ -1869,3 +1982,27 @@ void MethodData::check_extra_data_locked() const {
            "JavaThread must have NoSafepointVerifier inside lock scope");
 }
 #endif
+
+void MethodData::free_specialized_method_datas(ClassLoaderData* loader_data) {
+  ResourceMark rm;
+  for (ProfileData* data = first_data();
+         is_valid(data);
+       data = next_data(data)) {
+    MethodData* md;
+    if (data->is_CallData()) {
+      CallData* call = data->as_CallData();
+      md = call->callee_md()->method_data();
+      call->clear_method_data();
+    } else if (data->is_VirtualCallData()) {
+      VirtualCallData* call = data->as_VirtualCallData();
+      md = call->callee_md()->method_data();
+      call->clear_method_data();
+    } else {
+      continue;
+    }
+
+    if (md != nullptr) {
+      MetadataFactory::free_metadata(loader_data, md);
+    }
+  }
+}

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -127,7 +127,8 @@ public:
     call_type_data_tag,
     virtual_call_type_data_tag,
     parameters_type_data_tag,
-    speculative_trap_data_tag
+    speculative_trap_data_tag,
+    call_data_tag
   };
 
   enum {
@@ -287,8 +288,9 @@ class     CounterData;
 class       ReceiverTypeData;
 class         VirtualCallData;
 class           VirtualCallTypeData;
+class       CallData;
+class         CallTypeData;
 class       RetData;
-class       CallTypeData;
 class   JumpData;
 class     BranchData;
 class   ArrayData;
@@ -305,6 +307,7 @@ class ProfileData : public ResourceObj {
   friend class TypeEntries;
   friend class ReturnTypeEntry;
   friend class TypeStackSlotEntries;
+  friend class MethodDataEntry;
 private:
   enum {
     tab_width_one = 16,
@@ -422,6 +425,7 @@ public:
   virtual bool is_VirtualCallTypeData()const { return false; }
   virtual bool is_ParametersTypeData() const { return false; }
   virtual bool is_SpeculativeTrapData()const { return false; }
+  virtual bool is_CallData()        const { return false; }
 
 
   BitData* as_BitData() const {
@@ -479,6 +483,10 @@ public:
   SpeculativeTrapData* as_SpeculativeTrapData() const {
     assert(is_SpeculativeTrapData(), "wrong type");
     return is_SpeculativeTrapData() ? (SpeculativeTrapData*)this : nullptr;
+  }
+  CallData* as_CallData() const {
+    assert(is_CallData(), "wrong type");
+    return is_CallData() ? (CallData*)this : nullptr;
   }
 
 
@@ -925,6 +933,81 @@ public:
   void print_data_on(outputStream* st) const;
 };
 
+// Method Data entry used to store specialized callee profile data. A single cell to record the
+// mdo pointer.
+class MethodDataEntry {
+
+private:
+  enum {
+    method_data_entry,
+    md_entry_cell_count
+  };
+
+  // offset within the ProfileData object where the entry is
+  const int _offset;
+
+  void set_intptr_at(int index, intptr_t value) const {
+    _pd->set_intptr_at(_offset + index, value);
+  }
+
+  intptr_t* intptr_at_adr(int index) const {
+    return _pd->intptr_at_adr(_offset + index);
+  }
+
+  intptr_t intptr_at(int index) const {
+    return _pd->intptr_at(_offset + index);
+  }
+
+protected:
+  // ProfileData object this entry is part of
+  ProfileData* _pd;
+
+  intptr_t data() const {
+    return intptr_at(method_data_entry);
+  }
+
+  void set_data(intptr_t data) {
+    set_intptr_at(method_data_entry, data);
+  }
+
+public:
+  MethodDataEntry(int offset)
+    : _offset(offset), _pd(nullptr) {}
+
+  void set_profile_data(ProfileData* pd) {
+    _pd = pd;
+  }
+
+  MethodData* method_data() const {
+    return (MethodData*)data();
+  }
+
+  bool set_method_data(MethodData* md) {
+    MethodData** m = (MethodData**)intptr_at_adr(method_data_entry);
+    return AtomicAccess::replace_if_null(m, md);
+  }
+
+  void clear_method_data() {
+    set_data((intptr_t)nullptr);
+  }
+
+  static int static_cell_count() {
+    return md_entry_cell_count;
+  }
+
+  static ByteSize size() {
+    return in_ByteSize(static_cell_count() * DataLayout::cell_size);
+  }
+
+  // GC support
+  void clean_weak_klass_links(bool always_clean);
+
+  // CDS support
+  void metaspace_pointers_do(MetaspaceClosure* it);
+
+  void print_data_on(outputStream* st) const;
+};
+
 // Entries to collect type information at a call: contains arguments
 // (TypeStackSlotEntries), a return type (ReturnTypeEntry) and a
 // number of cells. Because the number of cells for the return type is
@@ -985,12 +1068,75 @@ public:
 
 };
 
+// CallData
+//
+// A CallData is used to access profiling information about a non
+// virtual call for which we collect callee`s profile in specialized mdo.
+class CallData : public CounterData {
+private:
+  // entry for callee`s specialized method data if any
+  MethodDataEntry _callee_md;
+
+public:
+  CallData(DataLayout* layout) :
+    CounterData(layout),
+    _callee_md(CounterData::static_cell_count())
+  {
+    assert(layout->tag() == DataLayout::call_type_data_tag ||
+           layout->tag() == DataLayout::call_data_tag, "wrong type");
+    // Some compilers (VC++) don't want this passed in member initialization list
+    _callee_md.set_profile_data(this);
+  }
+
+  const MethodDataEntry* callee_md() const {
+    return &_callee_md;
+  }
+
+  MethodDataEntry* updatable_callee_md() {
+    return &_callee_md;
+  }
+
+  void clear_method_data() {
+    _callee_md.clear_method_data();
+  }
+
+  virtual bool is_CallData() const { return true; }
+
+  static int static_cell_count() {
+    return CounterData::static_cell_count() + MethodDataEntry::static_cell_count();
+  }
+
+  virtual int cell_count() const {
+    return static_cell_count();
+  }
+
+  // Direct accessors
+  static ByteSize call_data_size() {
+    return cell_offset(static_cell_count());
+  }
+
+  // GC support
+  virtual void clean_weak_klass_links(bool always_clean) {
+    _callee_md.clean_weak_klass_links(always_clean);
+  }
+
+  // CDS support
+  virtual void metaspace_pointers_do(MetaspaceClosure* it) {
+    _callee_md.metaspace_pointers_do(it);
+  }
+
+  void print_md_entry_on(outputStream* st) const {
+    _callee_md.print_data_on(st);
+  }
+  virtual void print_data_on(outputStream* st, const char* extra = nullptr) const;
+};
+
 // CallTypeData
 //
 // A CallTypeData is used to access profiling information about a non
 // virtual call for which we collect type information about arguments
 // and return value.
-class CallTypeData : public CounterData {
+class CallTypeData : public CallData {
 private:
   // entries for arguments if any
   TypeStackSlotEntries _args;
@@ -998,7 +1144,7 @@ private:
   ReturnTypeEntry _ret;
 
   int cell_count_global_offset() const {
-    return CounterData::static_cell_count() + TypeEntriesAtCall::cell_count_local_offset();
+    return CallData::static_cell_count() + TypeEntriesAtCall::cell_count_local_offset();
   }
 
   // number of cells not counting the header
@@ -1012,8 +1158,8 @@ private:
 
 public:
   CallTypeData(DataLayout* layout) :
-    CounterData(layout),
-    _args(CounterData::static_cell_count()+TypeEntriesAtCall::header_cell_count(), number_of_arguments()),
+    CallData(layout),
+    _args(CallData::static_cell_count() + TypeEntriesAtCall::header_cell_count(), number_of_arguments()),
     _ret(cell_count() - ReturnTypeEntry::static_cell_count())
   {
     assert(layout->tag() == DataLayout::call_type_data_tag, "wrong type");
@@ -1039,17 +1185,17 @@ public:
   }
 
   static int compute_cell_count(BytecodeStream* stream) {
-    return CounterData::static_cell_count() + TypeEntriesAtCall::compute_cell_count(stream);
+    return CallData::static_cell_count() + TypeEntriesAtCall::compute_cell_count(stream);
   }
 
   static void initialize(DataLayout* dl, int cell_count) {
-    TypeEntriesAtCall::initialize(dl, CounterData::static_cell_count(), cell_count);
+    TypeEntriesAtCall::initialize(dl, CallData::static_cell_count(), cell_count);
   }
 
   virtual void post_initialize(BytecodeStream* stream, MethodData* mdo);
 
   virtual int cell_count() const {
-    return CounterData::static_cell_count() +
+    return CallData::static_cell_count() +
       TypeEntriesAtCall::header_cell_count() +
       int_at_unchecked(cell_count_global_offset());
   }
@@ -1092,7 +1238,7 @@ public:
 
   // Code generation support
   static ByteSize args_data_offset() {
-    return cell_offset(CounterData::static_cell_count()) + TypeEntriesAtCall::args_data_offset();
+    return cell_offset(CallData::static_cell_count()) + TypeEntriesAtCall::args_data_offset();
   }
 
   ByteSize argument_type_offset(int i) {
@@ -1105,6 +1251,7 @@ public:
 
   // GC support
   virtual void clean_weak_klass_links(bool always_clean) {
+    CallData::clean_weak_klass_links(always_clean);
     if (has_arguments()) {
       _args.clean_weak_klass_links(always_clean);
     }
@@ -1115,6 +1262,7 @@ public:
 
   // CDS support
   virtual void metaspace_pointers_do(MetaspaceClosure* it) {
+    CallData::metaspace_pointers_do(it);
     if (has_arguments()) {
       _args.metaspace_pointers_do(it);
     }
@@ -1156,7 +1304,7 @@ public:
   virtual bool is_ReceiverTypeData() const { return true; }
 
   static int static_cell_count() {
-    return counter_cell_count + (uint) TypeProfileWidth * receiver_type_row_cell_count;
+    return counter_cell_count + (uint)TypeProfileWidth * receiver_type_row_cell_count;
   }
 
   virtual int cell_count() const {
@@ -1244,20 +1392,24 @@ public:
 // VirtualCallData
 //
 // A VirtualCallData is used to access profiling information about a
-// virtual call.  For now, it has nothing more than a ReceiverTypeData.
+// virtual call.
 class VirtualCallData : public ReceiverTypeData {
+private:
+  // entry for callee`s specialized method data if any
+  MethodDataEntry _callee_md;
+
 public:
-  VirtualCallData(DataLayout* layout) : ReceiverTypeData(layout) {
+  VirtualCallData(DataLayout* layout) : ReceiverTypeData(layout), _callee_md(ReceiverTypeData::static_cell_count()) {
     assert(layout->tag() == DataLayout::virtual_call_data_tag ||
            layout->tag() == DataLayout::virtual_call_type_data_tag, "wrong type");
+    _callee_md.set_profile_data(this);
   }
 
   virtual bool is_VirtualCallData() const { return true; }
 
   static int static_cell_count() {
     // At this point we could add more profile state, e.g., for arguments.
-    // But for now it's the same size as the base record type.
-    return ReceiverTypeData::static_cell_count();
+    return ReceiverTypeData::static_cell_count() + MethodDataEntry::static_cell_count();
   }
 
   virtual int cell_count() const {
@@ -1269,6 +1421,27 @@ public:
     return cell_offset(static_cell_count());
   }
 
+  const MethodDataEntry* callee_md() const {
+    return &_callee_md;
+  }
+
+  MethodDataEntry* updatable_callee_md() {
+    return &_callee_md;
+  }
+
+  void clear_method_data() {
+    _callee_md.clear_method_data();
+  }
+
+  // GC support
+  virtual void clean_weak_klass_links(bool always_clean);
+
+  // CDS support
+  virtual void metaspace_pointers_do(MetaspaceClosure* it);
+
+  void print_md_entry_on(outputStream* st) const {
+    _callee_md.print_data_on(st);
+  }
   void print_data_on(outputStream* st, const char* extra = nullptr) const;
 };
 
@@ -1392,7 +1565,7 @@ public:
 
   // GC support
   virtual void clean_weak_klass_links(bool always_clean) {
-    ReceiverTypeData::clean_weak_klass_links(always_clean);
+    VirtualCallData::clean_weak_klass_links(always_clean);
     if (has_arguments()) {
       _args.clean_weak_klass_links(always_clean);
     }
@@ -1403,7 +1576,7 @@ public:
 
   // CDS support
   virtual void metaspace_pointers_do(MetaspaceClosure* it) {
-    ReceiverTypeData::metaspace_pointers_do(it);
+    VirtualCallData::metaspace_pointers_do(it);
     if (has_arguments()) {
       _args.metaspace_pointers_do(it);
     }
@@ -2199,6 +2372,7 @@ public:
   // My size
   int size_in_bytes() const { return _size; }
   int size() const    { return align_metadata_size(align_up(_size, BytesPerWord)/BytesPerWord); }
+  int specialized_size_in_bytes() const;
 
   int invocation_count() {
     if (invocation_counter()->carry()) {
@@ -2483,6 +2657,8 @@ public:
   void clean_weak_method_links();
   Mutex* extra_data_lock();
   void check_extra_data_locked() const NOT_DEBUG_RETURN;
+
+  void free_specialized_method_datas(ClassLoaderData* loader_data);
 };
 
 #endif // SHARE_OOPS_METHODDATA_HPP

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -237,7 +237,7 @@ JVMState* VirtualCallGenerator::generate(JVMState* jvms) {
   // However currently the conversion to implicit null checks in
   // Block::implicit_null_check() only looks for loads and stores, not calls.
   ciMethod *caller = kit.method();
-  ciMethodData *caller_md = (caller == nullptr) ? nullptr : caller->method_data();
+  ciMethodData *caller_md = kit.method_data();
   if (!UseInlineCaches || !ImplicitNullChecks || !os::zero_page_read_protected() ||
        ((ImplicitNullCheckThreshold > 0) && caller_md &&
        (caller_md->trap_count(Deoptimization::Reason_null_check)
@@ -1014,8 +1014,7 @@ CallGenerator* CallGenerator::for_method_handle_call(JVMState* jvms, ciMethod* c
       return cg;
     }
   }
-  int bci = jvms->bci();
-  ciCallProfile profile = caller->call_profile_at_bci(bci);
+  ciCallProfile profile = caller->call_profile_at_bci(jvms->bci(), jvms->method_data());
   int call_site_count = caller->scale_count(profile.count());
 
   if (IncrementalInlineMH && call_site_count > 0 &&

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -264,6 +264,7 @@ uint TailJumpNode::match_edge(uint idx) const {
 //=============================================================================
 JVMState::JVMState(ciMethod* method, JVMState* caller) :
   _method(method),
+  _method_data(ciEnv::current()->specialized_method_data(method, caller)),
   _receiver_info(nullptr) {
   assert(method != nullptr, "must be valid call site");
   _bci = InvocationEntryBci;
@@ -281,6 +282,7 @@ JVMState::JVMState(ciMethod* method, JVMState* caller) :
 }
 JVMState::JVMState(int stack_size) :
   _method(nullptr),
+  _method_data(nullptr),
   _receiver_info(nullptr) {
   _bci = InvocationEntryBci;
   _reexecute = Reexecute_Undefined;

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -215,6 +215,7 @@ private:
   int               _bci;       // Byte Code Index of this JVM point
   ReexecuteState    _reexecute; // Whether this bytecode need to be re-executed
   ciMethod*         _method;    // Method Pointer
+  ciMethodData*     _method_data;    // Method Data Pointer (specialized if exists)
   ciInstance*       _receiver_info; // Constant receiver instance for compiled lambda forms
   SafePointNode*    _map;       // Map node associated with this scope
 public:
@@ -258,6 +259,7 @@ public:
   bool  is_reexecute_undefined() const { return _reexecute==Reexecute_Undefined; }
   bool              has_method() const { return _method != nullptr; }
   ciMethod*             method() const { assert(has_method(), ""); return _method; }
+  ciMethodData*         method_data() const { assert(has_method(), ""); return _method_data; }
   ciInstance*    receiver_info() const { assert(has_method(), ""); return _receiver_info; }
   JVMState*             caller() const { return _caller; }
   SafePointNode*           map() const { return _map; }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4129,10 +4129,9 @@ bool Compile::final_graph_reshaping() {
 //-----------------------------too_many_traps----------------------------------
 // Report if there are too many traps at the current method and bci.
 // Return true if there was a trap, and/or PerMethodTrapLimit is exceeded.
-bool Compile::too_many_traps(ciMethod* method,
+bool Compile::too_many_traps(ciMethodData* md,
                              int bci,
                              Deoptimization::DeoptReason reason) {
-  ciMethodData* md = method->method_data();
   if (md->is_empty()) {
     // Assume the trap has not occurred, or that it occurred only
     // because of a transient condition during start-up in the interpreter.
@@ -4178,10 +4177,9 @@ bool Compile::too_many_traps(Deoptimization::DeoptReason reason,
 // Consults PerBytecodeRecompilationCutoff and PerMethodRecompilationCutoff.
 // Is not eager to return true, since this will cause the compiler to use
 // Action_none for a trap point, to avoid too many recompilations.
-bool Compile::too_many_recompiles(ciMethod* method,
+bool Compile::too_many_recompiles(ciMethodData* md,
                                   int bci,
                                   Deoptimization::DeoptReason reason) {
-  ciMethodData* md = method->method_data();
   if (md->is_empty()) {
     // Assume the trap has not occurred, or that it occurred only
     // because of a transient condition during start-up in the interpreter.

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1025,18 +1025,18 @@ public:
   // Report if there were too many traps at a current method and bci.
   // Report if a trap was recorded, and/or PerMethodTrapLimit was exceeded.
   // If there is no MDO at all, report no trap unless told to assume it.
-  bool too_many_traps(ciMethod* method, int bci, Deoptimization::DeoptReason reason);
+  bool too_many_traps(ciMethodData* md, int bci, Deoptimization::DeoptReason reason);
   // This version, unspecific to a particular bci, asks if
   // PerMethodTrapLimit was exceeded for all inlined methods seen so far.
   bool too_many_traps(Deoptimization::DeoptReason reason,
                       // Privately used parameter for logging:
                       ciMethodData* logmd = nullptr);
   // Report if there were too many recompiles at a method and bci.
-  bool too_many_recompiles(ciMethod* method, int bci, Deoptimization::DeoptReason reason);
+  bool too_many_recompiles(ciMethodData* md, int bci, Deoptimization::DeoptReason reason);
   // Report if there were too many traps or recompiles at a method and bci.
-  bool too_many_traps_or_recompiles(ciMethod* method, int bci, Deoptimization::DeoptReason reason) {
-    return too_many_traps(method, bci, reason) ||
-           too_many_recompiles(method, bci, reason);
+  bool too_many_traps_or_recompiles(ciMethodData* md, int bci, Deoptimization::DeoptReason reason) {
+    return too_many_traps(md, bci, reason) ||
+           too_many_recompiles(md, bci, reason);
   }
   // Return a bitset with the reasons where deoptimization is allowed,
   // i.e., where there were not too many uncommon traps.

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -94,6 +94,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
   assert(callee != nullptr, "failed method resolution");
 
   ciMethod*       caller      = jvms->method();
+  ciMethodData*       caller_md      = jvms->method_data();
   int             bci         = jvms->bci();
   Bytecodes::Code bytecode    = caller->java_code_at_bci(bci);
   ciMethod*       orig_callee = caller->get_method_at_bci(bci);
@@ -112,7 +113,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
   // Note: When we get profiling during stage-1 compiles, we want to pull
   // from more specific profile data which pertains to this inlining.
   // Right now, ignore the information in jvms->caller(), and do method[bci].
-  ciCallProfile profile = caller->call_profile_at_bci(bci);
+  ciCallProfile profile = caller->call_profile_at_bci(bci, caller_md);
 
   // See how many times this site has been invoked.
   int site_count = profile.count();
@@ -235,7 +236,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
 
       int morphism = profile.morphism();
       if (speculative_receiver_type != nullptr) {
-        if (!too_many_traps_or_recompiles(caller, bci, Deoptimization::Reason_speculate_class_check)) {
+        if (!too_many_traps_or_recompiles(caller_md, bci, Deoptimization::Reason_speculate_class_check)) {
           // We have a speculative type, we should be able to resolve
           // the call. We do that before looking at the profiling at
           // this invoke because it may lead to bimorphic inlining which
@@ -291,7 +292,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
                                                ? Deoptimization::Reason_bimorphic
                                                : Deoptimization::reason_class_check(speculative_receiver_type != nullptr));
           if ((morphism == 1 || (morphism == 2 && next_hit_cg != nullptr)) &&
-              !too_many_traps_or_recompiles(caller, bci, reason)
+              !too_many_traps_or_recompiles(caller_md, bci, reason)
              ) {
             // Generate uncommon trap for class check failure path
             // in case of monomorphic or bimorphic virtual call site.

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -128,6 +128,7 @@ bool GraphKit::jvms_in_sync() const {
     return true;
   }
   if (jvms()->method() != parse->method())    return false;
+  if (jvms()->method_data() != parse->method_data())    return false;
   if (jvms()->bci()    != parse->bci())       return false;
   int jvms_sp = jvms()->sp();
   if (jvms_sp          != parse->sp())        return false;
@@ -633,7 +634,7 @@ bool GraphKit::is_builtin_throw_hot(Deoptimization::DeoptReason reason) {
     // Also, if there is a local exception handler, treat all throws
     // as hot if there has been at least one in this method.
     if (C->trap_count(reason) != 0 &&
-        method()->method_data()->trap_count(reason) != 0 &&
+        method_data()->trap_count(reason) != 0 &&
         has_exception_handler()) {
       return true;
     }
@@ -648,7 +649,7 @@ bool GraphKit::builtin_throw_too_many_traps(Deoptimization::DeoptReason reason,
       return false; // no traps; throws preallocated exception instead
     }
     ciMethod* m = Deoptimization::reason_is_speculate(reason) ? C->method() : nullptr;
-    if (method()->method_data()->trap_recompiled_at(bci(), m) ||
+    if (method_data()->trap_recompiled_at(bci(), m) ||
         C->too_many_traps(reason)) {
       return true;
     }
@@ -1452,7 +1453,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
   } else if (!assert_null &&
              (ImplicitNullCheckThreshold > 0) &&
              method() != nullptr &&
-             (method()->method_data()->trap_count(reason)
+             (method_data()->trap_count(reason)
               >= (uint)ImplicitNullCheckThreshold)) {
     ok_prob =  PROB_LIKELY_MAG(3);
   }
@@ -2390,8 +2391,8 @@ Node* GraphKit::record_profiled_receiver_for_speculation(Node* n) {
   if ((java_bc() == Bytecodes::_checkcast ||
        java_bc() == Bytecodes::_instanceof ||
        java_bc() == Bytecodes::_aastore) &&
-      method()->method_data()->is_mature()) {
-    ciProfileData* data = method()->method_data()->bci_to_data(bci());
+      method_data()->is_mature()) {
+    ciProfileData* data = method_data()->bci_to_data(bci());
     if (data != nullptr) {
       if (!data->as_BitData()->null_seen()) {
         ptr_kind = ProfileNeverNull;
@@ -2433,7 +2434,7 @@ void GraphKit::record_profiled_arguments_for_speculation(ciMethod* dest_method, 
     if (is_reference_type(targ->basic_type())) {
       ProfilePtrKind ptr_kind = ProfileMaybeNull;
       ciKlass* better_type = nullptr;
-      if (method()->argument_profiled_type(bci(), i, better_type, ptr_kind)) {
+      if (method()->argument_profiled_type(bci(), i, method_data(), better_type, ptr_kind)) {
         record_profile_for_speculation(argument(j), better_type, ptr_kind);
       }
       i++;
@@ -2453,7 +2454,7 @@ void GraphKit::record_profiled_parameters_for_speculation() {
     if (_gvn.type(local(i))->isa_oopptr()) {
       ProfilePtrKind ptr_kind = ProfileMaybeNull;
       ciKlass* better_type = nullptr;
-      if (method()->parameter_profiled_type(j, better_type, ptr_kind)) {
+      if (method()->parameter_profiled_type(j, method_data(), better_type, ptr_kind)) {
         record_profile_for_speculation(local(i), better_type, ptr_kind);
       }
       j++;
@@ -2471,7 +2472,7 @@ void GraphKit::record_profiled_return_for_speculation() {
   }
   ProfilePtrKind ptr_kind = ProfileMaybeNull;
   ciKlass* better_type = nullptr;
-  if (method()->return_profiled_type(bci(), better_type, ptr_kind)) {
+  if (method()->return_profiled_type(bci(), method_data(), better_type, ptr_kind)) {
     // If profiling reports a single type for the return value,
     // feed it to the type system so it can propagate it as a
     // speculative type
@@ -2762,7 +2763,7 @@ static IfNode* gen_subtype_check_compare(Node* ctrl, Node* in1, Node* in2, BoolT
 // Object; if you wish to check an Object you need to load the Object's class
 // prior to coming here.
 Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, Node* mem, PhaseGVN& gvn,
-                               ciMethod* method, int bci) {
+                               ciMethod* method, ciMethodData* md, int bci) {
   Compile* C = gvn.C;
   if ((*ctrl)->is_top()) {
     return C->top();
@@ -2868,7 +2869,7 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
   // If we might perform an expensive check, first try to take advantage of profile data that was attached to the
   // SubTypeCheck node
   if (might_be_cache && method != nullptr && VM_Version::profile_all_receivers_at_type_check()) {
-    ciCallProfile profile = method->call_profile_at_bci(bci);
+    ciCallProfile profile = method->call_profile_at_bci(bci, md);
     float total_prob = 0;
     for (int i = 0; profile.has_receiver(i); ++i) {
       float prob = profile.receiver_prob(i);
@@ -2983,12 +2984,12 @@ Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
       subklass = load_object_klass(obj_or_subklass);
     }
 
-    Node* n = Phase::gen_subtype_check(subklass, superklass, &ctrl, mem, _gvn, method(), bci());
+    Node* n = Phase::gen_subtype_check(subklass, superklass, &ctrl, mem, _gvn, method(), method_data(), bci());
     set_control(ctrl);
     return n;
   }
 
-  Node* check = _gvn.transform(new SubTypeCheckNode(C, obj_or_subklass, superklass, method(), bci()));
+  Node* check = _gvn.transform(new SubTypeCheckNode(C, obj_or_subklass, superklass, method(), method_data(), bci()));
   Node* bol = _gvn.transform(new BoolNode(check, BoolTest::eq));
   IfNode* iff = create_and_xform_if(control(), bol, PROB_STATIC_FREQUENT, COUNT_UNKNOWN);
   set_control(_gvn.transform(new IfTrueNode(iff)));
@@ -3251,7 +3252,7 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
 
   ciProfileData* data = nullptr;
   if (java_bc() == Bytecodes::_instanceof) {  // Only for the bytecode
-    data = method()->method_data()->bci_to_data(bci());
+    data = method_data()->bci_to_data(bci());
   }
   bool speculative_not_null = false;
   bool never_see_null = (ProfileDynamicTypes  // aggressive use of profile
@@ -3384,7 +3385,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass,
     assert(java_bc() == Bytecodes::_aastore ||
            java_bc() == Bytecodes::_checkcast,
            "interpreter profiles type checks only for these BCs");
-    data = method()->method_data()->bci_to_data(bci());
+    data = method_data()->bci_to_data(bci());
     safe_for_replace = true;
   }
 

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -65,6 +65,7 @@ class GraphKit : public Phase {
   SafePointNode*    _exceptions;// Parser map(s) for exception state(s)
   int               _bci;       // JVM Bytecode Pointer
   ciMethod*         _method;    // JVM Current Method
+  ciMethodData*     _method_data;    // JVM Current Method Data (Specialized if exists)
   BarrierSetC2*     _barrier_set;
 
  private:
@@ -139,12 +140,14 @@ class GraphKit : public Phase {
   int                bci()      const { return _bci; }
   Bytecodes::Code    java_bc()  const;
   ciMethod*          method()   const { return _method; }
+  ciMethodData*          method_data()   const { return _method_data; }
 
   void set_jvms(JVMState* jvms)       { set_map(jvms->map());
                                         assert(jvms == this->jvms(), "sanity");
                                         _sp = jvms->sp();
                                         _bci = jvms->bci();
-                                        _method = jvms->has_method() ? jvms->method() : nullptr; }
+                                        _method = jvms->has_method() ? jvms->method() : nullptr;
+                                        _method_data = jvms->has_method() ? jvms->method_data() : nullptr; }
   void set_map(SafePointNode* m)      { _map = m; DEBUG_ONLY(verify_map()); }
   void set_sp(int sp)                 { assert(sp >= 0, "sp must be non-negative: %d", sp); _sp = sp; }
   void clean_stack(int from_sp); // clear garbage beyond from_sp to top
@@ -427,7 +430,7 @@ class GraphKit : public Phase {
 
   // Check for unique class for receiver at call
   ciKlass* profile_has_unique_klass() {
-    ciCallProfile profile = method()->call_profile_at_bci(bci());
+    ciCallProfile profile = method()->call_profile_at_bci(bci(), method_data());
     if (profile.count() >= 0 &&         // no cast failures here
         profile.has_receiver(0) &&
         profile.morphism() == 1) {
@@ -751,16 +754,16 @@ class GraphKit : public Phase {
   // Report if a trap was recorded, and/or PerMethodTrapLimit was exceeded.
   // If there is no MDO at all, report no trap unless told to assume it.
   bool too_many_traps(Deoptimization::DeoptReason reason) {
-    return C->too_many_traps(method(), bci(), reason);
+    return C->too_many_traps(method_data(), bci(), reason);
   }
 
   // Report if there were too many recompiles at the current method and bci.
   bool too_many_recompiles(Deoptimization::DeoptReason reason) {
-    return C->too_many_recompiles(method(), bci(), reason);
+    return C->too_many_recompiles(method_data(), bci(), reason);
   }
 
   bool too_many_traps_or_recompiles(Deoptimization::DeoptReason reason) {
-      return C->too_many_traps_or_recompiles(method(), bci(), reason);
+      return C->too_many_traps_or_recompiles(method_data(), bci(), reason);
   }
 
   // Returns the object (if any) which was created the moment before.

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -887,10 +887,10 @@ bool IfNode::has_only_uncommon_traps(IfProjNode* proj, IfProjNode*& success, IfP
       // will be changed and the state of the dominating If will be
       // used. Checked that we didn't apply this transformation in a
       // previous compilation and it didn't cause too many traps
-      ciMethod* dom_method = dom_unc->jvms()->method();
+      ciMethodData* dom_md = dom_unc->jvms()->method_data();
       int dom_bci = dom_unc->jvms()->bci();
-      if (!igvn->C->too_many_traps(dom_method, dom_bci, Deoptimization::Reason_unstable_fused_if) &&
-          !igvn->C->too_many_traps(dom_method, dom_bci, Deoptimization::Reason_range_check) &&
+      if (!igvn->C->too_many_traps(dom_md, dom_bci, Deoptimization::Reason_unstable_fused_if) &&
+          !igvn->C->too_many_traps(dom_md, dom_bci, Deoptimization::Reason_range_check) &&
           // Return true if c2 manages to reconcile with UnstableIf optimization. See the comments for it.
           igvn->C->remove_unstable_if_trap(dom_unc, true/*yield*/)) {
         success = unc_proj->as_IfProj();
@@ -1307,7 +1307,7 @@ bool IfNode::is_side_effect_free_test(IfProjNode* proj, PhaseIterGVN* igvn) cons
       int trap_request = unc->uncommon_trap_request();
       Deoptimization::DeoptReason reason = Deoptimization::trap_request_reason(trap_request);
 
-      if (igvn->C->too_many_traps(dom_unc->jvms()->method(), dom_unc->jvms()->bci(), reason)) {
+      if (igvn->C->too_many_traps(dom_unc->jvms()->method_data(), dom_unc->jvms()->bci(), reason)) {
         return false;
       }
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5390,11 +5390,11 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
 // initialization.
 JVMState* LibraryCallKit::arraycopy_restore_alloc_state(AllocateArrayNode* alloc, int& saved_reexecute_sp) {
   if (alloc != nullptr) {
-    ciMethod* trap_method = alloc->jvms()->method();
+    ciMethodData* trap_md = alloc->jvms()->method_data();
     int trap_bci = alloc->jvms()->bci();
 
-    if (!C->too_many_traps(trap_method, trap_bci, Deoptimization::Reason_intrinsic) &&
-        !C->too_many_traps(trap_method, trap_bci, Deoptimization::Reason_null_check)) {
+    if (!C->too_many_traps(trap_md, trap_bci, Deoptimization::Reason_intrinsic) &&
+        !C->too_many_traps(trap_md, trap_bci, Deoptimization::Reason_null_check)) {
       // Make sure there's no store between the allocation and the
       // arraycopy otherwise visible side effects could be rexecuted
       // in case of deoptimization and cause incorrect execution.
@@ -5915,16 +5915,16 @@ bool LibraryCallKit::inline_arraycopy() {
     }
   }
 
-  ciMethod* trap_method = method();
+  ciMethodData* trap_md = method_data();
   int trap_bci = bci();
   if (saved_jvms_before_guards != nullptr) {
-    trap_method = alloc->jvms()->method();
+    trap_md = alloc->jvms()->method_data();
     trap_bci = alloc->jvms()->bci();
   }
 
   bool negative_length_guard_generated = false;
 
-  if (!C->too_many_traps(trap_method, trap_bci, Deoptimization::Reason_intrinsic) &&
+  if (!C->too_many_traps(trap_md, trap_bci, Deoptimization::Reason_intrinsic) &&
       can_emit_guards &&
       !src->is_top() && !dest->is_top()) {
     // validate arguments: enables transformation the ArrayCopyNode

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -535,7 +535,7 @@ Node* PhaseIdealLoop::loop_nest_replace_iv(Node* iv_to_replace, Node* inner_iv, 
 // Add a Parse Predicate with an uncommon trap on the failing/false path. Normal control will continue on the true path.
 void PhaseIdealLoop::add_parse_predicate(Deoptimization::DeoptReason reason, Node* inner_head, IdealLoopTree* loop,
                                          SafePointNode* sfpt) {
-  if (!C->too_many_traps(sfpt->jvms()->method(), sfpt->jvms()->bci(), reason)) {
+  if (!C->too_many_traps(sfpt->jvms()->method_data(), sfpt->jvms()->bci(), reason)) {
     ParsePredicateNode* parse_predicate = new ParsePredicateNode(inner_head->in(LoopNode::EntryControl), reason, &_igvn);
     register_control(parse_predicate, loop, inner_head->in(LoopNode::EntryControl));
     Node* if_false = new IfFalseNode(parse_predicate);
@@ -4112,7 +4112,7 @@ static float estimate_path_freq( Node *n ) {
       Node *call = n->in(0)->in(0)->in(0);
       assert( call->is_Call(), "expect a call here" );
       const JVMState *jvms = ((CallNode*)call)->jvms();
-      ciMethodData* methodData = jvms->method()->method_data();
+      ciMethodData* methodData = jvms->method_data();
       if (!methodData->is_mature())  return 0.0f; // No call-site data
       ciProfileData* data = methodData->bci_to_data(jvms->bci());
       if ((data == nullptr) || !data->is_CounterData()) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2478,7 +2478,7 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
       subklass = _igvn.transform(LoadKlassNode::make(_igvn, C->immutable_memory(), k_adr, TypeInstPtr::KLASS));
     }
 
-    Node* not_subtype_ctrl = Phase::gen_subtype_check(subklass, superklass, &ctrl, nullptr, _igvn, check->method(), check->bci());
+    Node* not_subtype_ctrl = Phase::gen_subtype_check(subklass, superklass, &ctrl, nullptr, _igvn, check->method(), check->method_data(), check->bci());
 
     _igvn.replace_input_of(iff, 0, C->top());
     _igvn.replace_node(iftrue, not_subtype_ctrl);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -631,7 +631,7 @@ Node* PhaseMacroExpand::generate_arraycopy(ArrayCopyNode *ac, AllocateArrayNode*
       // Test S[] against D[], not S against D, because (probably)
       // the secondary supertype cache is less busy for S[] than S.
       // This usually only matters when D is an interface.
-      Node* not_subtype_ctrl = Phase::gen_subtype_check(src_klass, dest_klass, ctrl, mem, _igvn, nullptr, -1);
+      Node* not_subtype_ctrl = Phase::gen_subtype_check(src_klass, dest_klass, ctrl, mem, _igvn, nullptr, nullptr, -1);
       // Plug failing path into checked_oop_disjoint_arraycopy
       if (not_subtype_ctrl != top()) {
         Node* local_ctrl = not_subtype_ctrl;

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1164,6 +1164,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
 
     // Make method available for all Safepoints
     ciMethod* scope_method = method ? method : C->method();
+    ciMethodData* scope_md = jvms->has_method() ? jvms->method_data() : nullptr;
     // Describe the scope here
     assert(jvms->bci() >= InvocationEntryBci && jvms->bci() <= 0x10000, "must be a valid or entry BCI");
     assert(!jvms->should_reexecute() || depth == max_depth, "reexecute allowed only for the youngest");
@@ -1174,6 +1175,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
       safepoint_pc_offset,
       null_mh,
       scope_method,
+      scope_md,
       jvms->bci(),
       jvms->should_reexecute(),
       rethrow_exception,
@@ -1265,9 +1267,10 @@ void NonSafepointEmitter::emit_non_safepoint() {
   for (int depth = 1; depth <= max_depth; depth++) {
     JVMState* jvms = youngest_jvms->of_depth(depth);
     ciMethod* method = jvms->has_method() ? jvms->method() : nullptr;
+    ciMethodData* md = jvms->has_method() ? jvms->method_data() : nullptr;
     assert(!jvms->should_reexecute() || depth==max_depth, "reexecute allowed only for the youngest");
     methodHandle null_mh;
-    debug_info->describe_scope(pc_offset, null_mh, method, jvms->bci(), jvms->should_reexecute());
+    debug_info->describe_scope(pc_offset, null_mh, method, md, jvms->bci(), jvms->should_reexecute());
   }
 
   // Mark the end of the scope set.

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -422,6 +422,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   // Init some variables
   _caller = caller;
   _method = parse_method;
+  _method_data = ciEnv::current()->specialized_method_data(parse_method, caller);
   _expected_uses = expected_uses;
   _depth = 1 + (caller->has_method() ? caller->depth() : 0);
   _wrote_final = false;
@@ -485,7 +486,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
 
   // Accumulate deoptimization counts.
   // (The range_check and store_check counts are checked elsewhere.)
-  ciMethodData* md = method()->method_data();
+  ciMethodData* md = method_data();
   for (uint reason = 0; reason < md->trap_reason_limit(); reason++) {
     uint md_count = md->trap_count(reason);
     if (md_count != 0) {
@@ -1576,7 +1577,7 @@ void Parse::do_one_block() {
   iter().reset_to_bci(block()->start());
 
   if (ProfileExceptionHandlers && block()->is_handler()) {
-    ciMethodData* methodData = method()->method_data();
+    ciMethodData* methodData = method_data();
     if (methodData->is_mature()) {
       ciBitData data = methodData->exception_handler_bci_to_data(block()->start());
       if (!data.exception_handler_entered() || StressPrunedExceptionHandlers) {

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -423,7 +423,7 @@ void Parse::do_tableswitch() {
     return;
   }
 
-  ciMethodData* methodData = method()->method_data();
+  ciMethodData* methodData = method_data();
   ciMultiBranchData* profile = nullptr;
   if (methodData->is_mature() && UseSwitchProfiling) {
     ciProfileData* data = methodData->bci_to_data(bci());
@@ -431,7 +431,7 @@ void Parse::do_tableswitch() {
       profile = (ciMultiBranchData*)data;
     }
   }
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps(method_data(), bci(), Deoptimization::Reason_unstable_if);
 
   // generate decision tree, using trichotomy when possible
   int rnum = len+2;
@@ -497,7 +497,7 @@ void Parse::do_lookupswitch() {
     return;
   }
 
-  ciMethodData* methodData = method()->method_data();
+  ciMethodData* methodData = method_data();
   ciMultiBranchData* profile = nullptr;
   if (methodData->is_mature() && UseSwitchProfiling) {
     ciProfileData* data = methodData->bci_to_data(bci());
@@ -505,7 +505,7 @@ void Parse::do_lookupswitch() {
       profile = (ciMultiBranchData*)data;
     }
   }
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps(method_data(), bci(), Deoptimization::Reason_unstable_if);
 
   // generate decision tree, using trichotomy when possible
   jint* table = NEW_RESOURCE_ARRAY(jint, len*3);
@@ -753,7 +753,7 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
   // Are jumptables supported
   if (!Matcher::has_match_rule(Op_Jump))  return false;
 
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps(method_data(), bci(), Deoptimization::Reason_unstable_if);
 
   // Decide if a guard is needed to lop off big ranges at either (or
   // both) end(s) of the input set. We'll call this the default target
@@ -877,7 +877,7 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
     }
   }
 
-  ciMethodData* methodData = method()->method_data();
+  ciMethodData* methodData = method_data();
   ciMultiBranchData* profile = nullptr;
   if (methodData->is_mature()) {
     ciProfileData* data = methodData->bci_to_data(bci());
@@ -908,7 +908,7 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
 //----------------------------jump_switch_ranges-------------------------------
 void Parse::jump_switch_ranges(Node* key_val, SwitchRange *lo, SwitchRange *hi, int switch_depth) {
   Block* switch_block = block();
-  bool trim_ranges = !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+  bool trim_ranges = !C->too_many_traps(method_data(), bci(), Deoptimization::Reason_unstable_if);
 
   if (switch_depth == 0) {
     // Do special processing for the top-level call.
@@ -1232,7 +1232,7 @@ float Parse::dynamic_branch_prediction(float &cnt, BoolTest::mask btest, Node* t
   if (use_mdo) {
     // Use MethodData information if it is available
     // FIXME: free the ProfileData structure
-    ciMethodData* methodData = method()->method_data();
+    ciMethodData* methodData = method_data();
     if (!methodData->is_mature())  return PROB_UNKNOWN;
     ciProfileData* data = methodData->bci_to_data(bci());
     if (data == nullptr) {
@@ -1327,7 +1327,7 @@ float Parse::branch_prediction(float& cnt,
       // Since it's an OSR, we probably have profile data, but since
       // branch_prediction returned PROB_UNKNOWN, the counts are too small.
       // Let's make a special check here for completely zero counts.
-      ciMethodData* methodData = method()->method_data();
+      ciMethodData* methodData = method_data();
       if (!methodData->is_empty()) {
         ciProfileData* data = methodData->bci_to_data(bci());
         // Only stop for truly zero counts, which mean an unknown part
@@ -1639,7 +1639,7 @@ bool Parse::path_is_suitable_for_uncommon_trap(float prob) const {
     return false;
   }
   return seems_never_taken(prob) &&
-         !C->too_many_traps(method(), bci(), Deoptimization::Reason_unstable_if);
+         !C->too_many_traps(method_data(), bci(), Deoptimization::Reason_unstable_if);
 }
 
 void Parse::maybe_add_predicate_after_if(Block* path) {
@@ -2733,7 +2733,7 @@ void Parse::do_one_bytecode() {
     // See if we can get some profile data and hand it off to the next block
     Block *target_block = block()->successor_for_bci(target_bci);
     if (target_block->pred_count() != 1)  break;
-    ciMethodData* methodData = method()->method_data();
+    ciMethodData* methodData = method_data();
     if (!methodData->is_mature())  break;
     ciProfileData* data = methodData->bci_to_data(bci());
     assert(data != nullptr && data->is_JumpData(), "need JumpData for taken branch");

--- a/src/hotspot/share/opto/phase.hpp
+++ b/src/hotspot/share/opto/phase.hpp
@@ -33,6 +33,7 @@ class Node;
 class PhaseGVN;
 class Compile;
 class ciMethod;
+class ciMethodData;
 
 //------------------------------Phase------------------------------------------
 // Most optimizations are done in Phases.  Creating a phase does any long
@@ -156,7 +157,7 @@ protected:
   // Object; if you wish to check an Object you need to load the Object's
   // class prior to coming here.
   // Used in GraphKit and PhaseMacroExpand
-  static Node* gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, Node* mem, PhaseGVN& gvn, ciMethod* method, int bci);
+  static Node* gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, Node* mem, PhaseGVN& gvn, ciMethod* method, ciMethodData* md, int bci);
 
 public:
   Compile * C;

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -922,7 +922,7 @@ bool StringConcat::validate_control_flow() {
   // safe to transform the graph as we would expect.
 
   // Check to see if this resulted in too many uncommon traps previously
-  if (Compile::current()->too_many_traps(_begin->jvms()->method(), _begin->jvms()->bci(),
+  if (Compile::current()->too_many_traps(_begin->jvms()->method_data(), _begin->jvms()->bci(),
                         Deoptimization::Reason_intrinsic)) {
     return false;
   }

--- a/src/hotspot/share/opto/subtypenode.hpp
+++ b/src/hotspot/share/opto/subtypenode.hpp
@@ -35,8 +35,8 @@ public:
     SuperKlass
   };
 
-  SubTypeCheckNode(Compile* C, Node* obj_or_subklass, Node* superklass, ciMethod* method, int bci)
-    : CmpNode(obj_or_subklass, superklass), _method(method), _bci(bci) {
+  SubTypeCheckNode(Compile* C, Node* obj_or_subklass, Node* superklass, ciMethod* method, ciMethodData* md, int bci)
+    : CmpNode(obj_or_subklass, superklass), _method(method), _method_data(md), _bci(bci) {
     init_class_id(Class_SubTypeCheck);
     init_flags(Flag_is_macro);
     C->add_macro_node(this);
@@ -50,6 +50,7 @@ public:
   const Type* bottom_type() const { return TypeInt::CC; }
 
   ciMethod* method() const { return _method; }
+  ciMethodData* method_data() const { return _method_data; }
   int bci() const { return _bci; }
 
   uint size_of() const;
@@ -60,8 +61,9 @@ public:
 #endif
 
 private:
-  // method/bci for this subtype check so profile data can be retrieved after parsing is over
+  // method/method_data/bci for this subtype check so profile data can be retrieved after parsing is over
   ciMethod* _method;
+  ciMethodData* _method_data;
   int _bci;
 #ifdef ASSERT
   bool verify(PhaseGVN* phase);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1763,9 +1763,10 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     methodHandle profiled_method;
     profiled_method = trap_method;
-
-    MethodData* trap_mdo =
-      get_method_data(current, profiled_method, create_if_missing);
+    MethodData* trap_mdo = trap_scope->specialized_method_data();
+    if (trap_mdo == nullptr) {
+      trap_mdo = get_method_data(current, profiled_method, create_if_missing);
+    }
 
     Symbol* class_name = nullptr;
     bool unresolved = false;
@@ -2013,7 +2014,6 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
                               Mutex::_no_safepoint_check_flag);
     ProfileData* pdata = nullptr;
     if (ProfileTraps && CompilerConfig::is_c2_enabled() && update_trap_state && trap_mdo != nullptr) {
-      assert(trap_mdo == get_method_data(current, profiled_method, false), "sanity");
       uint this_trap_count = 0;
       bool maybe_prior_trap = false;
       bool maybe_prior_recompile = false;

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1182,6 +1182,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PrintMethodData, false, DIAGNOSTIC,                         \
           "Print the results of +ProfileInterpreter at end of run")         \
                                                                             \
+  product(bool, SpecializedMethodData, false, EXPERIMENTAL,                 \
+          "Enables use of individual profiles for inlined calls")           \
+                                                                            \
   develop(bool, VerifyDataPointer, trueInDebug,                             \
           "Verify the method data pointer during interpreter profiling")    \
                                                                             \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -148,6 +148,10 @@ static void print_method_profiling_data() {
         ss.print_cr("------------------------------------------------------------------------");
         m->print_invocation_count(&ss);
         ss.print_cr("  mdo size: %d bytes", m->method_data()->size_in_bytes());
+        int specialized_size = m->method_data()->specialized_size_in_bytes();
+        if (specialized_size != 0) {
+          ss.print_cr("  specialized mdo size: %d bytes", specialized_size);
+        }
         ss.cr();
         // Dump data on parameters if any
         if (m->method_data() != nullptr && m->method_data()->parameters_type_data() != nullptr) {
@@ -158,6 +162,7 @@ static void print_method_profiling_data() {
         m->print_codes_on(&ss, ClassPrinter::PRINT_METHOD_DATA, false);
         tty->print("%s", ss.as_string()); // print all at once
         total_size += m->method_data()->size_in_bytes();
+        total_size += specialized_size;
       }
       tty->print_cr("------------------------------------------------------------------------");
       tty->print_cr("Total MDO size: %d bytes", total_size);

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -183,6 +183,7 @@ inline void vframeStreamCommon::fill_from_compiled_frame(int decode_offset) {
   DebugInfoReadStream buffer(nm(), decode_offset);
   _sender_decode_offset = buffer.read_int();
   _method               = buffer.read_method();
+  buffer.read_method_data();
   _bci                  = buffer.read_bci();
 
   assert(_method->is_method(), "checking type of decoded method");

--- a/test/hotspot/jtreg/compiler/profiling/specialized/PerSiteUnstableIf.java
+++ b/test/hotspot/jtreg/compiler/profiling/specialized/PerSiteUnstableIf.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Verify that specialized profiles don`t trigger decompile
+ *          when call sites use different branches of unstable_if
+ *          and that triggered decompile affects only one site.
+ *
+ * @requires vm.flavor == "server" & vm.compMode == "Xmixed"
+ * @requires vm.compiler2.enabled
+ *
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+SpecializedMethodData
+ *                   -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
+ *                   compiler.profiling.specialized.PerSiteUnstableIf
+ */
+
+package compiler.profiling.specialized;
+
+import jdk.test.whitebox.WhiteBox;
+import java.lang.reflect.Method;
+
+public class PerSiteUnstableIf {
+
+    static final WhiteBox WB = WhiteBox.getWhiteBox();
+    static final int C2 = 4;
+
+    static int inlinee(int v) { return v > 0 ? v * 2 : -v; }
+    static int site1(int v) { return inlinee(v); }
+    static int site2(int v) { return inlinee(v); }
+
+    public static void main(String[] args) throws Exception {
+        Class<?> self = PerSiteUnstableIf.class;
+        Method m1 = self.getDeclaredMethod("site1", int.class);
+        Method m2 = self.getDeclaredMethod("site2", int.class);
+        Method inl = self.getDeclaredMethod("inlinee", int.class);
+
+        int size = 100000;
+        int[] thenData = new int[size];
+        int[] elseData = new int[size];
+        for (int i = 0; i < size; i++) {
+            thenData[i] = i + 1;
+            elseData[i] = -i;
+        }
+
+        for (int i = 0; i < size; i++) {
+            site1(thenData[i]);
+            site2(elseData[i]);
+        }
+        WB.enqueueMethodForCompilation(m1, C2);
+        WB.enqueueMethodForCompilation(m2, C2);
+        if (!WB.isMethodCompiled(m1) || !WB.isMethodCompiled(m2)) {
+            throw new RuntimeException("Methods not compiled by C2");
+        }
+
+        int dc1Before = WB.getMethodDecompileCount(m1);
+        int dc2Before = WB.getMethodDecompileCount(m2);
+        if (dc1Before != 0 || dc2Before != 0) {
+            throw new RuntimeException("Unexpected method decompiles");
+        }
+
+        int deopt = site1(elseData[0]);
+        int nodeopt = site2(elseData[0]);
+
+        int dc1After = WB.getMethodDecompileCount(m1);
+        int dc2After = WB.getMethodDecompileCount(m2);
+
+        if (dc1Before == dc1After) {
+            throw new RuntimeException("No expected decompile");
+        }
+        if (dc2Before != dc2After) {
+            throw new RuntimeException("Unexpected decompile");
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/specialized/BranchSpeculations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/specialized/BranchSpeculations.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need any additional information or
+ * have any questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for individual inline call site profiles with branch
+ * speculation scenarios.
+ *
+ * <p>To compare performance with and without specialized profiles, run with:
+ * <pre>
+ *   -XX:+UnlockExperimentalVMOptions -XX:+SpecializedMethodData
+ *   -XX:+UnlockExperimentalVMOptions -XX:-SpecializedMethodData
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public class BranchSpeculations {
+
+    static final int SIZE = 1024;
+
+    static int branchInlinee(int v) {
+        if (v > 0) {
+            return v;
+        } else {
+            return v * 31 + 7;
+        }
+    }
+
+    static int branchInlineeTwoBranches(int v) {
+        if (v > 0) {
+            return v;
+        } else if (v < -50) {
+            return v * 17 - 3;
+        } else {
+            return v * 31 + 7;
+        }
+    }
+
+    int[] posData;
+    int[] negData;
+
+    @Setup
+    public void setup() {
+        posData = new int[SIZE];
+        negData = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            posData[i] = i + 1;
+            negData[i] = -(i + 1);
+        }
+    }
+
+    @Benchmark
+    public int singleSiteSingleBranch() {
+        int sum = 0;
+        for (int i = 0; i < negData.length; i++) {
+            sum += branchInlinee(negData[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int twoSitesTwoBranches() {
+        int sum = 0;
+        for (int i = 0; i < posData.length; i++) {
+            sum += branchInlinee(posData[i]);
+            sum += branchInlinee(negData[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int threeSitesTwoBranches() {
+        int sum = 0;
+        for (int i = 0; i < posData.length; i++) {
+            sum += branchInlinee(posData[i]);
+            sum += branchInlinee(posData[i]);
+            sum += branchInlinee(negData[i]);
+        }
+        return sum;
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/specialized/CombinedSpeculations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/specialized/CombinedSpeculations.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need any additional information or
+ * have any questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for individual inline call site profiles with both branch and type
+ * speculation scenarios.
+ *
+ * <p>To compare performance with and without specialized profiles, run with:
+ * <pre>
+ *   -XX:+UnlockExperimentalVMOptions -XX:+SpecializedMethodData
+ *   -XX:+UnlockExperimentalVMOptions -XX:-SpecializedMethodData
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public class CombinedSpeculations {
+
+    static final int SIZE = 1024;
+
+    interface Data {
+        int compute(int v);
+    }
+
+    static class AddData implements Data {
+        public int compute(int v) { return v + 1; }
+    }
+
+    static class MulData implements Data {
+        public int compute(int v) { return v * 31; }
+    }
+
+    static class XorData implements Data {
+        public int compute(int v) { return v ^ 0x5555AAAA; }
+    }
+
+    static int combinedInlinee(Data d, int v) {
+        int result = d.compute(v);
+        if (v > 0) {
+            return result;
+        } else {
+            return result * 31 + 7;
+        }
+    }
+
+    Data[] receivers;
+    int[] posData;
+    int[] negData;
+    int[] data;
+
+    @Setup
+    public void setup() {
+        receivers = new Data[]{new AddData(), new MulData(), new XorData()};
+        posData = new int[SIZE];
+        negData = new int[SIZE];
+        data = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            posData[i] = i + 1;
+            negData[i] = -(i + 1);
+            data[i] = i + 1;
+        }
+    }
+
+    @Benchmark
+    public int singleSiteSingleTypeSingleBranch() {
+        int sum = 0;
+        for (int i = 0; i < posData.length; i++) {
+            sum += combinedInlinee(receivers[0], posData[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int twoSitesTwoTypesSingleBranch() {
+        int sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += combinedInlinee(receivers[0], data[i]);
+            sum += combinedInlinee(receivers[1], data[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int twoSitesTwoTypesTwoBranches() {
+        int sum = 0;
+        for (int i = 0; i < posData.length; i++) {
+            sum += combinedInlinee(receivers[0], posData[i]);
+            sum += combinedInlinee(receivers[1], negData[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int threeSitesThreeTypesTwoBranches() {
+        int sum = 0;
+        for (int i = 0; i < posData.length; i++) {
+            sum += combinedInlinee(receivers[0], posData[i]);
+            sum += combinedInlinee(receivers[1], negData[i]);
+            sum += combinedInlinee(receivers[2], posData[i]);
+        }
+        return sum;
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/specialized/VirtualCallSpeculations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/specialized/VirtualCallSpeculations.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need any additional information or
+ * have any questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for individual inline call site profiles with virtual call
+ * receiver type speculations scenarios.
+ *
+ * <p>To compare performance with and without specialized profiles, run with:
+ * <pre>
+ *   -XX:+UnlockExperimentalVMOptions -XX:+SpecializedMethodData
+ *   -XX:+UnlockExperimentalVMOptions -XX:-SpecializedMethodData
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public class VirtualCallSpeculations {
+
+    static final int SIZE = 1024;
+
+    abstract static class Transformer {
+        abstract int transform(int v);
+    }
+
+    static class AddTransformer extends Transformer {
+        int transform(int v) { return v + 1; }
+    }
+
+    static class MulTransformer extends Transformer {
+        int transform(int v) { return v * 31; }
+    }
+
+    static class XorTransformer extends Transformer {
+        int transform(int v) { return v ^ 0x5555AAAA; }
+    }
+
+    interface Folder {
+        int fold(int v);
+    }
+
+    static class SumFolder implements Folder {
+        public int fold(int v) { return v + v; }
+    }
+
+    static class HashFolder implements Folder {
+        public int fold(int v) { return v * 17 + 3; }
+    }
+
+    static class MaskFolder implements Folder {
+        public int fold(int v) { return v & 0xFFFF; }
+    }
+
+    static int virtualInlinee(Transformer t, int v) {
+        return t.transform(v);
+    }
+
+    static int interfaceInlinee(Folder f, int v) {
+        return f.fold(v);
+    }
+
+    Transformer[] classReceivers;
+    Folder[] ifaceReceivers;
+    int[] data;
+
+    @Setup
+    public void setup() {
+        classReceivers = new Transformer[]{new AddTransformer(), new MulTransformer(), new XorTransformer()};
+        ifaceReceivers = new Folder[]{new SumFolder(), new HashFolder(), new MaskFolder()};
+        data = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            data[i] = i + 1;
+        }
+    }
+
+    @Benchmark
+    public int singleSiteSingleType() {
+        int sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += virtualInlinee(classReceivers[0], data[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int twoSitesTwoTypes() {
+        int sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += virtualInlinee(classReceivers[0], data[i]);
+            sum += virtualInlinee(classReceivers[1], data[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int threeSitesThreeTypes() {
+        int sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += virtualInlinee(classReceivers[0], data[i]);
+            sum += virtualInlinee(classReceivers[1], data[i]);
+            sum += virtualInlinee(classReceivers[2], data[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int twoSitesTwoInterfaces() {
+        int sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += interfaceInlinee(ifaceReceivers[0], data[i]);
+            sum += interfaceInlinee(ifaceReceivers[1], data[i]);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int threeSitesThreeInterfaces() {
+        int sum = 0;
+        for (int i = 0; i < data.length; i++) {
+            sum += interfaceInlinee(ifaceReceivers[0], data[i]);
+            sum += interfaceInlinee(ifaceReceivers[1], data[i]);
+            sum += interfaceInlinee(ifaceReceivers[2], data[i]);
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
This pr introduces separate profiling mechanism for inlined calls of specific method. 
Motivation: 
C1 compilation produces code where different inlined calls of the same method have different behaviour. If profiles would be split based on those c1 inline decisions, then at the time of c2 compilation those specific profiles would be more optimistic towards expected call stack (or more "specialized").

I suggest to name those inlined calls specializations and their profiles - specialized.
Specialized profiles have the same structure as call tree thus they are organized as trees.
Changes:
- Introduced new oop - MethodDataEntry (one cell that stores mdo pointer)
- Every call`s profile data now should have such entry (for potential inline decision):
  + Introduced CallData (for direct calls)
  + Extended the VirtualCallData (for virtual calls)
- Introduced ci variant for those oops (specialized profiles also use lazy loading)
- Introduced new ci interface at ciMethod to build (on MethodDataEntry) and access (with load) those specialized profiles:
  + These changes are experimetal, so interface has a wrapper in ciEnv, which by default creates/provides old single profiles (controlled by the flag SpecializedMethodData) 
- Each compiler now should propagate profiles (as we can`t get them from the method alone):
  + c1: IRScope extended to store current profile
  + c2: JVMState extended to store current profile
- Deoptimization runtime should be provided with specific profile (to store traps):
  + ScopeDesc extended to store (only) specialized profiles 
  + Mdo pointer is now serialized/deserialized
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31183/head:pull/31183` \
`$ git checkout pull/31183`

Update a local copy of the PR: \
`$ git checkout pull/31183` \
`$ git pull https://git.openjdk.org/jdk.git pull/31183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31183`

View PR using the GUI difftool: \
`$ git pr show -t 31183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31183.diff">https://git.openjdk.org/jdk/pull/31183.diff</a>

</details>
