### PR TITLE
8384902: Update GIFlib to 6.1.3

### DIFF
--- a/src/java.desktop/share/legal/giflib.md
+++ b/src/java.desktop/share/legal/giflib.md
@@ -1,4 +1,4 @@
-## GIFLIB v6.1.2
+## GIFLIB v6.1.3
 
 ### GIFLIB License
 ```

--- a/src/java.desktop/share/native/libsplashscreen/giflib/dgif_lib.c
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/dgif_lib.c
@@ -1185,7 +1185,15 @@ void DGifDecreaseImageCounter(GifFileType *GifFile) {
                 GifFreeMapObject(GifFile->SavedImages[GifFile->ImageCount].ImageDesc.ColorMap);
         }
 
-        // Realloc array according to the new image counter.
+        // Avoid a dodgy edge casse in reallocarray() */
+        if (GifFile->ImageCount <= 0) {
+                free(GifFile->SavedImages);
+                GifFile->SavedImages = NULL;
+                GifFile->ImageCount = 0;
+                return;
+        }
+
+        /* Realloc array according to the new image counter. */
         SavedImage *correct_saved_images = (SavedImage *)reallocarray(
             GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
         if (correct_saved_images != NULL) {

--- a/src/java.desktop/share/native/libsplashscreen/giflib/gif_lib.h
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/gif_lib.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define GIFLIB_MAJOR 6
 #define GIFLIB_MINOR 1
-#define GIFLIB_RELEASE 2
+#define GIFLIB_RELEASE 3
 
 #define GIF_ERROR 0
 #define GIF_OK 1

--- a/src/java.desktop/share/native/libsplashscreen/giflib/gifalloc.c
+++ b/src/java.desktop/share/native/libsplashscreen/giflib/gifalloc.c
@@ -167,9 +167,9 @@ ColorMapObject *GifUnionColorMap(const ColorMapObject *ColorIn1,
          * of table 1.  This is very useful if your display is limited to
          * 16 colors.
          */
-        while (ColorIn1->Colors[CrntSlot - 1].Red == 0 &&
+        while (CrntSlot > 0 && (ColorIn1->Colors[CrntSlot - 1].Red == 0 &&
                ColorIn1->Colors[CrntSlot - 1].Green == 0 &&
-               ColorIn1->Colors[CrntSlot - 1].Blue == 0) {
+                            ColorIn1->Colors[CrntSlot - 1].Blue == 0)) {
                 CrntSlot--;
         }
 


### PR DESCRIPTION
Updating giflib which is used in Splashscreen implementation to latest 6.1.3 version.
CI testing is green.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384902](https://bugs.openjdk.org/browse/JDK-8384902): Update GIFlib to 6.1.3 (**Bug** - P3)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31277/head:pull/31277` \
`$ git checkout pull/31277`

Update a local copy of the PR: \
`$ git checkout pull/31277` \
`$ git pull https://git.openjdk.org/jdk.git pull/31277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31277`

View PR using the GUI difftool: \
`$ git pr show -t 31277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31277.diff">https://git.openjdk.org/jdk/pull/31277.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31277#issuecomment-4540416208)
</details>
