### PR TITLE
8384835: Parallel: Removing unused local variable in ParallelCompactData::clear_range

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -280,7 +280,6 @@ void ParallelCompactData::clear_range(size_t beg_region, size_t end_region) {
   assert(beg_region <= _region_count, "beg_region out of range");
   assert(end_region <= _region_count, "end_region out of range");
 
-  const size_t region_cnt = end_region - beg_region;
   for (size_t i = beg_region; i < end_region; i++) {
     ::new (&_region_data[i]) RegionData{};
   }


### PR DESCRIPTION
Trivial removing dead code.

Test: build

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384835](https://bugs.openjdk.org/browse/JDK-8384835): Parallel: Removing unused local variable in ParallelCompactData::clear_range (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31188/head:pull/31188` \
`$ git checkout pull/31188`

Update a local copy of the PR: \
`$ git checkout pull/31188` \
`$ git pull https://git.openjdk.org/jdk.git pull/31188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31188`

View PR using the GUI difftool: \
`$ git pr show -t 31188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31188.diff">https://git.openjdk.org/jdk/pull/31188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31188#issuecomment-4476358918)
</details>
