### PR TITLE
8385110: JFR: Race when accessing Recording::getSettings()

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -222,7 +222,7 @@ public final class Recording implements Closeable {
      * @return recording settings, not {@code null}
      */
     public Map<String, String> getSettings() {
-        return new HashMap<>(internal.getSettings());
+        return internal.getSettingsCopy();
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/OldObjectSample.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/OldObjectSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package jdk.jfr.internal;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -92,7 +91,7 @@ public final class OldObjectSample {
     }
 
     public static Map<String, String> createSettingsForSnapshot(PlatformRecording recording, Boolean pathToGcRoots) {
-        Map<String, String> settings = new HashMap<>(recording.getSettings());
+        Map<String, String> settings = recording.getSettingsCopy();
         updateSettingPathToGcRoots(settings, pathToGcRoots);
         return settings;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -585,7 +585,7 @@ public final class PlatformRecorder {
         boolean register = !isDestroyed() && r.getState() != RecordingState.CLOSED;
         Recording newRec = access.newRecording(register);
         PlatformRecording copy = access.getPlatformRecording(newRec);
-        copy.setSettings(r.getSettings());
+        copy.setSettings(r.getSettingsCopy());
         copy.setMaxAge(r.getMaxAge());
         copy.setMaxSize(r.getMaxSize());
         copy.setDumpOnExit(r.getDumpOnExit());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -253,9 +253,14 @@ public final class PlatformRecording implements AutoCloseable {
         }
     }
 
-    public Map<String, String> getSettings() {
+    Map<String, String> getSettings() {
+        assert Thread.holdsLock(recorder) : "Must have recorder lock when accessing recorder.settings";
+        return settings;
+    }
+
+    public Map<String, String> getSettingsCopy() {
         synchronized (recorder) {
-            return settings;
+            return new LinkedHashMap<>(settings);
         }
     }
 
@@ -371,7 +376,7 @@ public final class PlatformRecording implements AutoCloseable {
             clone.setStartTime(getStartTime());
         }
         if (pathToGcRoots == null) {
-            clone.setSettings(getSettings()); // needed for old object sample
+            clone.setSettings(getSettingsCopy()); // needed for old object sample
             clone.stop(reason); // dumps to destination path here
         } else {
             // Risk of violating lock order here, since


### PR DESCRIPTION
Could I have a review of a PR that improves synchronization of event settings for a recording?

Testing: jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385110](https://bugs.openjdk.org/browse/JDK-8385110): JFR: Race when accessing Recording::getSettings() (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31222/head:pull/31222` \
`$ git checkout pull/31222`

Update a local copy of the PR: \
`$ git checkout pull/31222` \
`$ git pull https://git.openjdk.org/jdk.git pull/31222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31222`

View PR using the GUI difftool: \
`$ git pr show -t 31222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31222.diff">https://git.openjdk.org/jdk/pull/31222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31222#issuecomment-4501417736)
</details>
