### PR TITLE
8384946: os::Bsd::gettid misses the return value

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -873,23 +873,20 @@ pid_t os::Bsd::gettid() {
   mach_port_deallocate(mach_task_self(), port);
   return (pid_t)port;
 
+#elif defined(__FreeBSD__)
+  return ::pthread_getthreadid_np();
+#elif defined(__OpenBSD__)
+  retval = getthrid();
+#elif defined(__NetBSD__)
+  retval = (pid_t) _lwp_self();
 #else
-  #ifdef __FreeBSD__
-  retval = syscall(SYS_thr_self);
-  #else
-    #ifdef __OpenBSD__
-  retval = syscall(SYS_getthrid);
-    #else
-      #ifdef __NetBSD__
-  retval = (pid_t) syscall(SYS__lwp_self);
-      #endif
-    #endif
-  #endif
+# error "unsupported OS"
 #endif
 
   if (retval == -1) {
     return getpid();
   }
+  return retval;
 }
 
 // Returns the uid of a process or -1 on error.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -888,7 +888,7 @@ pid_t os::Bsd::gettid() {
 #elif defined(__NetBSD__)
   retval = (pid_t) _lwp_self();
 #else
-# error "unsupported OS"
+#error "unsupported OS"
 #endif
 
   if (retval == -1) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -102,6 +102,14 @@
   #include <elf.h>
 #endif
 
+#ifdef __FreeBSD__
+  #include <pthread_np.h>
+#endif
+
+#ifdef __NetBSD__
+#include <lwp.h>
+#endif
+
 #ifdef __APPLE__
   #include <libproc.h>
   #include <mach/task_info.h>


### PR DESCRIPTION
Brings the changes for `os::Bsd::gettid()` from the out-of-tree BSD port to mainline. I added an extra `#error` directive to catch unsupported BSD variants.

**Edit:** This change does more than strictly necessary from the issue description by incorporating the changes needed to make the code actually work on current versions of FreeBSD, OpenBSD and NetBSD. This corresponds to the code that has been in production for the OpenJDK ports for these systems since OpenJDK 8.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384946](https://bugs.openjdk.org/browse/JDK-8384946): os::Bsd::gettid misses the return value (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Contributors
 * Kurt Miller `<kurt@openjdk.org>`
 * Greg Lewis `<glewis@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31199/head:pull/31199` \
`$ git checkout pull/31199`

Update a local copy of the PR: \
`$ git checkout pull/31199` \
`$ git pull https://git.openjdk.org/jdk.git pull/31199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31199`

View PR using the GUI difftool: \
`$ git pr show -t 31199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31199.diff">https://git.openjdk.org/jdk/pull/31199.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31199#issuecomment-4485982082)
</details>
