### PR TITLE
8382390: Shenandoah: heap usage log improvement

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -3053,25 +3053,27 @@ void ShenandoahFreeSet::log_status_under_lock() {
 }
 
 void ShenandoahFreeSet::log_freeset_stats(ShenandoahFreeSetPartitionId partition_id, LogStream& ls) {
-  size_t max = 0;
-  size_t total_free = 0;
-  size_t total_used = 0;
+  size_t max_free_in_single_region = 0;
+  size_t freeset_free = 0;
+  size_t freeset_total_used = 0;
 
   for (idx_t idx = _partitions.leftmost(partition_id);
         idx <= _partitions.rightmost(partition_id); idx++) {
     if (_partitions.in_free_set(partition_id, idx)) {
       ShenandoahHeapRegion *r = _heap->get_region(idx);
       size_t free = alloc_capacity(r);
-      max = MAX2(max, free);
-      total_free += free;
-      total_used += r->used();
+      max_free_in_single_region = MAX2(max_free_in_single_region, free);
+      freeset_free += free;
+      freeset_total_used += ShenandoahHeapRegion::region_size_bytes() - free;
     }
   }
 
-  ls.print(" %s freeset stats: Partition count: %zu, Reserved: " PROPERFMT ", Max free available in a single region: " PROPERFMT ";",
-            partition_name(partition_id),
-            _partitions.count(partition_id),
-            PROPERFMTARGS(total_free), PROPERFMTARGS(max)
+  ls.print_cr("  %s partition stats: Partition overall count: %zu, Partition count in freeset: %zu, "
+          "Used size including retired regions: " PROPERFMT ", used size in freeset: " PROPERFMT
+          ", free size: " PROPERFMT  ", max free available in a single region: " PROPERFMT ";",
+            partition_name(partition_id), _partitions.get_capacity_region_count(partition_id), _partitions.count(partition_id),
+            PROPERFMTARGS(_partitions.get_used(partition_id)), PROPERFMTARGS(freeset_total_used),
+            PROPERFMTARGS(freeset_free), PROPERFMTARGS(max_free_in_single_region)
           );
 }
 
@@ -3153,12 +3155,10 @@ void ShenandoahFreeSet::log_status() {
 
     {
       idx_t last_idx = 0;
-      size_t max = 0;
       size_t max_contig = 0;
       size_t empty_contig = 0;
 
-      size_t total_used = 0;
-      size_t total_free = 0;
+      size_t total_used_in_freeset = 0;
       size_t total_free_ext = 0;
 
       for (idx_t idx = _partitions.leftmost(ShenandoahFreeSetPartitionId::Mutator);
@@ -3166,7 +3166,6 @@ void ShenandoahFreeSet::log_status() {
         if (_partitions.in_free_set(ShenandoahFreeSetPartitionId::Mutator, idx)) {
           ShenandoahHeapRegion *r = _heap->get_region(idx);
           size_t free = alloc_capacity(r);
-          max = MAX2(max, free);
           size_t used_in_region = r->used();
           if (r->is_empty_or_trash()) {
             used_in_region = 0;
@@ -3179,42 +3178,33 @@ void ShenandoahFreeSet::log_status() {
           } else {
             empty_contig = 0;
           }
-          total_used += used_in_region;
-          total_free += free;
+          total_used_in_freeset += used_in_region;
           max_contig = MAX2(max_contig, empty_contig);
           last_idx = idx;
         }
       }
 
       size_t max_humongous = max_contig * ShenandoahHeapRegion::region_size_bytes();
-      // capacity() is capacity of mutator
-      // used() is used of mutator
-      size_t free = capacity_holding_lock() - used_holding_lock();
-      // Since certain regions that belonged to the Mutator free partition at the time of most recent rebuild may have been
-      // retired, the sum of used and capacities within regions that are still in the Mutator free partition may not match
-      // my internally tracked values of used() and free().
-      assert(free == total_free, "Free memory (%zu) should match calculated memory (%zu)", free, total_free);
-      ls.print("Whole heap stats: Total free: " PROPERFMT ", Total used: " PROPERFMT ", Max free in a single region: " PROPERFMT
-               ", Max humongous: " PROPERFMT "; ",
-               PROPERFMTARGS(total_free), PROPERFMTARGS(total_used), PROPERFMTARGS(max), PROPERFMTARGS(max_humongous));
 
-      ls.print("Frag stats: ");
-      size_t frag_ext;
+      size_t total_free = available_locked() + collector_available_locked();
+      ls.print("Whole heap stats: Total free: " PROPERFMT ", Total used: " PROPERFMT
+               ", Max humongous allocatable: " PROPERFMT "; ",
+               PROPERFMTARGS(total_free), PROPERFMTARGS(global_used()), PROPERFMTARGS(max_humongous));
+
+      double frag_ext;
       if (total_free_ext > 0) {
-        frag_ext = 100 - (100 * max_humongous / total_free_ext);
+        frag_ext = 100 - (1.0 * 100 * max_humongous / total_free_ext);
       } else {
         frag_ext = 0;
       }
-      ls.print("External: %zu%%, ", frag_ext);
+      ls.print("External fragmentation: %.2f%%, ", frag_ext);
 
-      size_t frag_int;
+      double mutator_filling_percentage = 0;
       if (_partitions.count(ShenandoahFreeSetPartitionId::Mutator) > 0) {
-        frag_int = (100 * (total_used / _partitions.count(ShenandoahFreeSetPartitionId::Mutator))
-                    / ShenandoahHeapRegion::region_size_bytes());
-      } else {
-        frag_int = 0;
+        mutator_filling_percentage = 100 * (1.0 * total_used_in_freeset / _partitions.count(ShenandoahFreeSetPartitionId::Mutator))
+                    / ShenandoahHeapRegion::region_size_bytes();
       }
-      ls.print("Internal: %zu%%; ", frag_int);
+      ls.print_cr("Mutator freeset filling percentage: %.2f%%", mutator_filling_percentage);
     }
 
     log_freeset_stats(ShenandoahFreeSetPartitionId::Mutator, ls);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -3187,6 +3187,9 @@ void ShenandoahFreeSet::log_status() {
       size_t max_humongous = max_contig * ShenandoahHeapRegion::region_size_bytes();
 
       size_t total_free = available_locked() + collector_available_locked();
+      if (_heap->mode()->is_generational()) {
+        total_free += old_collector_available_locked();
+      }
       ls.print("Whole heap stats: Total free: " PROPERFMT ", Total used: " PROPERFMT
                ", Max humongous allocatable: " PROPERFMT "; ",
                PROPERFMTARGS(total_free), PROPERFMTARGS(global_used()), PROPERFMTARGS(max_humongous));

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -3068,12 +3068,12 @@ void ShenandoahFreeSet::log_freeset_stats(ShenandoahFreeSetPartitionId partition
     }
   }
 
-  ls.print_cr("  %s partition stats: Partition overall count: %zu, Partition count in freeset: %zu, "
+  ls.print_cr("  %s partition stats: regions in capacity: %zu, regions in freeset: %zu. "
           "Used size including retired regions: " PROPERFMT ", used size in freeset: " PROPERFMT
-          ", free size: " PROPERFMT  ", max free available in a single region: " PROPERFMT ";",
-            partition_name(partition_id), _partitions.get_capacity_region_count(partition_id), _partitions.count(partition_id),
-            PROPERFMTARGS(_partitions.get_used(partition_id)), PROPERFMTARGS(freeset_total_used),
-            PROPERFMTARGS(freeset_free), PROPERFMTARGS(max_free_in_single_region)
+          ". Free available size: " PROPERFMT ". Max free available in a single region: " PROPERFMT ".",
+          partition_name(partition_id), _partitions.get_capacity_region_count(partition_id), _partitions.count(partition_id),
+          PROPERFMTARGS(_partitions.get_used(partition_id)), PROPERFMTARGS(freeset_total_used),
+          PROPERFMTARGS(freeset_free), PROPERFMTARGS(max_free_in_single_region)
           );
 }
 
@@ -3187,24 +3187,23 @@ void ShenandoahFreeSet::log_status() {
       size_t max_humongous = max_contig * ShenandoahHeapRegion::region_size_bytes();
 
       size_t total_free = available_locked() + collector_available_locked();
-      if (_heap->mode()->is_generational()) {
-        total_free += old_collector_available_locked();
-      }
+      total_free += old_collector_available_locked();
       ls.print("Whole heap stats: Total free: " PROPERFMT ", Total used: " PROPERFMT
                ", Max humongous allocatable: " PROPERFMT "; ",
                PROPERFMTARGS(total_free), PROPERFMTARGS(global_used()), PROPERFMTARGS(max_humongous));
 
       double frag_ext;
       if (total_free_ext > 0) {
-        frag_ext = 100 - (1.0 * 100 * max_humongous / total_free_ext);
+        frag_ext = 100 - (100.0 * max_humongous / total_free_ext);
       } else {
         frag_ext = 0;
       }
-      ls.print("External fragmentation: %.2f%%, ", frag_ext);
+      ls.print("External fragmentation: %.2f%%; ", frag_ext);
 
       double mutator_filling_percentage = 0;
-      if (_partitions.count(ShenandoahFreeSetPartitionId::Mutator) > 0) {
-        mutator_filling_percentage = 100 * (1.0 * total_used_in_freeset / _partitions.count(ShenandoahFreeSetPartitionId::Mutator))
+      size_t mutator_partition = _partitions.count(ShenandoahFreeSetPartitionId::Mutator);
+      if (mutator_partition > 0) {
+        mutator_filling_percentage = 100 * (1.0 * total_used_in_freeset / mutator_partition)
                     / ShenandoahHeapRegion::region_size_bytes();
       }
       ls.print_cr("Mutator freeset filling percentage: %.2f%%", mutator_filling_percentage);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -857,6 +857,11 @@ public:
     return _partitions.available_in(ShenandoahFreeSetPartitionId::Collector);
   }
 
+  inline size_t old_collector_available_locked() const {
+    return _partitions.available_in(ShenandoahFreeSetPartitionId::OldCollector);
+  }
+
+
   inline size_t total_humongous_waste() const      { return _total_humongous_waste; }
   inline size_t humongous_waste_in_mutator() const {
     return _partitions.humongous_waste(ShenandoahFreeSetPartitionId::Mutator);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -307,6 +307,10 @@ public:
     return _capacity[int(which_partition)];
   }
 
+  inline size_t get_capacity_region_count(ShenandoahFreeSetPartitionId which_partition) {
+    return get_capacity(which_partition) / ShenandoahHeapRegion::region_size_bytes();
+  }
+
   inline void increase_available(ShenandoahFreeSetPartitionId which_partition, size_t bytes);
   inline void decrease_available(ShenandoahFreeSetPartitionId which_partition, size_t bytes);
   inline size_t get_available(ShenandoahFreeSetPartitionId which_partition);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -302,12 +302,12 @@ public:
 
   inline void increase_capacity(ShenandoahFreeSetPartitionId which_partition, size_t bytes);
   inline void decrease_capacity(ShenandoahFreeSetPartitionId which_partition, size_t bytes);
-  inline size_t get_capacity(ShenandoahFreeSetPartitionId which_partition) {
+  inline size_t get_capacity(ShenandoahFreeSetPartitionId which_partition) const {
     assert (which_partition < NumPartitions, "Partition must be valid");
     return _capacity[int(which_partition)];
   }
 
-  inline size_t get_capacity_region_count(ShenandoahFreeSetPartitionId which_partition) {
+  inline size_t get_capacity_region_count(ShenandoahFreeSetPartitionId which_partition) const {
     return get_capacity(which_partition) / ShenandoahHeapRegion::region_size_bytes();
   }
 
@@ -764,7 +764,7 @@ public:
   }
 
   inline size_t total_old_regions() {
-    return _partitions.get_capacity(ShenandoahFreeSetPartitionId::OldCollector) / ShenandoahHeapRegion::region_size_bytes();
+    return _partitions.get_capacity_region_count(ShenandoahFreeSetPartitionId::OldCollector);
   }
 
   size_t total_global_regions() {
@@ -860,7 +860,6 @@ public:
   inline size_t old_collector_available_locked() const {
     return _partitions.available_in(ShenandoahFreeSetPartitionId::OldCollector);
   }
-
 
   inline size_t total_humongous_waste() const      { return _total_humongous_waste; }
   inline size_t humongous_waste_in_mutator() const {


### PR DESCRIPTION
### Problems

The heap usage log numbers don't add up and is misleading. Sample log:

```
[2.365s][info][gc,free ] Whole heap stats: Total free: 0B, Total used: 0B, Max free in a single region: 0B, Max humongous: 0B; 
Frag stats: External: 0%, Internal: 0%; Mutator freeset stats: Partition count: 0, Reserved: 0B, Max free available in a single region: 0B; 
Collector freeset stats: Partition count: 8, Reserved: 2048K, Max free available in a single region: 256K; 
OldCollector freeset stats: Partition count: 1, Reserved: 76800B, Max free available in a single region: 76800B; 
```

1. While it says whole heap stats, it actually only iterate through [mutator freeset partition](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp#L3164-L3166)
1. The numbers don't match because of `#1`. Total free in the log is not the sum of mutator free + collector free + old collector free. 


### Fix
- This change gives both used size in freeset and used size including retired regions (overall used). 
- Free size should be the same regardless it's calculated by `capacity - overall_used` or by iterating all regions and add up all free sizes
- Fixed a bug where freeset_total_used is calculated via `total_used += r->used();`, where `used` returns full region size(rather than 0) for trash regions, which leads to sum mismatch between `free + used` and `capacity` for partition logs.
- Fixed some unclear phrasing

After the fix, the sample output:

```
[0.468s][info][gc,free] Whole heap stats: Total free: 3446K, Total used: 62089K, Max humongous allocatable: 1280K; External fragmentation: 16.67%; Mutator freeset filling percentage: 7.93%
[0.468s][info][gc,free]   Mutator partition stats: regions in capacity: 116, regions in freeset: 7. Used size including retired regions: 28046K, used size in freeset: 142K. Free available size: 1649K. Max free available in a single region: 256K.
[0.468s][info][gc,free]   Collector partition stats: regions in capacity: 7, regions in freeset: 7. Used size including retired regions: 0B, used size in freeset: 0B. Free available size: 1792K. Max free available in a single region: 256K.
[0.468s][info][gc,free]   OldCollector partition stats: regions in capacity: 133, regions in freeset: 1. Used size including retired regions: 34043K, used size in freeset: 251K. Free available size: 4608B. Max free available in a single region: 4608B.
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382390](https://bugs.openjdk.org/browse/JDK-8382390): Shenandoah: heap usage log improvement (**Bug** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31221/head:pull/31221` \
`$ git checkout pull/31221`

Update a local copy of the PR: \
`$ git checkout pull/31221` \
`$ git pull https://git.openjdk.org/jdk.git pull/31221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31221`

View PR using the GUI difftool: \
`$ git pr show -t 31221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31221.diff">https://git.openjdk.org/jdk/pull/31221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31221#issuecomment-4501344140)
</details>
