### PR TITLE
8384864: Problemlist java/nio/channels/SocketChannel/OpenLeak.java and CloseDuringConnect.java on macos 26.4 and 26.5

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -470,8 +470,8 @@ java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-
 java/nio/channels/DatagramChannel/BasicMulticastTests.java      8144003 macosx-all
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java 8144003 macosx-all
 java/nio/channels/DatagramChannel/Promiscuous.java              8144003 macosx-all
-java/nio/channels/SocketChannel/CloseDuringConnect.java         8375658 macosx-26.0,macosx-26.1,macosx-26.2,macosx-26.3
-java/nio/channels/SocketChannel/OpenLeak.java                   8375658 macosx-26.0,macosx-26.1,macosx-26.2,macosx-26.3
+java/nio/channels/SocketChannel/CloseDuringConnect.java         8375658 macosx-26.0,macosx-26.1,macosx-26.2,macosx-26.3,macosx-26.4,macosx-26.5
+java/nio/channels/SocketChannel/OpenLeak.java                   8375658 macosx-26.0,macosx-26.1,macosx-26.2,macosx-26.3,macosx-26.4,macosx-26.5
 
 ############################################################################
 


### PR DESCRIPTION
Can I please get a review of this problem listing update which proposes to include macosx-26.4 and macosx-26.5 in the problem listed versions for `java/nio/channels/SocketChannel/CloseDuringConnect.java` and `java/nio/channels/SocketChannel/OpenLeak.java`?

The underlying bug https://bugs.openjdk.org/browse/JDK-8375658 has been reported to Apple and we are waiting to hear back on it. In the meantime, these tests have been problem listed in some versions of macosx 26.x. This new update marks it as problem listed for 26.4 and 26.5 versions of macosx. Ideally we would just problem list it for all versions of macosx 26, but jtreg currently doesn't have that ability.

I've triggered a few runs to verify that this works as expected and will integrate this once I see those results.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384864](https://bugs.openjdk.org/browse/JDK-8384864): Problemlist java/nio/channels/SocketChannel/OpenLeak.java and CloseDuringConnect.java on macos 26.4 and 26.5 (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31190/head:pull/31190` \
`$ git checkout pull/31190`

Update a local copy of the PR: \
`$ git checkout pull/31190` \
`$ git pull https://git.openjdk.org/jdk.git pull/31190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31190`

View PR using the GUI difftool: \
`$ git pr show -t 31190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31190.diff">https://git.openjdk.org/jdk/pull/31190.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31190#issuecomment-4478554700)
</details>
