### PR TITLE
8384466: Test io/Console/RestoreEchoTest.java fails with expect: spawn id exp3 not open

### DIFF
--- a/test/jdk/java/io/Console/restoreEcho.exp
+++ b/test/jdk/java/io/Console/restoreEcho.exp
@@ -54,5 +54,8 @@ test "$rlprompt" "$rlinput" "$initialEcho" "$rlexpected"
 # readPassword() - input is not displayed
 test "$rpprompt" "$rpinput" "-echo" "$rpexpected"
 # See if the initialEcho is restored with `stty -a`
-expect -- " $initialEcho "
+# Depending on the platform, initialEcho may appear on a single line,
+# separated by either a space or a semicolon.
+set initialEchoRE [format {(^|[[:space:];])%s([[:space:];]|$)} $initialEcho]
+expect -re $initialEchoRE
 expect eof

--- a/test/jdk/java/io/Console/restoreEcho.exp
+++ b/test/jdk/java/io/Console/restoreEcho.exp
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Fixing the response file for the `expect` command in the test. The expected output of `stty -a` is platform-dependent, and the previous expectation did not match the output generated on Ubuntu.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8384466](https://bugs.openjdk.org/browse/JDK-8384466): Test io/Console/RestoreEchoTest.java fails with expect: spawn id exp3 not open (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31259/head:pull/31259` \
`$ git checkout pull/31259`

Update a local copy of the PR: \
`$ git checkout pull/31259` \
`$ git pull https://git.openjdk.org/jdk.git pull/31259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31259`

View PR using the GUI difftool: \
`$ git pr show -t 31259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31259.diff">https://git.openjdk.org/jdk/pull/31259.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31259#issuecomment-4521441883)
</details>
