### PR TITLE
8385018: Consistently escape CLDR resources

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -1228,7 +1228,7 @@ public class CLDRConverter {
                     String zone001 = handlerMetaZones.zidMap().get(meta);
                     return zone001 == null ? "" :
                             String.format("        \"%s\", \"%s\", \"%s\",",
-                                            id, meta, zone001);
+                                escape(id), escape(meta), escape(zone001));
                 })
                 .filter(s -> !s.isEmpty())
                 .sorted();

--- a/make/jdk/src/classes/build/tools/cldrconverter/MetaZonesParseHandler.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/MetaZonesParseHandler.java
@@ -102,9 +102,9 @@ class MetaZonesParseHandler extends AbstractLDMLHandler<String> {
                 zones.put(attributes.getValue("other"), attributes.getValue("type"));
             } else {
                 mzoneMapEntryList.add(String.format("        \"%s\", \"%s\", \"%s\",",
-                    attributes.getValue("other"),
-                    territory,
-                    attributes.getValue("type")));
+                    CLDRConverter.escape(attributes.getValue("other")),
+                    CLDRConverter.escape(territory),
+                    CLDRConverter.escape(attributes.getValue("type"))));
             }
             pushIgnoredContainer(qName);
             break;

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -103,14 +103,14 @@ class ResourceBundleGenerator implements BundleGenerator {
             for (String key : map.keySet()) {
                 if (key.startsWith(CLDRConverter.METAZONE_ID_PREFIX)) {
                     String meta = key.substring(CLDRConverter.METAZONE_ID_PREFIX.length());
-                    String[] value;
-                    value = (String[]) map.get(key);
-                    fmt.format("        final String[] %s = new String[] {\n", meta);
-                    for (String s : value) {
-                        fmt.format("               \"%s\",\n", CLDRConverter.escape(s));
+                    if (map.get(key) instanceof String[] value) {
+                        fmt.format("        final String[] %s = new String[] {\n", CLDRConverter.escape(meta));
+                        for (String s : value) {
+                            fmt.format("               \"%s\",\n", CLDRConverter.escape(s));
+                        }
+                        fmt.format("            };\n");
+                        metaKeys.add(key);
                     }
-                    fmt.format("            };\n");
-                    metaKeys.add(key);
                 }
             }
             for (String key : metaKeys) {
@@ -143,15 +143,15 @@ class ResourceBundleGenerator implements BundleGenerator {
                         if (fmt == null) {
                             fmt = new Formatter();
                         }
-                        String metaVal = oldEntry.metaKey();
+                        String metaVal = CLDRConverter.escape(oldEntry.metaKey());
                         if (val instanceof String[] values) {
                             fmt.format("        final String[] %s = new String[] {\n", metaVal);
                             for (String s : values) {
                                 fmt.format("            \"%s\",\n", CLDRConverter.escape(s));
                             }
                             fmt.format("        };\n");
-                        } else {
-                            fmt.format("        final String %s = \"%s\";\n", metaVal, CLDRConverter.escape((String)val));
+                        } else if (val instanceof String str) {
+                            fmt.format("        final String %s = \"%s\";\n", metaVal, CLDRConverter.escape(str));
                         }
                         newMap.put(oldEntry.key, oldEntry.metaKey());
                     }
@@ -178,21 +178,21 @@ class ResourceBundleGenerator implements BundleGenerator {
             out.println("        final Object[][] data = new Object[][] {");
             for (String key : map.keySet()) {
                 Object value = map.get(key);
+                var keyStr = CLDRConverter.escape(key);
                 if (value == null) {
                     CLDRConverter.warning("null value for " + key);
-                } else if (value instanceof String) {
-                    String valStr = (String)value;
+                } else if (value instanceof String valStr) {
+                    var escapedVal = CLDRConverter.escape(valStr);
                     if (type == BundleType.TIMEZONE &&
                         !(key.startsWith(CLDRConverter.EXEMPLAR_CITY_PREFIX) ||
                           key.startsWith(CLDRConverter.METAZONE_DSTOFFSET_PREFIX)) ||
                         valStr.startsWith(META_VALUE_PREFIX)) {
-                        out.printf("            { \"%s\", %s },\n", key, CLDRConverter.escape(valStr));
+                        out.printf("            { \"%s\", %s },\n", keyStr, escapedVal);
                     } else {
-                        out.printf("            { \"%s\", \"%s\" },\n", key, CLDRConverter.escape(valStr));
+                        out.printf("            { \"%s\", \"%s\" },\n", keyStr, escapedVal);
                     }
-                } else if (value instanceof String[]) {
-                    String[] values = (String[]) value;
-                    out.println("            { \"" + key + "\",\n                new String[] {");
+                } else if (value instanceof String[] values) {
+                    out.println("            { \"" + keyStr + "\",\n                new String[] {");
                     for (String s : values) {
                         out.println("                    \"" + CLDRConverter.escape(s) + "\",");
                     }
@@ -311,7 +311,7 @@ class ResourceBundleGenerator implements BundleGenerator {
                             out.printf("        parentLocalesMap.put(Locale.ROOT,\n");
                         } else {
                             out.printf("        parentLocalesMap.put(Locale.forLanguageTag(\"%s\"),\n",
-                                    parentTag);
+                                    CLDRConverter.escape(parentTag));
                         }
                         generateStringArray(metaInfo.get(key), out);
                     }
@@ -320,7 +320,7 @@ class ResourceBundleGenerator implements BundleGenerator {
 
                 // for languageAliasMap
                 CLDRConverter.handlerSupplMeta.getLanguageAliasData().forEach((key, value) -> {
-                    out.printf("        languageAliasMap.put(\"%s\", \"%s\");\n", key, value);
+                    out.printf("        languageAliasMap.put(\"%s\", \"%s\");\n", CLDRConverter.escape(key), CLDRConverter.escape(value));
                 });
                 out.printf("    }\n\n");
 
@@ -338,11 +338,11 @@ class ResourceBundleGenerator implements BundleGenerator {
                 CLDRConverter.handlerTimeZone.getData().entrySet().stream()
                     .forEach(e -> {
                         String[] ids = ((String)e.getValue()).split("\\s");
-                        out.printf("            tzCanonicalIDMap.put(\"%s\", \"%s\");\n", e.getKey(),
-                            ids[0]);
+                        out.printf("            tzCanonicalIDMap.put(\"%s\", \"%s\");\n", CLDRConverter.escape(e.getKey()),
+                            CLDRConverter.escape(ids[0]));
                         for (int i = 1; i < ids.length; i++) {
-                            out.printf("            tzCanonicalIDMap.put(\"%s\", \"%s\");\n", ids[i],
-                                ids[0]);
+                            out.printf("            tzCanonicalIDMap.put(\"%s\", \"%s\");\n", CLDRConverter.escape(ids[i]),
+                                CLDRConverter.escape(ids[0]));
                         }
                     });
                 out.println();
@@ -352,8 +352,9 @@ class ResourceBundleGenerator implements BundleGenerator {
                     if (key.startsWith(CLDRConverter.LIKELY_SCRIPT_PREFIX)) {
                         // ensure spaces at the begin/end for delimiting purposes
                         out.printf("            likelyScriptMap.put(\"%s\", \"%s\");\n",
-                                key.substring(CLDRConverter.LIKELY_SCRIPT_PREFIX.length()),
-                                " " + metaInfo.get(key).stream().collect(Collectors.joining(" ")) + " ");
+                                CLDRConverter.escape(key.substring(CLDRConverter.LIKELY_SCRIPT_PREFIX.length())),
+                                " " + metaInfo.get(key).stream()
+                                    .map(l -> CLDRConverter.escape(l)).collect(Collectors.joining(" ")) + " ");
                     }
                 }
                 out.printf("        }\n    }\n");
@@ -371,7 +372,7 @@ class ResourceBundleGenerator implements BundleGenerator {
                         return " %s";
                     }
                 """,
-                toLocaleList(applyLanguageAliases(metaInfo.get("AvailableLocales")), false));
+                CLDRConverter.escape(toLocaleList(applyLanguageAliases(metaInfo.get("AvailableLocales")), false)));
 
             if(CLDRConverter.isBaseModule) {
                 out.printf("""
@@ -408,7 +409,7 @@ class ResourceBundleGenerator implements BundleGenerator {
         int count = 0;
         for (int i = 0; i < children.length; i++) {
             String child = children[i];
-            out.printf("\"%s\", ", child);
+            out.printf("\"%s\", ", CLDRConverter.escape(child));
             count += child.length() + 4;
             if (i != children.length - 1 && count > 64) {
                 out.printf("\n                ");

--- a/make/jdk/src/classes/build/tools/cldrconverter/SupplementalMetadataParseHandler.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/SupplementalMetadataParseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,9 @@ class SupplementalMetadataParseHandler extends AbstractLDMLHandler<Object> {
 
     public Stream<String> deprecatedMap() {
         return keySet().stream()
-                .map(k -> String.format("        \"%s\", \"%s\",", k, get(k)))
+                .map(k -> "        \"%s\", \"%s\",".formatted(
+                        CLDRConverter.escape(k),
+                        CLDRConverter.escape((String)get(k))))
                 .sorted();
     }
     Map<String, String> getLanguageAliasData() {


### PR DESCRIPTION
Modified the CLDRConverter tool to consistently escape input character data from CLDR XML. Some escaping had already been implemented, but it was not applied consistently across all XML sources.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385018](https://bugs.openjdk.org/browse/JDK-8385018): Consistently escape CLDR resources (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31208/head:pull/31208` \
`$ git checkout pull/31208`

Update a local copy of the PR: \
`$ git checkout pull/31208` \
`$ git pull https://git.openjdk.org/jdk.git pull/31208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31208`

View PR using the GUI difftool: \
`$ git pr show -t 31208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31208.diff">https://git.openjdk.org/jdk/pull/31208.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31208#issuecomment-4492237176)
</details>
