### PR TITLE
8381270: TestGCPhaseConcurrent.java#Z intermittent fails OOME

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,11 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.flagless
  * @library /test/lib /test/jdk /test/hotspot/jtreg
  * @requires vm.hasJFR & vm.gc.Z
- * @run main/othervm -XX:+UseZGC -Xmx32M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent Z
+ * @run main/othervm -XX:+UseZGC -Xmx64M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent Z
  */
 
 /**
- * @test TestGCPhaseConcurrent
+ * @test id=Shenandoah
  * @requires vm.flagless
  * @library /test/lib /test/jdk /test/hotspot/jtreg
  * @requires vm.hasJFR & vm.gc.Shenandoah


### PR DESCRIPTION
Hi all,

Test jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java#Z intermittent fails "java.lang.OutOfMemoryError: Java heap space", and the Shenandoah sub-test do not observed the same fails. This is because ZGC will enable JFR event recording, this will need more heap memory to enable the event recording than ShenandoahGC. This PR increase the max heap to 64M which make test more robustness.

Before this PR, TestGCPhaseConcurrent.java#Z failure probability about 1/50. After this PR, TestGCPhaseConcurrent.java#Z run 10k times and all passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381270](https://bugs.openjdk.org/browse/JDK-8381270): TestGCPhaseConcurrent.java#Z intermittent fails OOME (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31233/head:pull/31233` \
`$ git checkout pull/31233`

Update a local copy of the PR: \
`$ git checkout pull/31233` \
`$ git pull https://git.openjdk.org/jdk.git pull/31233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31233`

View PR using the GUI difftool: \
`$ git pr show -t 31233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31233.diff">https://git.openjdk.org/jdk/pull/31233.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31233#issuecomment-4508484883)
</details>
