### PR TITLE
8384941: AArch64: Use stlr for standalone release stores

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1581,7 +1581,67 @@ bool unnecessary_release(const Node *n)
 
   MemBarNode *barrier = n->as_MemBar();
   if (!barrier->leading()) {
-    return false;
+    // A non-leading MemBarRelease covers two cases:
+    //   (1) Op_MemBarRelease for putOrdered* / setRelease - created standalone
+    //       by C2AccessFence (no trailing pair) and immediately followed by
+    //       a Store with MO=release.  needs_releasing_store() will upgrade
+    //       that store to stlr, so this leading dmb ish is redundant.
+    //   (2) Op_MemBarRelease emitted at the end of a constructor (final-field
+    //       publication, parse1.cpp / stringopts.cpp).  Its preceding stores
+    //       are MO=unordered plain str, so the dmb ish MUST stay.
+    // Discriminate by walking the memory projection: case (1) drives a
+    // release-paired-less Store; case (2) does not.
+    if (!UseStlrForStandaloneRelease || !barrier->standalone()) {
+      return false;
+    }
+    Node* mem_proj = barrier->proj_out_or_null(TypeFunc::Memory);
+    if (mem_proj == nullptr) return false;
+
+    // Forward DU walk along the memory chain looking for a release-MO
+    // Store with no trailing membar (i.e. setRelease / putOrdered).  We
+    // pass transparently through:
+    //   - MergeMem       (per-alias splitter)
+    //   - MemBarCPUOrder (inserted right after MemBarRelease for Unsafe
+    //                    accesses; carries no aarch64 ordering of its own)
+    // Unique_Node_List dedups, so cycles via Phi / MergeMem terminate
+    // naturally.  A small unique-node cap keeps the predicate O(1) on
+    // pathological graphs; the bound is generous because each kept hop
+    // is either a MergeMem, a CPUOrder Proj, or a Store leaf, and the
+    // C2AccessFence pattern we target is at most ~3 hops deep.
+    ResourceMark rm;
+    Unique_Node_List wq;
+    wq.push(mem_proj);
+    const uint kNodeLimit = 32;
+    bool found = false;
+    uint walked = 0;
+    for (uint i = 0; i < wq.size(); i++) {
+      if (i >= kNodeLimit) { walked = wq.size(); break; }
+      Node* cur = wq.at(i);
+      walked = i + 1;
+      for (DUIterator_Fast jmax, j = cur->fast_outs(jmax); j < jmax; j++) {
+        Node* u = cur->fast_out(j);
+        if (u->is_Store() && u->as_Store()->is_release() &&
+            u->as_Store()->trailing_membar() == nullptr) {
+          found = true; goto done;
+        }
+        if (u->is_MergeMem()) {
+          wq.push(u);
+        } else if (u->Opcode() == Op_MemBarCPUOrder) {
+          Node* p = u->as_MemBar()->proj_out_or_null(TypeFunc::Memory);
+          if (p != nullptr) wq.push(p);
+        }
+        // Other users (Phi, other MemBars, Loads, LoadStore, ...) are
+        // not on the C2AccessFence release-store path - ignore.
+      }
+    }
+done:
+#ifndef PRODUCT
+    if (PrintStandaloneReleaseElisionStats) {
+      tty->print_cr("[stlr-release-elide] walked=%u nodes, %s",
+                    walked, found ? "elided" : "kept");
+    }
+#endif
+    return found;
   } else {
     Node* trailing = barrier->trailing_membar();
     MemBarNode* trailing_mb = trailing->as_MemBar();
@@ -1627,7 +1687,7 @@ bool needs_releasing_store(const Node *n)
 {
   // assert n->is_Store();
   StoreNode *st = n->as_Store();
-  return st->trailing_membar() != nullptr;
+  return st->trailing_membar() != nullptr || (UseStlrForStandaloneRelease && st->is_release());
 }
 
 // predicate controlling translation of CAS

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -135,6 +135,15 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Enable workaround for Neoverse N1 erratum 1542419")          \
   product(bool, UseSingleICacheInvalidation, false, DIAGNOSTIC,         \
           "Defer multiple ICache invalidation to single invalidation")  \
+  product(bool, UseStlrForStandaloneRelease, false,                     \
+          "Emit stlr (and elide the leading dmb ish) for release "      \
+          "stores that are not paired with a trailing membar - i.e. "   \
+          "setRelease / putXRelease / putOrdered*, but not volatile "   \
+          "stores (which are already handled).")                        \
+  develop(bool, PrintStandaloneReleaseElisionStats, false,              \
+          "Log unnecessary_release walker outcomes (hit/miss) when "    \
+          "UseStlrForStandaloneRelease is on. Develop-only, intended "  \
+          "for measuring walker coverage on real workloads.")           \
 
 // end of ARCH_FLAGS
 

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneRelease.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneRelease.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384941
+ * @summary Verify aarch64 release stores (sun.misc.Unsafe.putOrderedX /
+ *          jdk.internal.misc.Unsafe.putXRelease / VarHandle.setRelease) use
+ *          stlr<x> when UseStlrForStandaloneRelease is on, and fall back to plain
+ *          str<x> + dmb when off. All three APIs lower to the same C2 path
+ *          (C2AccessFence with is_release && !is_volatile) — sun.misc's
+ *          putOrderedX is force-inlined into the internal putXRelease, so we
+ *          exercise each surface to keep the patch's intent explicit.
+ * @library /test/lib
+ *
+ * @modules java.base/jdk.internal.misc
+ *          jdk.unsupported
+ *
+ * @requires vm.flagless
+ * @requires os.arch == "aarch64" & vm.debug == true &
+ *           vm.flavor == "server" & !vm.graal.enabled
+ *
+ * @run driver compiler.c2.aarch64.TestStlrForStandaloneRelease
+ */
+
+package compiler.c2.aarch64;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestStlrForStandaloneRelease {
+
+    // ---- Payload exercised inside the spawned JVM ----
+
+    @SuppressWarnings({"deprecation", "removal"})
+    public static class Payload {
+        private static final Unsafe U = Unsafe.getUnsafe();
+        // The deprecated public Unsafe — the literal "putOrdered*" API named in
+        // the patch's commit message. It @ForceInlines into U.putXRelease, so at
+        // C2 it lowers to the same Op_MemBarRelease + Store(release) idiom; we
+        // still test it so future inliner regressions can't quietly skip the API.
+        private static final sun.misc.Unsafe SUN_U;
+        static {
+            try {
+                java.lang.reflect.Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                SUN_U = (sun.misc.Unsafe) f.get(null);
+            } catch (Throwable t) {
+                throw new ExceptionInInitializerError(t);
+            }
+        }
+
+        public int    fInt;
+        public long   fLong;
+        public Object fRef;
+
+        // Use a single-element array so the array store rule is reached.
+        public static final Object[] refArr = new Object[1];
+        public static final int[]    intArr = new int[1];
+
+        // Volatile field for testing setRelease that follows a volatile load —
+        // the volatile load injects a trailing MemBarAcquire upstream of the
+        // MemBarRelease, exercising the walker's memory-chain navigation.
+        public static volatile int volInt = 0;
+
+        static final VarHandle VH_INT;
+        static final VarHandle VH_LONG;
+        static final VarHandle VH_REF;
+        static final VarHandle VH_VOL_INT;
+        static final VarHandle VH_INT_ARR =
+                MethodHandles.arrayElementVarHandle(int[].class);
+        static final VarHandle VH_REF_ARR =
+                MethodHandles.arrayElementVarHandle(Object[].class);
+
+        static final long OFF_INT;
+        static final long OFF_LONG;
+        static final long OFF_REF;
+
+        static {
+            try {
+                MethodHandles.Lookup L = MethodHandles.lookup();
+                VH_INT     = L.findVarHandle(Payload.class, "fInt",  int.class);
+                VH_LONG    = L.findVarHandle(Payload.class, "fLong", long.class);
+                VH_REF     = L.findVarHandle(Payload.class, "fRef",  Object.class);
+                VH_VOL_INT = L.findStaticVarHandle(Payload.class, "volInt", int.class);
+                OFF_INT  = U.objectFieldOffset(Payload.class.getDeclaredField("fInt"));
+                OFF_LONG = U.objectFieldOffset(Payload.class.getDeclaredField("fLong"));
+                OFF_REF  = U.objectFieldOffset(Payload.class.getDeclaredField("fRef"));
+            } catch (Throwable t) {
+                throw new ExceptionInInitializerError(t);
+            }
+        }
+
+        // setRelease via VarHandle
+        public static void testVhIntRelease(Payload p, int v)    { VH_INT.setRelease(p, v); }
+        public static void testVhLongRelease(Payload p, long v)  { VH_LONG.setRelease(p, v); }
+        public static void testVhRefRelease(Payload p, Object v) { VH_REF.setRelease(p, v); }
+
+        // Array element setRelease
+        public static void testVhIntArrRelease(int v)     { VH_INT_ARR.setRelease(intArr, 0, v); }
+        public static void testVhRefArrRelease(Object v)  { VH_REF_ARR.setRelease(refArr, 0, v); }
+
+        // jdk.internal.misc.Unsafe.put*Release
+        public static void testUnsafeIntRelease(Payload p, int v)    { U.putIntRelease(p, OFF_INT, v); }
+        public static void testUnsafeLongRelease(Payload p, long v)  { U.putLongRelease(p, OFF_LONG, v); }
+        public static void testUnsafeRefRelease(Payload p, Object v) { U.putReferenceRelease(p, OFF_REF, v); }
+
+        // sun.misc.Unsafe.putOrdered* — the legacy API the patch's commit
+        // message references. @ForceInlines into putXRelease above.
+        public static void testPutOrderedInt(Payload p, int v)       { SUN_U.putOrderedInt(p, OFF_INT, v); }
+        public static void testPutOrderedLong(Payload p, long v)     { SUN_U.putOrderedLong(p, OFF_LONG, v); }
+        public static void testPutOrderedObject(Payload p, Object v) { SUN_U.putOrderedObject(p, OFF_REF, v); }
+
+        // ---- Variant patterns: stress the walker's IR-shape assumptions ----
+        // Each variant places setRelease in a different surrounding IR context
+        // that has been known to perturb memory chains (Phi merges, loop
+        // unrolling, intervening barriers, fresh allocations, ...). The walker
+        // is expected to fire on all of these. If it misses, the codegen falls
+        // back to "dmb ish + stlr" (no miscompile, but optimization lost).
+
+        // (V1) setRelease in conditional branch — control flow split. Each
+        // branch has its own MemBarRelease + Store; no Phi sits between them
+        // inside a branch.
+        public static void testInBranch(Payload p, int v, boolean cond) {
+            if (cond) {
+                VH_INT.setRelease(p, v);
+            } else {
+                VH_INT.setRelease(p, -v);
+            }
+        }
+
+        // (V2) setRelease inside an inner loop — exercises C2 loop unrolling
+        // and peeling around the release store.
+        public static void testInLoop(Payload p, int v) {
+            for (int i = 0; i < 4; i++) {
+                VH_INT.setRelease(p, v + i);
+            }
+        }
+
+        // (V3) Two consecutive setReleases — two MemBarRelease nodes adjacent
+        // in memory order; each walker call must find its OWN store, not the
+        // other one.
+        public static void testConsecutiveSameField(Payload p, int a, int b) {
+            VH_INT.setRelease(p, a);
+            VH_INT.setRelease(p, b);
+        }
+
+        // (V4) Mixed types in sequence — three setReleases of different MO sizes.
+        public static void testInterleavedTypes(Payload p, int a, long b, Object c) {
+            VH_INT.setRelease(p, a);
+            VH_LONG.setRelease(p, b);
+            VH_REF.setRelease(p, c);
+        }
+
+        // (V5) setRelease after a volatile LOAD — volatile read inserts a
+        // trailing MemBarAcquire BEFORE the setRelease's MemBarRelease.
+        // Walker should ignore the upstream acquire (it walks downstream only).
+        public static void testAfterVolatileLoad(Payload p, int v) {
+            int x = (int) VH_VOL_INT.getVolatile();
+            VH_INT.setRelease(p, v + x);
+        }
+
+        // (V6) setRelease on a fresh allocation — publishing a newly-built
+        // object. Allocation + Initialize + ctor stores precede the release;
+        // these introduce MemBarStoreStore / Initialize nodes that the walker
+        // must navigate AROUND (they're upstream, not downstream).
+        public static Payload sink;
+        public static void testAfterAlloc(int v) {
+            Payload np = new Payload();
+            VH_INT.setRelease(np, v);
+            sink = np;
+        }
+
+        // (V7) Compute-heavy intermediate code — make sure ordinary integer
+        // arithmetic between setReleases doesn't break the walker.
+        public static void testWithIntermediateCompute(Payload p, int v) {
+            int x = (v * 31) ^ 0x12345;
+            int y = Integer.rotateLeft(x, 7);
+            VH_INT.setRelease(p, y);
+        }
+
+        // (V8) setRelease inside a try block — the implicit exception edges
+        // create extra control flow around the membar. C2 typically leaves
+        // the release path on the common (non-exceptional) basic block.
+        public static void testInTryCatch(Payload p, int v) {
+            try {
+                VH_INT.setRelease(p, v);
+            } catch (Throwable t) {
+                // Unreachable in normal execution.
+                throw new AssertionError(t);
+            }
+        }
+
+        // (V9) Critical correctness witness — a constructor body containing
+        // BOTH a final-field store (plain unordered) AND a setRelease on a
+        // regular field. With -UseStoreStoreForCtor the ctor-exit barrier
+        // is a MemBarRelease, so the walker is exposed to TWO standalone
+        // MemBarRelease nodes in the same method: the ctor-exit one (must
+        // be kept — its preceding stores include the FINAL field) and the
+        // setRelease's leading one (must be elided). The discriminator is
+        // direction: the ctor exit's memory projection points downstream
+        // of the body, where no release Store lives; the setRelease's
+        // points at the release Store immediately. This case proves the
+        // walker's directional discrimination is correct.
+        public static final class Pub {
+            final int finalField;
+            int regField;
+            static final VarHandle VH_REG;
+            static {
+                try {
+                    VH_REG = MethodHandles.lookup().findVarHandle(Pub.class, "regField", int.class);
+                } catch (ReflectiveOperationException e) {
+                    throw new ExceptionInInitializerError(e);
+                }
+            }
+            public Pub(int x, int y) {
+                this.finalField = x;          // plain unordered store of final
+                VH_REG.setRelease(this, y);   // standalone release store in same ctor
+            }                                  // ctor-exit MemBar emitted here
+        }
+        public static Pub pubSink;
+        public static void testCtorWithSetRelease(int v) {
+            pubSink = new Pub(v, v + 1);
+        }
+
+        public static void run() {
+            Payload p = new Payload();
+            for (int i = 0; i < 200_000; i++) {
+                // Baseline patterns
+                testVhIntRelease(p, i);
+                testVhLongRelease(p, (long) i);
+                testVhRefRelease(p, Integer.valueOf(i));
+                testVhIntArrRelease(i);
+                testVhRefArrRelease(Integer.valueOf(i));
+                testUnsafeIntRelease(p, i);
+                testUnsafeLongRelease(p, (long) i);
+                testUnsafeRefRelease(p, Integer.valueOf(i));
+                testPutOrderedInt(p, i);
+                testPutOrderedLong(p, (long) i);
+                testPutOrderedObject(p, Integer.valueOf(i));
+                // Variant patterns (V1–V8)
+                testInBranch(p, i, (i & 1) == 0);
+                testInLoop(p, i);
+                testConsecutiveSameField(p, i, i + 1);
+                testInterleavedTypes(p, i, (long) i, Integer.valueOf(i));
+                testAfterVolatileLoad(p, i);
+                testAfterAlloc(i);
+                testWithIntermediateCompute(p, i);
+                testInTryCatch(p, i);
+                testCtorWithSetRelease(i);
+            }
+            // Functional sanity — the patched codegen must preserve semantics.
+            if (p.fInt == 0 || p.fLong != 199_999L || !(p.fRef instanceof Integer)) {
+                throw new RuntimeException("bad payload result: fInt=" + p.fInt
+                        + " fLong=" + p.fLong + " fRef=" + p.fRef);
+            }
+            if (sink == null) {
+                throw new RuntimeException("testAfterAlloc never published");
+            }
+        }
+    }
+
+    // ---- Driver ----
+
+    // For each test method we list expected codegen: minimum number of stlr
+    // (when flag on) and matching str (when flag off) occurrences within the
+    // method body. Method-body window is delimited by the next "{method}"
+    // header in PrintOptoAssembly output.
+    private record Spec(String methodSuffix, String stlrRegex, String strRegex, int minCount) {
+        Spec(String m, String s, String t) { this(m, s, t, 1); }
+    }
+
+    // Width-agnostic stlr/str regex used by variant tests that mix sizes.
+    private static final String ANY_STLR = "\\bstlr[wbh]?\\b";
+    private static final String ANY_STR  = "\\bstr[wbh]?\\b";
+
+    // The "stlr" regex captures the expected releasing store instruction.
+    // The "str" regex captures the legacy plain store the patch is replacing.
+    //
+    // PrintOptoAssembly emits operand-type annotations after a tab. Per
+    // src/hotspot/cpu/aarch64/aarch64.ad:
+    //   int  field:  "stlrw  ... # int"
+    //   long field:  "stlr   ... # int"   (note: also "# int", differs by mnemonic width)
+    //   ref  field:  "stlrw  ... # compressed ptr"   (CompressedOops on, default)
+    //                "stlr   ... # ptr"              (CompressedOops off)
+    // We anchor the ref regex on " ptr" with a leading space, matching both
+    // "compressed ptr" and "ptr" without being confused by the int regex.
+    private static final List<Spec> SPECS = List.of(
+            // ---- Baseline patterns (one release store, type-specific regex) ----
+            new Spec("testVhIntRelease",     "\\bstlrw\\b\\s.*#\\s*int\\b",  "\\bstrw\\b\\s.*#\\s*int\\b"),
+            new Spec("testVhLongRelease",    "\\bstlr\\b\\s.*#\\s*int\\b",    "\\bstr\\b\\s.*#\\s*int\\b"),
+            new Spec("testVhRefRelease",     "\\bstlrw?\\b.* ptr\\b",          "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testVhIntArrRelease",  "\\bstlrw\\b\\s.*#\\s*int\\b",   "\\bstrw\\b\\s.*#\\s*int\\b"),
+            new Spec("testVhRefArrRelease",  "\\bstlrw?\\b.* ptr\\b",          "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testUnsafeIntRelease", "\\bstlrw\\b\\s.*#\\s*int\\b",   "\\bstrw\\b\\s.*#\\s*int\\b"),
+            new Spec("testUnsafeLongRelease","\\bstlr\\b\\s.*#\\s*int\\b",    "\\bstr\\b\\s.*#\\s*int\\b"),
+            new Spec("testUnsafeRefRelease", "\\bstlrw?\\b.* ptr\\b",          "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testPutOrderedInt",    "\\bstlrw\\b\\s.*#\\s*int\\b",   "\\bstrw\\b\\s.*#\\s*int\\b"),
+            new Spec("testPutOrderedLong",   "\\bstlr\\b\\s.*#\\s*int\\b",    "\\bstr\\b\\s.*#\\s*int\\b"),
+            new Spec("testPutOrderedObject", "\\bstlrw?\\b.* ptr\\b",          "\\bstrw?\\b.* ptr\\b"),
+
+            // ---- Variant patterns (V1–V8): walker must fire under each ----
+            // V1: both branches contain a setRelease → expect 2 stlr in the method
+            new Spec("testInBranch",                "\\bstlrw\\b",      "\\bstrw\\b", 2),
+            // V2: loop body has one setRelease per iteration; C2 may unroll → ≥1
+            new Spec("testInLoop",                  "\\bstlrw\\b",      "\\bstrw\\b", 1),
+            // V3: two consecutive setReleases on the same field → 2 stlr
+            new Spec("testConsecutiveSameField",    "\\bstlrw\\b",      "\\bstrw\\b", 2),
+            // V4: int + long + ref setReleases in sequence → 3 stlr of varying widths
+            new Spec("testInterleavedTypes",        ANY_STLR,           ANY_STR,      3),
+            // V5: volatile load (upstream acquire) then setRelease → 1 stlr
+            new Spec("testAfterVolatileLoad",       "\\bstlrw\\b",      "\\bstrw\\b", 1),
+            // V6: setRelease on a fresh allocation → 1 stlr
+            new Spec("testAfterAlloc",              "\\bstlrw\\b",      "\\bstrw\\b", 1),
+            // V7: arithmetic before setRelease → 1 stlr
+            new Spec("testWithIntermediateCompute", "\\bstlrw\\b",      "\\bstrw\\b", 1),
+            // V8: setRelease in try block → 1 stlr
+            new Spec("testInTryCatch",              "\\bstlrw\\b",      "\\bstrw\\b", 1),
+            // V9: ctor with setRelease — only the inner setRelease's leading
+            // MemBarRelease is elided; the ctor-exit barrier (whether StoreStore
+            // or MemBarRelease depending on UseStoreStoreForCtor) is preserved.
+            // We assert >= 1 stlr (the inner setRelease) and trust the codegen
+            // verification on the ctor-exit barrier to be checked separately.
+            new Spec("testCtorWithSetRelease",      "\\bstlrw\\b",      "\\bstrw\\b", 1)
+    );
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "payload".equals(args[0])) {
+            Payload.run();
+            return;
+        }
+        OutputAnalyzer on  = runJit(true);
+        OutputAnalyzer off = runJit(false);
+        check(on,  /*useStlr=*/true);
+        check(off, /*useStlr=*/false);
+    }
+
+    private static OutputAnalyzer runJit(boolean useStlr) throws Exception {
+        String compileOnly = "-XX:CompileCommand=compileonly,"
+                + "compiler.c2.aarch64.TestStlrForStandaloneRelease$Payload::test*";
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:-TieredCompilation",
+                "-XX:-BackgroundCompilation",
+                "-XX:+PrintOptoAssembly",
+                "-XX:" + (useStlr ? "+" : "-") + "UseStlrForStandaloneRelease",
+                compileOnly,
+                "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                TestStlrForStandaloneRelease.class.getName(),
+                "payload"
+        );
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldHaveExitValue(0);
+        return oa;
+    }
+
+    private static void check(OutputAnalyzer oa, boolean useStlr) {
+        List<String> lines = oa.asLines();
+        for (Spec s : SPECS) {
+            List<String> body = methodBody(lines, s.methodSuffix());
+            if (body == null) {
+                throw new RuntimeException("PrintOptoAssembly missing block for "
+                        + s.methodSuffix() + " (useStlr=" + useStlr + ")\n\n"
+                        + oa.getOutput());
+            }
+            int elidedCnt    = countRegex(body, "membar_release \\(elided\\)");
+            int fullMembarCnt = countRegex(body, "membar_release(?! \\(elided\\))");
+            int stlrCnt      = countRegex(body, s.stlrRegex());
+            int strCnt       = countRegex(body, s.strRegex());
+
+            // We deliberately don't count raw "dmb" instructions: the nmethod
+            // entry barrier emits a `dmb ishld` in every JIT'd method's
+            // prologue, and AlwaysMergeDMB further perturbs what MemBarRelease
+            // emits at the assembler layer. The membar_release elided/not-
+            // elided count from PrintOptoAssembly is the canonical signal.
+
+            if (useStlr) {
+                require(stlrCnt >= s.minCount(),
+                        "expected >= " + s.minCount() + " stlr matching " + s.stlrRegex()
+                                + " (got " + stlrCnt + ")", s, body);
+                require(elidedCnt >= s.minCount(),
+                        "expected >= " + s.minCount() + " elided membar_release (got "
+                                + elidedCnt + ")", s, body);
+                require(fullMembarCnt == 0,
+                        "expected NO non-elided membar_release (got " + fullMembarCnt + ")", s, body);
+            } else {
+                require(fullMembarCnt >= s.minCount(),
+                        "expected >= " + s.minCount() + " non-elided membar_release (got "
+                                + fullMembarCnt + ")", s, body);
+                int plainStrCnt = strCnt - stlrCnt;
+                require(plainStrCnt >= s.minCount(),
+                        "expected >= " + s.minCount() + " plain str matching " + s.strRegex()
+                                + " (got plain=" + plainStrCnt + ", stlr=" + stlrCnt + ")", s, body);
+                require(elidedCnt == 0,
+                        "expected NO elided membar_release with flag off (got " + elidedCnt + ")", s, body);
+            }
+        }
+        System.out.println("OK useStlr=" + useStlr + " — verified " + SPECS.size() + " methods.");
+    }
+
+    private static List<String> methodBody(List<String> lines, String methodSuffix) {
+        // PrintOptoAssembly prints a multi-line "{method}" header followed
+        // by " - name:              '<name>'" — leading whitespace, dash,
+        // "name:", and variable whitespace before the single-quoted name.
+        // We don't assume a specific column layout; instead we anchor on
+        // the "- name:" tag and the quoted name on the same line.
+        String quotedName = "'" + methodSuffix + "'";
+        int start = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String l = lines.get(i);
+            if (l.contains("- name:") && l.contains(quotedName)) {
+                start = i;
+                break;
+            }
+        }
+        if (start < 0) return null;
+        int end = lines.size();
+        for (int i = start + 1; i < lines.size(); i++) {
+            if (lines.get(i).contains("{method}")) { end = i; break; }
+        }
+        return lines.subList(start, end);
+    }
+
+    private static int countRegex(List<String> body, String regex) {
+        Pattern p = Pattern.compile(regex);
+        int n = 0;
+        for (String l : body) if (p.matcher(l).find()) n++;
+        return n;
+    }
+
+    private static void require(boolean cond, String msg, Spec s, List<String> body) {
+        if (cond) return;
+        StringBuilder sb = new StringBuilder();
+        sb.append(msg).append(" — method ").append(s.methodSuffix()).append('\n');
+        sb.append("--- method body ---\n");
+        for (String l : body) sb.append(l).append('\n');
+        throw new RuntimeException(sb.toString());
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneReleaseDifferential.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneReleaseDifferential.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384941
+ * @summary Functional differential test for UseStlrForStandaloneRelease.
+ *          Spawns two child JVMs running the same fuzz-generated workload —
+ *          one with -XX:+UseStlrForStandaloneRelease and one with -XX:-...
+ *          — and asserts that both produce byte-identical observable output
+ *          (a fingerprint accumulated over all release-store sites). The
+ *          optimization must NEVER change observable single-threaded program
+ *          behavior; this test backs that contract regardless of build flavor
+ *          (release build is supported because no PrintOptoAssembly is used).
+ *
+ *          Complements TestStlrForStandaloneReleaseFuzz (which verifies the
+ *          codegen but requires vm.debug). Failure of this test would indicate
+ *          a miscompile.
+ *
+ * @library /test/lib
+ *
+ * @modules java.base/jdk.internal.misc
+ *          jdk.compiler
+ *          jdk.unsupported
+ *
+ * @requires vm.flagless
+ * @requires os.arch == "aarch64" & vm.flavor == "server" & !vm.graal.enabled
+ *
+ * @run driver compiler.c2.aarch64.TestStlrForStandaloneReleaseDifferential
+ */
+
+package compiler.c2.aarch64;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestStlrForStandaloneReleaseDifferential {
+
+    private static final int N_METHODS = 30;
+    private static final int ITERATIONS_PER_METHOD = 50_000;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "payload".equals(args[0])) {
+            long seed = Long.parseLong(args[1]);
+            int n = Integer.parseInt(args[2]);
+            int iters = Integer.parseInt(args[3]);
+            runPayload(seed, n, iters);
+            return;
+        }
+        long seed = (args.length > 0) ? Long.parseLong(args[0]) : System.nanoTime();
+        System.out.println("[diff] seed=" + seed + " methods=" + N_METHODS
+                           + " iters=" + ITERATIONS_PER_METHOD);
+
+        String onFp  = runWorker(seed, true);
+        String offFp = runWorker(seed, false);
+        if (!onFp.equals(offFp)) {
+            throw new RuntimeException("[diff] MISMATCH: +flag=" + onFp + " -flag=" + offFp
+                    + " (seed=" + seed + ")");
+        }
+        System.out.println("[diff] OK: fingerprints match (" + onFp + ")");
+    }
+
+    private static String runWorker(long seed, boolean useStlr) throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-XX:" + (useStlr ? "+" : "-") + "UseStlrForStandaloneRelease",
+                "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                TestStlrForStandaloneReleaseDifferential.class.getName(),
+                "payload",
+                Long.toString(seed),
+                Integer.toString(N_METHODS),
+                Integer.toString(ITERATIONS_PER_METHOD)
+        );
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldHaveExitValue(0);
+        // The worker prints exactly one line of the form "FP=<hex>" at end.
+        for (String l : oa.asLines()) {
+            if (l.startsWith("FP=")) return l.substring(3);
+        }
+        throw new RuntimeException("[diff] worker output had no FP= line, useStlr="
+                + useStlr + "\n" + oa.getOutput());
+    }
+
+    // ---- Worker ----
+
+    private record Slot(int storeType, int ctx, int valueSalt) {}
+
+    private static List<Slot> plan(long seed, int n) {
+        Random rng = new Random(seed);
+        List<Slot> slots = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            int storeType = rng.nextInt(3);  // 0=int, 1=long, 2=ref-as-int-tag
+            int ctx       = rng.nextInt(5);   // 0=bare 1=branch 2=loop 3=try 4=compute
+            int salt      = rng.nextInt();
+            slots.add(new Slot(storeType, ctx, salt));
+        }
+        return slots;
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    private static void runPayload(long seed, int n, int iters) throws Exception {
+        List<Slot> plan = plan(seed, n);
+        String src = generateSource(plan);
+        byte[] bytes = InMemoryJavaCompiler.compile("DiffPayload", src,
+                "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+        DiffClassLoader cl = new DiffClassLoader(bytes);
+        Class<?> kls = cl.loadClass("DiffPayload");
+        Object instance = kls.getDeclaredConstructor().newInstance();
+
+        // Run each generated method `iters` times so C2 kicks in, then call
+        // the deterministic checksum() method which reads back state.
+        for (int i = 0; i < n; i++) {
+            Method m = kls.getDeclaredMethod("test" + i, kls, int.class);
+            for (int j = 0; j < iters; j++) {
+                m.invoke(null, instance, j);
+            }
+        }
+        long fp = (long) kls.getDeclaredMethod("checksum", kls).invoke(null, instance);
+        // Print the single line the driver greps for.
+        System.out.println("FP=" + Long.toHexString(fp));
+    }
+
+    private static String generateSource(List<Slot> plan) {
+        StringBuilder s = new StringBuilder(16_000);
+        s.append("""
+                import java.lang.invoke.MethodHandles;
+                import java.lang.invoke.VarHandle;
+                import jdk.internal.misc.Unsafe;
+                public class DiffPayload {
+                    public int    fInt;
+                    public long   fLong;
+                    public Object fRef;
+                    private static final Unsafe U = Unsafe.getUnsafe();
+                    private static final VarHandle VH_INT, VH_LONG, VH_REF;
+                    static {
+                      try {
+                        MethodHandles.Lookup L = MethodHandles.lookup();
+                        VH_INT  = L.findVarHandle(DiffPayload.class, "fInt",  int.class);
+                        VH_LONG = L.findVarHandle(DiffPayload.class, "fLong", long.class);
+                        VH_REF  = L.findVarHandle(DiffPayload.class, "fRef",  Object.class);
+                      } catch (Throwable t) { throw new ExceptionInInitializerError(t); }
+                    }
+                    public static long checksum(DiffPayload p) {
+                      long h = p.fInt;
+                      h = h * 1315423911L ^ p.fLong;
+                      h = h * 1315423911L ^ (p.fRef == null ? 0 : p.fRef.hashCode());
+                      return h;
+                    }
+                """);
+        for (int i = 0; i < plan.size(); i++) {
+            Slot slot = plan.get(i);
+            emitMethod(s, i, slot);
+        }
+        s.append("}\n");
+        return s.toString();
+    }
+
+    private static void emitMethod(StringBuilder s, int idx, Slot slot) {
+        // Method body: do one release store. Value computed from v ^ salt so each
+        // method has a distinct value sequence, accumulating into the fingerprint.
+        String op = switch (slot.storeType()) {
+            case 0 -> "VH_INT.setRelease(p, v ^ " + slot.valueSalt() + ")";
+            case 1 -> "VH_LONG.setRelease(p, ((long)v) ^ " + slot.valueSalt() + "L)";
+            case 2 -> "VH_REF.setRelease(p, Integer.valueOf(v ^ " + slot.valueSalt() + "))";
+            default -> throw new AssertionError();
+        };
+        s.append("  public static void test").append(idx)
+         .append("(DiffPayload p, int v) {\n");
+        switch (slot.ctx()) {
+            case 0 -> s.append("    ").append(op).append(";\n");
+            case 1 -> s.append("    if ((v & 1) == 0) { ").append(op).append("; }\n");
+            case 2 -> s.append("    for (int k = 0; k < 2; k++) { ").append(op).append("; }\n");
+            case 3 -> s.append("    try { ").append(op).append("; } catch (Throwable t) {}\n");
+            case 4 -> s.append("    int _c = Integer.rotateLeft(v ^ 0x12345, 7);\n")
+                       .append("    ").append(op.replaceAll("\\bv\\b", "_c")).append(";\n");
+            default -> throw new AssertionError();
+        }
+        s.append("  }\n");
+    }
+
+    private static class DiffClassLoader extends ClassLoader {
+        private final byte[] bytes;
+        DiffClassLoader(byte[] bytes) { this.bytes = bytes; }
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (name.equals("DiffPayload")) {
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+            return super.findClass(name);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneReleaseFuzz.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneReleaseFuzz.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384941
+ * @summary Coverage-oriented fuzz test for UseStlrForStandaloneRelease.
+ *          Randomly composes setRelease / putXRelease / putOrdered* stores
+ *          across a matrix of surrounding IR contexts (none, branch, loop,
+ *          try-catch, after-allocation, after-volatile-load, after-compute,
+ *          interleaved-types, ...) into N test methods, JIT-compiles them
+ *          in a child JVM with PrintOptoAssembly, and asserts that for
+ *          every generated method the walker fires (or doesn't, when the
+ *          flag is off). Driver and worker use the same RNG seed so the
+ *          driver can predict expected per-method release-store counts
+ *          without communicating with the worker. Failure modes:
+ *
+ *            +flag: stlr_count(method) < expected_releases(method)   → walker missed
+ *            +flag: dmb_ish_count(method) > 0                        → walker missed
+ *            -flag: stlr_count(method) > 0                           → flag not honored
+ *
+ *          Seed defaults to current nanos; can be passed explicitly to
+ *          reproduce a found failure.
+ *
+ * @library /test/lib
+ *
+ * @modules java.base/jdk.internal.misc
+ *          jdk.compiler
+ *          jdk.unsupported
+ *
+ * @requires vm.flagless
+ * @requires os.arch == "aarch64" & vm.debug == true &
+ *           vm.flavor == "server" & !vm.graal.enabled
+ *
+ * @run driver compiler.c2.aarch64.TestStlrForStandaloneReleaseFuzz
+ */
+
+package compiler.c2.aarch64;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Pattern;
+
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestStlrForStandaloneReleaseFuzz {
+
+    // How many fuzz methods to synthesize per run. Each method holds 1..3
+    // setRelease stores in randomized surrounding contexts.
+    private static final int N_METHODS = 50;
+
+    // Random RNG seed range for one method — defines the (count, type, contexts) tuple.
+    // Both driver and worker derive identical specs from the same parent seed.
+    private record MethodSpec(int idx, int releaseCount, int storeType,
+                              int[] contextChoices) {
+        String methodName() { return "testFuzz_" + idx; }
+
+        // Width-specific stlr/str regex matched against PrintOptoAssembly.
+        // Format follows src/hotspot/cpu/aarch64/aarch64.ad:
+        //   int:  "stlrw ... # int"
+        //   long: "stlr  ... # int"   (same "# int" — width carried by mnemonic)
+        //   ref:  "stlrw ... # compressed ptr" (CompressedOops on, default)
+        //         "stlr  ... # ptr"            (CompressedOops off)
+        // Anchor ref regex on " ptr" with a leading space to match both forms.
+        String stlrRegex() {
+            return switch (storeType) {
+                case 0 -> "\\bstlrw\\b\\s.*#\\s*int\\b";
+                case 1 -> "\\bstlr\\b\\s.*#\\s*int\\b";
+                case 2 -> "\\bstlrw?\\b.* ptr\\b";
+                default -> throw new AssertionError();
+            };
+        }
+        String strRegex() {
+            return switch (storeType) {
+                case 0 -> "\\bstrw\\b\\s.*#\\s*int\\b";
+                case 1 -> "\\bstr\\b\\s.*#\\s*int\\b";
+                case 2 -> "\\bstrw?\\b.* ptr\\b";
+                default -> throw new AssertionError();
+            };
+        }
+    }
+
+    // Number of surrounding-context variants the generator may pick from.
+    private static final int N_CONTEXTS = 7;
+
+    private static List<MethodSpec> generateSpecs(long seed, int n) {
+        Random rng = new Random(seed);
+        List<MethodSpec> out = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            int rc = 1 + rng.nextInt(3);                      // 1..3 release stores
+            int type = rng.nextInt(3);                        // 0=int, 1=long, 2=ref
+            int[] ctxs = new int[rc];
+            for (int j = 0; j < rc; j++) ctxs[j] = rng.nextInt(N_CONTEXTS);
+            out.add(new MethodSpec(i, rc, type, ctxs));
+        }
+        return out;
+    }
+
+    // ---- Driver ----
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "payload".equals(args[0])) {
+            runPayload(Long.parseLong(args[1]), Integer.parseInt(args[2]));
+            return;
+        }
+
+        long seed = (args.length > 0) ? Long.parseLong(args[0]) : System.nanoTime();
+        System.out.println("[fuzz] seed=" + seed + " methods=" + N_METHODS);
+
+        OutputAnalyzer on  = runChild(seed, N_METHODS, true);
+        OutputAnalyzer off = runChild(seed, N_METHODS, false);
+
+        List<MethodSpec> specs = generateSpecs(seed, N_METHODS);
+        int missed = 0;
+        for (MethodSpec spec : specs) {
+            missed += verifyOne(on,  spec, /*useStlr=*/true,  seed);
+            missed += verifyOne(off, spec, /*useStlr=*/false, seed);
+        }
+        if (missed > 0) {
+            throw new RuntimeException("[fuzz] " + missed + " coverage failures (seed=" + seed + ")");
+        }
+        System.out.println("[fuzz] OK: " + N_METHODS + " methods × 2 modes verified");
+    }
+
+    private static OutputAnalyzer runChild(long seed, int n, boolean useStlr) throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:-TieredCompilation",
+                "-XX:-BackgroundCompilation",
+                "-XX:+PrintOptoAssembly",
+                "-XX:" + (useStlr ? "+" : "-") + "UseStlrForStandaloneRelease",
+                "-XX:CompileCommand=compileonly,FuzzPayload::testFuzz_*",
+                "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                TestStlrForStandaloneReleaseFuzz.class.getName(),
+                "payload",
+                Long.toString(seed),
+                Integer.toString(n)
+        );
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldHaveExitValue(0);
+        return oa;
+    }
+
+    private static int verifyOne(OutputAnalyzer oa, MethodSpec spec, boolean useStlr, long seed) {
+        List<String> lines = oa.asLines();
+        List<String> body = methodBody(lines, spec.methodName());
+        if (body == null) {
+            System.err.println("[fuzz] FAIL seed=" + seed + " method=" + spec.methodName()
+                    + " (useStlr=" + useStlr + "): PrintOptoAssembly block missing");
+            return 1;
+        }
+        int stlrCnt  = countRegex(body, spec.stlrRegex());
+        int strCnt   = countRegex(body, spec.strRegex());
+        int elided   = countRegex(body, "membar_release \\(elided\\)");
+        int notElided = countRegex(body, "membar_release(?! \\(elided\\))");
+        int expected = spec.releaseCount();
+        // dmb counting is intentionally avoided: the nmethod entry barrier
+        // emits a dmb ishld in every JIT'd method's prologue (unrelated to our
+        // release path), and AlwaysMergeDMB perturbs MemBarRelease's emit shape.
+        // The membar_release elided/non-elided count from PrintOptoAssembly is
+        // the canonical, unambiguous signal.
+        boolean ok;
+        String reason;
+        if (useStlr) {
+            ok = (stlrCnt >= expected) && (notElided == 0) && (elided >= expected);
+            reason = String.format(
+                    "+flag stlr=%d (>=%d?) elided=%d (>=%d?) non_elided=%d (==0?)",
+                    stlrCnt, expected, elided, expected, notElided);
+        } else {
+            int plainStr = strCnt - stlrCnt;
+            ok = (stlrCnt == 0) && (plainStr >= expected) && (notElided >= expected) && (elided == 0);
+            reason = String.format(
+                    "-flag stlr=%d (==0?) plain_str=%d (>=%d?) non_elided=%d (>=%d?) elided=%d (==0?)",
+                    stlrCnt, plainStr, expected, notElided, expected, elided);
+        }
+        if (!ok) {
+            System.err.println("[fuzz] FAIL seed=" + seed + " method=" + spec.methodName()
+                    + " contexts=" + java.util.Arrays.toString(spec.contextChoices()) + ": " + reason);
+            return 1;
+        }
+        return 0;
+    }
+
+    private static List<String> methodBody(List<String> lines, String methodSuffix) {
+        // PrintOptoAssembly prints " - name:              '<name>'" with
+        // variable whitespace; don't assume a specific column layout.
+        String quotedName = "'" + methodSuffix + "'";
+        int start = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String l = lines.get(i);
+            if (l.contains("- name:") && l.contains(quotedName)) {
+                start = i;
+                break;
+            }
+        }
+        if (start < 0) return null;
+        int end = lines.size();
+        for (int i = start + 1; i < lines.size(); i++) {
+            if (lines.get(i).contains("{method}")) { end = i; break; }
+        }
+        return lines.subList(start, end);
+    }
+
+    private static int countRegex(List<String> body, String regex) {
+        Pattern p = Pattern.compile(regex);
+        int n = 0;
+        for (String l : body) if (p.matcher(l).find()) n++;
+        return n;
+    }
+
+    // ---- Worker: generate source from seed, in-memory compile, JIT, exit ----
+
+    private static void runPayload(long seed, int n) throws Exception {
+        List<MethodSpec> specs = generateSpecs(seed, n);
+        String source = generateSource(specs);
+        byte[] classBytes = InMemoryJavaCompiler.compile("FuzzPayload", source,
+                "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+        FuzzClassLoader loader = new FuzzClassLoader(classBytes);
+        Class<?> klass = loader.loadClass("FuzzPayload");
+        // Construct one instance and exercise each method 100k times to trigger C2.
+        Object instance = klass.getDeclaredConstructor().newInstance();
+        for (int i = 0; i < n; i++) {
+            Method m = klass.getDeclaredMethod("testFuzz_" + i, klass, int.class);
+            for (int j = 0; j < 100_000; j++) {
+                m.invoke(null, instance, j);
+            }
+        }
+    }
+
+    private static String generateSource(List<MethodSpec> specs) {
+        StringBuilder s = new StringBuilder(64_000);
+        s.append("""
+                import java.lang.invoke.MethodHandles;
+                import java.lang.invoke.VarHandle;
+                import jdk.internal.misc.Unsafe;
+                public class FuzzPayload {
+                    public int fInt;
+                    public long fLong;
+                    public Object fRef;
+                    public static volatile int volInt;
+                    public static FuzzPayload sink;
+                    private static final Unsafe U = Unsafe.getUnsafe();
+                    private static final long OFF_INT, OFF_LONG, OFF_REF;
+                    private static final VarHandle VH_INT, VH_LONG, VH_REF, VH_VOL;
+                    static {
+                      try {
+                        MethodHandles.Lookup L = MethodHandles.lookup();
+                        VH_INT  = L.findVarHandle(FuzzPayload.class, "fInt",  int.class);
+                        VH_LONG = L.findVarHandle(FuzzPayload.class, "fLong", long.class);
+                        VH_REF  = L.findVarHandle(FuzzPayload.class, "fRef",  Object.class);
+                        VH_VOL  = L.findStaticVarHandle(FuzzPayload.class, "volInt", int.class);
+                        OFF_INT  = U.objectFieldOffset(FuzzPayload.class.getDeclaredField("fInt"));
+                        OFF_LONG = U.objectFieldOffset(FuzzPayload.class.getDeclaredField("fLong"));
+                        OFF_REF  = U.objectFieldOffset(FuzzPayload.class.getDeclaredField("fRef"));
+                      } catch (Throwable t) { throw new ExceptionInInitializerError(t); }
+                    }
+                """);
+        for (MethodSpec spec : specs) {
+            emitMethod(s, spec);
+        }
+        s.append("}\n");
+        return s.toString();
+    }
+
+    private static void emitMethod(StringBuilder s, MethodSpec spec) {
+        s.append("  public static void ").append(spec.methodName())
+                .append("(FuzzPayload p, int v) {\n");
+        for (int j = 0; j < spec.releaseCount(); j++) {
+            String storeExpr = storeExprFor(spec.storeType(), "p", "v + " + j);
+            emitContext(s, spec.contextChoices()[j], storeExpr, j);
+        }
+        s.append("  }\n");
+    }
+
+    // 3 store types × 1 store target = 3 expressions for the inner release op.
+    private static String storeExprFor(int storeType, String pVar, String vExpr) {
+        return switch (storeType) {
+            case 0 -> "VH_INT.setRelease(" + pVar + ", " + vExpr + ")";
+            case 1 -> "VH_LONG.setRelease(" + pVar + ", (long)(" + vExpr + "))";
+            case 2 -> "VH_REF.setRelease(" + pVar + ", Integer.valueOf(" + vExpr + "))";
+            default -> throw new AssertionError();
+        };
+    }
+
+    // N_CONTEXTS surrounding-context variants. Each emits exactly one
+    // setRelease into the method body, with the configured context. The
+    // `slot` index is appended to any local variable name to keep two stores
+    // with the same context kind from clashing on the same identifier.
+    private static void emitContext(StringBuilder s, int ctx, String store, int slot) {
+        switch (ctx) {
+            case 0 -> // bare
+                    s.append("    ").append(store).append(";\n");
+            case 1 -> // store inside one branch of an if/else — the JIT
+                    // sees a Phi merging "store" and "no-store" memory states.
+                    s.append("    if ((v & 1) == 0) { ").append(store).append("; }\n");
+            case 2 -> // small inner loop, unrolled by C2
+                    s.append("    for (int k").append(slot).append(" = 0; k").append(slot)
+                     .append(" < 2; k").append(slot).append("++) { ").append(store).append("; }\n");
+            case 3 -> // try / catch
+                    s.append("    try { ").append(store).append("; } catch (Throwable t").append(slot)
+                     .append(") { /* unreachable */ }\n");
+            case 4 -> { // after fresh allocation
+                String np = "np" + slot;
+                s.append("    FuzzPayload ").append(np).append(" = new FuzzPayload();\n")
+                 .append("    ").append(store.replace("p,", np + ",")).append(";\n")
+                 .append("    sink = ").append(np).append(";\n");
+            }
+            case 5 -> { // after volatile load
+                String vl = "_vl" + slot;
+                s.append("    int ").append(vl).append(" = (int) VH_VOL.getVolatile();\n")
+                 .append("    ").append(store.replace("v + ", "(v ^ " + vl + ") + ")).append(";\n");
+            }
+            case 6 -> { // after compute
+                String c = "_c" + slot;
+                s.append("    int ").append(c).append(" = Integer.rotateLeft(v ^ 0x12345, 7);\n")
+                 .append("    ").append(store.replace("v + ", c + " + ")).append(";\n");
+            }
+            default -> throw new AssertionError("unknown ctx " + ctx);
+        }
+    }
+
+    private static class FuzzClassLoader extends ClassLoader {
+        private final byte[] bytes;
+        FuzzClassLoader(byte[] bytes) { this.bytes = bytes; }
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (name.equals("FuzzPayload")) {
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+            return super.findClass(name);
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/StlrForStandaloneRelease.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/StlrForStandaloneRelease.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Microbenchmark for the aarch64 "stlr for release" optimization. With
+ * {@code -XX:+UseStlrForStandaloneRelease} (default), C2 emits a single {@code stlr*}
+ * for {@code VarHandle.setRelease} / {@code Unsafe.put*Release} /
+ * {@code sun.misc.Unsafe.putOrdered*}; with {@code -XX:-UseStlrForStandaloneRelease}
+ * it emits a leading {@code dmb ish} plus a plain {@code str*}. The
+ * benchmark forks two child JVMs per method to make the delta visible
+ * directly in the report.
+ *
+ * Each @Benchmark iteration performs {@link #N} release stores so JMH's
+ * per-op time reflects the cost of a single store, including loop overhead.
+ * Coverage mirrors the patch's reach: int / long / ref fields, int[] /
+ * Object[] array elements, and the legacy {@code sun.misc.Unsafe.putOrderedX}
+ * surface (whose @ForceInline path lowers to the same Op_MemBarRelease +
+ * Store(release) idiom the patch rewrites).
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+public class StlrForStandaloneRelease {
+
+    private static final int N = 1024;
+
+    public int    fInt;
+    public long   fLong;
+    public Object fRef;
+
+    private static final VarHandle VH_INT;
+    private static final VarHandle VH_LONG;
+    private static final VarHandle VH_REF;
+    private static final VarHandle VH_INT_ARR =
+            MethodHandles.arrayElementVarHandle(int[].class);
+    private static final VarHandle VH_LONG_ARR =
+            MethodHandles.arrayElementVarHandle(long[].class);
+    private static final VarHandle VH_REF_ARR =
+            MethodHandles.arrayElementVarHandle(Object[].class);
+
+    // Single-slot targets — hot path is the SAME address every iteration. C2 /
+    // the cpu store buffer can collapse adjacent same-address release stores,
+    // which inflates the +/- delta. Treat these as "ideal-case" numbers.
+    private final int[]    intArr = new int[1];
+    private final Object[] refArr = new Object[1];
+
+    // N-slot targets — each iteration writes a DIFFERENT slot, so neither the
+    // JIT nor the hardware can merge stores. This gives the conservative
+    // per-store cost of dmb-ish elimination and should be the headline number
+    // when reporting the patch's real-world value.
+    private final int[]    intArrN  = new int[N];
+    private final long[]   longArrN = new long[N];
+    private final Object[] refArrN  = new Object[N];
+
+    private final Object[] values = new Object[N];
+
+    @SuppressWarnings({"deprecation", "removal"})
+    private static final sun.misc.Unsafe SUN_U;
+    private static final long OFF_INT;
+    private static final long OFF_LONG;
+    private static final long OFF_REF;
+
+    static {
+        try {
+            MethodHandles.Lookup L = MethodHandles.lookup();
+            VH_INT  = L.findVarHandle(StlrForStandaloneRelease.class, "fInt",  int.class);
+            VH_LONG = L.findVarHandle(StlrForStandaloneRelease.class, "fLong", long.class);
+            VH_REF  = L.findVarHandle(StlrForStandaloneRelease.class, "fRef",  Object.class);
+            Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            SUN_U = (sun.misc.Unsafe) f.get(null);
+            OFF_INT  = SUN_U.objectFieldOffset(StlrForStandaloneRelease.class.getDeclaredField("fInt"));
+            OFF_LONG = SUN_U.objectFieldOffset(StlrForStandaloneRelease.class.getDeclaredField("fLong"));
+            OFF_REF  = SUN_U.objectFieldOffset(StlrForStandaloneRelease.class.getDeclaredField("fRef"));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public StlrForStandaloneRelease() {
+        for (int i = 0; i < N; i++) values[i] = Integer.valueOf(i);
+    }
+
+    // ---- +UseStlrForStandaloneRelease (default) ----
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_intField() {
+        for (int i = 0; i < N; i++) VH_INT.setRelease(this, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_longField() {
+        for (int i = 0; i < N; i++) VH_LONG.setRelease(this, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_refField() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF.setRelease(this, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_intArray() {
+        int[] a = intArr;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, 0, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_refArray() {
+        Object[] a = refArr;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, 0, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void plusStlr_putOrderedInt() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedInt(this, OFF_INT, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void plusStlr_putOrderedLong() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedLong(this, OFF_LONG, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void plusStlr_putOrderedObject() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) SUN_U.putOrderedObject(this, OFF_REF, v[i]);
+    }
+
+    // ---- Varying-index variants (+UseStlrForStandaloneRelease): no same-address merging ----
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_intArrayVarying() {
+        int[] a = intArrN;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, i, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_longArrayVarying() {
+        long[] a = longArrN;
+        for (int i = 0; i < N; i++) VH_LONG_ARR.setRelease(a, i, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_refArrayVarying() {
+        Object[] a = refArrN;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, i, v[i]);
+    }
+
+    // ---- -UseStlrForStandaloneRelease (baseline: dmb ish + str) ----
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_intField() {
+        for (int i = 0; i < N; i++) VH_INT.setRelease(this, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_longField() {
+        for (int i = 0; i < N; i++) VH_LONG.setRelease(this, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_refField() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF.setRelease(this, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_intArray() {
+        int[] a = intArr;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, 0, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_refArray() {
+        Object[] a = refArr;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, 0, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void minusStlr_putOrderedInt() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedInt(this, OFF_INT, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void minusStlr_putOrderedLong() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedLong(this, OFF_LONG, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void minusStlr_putOrderedObject() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) SUN_U.putOrderedObject(this, OFF_REF, v[i]);
+    }
+
+    // ---- Varying-index variants (-UseStlrForStandaloneRelease): no same-address merging ----
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_intArrayVarying() {
+        int[] a = intArrN;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, i, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_longArrayVarying() {
+        long[] a = longArrN;
+        for (int i = 0; i < N; i++) VH_LONG_ARR.setRelease(a, i, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_refArrayVarying() {
+        Object[] a = refArrN;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, i, v[i]);
+    }
+}


### PR DESCRIPTION
Hi all,

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

Please review this change to optimize `setRelease` / `putXRelease` / `putOrdered*` codegen on AArch64. C2 currently lowers these to `dmb ish + str`; this change recognizes the standalone-release pattern and emits a single `stlr` (eliding the leading `dmb ish` that AlwaysMergeDMB merges from `dmb ishst + dmb ishld`).

**The transform is gated behind a new product flag `UseStlrForStandaloneRelease`, default `false` (opt-in).** Default-build behavior is unchanged from the current baseline; enabling the flag activates the optimization. Both halves of the transform (`needs_releasing_store` upgrade and `unnecessary_release` elision) are gated together so they stay consistent.

See the commit message for the technical write-up.

JBS: https://bugs.openjdk.org/browse/JDK-8384941

## Implementation summary

All changes are confined to `src/hotspot/cpu/aarch64/`; no shared C2 changes are required. The pattern is identified entirely from existing IR (MemBarRelease standalone kind + StoreNode `is_release()` / `trailing_membar()`).

- `aarch64.ad` `unnecessary_release()` — when the flag is on, walks the leading MemBarRelease's memory projection (transparently through `MergeMem` and `MemBarCPUOrder`, using `ResourceMark` + `Unique_Node_List` per the `InitializeNode::can_capture_store` idiom). Returns true (eliding the dmb) iff the chain drives a release Store with no trailing membar.
- `aarch64.ad` `needs_releasing_store()` — when the flag is on, also returns true for `is_release()` stores with no trailing membar, upgrading their emission from `str` to `stlr`.
- `globals_aarch64.hpp` — new `product` flag `UseStlrForStandaloneRelease` (default `false`) and a `develop`-only diagnostic flag `PrintStandaloneReleaseElisionStats` (stripped under PRODUCT) for measuring walker coverage on arbitrary workloads.

The walker's failure modes are asymmetric: a false negative (miss) yields `dmb ish + stlr` — no correctness impact, just optimization lost. A false positive is structurally impossible: the matched store must be `is_release() && trailing_membar() == nullptr`, which is exactly the population that `needs_releasing_store` upgrades to `stlr`, so eliding the leading dmb is safe by construction.

## Tests

Four test artifacts ship with this change. All tests explicitly toggle `-XX:+/-UseStlrForStandaloneRelease`, independent of the default.

- **`test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneRelease.java`** — codegen test, 20 cases:
  - 11 baseline patterns: `VarHandle.setRelease`, `jdk.internal.misc.Unsafe.putXRelease`, and `sun.misc.Unsafe.putOrderedX` over int/long/ref field and int[]/Object[] array element.
  - 9 variant patterns: setRelease inside a branch / inside a loop / two consecutive same-field / interleaved int+long+ref / after a volatile load / on a fresh allocation / with intermediate arithmetic / inside try-catch / inside a constructor body that also writes a final field (the last is a witness for the directional discrimination of the walker).
  - Spawns child JVMs with `-XX:+PrintOptoAssembly`, parses the OptoAssembly output per method, asserts that the `membar_release` is elided (or not) and the matching `stlr` (or `str`) is emitted (or not). Requires fastdebug (`vm.debug == true`).

- **`test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneReleaseFuzz.java`** — coverage-oriented pattern fuzz. Uses `jdk.test.lib.compiler.InMemoryJavaCompiler` to randomly synthesize 50 test methods per run from a seed. Each method places setRelease in one of 7 contexts (bare / branch / inner loop / try / after allocation / after volatile load / after compute) over one of 3 store types. Driver and worker share the same seed deterministically, so the driver can predict per-method expected stlr counts and assert on PrintOptoAssembly output. Locally exercised: 5 seeds × 50 methods = 250 random patterns, all 250 walker-fire assertions pass. Requires fastdebug.

- **`test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneReleaseDifferential.java`** — functional differential test, no PrintOptoAssembly dependency, **runs on release build**. Synthesizes 30 random test methods, runs them twice (with `-XX:+/-UseStlrForStandaloneRelease`), and asserts that the resulting state fingerprint is byte-identical. Any mismatch would indicate a miscompile. Locally exercised: 5 seeds, all fingerprints match.

- **`test/micro/org/openjdk/bench/vm/compiler/StlrForStandaloneRelease.java`** — JMH microbench. 22 benchmarks pairing every `setRelease`/`putXRelease`/`putOrderedX` × {int field, long field, ref field, int[]/long[]/Object[] varying-index, single-slot array} with both `-XX:+/-UseStlrForStandaloneRelease` forks.

## Performance (with `-XX:+UseStlrForStandaloneRelease`)

JMH microbench on Apple M5 Max (`@OperationsPerInvocation(1024)`):

| pattern                            | baseline (ns/op) | +flag (ns/op) | per-op savings |
|------------------------------------|-----------------:|--------------:|---------------:|
| `setRelease` int field             |            1.334 |         0.220 |        1.11 ns |
| `setRelease` int[] varying-idx     |            1.584 |         0.219 |        1.37 ns |
| `setRelease` long[] varying-idx    |            1.855 |         0.227 |        1.63 ns |
| `setRelease` Object[] varying-idx  |            1.725 |         0.379 |        1.35 ns |
| `putOrderedInt`                    |            1.317 |         0.219 |        1.10 ns |

JCTools `SpscArrayQueue` (used by Netty / Reactor / Hazelcast / RxJava), each op = 64 inner offer/poll:

| benchmark        | baseline (ops/μs) | +flag (ops/μs) | speedup |
|------------------|------------------:|---------------:|--------:|
| `offer`          |             4.907 |          8.231 |   1.68× |
| `offerThenPoll`  |             2.580 |          5.085 |   1.97× |
| `poll`           |             4.960 |         11.711 |   2.36× |

Absolute per-store savings ~1.1–1.6 ns, matching the cost of one `dmb ish` on M5 Max.

## Regression and concurrency coverage

- `hotspot:tier1` on macOS/aarch64 release build with `-XX:+UseStlrForStandaloneRelease` applied to every test JVM: **2707 / 2707 passed, 0 failed, 0 error** (TEST SUCCESS).
- `java/util/concurrent/atomic/` + `java/util/concurrent/locks/` (heavy putOrdered/setRelease consumers): 22/22 passing.
- jcstress publication-safety tests with `VarHandle.setRelease`, `sun.misc.Unsafe.putOrderedObject`, and an AQS-style release pattern, run with both flag values in sanity + default modes: **204 configurations total, 0 FORBIDDEN outcomes** across approximately 10 billion samples per mode.
- `AlwaysMergeDMB` × `UseStlrForStandaloneRelease` matrix verified across all 4 cells — the `+stlr` path is independent of `AlwaysMergeDMB` (no dmb to merge); the baseline path emits `dmb ish` with merge on and `dmb ishst + dmb ishld` with merge off, as expected.

## Tested on

- Apple M5 Max, macOS, aarch64 — all of the above passes.
- **Linux/aarch64 — verification by a colleague is in progress** (Neoverse / Ampere / Graviton). Will follow up with results.

## Notes

- Default `false` so we can gather production telemetry before flipping. Once stable, a follow-up can flip the default in a separate change.
- The walker has a `kNodeLimit = 32` upper bound on unique nodes visited. Empirically observed max during JMH + j.u.c. workloads was 4 unique nodes per call; the limit is defensive overhead, not a real ceiling.

Thanks,
Yadong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384941](https://bugs.openjdk.org/browse/JDK-8384941): AArch64: Use stlr for standalone release stores (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31197/head:pull/31197` \
`$ git checkout pull/31197`

Update a local copy of the PR: \
`$ git checkout pull/31197` \
`$ git pull https://git.openjdk.org/jdk.git pull/31197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31197`

View PR using the GUI difftool: \
`$ git pr show -t 31197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31197.diff">https://git.openjdk.org/jdk/pull/31197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31197#issuecomment-4485298916)
</details>
