### PR TITLE
8384817: Deprecate AlwaysCompileLoopMethods VM flag

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -535,6 +535,7 @@ static SpecialFlag const special_jvm_flags[] = {
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
   { "InitiatingHeapOccupancyPercent", JDK_Version::jdk(27),  JDK_Version::jdk(28), JDK_Version::jdk(29) },
+  { "AlwaysCompileLoopMethods",     JDK_Version::jdk(27),  JDK_Version::jdk(28), JDK_Version::jdk(29) },
 
   // -------------- Obsolete Flags - sorted by expired_in --------------
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1189,7 +1189,7 @@ const int ObjectAlignmentInBytes = 8;
           "Use Just-In-Time compilation")                                   \
                                                                             \
   product(bool, AlwaysCompileLoopMethods, false,                            \
-          "When using recompilation, never interpret methods "              \
+          "(Deprecated) When using recompilation, never interpret methods " \
           "containing loops")                                               \
                                                                             \
   product(int,  AllocatePrefetchStyle, 1,                                   \


### PR DESCRIPTION
`-XX:+AlwaysCompileLoopMethods` is very old VM flag which was introduced during HotSpot VM development. Later it was replaced by `On-Stack-Replacement` (OSR) compilation. It is product flag but it is not documented and never tested. In the presence of OSR compilation we don't need this flag.

`-XX:+AlwaysCompileLoopMethods` triggers compilation on first call of a Java method with any loop, small or big, without executing it in Interpreter or do any profiling. As result it triggers more compilations during startup when used. The performance testing shows 10-30% startup regression with this flag. There are several places in VM which check this flag and which we have to maintain.

I suggest to deprecate this flag for removal in JDK 27, obsolete in JDK 28, and remove in JDK 29.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8384818](https://bugs.openjdk.org/browse/JDK-8384818) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8384817](https://bugs.openjdk.org/browse/JDK-8384817): Deprecate AlwaysCompileLoopMethods VM flag (**Enhancement** - P4)
 * [JDK-8384818](https://bugs.openjdk.org/browse/JDK-8384818): Deprecate AlwaysCompileLoopMethods VM flag (**CSR**)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31184/head:pull/31184` \
`$ git checkout pull/31184`

Update a local copy of the PR: \
`$ git checkout pull/31184` \
`$ git pull https://git.openjdk.org/jdk.git pull/31184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31184`

View PR using the GUI difftool: \
`$ git pr show -t 31184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31184.diff">https://git.openjdk.org/jdk/pull/31184.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31184#issuecomment-4473245701)
</details>
