### PR TITLE
8385166: PPC: C2: c_return_value and return_value should not set 2nd OptoRegPair for Op_RegI

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3712,36 +3712,6 @@ frame %{
   //    4 what apparently works and saves us some spills.
   return_addr(STACK 4);
 
-  c_return_value %{
-    assert((ideal_reg >= Op_RegI && ideal_reg <= Op_RegL) ||
-            (ideal_reg == Op_RegN && CompressedOops::base() == nullptr && CompressedOops::shift() == 0),
-            "only return normal values");
-    // enum names from opcodes.hpp
-    static int typeToRegLo[Op_RegL+1] = {
-      0,              // Op_Node
-      0,              // Op_Set
-      R3_num,         // Op_RegN
-      R3_num,         // Op_RegI
-      R3_num,         // Op_RegP
-      F1_num,         // Op_RegF
-      F1_num,         // Op_RegD
-      R3_num,         // Op_RegL
-    };
-
-    static int typeToRegHi[Op_RegL+1] = {
-      0,              // Op_Node
-      0,              // Op_Set
-      OptoReg::Bad,   // Op_RegN
-      OptoReg::Bad,   // Op_RegI
-      R3_H_num,       // Op_RegP
-      OptoReg::Bad,   // Op_RegF
-      F1_H_num,       // Op_RegD
-      R3_H_num        // Op_RegL
-    };
-
-    return OptoRegPair(typeToRegHi[ideal_reg], typeToRegLo[ideal_reg]);
-  %}
-
   // Location of compiled Java return values.  Same as C
   return_value %{
     assert((ideal_reg >= Op_RegI && ideal_reg <= Op_RegL) ||

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3712,19 +3712,33 @@ frame %{
   //    4 what apparently works and saves us some spills.
   return_addr(STACK 4);
 
-  // Location of native (C/C++) and interpreter return values. This
-  // is specified to be the same as Java. In the 32-bit VM, long
-  // values are actually returned from native calls in O0:O1 and
-  // returned to the interpreter in I0:I1. The copying to and from
-  // the register pairs is done by the appropriate call and epilog
-  // opcodes. This simplifies the register allocator.
   c_return_value %{
     assert((ideal_reg >= Op_RegI && ideal_reg <= Op_RegL) ||
             (ideal_reg == Op_RegN && CompressedOops::base() == nullptr && CompressedOops::shift() == 0),
             "only return normal values");
-    // enum names from opcodes.hpp:    Op_Node Op_Set Op_RegN       Op_RegI       Op_RegP       Op_RegF       Op_RegD       Op_RegL
-    static int typeToRegLo[Op_RegL+1] = { 0,   0,     R3_num,   R3_num,   R3_num,   F1_num,   F1_num,   R3_num };
-    static int typeToRegHi[Op_RegL+1] = { 0,   0,     OptoReg::Bad, R3_H_num, R3_H_num, OptoReg::Bad, F1_H_num, R3_H_num };
+    // enum names from opcodes.hpp
+    static int typeToRegLo[Op_RegL+1] = {
+      0,              // Op_Node
+      0,              // Op_Set
+      R3_num,         // Op_RegN
+      R3_num,         // Op_RegI
+      R3_num,         // Op_RegP
+      F1_num,         // Op_RegF
+      F1_num,         // Op_RegD
+      R3_num,         // Op_RegL
+    };
+
+    static int typeToRegHi[Op_RegL+1] = {
+      0,              // Op_Node
+      0,              // Op_Set
+      OptoReg::Bad,   // Op_RegN
+      OptoReg::Bad,   // Op_RegI
+      R3_H_num,       // Op_RegP
+      OptoReg::Bad,   // Op_RegF
+      F1_H_num,       // Op_RegD
+      R3_H_num        // Op_RegL
+    };
+
     return OptoRegPair(typeToRegHi[ideal_reg], typeToRegLo[ideal_reg]);
   %}
 
@@ -3733,9 +3747,29 @@ frame %{
     assert((ideal_reg >= Op_RegI && ideal_reg <= Op_RegL) ||
             (ideal_reg == Op_RegN && CompressedOops::base() == nullptr && CompressedOops::shift() == 0),
             "only return normal values");
-    // enum names from opcodes.hpp:    Op_Node Op_Set Op_RegN       Op_RegI       Op_RegP       Op_RegF       Op_RegD       Op_RegL
-    static int typeToRegLo[Op_RegL+1] = { 0,   0,     R3_num,   R3_num,   R3_num,   F1_num,   F1_num,   R3_num };
-    static int typeToRegHi[Op_RegL+1] = { 0,   0,     OptoReg::Bad, R3_H_num, R3_H_num, OptoReg::Bad, F1_H_num, R3_H_num };
+    // enum names from opcodes.hpp
+    static int typeToRegLo[Op_RegL+1] = {
+      0,              // Op_Node
+      0,              // Op_Set
+      R3_num,         // Op_RegN
+      R3_num,         // Op_RegI
+      R3_num,         // Op_RegP
+      F1_num,         // Op_RegF
+      F1_num,         // Op_RegD
+      R3_num,         // Op_RegL
+    };
+
+    static int typeToRegHi[Op_RegL+1] = {
+      0,              // Op_Node
+      0,              // Op_Set
+      OptoReg::Bad,   // Op_RegN
+      OptoReg::Bad,   // Op_RegI
+      R3_H_num,       // Op_RegP
+      OptoReg::Bad,   // Op_RegF
+      F1_H_num,       // Op_RegD
+      R3_H_num        // Op_RegL
+    };
+
     return OptoRegPair(typeToRegHi[ideal_reg], typeToRegLo[ideal_reg]);
   %}
 %}


### PR DESCRIPTION
Op_RegI values occupy just one register. So OptoRegPair::_second should be set to OptoReg::Bad in ppc.ad `c_return_value` and `return_value` as it is done on other platforms.

`c_return_value` is actually redundant (identical to `return_value`). It's removed therefore.
Sparc comment is also removed.

The fix passed our CI testing:
Tier 1-4 of hotspot and jdk. All of langtools and jaxp. Renaissance Suite and SAP specific tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385166](https://bugs.openjdk.org/browse/JDK-8385166): PPC: C2: c_return_value and return_value should not set 2nd OptoRegPair for Op_RegI (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31237/head:pull/31237` \
`$ git checkout pull/31237`

Update a local copy of the PR: \
`$ git checkout pull/31237` \
`$ git pull https://git.openjdk.org/jdk.git pull/31237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31237`

View PR using the GUI difftool: \
`$ git pr show -t 31237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31237.diff">https://git.openjdk.org/jdk/pull/31237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31237#issuecomment-4646813333)
</details>
