### PR TITLE
8385165: [ubsan] TestDockerMemoryMetricsSubgroup.java jtreg test fails with ubsan-enabled binaries

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
@@ -41,6 +41,7 @@ import jtreg.SkippedException;
  * @summary Cgroup v1 subsystem fails to set subsystem path
  * @requires container.support
  * @requires !vm.asan
+ * @requires !vm.ubsan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build MetricsMemoryTester


### PR DESCRIPTION
The test TestDockerMemoryMetricsSubgroup.java fails when running with ubsan-enabled binaries.
This is because the test uses a standard docker image (usually ubuntu) and there ubsan - enabled binaries cannot be executed.
Error message is like this

```
 stdout: [/jdk/bin/java: error while loading shared libraries: libubsan.so.1: cannot open shared object file: No such file or directory
];

```
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385165](https://bugs.openjdk.org/browse/JDK-8385165): [ubsan] TestDockerMemoryMetricsSubgroup.java jtreg test fails with ubsan-enabled binaries (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Arno Zeller](https://openjdk.org/census#azeller) (@ArnoZeller - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31239/head:pull/31239` \
`$ git checkout pull/31239`

Update a local copy of the PR: \
`$ git checkout pull/31239` \
`$ git pull https://git.openjdk.org/jdk.git pull/31239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31239`

View PR using the GUI difftool: \
`$ git pr show -t 31239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31239.diff">https://git.openjdk.org/jdk/pull/31239.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31239#issuecomment-4509881789)
</details>
