### PR TITLE
8384948: Disable DelayAfterInliningCutoff until memory consumption issues are fixed

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -510,7 +510,7 @@
           "If node count exceeds limit stop inlining")                      \
           range(0, max_jint)                                                \
                                                                             \
-  product(bool, DelayAfterInliningCutoff, true, DIAGNOSTIC,                 \
+  product(bool, DelayAfterInliningCutoff, false, DIAGNOSTIC,                \
           "If node count exceeds limit during parsing, attempt inlining "   \
           "later instead of giving up completely")                          \
                                                                             \


### PR DESCRIPTION
Hi,

[JDK-8382700](https://bugs.openjdk.org/browse/JDK-8382700) introduces the mechanism that, after we reach `NodeCountInliningCutoff` during parsing, we delay the inlining until incremental inlining. This inevitably puts a greater stress on other mechanisms of the compiler, which results in a large number of failures with stress tests, as well as excessive runtime for some others.

As a result, it is advisable to disable this option by default until those aforementioned issues are resolved/mitigated.

Testing:

- [x] tier1-4,hs-comp-stress
- [x] Stress tests that fail are confirmed to pass with `-XX:-DelayAfterInliningCutoff`

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384948](https://bugs.openjdk.org/browse/JDK-8384948): Disable DelayAfterInliningCutoff until memory consumption issues are fixed (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31198/head:pull/31198` \
`$ git checkout pull/31198`

Update a local copy of the PR: \
`$ git checkout pull/31198` \
`$ git pull https://git.openjdk.org/jdk.git pull/31198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31198`

View PR using the GUI difftool: \
`$ git pr show -t 31198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31198.diff">https://git.openjdk.org/jdk/pull/31198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31198#issuecomment-4485308452)
</details>
