### PR TITLE
8376621: Should not suspend thread in start_transition if _is_disable_suspend set

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -87,7 +87,7 @@ class UnmountBeginMark : public StackObj {
   }
   ~UnmountBeginMark() {
     assert(!_current->is_suspended()
-           JVMTI_ONLY(|| (_current->is_vthread_transition_disabler() && _result != freeze_ok)), "must be");
+           JVMTI_ONLY(|| (_current->should_defer_self_suspend() && _result != freeze_ok)), "must be");
     assert(_current->is_in_vthread_transition(), "must be");
 
     if (_result != freeze_ok) {

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -87,7 +87,8 @@ class UnmountBeginMark : public StackObj {
   }
   ~UnmountBeginMark() {
     assert(!_current->is_suspended()
-           JVMTI_ONLY(|| (_current->should_defer_self_suspend() && _result != freeze_ok)), "must be");
+           JVMTI_ONLY(|| (_result != freeze_ok &&
+                          (_current->is_vthread_transition_disabler() || _current->is_disable_suspend()))), "must be");
     assert(_current->is_in_vthread_transition(), "must be");
 
     if (_result != freeze_ok) {

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -528,16 +528,13 @@ HandshakeOperation* HandshakeState::get_op_for_self(bool allow_suspend, bool che
   assert(_handshakee == Thread::current(), "Must be called by self");
   assert(_lock.owned_by_self(), "Lock must be held");
   assert(allow_suspend || !check_async_exception, "invalid case");
-#if INCLUDE_JVMTI
+
   // Filter out suspend operations while JavaThread can not be suspended.
   // Potentially this could be folded into the `is_enabled` state of the operation
   // and filtered directly through _queue.peek, but the incoming `allow_suspend`
   // complicates that so we just maintain the explicit checks for now.
-  if (allow_suspend && (_handshakee->is_disable_suspend() || _handshakee->is_vthread_transition_disabler() ||
-                        _handshakee->jni_deferred_suspension())) {
-    allow_suspend = false;
-  }
-#endif
+  JVMTI_ONLY(allow_suspend = allow_suspend && !_handshakee->should_defer_self_suspend();)
+
   if (!allow_suspend) {
     return _queue.peek(no_suspend_no_async_exception_filter);
   } else if (check_async_exception && !_async_exceptions_blocked) {

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -528,13 +528,16 @@ HandshakeOperation* HandshakeState::get_op_for_self(bool allow_suspend, bool che
   assert(_handshakee == Thread::current(), "Must be called by self");
   assert(_lock.owned_by_self(), "Lock must be held");
   assert(allow_suspend || !check_async_exception, "invalid case");
-
+#if INCLUDE_JVMTI
   // Filter out suspend operations while JavaThread can not be suspended.
   // Potentially this could be folded into the `is_enabled` state of the operation
   // and filtered directly through _queue.peek, but the incoming `allow_suspend`
   // complicates that so we just maintain the explicit checks for now.
-  JVMTI_ONLY(allow_suspend = allow_suspend && !_handshakee->should_defer_self_suspend();)
-
+  if (allow_suspend && (_handshakee->is_disable_suspend() || _handshakee->is_vthread_transition_disabler() ||
+                        _handshakee->jni_deferred_suspension())) {
+    allow_suspend = false;
+  }
+#endif
   if (!allow_suspend) {
     return _queue.peek(no_suspend_no_async_exception_filter);
   } else if (check_async_exception && !_async_exceptions_blocked) {

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -788,6 +788,10 @@ public:
     return _is_in_vthread_transition || _is_disable_suspend || _is_in_java_upcall || _jvmti_events_disabled != 0;
   }
 
+  bool should_defer_self_suspend() const {
+    return _is_disable_suspend || _is_vthread_transition_disabler || jni_deferred_suspension();
+  }
+
   bool on_monitor_waited_event()             { return _on_monitor_waited_event; }
   void set_on_monitor_waited_event(bool val) { _on_monitor_waited_event = val; }
 
@@ -986,7 +990,7 @@ public:
   // Atomic version; invoked by a thread other than the owning thread.
   bool in_critical_atomic() { return AtomicAccess::load(&_jni_active_critical) > 0; }
 
-  bool jni_deferred_suspension() { return AtomicAccess::load(&_jni_deferred_suspension_count); }
+  bool jni_deferred_suspension() const { return AtomicAccess::load(&_jni_deferred_suspension_count); }
   inline void enter_jni_deferred_suspension();
   void exit_jni_deferred_suspension() {
     precond(Thread::current() == this);

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -788,10 +788,6 @@ public:
     return _is_in_vthread_transition || _is_disable_suspend || _is_in_java_upcall || _jvmti_events_disabled != 0;
   }
 
-  bool should_defer_self_suspend() const {
-    return _is_disable_suspend || _is_vthread_transition_disabler || jni_deferred_suspension();
-  }
-
   bool on_monitor_waited_event()             { return _on_monitor_waited_event; }
   void set_on_monitor_waited_event(bool val) { _on_monitor_waited_event = val; }
 

--- a/src/hotspot/share/runtime/mountUnmountDisabler.cpp
+++ b/src/hotspot/share/runtime/mountUnmountDisabler.cpp
@@ -129,7 +129,7 @@ bool MountUnmountDisabler::is_start_transition_disabled(JavaThread* thread, oop 
   int base_disable_count = notify_jvmti_events() ? 1 : 0;
   return java_lang_Thread::vthread_transition_disable_count(vthread) > 0
          || global_vthread_transition_disable_count() > base_disable_count
-         JVMTI_ONLY(|| (!thread->is_vthread_transition_disabler() &&
+         JVMTI_ONLY(|| (!thread->should_defer_self_suspend() &&
                         (JvmtiVTSuspender::is_vthread_suspended(java_lang_Thread::thread_id(vthread)) || thread->is_suspended())));
 }
 

--- a/src/hotspot/share/runtime/mountUnmountDisabler.cpp
+++ b/src/hotspot/share/runtime/mountUnmountDisabler.cpp
@@ -129,7 +129,7 @@ bool MountUnmountDisabler::is_start_transition_disabled(JavaThread* thread, oop 
   int base_disable_count = notify_jvmti_events() ? 1 : 0;
   return java_lang_Thread::vthread_transition_disable_count(vthread) > 0
          || global_vthread_transition_disable_count() > base_disable_count
-         JVMTI_ONLY(|| (!thread->should_defer_self_suspend() &&
+         JVMTI_ONLY(|| (!thread->is_vthread_transition_disabler() && !thread->is_disable_suspend() &&
                         (JvmtiVTSuspender::is_vthread_suspended(java_lang_Thread::thread_id(vthread)) || thread->is_suspended())));
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume4/SuspendResume4.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume4/SuspendResume4.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8376621
+ * @summary Suspend virtual thread while it's inside disableSuspendAndPreempt region
+ * @requires vm.continuations
+ * @requires vm.jvmti
+ * @library /test/lib /test/hotspot/jtreg/testlibrary
+ * @run main/othervm SuspendResume4
+ */
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.File;
+
+import jvmti.JVMTIUtils;
+
+public class SuspendResume4 {
+    native static void suspendThread(Thread thread);
+    native static void resumeThread(Thread thread);
+
+    public static void main(String[] args) throws Exception {
+        // Run test in child VM where Locale won't be initialized already by jtreg
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+            "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+            "-agentpath:" + Utils.TEST_NATIVE_PATH + File.separator + System.mapLibraryName("SuspendResume4"),
+            "SuspendResume4$Test");
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        System.out.println(output.getStdout());
+        output.shouldHaveExitValue(0);
+    }
+
+    static class Test{
+        static String targetName;
+
+        private void runTest() throws Exception {
+            // start target vthread
+            Thread target = Thread.ofVirtual().name("target").start(() -> {
+                // Give time for reader to get suspended in
+                // disableSuspendAndPreempt region.
+                spinWaitMillis(100);
+                // Force unmounting. If reader was suspended inside
+                // disableSuspendAndPreempt region this will block
+                // in VirtualThread.unmount.
+                Thread.yield();
+            });
+
+            // start clinit contender
+            Thread contender = Thread.ofPlatform().name("contender").start(() -> {
+                "JAVA".toLowerCase(java.util.Locale.ROOT);
+            });
+
+            // start vthread that reads target's state
+            Thread reader = Thread.ofVirtual().name("reader").start(() -> {
+                targetName = "name: " + target;
+            });
+
+            // start suspend/resumer
+            Thread suspender = Thread.ofPlatform().name("suspender").start(() -> {
+                SuspendResume4.suspendThread(reader);
+                // Give target time for Thread.yield
+                spinWaitMillis(100);
+                SuspendResume4.resumeThread(reader);
+            });
+
+            target.join();
+            contender.join();
+            suspender.join();
+            reader.join();
+        }
+
+        public static void main(String[] args) throws Exception {
+            Test obj = new Test();
+            obj.runTest();
+        }
+
+        static void spinWaitMillis(long millis) {
+            long durationNanos = millis * 1_000_000L;
+            long start = System.nanoTime();
+            while (System.nanoTime() - start < durationNanos) {
+                Thread.onSpinWait();
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume4/libSuspendResume4.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume4/libSuspendResume4.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+#include <jvmti.h>
+#include <stdio.h>
+#include <string.h>
+#include "jvmti_common.hpp"
+
+// set by Agent_OnLoad
+static jvmtiEnv* jvmti = nullptr;
+
+extern "C" {
+
+JNIEXPORT void JNICALL
+Java_SuspendResume4_suspendThread(JNIEnv* jni, jclass klass, jthread thread) {
+  jvmtiError err = jvmti->SuspendThread(thread);
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_THREAD_NOT_ALIVE) {
+    jni->FatalError("error in JVMTI SuspendThread");
+  }
+}
+
+JNIEXPORT void JNICALL
+Java_SuspendResume4_resumeThread(JNIEnv* jni, jclass klass, jthread thread) {
+  jvmtiError err = jvmti->ResumeThread(thread);
+  if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_THREAD_NOT_ALIVE) {
+    jni->FatalError("error in JVMTI ResumeThread");
+  }
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
+  jvmtiCapabilities caps;
+  jvmtiError err;
+
+  printf("Agent_OnLoad: started\n");
+  if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
+    LOG("Agent_OnLoad: error in GetEnv");
+    return JNI_ERR;
+  }
+
+  memset(&caps, 0, sizeof(caps));
+  caps.can_suspend = 1;
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("Agent_OnLoad: error in JVMTI AddCapabilities: %d\n", err);
+  }
+
+  printf("Agent_OnLoad: finished\n");
+
+  return 0;
+}
+
+} // extern "C"


### PR DESCRIPTION
In JDK-8311218, processing of self suspend operations was deferred while holding the `interruptLock` monitor of a virtual thread to avoid possible deadlocks. In particular, suspending a thread while holding the `interruptLock` of a given virtual thread would cause that virtual thread to block in `VirtualThread.unmount`, preventing it from completing the unmount transition. That in turn would block the resumer thread, since it needs to wait until no virtual thread is in a transition, leading to a deadlock. We need to do the same deferral in `MountUnmountDisabler::start_transition`, as this is also a suspend-checking point.

There are no obvious unmount points leading to `MountUnmountDisabler::start_transition` while in these critical regions. But with the changes in JDK-8369238, class initialization was added to the set of possibilities. In fact, I was able to create a test that reproduces the deadlock by triggering contention during initialization of class `java.util.Locale` in `appendCarrierInfo`. Regardless of this case though, the `VirtualThread` code could change so we need to guard against this.

Together with JDK-8375362, this issue shows that we need to skip the suspend check for the same cases where we skip processing of self suspend operations in the handshake code. So I grouped these together under `should_defer_self_suspend` and updated the relevant call sites.

The patch includes a test that deadlocks as described above without this fix. I also tested the changes in mach5 tiers1-6.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376621](https://bugs.openjdk.org/browse/JDK-8376621): Should not suspend thread in start_transition if _is_disable_suspend set (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31281/head:pull/31281` \
`$ git checkout pull/31281`

Update a local copy of the PR: \
`$ git checkout pull/31281` \
`$ git pull https://git.openjdk.org/jdk.git pull/31281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31281`

View PR using the GUI difftool: \
`$ git pr show -t 31281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31281.diff">https://git.openjdk.org/jdk/pull/31281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31281#issuecomment-4544677434)
</details>
