### PR TITLE
8041911: media sizes with width > height are not supported by the java printing api

### DIFF
--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaPrintableArea.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaPrintableArea.java
@@ -66,9 +66,7 @@ import javax.print.attribute.PrintRequestAttribute;
  * <p>
  * The rectangular printable area is defined thus: The (x,y) origin is
  * positioned at the top-left of the paper in portrait mode regardless of the
- * orientation specified in the requesting context. For example a printable area
- * for A4 paper in portrait or landscape orientation will have height
- * {@literal >} width.
+ * orientation specified in the requesting context.
  * <p>
  * A printable area attribute's values are stored internally as integers in
  * units of micrometers (&#181;m), where 1 micrometer = 10<SUP>-6</SUP> meter =

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
@@ -77,13 +77,10 @@ public class MediaSize extends Size2DSyntax implements Attribute {
      * @param  units unit conversion factor, e.g. {@code Size2DSyntax.INCH} or
      *         {@code Size2DSyntax.MM}
      * @throws IllegalArgumentException if {@code x < 0} or {@code y < 0} or
-     *         {@code units < 1} or {@code x > y}
+     *         {@code units < 1}
      */
     public MediaSize(float x, float y,int units) {
         super (x, y, units);
-        if (x > y) {
-            throw new IllegalArgumentException("X dimension > Y dimension");
-        }
         sizeVector.add(this);
     }
 
@@ -95,13 +92,10 @@ public class MediaSize extends Size2DSyntax implements Attribute {
      * @param  units unit conversion factor, e.g. {@code Size2DSyntax.INCH} or
      *         {@code Size2DSyntax.MM}
      * @throws IllegalArgumentException if {@code x < 0} or {@code y < 0} or
-     *         {@code units < 1} or {@code x > y}
+     *         {@code units < 1}
      */
     public MediaSize(int x, int y,int units) {
         super (x, y, units);
-        if (x > y) {
-            throw new IllegalArgumentException("X dimension > Y dimension");
-        }
         sizeVector.add(this);
     }
 
@@ -115,13 +109,10 @@ public class MediaSize extends Size2DSyntax implements Attribute {
      *         {@code Size2DSyntax.MM}
      * @param  media a media name to associate with this {@code MediaSize}
      * @throws IllegalArgumentException if {@code x < 0} or {@code y < 0} or
-     *         {@code units < 1} or {@code x > y}
+     *         {@code units < 1}
      */
     public MediaSize(float x, float y,int units, MediaSizeName media) {
         super (x, y, units);
-        if (x > y) {
-            throw new IllegalArgumentException("X dimension > Y dimension");
-        }
         if (media != null && mediaMap.get(media) == null) {
             mediaName = media;
             mediaMap.put(mediaName, this);
@@ -138,13 +129,10 @@ public class MediaSize extends Size2DSyntax implements Attribute {
      *         {@code Size2DSyntax.MM}
      * @param  media a media name to associate with this {@code MediaSize}
      * @throws IllegalArgumentException if {@code x < 0} or {@code y < 0} or
-     *         {@code units < 1} or {@code x > y}
+     *         {@code units < 1}
      */
     public MediaSize(int x, int y,int units, MediaSizeName media) {
         super (x, y, units);
-        if (x > y) {
-            throw new IllegalArgumentException("X dimension > Y dimension");
-        }
         if (media != null && mediaMap.get(media) == null) {
             mediaName = media;
             mediaMap.put(mediaName, this);

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
@@ -36,7 +36,7 @@ import javax.print.attribute.Size2DSyntax;
  * Class {@code MediaSize} is a two-dimensional size valued printing attribute
  * class that indicates the dimensions of the medium in a portrait orientation,
  * with the {@code X} dimension running along the bottom edge and the {@code Y}
- * dimension running along the left edge. Thus, the {@code Y} dimension must be
+ * dimension running along the left edge. For most media, the {@code Y} dimension will be
  * greater than or equal to the {@code X} dimension. Class {@code MediaSize}
  * declares many standard media size values, organized into nested classes for
  * ISO, JIS, North American, engineering, and other media.

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/OrientationRequested.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/OrientationRequested.java
@@ -73,16 +73,17 @@ public final class OrientationRequested extends EnumSyntax
     private static final long serialVersionUID = -4447437289862822276L;
 
     /**
-     * The content will be imaged across the short edge of the medium.
+     * The content will be imaged across the default orientation of the medium.
+     * For almost all media this means across the short edge.
      */
     public static final OrientationRequested
         PORTRAIT = new OrientationRequested(3);
 
     /**
-     * The content will be imaged across the long edge of the medium. Landscape
-     * is defined to be a rotation of the print-stream page to be imaged by +90
+     * Landscape is defined to be a rotation of the print-stream page to be imaged by +90
      * degrees with respect to the medium (i.e. anti-clockwise) from the
-     * portrait orientation. <i>Note:</i> The +90 direction was chosen because
+     * portrait orientation. For almost all media this means across the long edge.
+     * <i>Note:</i> The +90 direction was chosen because
      * simple finishing on the long edge is the same edge whether portrait or
      * landscape.
      */
@@ -90,7 +91,7 @@ public final class OrientationRequested extends EnumSyntax
         LANDSCAPE = new OrientationRequested(4);
 
     /**
-     * The content will be imaged across the long edge of the medium, but in the
+     * The content will be imaged similarly, but in the
      * opposite manner from landscape. Reverse-landscape is defined to be a
      * rotation of the print-stream page to be imaged by -90 degrees with
      * respect to the medium (i.e. clockwise) from the portrait orientation.
@@ -102,7 +103,7 @@ public final class OrientationRequested extends EnumSyntax
         REVERSE_LANDSCAPE = new OrientationRequested(5);
 
     /**
-     * The content will be imaged across the short edge of the medium, but in
+     * The content will be imaged similarly to, but in
      * the opposite manner from portrait. Reverse-portrait is defined to be a
      * rotation of the print-stream page to be imaged by 180 degrees with
      * respect to the medium from the portrait orientation. <i>Note:</i> The

--- a/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
@@ -209,10 +209,7 @@ class CustomMediaSizeName extends MediaSizeName {
                     try {
                         new MediaSize(width, length, Size2DSyntax.INCH, value);
                     } catch (IllegalArgumentException e) {
-                        /* PDF printer in Linux for Ledger paper causes
-                        "IllegalArgumentException: X dimension > Y dimension".
-                        We rotate based on IPP spec. */
-                        new MediaSize(length, width, Size2DSyntax.INCH, value);
+                        // Should not happen, keep for safety
                     }
                 }
             }

--- a/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
@@ -206,11 +206,7 @@ class CustomMediaSizeName extends MediaSizeName {
             if (value.getStandardMedia() == null) {
                 // add this new custom media size name to MediaSize array
                 if ((width > 0.0) && (length > 0.0)) {
-                    try {
-                        new MediaSize(width, length, Size2DSyntax.INCH, value);
-                    } catch (IllegalArgumentException e) {
-                        // Should not happen, keep for safety
-                    }
+                    new MediaSize(width, length, Size2DSyntax.INCH, value);
                 }
             }
         }

--- a/test/jdk/javax/print/attribute/MediaSizeTest.java
+++ b/test/jdk/javax/print/attribute/MediaSizeTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8041911
+ * @summary Test that MediaSize with non-standard portrait dimensions is OK
+*/
+
+import javax.print.attribute.standard.MediaSize;
+import static javax.print.attribute.standard.MediaSize.INCH;
+
+public class MediaSizeTest {
+
+   public static void main(String args[]) {
+       new MediaSize(0, 0, INCH);
+       new MediaSize(1, 1, INCH);
+       new MediaSize(2, 1, INCH);
+       new MediaSize(1, 2, INCH);
+   }
+}


### PR DESCRIPTION
Strictly enforcing that Media in portrait mode must have width < height causes recurring problems.
However the spec requires it so we need update that spec as well as removing the enforcing code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8385972](https://bugs.openjdk.org/browse/JDK-8385972) to be approved
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8041911: media sizes with width > height are not supported by the java printing api`

### Issues
 * [JDK-8041911](https://bugs.openjdk.org/browse/JDK-8041911): media sizes with width &gt; height are not supported by the java printing api (**Bug** - P3)
 * [JDK-8385972](https://bugs.openjdk.org/browse/JDK-8385972): media sizes with width &gt; height are not supported by the java printing api (**CSR**)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31226/head:pull/31226` \
`$ git checkout pull/31226`

Update a local copy of the PR: \
`$ git checkout pull/31226` \
`$ git pull https://git.openjdk.org/jdk.git pull/31226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31226`

View PR using the GUI difftool: \
`$ git pr show -t 31226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31226.diff">https://git.openjdk.org/jdk/pull/31226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31226#issuecomment-4503315530)
</details>
