### PR TITLE
8375062: vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java fails to output debuggee prompt after cont cmd

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,13 @@ import java.util.*;
 /* This is debuggee aplication */
 public class exclude001a {
     public static void main(String args[]) {
-       exclude001a _exclude001a = new exclude001a();
-       System.exit(exclude001.JCK_STATUS_BASE + _exclude001a.runIt(args, System.out));
+        // The following will cause intialization of a bunch of classes before we
+        // enable MethoEntry/Exit events, which would otherwise result in long test runs.
+        // See JDK-8375062. Also see MyThread.run() below, which is where this came from.
+        String caltype = GregorianCalendar.getInstance().getCalendarType();
+
+        exclude001a _exclude001a = new exclude001a();
+        System.exit(exclude001.JCK_STATUS_BASE + _exclude001a.runIt(args, System.out));
     }
 
     static void lastBreak () {}


### PR DESCRIPTION
This tests enables jdb method tracing, which relies on JDWP/JDI MethodEnter/Exit events. Over the years the test has made performance improvements by filtering out more and more classes, but this is only filtering out the events at the JDWP level. JVMTI events are still generated for every method call, and the debug agent needs to process and filter them, and this takes a lot of time. The fix is to trigger some early class loading an initialization before tracing is enabled rather than while tracing is enable. In particular, the following line from MyThread.run(), which is execute while tracing is enabled, triggers a lot of class loading and initialization:

        String caltype = GregorianCalendar.getInstance().getCalendarType();

Moving this to the main() method of the debuggee gets it out of the way early. I was seeing about 1.1m method calls while tracing was enabled, and this jumped to 2.2m after [JDK-8384569](https://bugs.openjdk.org/browse/JDK-8384569). It's about 500 calls after this change.

Tested by running the test 100's of times on windows-x64 and also running all svc tier1, tier2, and tier5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8375062](https://bugs.openjdk.org/browse/JDK-8375062): vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java fails to output debuggee prompt after cont cmd (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31263/head:pull/31263` \
`$ git checkout pull/31263`

Update a local copy of the PR: \
`$ git checkout pull/31263` \
`$ git pull https://git.openjdk.org/jdk.git pull/31263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31263`

View PR using the GUI difftool: \
`$ git pr show -t 31263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31263.diff">https://git.openjdk.org/jdk/pull/31263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31263#issuecomment-4523211058)
</details>
