### PR TITLE
8385096: Test runtime/cds/MetaspaceAllocGaps.java fails on Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/MetaspaceAllocGaps.java
+++ b/test/hotspot/jtreg/runtime/cds/MetaspaceAllocGaps.java
@@ -49,14 +49,8 @@ public class MetaspaceAllocGaps {
                 .classpath(appJar)
                 .appCommandLine("Hello")
                 .setTrainingChecker((OutputAnalyzer out) -> {
-                    // Typically all gaps should be filled. If not, we probably have a regression in C++ class ArchiveUtils.
-                    //
-                    // [0.422s][debug][aot ] Detailed metadata info (excluding heap region):
-                    // [...]
-                    // [0.422s][debug][aot ] Gap : 0 0 0.0 | 0 0 0.0 | 0 0 0.0 <<< look for this pattern
-                    out.shouldMatch("Allocated [1-9][0-9]+ objects of [1-9][0-9]+ bytes in gaps .remain = 0 bytes")
-                       .shouldMatch("debug.* Gap .*0[.]0.*0[.]0.*0[.]0")
-                       .shouldNotMatch("Unexpected .* gaps .* for Klass alignment");
+                    // We should have only very minimal amount of gaps left unfilled. See JDK-8383503
+                    out.shouldNotMatch("Unexpected .* gaps .* for Klass alignment");
                 })
                 .setProductionChecker((OutputAnalyzer out) -> {
                     out.shouldContain("HelloWorld");


### PR DESCRIPTION
Please review this trivial change: the test case needs to be updated to match the changes in [JDK-8383503](https://bugs.openjdk.org/browse/JDK-8383503)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385096](https://bugs.openjdk.org/browse/JDK-8385096): Test runtime/cds/MetaspaceAllocGaps.java fails on Windows (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31219/head:pull/31219` \
`$ git checkout pull/31219`

Update a local copy of the PR: \
`$ git checkout pull/31219` \
`$ git pull https://git.openjdk.org/jdk.git pull/31219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31219`

View PR using the GUI difftool: \
`$ git pr show -t 31219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31219.diff">https://git.openjdk.org/jdk/pull/31219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31219#issuecomment-4499723518)
</details>
