### PR TITLE
make UUID#timestamp() available for type 7

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -419,21 +419,22 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      * October 15, 1582 UTC.
      *
      * <p> The timestamp value is only meaningful in a time-based UUID, which
-     * has version type 1.  If this {@code UUID} is not a time-based UUID then
+     * has version type 1 or 7. If this {@code UUID} is not a time-based UUID then
      * this method throws UnsupportedOperationException.
      *
      * @throws UnsupportedOperationException
-     *         If this UUID is not a version 1 UUID
+     *         If this UUID is not a version 1 or 7 UUID
      * @return The timestamp of this {@code UUID}.
      */
     public long timestamp() {
-        if (version() != 1) {
-            throw new UnsupportedOperationException("Not a time-based UUID");
-        }
-
-        return (mostSigBits & 0x0FFFL) << 48
-             | ((mostSigBits >> 16) & 0x0FFFFL) << 32
-             | mostSigBits >>> 32;
+        return switch(version()) {
+            case 1 -> 
+                (mostSigBits & 0x0FFFL) << 48
+                | ((mostSigBits >> 16) & 0x0FFFFL) << 32
+                | mostSigBits >>> 32;
+            case 7 -> mostSigBits >>> 16;
+            default -> throw new UnsupportedOperationException("Not a time-based UUID");
+        };
     }
 
     /**

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -333,6 +333,11 @@ public class UUIDTest {
         if (test.timestamp() != (Long.MAX_VALUE >> 3)) {
             throw new Exception("Incorrect timestamp");
         }
+        // UUIDv7
+        test = UUID.fromString("00000000-0001-7000-8a5a-be785f17dcda");
+        if (test.timestamp() != 1) {
+            throw new Exception("Incorrect timestamp");
+        }
     }
 
     private static void clockSequenceTest() throws Exception {


### PR DESCRIPTION
`UUID#timestamp()` does not throw `UnsupportedOperationException` for UUID type 7.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31223/head:pull/31223` \
`$ git checkout pull/31223`

Update a local copy of the PR: \
`$ git checkout pull/31223` \
`$ git pull https://git.openjdk.org/jdk.git pull/31223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31223`

View PR using the GUI difftool: \
`$ git pr show -t 31223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31223.diff">https://git.openjdk.org/jdk/pull/31223.diff</a>

</details>
