### PR TITLE
8385092: KeyChainStore entry creation time is always now

### DIFF
--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -64,24 +64,9 @@ errOut:
 
 static jlong getModDateFromItem(JNIEnv *env, SecKeychainItemRef inItem)
 {
-    OSStatus status;
-    SecKeychainAttribute itemAttrs[] = { { kSecModDateItemAttr, 0, NULL } };
-    SecKeychainAttributeList attrList = { sizeof(itemAttrs) / sizeof(itemAttrs[0]), itemAttrs };
-    jlong returnValue = 0;
-
-    status = SecKeychainItemCopyContent(inItem, NULL, &attrList, NULL, NULL);
-
-    if(status) {
-        // This is almost always missing, so don't dump an error.
-        // cssmPerror("getModDateFromItem: SecKeychainItemCopyContent", status);
-        goto errOut;
-    }
-
-    memcpy(&returnValue, itemAttrs[0].data, itemAttrs[0].length);
-
-errOut:
-    SecKeychainItemFreeContent(&attrList, NULL);
-    return returnValue;
+    // SecKeychainItemCopyContent on kSecModDateItemAttr fails
+    // with errSecNoSuchAttr: The attribute does not exist.
+    return 0;
 }
 
 static void setLabelForItem(NSString *inLabel, SecKeychainItemRef inItem)


### PR DESCRIPTION
Always use the current time before we find a better way to get the creation time (if exists).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385092](https://bugs.openjdk.org/browse/JDK-8385092): KeyChainStore entry creation time is always now (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31215/head:pull/31215` \
`$ git checkout pull/31215`

Update a local copy of the PR: \
`$ git checkout pull/31215` \
`$ git pull https://git.openjdk.org/jdk.git pull/31215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31215`

View PR using the GUI difftool: \
`$ git pr show -t 31215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31215.diff">https://git.openjdk.org/jdk/pull/31215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31215#issuecomment-4499323590)
</details>
