### PR TITLE
8384883: Shenandoah: de-virtualize gc worker calls to evacuate_object

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
@@ -41,7 +41,7 @@ public:
   void do_object(oop p) override {
     shenandoah_assert_marked(nullptr, p);
     if (!p->is_forwarded()) {
-      _heap->evacuate_object(p, _thread);
+      _heap->evacuate_or_promote_object(p, _thread);
     }
   }
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -198,6 +198,11 @@ void ShenandoahGenerationalHeap::promote_regions_in_place(ShenandoahGeneration* 
 }
 
 oop ShenandoahGenerationalHeap::evacuate_object(oop p, Thread* thread) {
+  return evacuate_or_promote_object(p, thread);
+}
+
+oop ShenandoahGenerationalHeap::evacuate_or_promote_object(oop p, Thread* thread) {
+  assert(mode()->is_generational(), "This method is only for the generational mode");
   assert(thread == Thread::current(), "Expected thread parameter to be current thread.");
 
   ShenandoahHeapRegion* from_region = heap_region_containing(p);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -89,7 +89,13 @@ public:
   // Resets ages for regions that have been used for allocations.
   void update_region_ages(ShenandoahMarkingContext* ctx);
 
+  // Evacuates or promotes object src. Returns the evacuated object, either evacuated
+  // by this thread, or by some other thread. On allocation failure, installs the
+  // self-forwarded bit on src, flags src's region, and returns src.
   oop evacuate_object(oop p, Thread* thread) override;
+
+  // A non-virtual implementation for callers that know what kind of heap they have
+  oop evacuate_or_promote_object(oop src, Thread* thread);
 
   template<ShenandoahAffiliation FROM_REGION, ShenandoahAffiliation TO_REGION>
   oop try_evacuate_object(oop p, Thread* thread, uint from_region_age);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1126,7 +1126,7 @@ public:
   void do_object(oop p) {
     shenandoah_assert_marked(nullptr, p);
     if (!p->is_forwarded()) {
-      _heap->evacuate_object(p, _thread);
+      _heap->evacuate_object_nongen(p, _thread);
     }
   }
 };
@@ -1299,6 +1299,11 @@ void ShenandoahHeap::concurrent_final_roots(HandshakeClosure* handshake_closure)
 }
 
 oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
+  return evacuate_object_nongen(p, thread);
+}
+
+oop ShenandoahHeap::evacuate_object_nongen(oop p, Thread* thread) {
+  assert(!mode()->is_generational(), "This method should not be used in generational mode");
   assert(thread == Thread::current(), "Expected thread parameter to be current thread.");
 
   ShenandoahHeapRegion* r = heap_region_containing(p);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -808,10 +808,13 @@ public:
   // Checks if location is in the collection set. Can be interior pointer, not the oop itself.
   inline bool in_collection_set_loc(void* loc) const;
 
-  // Evacuates or promotes object src. Returns the evacuated object, either evacuated
+  // Evacuates object src. Returns the evacuated object, either evacuated
   // by this thread, or by some other thread. On allocation failure, installs the
   // self-forwarded bit on src, flags src's region, and returns src.
   virtual oop evacuate_object(oop src, Thread* thread);
+
+  // A non-virtual implementation for callers that no what kind of heap they have
+  oop evacuate_object_nongen(oop src, Thread* thread);
 
   // Parallel scan of flagged cset regions to clear self-forwarded bits on live
   // objects. Must be called at a safepoint; intended for the degenerated and

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -813,7 +813,7 @@ public:
   // self-forwarded bit on src, flags src's region, and returns src.
   virtual oop evacuate_object(oop src, Thread* thread);
 
-  // A non-virtual implementation for callers that no what kind of heap they have
+  // A non-virtual implementation for callers that know what kind of heap they have
   oop evacuate_object_nongen(oop src, Thread* thread);
 
   // Parallel scan of flagged cset regions to clear self-forwarded bits on live


### PR DESCRIPTION
For historical reasons, we made `evacuate_object` a virtual function when we extracted out the generational variant of ShenandoahHeap. This call itself still needs to be virtual, but we can introduce a non-virtual evac function for the gc-workers to use (the workers will make the vast majority of these calls). Internal testing shows no significant performance changes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384883](https://bugs.openjdk.org/browse/JDK-8384883): Shenandoah: de-virtualize gc worker calls to evacuate_object (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31193/head:pull/31193` \
`$ git checkout pull/31193`

Update a local copy of the PR: \
`$ git checkout pull/31193` \
`$ git pull https://git.openjdk.org/jdk.git pull/31193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31193`

View PR using the GUI difftool: \
`$ git pr show -t 31193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31193.diff">https://git.openjdk.org/jdk/pull/31193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31193#issuecomment-4479824478)
</details>
