### PR TITLE
8385070: Compiler should use subtype checks for language rules specified in terms of subtyping

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4361,7 +4361,7 @@ public class Types {
             isSameType(t, s) ||
             !t.isPrimitive() &&
             !s.isPrimitive() &&
-            isAssignable(t, s, warner);
+            isSubtypeUnchecked(t, s, warner);
     }
     // </editor-fold>
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1177,7 +1177,7 @@ public class Attr extends JCTree.Visitor {
             }
 
             for (List<JCExpression> l = tree.thrown; l.nonEmpty(); l = l.tail)
-                chk.checkType(l.head.pos(), l.head.type, syms.throwableType);
+                chk.checkType(l.head.pos(), l.head.type, syms.throwableType, chk.subtypeHandler);
 
             if (tree.body == null) {
                 // Empty bodies are only allowed for
@@ -1975,7 +1975,7 @@ public class Attr extends JCTree.Visitor {
             try {
                 // Attribute resource declarations
                 for (JCTree resource : tree.resources) {
-                    CheckContext twrContext = new Check.NestedCheckContext(resultInfo.checkContext) {
+                    CheckContext twrContext = new Check.NestedCheckContext(chk.subtypeHandler) {
                         @Override
                         public void report(DiagnosticPosition pos, JCDiagnostic details) {
                             chk.basicHandler.report(pos, diags.fragment(Fragments.TryNotApplicableToType(details)));
@@ -2023,7 +2023,8 @@ public class Attr extends JCTree.Visitor {
                     }
                     chk.checkType(c.param.vartype.pos(),
                                   chk.checkClassType(c.param.vartype.pos(), ctype),
-                                  syms.throwableType);
+                                  syms.throwableType,
+                                  chk.subtypeHandler);
                     attribStat(c.body, catchEnv);
                 } finally {
                     catchEnv.info.scope.leave();
@@ -2243,7 +2244,7 @@ public class Attr extends JCTree.Visitor {
                                  .collect(List.collector());
 
             for (Type type : condTypes) {
-                if (condTypes.stream().filter(t -> t != type).allMatch(t -> types.isAssignable(t, type)))
+                if (condTypes.stream().filter(t -> t != type).allMatch(t -> types.isSubtype(t, type)))
                     return type.baseType();
             }
 
@@ -2604,8 +2605,10 @@ public class Attr extends JCTree.Visitor {
                         // Check that the prefix expression conforms
                         // to the outer instance type of the class.
                         chk.checkRefType(qualifier.pos(),
-                                         attribExpr(qualifier, localEnv,
-                                                    encl));
+                                attribTree(qualifier, localEnv,
+                                           new ResultInfo(KindSelector.VAL,
+                                                          encl,
+                                                          chk.subtypeHandler)));
                     }
                 } else if (tree.meth.hasTag(SELECT)) {
                     log.error(tree.meth.pos(),
@@ -5123,7 +5126,8 @@ public class Attr extends JCTree.Visitor {
             Type ctype = attribType(typeTree, env);
             ctype = chk.checkType(typeTree.pos(),
                           chk.checkClassType(typeTree.pos(), ctype),
-                          syms.throwableType);
+                          syms.throwableType,
+                          chk.subtypeHandler);
             if (!ctype.isErroneous()) {
                 //check that alternatives of a union type are pairwise
                 //unrelated w.r.t. subtyping

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -530,6 +530,37 @@ public class Check {
         }
     };
 
+    /**
+     * Check context to be used when a type must be a subtype of a target,
+     * rather than querying isAssignable in general. This prevents
+     * isAssignable from leaking into subtype-only language checks.
+     */
+    CheckContext subtypeHandler = new CheckContext() {
+        public void report(DiagnosticPosition pos, JCDiagnostic details) {
+            log.error(pos, Errors.ProbFoundReq(details));
+        }
+        public boolean compatible(Type found, Type req, Warner warn) {
+            return found.hasTag(ERROR) || found.hasTag(BOT) || types.isSubtype(found, req);
+        }
+
+        public Warner checkWarner(DiagnosticPosition pos, Type found, Type req) {
+            return types.noWarnings;
+        }
+
+        public InferenceContext inferenceContext() {
+            return infer.emptyContext;
+        }
+
+        public DeferredAttrContext deferredAttrContext() {
+            return deferredAttr.emptyDeferredAttrContext;
+        }
+
+        @Override
+        public String toString() {
+            return "CheckContext: subtypeHandler";
+        }
+    };
+
     /** Check that a given type is assignable to a given proto-type.
      *  If it is, return the type, otherwise return errType.
      *  @param pos        Position to be used for error reporting.

--- a/test/langtools/tools/javac/types/AssignmentConversions.java
+++ b/test/langtools/tools/javac/types/AssignmentConversions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8385070
+ * @summary javac should use subtype checks for language rules specified in terms of subtyping
+ * @compile AssignmentConversions.java
+ * @run main AssignmentConversions
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AssignmentConversions {
+    sealed interface I permits A {}
+    static final class A implements I {}
+
+    public static void main(String... args) {
+        orderIndependentConditional(true);
+        orderIndependentConditional(false);
+        orderIndependentSwitch(0);
+        orderIndependentSwitch(1);
+        pureAssignmentContexts(true, 0);
+        pureAssignmentContexts(false, 1);
+        throwExpressionContext();
+    }
+
+    static void orderIndependentConditional(boolean flag) {
+        I i = new A();
+
+        var v1 = flag ? new A() : i;
+        var v2 = flag ? i : new A();
+
+        String s1 = overloadShouldPickI(v1);
+        String s2 = overloadShouldPickI(v2);
+    }
+
+    static void orderIndependentSwitch(int selector) {
+        I i = new A();
+
+        var v1 = switch (selector) {
+            case 0 -> new A();
+            default -> i;
+        };
+        var v2 = switch (selector) {
+            case 0 -> i;
+            default -> new A();
+        };
+
+        String s1 = overloadShouldPickI(v1);
+        String s2 = overloadShouldPickI(v2);
+    }
+
+    static void pureAssignmentContexts(boolean flag, int selector) {
+        // asserting the pure assignment context (a raw type ArrayList is not a
+        // clean subtype of ArrayList<String> but it is accepted by assignment)
+        ArrayList raw = new ArrayList();
+
+        ArrayList<String> declarationInitializer = raw;
+
+        ArrayList<String> simple;
+        simple = raw;
+
+        ArrayList<String>[] array = new ArrayList[1];
+        array[0] = raw;
+
+        ArrayList<String>[] arrayInitializer = new ArrayList[] { raw };
+
+        ArrayList<String> returned = methodReturn(raw);
+
+        Supplier<ArrayList<String>> lambda = () -> raw;
+
+        Supplier<ArrayList<String>> methodRef = new Box()::val;
+
+        Iterable<ArrayList> rawIterable = List.of(raw);
+        for (ArrayList<String> item : rawIterable) { }
+
+        ArrayList<String> conditional = flag ? raw : new ArrayList<String>();
+
+        ArrayList<String> switchExpression = switch (selector) {
+            case 0 -> raw;
+            default -> new ArrayList<String>();
+        };
+    }
+
+    static String overloadShouldPickI(I i) {
+        return "";
+    }
+    static Integer overloadShouldPickI(A a) {
+        return 0;
+    }
+
+    static ArrayList<String> methodReturn(ArrayList list) {
+        return list;
+    }
+
+    static void throwExpressionContext() {
+        try {
+            throwRuntime(new RuntimeException());
+        } catch (RuntimeException ex) {
+        }
+    }
+
+    static void throwRuntime(RuntimeException ex) {
+        throw ex;
+    }
+
+    static class Box {
+        ArrayList val() {
+            return new ArrayList();
+        }
+    }
+}

--- a/test/langtools/tools/javac/types/AssignmentConversionsRegression.java
+++ b/test/langtools/tools/javac/types/AssignmentConversionsRegression.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8385070
+ * @summary javac should use subtype checks for language rules specified in terms of subtyping
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main AssignmentConversionsRegression
+ */
+
+import java.util.List;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class AssignmentConversionsRegression {
+    final ToolBox tb = new ToolBox();
+
+    public static void main(String... args) throws Exception {
+        AssignmentConversionsRegression test = new AssignmentConversionsRegression();
+        test.subtypeOnlyChecks();
+    }
+
+    void subtypeOnlyChecks() {
+        List<String> output = new JavacTask(tb)
+                .options("-XDrawDiagnostics")
+                .sources("""
+                         class Cases {
+                             sealed interface I permits A {}
+                             static final class A implements I {}
+                             static class Super {
+                                 A m() {
+                                     return null;
+                                 }
+                             }
+                             static class BadCovariantReturn extends Super {
+                                 @Override // always error
+                                 I m() { // always error
+                                     return null;
+                                 }
+                             }
+
+                             sealed interface Enclosing permits Outer {}
+                             static final class Outer implements Enclosing {
+                                 class Base {}
+                             }
+                             static class BadQualifiedSuper extends Outer.Base {
+                                 BadQualifiedSuper(Enclosing outer) {
+                                     outer.super(); // always error
+                                 }
+                             }
+
+                             sealed interface Resource permits ResourceImpl {}
+                             static final class ResourceImpl implements Resource, AutoCloseable {
+                                 public void close() {}
+                             }
+                             void badTwr(Resource r) throws Exception {
+                                 try (r) { // always error
+                                 }
+                             }
+
+                             sealed interface ExceptionType permits ExceptionImpl {}
+                             static final class ExceptionImpl extends Exception implements ExceptionType {}
+                             void badThrows() throws ExceptionType { // always error
+                             }
+
+                             static final class NotThrowable {}
+                             void badCatch() {
+                                 try {
+                                 } catch (NotThrowable ex) { // always error
+                                 }
+                             }
+
+                             void badMultiCatch() {
+                                 try {
+                                 } catch (NotThrowable | RuntimeException ex) { // always error
+                                 }
+                             }
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        tb.checkEqual(output, List.of(
+                "Cases.java:11:11: compiler.err.override.incompatible.ret: (compiler.misc.cant.override: m(), Cases.BadCovariantReturn, m(), Cases.Super), Cases.I, Cases.A",
+                "Cases.java:10:9: compiler.err.method.does.not.override.superclass: m(), Cases.BadCovariantReturn",
+                "Cases.java:22:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: Cases.Enclosing, Cases.Outer)",
+                "Cases.java:31:14: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: Cases.Resource, java.lang.AutoCloseable))",
+                "Cases.java:37:29: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: Cases.ExceptionType, java.lang.Throwable)",
+                "Cases.java:43:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: Cases.NotThrowable, java.lang.Throwable)",
+                "Cases.java:49:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: Cases.NotThrowable, java.lang.Throwable)",
+                "7 errors"));
+    }
+}


### PR DESCRIPTION
This PR replaces some direct and indirect calls to `isAssignable` with subtype checks, in javac areas where the JLS specifies subtyping (and not assignment compatibility). This PR preserves assignment conversion for true assignment contexts according to the JLS. The added tests ensure that both the subtype-only checks and the contexts that must continue accepting assignment conversions based on `isAssignable`, retain behaviour. 

- In AssignmentConversions.java I cover the standalone conditional/switch type inference and true assignment contexts, including raw-to-generic unchecked assignment cases (to differentiate with something that subtyping does not allow).
- In AssignmentConversionsRegression.java I include a short negative regression test ensuring that sealed-supertype values are rejected where subtype-only rules apply, such as covariant returns, TWR, throws/catch, multi-catch, and qualified super. If `isAssignable` changes behavior this test ensures that these sites should not change behavior.

Other direct callers of `Types.isAssignable` are intentionally outside the source-language split above (but reviewers should also confirm that):

- `Attr.handleSwitch` uses `isAssignable` to classify numeric switch selectors as `int`-compatible.
- `Attr.condType` still uses `isAssignable` for the numeric constant narrowing rule in conditional expression typing; the reference-type shortcut is the part that moved to subtyping.
- `Check.checkLossOfPrecision` uses `isAssignable` for a numeric lint warning.
- `JavacTypes.isAssignable` exposes the public language-model assignment query and should remain assignment-based.
- JShell completion, javadoc/doclint, and doclet call sites use the public `Types.isAssignable` query for tool-specific filtering/checking, not javac source attribution.
- `TransTypes.coerce` uses `isAssignable` during lowering to decide whether an erased expression needs a cast; this is an implementation audit item rather than a source-language program location.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change requires CSR request [JDK-8385926](https://bugs.openjdk.org/browse/JDK-8385926) to be approved
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8385070](https://bugs.openjdk.org/browse/JDK-8385070): Compiler should use subtype checks for language rules specified in terms of subtyping (**Bug** - P4)
 * [JDK-8385925](https://bugs.openjdk.org/browse/JDK-8385925): Conditional expression type depends on operand order for raw and parameterized types (**Bug** - P4)
 * [JDK-8385926](https://bugs.openjdk.org/browse/JDK-8385926): Conditional expression type depends on operand order for raw and parameterized types (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31217/head:pull/31217` \
`$ git checkout pull/31217`

Update a local copy of the PR: \
`$ git checkout pull/31217` \
`$ git pull https://git.openjdk.org/jdk.git pull/31217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31217`

View PR using the GUI difftool: \
`$ git pr show -t 31217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31217.diff">https://git.openjdk.org/jdk/pull/31217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31217#issuecomment-4499631632)
</details>
