### PR TITLE
8384862: CompilationLog::log_failure() does not produce report message

### DIFF
--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -35,11 +35,11 @@ CompilationLog* CompilationLog::_log;
 CompilationLog::CompilationLog() : StringEventLog("Compilation events", "jit") {
 }
 
+// Initial size for stringStream, big enough for these logs
 static const size_t buf_size = FormatBufferBase::BufferSize;
 
 void CompilationLog::log_compile(JavaThread* thread, CompileTask* task) {
-  ResourceMark rm;
-  stringStream ss(NEW_RESOURCE_ARRAY(char, buf_size), buf_size);
+  stringStream ss(buf_size);
   // msg.time_stamp().update_to(tty->time_stamp().ticks());
   task->print(&ss, nullptr, true, false);
   log(thread, "%s", ss.freeze());
@@ -52,8 +52,7 @@ void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
 }
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
-  ResourceMark rm;
-  stringStream ss(NEW_RESOURCE_ARRAY(char, buf_size), buf_size);
+  stringStream ss(buf_size);
   if (task == nullptr) {
     ss.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
   } else {
@@ -68,8 +67,7 @@ void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const ch
 void CompilationLog::log_metaspace_failure(const char* reason) {
   // Note: This method can be called from non-Java/compiler threads to
   // log the global metaspace failure that might affect profiling.
-  ResourceMark rm;
-  stringStream ss(NEW_RESOURCE_ARRAY(char, buf_size), buf_size);
+  stringStream ss(buf_size);
   ss.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
   log(Thread::current(), "%s", ss.freeze());
 }

--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -35,13 +35,14 @@ CompilationLog* CompilationLog::_log;
 CompilationLog::CompilationLog() : StringEventLog("Compilation events", "jit") {
 }
 
+static const size_t buf_size = FormatBufferBase::BufferSize;
+
 void CompilationLog::log_compile(JavaThread* thread, CompileTask* task) {
   ResourceMark rm;
-  StringLogMessage lm;
-  stringStream sstr(lm.buffer(), lm.size());
+  stringStream ss(NEW_RESOURCE_ARRAY(char, buf_size), buf_size);
   // msg.time_stamp().update_to(tty->time_stamp().ticks());
-  task->print(&sstr, nullptr, true, false);
-  log(thread, "%s", (const char*)lm);
+  task->print(&ss, nullptr, true, false);
+  log(thread, "%s", ss.freeze());
 }
 
 void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
@@ -52,27 +53,25 @@ void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
   ResourceMark rm;
-  StringLogMessage lm;
-  stringStream sstr(lm.buffer(), lm.size());
+  stringStream ss(NEW_RESOURCE_ARRAY(char, buf_size), buf_size);
   if (task == nullptr) {
-    sstr.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
+    ss.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
   } else {
-    sstr.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+    ss.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
   }
   if (retry_message != nullptr) {
-    sstr.print(" (%s)", retry_message);
+    ss.print(" (%s)", retry_message);
   }
-  log(thread, "%s", (const char*)lm);
+  log(thread, "%s", ss.freeze());
 }
 
 void CompilationLog::log_metaspace_failure(const char* reason) {
   // Note: This method can be called from non-Java/compiler threads to
   // log the global metaspace failure that might affect profiling.
   ResourceMark rm;
-  StringLogMessage lm;
-  stringStream sstr(lm.buffer(), lm.size());
-  sstr.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
-  log(Thread::current(), "%s", (const char*)lm);
+  stringStream ss(NEW_RESOURCE_ARRAY(char, buf_size), buf_size);
+  ss.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
+  log(Thread::current(), "%s", ss.freeze());
 }
 
 void CompilationLog::init() {

--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -36,6 +36,7 @@ CompilationLog::CompilationLog() : StringEventLog("Compilation events", "jit") {
 }
 
 void CompilationLog::log_compile(JavaThread* thread, CompileTask* task) {
+  ResourceMark rm;
   StringLogMessage lm;
   stringStream sstr(lm.buffer(), lm.size());
   // msg.time_stamp().update_to(tty->time_stamp().ticks());
@@ -50,16 +51,17 @@ void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
 }
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
+  ResourceMark rm;
   StringLogMessage lm;
+  stringStream sstr(lm.buffer(), lm.size());
   if (task == nullptr) {
-    lm.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
+    sstr.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
   } else {
-    lm.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+    sstr.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
   }
   if (retry_message != nullptr) {
-    lm.append(" (%s)", retry_message);
+    sstr.print(" (%s)", retry_message);
   }
-  lm.print("\n");
   log(thread, "%s", (const char*)lm);
 }
 
@@ -68,8 +70,8 @@ void CompilationLog::log_metaspace_failure(const char* reason) {
   // log the global metaspace failure that might affect profiling.
   ResourceMark rm;
   StringLogMessage lm;
-  lm.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
-  lm.print("\n");
+  stringStream sstr(lm.buffer(), lm.size());
+  sstr.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
   log(Thread::current(), "%s", (const char*)lm);
 }
 

--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -35,14 +35,12 @@ CompilationLog* CompilationLog::_log;
 CompilationLog::CompilationLog() : StringEventLog("Compilation events", "jit") {
 }
 
-// Initial size for stringStream, big enough for these logs
-static const size_t buf_size = FormatBufferBase::BufferSize;
-
 void CompilationLog::log_compile(JavaThread* thread, CompileTask* task) {
-  stringStream ss(buf_size);
+  StringLogMessage lm;
+  stringStream sstr(lm.buffer(), lm.size());
   // msg.time_stamp().update_to(tty->time_stamp().ticks());
-  task->print(&ss, nullptr, true, false);
-  log(thread, "%s", ss.freeze());
+  task->print(&sstr, nullptr, true, false);
+  log(thread, "%s", (const char*)lm);
 }
 
 void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
@@ -52,24 +50,26 @@ void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
 }
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
-  stringStream ss(buf_size);
+  StringLogMessage lm;
+  stringStream sstr(lm.buffer(), lm.size());
   if (task == nullptr) {
-    ss.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
+    sstr.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
   } else {
-    ss.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+    sstr.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
   }
   if (retry_message != nullptr) {
-    ss.print(" (%s)", retry_message);
+    sstr.print(" (%s)", retry_message);
   }
-  log(thread, "%s", ss.freeze());
+  log(thread, "%s", (const char*)lm);
 }
 
 void CompilationLog::log_metaspace_failure(const char* reason) {
   // Note: This method can be called from non-Java/compiler threads to
   // log the global metaspace failure that might affect profiling.
-  stringStream ss(buf_size);
-  ss.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
-  log(Thread::current(), "%s", ss.freeze());
+  StringLogMessage lm;
+  stringStream sstr(lm.buffer(), lm.size());
+  sstr.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
+  log(Thread::current(), "%s", (const char*)lm);
 }
 
 void CompilationLog::init() {


### PR DESCRIPTION
While working on AOT code load failure I noticed in hs_err file that compilation failure does not reported correctly - they have empty line instead:
```
Event: 16.473 Thread 0x00007fd2682fa3e0 7576 A 2 java.beans.PropertyEditorSupport::<init> (10 bytes)
Event: 16.473 Thread 0x00007fd2682fa3e0

Event: 16.475 Thread 0x00007fd2682fa3e0 7577 A 2 java.util.concurrent.ConcurrentLinkedDeque$AbstractItr::next (23 bytes)
Event: 16.475 Thread 0x00007fd2682fa3e0 nmethod 7577 A 0x00007fd2506d6988 code [0x00007fd2506d6a80, 0x00007fd2506d6ce8]
```
Notice that compilation request (similar to `PrintCompilation` output) and `nmethod` information are correct.

Looking on code in `compiler/compilationLog.cpp` I see that in both these two cases `StringLogMessage` instance is not used or not used directly to create output. They use `stringStream`.

Using `stringStream` in `log_*_failure` fixed the issue.

I looked on `utilities/formatBuffer.hpp` sources and can't find what could cause the issue. So I used workaround which works. Using `stringStream` in `log_*_failure` fixed the issue.

Testing: GHA and local test to see if hs_err has correct output.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384862](https://bugs.openjdk.org/browse/JDK-8384862): CompilationLog::log_failure() does not produce report message (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer) Review applies to [31e965f7](https://git.openjdk.org/jdk/pull/31191/files/31e965f781745a1751a6b4526a8692a9f89a1eab)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31191/head:pull/31191` \
`$ git checkout pull/31191`

Update a local copy of the PR: \
`$ git checkout pull/31191` \
`$ git pull https://git.openjdk.org/jdk.git pull/31191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31191`

View PR using the GUI difftool: \
`$ git pr show -t 31191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31191.diff">https://git.openjdk.org/jdk/pull/31191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31191#issuecomment-4479348459)
</details>
