### PR TITLE
8352794: PoolEntry and BootstrapMethodEntry hashCode inconsistent with equals

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -102,6 +102,12 @@ public abstract sealed class AbstractPoolEntry {
         return hash;
     }
 
+    int poolHash() {
+        // Hash used by constant pool maps.  Unlike Object.hashCode(), this may be
+        // based on pool-local indices to keep lookup and building paths cheap.
+        return hash != 0 ? hash : hashCode();
+    }
+
     public abstract int tag();
 
     public int width() {
@@ -521,14 +527,23 @@ public abstract sealed class AbstractPoolEntry {
 
     abstract static sealed class AbstractRefEntry<T extends PoolEntry> extends AbstractPoolEntry {
         protected final T ref1;
+        private @Stable int contentHash;
 
         public AbstractRefEntry(ConstantPool constantPool, int tag, int index, T ref1) {
-            super(constantPool, index, hash1(tag, ref1.hashCode()));
+            super(constantPool, index, hash1(tag, ref1.index()));
             this.ref1 = ref1;
         }
 
         public T ref1() {
             return ref1;
+        }
+
+        @Override
+        public int hashCode() {
+            var hash = this.contentHash;
+            if (hash != 0)
+                return hash;
+            return this.contentHash = hash1(tag(), ref1.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -545,9 +560,10 @@ public abstract sealed class AbstractPoolEntry {
             extends AbstractPoolEntry {
         protected final T ref1;
         protected final U ref2;
+        private @Stable int contentHash;
 
         public AbstractRefsEntry(ConstantPool constantPool, int tag, int index, T ref1, U ref2) {
-            super(constantPool, index, hash2(tag, ref1.hashCode(), ref2.hashCode()));
+            super(constantPool, index, hash2(tag, ref1.index(), ref2.index()));
             this.ref1 = ref1;
             this.ref2 = ref2;
         }
@@ -558,6 +574,14 @@ public abstract sealed class AbstractPoolEntry {
 
         public U ref2() {
             return ref2;
+        }
+
+        @Override
+        public int hashCode() {
+            var hash = this.contentHash;
+            if (hash != 0)
+                return hash;
+            return this.contentHash = hash2(tag(), ref1.hashCode(), ref2.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -673,6 +697,11 @@ public abstract sealed class AbstractPoolEntry {
                 return hash;
 
             return this.hash = hashClassFromUtf8(ref1.mayBeArrayDescriptor(), ref1);
+        }
+
+        @Override
+        int poolHash() {
+            return hashCode();
         }
     }
 
@@ -881,7 +910,7 @@ public abstract sealed class AbstractPoolEntry {
         private final int bsmIndex;
         private BootstrapMethodEntryImpl bootstrapMethod;
         private final NameAndTypeEntryImpl nameAndType;
-        private @Stable int hash;
+        private @Stable int contentHash;
 
         AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int hash, BootstrapMethodEntryImpl bootstrapMethod,
                                          NameAndTypeEntryImpl nameAndType) {
@@ -889,12 +918,11 @@ public abstract sealed class AbstractPoolEntry {
             this.bsmIndex = bootstrapMethod.bsmIndex();
             this.bootstrapMethod = bootstrapMethod;
             this.nameAndType = nameAndType;
-            this.hash = hash;
         }
 
-        AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int bsmIndex,
+        AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int hash, int bsmIndex,
                                          NameAndTypeEntryImpl nameAndType) {
-            super(cpm, index, 0);
+            super(cpm, index, hash);
             this.bsmIndex = bsmIndex;
             this.bootstrapMethod = null;
             this.nameAndType = nameAndType;
@@ -926,11 +954,11 @@ public abstract sealed class AbstractPoolEntry {
 
         @Override
         public int hashCode() {
-            var h = this.hash;
+            int h = this.contentHash;
             if (h != 0) {
                 return h;
             }
-            return this.hash = hash2(tag(), bootstrap().hashCode(), nameAndType.hashCode());
+            return this.contentHash = hash2(tag(), bootstrap().hashCode(), nameAndType.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -968,7 +996,8 @@ public abstract sealed class AbstractPoolEntry {
 
         InvokeDynamicEntryImpl(ConstantPool cpm, int index, int bsmIndex,
                                    NameAndTypeEntryImpl nameAndType) {
-            super(cpm, index, bsmIndex, nameAndType);
+            super(cpm, index, hash2(TAG_INVOKE_DYNAMIC, bsmIndex, nameAndType.index()),
+                  bsmIndex, nameAndType);
         }
 
         @Override
@@ -1006,7 +1035,8 @@ public abstract sealed class AbstractPoolEntry {
 
         ConstantDynamicEntryImpl(ConstantPool cpm, int index, int bsmIndex,
                                      NameAndTypeEntryImpl nameAndType) {
-            super(cpm, index, bsmIndex, nameAndType);
+            super(cpm, index, hash2(TAG_DYNAMIC, bsmIndex, nameAndType.index()),
+                  bsmIndex, nameAndType);
         }
 
         @Override
@@ -1037,6 +1067,7 @@ public abstract sealed class AbstractPoolEntry {
 
         private final int refKind;
         private final AbstractPoolEntry.AbstractMemberRefEntry reference;
+        private @Stable int contentHash;
         public @Stable DirectMethodHandleDesc sym;
 
         MethodHandleEntryImpl(ConstantPool cpm, int index, int hash, int refKind, AbstractPoolEntry.AbstractMemberRefEntry
@@ -1048,7 +1079,7 @@ public abstract sealed class AbstractPoolEntry {
 
         MethodHandleEntryImpl(ConstantPool cpm, int index, int refKind, AbstractPoolEntry.AbstractMemberRefEntry
                 reference) {
-            super(cpm, index, hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode()));
+            super(cpm, index, hash2(TAG_METHOD_HANDLE, refKind, reference.index()));
             this.refKind = refKind;
             this.reference = reference;
         }
@@ -1066,6 +1097,14 @@ public abstract sealed class AbstractPoolEntry {
         @Override
         public AbstractPoolEntry.AbstractMemberRefEntry reference() {
             return reference;
+        }
+
+        @Override
+        public int hashCode() {
+            var hash = this.contentHash;
+            if (hash != 0)
+                return hash;
+            return this.contentHash = hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode());
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -523,7 +523,7 @@ public abstract sealed class AbstractPoolEntry {
         protected final T ref1;
 
         public AbstractRefEntry(ConstantPool constantPool, int tag, int index, T ref1) {
-            super(constantPool, index, hash1(tag, ref1.index()));
+            super(constantPool, index, hash1(tag, ref1.hashCode()));
             this.ref1 = ref1;
         }
 
@@ -547,7 +547,7 @@ public abstract sealed class AbstractPoolEntry {
         protected final U ref2;
 
         public AbstractRefsEntry(ConstantPool constantPool, int tag, int index, T ref1, U ref2) {
-            super(constantPool, index, hash2(tag, ref1.index(), ref2.index()));
+            super(constantPool, index, hash2(tag, ref1.hashCode(), ref2.hashCode()));
             this.ref1 = ref1;
             this.ref2 = ref2;
         }
@@ -881,6 +881,7 @@ public abstract sealed class AbstractPoolEntry {
         private final int bsmIndex;
         private BootstrapMethodEntryImpl bootstrapMethod;
         private final NameAndTypeEntryImpl nameAndType;
+        private @Stable int hash;
 
         AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int hash, BootstrapMethodEntryImpl bootstrapMethod,
                                          NameAndTypeEntryImpl nameAndType) {
@@ -888,11 +889,12 @@ public abstract sealed class AbstractPoolEntry {
             this.bsmIndex = bootstrapMethod.bsmIndex();
             this.bootstrapMethod = bootstrapMethod;
             this.nameAndType = nameAndType;
+            this.hash = hash;
         }
 
-        AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int hash, int bsmIndex,
+        AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int bsmIndex,
                                          NameAndTypeEntryImpl nameAndType) {
-            super(cpm, index, hash);
+            super(cpm, index, 0);
             this.bsmIndex = bsmIndex;
             this.bootstrapMethod = null;
             this.nameAndType = nameAndType;
@@ -920,6 +922,15 @@ public abstract sealed class AbstractPoolEntry {
          */
         public NameAndTypeEntryImpl nameAndType() {
             return nameAndType;
+        }
+
+        @Override
+        public int hashCode() {
+            var h = this.hash;
+            if (h != 0) {
+                return h;
+            }
+            return this.hash = hash2(tag(), bootstrap().hashCode(), nameAndType.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -957,8 +968,7 @@ public abstract sealed class AbstractPoolEntry {
 
         InvokeDynamicEntryImpl(ConstantPool cpm, int index, int bsmIndex,
                                    NameAndTypeEntryImpl nameAndType) {
-            super(cpm, index, hash2(TAG_INVOKE_DYNAMIC, bsmIndex, nameAndType.index()),
-                  bsmIndex, nameAndType);
+            super(cpm, index, bsmIndex, nameAndType);
         }
 
         @Override
@@ -996,8 +1006,7 @@ public abstract sealed class AbstractPoolEntry {
 
         ConstantDynamicEntryImpl(ConstantPool cpm, int index, int bsmIndex,
                                      NameAndTypeEntryImpl nameAndType) {
-            super(cpm, index, hash2(TAG_DYNAMIC, bsmIndex, nameAndType.index()),
-                  bsmIndex, nameAndType);
+            super(cpm, index, bsmIndex, nameAndType);
         }
 
         @Override
@@ -1039,7 +1048,7 @@ public abstract sealed class AbstractPoolEntry {
 
         MethodHandleEntryImpl(ConstantPool cpm, int index, int refKind, AbstractPoolEntry.AbstractMemberRefEntry
                 reference) {
-            super(cpm, index, hash2(TAG_METHOD_HANDLE, refKind, reference.index()));
+            super(cpm, index, hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode()));
             this.refKind = refKind;
             this.reference = reference;
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -68,7 +68,7 @@ public abstract sealed class AbstractPoolEntry {
     }
 
     static int hashClassFromUtf8(boolean isArray, Utf8EntryImpl content) {
-        int hash = content.contentHash();
+        int hash = content.stringHash();
         return hashClassFromDescriptor(isArray ? hash : Util.descriptorStringHash(content.length(), hash));
     }
 
@@ -85,11 +85,12 @@ public abstract sealed class AbstractPoolEntry {
 
     final ConstantPool constantPool;
     private final int index;
-    private final int hash;
+    private final int constructionHash;
+    private @Stable int fullHash;
 
-    private AbstractPoolEntry(ConstantPool constantPool, int index, int hash) {
+    private AbstractPoolEntry(ConstantPool constantPool, int index, int constructionHash) {
         this.index = index;
-        this.hash = hash;
+        this.constructionHash = constructionHash;
         this.constantPool = constantPool;
     }
 
@@ -98,14 +99,22 @@ public abstract sealed class AbstractPoolEntry {
     public int index() { return index; }
 
     @Override
-    public int hashCode() {
-        return hash;
+    public final int hashCode() {
+        int hash = fullHash;
+        if (hash != 0)
+            return hash;
+        return fullHash = computeFullHash();
     }
 
-    int poolHash() {
+    int constructionHash() {
         // Hash used by constant pool maps.  Unlike Object.hashCode(), this may be
         // based on pool-local indices to keep lookup and building paths cheap.
-        return hash != 0 ? hash : hashCode();
+        assert constructionHash != 0;
+        return constructionHash;
+    }
+
+    int computeFullHash() {
+        return constructionHash();
     }
 
     public abstract int tag();
@@ -138,7 +147,7 @@ public abstract sealed class AbstractPoolEntry {
         private final int offset;
         private final int rawLen;
         // Set in any state other than RAW
-        private @Stable int contentHash;
+        private @Stable int stringHash;
         private @Stable int charLen;
         // Set in CHAR state
         private @Stable char[] chars;
@@ -160,7 +169,7 @@ public abstract sealed class AbstractPoolEntry {
             this(cpm, index, s, s.hashCode());
         }
 
-        Utf8EntryImpl(ConstantPool cpm, int index, String s, int contentHash) {
+        Utf8EntryImpl(ConstantPool cpm, int index, String s, int stringHash) {
             // Prevent creation of unwritable entries
             if (!ModifiedUtf.isValidLengthInConstantPool(s)) {
                 throw new IllegalArgumentException("utf8 length out of range of u2: " + ModifiedUtf.utfLen(s));
@@ -172,7 +181,7 @@ public abstract sealed class AbstractPoolEntry {
             this.state = State.STRING;
             this.stringValue = s;
             this.charLen = s.length();
-            this.contentHash = contentHash;
+            this.stringHash = stringHash;
         }
 
         Utf8EntryImpl(ConstantPool cpm, int index, Utf8EntryImpl u) {
@@ -181,7 +190,7 @@ public abstract sealed class AbstractPoolEntry {
             this.offset = u.offset;
             this.rawLen = u.rawLen;
             this.state = u.state;
-            this.contentHash = u.contentHash;
+            this.stringHash = u.stringHash;
             this.charLen = u.charLen;
             this.chars = u.chars;
             this.stringValue = u.stringValue;
@@ -232,7 +241,7 @@ public abstract sealed class AbstractPoolEntry {
             int singleBytes = JLA.countPositives(rawBytes, offset, rawLen);
             int hash = ArraysSupport.hashCodeOfUnsigned(rawBytes, offset, singleBytes, 0);
             if (singleBytes == rawLen) {
-                this.contentHash = hash;
+                this.stringHash = hash;
                 charLen = rawLen;
                 state = State.BYTE;
             } else {
@@ -294,7 +303,7 @@ public abstract sealed class AbstractPoolEntry {
                         throw malformedInput(px);
                 }
             }
-            this.contentHash = hash;
+            this.stringHash = hash;
             charLen = chararr_count;
             this.chars = chararr;
             state = State.CHAR;
@@ -316,14 +325,19 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public int hashCode() {
-            return hashString(contentHash());
+        int computeFullHash() {
+            return hashString(stringHash());
         }
 
-        int contentHash() {
+        @Override
+        int constructionHash() {
+            return hashCode();
+        }
+
+        int stringHash() {
             if (state == State.RAW)
                 inflate();
-            return contentHash;
+            return stringHash;
         }
 
         @Override
@@ -402,7 +416,7 @@ public abstract sealed class AbstractPoolEntry {
                 case STRING:
                     return stringValue.equals(requireNonNull(s));
                 case CHAR:
-                    if (charLen != s.length() || contentHash != s.hashCode())
+                    if (charLen != s.length() || stringHash != s.hashCode())
                         return false;
                     for (int i=0; i<charLen; i++)
                         if (chars[i] != s.charAt(i))
@@ -411,7 +425,7 @@ public abstract sealed class AbstractPoolEntry {
                     state = State.STRING;
                     return true;
                 case BYTE:
-                    if (rawLen != s.length() || contentHash != s.hashCode())
+                    if (rawLen != s.length() || stringHash != s.hashCode())
                         return false;
                     for (int i=0; i<rawLen; i++)
                         if (rawBytes[offset+i] != s.charAt(i))
@@ -527,7 +541,6 @@ public abstract sealed class AbstractPoolEntry {
 
     abstract static sealed class AbstractRefEntry<T extends PoolEntry> extends AbstractPoolEntry {
         protected final T ref1;
-        private @Stable int contentHash;
 
         public AbstractRefEntry(ConstantPool constantPool, int tag, int index, T ref1) {
             super(constantPool, index, hash1(tag, ref1.index()));
@@ -539,11 +552,8 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public int hashCode() {
-            var hash = this.contentHash;
-            if (hash != 0)
-                return hash;
-            return this.contentHash = hash1(tag(), ref1.hashCode());
+        int computeFullHash() {
+            return hash1(tag(), ref1.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -560,7 +570,6 @@ public abstract sealed class AbstractPoolEntry {
             extends AbstractPoolEntry {
         protected final T ref1;
         protected final U ref2;
-        private @Stable int contentHash;
 
         public AbstractRefsEntry(ConstantPool constantPool, int tag, int index, T ref1, U ref2) {
             super(constantPool, index, hash2(tag, ref1.index(), ref2.index()));
@@ -577,11 +586,8 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public int hashCode() {
-            var hash = this.contentHash;
-            if (hash != 0)
-                return hash;
-            return this.contentHash = hash2(tag(), ref1.hashCode(), ref2.hashCode());
+        int computeFullHash() {
+            return hash2(tag(), ref1.hashCode(), ref2.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -612,7 +618,7 @@ public abstract sealed class AbstractPoolEntry {
     public static final class ClassEntryImpl extends AbstractNamedEntry implements ClassEntry {
 
         public @Stable ClassDesc sym;
-        private @Stable int hash;
+        private @Stable int constructionHash;
 
         ClassEntryImpl(ConstantPool cpm, int index, Utf8EntryImpl name) {
             super(cpm, TAG_CLASS, index, name);
@@ -620,7 +626,7 @@ public abstract sealed class AbstractPoolEntry {
 
         ClassEntryImpl(ConstantPool cpm, int index, Utf8EntryImpl name, int hash, ClassDesc sym) {
             super(cpm, TAG_CLASS, index, name);
-            this.hash = hash;
+            this.constructionHash = hash;
             this.sym = sym;
         }
 
@@ -691,17 +697,12 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public int hashCode() {
-            var hash = this.hash;
+        int constructionHash() {
+            var hash = this.constructionHash;
             if (hash != 0)
                 return hash;
 
-            return this.hash = hashClassFromUtf8(ref1.mayBeArrayDescriptor(), ref1);
-        }
-
-        @Override
-        int poolHash() {
-            return hashCode();
+            return this.constructionHash = hashClassFromUtf8(ref1.mayBeArrayDescriptor(), ref1);
         }
     }
 
@@ -910,7 +911,6 @@ public abstract sealed class AbstractPoolEntry {
         private final int bsmIndex;
         private BootstrapMethodEntryImpl bootstrapMethod;
         private final NameAndTypeEntryImpl nameAndType;
-        private @Stable int contentHash;
 
         AbstractDynamicConstantPoolEntry(ConstantPool cpm, int index, int hash, BootstrapMethodEntryImpl bootstrapMethod,
                                          NameAndTypeEntryImpl nameAndType) {
@@ -953,12 +953,8 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public int hashCode() {
-            int h = this.contentHash;
-            if (h != 0) {
-                return h;
-            }
-            return this.contentHash = hash2(tag(), bootstrap().hashCode(), nameAndType.hashCode());
+        int computeFullHash() {
+            return hash2(tag(), bootstrap().hashCode(), nameAndType.hashCode());
         }
 
         void writeTo(BufWriterImpl pool) {
@@ -1067,7 +1063,6 @@ public abstract sealed class AbstractPoolEntry {
 
         private final int refKind;
         private final AbstractPoolEntry.AbstractMemberRefEntry reference;
-        private @Stable int contentHash;
         public @Stable DirectMethodHandleDesc sym;
 
         MethodHandleEntryImpl(ConstantPool cpm, int index, int hash, int refKind, AbstractPoolEntry.AbstractMemberRefEntry
@@ -1100,11 +1095,8 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public int hashCode() {
-            var hash = this.contentHash;
-            if (hash != 0)
-                return hash;
-            return this.contentHash = hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode());
+        int computeFullHash() {
+            return hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode());
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -79,9 +79,9 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
         // Keep bootstrap method table lookup independent of recursive content hash computation
         int argumentsHash = 1;
         for (LoadableConstantEntry argument : arguments) {
-            argumentsHash = 31 * argumentsHash + argument.index();
+            argumentsHash = 31 * argumentsHash + ((AbstractPoolEntry) argument).poolHash();
         }
-        return (31 * handle.index() + argumentsHash) | AbstractPoolEntry.NON_ZERO;
+        return (31 * handle.poolHash() + argumentsHash) | AbstractPoolEntry.NON_ZERO;
     }
 
     private static int computeContentHashCode(MethodHandleEntryImpl handle,

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -29,22 +29,24 @@ import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.LoadableConstantEntry;
 import java.lang.classfile.constantpool.MethodHandleEntry;
 import java.util.List;
+import jdk.internal.vm.annotation.Stable;
 
 import static jdk.internal.classfile.impl.AbstractPoolEntry.MethodHandleEntryImpl;
 
 public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
 
     final int index;
-    final int hash;
+    final int poolHash;
     private final ConstantPool constantPool;
     private final MethodHandleEntryImpl handle;
     private final List<LoadableConstantEntry> arguments;
+    private @Stable int contentHash;
 
     BootstrapMethodEntryImpl(ConstantPool constantPool, int bsmIndex, int hash,
                              MethodHandleEntryImpl handle,
                              List<LoadableConstantEntry> arguments) {
         this.index = bsmIndex;
-        this.hash = hash;
+        this.poolHash = hash;
         this.constantPool = constantPool;
         this.handle = handle;
         this.arguments = Util.sanitizeU2List(arguments);
@@ -72,8 +74,18 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
                 && e.arguments().equals(arguments);
     }
 
-    static int computeHashCode(MethodHandleEntryImpl handle,
-                               List<? extends LoadableConstantEntry> arguments) {
+    static int computePoolHashCode(MethodHandleEntryImpl handle,
+                                   List<? extends LoadableConstantEntry> arguments) {
+        // Keep bootstrap method table lookup independent of recursive content hash computation
+        int argumentsHash = 1;
+        for (LoadableConstantEntry argument : arguments) {
+            argumentsHash = 31 * argumentsHash + argument.index();
+        }
+        return (31 * handle.index() + argumentsHash) | AbstractPoolEntry.NON_ZERO;
+    }
+
+    private static int computeContentHashCode(MethodHandleEntryImpl handle,
+                                              List<? extends LoadableConstantEntry> arguments) {
         return (31 * handle.hashCode() + arguments.hashCode()) | AbstractPoolEntry.NON_ZERO;
     }
 
@@ -82,7 +94,11 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
 
     @Override
     public int hashCode() {
-        return hash;
+        int hash = this.contentHash;
+        if (hash != 0)
+            return hash;
+
+        return this.contentHash = computeContentHashCode(handle, arguments);
     }
 
     void writeTo(BufWriterImpl writer) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -36,17 +36,17 @@ import static jdk.internal.classfile.impl.AbstractPoolEntry.MethodHandleEntryImp
 public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
 
     final int index;
-    final int poolHash;
+    final int constructionHash;
     private final ConstantPool constantPool;
     private final MethodHandleEntryImpl handle;
     private final List<LoadableConstantEntry> arguments;
-    private @Stable int contentHash;
+    private @Stable int fullHash;
 
     BootstrapMethodEntryImpl(ConstantPool constantPool, int bsmIndex, int hash,
                              MethodHandleEntryImpl handle,
                              List<LoadableConstantEntry> arguments) {
         this.index = bsmIndex;
-        this.poolHash = hash;
+        this.constructionHash = hash;
         this.constantPool = constantPool;
         this.handle = handle;
         this.arguments = Util.sanitizeU2List(arguments);
@@ -74,18 +74,18 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
                 && e.arguments().equals(arguments);
     }
 
-    static int computePoolHashCode(MethodHandleEntryImpl handle,
-                                   List<? extends LoadableConstantEntry> arguments) {
+    static int computeConstructionHashCode(MethodHandleEntryImpl handle,
+                                           List<? extends LoadableConstantEntry> arguments) {
         // Keep bootstrap method table lookup independent of recursive content hash computation
         int argumentsHash = 1;
         for (LoadableConstantEntry argument : arguments) {
-            argumentsHash = 31 * argumentsHash + ((AbstractPoolEntry) argument).poolHash();
+            argumentsHash = 31 * argumentsHash + ((AbstractPoolEntry) argument).constructionHash();
         }
-        return (31 * handle.poolHash() + argumentsHash) | AbstractPoolEntry.NON_ZERO;
+        return (31 * handle.constructionHash() + argumentsHash) | AbstractPoolEntry.NON_ZERO;
     }
 
-    private static int computeContentHashCode(MethodHandleEntryImpl handle,
-                                              List<? extends LoadableConstantEntry> arguments) {
+    private static int computeFullHashCode(MethodHandleEntryImpl handle,
+                                           List<? extends LoadableConstantEntry> arguments) {
         return (31 * handle.hashCode() + arguments.hashCode()) | AbstractPoolEntry.NON_ZERO;
     }
 
@@ -94,11 +94,11 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
 
     @Override
     public int hashCode() {
-        int hash = this.contentHash;
+        int hash = this.fullHash;
         if (hash != 0)
             return hash;
 
-        return this.contentHash = computeContentHashCode(handle, arguments);
+        return this.fullHash = computeFullHashCode(handle, arguments);
     }
 
     void writeTo(BufWriterImpl writer) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -760,7 +760,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                     final var handle = classReader.readEntry(p, AbstractPoolEntry.MethodHandleEntryImpl.class);
                     final List<LoadableConstantEntry> args = readEntryList(p + 2, LoadableConstantEntry.class);
                     p += 4 + args.size() * 2;
-                    int hash = BootstrapMethodEntryImpl.computeHashCode(handle, args);
+                    int hash = BootstrapMethodEntryImpl.computePoolHashCode(handle, args);
                     bs[i] = new BootstrapMethodEntryImpl(classReader, i, hash, handle, args);
                 }
                 bootstraps = List.of(bs);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -760,7 +760,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                     final var handle = classReader.readEntry(p, AbstractPoolEntry.MethodHandleEntryImpl.class);
                     final List<LoadableConstantEntry> args = readEntryList(p + 2, LoadableConstantEntry.class);
                     p += 4 + args.size() * 2;
-                    int hash = BootstrapMethodEntryImpl.computePoolHashCode(handle, args);
+                    int hash = BootstrapMethodEntryImpl.computeConstructionHashCode(handle, args);
                     bs[i] = new BootstrapMethodEntryImpl(classReader, i, hash, handle, args);
                 }
                 bootstraps = List.of(bs);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -292,7 +292,7 @@ public final class ClassReaderImpl
                 for (BootstrapMethodEntry bm : list) {
                     AbstractPoolEntry.MethodHandleEntryImpl handle = (AbstractPoolEntry.MethodHandleEntryImpl) bm.bootstrapMethod();
                     List<LoadableConstantEntry> args = bm.arguments();
-                    int hash = BootstrapMethodEntryImpl.computeHashCode(handle, args);
+                    int hash = BootstrapMethodEntryImpl.computePoolHashCode(handle, args);
                     bsmEntries.add(new BootstrapMethodEntryImpl(this, bsmEntries.size(), hash, handle, args));
                 }
             }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -292,7 +292,7 @@ public final class ClassReaderImpl
                 for (BootstrapMethodEntry bm : list) {
                     AbstractPoolEntry.MethodHandleEntryImpl handle = (AbstractPoolEntry.MethodHandleEntryImpl) bm.bootstrapMethod();
                     List<LoadableConstantEntry> args = bm.arguments();
-                    int hash = BootstrapMethodEntryImpl.computePoolHashCode(handle, args);
+                    int hash = BootstrapMethodEntryImpl.computeConstructionHashCode(handle, args);
                     bsmEntries.add(new BootstrapMethodEntryImpl(this, bsmEntries.size(), hash, handle, args));
                 }
             }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -328,7 +328,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     private<T extends AbstractPoolEntry> AbstractPoolEntry findEntry(int tag, T ref1) {
         // invariant: canWriteDirect(ref1.constantPool())
-        int hash = AbstractPoolEntry.hash1(tag, ref1.index());
+        int hash = AbstractPoolEntry.hash1(tag, ref1.hashCode());
         EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map.getIndexByToken(token));
@@ -347,7 +347,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     private <T extends AbstractPoolEntry, U extends AbstractPoolEntry>
             AbstractPoolEntry findEntry(int tag, T ref1, U ref2) {
         // invariant: canWriteDirect(ref1.constantPool()), canWriteDirect(ref2.constantPool())
-        int hash = AbstractPoolEntry.hash2(tag, ref1.index(), ref2.index());
+        int hash = AbstractPoolEntry.hash2(tag, ref1.hashCode(), ref2.hashCode());
         EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map.getIndexByToken(token));
@@ -596,7 +596,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     public MethodHandleEntry methodHandleEntry(int refKind, MemberRefEntry reference) {
         Util.checkU1(refKind, "reference kind");
         reference = AbstractPoolEntry.maybeClone(this, reference);
-        int hash = AbstractPoolEntry.hash2(TAG_METHOD_HANDLE, refKind, reference.index());
+        int hash = AbstractPoolEntry.hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode());
         EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map1.getIndexByToken(token));
@@ -621,7 +621,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
                                             bootstrapMethodEntry.arguments());
         nameAndType = AbstractPoolEntry.maybeClone(this, nameAndType);
         int hash = AbstractPoolEntry.hash2(TAG_INVOKE_DYNAMIC,
-                bootstrapMethodEntry.bsmIndex(), nameAndType.index());
+                bootstrapMethodEntry.hashCode(), nameAndType.hashCode());
         EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map1.getIndexByToken(token));
@@ -651,7 +651,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
                                             bootstrapMethodEntry.arguments());
         nameAndType = AbstractPoolEntry.maybeClone(this, nameAndType);
         int hash = AbstractPoolEntry.hash2(TAG_DYNAMIC,
-                bootstrapMethodEntry.bsmIndex(), nameAndType.index());
+                bootstrapMethodEntry.hashCode(), nameAndType.hashCode());
         EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map1.getIndexByToken(token));

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -82,6 +82,11 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         return bsmSize;
     }
 
+    private static int poolHash(PoolEntry cpi) {
+        // SplitConstantPool only stores the AbstractPoolEntry implementation.
+        return ((AbstractPoolEntry) cpi).poolHash();
+    }
+
     @Override
     public PoolEntry entryByIndex(int index) {
         if (index <= 0 || index >= size()) {
@@ -193,13 +198,13 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
                     doneFullScan = false;
                     i++;
                 } else {
-                    map.put(cpi.hashCode(), cpi.index());
+                    map.put(poolHash(cpi), cpi.index());
                     i += cpi.width();
                 }
             }
             for (int i = Math.max(parentSize, 1); i < size; ) {
                 PoolEntry cpi = myEntries[i - parentSize];
-                map.put(cpi.hashCode(), cpi.index());
+                map.put(poolHash(cpi), cpi.index());
                 i += cpi.width();
             }
         }
@@ -209,7 +214,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     private void fullScan() {
         for (int i=1; i<parentSize;) {
             PoolEntry cpi = parent.entryByIndex(i);
-            map.put(cpi.hashCode(), cpi.index());
+            map.put(poolHash(cpi), cpi.index());
             i += cpi.width();
         }
         doneFullScan = true;
@@ -222,18 +227,18 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             this.bsmMap = bsmMap = new EntryMap(Math.max(bsmSize, 16), .75f);
             for (int i=0; i<parentBsmSize; i++) {
                 BootstrapMethodEntryImpl bsm = parent.bootstrapMethodEntry(i);
-                bsmMap.put(bsm.hash, bsm.index);
+                bsmMap.put(bsm.poolHash, bsm.index);
             }
             for (int i = parentBsmSize; i < bsmSize; ++i) {
                 BootstrapMethodEntryImpl bsm = myBsmEntries[i - parentBsmSize];
-                bsmMap.put(bsm.hash, bsm.index);
+                bsmMap.put(bsm.poolHash, bsm.index);
             }
         }
         return bsmMap;
     }
 
     private <E extends PoolEntry> E internalAdd(E cpi) {
-        return internalAdd(cpi, cpi.hashCode());
+        return internalAdd(cpi, poolHash(cpi));
     }
 
     private <E extends PoolEntry> E internalAdd(E cpi, int hash) {
@@ -328,7 +333,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     private<T extends AbstractPoolEntry> AbstractPoolEntry findEntry(int tag, T ref1) {
         // invariant: canWriteDirect(ref1.constantPool())
-        int hash = AbstractPoolEntry.hash1(tag, ref1.hashCode());
+        int hash = AbstractPoolEntry.hash1(tag, ref1.index());
         EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map.getIndexByToken(token));
@@ -347,7 +352,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     private <T extends AbstractPoolEntry, U extends AbstractPoolEntry>
             AbstractPoolEntry findEntry(int tag, T ref1, U ref2) {
         // invariant: canWriteDirect(ref1.constantPool()), canWriteDirect(ref2.constantPool())
-        int hash = AbstractPoolEntry.hash2(tag, ref1.hashCode(), ref2.hashCode());
+        int hash = AbstractPoolEntry.hash2(tag, ref1.index(), ref2.index());
         EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map.getIndexByToken(token));
@@ -596,7 +601,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     public MethodHandleEntry methodHandleEntry(int refKind, MemberRefEntry reference) {
         Util.checkU1(refKind, "reference kind");
         reference = AbstractPoolEntry.maybeClone(this, reference);
-        int hash = AbstractPoolEntry.hash2(TAG_METHOD_HANDLE, refKind, reference.hashCode());
+        int hash = AbstractPoolEntry.hash2(TAG_METHOD_HANDLE, refKind, reference.index());
         EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map1.getIndexByToken(token));
@@ -621,7 +626,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
                                             bootstrapMethodEntry.arguments());
         nameAndType = AbstractPoolEntry.maybeClone(this, nameAndType);
         int hash = AbstractPoolEntry.hash2(TAG_INVOKE_DYNAMIC,
-                bootstrapMethodEntry.hashCode(), nameAndType.hashCode());
+                bootstrapMethodEntry.bsmIndex(), nameAndType.index());
         EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map1.getIndexByToken(token));
@@ -651,7 +656,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
                                             bootstrapMethodEntry.arguments());
         nameAndType = AbstractPoolEntry.maybeClone(this, nameAndType);
         int hash = AbstractPoolEntry.hash2(TAG_DYNAMIC,
-                bootstrapMethodEntry.hashCode(), nameAndType.hashCode());
+                bootstrapMethodEntry.bsmIndex(), nameAndType.index());
         EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
             PoolEntry e = entryByIndex(map1.getIndexByToken(token));
@@ -720,7 +725,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             }
         }
         AbstractPoolEntry.MethodHandleEntryImpl mre = (AbstractPoolEntry.MethodHandleEntryImpl) methodReference;
-        int hash = BootstrapMethodEntryImpl.computeHashCode(mre, arguments);
+        int hash = BootstrapMethodEntryImpl.computePoolHashCode(mre, arguments);
         EntryMap map = bsmMap();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             BootstrapMethodEntryImpl e = bootstrapMethodEntry(map.getIndexByToken(token));

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -82,9 +82,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         return bsmSize;
     }
 
-    private static int poolHash(PoolEntry cpi) {
+    private static int constructionHash(PoolEntry cpi) {
         // SplitConstantPool only stores the AbstractPoolEntry implementation.
-        return ((AbstractPoolEntry) cpi).poolHash();
+        return ((AbstractPoolEntry) cpi).constructionHash();
     }
 
     @Override
@@ -198,13 +198,13 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
                     doneFullScan = false;
                     i++;
                 } else {
-                    map.put(poolHash(cpi), cpi.index());
+                    map.put(constructionHash(cpi), cpi.index());
                     i += cpi.width();
                 }
             }
             for (int i = Math.max(parentSize, 1); i < size; ) {
                 PoolEntry cpi = myEntries[i - parentSize];
-                map.put(poolHash(cpi), cpi.index());
+                map.put(constructionHash(cpi), cpi.index());
                 i += cpi.width();
             }
         }
@@ -214,7 +214,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     private void fullScan() {
         for (int i=1; i<parentSize;) {
             PoolEntry cpi = parent.entryByIndex(i);
-            map.put(poolHash(cpi), cpi.index());
+            map.put(constructionHash(cpi), cpi.index());
             i += cpi.width();
         }
         doneFullScan = true;
@@ -227,18 +227,18 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             this.bsmMap = bsmMap = new EntryMap(Math.max(bsmSize, 16), .75f);
             for (int i=0; i<parentBsmSize; i++) {
                 BootstrapMethodEntryImpl bsm = parent.bootstrapMethodEntry(i);
-                bsmMap.put(bsm.poolHash, bsm.index);
+                bsmMap.put(bsm.constructionHash, bsm.index);
             }
             for (int i = parentBsmSize; i < bsmSize; ++i) {
                 BootstrapMethodEntryImpl bsm = myBsmEntries[i - parentBsmSize];
-                bsmMap.put(bsm.poolHash, bsm.index);
+                bsmMap.put(bsm.constructionHash, bsm.index);
             }
         }
         return bsmMap;
     }
 
     private <E extends PoolEntry> E internalAdd(E cpi) {
-        return internalAdd(cpi, poolHash(cpi));
+        return internalAdd(cpi, constructionHash(cpi));
     }
 
     private <E extends PoolEntry> E internalAdd(E cpi, int hash) {
@@ -487,9 +487,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     @Override
     public AbstractPoolEntry.Utf8EntryImpl utf8Entry(String s) {
-        int contentHash = s.hashCode();
-        var ce = tryFindUtf8(AbstractPoolEntry.hashString(contentHash), s);
-        return ce == null ? internalAdd(new AbstractPoolEntry.Utf8EntryImpl(this, size, s, contentHash)) : ce;
+        int stringHash = s.hashCode();
+        var ce = tryFindUtf8(AbstractPoolEntry.hashString(stringHash), s);
+        return ce == null ? internalAdd(new AbstractPoolEntry.Utf8EntryImpl(this, size, s, stringHash)) : ce;
     }
 
     AbstractPoolEntry.Utf8EntryImpl maybeCloneUtf8Entry(Utf8Entry entry) {
@@ -525,7 +525,8 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     }
 
     AbstractPoolEntry.ClassEntryImpl cloneClassEntry(AbstractPoolEntry.ClassEntryImpl e) {
-        var ce = tryFindClassEntry(e.hashCode(), e.ref1);
+        int hash = e.constructionHash();
+        var ce = tryFindClassEntry(hash, e.ref1);
         if (ce != null) {
             var mySym = e.sym;
             if (ce.sym == null && mySym != null) {
@@ -536,7 +537,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
         var utf8 = maybeCloneUtf8Entry(e.ref1); // call order matters
         return internalAdd(new AbstractPoolEntry.ClassEntryImpl(this, size,
-                utf8, e.hashCode(), e.sym));
+                utf8, hash, e.sym));
     }
 
     @Override
@@ -725,7 +726,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             }
         }
         AbstractPoolEntry.MethodHandleEntryImpl mre = (AbstractPoolEntry.MethodHandleEntryImpl) methodReference;
-        int hash = BootstrapMethodEntryImpl.computePoolHashCode(mre, arguments);
+        int hash = BootstrapMethodEntryImpl.computeConstructionHashCode(mre, arguments);
         EntryMap map = bsmMap();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             BootstrapMethodEntryImpl e = bootstrapMethodEntry(map.getIndexByToken(token));

--- a/test/jdk/jdk/classfile/PoolEntryHashCodeTest.java
+++ b/test/jdk/jdk/classfile/PoolEntryHashCodeTest.java
@@ -57,6 +57,7 @@ import java.lang.constant.ModuleDesc;
 import java.lang.constant.PackageDesc;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.StringConcatFactory;
+import java.lang.invoke.TypeDescriptor;
 import java.util.List;
 import java.util.function.Function;
 
@@ -68,11 +69,13 @@ import static java.lang.constant.ConstantDescs.CD_CallSite;
 import static java.lang.constant.ConstantDescs.CD_Collection;
 import static java.lang.constant.ConstantDescs.CD_Exception;
 import static java.lang.constant.ConstantDescs.CD_MethodHandle;
+import static java.lang.constant.ConstantDescs.CD_MethodHandles_Lookup;
 import static java.lang.constant.ConstantDescs.CD_MethodType;
 import static java.lang.constant.ConstantDescs.CD_Object;
 import static java.lang.constant.ConstantDescs.CD_String;
 import static java.lang.constant.ConstantDescs.CD_boolean;
 import static java.lang.constant.ConstantDescs.CD_int;
+import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
 import static java.lang.constant.ConstantDescs.FALSE;
 import static java.lang.constant.ConstantDescs.INIT_NAME;
 import static java.lang.constant.ConstantDescs.MTD_void;
@@ -151,5 +154,15 @@ class PoolEntryHashCodeTest {
         for (int i = 0; i < 10; i++) {
             pool.utf8Entry("ignore: " + i);
         }
+
+        pool.bsmEntry(
+                MethodHandleDesc.ofMethod(
+                        DirectMethodHandleDesc.Kind.STATIC,
+                        ClassDesc.of(DEFAULT_NAME),
+                        DEFAULT_NAME,
+                        MethodTypeDesc.of(CD_Object, CD_MethodHandles_Lookup, CD_String, ClassDesc.of(TypeDescriptor.class.getName()))
+                ),
+                List.of()
+        );
     }
 }

--- a/test/jdk/jdk/classfile/PoolEntryHashCodeTest.java
+++ b/test/jdk/jdk/classfile/PoolEntryHashCodeTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8352794
+ * @summary Test equal PoolEntry and BootstrapMethodEntry objects have equal hash codes.
+ * @run junit ${test.main.class}
+ */
+
+import java.lang.classfile.BootstrapMethodEntry;
+import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.classfile.constantpool.ConstantDynamicEntry;
+import java.lang.classfile.constantpool.ConstantPoolBuilder;
+import java.lang.classfile.constantpool.DoubleEntry;
+import java.lang.classfile.constantpool.FieldRefEntry;
+import java.lang.classfile.constantpool.FloatEntry;
+import java.lang.classfile.constantpool.IntegerEntry;
+import java.lang.classfile.constantpool.InterfaceMethodRefEntry;
+import java.lang.classfile.constantpool.InvokeDynamicEntry;
+import java.lang.classfile.constantpool.LongEntry;
+import java.lang.classfile.constantpool.MethodHandleEntry;
+import java.lang.classfile.constantpool.MethodRefEntry;
+import java.lang.classfile.constantpool.MethodTypeEntry;
+import java.lang.classfile.constantpool.ModuleEntry;
+import java.lang.classfile.constantpool.NameAndTypeEntry;
+import java.lang.classfile.constantpool.PackageEntry;
+import java.lang.classfile.constantpool.StringEntry;
+import java.lang.classfile.constantpool.Utf8Entry;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicCallSiteDesc;
+import java.lang.constant.MethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.constant.ModuleDesc;
+import java.lang.constant.PackageDesc;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.StringConcatFactory;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import static java.lang.constant.ConstantDescs.BSM_INVOKE;
+import static java.lang.constant.ConstantDescs.CD_Boolean;
+import static java.lang.constant.ConstantDescs.CD_CallSite;
+import static java.lang.constant.ConstantDescs.CD_Collection;
+import static java.lang.constant.ConstantDescs.CD_Exception;
+import static java.lang.constant.ConstantDescs.CD_MethodHandle;
+import static java.lang.constant.ConstantDescs.CD_MethodType;
+import static java.lang.constant.ConstantDescs.CD_Object;
+import static java.lang.constant.ConstantDescs.CD_String;
+import static java.lang.constant.ConstantDescs.CD_boolean;
+import static java.lang.constant.ConstantDescs.CD_int;
+import static java.lang.constant.ConstantDescs.FALSE;
+import static java.lang.constant.ConstantDescs.INIT_NAME;
+import static java.lang.constant.ConstantDescs.MTD_void;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PoolEntryHashCodeTest {
+
+    @Test
+    void testHashCodeContractAcrossConstantPools() {
+        ConstantPoolBuilder pool1 = ConstantPoolBuilder.of();
+        ConstantPoolBuilder pool2 = ConstantPoolBuilder.of();
+
+        // Prefill the pools with some rubbish entries to make
+        prefillWithGarbage(pool1);
+
+        testEntry(Utf8Entry.class, pool1, pool2, pool -> pool.utf8Entry("Test Utf8Entry"));
+        testEntry(IntegerEntry.class, pool1, pool2, pool -> pool.intEntry(12345));
+        testEntry(FloatEntry.class, pool1, pool2, pool -> pool.floatEntry(12345f));
+        testEntry(LongEntry.class, pool1, pool2, pool -> pool.longEntry(12345L));
+        testEntry(DoubleEntry.class, pool1, pool2, pool -> pool.doubleEntry(12345d));
+
+        testEntry(ClassEntry.class, pool1, pool2, pool -> pool.classEntry(CD_Object));
+        testEntry(StringEntry.class, pool1, pool2, pool -> pool.stringEntry("Test String"));
+
+        testEntry(FieldRefEntry.class, pool1, pool2, pool -> pool.fieldRefEntry(CD_Boolean, "TRUE", CD_Boolean));
+        testEntry(MethodRefEntry.class, pool1, pool2, pool -> pool.methodRefEntry(CD_Exception, INIT_NAME, MTD_void));
+        testEntry(InterfaceMethodRefEntry.class, pool1, pool2,
+                pool -> pool.interfaceMethodRefEntry(CD_Collection, "isEmpty", MethodTypeDesc.of(CD_boolean)));
+        testEntry(NameAndTypeEntry.class, pool1, pool2, pool -> pool.nameAndTypeEntry("hoge", MethodTypeDesc.of(CD_Object)));
+        testEntry(MethodHandleEntry.class, pool1, pool2, pool -> pool.methodHandleEntry(BSM_INVOKE));
+        testEntry(MethodTypeEntry.class, pool1, pool2, pool -> pool.methodTypeEntry(MethodTypeDesc.of(CD_String)));
+
+        testEntry(ConstantDynamicEntry.class, pool1, pool2, pool -> pool.constantDynamicEntry(FALSE));
+        testEntry(InvokeDynamicEntry.class, pool1, pool2, pool -> pool.invokeDynamicEntry(
+                DynamicCallSiteDesc.of(
+                        ConstantDescs.ofCallsiteBootstrap(
+                                ClassDesc.of(StringConcatFactory.class.getName()),
+                                "makeConcat",
+                                CD_CallSite),
+                        MethodTypeDesc.of(CD_String, CD_Object, CD_Object, CD_Object))));
+
+        testEntry(ModuleEntry.class, pool1, pool2, pool -> pool.moduleEntry(ModuleDesc.of("java.base")));
+        testEntry(PackageEntry.class, pool1, pool2,
+                pool -> pool.packageEntry(PackageDesc.ofInternalName("java/lang")));
+
+        testEntry(BootstrapMethodEntry.class, pool1, pool2, pool -> pool.bsmEntry(
+                ConstantDescs.ofCallsiteBootstrap(
+                        ClassDesc.of(LambdaMetafactory.class.getName()),
+                        "metafactory",
+                        CD_CallSite,
+                        CD_MethodType,
+                        CD_MethodHandle,
+                        CD_MethodType),
+                List.of(
+                        MethodTypeDesc.of(CD_Object, CD_Object),
+                        MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.VIRTUAL,
+                                CD_Object,
+                                "hashCode",
+                                MethodTypeDesc.of(CD_int)),
+                        MethodTypeDesc.of(CD_int, CD_Object))));
+    }
+
+    private static <T> void testEntry(Class<T> type,
+                                      ConstantPoolBuilder pool1,
+                                      ConstantPoolBuilder pool2,
+                                      Function<? super ConstantPoolBuilder, ? extends T> factory) {
+        T entry1 = factory.apply(pool1);
+        T entry2 = factory.apply(pool2);
+
+        assertEquals(entry1, entry2, type::getName);
+        assertEquals(entry1.hashCode(), entry2.hashCode(), type::getName);
+    }
+
+    private static void prefillWithGarbage(ConstantPoolBuilder pool) {
+        for (int i = 0; i < 10; i++) {
+            pool.utf8Entry("ignore: " + i);
+        }
+    }
+}

--- a/test/jdk/jdk/classfile/PoolEntryHashCodeTest.java
+++ b/test/jdk/jdk/classfile/PoolEntryHashCodeTest.java
@@ -85,7 +85,8 @@ class PoolEntryHashCodeTest {
         ConstantPoolBuilder pool1 = ConstantPoolBuilder.of();
         ConstantPoolBuilder pool2 = ConstantPoolBuilder.of();
 
-        // Prefill the pools with some rubbish entries to make
+        // Prefill the pools with some rubbish entries to offset
+        // the indices so that the index-based hash codes differ
         prefillWithGarbage(pool1);
 
         testEntry(Utf8Entry.class, pool1, pool2, pool -> pool.utf8Entry("Test Utf8Entry"));


### PR DESCRIPTION
I fixed inconsistent `equals` / `hashCode` behaviour in `PoolEntry` and `BootstrapMethodEntry` objects created by different `ConstantPoolBuilder` instances.

Previously, some hash codes depended on constant pool indices of referenced entries.
Because of this, two entries with the same content could be equal but still have different hash codes if they came from different pools.

This patch splits hashing into two types:
1. `public hashCode()`, now based only on content and consistent with `equals`(slower than the type 2)
2. internal pool lookup hash, still based on indices for fast `SplitConstantPool` and bootstrap method table deduplication

This keeps fast local lookup performance while fixing the public `equals` / `hashCode` contract.

Added `PoolEntryHashCodeTest`, migrated from the original issue reproducer, which compares equivalent entries created by distinct `ConstantPoolBuilders` with different index layouts.

```
Running test 'jtreg:test/jdk/jdk/classfile/PoolEntryHashCodeTest.java'
Passed: jdk/classfile/PoolEntryHashCodeTest.java
Test results: passed: 1
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8352794](https://bugs.openjdk.org/browse/JDK-8352794): PoolEntry and BootstrapMethodEntry hashCode inconsistent with equals (**Bug** - P4)


### Reviewers without OpenJDK IDs
 * @ExE-Boss (no known openjdk.org user name / role) 🔄 Re-review required (review applies to [ea665bc0](https://git.openjdk.org/jdk/pull/31255/files/ea665bc0f306d0ae6d32af537ddc6f5b6ae776cb))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31255/head:pull/31255` \
`$ git checkout pull/31255`

Update a local copy of the PR: \
`$ git checkout pull/31255` \
`$ git pull https://git.openjdk.org/jdk.git pull/31255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31255`

View PR using the GUI difftool: \
`$ git pr show -t 31255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31255.diff">https://git.openjdk.org/jdk/pull/31255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31255#issuecomment-4518110551)
</details>
