### PR TITLE
8385425: AArch64: Comment re set_and_get_current_sve_vector_length() is misleading

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -70,9 +70,9 @@ protected:
   // Read additional info using OS-specific interfaces
   static void get_os_cpu_info();
 
-  // Sets the SVE length and returns a new actual value or negative on error.
-  // If the len is larger than the system largest supported SVE vector length,
-  // the function sets the largest supported value.
+  // Set the SVE vector length to len. If the vector length cannot be
+  // changed to len, set the length to the largest possible value.
+  // Return the length that will be used, or -ve if an error occurred.
   static int set_and_get_current_sve_vector_length(int len);
   static int get_current_sve_vector_length();
 


### PR DESCRIPTION
See https://github.com/openjdk/jdk26u/pull/205#pullrequestreview-4353052319 for context

CC @theRealAph 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385425](https://bugs.openjdk.org/browse/JDK-8385425): AArch64: Comment re set_and_get_current_sve_vector_length() is misleading (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Mat Carter](https://openjdk.org/census#macarte) (@macarte - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31278/head:pull/31278` \
`$ git checkout pull/31278`

Update a local copy of the PR: \
`$ git checkout pull/31278` \
`$ git pull https://git.openjdk.org/jdk.git pull/31278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31278`

View PR using the GUI difftool: \
`$ git pr show -t 31278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31278.diff">https://git.openjdk.org/jdk/pull/31278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31278#issuecomment-4543452831)
</details>
