### PR TITLE
8385116: nmethod::Flags is not guaranteed to fit uint8_t

### DIFF
--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -268,26 +268,22 @@ class nmethod : public CodeBlob {
   volatile signed char _state;         // {not_installed, in_use, not_entrant}
 
 public:
-  union Flags {
-    uint8_t _raw;
-    struct {
-      bool _has_unsafe_access:1;   // May fault due to unsafe access.
-      bool _has_wide_vectors:1;    // Preserve wide vectors at safepoints
-      bool _has_monitors:1;        // Fastpath monitor detection for continuations
-      bool _has_scoped_access:1;   // Used by shared scope closure (scopedMemoryAccess.cpp)
-    };
+  struct Flags {
+    uint8_t _bits;
     Flags() {
-      _raw = 0;
+      _bits = 0;
     }
-    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access) : Flags() {
-      _has_unsafe_access = has_unsafe_access;
-      _has_wide_vectors = has_wide_vectors;
-      _has_monitors = has_monitors;
-      _has_scoped_access = has_scoped_access;
+    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access) {
+      _bits = (has_unsafe_access ? 0x1 : 0x0) |
+              (has_wide_vectors  ? 0x2 : 0x0) |
+              (has_monitors      ? 0x4 : 0x0) |
+              (has_scoped_access ? 0x8 : 0x0);
     }
+    bool has_unsafe_access() const { return _bits & 0x1; }  // May fault due to unsafe access
+    bool has_wide_vectors()  const { return _bits & 0x2; }  // Preserve wide vectors at safepoints
+    bool has_monitors()      const { return _bits & 0x4; }  // Fastpath monitor detection for continuations
+    bool has_scoped_access() const { return _bits & 0x8; }  // Used by shared scope closure (scopedMemoryAccess.cpp)
   };
-
-  static_assert(sizeof(Flags) == sizeof(uint8_t), "Must fit exactly");
 
 private:
   // Persistent bits, set once during construction.
@@ -779,10 +775,10 @@ public:
   template<typename T>
   void set_gc_data(T* gc_data)                    { _gc_data = reinterpret_cast<void*>(gc_data); }
 
-  bool  has_unsafe_access() const                 { return _flags._has_unsafe_access; }
-  bool  has_monitors() const                      { return _flags._has_monitors; }
-  bool  has_scoped_access() const                 { return _flags._has_scoped_access; }
-  bool  has_wide_vectors() const                  { return _flags._has_wide_vectors; }
+  bool  has_unsafe_access() const                 { return _flags.has_unsafe_access(); }
+  bool  has_monitors() const                      { return _flags.has_monitors(); }
+  bool  has_scoped_access() const                 { return _flags.has_scoped_access(); }
+  bool  has_wide_vectors() const                  { return _flags.has_wide_vectors(); }
 
   bool  has_flushed_dependencies() const          { return _has_flushed_dependencies; }
   void  set_has_flushed_dependencies(bool z)      {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -269,20 +269,34 @@ class nmethod : public CodeBlob {
 
 public:
   struct Flags {
-    uint8_t _bits;
-    Flags() {
-      _bits = 0;
-    }
-    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access) {
-      _bits = (has_unsafe_access ? 0x1 : 0x0) |
-              (has_wide_vectors  ? 0x2 : 0x0) |
-              (has_monitors      ? 0x4 : 0x0) |
-              (has_scoped_access ? 0x8 : 0x0);
-    }
-    bool has_unsafe_access() const { return _bits & 0x1; }  // May fault due to unsafe access
-    bool has_wide_vectors()  const { return _bits & 0x2; }  // Preserve wide vectors at safepoints
-    bool has_monitors()      const { return _bits & 0x4; }  // Fastpath monitor detection for continuations
-    bool has_scoped_access() const { return _bits & 0x8; }  // Used by shared scope closure (scopedMemoryAccess.cpp)
+    uint8_t const _bits;
+
+    enum : uint8_t {
+      UNSAFE_ACCESS = 1 << 0,
+      WIDE_VECTORS  = 1 << 1,
+      MONITORS      = 1 << 2,
+      SCOPED_ACCESS = 1 << 3
+    };
+
+    Flags() : _bits(0) {}
+    Flags(bool has_unsafe_access, bool has_wide_vectors, bool has_monitors, bool has_scoped_access) :
+      _bits((has_unsafe_access ? UNSAFE_ACCESS : 0) |
+            (has_wide_vectors  ? WIDE_VECTORS  : 0) |
+            (has_monitors      ? MONITORS      : 0) |
+            (has_scoped_access ? SCOPED_ACCESS : 0))
+    {}
+
+    // May fault due to unsafe access
+    bool has_unsafe_access() const { return (_bits & UNSAFE_ACCESS) != 0; }
+
+    // Preserve wide vectors at safepoints
+    bool has_wide_vectors()  const { return (_bits & WIDE_VECTORS)  != 0; }
+
+    // Fastpath monitor detection for continuations
+    bool has_monitors()      const { return (_bits & MONITORS)      != 0; }
+
+    // Used by shared scope closure (scopedMemoryAccess.cpp)
+    bool has_scoped_access() const { return (_bits & SCOPED_ACCESS) != 0; }
   };
 
 private:


### PR DESCRIPTION
AIX XLC compiler shows us that C++ bitfield representation is implementation-defined, so the recently added `nmethod::Flags` refactoring fails its own assert. This PR rewrites it to manual bitmap.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_compiler`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385116](https://bugs.openjdk.org/browse/JDK-8385116): nmethod::Flags is not guaranteed to fit uint8_t (**Bug** - P2)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31229/head:pull/31229` \
`$ git checkout pull/31229`

Update a local copy of the PR: \
`$ git checkout pull/31229` \
`$ git pull https://git.openjdk.org/jdk.git pull/31229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31229`

View PR using the GUI difftool: \
`$ git pr show -t 31229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31229.diff">https://git.openjdk.org/jdk/pull/31229.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31229#issuecomment-4505104403)
</details>
