### PR TITLE
8383867: File.getCanonicalPath drops backslash from UNC path with directory junctions

### DIFF
--- a/src/java.base/windows/native/libjava/canonicalize_md.c
+++ b/src/java.base/windows/native/libjava/canonicalize_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,10 +181,12 @@ WCHAR* getFinalPath(WCHAR* path, WCHAR* finalPath, DWORD size)
                 int isUnc = (finalPath[4] == L'U' &&
                              finalPath[5] == L'N' &&
                              finalPath[6] == L'C');
+                // keep leading double backslashes in case of UNC
+                const int startIdx = (isUnc) ? 1 : 0;
                 int prefixLen = (isUnc) ? 7 : 4;
                 // the amount to copy includes terminator
                 int amountToCopy = len - prefixLen + 1;
-                wmemmove(finalPath, finalPath + prefixLen, amountToCopy);
+                wmemmove(finalPath + startIdx, finalPath + prefixLen, amountToCopy);
             }
 
             return finalPath;

--- a/test/jdk/java/io/File/GetCanonicalPath.java
+++ b/test/jdk/java/io/File/GetCanonicalPath.java
@@ -150,13 +150,13 @@ public class GetCanonicalPath {
             "\\\\localhost\\" + cwd.charAt(0) + "$" + cwd.substring(2);
         String junctionName = "tmpDir";
         try {
-            Process p = rt.exec(new String[] {"net", "use", drive + ":", share});
-            assertEquals(0, p.waitFor());
-
             // create directory junction
             Path tmpDir = Files.createTempDirectory(junctionName);
             String tmpDirLink = cwd + "\\" + junctionName;
-            p = rt.exec(new String[] {"cmd", "/c", "mklink", "/J", tmpDirLink, tmpDir.toString()});
+            Process pmklink = rt.exec(new String[] {"cmd", "/c", "mklink", "/J", tmpDirLink, tmpDir.toString()});
+            assertEquals(0, pmklink.waitFor());
+
+            Process p = rt.exec(new String[] {"net", "use", drive + ":", share});
             assertEquals(0, p.waitFor());
         } catch (InterruptedException x) {
             fail(x);

--- a/test/jdk/java/io/File/GetCanonicalPath.java
+++ b/test/jdk/java/io/File/GetCanonicalPath.java
@@ -174,7 +174,7 @@ public class GetCanonicalPath {
                 assertEquals(drive + ":\\" + filename, canonicalPath);
                 assertEquals(text, Files.readString(Path.of(canonicalPath)));
             }
-            // use directory junction
+            // use reparse point (directory junction)
             {
                 final String filename = junctionName + "\\file.txt";
                 final String text = "This is some text";

--- a/test/jdk/java/io/File/GetCanonicalPath.java
+++ b/test/jdk/java/io/File/GetCanonicalPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4899022 8003887 8355342
+ * @bug 4899022 8003887 8355342 8383867
  * @summary Look for erroneous representation of drive letter
  * @run junit GetCanonicalPath
  */
@@ -148,8 +148,15 @@ public class GetCanonicalPath {
         Runtime rt = Runtime.getRuntime();
         String share =
             "\\\\localhost\\" + cwd.charAt(0) + "$" + cwd.substring(2);
+        String junctionName = "tmpDir";
         try {
             Process p = rt.exec(new String[] {"net", "use", drive + ":", share});
+            assertEquals(0, p.waitFor());
+
+            // create directory junction
+            Path tmpDir = Files.createTempDirectory(junctionName);
+            String tmpDirLink = cwd + "\\" + junctionName;
+            p = rt.exec(new String[] {"cmd", "/c", "mklink", "/J", tmpDirLink, tmpDir.toString()});
             assertEquals(0, p.waitFor());
         } catch (InterruptedException x) {
             fail(x);
@@ -157,13 +164,26 @@ public class GetCanonicalPath {
 
         // check that the canonical path name and its content are as expected
         try {
-            final String filename = "file.txt";
-            final String text = "This is some text";
-            Files.writeString(Path.of(share, filename), text);
-            File file = new File(drive + ":\\" + filename);
-            String canonicalPath = file.getCanonicalPath();
-            assertEquals(drive + ":\\" + filename, canonicalPath);
-            assertEquals(text, Files.readString(Path.of(canonicalPath)));
+            // use drive letter
+            {
+                final String filename = "file.txt";
+                final String text = "This is some text";
+                Files.writeString(Path.of(share, filename), text);
+                File file = new File(drive + ":\\" + filename);
+                String canonicalPath = file.getCanonicalPath();
+                assertEquals(drive + ":\\" + filename, canonicalPath);
+                assertEquals(text, Files.readString(Path.of(canonicalPath)));
+            }
+            // use directory junction
+            {
+                final String filename = junctionName + "\\file.txt";
+                final String text = "This is some text";
+                Files.writeString(Path.of(share, filename), text);
+                File file = new File(drive + ":\\" + filename);
+                String canonicalPath = file.getCanonicalPath();
+                assertTrue(canonicalPath.startsWith("\\\\localhost\\"));
+                assertEquals(text, Files.readString(Path.of(canonicalPath)));
+            }
         } finally {
             try {
                 Process p = rt.exec(new String[] {"net", "use", drive + ":", "/Delete"});


### PR DESCRIPTION
This change fixes "JDK-8383867: File.getCanonicalPath drops backslash from UNC path with directory junctions" when running Java in Windows from a network shared folder, like "\\MyNetworkShare\jdk\bin\java.exe", JVM drops a backslash when creating a canonical path if the path goes through a reparse point - it turns to "\MyNetworkShare\jdk\bin\java.exe" (the only backslash in the front).

I extended `test\jdk\java\io\File\GetCanonicalPath.java` test with the reparse point scenario. The test fails before the fix, and passes with the fix.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8383867](https://bugs.openjdk.org/browse/JDK-8383867): File.getCanonicalPath drops backslash from UNC path with directory junctions (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31192/head:pull/31192` \
`$ git checkout pull/31192`

Update a local copy of the PR: \
`$ git checkout pull/31192` \
`$ git pull https://git.openjdk.org/jdk.git pull/31192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31192`

View PR using the GUI difftool: \
`$ git pr show -t 31192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31192.diff">https://git.openjdk.org/jdk/pull/31192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31192#issuecomment-4479375494)
</details>
