### PR TITLE
8385100: Null pointer dereference in java.desktop/windows/classes/sun/print/Win32PrintJob.java:606 and other PrintJob implementations

### DIFF
--- a/src/java.desktop/share/classes/sun/print/PSStreamPrintJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSStreamPrintJob.java
@@ -436,8 +436,8 @@ public class PSStreamPrintJob implements CancelablePrintJob {
         /* add the user name to the job */
         String userName = System.getProperty("user.name");
         if (userName == null || userName.isEmpty()) {
-            RequestingUserName ruName =
-                (RequestingUserName)reqSet.get(RequestingUserName.class);
+            RequestingUserName ruName = (reqSet != null) ?
+                (RequestingUserName)reqSet.get(RequestingUserName.class) : null;
             if (ruName != null) {
                 jobAttrSet.add(
                     new JobOriginatingUserName(ruName.getValue(),

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -716,8 +716,8 @@ public final class UnixPrintJob implements CancelablePrintJob {
         /* add the user name to the job */
         String userName = System.getProperty("user.name");
         if (userName == null || userName.isEmpty()) {
-            RequestingUserName ruName =
-                (RequestingUserName)reqSet.get(RequestingUserName.class);
+            RequestingUserName ruName = (reqSet != null) ?
+                (RequestingUserName)reqSet.get(RequestingUserName.class) : null;
             if (ruName != null) {
                 jobAttrSet.add(
                     new JobOriginatingUserName(ruName.getValue(),

--- a/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
+++ b/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
@@ -602,8 +602,8 @@ public final class Win32PrintJob implements CancelablePrintJob {
         String userName = System.getProperty("user.name");
 
         if (userName == null || userName.isEmpty()) {
-            RequestingUserName ruName =
-                (RequestingUserName)reqSet.get(RequestingUserName.class);
+            RequestingUserName ruName = (reqSet != null) ?
+                (RequestingUserName)reqSet.get(RequestingUserName.class) : null;
             if (ruName != null) {
                 jobAttrSet.add(
                     new JobOriginatingUserName(ruName.getValue(),

--- a/test/jdk/javax/print/NullUserNamePrintingTest.java
+++ b/test/jdk/javax/print/NullUserNamePrintingTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8385100
+ * @key printer
+ * @summary Should not get NPE if atttribute set is null.
+ */
+
+import java.io.ByteArrayInputStream;
+import javax.print.Doc;
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.PrintException;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.SimpleDoc;
+
+public class NullUserNamePrintingTest {
+
+    public static void main(String[] args) throws PrintException {
+        PrintService[] services = PrintServiceLookup.lookupPrintServices(null, null);
+        if (services.length == 0) {
+            System.err.println("This test requires a printer.");
+            return;
+        }
+        PrintService service = services[0];
+
+        DocPrintJob job = service.createPrintJob();
+
+        Doc doc = new SimpleDoc(
+                new ByteArrayInputStream("Test print".getBytes()),
+                DocFlavor.INPUT_STREAM.AUTOSENSE, null);
+        System.setProperty("user.name", "");
+        job.print(doc, null);
+    }
+}

--- a/test/jdk/javax/print/NullUserNameStreamPrintingTest.java
+++ b/test/jdk/javax/print/NullUserNameStreamPrintingTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8385100
+ * @summary Should not get NPE if atttribute set is null.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import javax.print.Doc;
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.PrintException;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.SimpleDoc;
+import javax.print.StreamPrintService;
+import javax.print.StreamPrintServiceFactory;
+
+public class NullUserNameStreamPrintingTest implements Printable {
+
+    public static void main(String[] args) throws PrintException {
+
+        DocFlavor flavor = DocFlavor.SERVICE_FORMATTED.PRINTABLE;
+        String mime = "application/postscript";
+        StreamPrintServiceFactory[] factories =
+            StreamPrintServiceFactory.lookupStreamPrintServiceFactories(flavor, mime);
+        if (factories.length == 0) {
+            throw new RuntimeException("Unable to find PostScript print service factory");
+        }
+        StreamPrintServiceFactory factory = factories[0];
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        StreamPrintService service = factory.getPrintService(output);
+
+        DocPrintJob job = service.createPrintJob();
+
+        Doc doc = new SimpleDoc(new NullUserNameStreamPrintingTest(), flavor, null);
+        System.setProperty("user.name", "");
+        job.print(doc, null);
+    }
+
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)
+                     throws PrinterException {
+        if (pageIndex > 0) {
+            return NO_SUCH_PAGE;
+        }
+        return PAGE_EXISTS;
+     }
+}


### PR DESCRIPTION

if the System Property "user.name" is unset, then in some also unlikely circumstance the printing implementation will get an NPE.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385100](https://bugs.openjdk.org/browse/JDK-8385100): Null pointer dereference in java.desktop/windows/classes/sun/print/Win32PrintJob.java:606 and other PrintJob implementations (**Bug** - P3)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31225/head:pull/31225` \
`$ git checkout pull/31225`

Update a local copy of the PR: \
`$ git checkout pull/31225` \
`$ git pull https://git.openjdk.org/jdk.git pull/31225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31225`

View PR using the GUI difftool: \
`$ git pr show -t 31225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31225.diff">https://git.openjdk.org/jdk/pull/31225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31225#issuecomment-4503140349)
</details>
