### PR TITLE
8385011: GHA: Enable Linux AArch64 tests

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -54,18 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         target-cpu:
-          - aarch64
           - arm
           - s390x
           - ppc64le
           - riscv64
         include:
-          - target-cpu: aarch64
-            gnu-arch: aarch64
-            debian-arch: arm64
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: trixie
-            tolerate-sysroot-errors: false
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,6 +31,14 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: false
+        type: string
+        default: 'ubuntu-24.04'
+      bootjdk-platform:
+        required: false
+        type: string
+        default: 'linux-x64'
       extra-conf-options:
         required: false
         type: string
@@ -75,7 +83,7 @@ on:
 jobs:
   build-linux:
     name: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runs-on }}
 
     strategy:
       fail-fast: false
@@ -90,7 +98,7 @@ jobs:
         id: bootjdk
         uses: ./.github/actions/get-bootjdk
         with:
-          platform: linux-x64
+          platform: ${{ inputs.bootjdk-platform }}
 
       - name: 'Get JTReg'
         id: jtreg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x64-variants, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
+        default: 'linux-x64, linux-x64-variants, linux-aarch64, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -64,6 +64,7 @@ jobs:
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
       linux-x64-variants: ${{ steps.include.outputs.linux-x64-variants }}
+      linux-aarch64: ${{ steps.include.outputs.linux-aarch64 }}
       linux-cross-compile: ${{ steps.include.outputs.linux-cross-compile }}
       alpine-linux-x64: ${{ steps.include.outputs.alpine-linux-x64 }}
       macos-x64: ${{ steps.include.outputs.macos-x64 }}
@@ -176,6 +177,7 @@ jobs:
 
           echo "linux-x64=$(check_platform linux-x64 linux x64)" >> $GITHUB_OUTPUT
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
+          echo "linux-aarch64=$(check_platform linux-aarch64 linux aarch64)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
           echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
@@ -200,6 +202,20 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
     if: needs.prepare.outputs.linux-x64 == 'true'
+
+  build-linux-aarch64:
+    name: linux-aarch64
+    needs: prepare
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      platform: linux-aarch64
+      runs-on: 'ubuntu-24.04-arm'
+      bootjdk-platform: linux-aarch64
+      gcc-major-version: '14'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
+      dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
+    if: needs.prepare.outputs.linux-aarch64 == 'true'
 
   build-linux-x64-hs-nopch:
     name: linux-x64-hs-nopch
@@ -424,6 +440,19 @@ jobs:
       runs-on: ubuntu-24.04
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       static-suffix: "-static"
+
+  test-linux-aarch64:
+    name: linux-aarch64
+    needs:
+      - prepare
+      - build-linux-aarch64
+    uses: ./.github/workflows/test.yml
+    with:
+      platform: linux-aarch64
+      bootjdk-platform: linux-aarch64
+      runs-on: ubuntu-24.04-arm
+      dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
+      debug-suffix: -debug
 
   test-macos-aarch64:
     name: macos-aarch64

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -32,6 +32,10 @@ LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk26/c3cc523845074aa0af4f5e1e1ed4151d/35/GPL/openjdk-26_linux-x64_bin.tar.gz
 LINUX_X64_BOOT_JDK_SHA256=83c78367f8c81257beef72aca4bbbf8e6dac8ca2b3a4546a85879a09e6e4e128
 
+LINUX_AARCH64_BOOT_JDK_EXT=tar.gz
+LINUX_AARCH64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk26/c3cc523845074aa0af4f5e1e1ed4151d/35/GPL/openjdk-26_linux-aarch64_bin.tar.gz
+LINUX_AARCH64_BOOT_JDK_SHA256=403ccf451e88d0be9e1dec129fcb9318de9752121e0eb92dfa9a8cf06f249007
+
 ALPINE_LINUX_X64_BOOT_JDK_EXT=tar.gz
 ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_alpine-linux_hotspot_26_35.tar.gz
 ALPINE_LINUX_X64_BOOT_JDK_SHA256=c105e581fdccb4e7120d889235d1ad8d5b2bed0af4972bc881e0a8ba687c94a4


### PR DESCRIPTION
Switches Linux aarch64 builds from cross-compile to native + adds testing. Noting that I pinned to `gcc-major-version: '14'` to be consistent with the existing cross-compile Linux aarch64 equivalent. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385011](https://bugs.openjdk.org/browse/JDK-8385011): GHA: Enable Linux AArch64 tests (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Mat Carter](https://openjdk.org/census#macarte) (@macarte - Committer)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31205/head:pull/31205` \
`$ git checkout pull/31205`

Update a local copy of the PR: \
`$ git checkout pull/31205` \
`$ git pull https://git.openjdk.org/jdk.git pull/31205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31205`

View PR using the GUI difftool: \
`$ git pr show -t 31205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31205.diff">https://git.openjdk.org/jdk/pull/31205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31205#issuecomment-4490604111)
</details>
