### PR TITLE
8384514: Shenandoah: gc/shenandoah/mxbeans/TestCycleEndMessage.java intermittent fails

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestCycleEndMessage.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestCycleEndMessage.java
@@ -43,10 +43,16 @@ import javax.management.openmbean.CompositeData;
 
 import com.sun.management.GarbageCollectionNotificationInfo;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 public class TestCycleEndMessage {
 
     public static void main(String[] args) throws Exception {
         final AtomicBoolean foundGenerationInCycle = new AtomicBoolean(false);
+        final AtomicBoolean oneCycleCompleted = new AtomicBoolean(false);
+
+        final Object lock = new Object();
 
         NotificationListener listener = new NotificationListener() {
             @Override
@@ -59,9 +65,15 @@ public class TestCycleEndMessage {
 
                     System.out.println("Received: " + name + " / " + action);
 
-                    if (name.equals("Shenandoah Cycles") &&
-                        (action.contains("Global") || action.contains("Young") || action.contains("Old"))) {
-                        foundGenerationInCycle.set(true);
+                    if (name.equals("Shenandoah Cycles")) {
+                        oneCycleCompleted.set(true);
+
+                        if ((action.contains("Global") || action.contains("Young") || action.contains("Old"))) {
+                            foundGenerationInCycle.set(true);
+                        }
+                        synchronized (lock) {
+                            lock.notifyAll();
+                        }
                     }
                 }
             }
@@ -71,8 +83,21 @@ public class TestCycleEndMessage {
             ((NotificationEmitter) bean).addNotificationListener(listener, null, null);
         }
 
-        System.gc();
-        Thread.sleep(2000);
+        synchronized (lock) {
+            System.gc();
+            long deadline = System.nanoTime() + SECONDS.toNanos(5);
+            while (!oneCycleCompleted.get()) {
+                long remaining = NANOSECONDS.toMillis(deadline - System.nanoTime());
+                if (remaining <= 0) {
+                    break;
+                }
+                lock.wait(remaining);
+            }
+        }
+
+        if (!oneCycleCompleted.get()) {
+            throw new IllegalStateException("Test did not complete at least one GC cycle");
+        }
 
         if (!foundGenerationInCycle.get()) {
             throw new IllegalStateException("Expected to find generation name (Global/Young/Old) in Shenandoah Cycles action message");


### PR DESCRIPTION
This test uses a naked 2-second sleep to wait for gc events. It is possible for it wake up before it receives the expected event, which fails the test. The change here has it use synchronization and a timed wait (with an increased timeout of 5 seconds).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384514](https://bugs.openjdk.org/browse/JDK-8384514): Shenandoah: gc/shenandoah/mxbeans/TestCycleEndMessage.java intermittent fails (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31195/head:pull/31195` \
`$ git checkout pull/31195`

Update a local copy of the PR: \
`$ git checkout pull/31195` \
`$ git pull https://git.openjdk.org/jdk.git pull/31195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31195`

View PR using the GUI difftool: \
`$ git pr show -t 31195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31195.diff">https://git.openjdk.org/jdk/pull/31195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31195#issuecomment-4483107476)
</details>
