### PR TITLE
8385019: Build error without CDS

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -266,9 +266,9 @@ public:
   address load_archive_data(StubId stub_id, address &end, GrowableArray<address>* entries = nullptr, GrowableArray<address>* extras = nullptr) NOT_CDS_RETURN_(nullptr);
   void store_archive_data(StubId stub_id, address start, address end, GrowableArray<address>* entries = nullptr, GrowableArray<address>* extras = nullptr) NOT_CDS_RETURN;
 
-  void stub_epilog(StubId stub_id);
+  void stub_epilog(StubId stub_id) NOT_CDS_RETURN;
 #ifdef ASSERT
-  void check_stored(StubId stub_id);
+  void check_stored(StubId stub_id) NOT_CDS_RETURN;
 #endif
   const AOTStubData* as_const() { return (const AOTStubData*)this; }
 };


### PR DESCRIPTION
Trivial build fix for building without CDS after [JDK-8383366](https://bugs.openjdk.org/browse/JDK-8383366).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385019](https://bugs.openjdk.org/browse/JDK-8385019): Build error without CDS (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31206/head:pull/31206` \
`$ git checkout pull/31206`

Update a local copy of the PR: \
`$ git checkout pull/31206` \
`$ git pull https://git.openjdk.org/jdk.git pull/31206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31206`

View PR using the GUI difftool: \
`$ git pr show -t 31206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31206.diff">https://git.openjdk.org/jdk/pull/31206.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31206#issuecomment-4491465177)
</details>
