### PR TITLE
8375076: Two JDI scenario tests are failing with out of wait time after completing successfully

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
@@ -213,12 +213,6 @@ public class tc02x004 {
         display("method:\t" + event.location().method().name());
         display("line:\t" + event.location().lineNumber());
 
-        // When done() is called we disable the MethodEntryRequest because we don't
-        // want it enabled while the debuggee exits. See JDK-8375076 and JDK-8384569.
-        if (event.method().name().equals("done")) {
-            return;
-        }
-
         if (event.location().lineNumber() == tc02x004a.checkClassBrkpLine) {
             display("ClassBreakpoint stops on the expected line "
                         + event.location().lineNumber() + " in method "
@@ -237,7 +231,7 @@ public class tc02x004 {
         if (brkpEventCount == tc02x004a.threadCount) {
             // When done we disable the MethodEntryRequest because we don't
             // want it enabled while the debuggee exits. See JDK-8375076 and JDK-8384569.
-            event.request().disable();
+            //event.request().disable();
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
@@ -204,6 +204,7 @@ public class tc02x004 {
         }
         display("\tmethod\t- " + event.location().method().name());
         display("\tline\t- " + event.location().lineNumber());
+        
         display("thread:\t" + event.thread().name());
         try {
             display("source:\t" + event.location().sourceName());
@@ -211,7 +212,6 @@ public class tc02x004 {
         }
         display("method:\t" + event.location().method().name());
         display("line:\t" + event.location().lineNumber());
-
         if (event.location().lineNumber() == tc02x004a.checkClassBrkpLine) {
             display("ClassBreakpoint stops on the expected line "
                         + event.location().lineNumber() + " in method "

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
@@ -204,7 +204,7 @@ public class tc02x004 {
         }
         display("\tmethod\t- " + event.location().method().name());
         display("\tline\t- " + event.location().lineNumber());
-        
+
         display("thread:\t" + event.thread().name());
         try {
             display("source:\t" + event.location().sourceName());

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
@@ -204,7 +204,6 @@ public class tc02x004 {
         }
         display("\tmethod\t- " + event.location().method().name());
         display("\tline\t- " + event.location().lineNumber());
-
         display("thread:\t" + event.thread().name());
         try {
             display("source:\t" + event.location().sourceName());
@@ -231,7 +230,7 @@ public class tc02x004 {
         if (brkpEventCount == tc02x004a.threadCount) {
             // When done we disable the MethodEntryRequest because we don't
             // want it enabled while the debuggee exits. See JDK-8375076 and JDK-8384569.
-            //event.request().disable();
+            event.request().disable();
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,6 +212,13 @@ public class tc02x004 {
         }
         display("method:\t" + event.location().method().name());
         display("line:\t" + event.location().lineNumber());
+
+        // When done() is called we disable the MethodEntryRequest because we don't
+        // want it enabled while the debuggee exits. See JDK-8375076 and JDK-8384569.
+        if (event.method().name().equals("done")) {
+            return;
+        }
+
         if (event.location().lineNumber() == tc02x004a.checkClassBrkpLine) {
             display("ClassBreakpoint stops on the expected line "
                         + event.location().lineNumber() + " in method "
@@ -227,5 +234,10 @@ public class tc02x004 {
         display("");
 
         brkpEventCount++;
+        if (brkpEventCount == tc02x004a.threadCount) {
+            // When done we disable the MethodEntryRequest because we don't
+            // want it enabled while the debuggee exits. See JDK-8375076 and JDK-8384569.
+            event.request().disable();
+        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,6 +208,14 @@ public class tc04x001 {
         }
         display("\tmethod\t- " + event.location().method().name());
         display("\tline\t- " + event.location().lineNumber());
+
+        // When done() is called we disable the MethodEntryRequest because we don't
+        // want it enabled while the debuggee exits. See JDK-8375076 and JDK-8384569.
+        if (event.method().name().equals("done")) {
+            display("done() called - disabling MethodEntryRequest\n");
+            event.request().disable();
+            return;
+        }
 
         if (!event.method().name().equals(methodName)) {
             display("the event skipped, method - " + event.method().name() + "\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,14 @@ import nsk.share.jdi.*;
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
 /**
- *  <code>tc04x001a</code> is deugee's part of the tc04x001.
+ *  <code>tc04x001a</code> is debugee's part of the tc04x001.
  */
 public class tc04x001a {
 
     public final static int threadCount = 3;
     static Log log;
 
-    public final static int checkMethodBrkpLine = 73;
+    public final static int checkMethodBrkpLine = 74;
     Thread[] thrds = new Thread[threadCount];
 
     public static void main (String argv[]) {
@@ -58,6 +58,7 @@ public class tc04x001a {
                 System.exit(Consts.TEST_FAILED + Consts.JCK_STATUS_BASE);
             }
         }
+        done(); // Signal the disabling of MethodEntryRequest
         log.display("completed succesfully.");
         System.exit(Consts.TEST_PASSED + Consts.JCK_STATUS_BASE);
     }
@@ -75,6 +76,10 @@ public class tc04x001a {
 
     public static void bar(String caller) {
         log.display(caller + "::bar is called");
+    }
+
+    public static void done() {
+        log.display("done is called");
     }
 
     static class Thready extends NamedTask {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001.java
@@ -160,10 +160,9 @@ public class popframes001 {
             if (eventIterator != null) {
                 while (eventIterator.hasNext()) {
                     event = eventIterator.nextEvent();
-//                    display("\nevent ===>>> " + event);
+                    display("\nevent ===>>> " + event);
 
                     if (event instanceof ClassPrepareEvent) {
-                        display("\nevent ===>>> " + event);
                         testedClass = (ClassType )debugee.classByName(testedClassName);
                         debugeeClass = (ClassType )debugee.classByName(debugeeName);
 
@@ -179,11 +178,9 @@ public class popframes001 {
                         debugee.resume();
 
                     } else if (event instanceof MethodExitEvent) {
-                        display("\nevent ===>>> " + event);
                         hitMethodExitEvent((MethodExitEvent )event);
 
                     } else if (event instanceof MethodEntryEvent) {
-                        display("\nevent ===>>> " + event);
                         hitMethodEntryEvent((MethodEntryEvent )event);
                         display("\nresuming...");
                         debugee.resume();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import nsk.share.jdi.*;
 import java.io.*;
 
 /**
- *  <code>popframes001a</code> is deugee's part of the popframes001.
+ *  <code>popframes001a</code> is debugee's part of the popframes001.
  */
 
 public class popframes001a {
@@ -38,6 +38,11 @@ public class popframes001a {
     volatile public static boolean finishIt = false;
 
     public static void main(String argv[]) {
+        // The following will cause intialization of a bunch of classes before we
+        // enable MethoEntry/Exit events, which would otherwise result in long test runs.
+        // See JDK-8375076 and JDK-8384569.
+        System.getLogger("java.lang.Runtime");
+
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(System.out, argHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001a.java
@@ -39,7 +39,7 @@ public class popframes001a {
 
     public static void main(String argv[]) {
         // The following will cause intialization of a bunch of classes before we
-        // enable MethoEntry/Exit events, which would otherwise result in long test runs.
+        // enable MethodEntry/Exit events, which would otherwise result in long test runs.
         // See JDK-8375076 and JDK-8384569.
         System.getLogger("java.lang.Runtime");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -408,6 +408,7 @@ public class popframes003 extends JDIBase {
         }
 
         log2("......disabling requests and resuming vm");
+        meRequest.disable();
         meRequest3.disable();
         vm.resume();
 


### PR DESCRIPTION
The issue is a large number of method calls and exits that are done in library initialization code while the test has enabled MethodExit and/or MethodEntry events. These events are being be generated during the debuggee System.exit() call, sometimes resulting in the test timing out during exit.

There are 3 tests that appear to have timedout as a result of this at some point, and I found 1 other that is at risk.

     vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004/TestDescription.java. <--- hasn't failed yet
     vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001/TestDescription.java
     vmTestbase/nsk/jdi/ThreadReference/popFrames/popframes003/TestDescription.java
     vmTestbase/nsk/jdi/Scenarios/invokeMethod/popframes001/TestDescription.java

The timeouts only happens on Windows hosts where the API to get a timestamp is slow. The delivery of a JVMTI MethodEntry or Exit events to the debug agent results in this timestamp API being called. The fix is to modify the tests to reduce the number of JVMTI events, either by disabling the events before doing the System.exit() or triggering the loading and initialization of the classes early before the events are enabled. The latter is chosen when it is difficult to find a good time to disable the events.

Note that these MethodEntry/Exits events for the most part are all filtered out by the debug agent because the test only wants them from certain test classes. Valhalla made the issue worse by triggering more class loading and initialization while the events are enabled, and the changes in valhalla responsible for this have since been integrated into mainline with [JDK-8377070](https://bugs.openjdk.org/browse/JDK-8377070), causing at least the popframes001 failure to start appearing there also.

Tested by running all the tests 100s of times on Windows, and also tested these changes in the valhalla repo.
Also ran all svc tier1, tier2, and tier5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8375076](https://bugs.openjdk.org/browse/JDK-8375076): Two JDI scenario tests are failing with out of wait time after completing successfully (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [77834c9c](https://git.openjdk.org/jdk/pull/31264/files/77834c9c5bb4ea9285696038accae73d7f25d492)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31264/head:pull/31264` \
`$ git checkout pull/31264`

Update a local copy of the PR: \
`$ git checkout pull/31264` \
`$ git pull https://git.openjdk.org/jdk.git pull/31264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31264`

View PR using the GUI difftool: \
`$ git pr show -t 31264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31264.diff">https://git.openjdk.org/jdk/pull/31264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31264#issuecomment-4523503360)
</details>
