### PR TITLE
8385137: C2: Uncast arguments to MemNode::all_control_dominate in some cases

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -893,7 +893,7 @@ AccessAnalyzer::AccessIndependence AccessAnalyzer::detect_access_independence(No
     if (known_independent) {
       // The bases are provably independent: Either they are
       // manifestly distinct allocations, or else the control
-      // of _n dominates the store's allocation.
+      // of _base dominates the store's allocation.
       if (_alias_idx == Compile::AliasIdxRaw) {
         other = st_alloc->in(TypeFunc::Memory);
       } else {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -578,9 +578,9 @@ bool MemNode::detect_ptr_independence(Node* p1, AllocateNode* a1,
     return (a1 != a2);
   } else if (a1 != nullptr) {                  // one allocation a1
     // (Note:  p2->is_Con implies p2->in(0)->is_Root, which dominates.)
-    return all_controls_dominate(p2, a1, phase);
+    return all_controls_dominate(p2->uncast(), a1, phase);
   } else { //(a2 != null)                   // one allocation a2
-    return all_controls_dominate(p1, a2, phase);
+    return all_controls_dominate(p1->uncast(), a2, phase);
   }
   return false;
 }
@@ -886,7 +886,7 @@ AccessAnalyzer::AccessIndependence AccessAnalyzer::detect_access_independence(No
       known_identical = true;
     } else if (_alloc != nullptr) {
       known_independent = true;
-    } else if (MemNode::all_controls_dominate(_n, st_alloc, _phase)) {
+    } else if (MemNode::all_controls_dominate(_base->uncast(), st_alloc, _phase)) {
       known_independent = true;
     }
 

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -562,7 +562,7 @@ bool MemNode::detect_ptr_independence(Node* p1, AllocateNode* a1,
   // TypePtr::NULL_PTR, so we exclude that case.
   const Type* p1_type = p1->bottom_type();
   const Type* p2_type = p2->bottom_type();
-  if (p1_type->isa_oopptr() && p2_type->isa_oopptr() &&
+  if (p1_type != p2_type && p1_type->isa_oopptr() && p2_type->isa_oopptr() &&
       (!p1_type->maybe_null() || !p2_type->maybe_null()) &&
       p1_type->join(p2_type)->empty()) {
     return true;

--- a/test/hotspot/jtreg/compiler/c2/gvn/TestFindStore.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/TestFindStore.java
@@ -55,7 +55,8 @@ public class TestFindStore {
 
     @Run(test = {"testLoad", "testStore", "testLoadDependent1", "testLoadDependent2", "testLoadArray",
                  "testLoadArrayOverlap", "testLoadIndependentAliasClasses", "testLoadMismatched",
-                 "testLoadArrayCopy", "testLoadArrayCopyUnknownLength"})
+                 "testLoadArrayCopy", "testLoadArrayCopyUnknownLength",
+                 "testAllocationIndependence1", "testAllocationIndependence2"})
     public void run() {
         C1 c1 = new C1();
         C2 c2 = new C2();
@@ -81,6 +82,9 @@ public class TestFindStore {
         Asserts.assertEQ(1, testLoadArrayCopyUnknownLength(a1, a2, 100, 1));
         a1[2] = 0;
         Asserts.assertEQ(0, testLoadArrayCopyUnknownLength(a1, a2, 2, 1));
+
+        Asserts.assertEQ(3, testAllocationIndependence1(c1, 1, 2).v);
+        Asserts.assertEQ(3, testAllocationIndependence2(c1, 1, 2).v);
     }
 
     @Test
@@ -169,5 +173,26 @@ public class TestFindStore {
         // Cannot determine if this overwrites a1[2]
         System.arraycopy(a2, 0, a1, 0, len);
         return a1[2];
+    }
+
+    @Test
+    @IR(failOn = IRNode.LOAD, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
+    static C1 testAllocationIndependence1(C1 o1, int v1, int v2) {
+        // o1 and o2 are independent
+        o1.v = v1;
+        C1 o2 = new C1();
+        o2.v = o1.v + v2;
+        return o2;
+    }
+
+    @Test
+    @IR(failOn = IRNode.LOAD, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
+    static C1 testAllocationIndependence2(C1 o1, int v1, int v2) {
+        // o1 and o2 are independent, but we also want CastPP(o1) and o2 being independent
+        C1 o2 = new C1();
+        o1.v = v1;
+        o2.v = v2;
+        o2.v = o1.v + o2.v;
+        return o2;
     }
 }


### PR DESCRIPTION
Hi,

This PR cherry-picks the change in `memnode.cpp` in #30277.

The idea of these usages is that, if a node is defined before an allocation, then there is no chance that at runtime, it can have the same value as that of the allocation. As a result, the higher the first input is in the dominator tree, there is more chance this will return true.

A ConstraintCastNode does not modify the runtime value of a node, so _base->uncast() cannot alias st_base, _base cannot do that, either. And as reasoned above, the uncast value is higher in the dominator tree, giving us a better chance determining that _base and st_base do not alias.

In addition, inside AccessAnalyzer::detect_access_independence, when other is the Proj of an InitializeNode, we check the independence by check whether this dominates the allocation corresponding to other. This is unnecessary, what we need to check is if the base of this can alias with the result of the allocation. As a result, it is more reasonable to check for _base instead of _n.

Testing:

- [x] tier1-4,hs-comp-stress

Please take a look and leave your review, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385137](https://bugs.openjdk.org/browse/JDK-8385137): C2: Uncast arguments to MemNode::all_control_dominate in some cases (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31231/head:pull/31231` \
`$ git checkout pull/31231`

Update a local copy of the PR: \
`$ git checkout pull/31231` \
`$ git pull https://git.openjdk.org/jdk.git pull/31231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31231`

View PR using the GUI difftool: \
`$ git pr show -t 31231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31231.diff">https://git.openjdk.org/jdk/pull/31231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31231#issuecomment-4505555675)
</details>
