### PR TITLE
8385013: Startup regression ~30% / 7-10ms with noop

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -423,9 +423,9 @@ public abstract class Charset
 
     }
 
-    /* The extended set of charsets */
-    private static final LazyConstant<List<CharsetProvider>> EXTENDED_PROVIDERS = LazyConstant.of(
-            new Supplier<>() { public List<CharsetProvider> get() { return extendedProviders0(); }});
+    private final class ExtendedProvidersHolder {
+        private static final List<CharsetProvider> EXTENDED_PROVIDERS = extendedProviders0();
+    }
 
     private static List<CharsetProvider> extendedProviders0() {
         CharsetProvider[] cps = new CharsetProvider[1];
@@ -444,7 +444,7 @@ public abstract class Charset
     private static Charset lookupExtendedCharset(String charsetName) {
         if (!VM.isBooted())  // see lookupViaProviders()
             return null;
-        for (CharsetProvider cp : EXTENDED_PROVIDERS.get()) {
+        for (CharsetProvider cp : ExtendedProvidersHolder.EXTENDED_PROVIDERS) {
             Charset cs = cp.charsetForName(charsetName);
             if (cs != null)
                 return cs;
@@ -605,7 +605,7 @@ public abstract class Charset
             new TreeMap<>(
                 String.CASE_INSENSITIVE_ORDER);
         put(standardProvider.charsets(), m);
-        for (CharsetProvider ecp : EXTENDED_PROVIDERS.get()) {
+        for (CharsetProvider ecp : ExtendedProvidersHolder.EXTENDED_PROVIDERS) {
             put(ecp.charsets(), m);
         }
         for (Iterator<CharsetProvider> i = providers(); i.hasNext();) {
@@ -615,8 +615,9 @@ public abstract class Charset
         return Collections.unmodifiableSortedMap(m);
     }
 
-    private static final LazyConstant<Charset> defaultCharset = LazyConstant.of(
-            new Supplier<>() { public Charset get() { return defaultCharset0(); }});
+    private static final class DefaultChasetHolder {
+        static final Charset defaultCharset = defaultCharset0();
+    }
 
     private static Charset defaultCharset0() {
         // do not look for providers other than the standard one
@@ -645,7 +646,7 @@ public abstract class Charset
      * @since 1.5
      */
     public static Charset defaultCharset() {
-        return defaultCharset.get();
+        return DefaultChasetHolder.defaultCharset;
     }
 
 
@@ -654,10 +655,7 @@ public abstract class Charset
     @Stable
     private final String name;
     @Stable
-    private final String[] aliases;
-    @Stable
-    private final LazyConstant<Set<String>> aliasSet = LazyConstant.of(
-            new Supplier<>() { public Set<String> get() { return Set.of(aliases); }});
+    private final Set<String> aliasSet;
 
     /**
      * Initializes a new charset with the given canonical name and alias
@@ -691,7 +689,7 @@ public abstract class Charset
             }
         }
         this.name = canonicalName;
-        this.aliases = as;
+        this.aliasSet = Set.of(as);
     }
 
     /**
@@ -709,7 +707,7 @@ public abstract class Charset
      * @return  An immutable set of this charset's aliases
      */
     public final Set<String> aliases() {
-        return aliasSet.get();
+        return aliasSet;
     }
 
     /**

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -424,6 +424,7 @@ public abstract class Charset
     }
 
     private final class ExtendedProvidersHolder {
+        /* The extended set of charsets */
         private static final List<CharsetProvider> EXTENDED_PROVIDERS = extendedProviders0();
     }
 


### PR DESCRIPTION
This PR proposes to delay the loading of `LazyConstant` and `LazyConstantImpl`, thereby improving startup time.

Performance runs across several platforms suggest a ~20-30% startup improvement for `noop`. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385013](https://bugs.openjdk.org/browse/JDK-8385013): Startup regression ~30% / 7-10ms with noop (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31272/head:pull/31272` \
`$ git checkout pull/31272`

Update a local copy of the PR: \
`$ git checkout pull/31272` \
`$ git pull https://git.openjdk.org/jdk.git pull/31272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31272`

View PR using the GUI difftool: \
`$ git pr show -t 31272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31272.diff">https://git.openjdk.org/jdk/pull/31272.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31272#issuecomment-4532788046)
</details>
