### PR TITLE
8384941: AArch64: Use stlr for standalone release stores

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1580,9 +1580,7 @@ bool unnecessary_release(const Node *n)
          "expecting a release membar");
 
   MemBarNode *barrier = n->as_MemBar();
-  if (!barrier->leading()) {
-    return false;
-  } else {
+  if (barrier->leading()) {
     Node* trailing = barrier->trailing_membar();
     MemBarNode* trailing_mb = trailing->as_MemBar();
     assert(trailing_mb->trailing(), "Not a trailing membar?");
@@ -1597,6 +1595,44 @@ bool unnecessary_release(const Node *n)
       assert(mem->is_LoadStore(), "");
       assert(trailing_mb->Opcode() == Op_MemBarAcquire, "");
       return is_CAS(mem->Opcode(), true);
+    }
+  } else if (UseStlrForStandaloneRelease && barrier->standalone()) {
+    // A standalone MemBarRelease appears in front of a release store
+    // created by C2AccessFence (setRelease / putXRelease / putOrdered*)
+    // and also at the end of a constructor that publishes final fields.
+    // In the first case the following store carries MO=release and can
+    // be emitted as stlr, so the dmb ish is redundant; in the second
+    // case the preceding stores are MO=unordered and the barrier must
+    // stay. Walk forward along the memory projection: if we reach a
+    // release store with no trailing membar, the dmb can be elided.
+    // MergeMem and MemBarCPUOrder carry no aarch64 ordering of their
+    // own and are traversed transparently. Memory Phi nodes are not
+    // traversed; a release store that is only reachable through a Phi
+    // (some non-trivial loop shapes) will keep its leading dmb ish.
+    Node* mem_proj = barrier->proj_out_or_null(TypeFunc::Memory);
+    if (mem_proj == nullptr) {
+      return false;
+    }
+    ResourceMark rm;
+    Unique_Node_List wq;
+    wq.push(mem_proj);
+    for (uint i = 0; i < wq.size(); i++) {
+      Node* cur = wq.at(i);
+      for (DUIterator_Fast jmax, j = cur->fast_outs(jmax); j < jmax; j++) {
+        Node* u = cur->fast_out(j);
+        if (u->is_Store() && u->as_Store()->is_release() &&
+            u->as_Store()->trailing_membar() == nullptr) {
+          return true;
+        }
+        if (u->is_MergeMem()) {
+          wq.push(u);
+        } else if (u->Opcode() == Op_MemBarCPUOrder) {
+          Node* p = u->as_MemBar()->proj_out_or_null(TypeFunc::Memory);
+          if (p != nullptr) {
+            wq.push(p);
+          }
+        }
+      }
     }
   }
   return false;
@@ -1627,7 +1663,7 @@ bool needs_releasing_store(const Node *n)
 {
   // assert n->is_Store();
   StoreNode *st = n->as_Store();
-  return st->trailing_membar() != nullptr;
+  return st->trailing_membar() != nullptr || (UseStlrForStandaloneRelease && st->is_release());
 }
 
 // predicate controlling translation of CAS

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -135,6 +135,9 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Enable workaround for Neoverse N1 erratum 1542419")          \
   product(bool, UseSingleICacheInvalidation, false, DIAGNOSTIC,         \
           "Defer multiple ICache invalidation to single invalidation")  \
+  product(bool, UseStlrForStandaloneRelease, false,                     \
+          "Emit stlr for setRelease/putXRelease/putOrdered* stores "    \
+          "and elide the leading dmb ish")                              \
 
 // end of ARCH_FLAGS
 

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneRelease.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestStlrForStandaloneRelease.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384941
+ * @summary Verify aarch64 standalone release stores lower to stlr when
+ *          UseStlrForStandaloneRelease is on, and to dmb ish + str when off.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          jdk.unsupported
+ * @requires vm.flagless
+ * @requires os.arch == "aarch64" & vm.debug == true &
+ *           vm.flavor == "server" & !vm.graal.enabled
+ * @run driver compiler.c2.aarch64.TestStlrForStandaloneRelease
+ */
+
+package compiler.c2.aarch64;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestStlrForStandaloneRelease {
+
+    @SuppressWarnings({"deprecation", "removal"})
+    public static class Payload {
+        private static final Unsafe U = Unsafe.getUnsafe();
+        private static final sun.misc.Unsafe SUN_U;
+
+        public int    fInt;
+        public long   fLong;
+        public Object fRef;
+
+        public static final int[]    intArr = new int[1];
+        public static final Object[] refArr = new Object[1];
+
+        static final VarHandle VH_INT, VH_LONG, VH_REF;
+        static final VarHandle VH_INT_ARR =
+                MethodHandles.arrayElementVarHandle(int[].class);
+        static final VarHandle VH_REF_ARR =
+                MethodHandles.arrayElementVarHandle(Object[].class);
+
+        static final long OFF_INT, OFF_LONG, OFF_REF;
+
+        static {
+            try {
+                MethodHandles.Lookup l = MethodHandles.lookup();
+                VH_INT  = l.findVarHandle(Payload.class, "fInt",  int.class);
+                VH_LONG = l.findVarHandle(Payload.class, "fLong", long.class);
+                VH_REF  = l.findVarHandle(Payload.class, "fRef",  Object.class);
+                OFF_INT  = U.objectFieldOffset(Payload.class.getDeclaredField("fInt"));
+                OFF_LONG = U.objectFieldOffset(Payload.class.getDeclaredField("fLong"));
+                OFF_REF  = U.objectFieldOffset(Payload.class.getDeclaredField("fRef"));
+                Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                SUN_U = (sun.misc.Unsafe) f.get(null);
+            } catch (Throwable t) {
+                throw new ExceptionInInitializerError(t);
+            }
+        }
+
+        public static void testVhIntRelease(Payload p, int v)    { VH_INT.setRelease(p, v); }
+        public static void testVhLongRelease(Payload p, long v)  { VH_LONG.setRelease(p, v); }
+        public static void testVhRefRelease(Payload p, Object v) { VH_REF.setRelease(p, v); }
+        public static void testVhIntArrRelease(int v)            { VH_INT_ARR.setRelease(intArr, 0, v); }
+        public static void testVhRefArrRelease(Object v)         { VH_REF_ARR.setRelease(refArr, 0, v); }
+
+        public static void testUnsafeIntRelease(Payload p, int v)    { U.putIntRelease(p, OFF_INT, v); }
+        public static void testUnsafeLongRelease(Payload p, long v)  { U.putLongRelease(p, OFF_LONG, v); }
+        public static void testUnsafeRefRelease(Payload p, Object v) { U.putReferenceRelease(p, OFF_REF, v); }
+
+        public static void testPutOrderedInt(Payload p, int v)       { SUN_U.putOrderedInt(p, OFF_INT, v); }
+        public static void testPutOrderedLong(Payload p, long v)     { SUN_U.putOrderedLong(p, OFF_LONG, v); }
+        public static void testPutOrderedObject(Payload p, Object v) { SUN_U.putOrderedObject(p, OFF_REF, v); }
+
+        public static void testLoopRelease(Payload p, int v) {
+            for (int i = 0; i < 4; i++) {
+                VH_INT.setRelease(p, v + i);
+            }
+        }
+
+        // Constructor-exit MemBarRelease for final-field publication must
+        // not be elided regardless of the flag, otherwise the final write
+        // could be observed before the object is published.
+        public static final class WithFinal {
+            final int x;
+            WithFinal(int v) { this.x = v; }
+        }
+        public static WithFinal sink;
+        public static void testCtorFinal(int v) {
+            sink = new WithFinal(v);
+        }
+
+        public static void run() {
+            Payload p = new Payload();
+            for (int i = 0; i < 200_000; i++) {
+                testVhIntRelease(p, i);
+                testVhLongRelease(p, (long) i);
+                testVhRefRelease(p, Integer.valueOf(i));
+                testVhIntArrRelease(i);
+                testVhRefArrRelease(Integer.valueOf(i));
+                testUnsafeIntRelease(p, i);
+                testUnsafeLongRelease(p, (long) i);
+                testUnsafeRefRelease(p, Integer.valueOf(i));
+                testPutOrderedInt(p, i);
+                testPutOrderedLong(p, (long) i);
+                testPutOrderedObject(p, Integer.valueOf(i));
+                testLoopRelease(p, i);
+                testCtorFinal(i);
+            }
+            if (p.fInt == 0 || p.fLong != 199_999L || !(p.fRef instanceof Integer)
+                    || sink == null || sink.x == 0) {
+                throw new RuntimeException("bad payload result");
+            }
+        }
+    }
+
+    // mustKeepBarrier=true means the method's MemBarRelease must NEVER be
+    // elided, regardless of the flag (e.g. ctor-exit final-field publication).
+    private record Spec(String method, String stlrRegex, String strRegex,
+                        boolean mustKeepBarrier) {
+        Spec(String m, String stlr, String str) { this(m, stlr, str, false); }
+    }
+
+    // PrintOptoAssembly emits "stlrw ... # int" / "stlr ... # int" /
+    // "stlrw ... # compressed ptr" (or "# ptr" with -UseCompressedOops).
+    // The " ptr" anchor matches both compressed and uncompressed forms.
+    private static final List<Spec> SPECS = List.of(
+            new Spec("testVhIntRelease",      "\\bstlrw\\b.*#\\s*int\\b", "\\bstrw\\b.*#\\s*int\\b"),
+            new Spec("testVhLongRelease",     "\\bstlr\\b.*#\\s*int\\b",  "\\bstr\\b.*#\\s*int\\b"),
+            new Spec("testVhRefRelease",      "\\bstlrw?\\b.* ptr\\b",    "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testVhIntArrRelease",   "\\bstlrw\\b.*#\\s*int\\b", "\\bstrw\\b.*#\\s*int\\b"),
+            new Spec("testVhRefArrRelease",   "\\bstlrw?\\b.* ptr\\b",    "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testUnsafeIntRelease",  "\\bstlrw\\b.*#\\s*int\\b", "\\bstrw\\b.*#\\s*int\\b"),
+            new Spec("testUnsafeLongRelease", "\\bstlr\\b.*#\\s*int\\b",  "\\bstr\\b.*#\\s*int\\b"),
+            new Spec("testUnsafeRefRelease",  "\\bstlrw?\\b.* ptr\\b",    "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testPutOrderedInt",     "\\bstlrw\\b.*#\\s*int\\b", "\\bstrw\\b.*#\\s*int\\b"),
+            new Spec("testPutOrderedLong",    "\\bstlr\\b.*#\\s*int\\b",  "\\bstr\\b.*#\\s*int\\b"),
+            new Spec("testPutOrderedObject",  "\\bstlrw?\\b.* ptr\\b",    "\\bstrw?\\b.* ptr\\b"),
+            new Spec("testLoopRelease",       "\\bstlrw\\b.*#\\s*int\\b", "\\bstrw\\b.*#\\s*int\\b"),
+            new Spec("testCtorFinal",         "",                          "",                         true)
+    );
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "payload".equals(args[0])) {
+            Payload.run();
+            return;
+        }
+        check(runJit(true),  true);
+        check(runJit(false), false);
+    }
+
+    private static OutputAnalyzer runJit(boolean useStlr) throws Exception {
+        // -UseStoreStoreForCtor forces ctor exit to emit Op_MemBarRelease
+        // instead of Op_MemBarStoreStore, which is what the walker has to
+        // discriminate from in the standalone setRelease pattern.
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:-TieredCompilation",
+                "-XX:-BackgroundCompilation",
+                "-XX:+PrintOptoAssembly",
+                "-XX:-UseStoreStoreForCtor",
+                "-XX:" + (useStlr ? "+" : "-") + "UseStlrForStandaloneRelease",
+                "-XX:CompileCommand=compileonly,"
+                    + "compiler.c2.aarch64.TestStlrForStandaloneRelease$Payload::test*",
+                "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                TestStlrForStandaloneRelease.class.getName(),
+                "payload"
+        );
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldHaveExitValue(0);
+        return oa;
+    }
+
+    private static void check(OutputAnalyzer oa, boolean useStlr) {
+        List<String> lines = oa.asLines();
+        for (Spec s : SPECS) {
+            List<String> body = methodBody(lines, s.method());
+            if (body == null) {
+                throw new RuntimeException("PrintOptoAssembly missing block for "
+                        + s.method() + " (useStlr=" + useStlr + ")");
+            }
+            int elided    = countRegex(body, "membar_release \\(elided\\)");
+            int notElided = countRegex(body, "membar_release(?! \\(elided\\))");
+            if (s.mustKeepBarrier()) {
+                if (notElided < 1 || elided != 0) {
+                    fail(s, body, "ctor barrier must stay: elided=" + elided
+                            + " notElided=" + notElided);
+                }
+                continue;
+            }
+            int stlr = countRegex(body, s.stlrRegex());
+            int str  = countRegex(body, s.strRegex());
+            if (useStlr) {
+                if (stlr < 1 || elided < 1 || notElided != 0) {
+                    fail(s, body, "useStlr=on: stlr=" + stlr + " elided=" + elided
+                            + " notElided=" + notElided);
+                }
+            } else {
+                int plain = str - stlr;
+                if (plain < 1 || notElided < 1 || elided != 0) {
+                    fail(s, body, "useStlr=off: plain_str=" + plain
+                            + " notElided=" + notElided + " elided=" + elided);
+                }
+            }
+        }
+    }
+
+    private static List<String> methodBody(List<String> lines, String name) {
+        String anchor = "'" + name + "'";
+        int start = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            String l = lines.get(i);
+            if (l.contains("- name:") && l.contains(anchor)) {
+                start = i;
+                break;
+            }
+        }
+        if (start < 0) {
+            return null;
+        }
+        int end = lines.size();
+        for (int i = start + 1; i < lines.size(); i++) {
+            if (lines.get(i).contains("{method}")) {
+                end = i;
+                break;
+            }
+        }
+        return lines.subList(start, end);
+    }
+
+    private static int countRegex(List<String> body, String regex) {
+        Pattern p = Pattern.compile(regex);
+        int n = 0;
+        for (String l : body) {
+            if (p.matcher(l).find()) n++;
+        }
+        return n;
+    }
+
+    private static void fail(Spec s, List<String> body, String reason) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(reason).append(" -- method ").append(s.method()).append('\n');
+        for (String l : body) sb.append(l).append('\n');
+        throw new RuntimeException(sb.toString());
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/StlrForStandaloneRelease.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/StlrForStandaloneRelease.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+// Microbenchmark for aarch64 standalone release stores. Forks each method
+// twice so the +/-UseStlrForStandaloneRelease delta shows up in the report.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+public class StlrForStandaloneRelease {
+
+    private static final int N = 1024;
+
+    public int    fInt;
+    public long   fLong;
+    public Object fRef;
+
+    private static final VarHandle VH_INT;
+    private static final VarHandle VH_LONG;
+    private static final VarHandle VH_REF;
+    private static final VarHandle VH_INT_ARR =
+            MethodHandles.arrayElementVarHandle(int[].class);
+    private static final VarHandle VH_LONG_ARR =
+            MethodHandles.arrayElementVarHandle(long[].class);
+    private static final VarHandle VH_REF_ARR =
+            MethodHandles.arrayElementVarHandle(Object[].class);
+
+    // Single-slot targets: same address every iteration, store-buffer
+    // coalescing may inflate the delta.
+    private final int[]    intArr = new int[1];
+    private final Object[] refArr = new Object[1];
+
+    // N-slot targets: distinct address every iteration, gives the
+    // per-store cost of removing the dmb ish.
+    private final int[]    intArrN  = new int[N];
+    private final long[]   longArrN = new long[N];
+    private final Object[] refArrN  = new Object[N];
+
+    private final Object[] values = new Object[N];
+
+    @SuppressWarnings({"deprecation", "removal"})
+    private static final sun.misc.Unsafe SUN_U;
+    private static final long OFF_INT;
+    private static final long OFF_LONG;
+    private static final long OFF_REF;
+
+    static {
+        try {
+            MethodHandles.Lookup L = MethodHandles.lookup();
+            VH_INT  = L.findVarHandle(StlrForStandaloneRelease.class, "fInt",  int.class);
+            VH_LONG = L.findVarHandle(StlrForStandaloneRelease.class, "fLong", long.class);
+            VH_REF  = L.findVarHandle(StlrForStandaloneRelease.class, "fRef",  Object.class);
+            Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            SUN_U = (sun.misc.Unsafe) f.get(null);
+            OFF_INT  = SUN_U.objectFieldOffset(StlrForStandaloneRelease.class.getDeclaredField("fInt"));
+            OFF_LONG = SUN_U.objectFieldOffset(StlrForStandaloneRelease.class.getDeclaredField("fLong"));
+            OFF_REF  = SUN_U.objectFieldOffset(StlrForStandaloneRelease.class.getDeclaredField("fRef"));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public StlrForStandaloneRelease() {
+        for (int i = 0; i < N; i++) values[i] = Integer.valueOf(i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_intField() {
+        for (int i = 0; i < N; i++) VH_INT.setRelease(this, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_longField() {
+        for (int i = 0; i < N; i++) VH_LONG.setRelease(this, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_refField() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF.setRelease(this, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_intArray() {
+        int[] a = intArr;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, 0, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_refArray() {
+        Object[] a = refArr;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, 0, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void plusStlr_putOrderedInt() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedInt(this, OFF_INT, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void plusStlr_putOrderedLong() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedLong(this, OFF_LONG, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void plusStlr_putOrderedObject() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) SUN_U.putOrderedObject(this, OFF_REF, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_intArrayVarying() {
+        int[] a = intArrN;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, i, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_longArrayVarying() {
+        long[] a = longArrN;
+        for (int i = 0; i < N; i++) VH_LONG_ARR.setRelease(a, i, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:+UseStlrForStandaloneRelease"})
+    public void plusStlr_refArrayVarying() {
+        Object[] a = refArrN;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, i, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_intField() {
+        for (int i = 0; i < N; i++) VH_INT.setRelease(this, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_longField() {
+        for (int i = 0; i < N; i++) VH_LONG.setRelease(this, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_refField() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF.setRelease(this, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_intArray() {
+        int[] a = intArr;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, 0, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_refArray() {
+        Object[] a = refArr;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, 0, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void minusStlr_putOrderedInt() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedInt(this, OFF_INT, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void minusStlr_putOrderedLong() {
+        for (int i = 0; i < N; i++) SUN_U.putOrderedLong(this, OFF_LONG, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    @SuppressWarnings({"deprecation", "removal"})
+    public void minusStlr_putOrderedObject() {
+        Object[] v = values;
+        for (int i = 0; i < N; i++) SUN_U.putOrderedObject(this, OFF_REF, v[i]);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_intArrayVarying() {
+        int[] a = intArrN;
+        for (int i = 0; i < N; i++) VH_INT_ARR.setRelease(a, i, i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_longArrayVarying() {
+        long[] a = longArrN;
+        for (int i = 0; i < N; i++) VH_LONG_ARR.setRelease(a, i, (long) i);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    @Fork(value = 1, jvmArgs = {"-XX:-UseStlrForStandaloneRelease"})
+    public void minusStlr_refArrayVarying() {
+        Object[] a = refArrN;
+        Object[] v = values;
+        for (int i = 0; i < N; i++) VH_REF_ARR.setRelease(a, i, v[i]);
+    }
+}


### PR DESCRIPTION
On AArch64, C2 lowers `setRelease` / `putXRelease` / `putOrdered*` to a leading
`dmb ish` followed by a plain `str`. The release ordering can be provided by
`stlr` on its own, so the `dmb` is redundant.

This patch adds the elision in the aarch64 backend:

- `unnecessary_release()` recognizes a standalone `MemBarRelease` whose
  downstream memory chain — passed through `MergeMem` and `MemBarCPUOrder`
  transparently — reaches a release-MO store with no trailing membar, and
  reports the `dmb` as redundant. Memory `Phi` is not traversed; a release
  store hidden behind a `Phi` (some non-trivial loop shapes) keeps its
  leading `dmb ish`.

- `needs_releasing_store()` upgrades the matched store to `stlr`.

The constructor-exit `MemBarRelease` used for final-field publication is
left alone because its preceding stores are `MO=unordered` and the walker
cannot reach a release store. The test forces this path with
`-UseStoreStoreForCtor` and asserts the barrier is preserved.

The transform is gated by the product flag `UseStlrForStandaloneRelease`
(default off). 

## Testing

- New jtreg test `compiler/c2/aarch64/TestStlrForStandaloneRelease.java`:
- `compiler/c2/aarch64/` 
- `hotspot:tier1` on macosx-aarch64-server-fastdebug
- jcstress (release build, aarch64) with `+UseStlrForStandaloneRelease`

## Performance

| Benchmark         | -flag (ns/op)   | +flag (ns/op)   | speedup |
|-------------------|-----------------|-----------------|---------|
| intField          | 1.330 ± 0.032   | 0.223 ± 0.004   | 6.0x    |
| longField         | 1.332 ± 0.028   | 0.219 ± 0.002   | 6.1x    |
| refField          | 1.447 ± 0.008   | 0.359 ± 0.010   | 4.0x    |
| intArray          | 1.345 ± 0.015   | 0.225 ± 0.004   | 6.0x    |
| refArray          | 1.436 ± 0.021   | 0.351 ± 0.005   | 4.1x    |
| putOrderedInt     | 1.331 ± 0.020   | 0.219 ± 0.002   | 6.1x    |
| putOrderedLong    | 1.329 ± 0.009   | 0.219 ± 0.002   | 6.1x    |
| putOrderedObject  | 1.431 ± 0.033   | 0.384 ± 0.003   | 3.7x    |
| intArrayVarying   | 1.770 ± 0.662   | 0.224 ± 0.001   | 7.9x    |
| longArrayVarying  | 2.377 ± 0.753   | 0.225 ± 0.014   | 10.6x   |
| refArrayVarying   | 1.816 ± 0.103   | 0.372 ± 0.003   | 4.9x    |

This is a performance issue reported by our customers; it introduces a 10% performance overhead within their high-frequency financial trading pipeline, which relies heavily on https://github.com/JCTools/JCTools.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384941](https://bugs.openjdk.org/browse/JDK-8384941): AArch64: Use stlr for standalone release stores (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31258/head:pull/31258` \
`$ git checkout pull/31258`

Update a local copy of the PR: \
`$ git checkout pull/31258` \
`$ git pull https://git.openjdk.org/jdk.git pull/31258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31258`

View PR using the GUI difftool: \
`$ git pr show -t 31258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31258.diff">https://git.openjdk.org/jdk/pull/31258.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31258#issuecomment-4520519744)
</details>
