### PR TITLE
8385319: AOT: Missed BAD_ADDRESS_ID spots in JDK-8357175

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -1794,7 +1794,7 @@ bool AOTCodeCache::write_asm_remarks(CodeBlob& cb) {
     }
     const char* cstr = add_C_string(str);
     int id = _table->id_for_C_string((address)cstr);
-    assert(id != -1, "asm remark string '%s' not found in AOTCodeAddressTable", str);
+    assert(id != BAD_ADDRESS_ID, "asm remark string '%s' not found in AOTCodeAddressTable", str);
     n = write_bytes(&id, sizeof(int));
     if (n != sizeof(int)) {
       return false;
@@ -1836,7 +1836,7 @@ bool AOTCodeCache::write_dbg_strings(CodeBlob& cb) {
     log_trace(aot, codecache, stubs)("dbg string=%s", str);
     const char* cstr = add_C_string(str);
     int id = _table->id_for_C_string((address)cstr);
-    assert(id != -1, "db string '%s' not found in AOTCodeAddressTable", str);
+    assert(id != BAD_ADDRESS_ID, "db string '%s' not found in AOTCodeAddressTable", str);
     uint n = write_bytes(&id, sizeof(int));
     if (n != sizeof(int)) {
       return false;


### PR DESCRIPTION
Fixed two places missed in [JDK-8357175]( https://bugs.openjdk.org/browse/JDK-8357175) changes.

Testing: GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385319](https://bugs.openjdk.org/browse/JDK-8385319): AOT: Missed BAD_ADDRESS_ID spots in JDK-8357175 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31257/head:pull/31257` \
`$ git checkout pull/31257`

Update a local copy of the PR: \
`$ git checkout pull/31257` \
`$ git pull https://git.openjdk.org/jdk.git pull/31257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31257`

View PR using the GUI difftool: \
`$ git pr show -t 31257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31257.diff">https://git.openjdk.org/jdk/pull/31257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31257#issuecomment-4519683415)
</details>
