### PR TITLE
8383738: javac crashes with StackOverflowError when a class extends a type parameter

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -895,7 +895,7 @@ public class Attr extends JCTree.Visitor {
             tree.type :
             attribType(tree, env);
         try {
-            return checkBase(t, tree, env, classExpected, interfaceExpected, checkExtensible);
+            return tree.type = checkBase(t, tree, env, classExpected, interfaceExpected, checkExtensible);
         } catch (CompletionFailure ex) {
             chk.completionError(tree.pos(), ex);
             return t;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -268,17 +268,17 @@ public class Check {
      *  @param pos        Position to be used for error reporting.
      *  @param required   An internationalized string describing the type tag
      *                    required.
-     *  @param found      The type that was found.
+     *  @param type       The type that was found.
      */
-    Type typeTagError(DiagnosticPosition pos, JCDiagnostic required, Object found) {
+    Type typeTagError(DiagnosticPosition pos, JCDiagnostic required, Type type) {
         // this error used to be raised by the parser,
         // but has been delayed to this point:
-        if (found instanceof Type type && type.hasTag(VOID)) {
+        if (type.hasTag(VOID)) {
             log.error(pos, Errors.IllegalStartOfType);
             return syms.errType;
         }
-        log.error(pos, Errors.TypeFoundReq(found, required));
-        return types.createErrorType(found instanceof Type type ? type : syms.errType);
+        log.error(pos, Errors.TypeFoundReq(asTypeParam(type), required));
+        return types.createErrorType(type);
     }
 
     /** Report duplicate declaration error.
@@ -645,7 +645,7 @@ public class Check {
         if (!t.hasTag(CLASS) && !t.hasTag(ARRAY) && !t.hasTag(ERROR)) {
             return typeTagError(pos,
                                 diags.fragment(Fragments.TypeReqClassArray),
-                                asTypeParam(t));
+                                t);
         } else {
             return t;
         }
@@ -659,7 +659,7 @@ public class Check {
         if (!t.hasTag(CLASS) && !t.hasTag(ERROR)) {
             return typeTagError(pos,
                                 diags.fragment(Fragments.TypeReqClass),
-                                asTypeParam(t));
+                                t);
         } else {
             return t;
         }

--- a/test/langtools/tools/javac/types/StackOverflowWhenClassExtendsTypeParam.java
+++ b/test/langtools/tools/javac/types/StackOverflowWhenClassExtendsTypeParam.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8383738
+ * @summary Check that javac does not crashes with StackOverflowError when compiling
+ *          a class that extends a type parameter.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.Task;
+
+public class StackOverflowWhenClassExtendsTypeParam {
+
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testIsDerivedRaw() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         class Test {
+                             class A<T extends A<T>[]> implements T {}
+                             class B<T extends A<T>[]> extends A<B<T>> {}
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll();
+    }
+
+    @Test
+    void testCheckClassBounds() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         class Test {
+                             interface I extends J<I> { }
+                             interface J<T> extends T { }
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll();
+    }
+
+    @Test
+    void testTypesClosure() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         public class Test {
+                             public static void main(String[] args) {
+                                 LayerThree<Runnable, ? extends LayerThree<Runnable, ?>> testInstance = new LayerThree<>() {};
+                             }
+                         }
+
+                         class LayerOne<A extends Number> {
+                         }
+
+                         class LayerTwo<B extends Comparable<B>, C extends LayerOne<B>> extends C {
+                         }
+
+                         class LayerThree<D extends Runnable, E extends LayerTwo<D, E>> extends E {
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll();
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Consider the following source code:
```
class Test {
    class A<T extends A<T>[]> implements T {}
    class B<T extends A<T>[]> extends A<B<T>> {}
}
```
Compiling this file, javac ends up with `StackOverflowError`.

The problem is an illegal base clause where a class or interface extends/implements a type parameter. In these cases javac reports the expected error, such as `unexpected type: required class, found type parameter`, but the invalid superclass/superinterface type remains recorded on the attributed tree. Later hierarchy checks could then revisit that invalid type and recurse through `Types.asSuper` / `Types.supertype` until the compiler fails with `StackOverflowError`.

The proposal here is to create the recovery error type based on the original `TypeVar` and store it back to the attributed tree. Invalid inheritance clauses would be represented as erroneous bases, so later type hierarchy checks stops after the diagnostic instead of walking the cycle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8383738: javac crashes with StackOverflowError when a class extends a type parameter`

### Issue
 * [JDK-8383738](https://bugs.openjdk.org/browse/JDK-8383738): javac crashes with StackOverflowError when a class extends a type parameter (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31203/head:pull/31203` \
`$ git checkout pull/31203`

Update a local copy of the PR: \
`$ git checkout pull/31203` \
`$ git pull https://git.openjdk.org/jdk.git pull/31203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31203`

View PR using the GUI difftool: \
`$ git pr show -t 31203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31203.diff">https://git.openjdk.org/jdk/pull/31203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31203#issuecomment-4486834255)
</details>
