### PR TITLE
8385127: Sync the libpng.md with actual PNG License 2

### DIFF
--- a/src/java.desktop/share/legal/libpng.md
+++ b/src/java.desktop/share/legal/libpng.md
@@ -9,11 +9,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
-Copyright (C) 1995-2026 The PNG Reference Library Authors.
-Copyright (C) 2018-2026 Cosmin Truta
-Copyright (C) 1998-2018 Glenn Randers-Pehrson
-Copyright (C) 1996-1997 Andreas Dilger
-Copyright (C) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2026 The PNG Reference Library Authors.
+Copyright (c) 2018-2026 Cosmin Truta.
+Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
+Copyright (c) 1996-1997 Andreas Dilger.
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties


### PR DESCRIPTION
Some formal and non-formal changes were introduced in libpng.md so the file now contains inexact version of PNG License 2.
see: https://www.libpng.org/pub/png/src/libpng-LICENSE.txt

This PR will revert some of the changes introduce in [JDK-8295685](https://github.com/openjdk/jdk/pull/10953/changes#diff-83af859c7219920b3989aa0d05bac26a97c54cf7b8106ae46736800937f0ab31).

This issue was found in [this](https://github.com/openjdk/jdk/pull/31173#discussion_r3263747492) discussion.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385127](https://bugs.openjdk.org/browse/JDK-8385127): Sync the libpng.md with actual PNG License 2 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31228/head:pull/31228` \
`$ git checkout pull/31228`

Update a local copy of the PR: \
`$ git checkout pull/31228` \
`$ git pull https://git.openjdk.org/jdk.git pull/31228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31228`

View PR using the GUI difftool: \
`$ git pr show -t 31228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31228.diff">https://git.openjdk.org/jdk/pull/31228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31228#issuecomment-4526662832)
</details>
