### PR TITLE
8384964: Add an entry count to the MallocSiteTable

### DIFF
--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -83,7 +83,7 @@ bool MallocSiteTable::initialize() {
   // Add the allocation site to hashtable.
   int index = hash_to_index(entry.hash());
   _table[index].store_relaxed(const_cast<MallocSiteHashtableEntry*>(&entry));
-  _entry_count.add_then_fetch(1, memory_order_relaxed);
+  _entry_count.add_then_fetch(1ul, memory_order_relaxed);
 
   return true;
 }
@@ -129,7 +129,7 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
 
     // swap in the head
     if (_table[index].compare_set(nullptr, entry)) {
-      _entry_count.add_then_fetch(1, memory_order_relaxed);
+      _entry_count.add_then_fetch(1ul, memory_order_relaxed);
       *marker = build_marker(index, 0);
       return entry->data();
     }
@@ -155,7 +155,7 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
       if (head->atomic_insert(entry)) {
         pos_idx ++;
         *marker = build_marker(index, pos_idx);
-        _entry_count.add_then_fetch(1, memory_order_relaxed);
+        _entry_count.add_then_fetch(1ul, memory_order_relaxed);
         return entry->data();
       }
       // contended, other thread won

--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -242,7 +242,7 @@ void MallocSiteTable::print_tuning_statistics(outputStream* st) {
   st->print_cr("Malloc allocation site table:");
 #ifdef ASSERT
   // This is solely for testing
-  st->print_cr("\tExpected entry count: %d", _entry_count.load_relaxed());
+  st->print_cr("\tExpected entry count: %lu", _entry_count.load_relaxed());
 #endif
   st->print_cr("\tTotal entries: %d", total_entries);
   st->print_cr("\tEmpty entries (no outstanding mallocs): %d (%2.2f%%)",

--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -32,6 +32,7 @@
 Atomic<MallocSiteHashtableEntry*>*  MallocSiteTable::_table = nullptr;
 const NativeCallStack* MallocSiteTable::_hash_entry_allocation_stack = nullptr;
 const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = nullptr;
+Atomic<int> MallocSiteTable::_entry_count(0);
 
 /*
  * Initialize malloc site table.
@@ -82,6 +83,7 @@ bool MallocSiteTable::initialize() {
   // Add the allocation site to hashtable.
   int index = hash_to_index(entry.hash());
   _table[index].store_relaxed(const_cast<MallocSiteHashtableEntry*>(&entry));
+  _entry_count.add_then_fetch(1, memory_order_relaxed);
 
   return true;
 }
@@ -127,6 +129,7 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
 
     // swap in the head
     if (_table[index].compare_set(nullptr, entry)) {
+      _entry_count.add_then_fetch(1, memory_order_relaxed);
       *marker = build_marker(index, 0);
       return entry->data();
     }
@@ -152,6 +155,7 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint32_t*
       if (head->atomic_insert(entry)) {
         pos_idx ++;
         *marker = build_marker(index, pos_idx);
+        _entry_count.add_then_fetch(1, memory_order_relaxed);
         return entry->data();
       }
       // contended, other thread won
@@ -236,6 +240,10 @@ void MallocSiteTable::print_tuning_statistics(outputStream* st) {
   }
 
   st->print_cr("Malloc allocation site table:");
+#ifdef ASSERT
+  // This is solely for testing
+  st->print_cr("\tExpected entry count: %d", _entry_count.load_relaxed());
+#endif
   st->print_cr("\tTotal entries: %d", total_entries);
   st->print_cr("\tEmpty entries (no outstanding mallocs): %d (%2.2f%%)",
                   empty_entries, ((float)empty_entries * 100) / (float)total_entries);

--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -32,7 +32,7 @@
 Atomic<MallocSiteHashtableEntry*>*  MallocSiteTable::_table = nullptr;
 const NativeCallStack* MallocSiteTable::_hash_entry_allocation_stack = nullptr;
 const MallocSiteHashtableEntry* MallocSiteTable::_hash_entry_allocation_site = nullptr;
-Atomic<int> MallocSiteTable::_entry_count(0);
+Atomic<size_t> MallocSiteTable::_entry_count(0);
 
 /*
  * Initialize malloc site table.

--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -242,7 +242,7 @@ void MallocSiteTable::print_tuning_statistics(outputStream* st) {
   st->print_cr("Malloc allocation site table:");
 #ifdef ASSERT
   // This is solely for testing
-  st->print_cr("\tExpected entry count: %lu", _entry_count.load_relaxed());
+  st->print_cr("\tExpected entry count: %zu", _entry_count.load_relaxed());
 #endif
   st->print_cr("\tTotal entries: %d", total_entries);
   st->print_cr("\tEmpty entries (no outstanding mallocs): %d (%2.2f%%)",

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -196,7 +196,7 @@ class MallocSiteTable : AllStatic {
  private:
   // The callsite hashtable. It has to be a static table,
   // since malloc call can come from C runtime linker.
-  static Atomic<int>                        _entry_count;
+  static Atomic<size_t>                     _entry_count;
   static Atomic<MallocSiteHashtableEntry*>* _table;
   static const NativeCallStack*             _hash_entry_allocation_stack;
   static const MallocSiteHashtableEntry*    _hash_entry_allocation_site;

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -196,6 +196,7 @@ class MallocSiteTable : AllStatic {
  private:
   // The callsite hashtable. It has to be a static table,
   // since malloc call can come from C runtime linker.
+  static Atomic<int>                        _entry_count;
   static Atomic<MallocSiteHashtableEntry*>* _table;
   static const NativeCallStack*             _hash_entry_allocation_stack;
   static const MallocSiteHashtableEntry*    _hash_entry_allocation_site;

--- a/test/hotspot/jtreg/runtime/NMT/MallocStressTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -137,6 +137,27 @@ public class MallocStressTest {
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "statistics"});
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("Tracking level has been downgraded due to lack of resources");
+
+        if (Platform.isDebugBuild()) {
+            String expectedCountString = output.firstMatch("\\s*Expected entry count: (\\d+)", 1);
+            String totalEntriesString = output.firstMatch("\\s*Total entries: (\\d+)", 1);
+
+            if (expectedCountString == null || totalEntriesString == null) {
+                throw new RuntimeException("Missing malloc site table entry counts in NMT statistics output");
+            }
+
+            int expectedCount = Integer.parseInt(expectedCountString);
+            int totalEntries = Integer.parseInt(totalEntriesString);
+
+            // The expected count is loaded after the total entries has accumulated (internal impl detail from hotspot).
+            // As this is a concurrent hashtable, we might have added more malloc sites.
+            // So, we're ok with the expectedCount being larger than totalEntries, but if it's *A lot* larger something
+            // really weird is going on.
+            if (expectedCount - totalEntries > 5) {
+                throw new RuntimeException("Malloc site table entry count mismatch: expected "
+                                           + expectedCount + ", walked " + totalEntries);
+            }
+        }
     }
 
     private static void sleep_wait(int n) {


### PR DESCRIPTION
This PR adds an entry count to the MallocSiteTable. As the site walking is concurrent, new entries may also be seen, meaning that the entry count does not represent a reliable upper bound on the number of sites seen, but rather a reliable lower bound.

This PR is done in preparation for https://github.com/openjdk/jdk/pull/31137 which will replace the current linked list solution for mallocsite storage during reporting with an array based one.

As this is an AllStatic class, testing is only done through a new JTReg test looking at the printing statistics.

Testing: tier1-tier3

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384964](https://bugs.openjdk.org/browse/JDK-8384964): Add an entry count to the MallocSiteTable (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31202/head:pull/31202` \
`$ git checkout pull/31202`

Update a local copy of the PR: \
`$ git checkout pull/31202` \
`$ git pull https://git.openjdk.org/jdk.git pull/31202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31202`

View PR using the GUI difftool: \
`$ git pr show -t 31202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31202.diff">https://git.openjdk.org/jdk/pull/31202.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31202#issuecomment-4518759207)
</details>
