### PR TITLE
8385136: SA cannot unwind the native frame which does not have DWARF

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfCFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfCFrame.java
@@ -43,6 +43,7 @@ public class DwarfCFrame extends BasicCFrame {
     private LinuxDebugger linuxDbg;
     private DwarfParser dwarf;
     private boolean use1ByteBeforeToLookup;
+    private boolean hasNativeLibrary;
 
     /**
      * @return DwarfParser instance for the PC, null if native library relates to the pc not found.
@@ -73,6 +74,7 @@ public class DwarfCFrame extends BasicCFrame {
         this.linuxDbg = linuxDbg;
         this.dwarf = dwarf;
         this.use1ByteBeforeToLookup = use1ByteBeforeToLookup;
+        this.hasNativeLibrary = linuxDbg.findLibPtrByAddress(pc) != null;
     }
 
     public Address sp() {
@@ -93,6 +95,10 @@ public class DwarfCFrame extends BasicCFrame {
 
     public DwarfParser dwarf() {
         return dwarf;
+    }
+
+    public boolean hasNativeLibrary() {
+        return hasNativeLibrary;
     }
 
     // override base class impl to avoid ELF parsing

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
@@ -128,6 +128,11 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
         return getFrameFromReg(linuxDbg(), r -> LinuxAARCH64ThreadContext.getRegFromSignalTrampoline(sp(), r.intValue()));
       }
 
+      if (hasNativeLibrary() && dwarf() == null) {
+        // Cannot find a sender frame if DWARF is missing even though PC in native library.
+        return null;
+      }
+
       if (senderPC == null) {
         // Use getSenderPC() if current frame is Java because we cannot rely on lr in this case.
         senderPC = dwarf() == null ? getSenderPC(null) : lr;
@@ -184,8 +189,11 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
             return new LinuxAARCH64CFrame(linuxDbg(), senderSP, senderFP, null, senderPC, senderDwarf);
           }
 
-          // We cannot unwind anymore without appropriate DWARF.
-          return null;
+          // Returns CFrame if the sender is native frame even though it does not have DWARF,
+          // otherwise returns null because we cannot unwind anymore.
+          return linuxDbg().findLibPtrByAddress(senderPC) != null
+            ? new LinuxAARCH64CFrame(linuxDbg(), senderSP, senderFP, null /* no CFA */, senderPC, null /* no DWARF */)
+            : null;
         }
       }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
@@ -87,6 +87,11 @@ public final class LinuxAMD64CFrame extends DwarfCFrame {
        return getFrameFromReg(linuxDbg(), r -> LinuxAMD64ThreadContext.getRegFromSignalTrampoline(sp(), r.intValue()));
      }
 
+     if (hasNativeLibrary() && dwarf() == null) {
+       // Cannot find a sender frame if DWARF is missing even though PC in native library.
+       return null;
+     }
+
      senderSP = getSenderSP(senderSP);
      if (senderSP == null) {
        return null;
@@ -95,6 +100,8 @@ public final class LinuxAMD64CFrame extends DwarfCFrame {
      if (senderPC == null) {
        return null;
      }
+
+     senderFP = getSenderFP(senderFP);
 
      DwarfParser senderDwarf = null;
      boolean fallback = false;
@@ -107,12 +114,13 @@ public final class LinuxAMD64CFrame extends DwarfCFrame {
          senderDwarf = createDwarfParser(linuxDbg(), senderPC.addOffsetTo(-1));
          fallback = true;
        } catch (DebuggerException _) {
-         // We cannot unwind anymore without appropriate DWARF.
-         return null;
+         // Returns CFrame if the sender is native frame even though it does not have DWARF,
+         // otherwise returns null because we cannot unwind anymore.
+         return linuxDbg().findLibPtrByAddress(senderPC) != null
+           ? new LinuxAMD64CFrame(linuxDbg(), senderSP, senderFP, null /* no CFA */, senderPC, null /* no DWARF */)
+           : null;
        }
      }
-
-     senderFP = getSenderFP(senderFP);
 
      try {
        Address senderCFA = getSenderCFA(senderDwarf, senderSP, senderFP);


### PR DESCRIPTION
`jhsdb jstack --mixed` would try to unwind all of native call frames. It will reach `_start()` (startup routine by glibc), but it couldn't on the JDK built by older glibc such as glibc-2.12 (used in devkit for Linux x86_64).

Expected:
```
0x000055ad324dfadb main + 0x13b
0x00007f3df876c681 __libc_start_call_main + 0x81
0x00007f3df876c798 __libc_start_main_alias_2 + 0x88
0x000055ad324dfb79 _start + 0x25
```

Actual (no `_start` in call stacks):
```
0x000055ad324dfadb main + 0x13b
0x00007f3df876c681 __libc_start_call_main + 0x81
0x00007f3df876c798 __libc_start_main_alias_2 + 0x88
```

Startup routine would be provided by crt1.o, and it would be linked into `java`. `_start()` in crt1.o by glibc-2.12 does not have Frame Description Entry (FDE) in DWARF. In DWARF parser in SA assumes native function has FDE, thus unwinder in SA would stop if it cannot find appropriate DWARF information.

I saw the problem on `_start()` only so far. This is not critical, but same problem can happen on other places (functions / libraries). We cannot find caller frame from DWARF-less function of course, but we should show the frame even if it does not have DWARF.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385136](https://bugs.openjdk.org/browse/JDK-8385136): SA cannot unwind the native frame which does not have DWARF (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31230/head:pull/31230` \
`$ git checkout pull/31230`

Update a local copy of the PR: \
`$ git checkout pull/31230` \
`$ git pull https://git.openjdk.org/jdk.git pull/31230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31230`

View PR using the GUI difftool: \
`$ git pr show -t 31230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31230.diff">https://git.openjdk.org/jdk/pull/31230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31230#issuecomment-4505534695)
</details>
