### PR TITLE
8384963: C2: Incorrect uint constant match mishandles negative values in vectors

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -2768,6 +2768,7 @@ static bool is_replicate_uint_constant(const Node* n) {
   return n->Opcode() == Op_Replicate &&
          n->in(1)->is_Con() &&
          n->in(1)->bottom_type()->isa_long() &&
+         n->in(1)->bottom_type()->is_long()->get_con() >= 0 &&
          n->in(1)->bottom_type()->is_long()->get_con() <= 0xFFFFFFFFL;
 }
 
@@ -2784,7 +2785,7 @@ static bool has_vector_elements_fit_uint(Node* n) {
            n->in(2)->in(1)->bottom_type()->isa_int() &&
            n->in(2)->in(1)->bottom_type()->is_int()->get_con() >= 32;
   };
-  return is_lower_doubleword_mask_pattern(n) ||             // (AndV     SRC (Replicate C)) where C <= 0xFFFFFFFF
+  return is_lower_doubleword_mask_pattern(n) ||             // (AndV     SRC (Replicate C)) where (0 <= C <= 0xFFFFFFFF)
          is_clear_upper_doubleword_uright_shift_pattern(n); // (URShiftV SRC S) where S >= 32
 }
 

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorNegativeUint.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorNegativeUint.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.*;
+import static jdk.incubator.vector.VectorOperators.*;
+
+/*
+ * @test
+ * @bug 8384963
+ * @summary C2: Incorrect uint constant match mishandles negative values in vectors
+ * @modules jdk.incubator.vector
+ * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.vectorapi.TestVectorNegativeUint
+ */
+
+public class TestVectorNegativeUint {
+    static final int SIZE = 64; // 8*64 = 512, should be enough
+
+    static final long[] S1 = new long[SIZE];
+    static final long[] S2 = new long[SIZE];
+    static final LongVector V1;
+    static final LongVector V2;
+    static final long MASK = -2L;
+
+    static {
+        // Upper 32-bits should be non-zero to trigger the bug.
+        S1[0] = 0x1_0000_0001L;
+        S2[0] = 0x2_0000_0002L;
+        V1 = LongVector.fromArray(LongVector.SPECIES_PREFERRED, S1, 0);
+        V2 = LongVector.fromArray(LongVector.SPECIES_PREFERRED, S2, 0);
+    }
+
+    public static void main(String... args) {
+        for (int c = 0; c < 100_000; c++) {
+            test();
+        }
+    }
+
+    static void test() {
+        long[] res = V1.lanewise(AND, MASK).lanewise(MUL, V2.lanewise(AND, MASK)).toArray();
+        long actual = res[0];
+        long expected = (S1[0] & MASK) * (S2[0] & MASK);
+        if (expected != actual) {
+            throw new AssertionError("expected: " + Long.toHexString(expected) + ", actual: " + Long.toHexString(actual));
+        }
+    }
+}


### PR DESCRIPTION
See the bug for explanation how it happens. The broken match reachable from simple test, now a jtreg test. Without a fix, the new test fails with:

```
TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.AssertionError: \
 expected: 200000000, actual: 0
```

This is a regression in code added in JDK 24, so it is a problem in JDK 25 LTS as well.

Additional testing:
 - [x] Linux x86_64 server fastdebug, reproducer no longer fails
 - [x] Linux x86_64 server fastdebug, `compiler/vectorapi`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384963](https://bugs.openjdk.org/browse/JDK-8384963): C2: Incorrect uint constant match mishandles negative values in vectors (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31201/head:pull/31201` \
`$ git checkout pull/31201`

Update a local copy of the PR: \
`$ git checkout pull/31201` \
`$ git pull https://git.openjdk.org/jdk.git pull/31201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31201`

View PR using the GUI difftool: \
`$ git pr show -t 31201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31201.diff">https://git.openjdk.org/jdk/pull/31201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31201#issuecomment-4486463031)
</details>
