### PR TITLE
8360595: OOM in java/foreign/TestUpcallStress.java

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -109,8 +109,7 @@ tier4 = \
     / \
    -:tier1 \
    -:tier2 \
-   -:tier3 \
-   :jdk_foreign_stress
+   -:tier3
 
 ###############################################################################
 #
@@ -391,11 +390,7 @@ jdk_svc = \
 jdk_foreign = \
     java/foreign \
     jdk/internal/reflect/CallerSensitive/CheckCSMs.java \
-    -java/foreign/TestMatrix.java \
-    -java/foreign/TestUpcallStress.java
-
-jdk_foreign_stress = \
-    java/foreign/TestUpcallStress.java
+    -java/foreign/TestMatrix.java
 
 jdk_vector = \
     jdk/incubator/vector

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @requires jdk.foreign.linker != "FALLBACK"
- * @requires (os.arch == "aarch64" | os.arch=="riscv64" | os.arch=="x86_64" | os.arch=="amd64") & os.name == "Linux"
  * @requires vm.compMode != "Xcomp"
  * @modules java.base/jdk.internal.foreign
  * @library /test/lib

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -25,13 +25,13 @@
  * @test
  * @requires jdk.foreign.linker != "FALLBACK"
  * @requires (os.arch == "aarch64" | os.arch=="riscv64" | os.arch=="x86_64" | os.arch=="amd64") & os.name == "Linux"
- * @requires os.maxMemory > 4G
  * @requires vm.compMode != "Xcomp"
  * @modules java.base/jdk.internal.foreign
+ * @library /test/lib
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  * @bug 8337753
  *
- * @run testng/native/othervm/timeout=3200
+ * @run testng/native/othervm
  *   -Xcheck:jni
  *   -XX:+IgnoreUnrecognizedVMOptions
  *   -XX:-VerifyDependencies
@@ -44,7 +44,10 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import jdk.test.lib.Utils;
 
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
@@ -59,11 +62,27 @@ public class TestUpcallStress extends TestUpcallBase {
         System.loadLibrary("TestUpcall");
     }
 
+    static final int THREAD_COUNT = 100;
+
+    ExecutorService executor;
+
+    @BeforeClass
+    public void setup() {
+        executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    }
+
+    @AfterClass
+    public void tearDown() throws InterruptedException {
+        executor.shutdown();
+        // Let it run for a while, and then just terminate
+        executor.awaitTermination(Utils.adjustTimeout(30), TimeUnit.SECONDS);
+    }
+
+
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
     public void testUpcallsStress(int count, String fName, Ret ret, List<ParamType> paramTypes,
-                                  List<StructFieldType> fields) throws Throwable {
-        ExecutorService executor = Executors.newFixedThreadPool(16);
-        for (int threadIdx = 0; threadIdx < 16; threadIdx++) {
+                                  List<StructFieldType> fields) {
+        for (int threadIdx = 0; threadIdx < THREAD_COUNT; threadIdx++) {
             executor.submit(() -> {
                 for (int iter = 0; iter < 10000; iter++) {
                     List<Consumer<Object>> returnChecks = new ArrayList<>();
@@ -91,8 +110,5 @@ public class TestUpcallStress extends TestUpcallBase {
                 }
             });
         }
-        // This shutdownNow is 'wrong', since it doesn't wait for tasks to terminate,
-        // but it seems to be the only way to reproduce the race of JDK-8337753
-        executor.shutdownNow();
     }
 }


### PR DESCRIPTION
We were already seeing some issues on mac when the test was added, and it was therefor disabled on those platforms. Now we've had reports that this test is causing OOMs on other systems as well.

Rather than outright removing the test, I've detuned it to create less thread/memory churn, more in line with other tests.

Since The test has been detuned, it no longer needs to be in it's own test group, and can safely run as part of the regular `jdk_foreign` tests. I've changed the jtreg test groups to reflect this.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360595](https://bugs.openjdk.org/browse/JDK-8360595): OOM in java/foreign/TestUpcallStress.java (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31216/head:pull/31216` \
`$ git checkout pull/31216`

Update a local copy of the PR: \
`$ git checkout pull/31216` \
`$ git pull https://git.openjdk.org/jdk.git pull/31216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31216`

View PR using the GUI difftool: \
`$ git pr show -t 31216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31216.diff">https://git.openjdk.org/jdk/pull/31216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31216#issuecomment-4499711957)
</details>
