### PR TITLE
8385309: Test jdk/jfr/event/gc/collection/TestGCEventMixedWithParallelOld.java failed

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/GCEventAll.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/GCEventAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/gc/collection/GCEventAll.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/GCEventAll.java
@@ -166,9 +166,11 @@ public class GCEventAll {
         List<GCHelper.GcBatch> gcBatches = null;
         GCHelper.CollectionSummary eventCounts = null;
 
-        // For some GC configurations, the JFR recording may have stopped before we received the last gc event.
+        // The first/last GC batch can be incomplete if recording starts before all
+        // event settings are applied or stops before all events are received.
         try {
-            gcBatches = GCHelper.GcBatch.createFromEvents(events);
+            List<RecordedEvent> completeEvents = GCHelper.removeFirstAndLastGC(events);
+            gcBatches = GCHelper.GcBatch.createFromEvents(completeEvents);
             eventCounts = GCHelper.CollectionSummary.createFromEvents(gcBatches);
 
             verifyUniqueIds(gcBatches);
@@ -244,9 +246,10 @@ public class GCEventAll {
         }
         // JFR events and GarbageCollectorMXBean events are not updated at the same time.
         // This means that number of collections may diff.
-        // We allow a diff of +- 1 collection count.
-        long minCount = Math.max(0, beanCounts - 1);
-        long maxCount = beanCounts + 1;
+        // We allow a diff of +- 2 collection counts, since the first and last
+        // GC batches are removed to avoid recording-boundary races.
+        long minCount = Math.max(0, beanCounts - 2);
+        long maxCount = beanCounts + 2;
         Asserts.assertGreaterThanOrEqual(eventCounts, minCount, "Too few event counts for collector " + collector);
         Asserts.assertLessThanOrEqual(eventCounts, maxCount, "Too many event counts for collector " + collector);
     }


### PR DESCRIPTION
This test can fail if the first or last recorded GC batch is incomplete, due to inherent race btw GC and jfr-starting/stopping. Other JFR GC tests already handle this by removing the first and last GC, so this patch does the same before creating `GcBatch` instances.

Since the test also compares JFR collection counts with MXBean deltas, and the two edge GCs are now removed, the accepted count difference is widened from `+/-1` to `+/-2`.

Stress reproduction:

```
without patch: 32/2000 failures
with patch:     0/2000 failures
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385309](https://bugs.openjdk.org/browse/JDK-8385309): Test jdk/jfr/event/gc/collection/TestGCEventMixedWithParallelOld.java failed (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31254/head:pull/31254` \
`$ git checkout pull/31254`

Update a local copy of the PR: \
`$ git checkout pull/31254` \
`$ git pull https://git.openjdk.org/jdk.git pull/31254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31254`

View PR using the GUI difftool: \
`$ git pr show -t 31254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31254.diff">https://git.openjdk.org/jdk/pull/31254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31254#issuecomment-4517236367)
</details>
