### PR TITLE
8384869: C2: IR Verification Test failures on x86_64 after JDK-8383881 

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/stress/TestStressArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/TestStressArrayCopy.java
@@ -122,9 +122,8 @@ public class TestStressArrayCopy {
             if (containsFuzzy(cpuFeatures, "sse3")) {
                 configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=3"));
             }
-            if (containsFuzzy(cpuFeatures, "sse2")) {
-                configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=2"));
-            }
+            // On x86-64 at least SSE=2 should always be present.
+            configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=2"));
 
             // Alternate configs with other flags
             if (Platform.isX64()) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ApplicableIRRulesPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ApplicableIRRulesPrinter.java
@@ -91,8 +91,6 @@ public class ApplicableIRRulesPrinter {
         "fma",
         "f16c",
         // Intel SSE
-        "sse",
-        "sse2",
         "sse3",
         "ssse3",
         "sse4.1",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/VMInfoPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/VMInfoPrinter.java
@@ -51,8 +51,9 @@ public class VMInfoPrinter {
         // CPU feature dependent info
         long useAVX = 0;
         boolean useAVXIsDefault = true;
-        if (cpuFeatures.contains(" sse, ")) {
-            useAVX = WHITE_BOX.getIntVMFlag("UseAVX");
+        Long useAVXLong = WHITE_BOX.getIntVMFlag("UseAVX");
+        if (useAVXLong != null) {
+            useAVX = useAVXLong;
             useAVXIsDefault = WHITE_BOX.isDefaultVMFlag("UseAVX");
         }
         vmInfo.append("UseAVX:").append(useAVX).append(System.lineSeparator());

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
@@ -126,7 +126,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true", "rvv", "true"},
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.NEG_VF, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"},
         counts = {IRNode.NEG_VF, ">0"})
     public float[] vectorNeg() {
         float[] res = new float[SIZE];
@@ -137,7 +139,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true", "rvv", "true"},
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.ABS_VF, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "true", "rvv", "true"},
         counts = {IRNode.ABS_VF, ">0"})
     public float[] vectorAbs() {
         float[] res = new float[SIZE];
@@ -159,7 +163,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.ADD_VF, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"},
         counts = {IRNode.ADD_VF, ">0"})
     public float[] vectorAdd() {
         float[] res = new float[SIZE];
@@ -170,7 +176,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.SUB_VF, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"},
         counts = {IRNode.SUB_VF, ">0"})
     public float[] vectorSub() {
         float[] res = new float[SIZE];
@@ -181,7 +189,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.MUL_VF, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"},
         counts = {IRNode.MUL_VF, ">0"})
     public float[] vectorMul() {
         float[] res = new float[SIZE];
@@ -192,7 +202,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.DIV_VF, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "rvv", "true"},
         counts = {IRNode.DIV_VF, ">0"})
     public float[] vectorDiv() {
         float[] res = new float[SIZE];

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -45,15 +45,15 @@ public class TestPreconditions {
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyIfOnly() {}
 
-    // The IR check should not be applied, since asimd is aarch64 and sse intel.
+    // The IR check should not be applied, since asimd is aarch64 and sse3 intel.
     @Test
-    @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse", "true"},
+    @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse3", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyIfCPUFeatureOnly() {}
 
-    // The IR check should not be applied, since asimd is aarch64 and sse intel.
+    // The IR check should not be applied, since asimd is aarch64 and sse3 intel.
     @Test
-    @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse", "true"},
+    @IR(applyIfCPUFeatureAnd = {"asimd", "true", "sse3", "true"},
         applyIf = {"LoopMaxUnroll", "= 8"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBoth1() {}


### PR DESCRIPTION
This PR fixes IR verification framework to correctly determine Cascade Lake architecture. The current mechanism relied on "sse" to be present in the cpu feature string generated by the VM to guard the code for querying the value of UseAVX. This is done in `VMInfoPrinter.java`. But after JDK-8383881 VM no longer displays "sse" or "sse2" in the cpu feature list. So `VMInfoPrinter.java` has been updated to remove the check for "sse".
The patch also updates `verifiedCPUFeatures` list in `ApplicableIRRulesPrinter.java` to remove "sse" and "sse2" from the list. As a consequence, IR verification tests that specified "sse" or "sse2" cpu feature as the precondition need to be updated as well.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384869](https://bugs.openjdk.org/browse/JDK-8384869): C2: IR Verification Test failures on x86_64 after JDK-8383881 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31276/head:pull/31276` \
`$ git checkout pull/31276`

Update a local copy of the PR: \
`$ git checkout pull/31276` \
`$ git pull https://git.openjdk.org/jdk.git pull/31276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31276`

View PR using the GUI difftool: \
`$ git pr show -t 31276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31276.diff">https://git.openjdk.org/jdk/pull/31276.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31276#issuecomment-4537087585)
</details>
