### PR TITLE
8384960: Convert MallocSiteTable to use Atomic<T>

### DIFF
--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -42,7 +42,7 @@ const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = n
  * time, it is in single-threaded mode from JVM perspective.
  */
 bool MallocSiteTable::initialize() {
-  _table = (Atomic<MallocSiteHashtableEntry*>*)permit_forbidden_function::calloc(table_size, sizeof(Atomic<MallocSiteHashtableEntry*>));
+  _table = (Atomic<MallocSiteHashtableEntry*>*)permit_forbidden_function::malloc(table_size * sizeof(Atomic<MallocSiteHashtableEntry*>));
   if (_table == nullptr) {
     return false;
   }

--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -46,6 +46,9 @@ bool MallocSiteTable::initialize() {
   if (_table == nullptr) {
     return false;
   }
+  for (int i = 0; i < table_size; i++) {
+    new (&_table[i]) Atomic<MallocSiteHashtableEntry*>(nullptr);
+  }
 
   // Fake the call stack for hashtable entry allocation
   assert(NMT_TrackingStackDepth > 1, "At least one tracking stack");

--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 #include "utilities/permitForbiddenFunctions.hpp"
 
 // Malloc site hashtable buckets
-MallocSiteHashtableEntry**  MallocSiteTable::_table = nullptr;
+Atomic<MallocSiteHashtableEntry*>*  MallocSiteTable::_table = nullptr;
 const NativeCallStack* MallocSiteTable::_hash_entry_allocation_stack = nullptr;
 const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = nullptr;
 
@@ -42,7 +42,7 @@ const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = n
  * time, it is in single-threaded mode from JVM perspective.
  */
 bool MallocSiteTable::initialize() {
-  _table = (MallocSiteHashtableEntry**)permit_forbidden_function::calloc(table_size, sizeof(MallocSiteHashtableEntry*));
+  _table = (Atomic<MallocSiteHashtableEntry*>*)permit_forbidden_function::calloc(table_size, sizeof(Atomic<MallocSiteHashtableEntry*>));
   if (_table == nullptr) {
     return false;
   }
@@ -78,7 +78,7 @@ bool MallocSiteTable::initialize() {
 
   // Add the allocation site to hashtable.
   int index = hash_to_index(entry.hash());
-  _table[index] = const_cast<MallocSiteHashtableEntry*>(&entry);
+  _table[index].store_relaxed(const_cast<MallocSiteHashtableEntry*>(&entry));
 
   return true;
 }
@@ -88,12 +88,12 @@ bool MallocSiteTable::initialize() {
 bool MallocSiteTable::walk(MallocSiteWalker* walker) {
   MallocSiteHashtableEntry* head;
   for (int index = 0; index < table_size; index ++) {
-    head = _table[index];
+    head = _table[index].load_relaxed();
     while (head != nullptr) {
       if (!walker->do_malloc_site(head->peek())) {
         return false;
       }
-      head = (MallocSiteHashtableEntry*)head->next();
+      head = head->next();
     }
   }
   return true;
@@ -117,13 +117,13 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
   *marker = 0;
 
   // First entry for this hash bucket
-  if (_table[index] == nullptr) {
+  if (_table[index].load_relaxed() == nullptr) {
     MallocSiteHashtableEntry* entry = new_entry(key, mem_tag);
     // OOM check
     if (entry == nullptr) return nullptr;
 
     // swap in the head
-    if (AtomicAccess::replace_if_null(&_table[index], entry)) {
+    if (_table[index].compare_set(nullptr, entry)) {
       *marker = build_marker(index, 0);
       return entry->data();
     }
@@ -132,7 +132,7 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
   }
 
   unsigned pos_idx = 0;
-  MallocSiteHashtableEntry* head = _table[index];
+  MallocSiteHashtableEntry* head = _table[index].load_relaxed();
   while (head != nullptr && pos_idx < MAX_BUCKET_LENGTH) {
     if (head->hash() == hash) {
       MallocSite* site = head->data();
@@ -154,7 +154,7 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
       // contended, other thread won
       delete entry;
     }
-    head = (MallocSiteHashtableEntry*)head->next();
+    head = head->next();
     pos_idx ++;
   }
   return nullptr;
@@ -167,10 +167,10 @@ MallocSite* MallocSiteTable::malloc_site(uint32_t marker) {
     return nullptr;
   }
   const uint16_t pos_idx = pos_idx_from_marker(marker);
-  MallocSiteHashtableEntry* head = _table[bucket_idx];
+  MallocSiteHashtableEntry* head = _table[bucket_idx].load_relaxed();
   for (size_t index = 0;
        index < pos_idx && head != nullptr;
-       index++, head = (MallocSiteHashtableEntry*)head->next()) {}
+       index++, head = head->next()) {}
   if (head == nullptr) {
     return nullptr;
   }
@@ -213,7 +213,7 @@ void MallocSiteTable::print_tuning_statistics(outputStream* st) {
 
   for (int i = 0; i < table_size; i ++) {
     int this_chain_length = 0;
-    const MallocSiteHashtableEntry* head = _table[i];
+    const MallocSiteHashtableEntry* head = _table[i].load_relaxed();
     if (head == nullptr) {
       unused_buckets ++;
     }
@@ -254,5 +254,5 @@ void MallocSiteTable::print_tuning_statistics(outputStream* st) {
 }
 
 bool MallocSiteHashtableEntry::atomic_insert(MallocSiteHashtableEntry* entry) {
-  return AtomicAccess::replace_if_null(&_next, entry);
+  return _next.compare_set(nullptr, entry);
 }

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -196,9 +196,9 @@ class MallocSiteTable : AllStatic {
  private:
   // The callsite hashtable. It has to be a static table,
   // since malloc call can come from C runtime linker.
-  static Atomic<MallocSiteHashtableEntry*>*       _table;
-  static const NativeCallStack*                   _hash_entry_allocation_stack;
-  static const MallocSiteHashtableEntry*          _hash_entry_allocation_site;
+  static Atomic<MallocSiteHashtableEntry*>* _table;
+  static const NativeCallStack*             _hash_entry_allocation_stack;
+  static const MallocSiteHashtableEntry*    _hash_entry_allocation_site;
 };
 
 #endif // SHARE_NMT_MALLOCSITETABLE_HPP

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -57,9 +57,9 @@ class MallocSite : public AllocationSite {
 // Malloc site hashtable entry
 class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
  private:
-  MallocSite                         _malloc_site;
-  const unsigned int                 _hash;
-  Atomic<MallocSiteHashtableEntry*>  _next;
+  MallocSite                        _malloc_site;
+  const unsigned int                _hash;
+  Atomic<MallocSiteHashtableEntry*> _next;
 
  public:
 

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -197,8 +197,8 @@ class MallocSiteTable : AllStatic {
   // The callsite hashtable. It has to be a static table,
   // since malloc call can come from C runtime linker.
   static Atomic<MallocSiteHashtableEntry*>*       _table;
-  static const NativeCallStack*           _hash_entry_allocation_stack;
-  static const MallocSiteHashtableEntry*  _hash_entry_allocation_site;
+  static const NativeCallStack*                   _hash_entry_allocation_stack;
+  static const MallocSiteHashtableEntry*          _hash_entry_allocation_site;
 };
 
 #endif // SHARE_NMT_MALLOCSITETABLE_HPP

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 #include "nmt/allocationSite.hpp"
 #include "nmt/mallocTracker.hpp"
 #include "nmt/nmtCommon.hpp"
-#include "runtime/atomicAccess.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 
@@ -59,7 +59,7 @@ class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
  private:
   MallocSite                         _malloc_site;
   const unsigned int                 _hash;
-  MallocSiteHashtableEntry* volatile _next;
+  Atomic<MallocSiteHashtableEntry*>  _next;
 
  public:
 
@@ -69,7 +69,10 @@ class MallocSiteHashtableEntry : public CHeapObj<mtNMT> {
   }
 
   inline const MallocSiteHashtableEntry* next() const {
-    return _next;
+    return _next.load_relaxed();
+  }
+  inline MallocSiteHashtableEntry* next() {
+    return _next.load_relaxed();
   }
 
   // Insert an entry atomically.
@@ -193,7 +196,7 @@ class MallocSiteTable : AllStatic {
  private:
   // The callsite hashtable. It has to be a static table,
   // since malloc call can come from C runtime linker.
-  static MallocSiteHashtableEntry**       _table;
+  static Atomic<MallocSiteHashtableEntry*>*       _table;
   static const NativeCallStack*           _hash_entry_allocation_stack;
   static const MallocSiteHashtableEntry*  _hash_entry_allocation_site;
 };


### PR DESCRIPTION
Hi,

This PR converts the MallocSiteTable to use Atomic<T> instead of volatile + AtomicAccess<T>.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384960](https://bugs.openjdk.org/browse/JDK-8384960): Convert MallocSiteTable to use Atomic&lt;T&gt; (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [687e9b61](https://git.openjdk.org/jdk/pull/31200/files/687e9b615f21d3e5b7f583a89ed2c738a4af5266)
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Author) Review applies to [687e9b61](https://git.openjdk.org/jdk/pull/31200/files/687e9b615f21d3e5b7f583a89ed2c738a4af5266)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31200/head:pull/31200` \
`$ git checkout pull/31200`

Update a local copy of the PR: \
`$ git checkout pull/31200` \
`$ git pull https://git.openjdk.org/jdk.git pull/31200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31200`

View PR using the GUI difftool: \
`$ git pr show -t 31200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31200.diff">https://git.openjdk.org/jdk/pull/31200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31200#issuecomment-4505462938)
</details>
