### PR TITLE
8384958: Regression of jvmti/init/GetAllStackTraces/getallstktr001.java caused by JDK-8382273

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001.java
@@ -23,7 +23,6 @@
 
 package nsk.jvmti.unit.GetAllStackTraces;
 
-import jdk.test.lib.thread.ThreadWrapper;
 import java.io.PrintStream;
 import nsk.share.Consts;
 
@@ -118,8 +117,12 @@ public class getallstktr001 {
         }
         return GetResult();
     }
+    // Note: TestThread must extend Thread, not ThreadWrapper. This test uses
+    // JVMTI GetAllStackTraces which only returns platform threads, and 40
+    // threads blocking on native RawMonitorEnter pins carriers causing deadlock.
+    // See JDK-8384958.
 
-    static class TestThread extends ThreadWrapper {
+    static class TestThread extends Thread {
         static int counter=0;
         int ind;
         public TestThread(String name) {


### PR DESCRIPTION
getallstktr001 is not virtual-thread-safe. JVMTI GetAllStackTraces() only returns platform thread stacks, not virtual threads. Additionally, 40 threads all block on native RawMonitorEnter() which pins carrier threads and causes deadlock when run as virtual threads (confirmed during JDK-8382273 testing). 
Reverted TestThread to extends Thread.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384958](https://bugs.openjdk.org/browse/JDK-8384958): Regression of jvmti/init/GetAllStackTraces/getallstktr001.java caused by JDK-8382273 (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31220/head:pull/31220` \
`$ git checkout pull/31220`

Update a local copy of the PR: \
`$ git checkout pull/31220` \
`$ git pull https://git.openjdk.org/jdk.git pull/31220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31220`

View PR using the GUI difftool: \
`$ git pr show -t 31220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31220.diff">https://git.openjdk.org/jdk/pull/31220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31220#issuecomment-4511964089)
</details>
