### PR TITLE
8384997: "Unrecognized system!" failures on MSys2/Windows

### DIFF
--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
@@ -58,6 +58,11 @@ case "$OS" in
     FS="\\"
     isCygwin=true
     ;;
+  MSYS* | MINGW*)
+    PS=";"
+    OS="Windows"
+    FS="\\"
+    ;;
   * )
     echo "Unrecognized system!"
     exit 1;

--- a/test/jdk/javax/script/CommonSetup.sh
+++ b/test/jdk/javax/script/CommonSetup.sh
@@ -51,6 +51,11 @@ case "$OS" in
     FS="\\"
     isCygwin=true
     ;;
+  MSYS* | MINGW* )
+    PS=";"
+    OS="Windows"
+    FS="\\"
+    ;;
   * )
     echo "Unrecognized system!"
     exit 1;

--- a/test/jdk/tools/launcher/ClassPathWildCard.sh
+++ b/test/jdk/tools/launcher/ClassPathWildCard.sh
@@ -149,7 +149,7 @@ CreateClassFiles D
 
 OS=`uname -s`
 case $OS in 
-    Windows*|CYGWIN*)
+    Windows*|CYGWIN*|MSYS*|MINGW*)
         PATHSEP=";"
         ExecJava "" "${PATHSEP}NOOPDIR"
         ExecJava "w" "${PATHSEP}NOOPDIR"


### PR DESCRIPTION
Prior to this patch, the following tests failed when they were run using
MSys2/MinGW with the error "Unrecognized system!":

- javax/script/ProviderTest
- javax/script/ScriptEngineOrder
- tools/launcher/ClassPathWildCard
- java/lang/instrument/appendToClassLoaderSearch/CircularityErrorTest
- java/lang/instrument/appendToClassLoaderSearch/ClassUnloadTest
- java/lang/instrument/appendToClassLoaderSearch/run_tests

This patch fixes the problem by enabling support for MSys2 required for
running these tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384997](https://bugs.openjdk.org/browse/JDK-8384997): "Unrecognized system!" failures on MSys2/Windows (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31204/head:pull/31204` \
`$ git checkout pull/31204`

Update a local copy of the PR: \
`$ git checkout pull/31204` \
`$ git pull https://git.openjdk.org/jdk.git pull/31204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31204`

View PR using the GUI difftool: \
`$ git pr show -t 31204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31204.diff">https://git.openjdk.org/jdk/pull/31204.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31204#issuecomment-4488646995)
</details>
