### PR TITLE
8357593: Crash in Matcher::init_first_stack_mask() during production run

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1017,11 +1017,6 @@ bool AOTCodeCache::store_code_blob(CodeBlob& blob, AOTCodeEntry::Kind entry_kind
   if (AOTCodeEntry::is_blob(entry_kind) && !is_dumping_stub()) {
     return false;
   }
-  // we do not currently store C2 stubs because we are seeing weird
-  // memory errors when loading them -- see JDK-8357593
-  if (entry_kind == AOTCodeEntry::C2Blob) {
-    return false;
-  }
   log_debug(aot, codecache, stubs)("Writing blob '%s' (id=%u, kind=%s) to AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);
 
 #ifdef ASSERT
@@ -1290,11 +1285,6 @@ CodeBlob* AOTCodeCache::load_code_blob(AOTCodeEntry::Kind entry_kind, uint id, c
     return nullptr;
   }
   if (AOTCodeEntry::is_blob(entry_kind) && !is_using_stub()) {
-    return nullptr;
-  }
-  // we do not currently load C2 stubs because we are seeing weird
-  // memory errors when loading them -- see JDK-8357593
-  if (entry_kind == AOTCodeEntry::C2Blob) {
     return nullptr;
   }
   log_debug(aot, codecache, stubs)("Reading blob '%s' (id=%u, kind=%s) from AOT Code Cache", name, id, aot_code_entry_kind_name[entry_kind]);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -902,6 +902,13 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
   Code_Gen();
 }
 
+// C2 uses runtime stubs serialized generation to initialize its static tables
+// shared by all compilations, like Type::_shared_type_dict.
+// At least one stub have to be completely generated to execute intialization
+// before we can skip the rest stubs generation by loading AOT cached stubs.
+
+static bool c2_do_stub_init_complete = false;
+
 //------------------------------Compile----------------------------------------
 // Compile a runtime stub
 Compile::Compile(ciEnv* ci_env,
@@ -976,7 +983,7 @@ Compile::Compile(ciEnv* ci_env,
   C = this;
 
   // try to reuse an existing stub
-  {
+  if (c2_do_stub_init_complete) {
     BlobId blob_id = StubInfo::blob(_stub_id);
     CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::C2Blob, blob_id);
     if (blob != nullptr) {
@@ -1021,6 +1028,8 @@ Compile::Compile(ciEnv* ci_env,
   NOT_PRODUCT( verify_graph_edges(); )
 
   Code_Gen();
+
+  c2_do_stub_init_complete = (_stub_entry_point != nullptr);
 }
 
 Compile::~Compile() {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1031,7 +1031,7 @@ Compile::Compile(ciEnv* ci_env,
 
   // First successful stub generation will set it to `true`
   // and it will stay `true` after that.
-  c2_do_stub_init_complete ||= (_stub_entry_point != nullptr);
+  c2_do_stub_init_complete = c2_do_stub_init_complete || (_stub_entry_point != nullptr);
 }
 
 Compile::~Compile() {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1029,7 +1029,9 @@ Compile::Compile(ciEnv* ci_env,
 
   Code_Gen();
 
-  c2_do_stub_init_complete = (_stub_entry_point != nullptr);
+  // First successful stub generation will set it to `true`
+  // and it will stay `true` after that.
+  c2_do_stub_init_complete ||= (_stub_entry_point != nullptr);
 }
 
 Compile::~Compile() {

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -217,10 +217,7 @@ public class AOTCodeFlags {
                         // AOTStubCaching is on, non-zero stubs should be stored
                         out.shouldMatch("Shared Blobs:\\s+total=[1-9][0-9]+");
                         out.shouldMatch("C1 Blobs:\\s+total=[1-9][0-9]+");
-                        // we do not currently load or store C2 stubs
-                        // because we are seeing weird memory errors
-                        // when loading them -- see JDK-8357593
-                        out.shouldMatch("C2 Blobs:\\s+total=0");
+                        out.shouldMatch("C2 Blobs:\\s+total=[1-9][0-9]+");
                     } else {
                         // AOTStubCaching is off, no stubs should be stored
                         out.shouldMatch("Shared Blobs:\\s+total=0");


### PR DESCRIPTION
C2 implicitly use serialized (under CompileThread_lock) generation of C2's runtime stubs to initialize some static tables which are shared by all compilations without using any synchronization. Such tables are `Type::_shared_type_dict` and `Matcher::idealreg2regmask[]`. And may be others.

If we skip all C2's runtime stubs generation by loading then from AOT cache those tables will not be initialized during compiler startup. Instead they will be initialized concurrently by following compilations leading to incorrect values in them and failures.

To guarantee that all shared structures in C2 are correctly initialized I suggest to let at least one runtime stub to be fully generated instead of loading it from AOT cache.

Tested with JCK test in loop which failed before at least once in 50 runs. After fix I was able to ru nit > 150 times without failure.

Tested tier1-6, 9-rt(jck) ,hs-comp-stress, hs-aot-stress (aot jck with stress flags )

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357593](https://bugs.openjdk.org/browse/JDK-8357593): Crash in Matcher::init_first_stack_mask() during production run (**Bug** - P3)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) Review applies to [3f754471](https://git.openjdk.org/jdk/pull/31211/files/3f75447159510bccb90e12413b52669c4504ae2c)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31211/head:pull/31211` \
`$ git checkout pull/31211`

Update a local copy of the PR: \
`$ git checkout pull/31211` \
`$ git pull https://git.openjdk.org/jdk.git pull/31211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31211`

View PR using the GUI difftool: \
`$ git pr show -t 31211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31211.diff">https://git.openjdk.org/jdk/pull/31211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31211#issuecomment-4495474302)
</details>
