### PR TITLE
8384653: Potential null pointer dereference in java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -215,7 +215,6 @@ public final class StackMapGenerator {
     private final List<RawExceptionCatch> rawHandlers;
     private final ClassHierarchyImpl classHierarchy;
     private final boolean patchDeadCode;
-    private final boolean filterDeadLabels;
     private Frame[] frames = EMPTY_FRAME_ARRAY;
     private int framesCount = 0;
     private final Frame currentFrame;
@@ -257,7 +256,6 @@ public final class StackMapGenerator {
         this.rawHandlers = new ArrayList<>(handlers.size());
         this.classHierarchy = new ClassHierarchyImpl(context.classHierarchyResolver());
         this.patchDeadCode = context.patchDeadCode();
-        this.filterDeadLabels = context.dropDeadLabels();
         this.currentFrame = new Frame(classHierarchy);
         generate();
     }
@@ -925,8 +923,7 @@ public final class StackMapGenerator {
         for (int i = 0; i < rawHandlers.size(); i++) try {
             addFrame(rawHandlers.get(i).handler());
         } catch (IllegalArgumentException iae) {
-            if (!filterDeadLabels)
-                throw generatorError("Detected exception handler out of bytecode range");
+            throw generatorError("Detected exception handler out of bytecode range");
         }
     }
 

--- a/test/jdk/jdk/classfile/OptionsTest.java
+++ b/test/jdk/jdk/classfile/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Testing ClassFile options on small Corpus.
+ * @bug 8384653
  * @run junit/othervm -Djunit.jupiter.execution.parallel.enabled=true OptionsTest
  */
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,6 +44,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.lang.classfile.*;
+import java.lang.constant.ConstantDescs;
 
 /**
  * OptionsTest
@@ -111,6 +113,19 @@ class OptionsTest {
                 ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNKNOWN_ATTRIBUTES).transformClass(
                         ClassFile.of().parse(classBytes),
                         ClassTransform.ACCEPT_ALL)).attributes().isEmpty());
+    }
+
+    @Test
+    void testDropDeadLabelsNoNPE() {
+        // see JDK-8384653
+        assertThrows(IllegalArgumentException.class, () ->
+                ClassFile.of(ClassFile.DeadLabelsOption.DROP_DEAD_LABELS).build(ClassDesc.of("C"), clb ->
+                        clb.withMethodBody("m", ConstantDescs.MTD_void, 0, cob ->
+                                cob.nop()
+                                   .exceptionCatch(cob.startLabel(),
+                                                   cob.endLabel(),
+                                                   cob.endLabel(),
+                                                   ConstantDescs.CD_Throwable))));
     }
 
     void testNoUnstable(Path path, ClassFileElement e) {


### PR DESCRIPTION
Class-File API provides an option to filter unbound labels and optionally drop related enclosing structures. After performance-related optimizations, this option started causing a side effect where silently dropped structures result in a `NullPointerException` instead of the expected `IllegalArgumentException`.

This PR narrows that scenario and adds a test for it.

Please review.

Thank you,
Adam

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384653](https://bugs.openjdk.org/browse/JDK-8384653): Potential null pointer dereference in java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31232/head:pull/31232` \
`$ git checkout pull/31232`

Update a local copy of the PR: \
`$ git checkout pull/31232` \
`$ git pull https://git.openjdk.org/jdk.git pull/31232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31232`

View PR using the GUI difftool: \
`$ git pr show -t 31232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31232.diff">https://git.openjdk.org/jdk/pull/31232.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31232#issuecomment-4508090797)
</details>
