### PR TITLE
8378699: runtime/ClassUnload/KeepAliveSoftReference.java Test failed: true != false

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,15 +60,16 @@ public class KeepAliveSoftReference {
         ClassUnloadCommon.failIf(isAlive != shouldBeAlive, "" + isAlive + " != " + shouldBeAlive);
     }
 
+    // This version of triggerUnloading only calls a System.gc() which clears weak references, but
+    // may not unload the class yet.
     ClassUnloadCommon.triggerUnloading();
-
     {
         boolean isAlive = wb.isClassAlive(className);
         System.out.println("testSoftReference (2) alive: " + isAlive);
         boolean cleared = (sr.get() == null);
-        boolean shouldBeAlive = !cleared;
-        ClassUnloadCommon.failIf(isAlive != shouldBeAlive, "" + isAlive + " != " + shouldBeAlive);
+        ClassUnloadCommon.failIf(!cleared, "should be cleared " + cleared);
     }
+
     sr.clear();
     ClassUnloadCommon.triggerUnloading(List.of(className));
     {

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
@@ -60,7 +60,7 @@ public class KeepAliveSoftReference {
         ClassUnloadCommon.failIf(isAlive != shouldBeAlive, "" + isAlive + " != " + shouldBeAlive);
     }
 
-    // This version of triggerUnloading only calls a System.gc() which clears weak references, but
+    // This version of triggerUnloading calls a WhiteBox Full GC, which clears soft references, but
     // may not unload the class yet.
     ClassUnloadCommon.triggerUnloading();
     {

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
@@ -55,7 +55,7 @@ public class KeepAliveSoftReference {
     {
         boolean isAlive = wb.isClassAlive(className);
         System.out.println("testSoftReference (1) alive: " + isAlive);
-        boolean cleared = (sr.get() == null);
+        boolean cleared = sr.refersTo(null);
         boolean shouldBeAlive = !cleared;
         ClassUnloadCommon.failIf(isAlive != shouldBeAlive, "" + isAlive + " != " + shouldBeAlive);
     }
@@ -66,7 +66,7 @@ public class KeepAliveSoftReference {
     {
         boolean isAlive = wb.isClassAlive(className);
         System.out.println("testSoftReference (2) alive: " + isAlive);
-        boolean cleared = (sr.get() == null);
+        boolean cleared = sr.refersTo(null);
         ClassUnloadCommon.failIf(!cleared, "should be cleared " + cleared);
     }
 
@@ -75,7 +75,7 @@ public class KeepAliveSoftReference {
     {
         boolean isAlive = wb.isClassAlive(className);
         System.out.println("testSoftReference (3) alive: " + isAlive);
-        boolean cleared = (sr.get() == null);
+        boolean cleared = sr.refersTo(null);
         boolean shouldBeAlive = !cleared;
         ClassUnloadCommon.failIf(isAlive != shouldBeAlive, "" + isAlive + " != " + shouldBeAlive);
     }


### PR DESCRIPTION
Please review this trivial change to not check that the class is unloaded for triggerUnloading() that doesn't wait for the class to be unloaded.  Keep the test that the weak reference was cleared in this case.
Tested with tier1 on Oracle platforms.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8378699](https://bugs.openjdk.org/browse/JDK-8378699): runtime/ClassUnload/KeepAliveSoftReference.java Test failed: true != false (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer) Review applies to [c2bfd9ae](https://git.openjdk.org/jdk/pull/31194/files/c2bfd9aec10918437e28261dfa144875a6a5b2b0)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31194/head:pull/31194` \
`$ git checkout pull/31194`

Update a local copy of the PR: \
`$ git checkout pull/31194` \
`$ git pull https://git.openjdk.org/jdk.git pull/31194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31194`

View PR using the GUI difftool: \
`$ git pr show -t 31194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31194.diff">https://git.openjdk.org/jdk/pull/31194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31194#issuecomment-4482117388)
</details>
