### PR TITLE
8384999: Rename CodeBuffer::last_insn() to something more descriptive

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2667,7 +2667,7 @@ int MacroAssembler::corrected_idivq(Register result, Register ra, Register rb,
 
 void MacroAssembler::membar(Membar_mask_bits order_constraint) {
   address prev = pc() - NativeMembar::instruction_size;
-  address last = code()->last_insn();
+  address last = code()->last_merge_candidate();
   if (last != nullptr && nativeInstruction_at(last)->is_Membar() && prev == last) {
     NativeMembar *bar = NativeMembar_at(prev);
     if (AlwaysMergeDMB) {
@@ -2698,21 +2698,21 @@ void MacroAssembler::membar(Membar_mask_bits order_constraint) {
       }
     }
   }
-  code()->set_last_insn(pc());
+  code()->set_last_merge_candidate(pc());
   dmb(Assembler::barrier(order_constraint));
 }
 
 bool MacroAssembler::try_merge_ldst(Register rt, const Address &adr, size_t size_in_bytes, bool is_store) {
   if (ldst_can_merge(rt, adr, size_in_bytes, is_store)) {
     merge_ldst(rt, adr, size_in_bytes, is_store);
-    code()->clear_last_insn();
+    code()->clear_last_merge_candidate();
     return true;
   } else {
     assert(size_in_bytes == 8 || size_in_bytes == 4, "only 8 bytes or 4 bytes load/store is supported.");
     const uint64_t mask = size_in_bytes - 1;
     if (adr.getMode() == Address::base_plus_offset &&
         (adr.offset() & mask) == 0) { // only supports base_plus_offset.
-      code()->set_last_insn(pc());
+      code()->set_last_merge_candidate(pc());
     }
     return false;
   }
@@ -3875,7 +3875,7 @@ bool MacroAssembler::ldst_can_merge(Register rt,
                                     size_t cur_size_in_bytes,
                                     bool is_store) const {
   address prev = pc() - NativeInstruction::instruction_size;
-  address last = code()->last_insn();
+  address last = code()->last_merge_candidate();
 
   if (last == nullptr || !nativeInstruction_at(last)->is_Imm_LdSt()) {
     return false;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -168,7 +168,7 @@ class MacroAssembler: public Assembler {
 
   void bind(Label& L) {
     Assembler::bind(L);
-    code()->clear_last_insn();
+    code()->clear_last_merge_candidate();
     code()->set_last_label(pc());
   }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4117,7 +4117,7 @@ void MacroAssembler::membar(uint32_t order_constraint) {
   }
 
   address prev = pc() - MacroAssembler::instruction_size;
-  address last = code()->last_insn();
+  address last = code()->last_merge_candidate();
 
   if (last != nullptr && is_membar(last) && prev == last) {
     // We are merging two memory barrier instructions.  On RISCV we
@@ -4127,7 +4127,7 @@ void MacroAssembler::membar(uint32_t order_constraint) {
     return;
   }
 
-  code()->set_last_insn(pc());
+  code()->set_last_merge_candidate(pc());
   uint32_t predecessor = 0;
   uint32_t successor = 0;
   membar_mask_to_pred_succ(order_constraint, predecessor, successor);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -876,7 +876,7 @@ public:
   void bind(Label& L) {
     Assembler::bind(L);
     // fences across basic blocks should not be merged
-    code()->clear_last_insn();
+    code()->clear_last_merge_candidate();
   }
 
   typedef void (MacroAssembler::* compare_and_branch_insn)(Register Rs1, Register Rs2, const address dest);

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -937,8 +937,8 @@ void CodeBuffer::expand(CodeSection* which_cs, csize_t amount) {
   // Move all the code and relocations to the new blob:
   relocate_code_to(&cb);
 
-  // some internal addresses, _last_insn _last_label, are used during code emission,
-  // adjust them in expansion
+  // some internal addresses, _last_merge_candidate and _last_label, are used during
+  // code emission, adjust them in expansion
   adjust_internal_address(insts_begin(), cb.insts_begin());
 
   // Copy the temporary code buffer into the current code buffer.
@@ -966,8 +966,8 @@ void CodeBuffer::expand(CodeSection* which_cs, csize_t amount) {
 }
 
 void CodeBuffer::adjust_internal_address(address from, address to) {
-  if (_last_insn != nullptr) {
-    _last_insn += to - from;
+  if (_last_merge_candidate != nullptr) {
+    _last_merge_candidate += to - from;
   }
   if (_last_label != nullptr) {
     _last_label += to - from;

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -561,11 +561,11 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
   OopRecorder* _oop_recorder;
 
-  OopRecorder  _default_oop_recorder;  // override with initialize_oop_recorder
+  OopRecorder  _default_oop_recorder; // override with initialize_oop_recorder
   Arena*       _overflow_arena;
 
-  address      _last_insn;      // used to merge consecutive memory barriers, loads or stores.
-  address      _last_label;     // record last bind label address, it's also the start of current bb.
+  address      _last_label;           // record last bind label address, it's also the start of current bb.
+  address      _last_merge_candidate; // used to merge consecutive memory barriers, loads or stores.
 
   SharedStubToInterpRequests* _shared_stub_to_interp_requests; // used to collect requests for shared iterpreter stubs
   SharedTrampolineRequests*   _shared_trampoline_requests;     // used to collect requests for shared trampolines
@@ -591,11 +591,11 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _total_size      = 0;
     _oop_recorder    = nullptr;
     _overflow_arena  = nullptr;
-    _last_insn       = nullptr;
     _last_label      = nullptr;
-    _finalize_stubs  = false;
+    _last_merge_candidate = nullptr;
     _shared_stub_to_interp_requests = nullptr;
     _shared_trampoline_requests = nullptr;
+    _finalize_stubs  = false;
 
     _consts.initialize_outer(this, SECT_CONSTS);
     _insts.initialize_outer(this,  SECT_INSTS);
@@ -812,9 +812,9 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
   OopRecorder* oop_recorder() const { return _oop_recorder; }
 
-  address last_insn() const { return _last_insn; }
-  void set_last_insn(address a) { _last_insn = a; }
-  void clear_last_insn() { set_last_insn(nullptr); }
+  address last_merge_candidate() const { return _last_merge_candidate; }
+  void set_last_merge_candidate(address a) { _last_merge_candidate = a; }
+  void clear_last_merge_candidate() { set_last_merge_candidate(nullptr); }
 
   address last_label() const { return _last_label; }
   void set_last_label(address a) { _last_label = a; }


### PR DESCRIPTION
Hello,

When working on [JDK-8384520](https://bugs.openjdk.org/browse/JDK-8384520) I felt that the name of `last_insn` was misleadning, as it appears to be recording an arbitrary "last instruction" for some unspecified use-case, which is not the case. `last_insn` really only records membars, loads or stores, for the purpose of merging consecutive instructions.

To make it easier to approach this (maybe for someone new to this code, like me!), I suggest we rename it to indicate it's specific purpose of merging instructions.

It's only the MacroAssembler for AArch64 and RISCV which uses this infrastructure to merge instructions.

Testing:
* Oracle's tier1-3 and hs-comp-stress
* GHA (which cross-compiles to riscv) 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384999](https://bugs.openjdk.org/browse/JDK-8384999): Rename CodeBuffer::last_insn() to something more descriptive (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31212/head:pull/31212` \
`$ git checkout pull/31212`

Update a local copy of the PR: \
`$ git checkout pull/31212` \
`$ git pull https://git.openjdk.org/jdk.git pull/31212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31212`

View PR using the GUI difftool: \
`$ git pr show -t 31212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31212.diff">https://git.openjdk.org/jdk/pull/31212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31212#issuecomment-4496292636)
</details>
