### PR TITLE
8385334: Shenandoah: Improve gc+stats logging

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -991,7 +991,7 @@ public:
       // state is cached, therefore, during concurrent class unloading phase,
       // we will not touch the metadata of unloading nmethods
       {
-        ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
+        ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCache, worker_id);
         ShenandoahIsNMethodAliveClosure is_nmethod_alive;
         _nmethod_itr.nmethods_do(&is_nmethod_alive);
       }
@@ -1004,9 +1004,8 @@ void ShenandoahConcurrentGC::op_weak_roots() {
   assert(heap->is_concurrent_weak_root_in_progress(), "Only during this phase");
   {
     // Concurrent weak root processing
-    ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_work);
-    ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots_work);
-    ShenandoahConcurrentWeakRootsEvacUpdateTask task(_generation, ShenandoahPhaseTimings::conc_weak_roots_work);
+    ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots);
+    ShenandoahConcurrentWeakRootsEvacUpdateTask task(_generation, ShenandoahPhaseTimings::conc_weak_roots);
     heap->workers()->run_task(&task);
   }
 
@@ -1080,7 +1079,7 @@ public:
     }
 
     if (!ShenandoahHeap::heap()->unload_classes()) {
-      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
+      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCache, worker_id);
       ShenandoahEvacUpdateCodeCacheClosure cl;
       _nmethod_itr.nmethods_do(&cl);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -57,7 +57,7 @@ public:
 
   void work(uint worker_id) {
     ShenandoahConcurrentWorkerSession worker_session(worker_id);
-    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_mark, ShenandoahPhaseTimings::ParallelMark, worker_id, true);
+    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_mark, ShenandoahPhaseTimings::Work, worker_id, true);
     SuspendibleThreadSetJoiner stsj;
     StringDedup::Requests requests;
     _cm->mark_loop(worker_id, _terminator, GENERATION, true /*cancellable*/,
@@ -83,6 +83,7 @@ public:
   void work(uint worker_id) {
     ShenandoahHeap* heap = ShenandoahHeap::heap();
 
+    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::finish_mark, ShenandoahPhaseTimings::Work, worker_id, true);
     ShenandoahParallelWorkerSession worker_session(worker_id);
     StringDedup::Requests requests;
     // First drain remaining SATB buffers.

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -347,7 +347,7 @@ void ShenandoahDegenGC::op_reset() {
 
 void ShenandoahDegenGC::op_mark() {
   assert(!_generation->is_concurrent_mark_in_progress(), "Should be reset");
-  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_stw_mark);
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_mark);
   ShenandoahSTWMark mark(_generation, false /*full gc*/);
   mark.mark();
 }
@@ -410,7 +410,7 @@ void ShenandoahDegenGC::op_cleanup_early() {
 }
 
 void ShenandoahDegenGC::op_evacuate() {
-  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_stw_evac);
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_evac);
   ShenandoahHeap::heap()->evacuate_collection_set(_generation, false /* concurrent*/);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -672,7 +672,7 @@ void ShenandoahGenerationalHeap::coalesce_and_fill_old_regions(bool concurrent) 
 
     void work(uint worker_id) override {
       ShenandoahWorkerTimingsTracker timer(_phase,
-                                           ShenandoahPhaseTimings::ScanClusters,
+                                           ShenandoahPhaseTimings::Work,
                                            worker_id, true);
       ShenandoahHeapRegion* region;
       while ((region = _regions.next()) != nullptr) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1154,10 +1154,12 @@ public:
 
   void work(uint worker_id) {
     if (_concurrent) {
+      ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_evac, ShenandoahPhaseTimings::Work, worker_id, true);
       ShenandoahConcurrentWorkerSession worker_session(worker_id);
       SuspendibleThreadSetJoiner stsj;
       do_work();
     } else {
+      ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::degen_gc_evac, ShenandoahPhaseTimings::Work, worker_id, true);
       ShenandoahParallelWorkerSession worker_session(worker_id);
       do_work();
     }
@@ -2560,10 +2562,12 @@ public:
 
   void work(uint worker_id) {
     if (CONCURRENT) {
+      ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_update_refs, ShenandoahPhaseTimings::Work, worker_id, true);
       ShenandoahConcurrentWorkerSession worker_session(worker_id);
       SuspendibleThreadSetJoiner stsj;
       do_work<ShenandoahConcUpdateRefsClosure>(worker_id);
     } else {
+      ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::degen_gc_update_refs, ShenandoahPhaseTimings::Work, worker_id, true);
       ShenandoahParallelWorkerSession worker_session(worker_id);
       do_work<ShenandoahNonConcUpdateRefsClosure>(worker_id);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -78,7 +78,7 @@ public:
   }
 
   void work(uint worker_id) override {
-    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_coalesce_and_fill, ShenandoahPhaseTimings::ScanClusters, worker_id);
+    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_coalesce_and_fill, ShenandoahPhaseTimings::Work, worker_id);
     for (uint region_idx = worker_id; region_idx < _coalesce_and_fill_region_count; region_idx += _nworkers) {
       ShenandoahHeapRegion* r = _coalesce_and_fill_region_array[region_idx];
       if (r->is_humongous()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.cpp
@@ -41,14 +41,14 @@ ShenandoahClassUnloadingTask::ShenandoahClassUnloadingTask(ShenandoahPhaseTiming
 
 void ShenandoahClassUnloadingTask::work(uint worker_id) {
   {
-    ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::CodeCacheUnload, worker_id);
+    ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::CodeCache, worker_id);
     _code_cache_task.work(worker_id);
   }
   // Clean all klasses that were not unloaded.
   // The weak metadata in klass doesn't need to be
   // processed if there was no unloading.
   if (_unloading_occurred) {
-    ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::CLDUnlink, worker_id);
+    ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::Classes, worker_id);
     _klass_cleaning_task.work();
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
@@ -54,7 +54,7 @@ ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::~ShenandoahParallel
 template<typename IsAlive, typename KeepAlive>
 void ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::work(uint worker_id) {
   {
-    ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::VMWeakRoots, worker_id);
+    ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::VMWeaks, worker_id);
     _weak_processing_task.work<IsAlive, KeepAlive>(worker_id, _is_alive, _keep_alive);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -40,14 +40,19 @@
 #define SHENANDOAH_US_WORKER_NOTIME_FORMAT "%3s"
 #define SHENANDOAH_PARALLELISM_FORMAT "%4.2lf"
 
-#define SHENANDOAH_PHASE_DECLARE_NAME(type, title) \
-  title,
+#define SHENANDOAH_PHASE_DECLARE_DESC(name, desc, has_worker_phase) desc,
+#define SHENANDOAH_PHASE_DECLARE_HAS_WORKER_PHASE(name, desc, has_worker_phase) has_worker_phase,
 
-const char* ShenandoahPhaseTimings::_phase_names[] = {
-  SHENANDOAH_PHASE_DO(SHENANDOAH_PHASE_DECLARE_NAME)
+const char* ShenandoahPhaseTimings::_desc[] = {
+  SHENANDOAH_PHASE_DO(SHENANDOAH_PHASE_DECLARE_DESC)
 };
 
-#undef SHENANDOAH_PHASE_DECLARE_NAME
+bool ShenandoahPhaseTimings::_has_worker_phase[] = {
+  SHENANDOAH_PHASE_DO(SHENANDOAH_PHASE_DECLARE_HAS_WORKER_PHASE)
+};
+
+#undef SHENANDOAH_PHASE_DECLARE_DESC
+#undef SHENANDOAH_PHASE_DECLARE_HAS_WORKER_PHASE
 
 ShenandoahPhaseTimings::ShenandoahPhaseTimings(uint max_workers) :
   _max_workers(max_workers) {
@@ -55,22 +60,17 @@ ShenandoahPhaseTimings::ShenandoahPhaseTimings(uint max_workers) :
 
   // Initialize everything to sane defaults
   for (uint i = 0; i < _num_phases; i++) {
-#define SHENANDOAH_WORKER_DATA_NULL(type, title) \
     _worker_data[i] = nullptr;
-    SHENANDOAH_PAR_PHASE_DO(,, SHENANDOAH_WORKER_DATA_NULL)
-#undef SHENANDOAH_WORKER_DATA_NULL
     _cycle_data[i] = uninitialized();
   }
 
   // Then punch in the worker-related data.
-  // Every worker phase get a bunch of internal objects, except
-  // the very first slot, which is "<total>" and is not populated.
   for (uint i = 0; i < _num_phases; i++) {
-    if (is_worker_phase(Phase(i))) {
-      int c = 0;
-#define SHENANDOAH_WORKER_DATA_INIT(type, title) \
-      if (c++ != 0) _worker_data[i + c] = new ShenandoahWorkerData(nullptr, title, _max_workers);
-      SHENANDOAH_PAR_PHASE_DO(,, SHENANDOAH_WORKER_DATA_INIT)
+    if (has_worker_phases(Phase(i))) {
+      int c = i + 1;
+#define SHENANDOAH_WORKER_DATA_INIT(name, desc, has_worker_phase) \
+      _worker_data[c++] = new ShenandoahWorkerData(nullptr, desc, _max_workers);
+      SHENANDOAH_WORKER_PHASE_DO(,, SHENANDOAH_WORKER_DATA_INIT)
 #undef SHENANDOAH_WORKER_DATA_INIT
     }
   }
@@ -79,59 +79,23 @@ ShenandoahPhaseTimings::ShenandoahPhaseTimings(uint max_workers) :
   assert(_policy != nullptr, "Can not be null");
 }
 
-ShenandoahPhaseTimings::Phase ShenandoahPhaseTimings::worker_par_phase(Phase phase, ParPhase par_phase) {
-  assert(is_worker_phase(phase), "Phase should accept worker phase times: %s", phase_name(phase));
-  Phase p = Phase(phase + 1 + par_phase);
-  assert(p >= 0 && p < _num_phases, "Out of bound for: %s", phase_name(phase));
+ShenandoahPhaseTimings::Phase ShenandoahPhaseTimings::compute_phase_slot(Phase phase, WorkerPhase worker_phase) {
+  assert(has_worker_phases(phase), "Phase should accept worker phase times: %s", phase_desc(phase));
+  Phase p = Phase(phase + 1 + worker_phase);
+  assert(p >= 0 && p < _num_phases, "Out of bound for: %s", phase_desc(phase));
   return p;
 }
 
-ShenandoahWorkerData* ShenandoahPhaseTimings::worker_data(Phase phase, ParPhase par_phase) {
-  Phase p = worker_par_phase(phase, par_phase);
+ShenandoahWorkerData* ShenandoahPhaseTimings::worker_data(Phase phase, WorkerPhase worker_phase) {
+  Phase p = compute_phase_slot(phase, worker_phase);
   ShenandoahWorkerData* wd = _worker_data[p];
-  assert(wd != nullptr, "Counter initialized: %s", phase_name(p));
+  assert(wd != nullptr, "Counter initialized: %s", phase_desc(p));
   return wd;
-}
-
-bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
-  assert(phase >= 0 && phase < _num_phases, "Out of bounds");
-  switch (phase) {
-    case init_evac:
-    case init_scan_rset:
-    case finish_mark:
-    case purge_weak_par:
-    case full_gc_mark:
-    case full_gc_update_roots:
-    case full_gc_adjust_roots:
-    case degen_gc_stw_mark:
-    case degen_gc_mark:
-    case degen_gc_update_roots:
-    case full_gc_weakrefs:
-    case full_gc_purge_class_unload:
-    case full_gc_purge_weak_par:
-    case degen_gc_coalesce_and_fill:
-    case degen_gc_weakrefs:
-    case degen_gc_purge_class_unload:
-    case degen_gc_purge_weak_par:
-    case heap_iteration_roots:
-    case conc_mark:
-    case conc_mark_roots:
-    case conc_thread_roots:
-    case conc_weak_roots_work:
-    case conc_weak_refs:
-    case conc_strong_roots:
-    case conc_coalesce_and_fill:
-    case promote_in_place:
-      return true;
-    default:
-      return false;
-  }
 }
 
 bool ShenandoahPhaseTimings::is_root_work_phase(Phase phase) {
   switch (phase) {
     case finish_mark:
-    case init_evac:
     case degen_gc_update_roots:
     case full_gc_mark:
     case full_gc_update_roots:
@@ -147,9 +111,7 @@ void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time, bool shoul
   if (should_aggregate) {
     _cycle_data[phase] = (cycle_data == uninitialized()) ? time :  (cycle_data + time);
   } else {
-#ifdef ASSERT
-    assert(cycle_data == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), cycle_data);
-#endif
+    assert(cycle_data == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_desc(phase), cycle_data);
     _cycle_data[phase] = time;
   }
 }
@@ -161,38 +123,37 @@ void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time, bool sh
 }
 
 void ShenandoahPhaseTimings::record_workers_start(Phase phase) {
-  assert(is_worker_phase(phase), "Phase should accept worker phase times: %s", phase_name(phase));
+  assert(has_worker_phases(phase), "Phase should accept worker phase times: %s", phase_desc(phase));
 
   // Special case: these phases can enter multiple times, need to reset
   // their worker data every time.
   if (phase == heap_iteration_roots) {
-    for (uint i = 1; i < _num_par_phases; i++) {
-      worker_data(phase, ParPhase(i))->reset();
+    for (uint i = 0; i < _num_par_phases; i++) {
+      worker_data(phase, WorkerPhase(i))->reset();
     }
   }
 
 #ifdef ASSERT
-  for (uint i = 1; i < _num_par_phases; i++) {
-    ShenandoahWorkerData* wd = worker_data(phase, ParPhase(i));
+  for (uint i = 0; i < _num_par_phases; i++) {
+    ShenandoahWorkerData* wd = worker_data(phase, WorkerPhase(i));
     for (uint c = 0; c < _max_workers; c++) {
       assert(wd->get(c) == ShenandoahWorkerData::uninitialized(),
-             "Should not be set: %s", phase_name(worker_par_phase(phase, ParPhase(i))));
+             "Should not be set: %s", phase_desc(compute_phase_slot(phase, WorkerPhase(i))));
     }
   }
 #endif
 }
 
 void ShenandoahPhaseTimings::record_workers_end(Phase phase) {
-  assert(is_worker_phase(phase), "Phase should accept worker phase times: %s", phase_name(phase));
+  assert(has_worker_phases(phase), "Phase should accept worker phase times: %s", phase_desc(phase));
 }
 
 void ShenandoahPhaseTimings::flush_par_workers_to_cycle() {
   for (uint pi = 0; pi < _num_phases; pi++) {
     Phase phase = Phase(pi);
-    if (is_worker_phase(phase)) {
-      double sum = uninitialized();
-      for (uint i = 1; i < _num_par_phases; i++) {
-        ShenandoahWorkerData* wd = worker_data(phase, ParPhase(i));
+    if (has_worker_phases(phase)) {
+      for (uint i = 0; i < _num_par_phases; i++) {
+        ShenandoahWorkerData* wd = worker_data(phase, WorkerPhase(i));
         double worker_sum = uninitialized();
         for (uint c = 0; c < _max_workers; c++) {
           double worker_time = wd->get(c);
@@ -207,16 +168,7 @@ void ShenandoahPhaseTimings::flush_par_workers_to_cycle() {
         if (worker_sum != uninitialized()) {
           // add to each line in phase
           set_cycle_data(Phase(phase + i + 1), worker_sum);
-          if (sum == uninitialized()) {
-            sum = worker_sum;
-          } else {
-            sum += worker_sum;
-          }
         }
-      }
-      if (sum != uninitialized()) {
-        // add to total for phase
-        set_cycle_data(Phase(phase + 1), sum);
       }
     }
   }
@@ -237,23 +189,29 @@ void ShenandoahPhaseTimings::flush_cycle_to_global() {
 
 void ShenandoahPhaseTimings::print_cycle_on(outputStream* out) const {
   out->cr();
-  out->print_cr("All times are wall-clock times, except per-root-class counters, that are sum over");
-  out->print_cr("all workers. Dividing the <total> over the root stage time estimates parallelism.");
+  out->print_cr("  All times are wall-clock times, except for ones explicitly marked as \"total\", those are");
+  out->print_cr("  sum over all workers. Dividing the total over the root stage time estimates parallelism.");
   out->cr();
   for (uint i = 0; i < _num_phases; i++) {
     double v = _cycle_data[i] * 1000000.0;
     if (v > 0) {
-      out->print(SHENANDOAH_PHASE_NAME_FORMAT " " SHENANDOAH_US_TIME_FORMAT " us", _phase_names[i], v);
+      out->print(SHENANDOAH_PHASE_NAME_FORMAT " " SHENANDOAH_US_TIME_FORMAT " us", _desc[i], v);
 
-      if (is_worker_phase(Phase(i))) {
-        double total = _cycle_data[i + 1] * 1000000.0;
+      if (has_worker_phases(Phase(i))) {
+        double total = 0;
+        for (uint pi = 0; pi < _num_par_phases; pi++) {
+          uint idx = i + 1 + pi;
+          if (_cycle_data[idx] != uninitialized()) {
+            total += _cycle_data[idx];
+          }
+        }
         if (total > 0) {
-          out->print(", parallelism: " SHENANDOAH_PARALLELISM_FORMAT "x", total / v);
+          out->print(" with " SHENANDOAH_PARALLELISM_FORMAT "x parallelism", total * 1000000.0 / v);
         }
       }
 
       if (_worker_data[i] != nullptr) {
-        out->print(", workers (us): ");
+        out->print(" total, per worker: ");
         for (uint c = 0; c < _max_workers; c++) {
           double tv = _worker_data[i]->get(c);
           if (tv != ShenandoahWorkerData::uninitialized()) {
@@ -277,8 +235,8 @@ void ShenandoahPhaseTimings::print_global_on(outputStream* out) const {
   out->print_cr("  \"a\" is average time for each phase, look at levels to see if average makes sense.");
   out->print_cr("  \"lvls\" are quantiles: 0%% (minimum), 25%%, 50%% (median), 75%%, 100%% (maximum).");
   out->cr();
-  out->print_cr("  All times are wall-clock times, except per-root-class counters, that are sum over");
-  out->print_cr("  all workers. Dividing the <total> over the root stage time estimates parallelism.");
+  out->print_cr("  All times are wall-clock times, except for ones explicitly marked as \"total\", those are");
+  out->print_cr("  sum over all workers. Dividing the total over the root stage time estimates parallelism.");
   out->cr();
 
   for (uint i = 0; i < _num_phases; i++) {
@@ -291,7 +249,7 @@ void ShenandoahPhaseTimings::print_global_on(outputStream* out) const {
                     SHENANDOAH_US_TIME_FORMAT ", "
                     SHENANDOAH_US_TIME_FORMAT ", "
                     SHENANDOAH_US_TIME_FORMAT ")",
-                    _phase_names[i],
+                    _desc[i],
                     _global_data[i].sum(),
                     _global_data[i].avg() * 1000000.0,
                     _global_data[i].num(),
@@ -306,21 +264,21 @@ void ShenandoahPhaseTimings::print_global_on(outputStream* out) const {
 }
 
 ShenandoahWorkerTimingsTracker::ShenandoahWorkerTimingsTracker(ShenandoahPhaseTimings::Phase phase,
-        ShenandoahPhaseTimings::ParPhase par_phase, uint worker_id, bool cumulative) :
+        ShenandoahPhaseTimings::WorkerPhase worker_phase, uint worker_id, bool cumulative) :
         _timings(ShenandoahHeap::heap()->phase_timings()),
-        _phase(phase), _par_phase(par_phase), _worker_id(worker_id) {
+        _phase(phase), _worker_phase(worker_phase), _worker_id(worker_id) {
 
-  assert(_timings->worker_data(_phase, _par_phase)->get(_worker_id) == ShenandoahWorkerData::uninitialized() || cumulative,
-         "Should not be set yet: %s", ShenandoahPhaseTimings::phase_name(_timings->worker_par_phase(_phase, _par_phase)));
+  assert(_timings->worker_data(_phase, _worker_phase)->get(_worker_id) == ShenandoahWorkerData::uninitialized() || cumulative,
+         "Should not be set yet: %s", ShenandoahPhaseTimings::phase_desc(_timings->compute_phase_slot(_phase, _worker_phase)));
   _start_time = os::elapsedTime();
 }
 
 ShenandoahWorkerTimingsTracker::~ShenandoahWorkerTimingsTracker() {
-  _timings->worker_data(_phase, _par_phase)->set_or_add(_worker_id, os::elapsedTime() - _start_time);
+  _timings->worker_data(_phase, _worker_phase)->set_or_add(_worker_id, os::elapsedTime() - _start_time);
 
   if (ShenandoahPhaseTimings::is_root_work_phase(_phase)) {
     ShenandoahPhaseTimings::Phase root_phase = _phase;
-    ShenandoahPhaseTimings::Phase cur_phase = _timings->worker_par_phase(root_phase, _par_phase);
-    _event.commit(GCId::current(), _worker_id, ShenandoahPhaseTimings::phase_name(cur_phase));
+    ShenandoahPhaseTimings::Phase cur_phase = _timings->compute_phase_slot(root_phase, _worker_phase);
+    _event.commit(GCId::current(), _worker_id, ShenandoahPhaseTimings::phase_desc(cur_phase));
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -34,177 +34,171 @@
 class ShenandoahCollectorPolicy;
 class outputStream;
 
-#define SHENANDOAH_PAR_PHASE_DO(CNT_PREFIX, DESC_PREFIX, f)                            \
-  f(CNT_PREFIX ## TotalWork,                DESC_PREFIX "<total>")                     \
-  f(CNT_PREFIX ## ThreadRoots,              DESC_PREFIX "Thread Roots")                \
-  f(CNT_PREFIX ## CodeCacheRoots,           DESC_PREFIX "Code Cache Roots")            \
-  f(CNT_PREFIX ## VMStrongRoots,            DESC_PREFIX "VM Strong Roots")             \
-  f(CNT_PREFIX ## VMWeakRoots,              DESC_PREFIX "VM Weak Roots")               \
-  f(CNT_PREFIX ## CLDGRoots,                DESC_PREFIX "CLDG Roots")                  \
-  f(CNT_PREFIX ## CodeCacheUnload,          DESC_PREFIX "Unload Code Caches")          \
-  f(CNT_PREFIX ## CLDUnlink,                DESC_PREFIX "Unlink CLDs")                 \
-  f(CNT_PREFIX ## WeakRefProc,              DESC_PREFIX "Weak References")             \
-  f(CNT_PREFIX ## ParallelMark,             DESC_PREFIX "Parallel Mark")               \
-  f(CNT_PREFIX ## ScanClusters,             DESC_PREFIX "Scan Clusters")               \
-  // end
+#define SHENANDOAH_WORKER_PHASE_DO(NAME_PREFIX, DESC_PREFIX, f)             \
+  f(NAME_PREFIX ## Work,                 DESC_PREFIX "Work",        false)  \
+  f(NAME_PREFIX ## Threads,              DESC_PREFIX "Threads",     false)  \
+  f(NAME_PREFIX ## CodeCache,            DESC_PREFIX "Code Cache",  false)  \
+  f(NAME_PREFIX ## VMStrongs,            DESC_PREFIX "VM Strongs",  false)  \
+  f(NAME_PREFIX ## VMWeaks,              DESC_PREFIX "VM Weaks",    false)  \
+  f(NAME_PREFIX ## Classes,              DESC_PREFIX "Classes",     false)  \
+  // END
 
-#define SHENANDOAH_PHASE_DO(f)                                                         \
-  f(conc_reset,                                     "Concurrent Reset")                \
-  f(conc_reset_after_collect,                       "Concurrent Reset After Collect")  \
-  f(conc_reset_old,                                 "Concurrent Reset (OLD)")          \
-  f(init_mark_gross,                                "Pause Init Mark (G)")             \
-  f(init_mark,                                      "Pause Init Mark (N)")             \
-  f(init_mark_verify,                               "  Verify")                        \
-  f(init_manage_tlabs,                              "  Manage TLABs")                  \
-  f(init_swap_rset,                                 "  Swap Remembered Set")           \
-  f(init_transfer_satb,                             "  Transfer Old From SATB")        \
-  f(init_update_region_states,                      "  Update Region States")          \
-  f(init_propagate_gc_state,                        "  Propagate GC State")            \
-                                                                                       \
-  f(init_scan_rset,                                 "Concurrent Scan Remembered Set")  \
-  SHENANDOAH_PAR_PHASE_DO(init_scan_rset_,          "  RS: ", f)                       \
-                                                                                       \
-  f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
-  SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
-  f(conc_mark,                                      "Concurrent Marking")              \
-  SHENANDOAH_PAR_PHASE_DO(conc_mark,                "  CM: ", f)                       \
-  f(conc_mark_satb_flush,                           "  Flush SATB")                    \
-                                                                                       \
-  f(final_mark_gross,                               "Pause Final Mark (G)")            \
-  f(final_mark,                                     "Pause Final Mark (N)")            \
-  f(final_mark_verify,                              "  Verify")                        \
-  f(finish_mark,                                    "  Finish Mark")                   \
-  f(final_mark_propagate_gc_state,                  "  Propagate GC State")            \
-  SHENANDOAH_PAR_PHASE_DO(finish_mark_,             "    FM: ", f)                     \
-  f(purge,                                          "  System Purge")                  \
-  SHENANDOAH_PAR_PHASE_DO(purge_cu_par_,            "      CU: ", f)                   \
-  f(purge_weak_par,                                 "    Weak Roots")                  \
-  SHENANDOAH_PAR_PHASE_DO(purge_weak_par_,          "      WR: ", f)                   \
-  f(final_update_region_states,                     "  Update Region States")          \
-  f(final_manage_labs,                              "  Manage GC/TLABs")               \
-  f(choose_cset,                                    "  Choose Collection Set")         \
-  f(final_rebuild_freeset,                          "  Rebuild Free Set")              \
-  f(init_evac,                                      "  Initial Evacuation")            \
-  SHENANDOAH_PAR_PHASE_DO(evac_,                    "    E: ", f)                      \
-                                                                                       \
-  f(conc_thread_roots,                              "Concurrent Thread Roots")         \
-  SHENANDOAH_PAR_PHASE_DO(conc_thread_roots_,       "  CTR: ", f)                      \
-  f(conc_weak_refs,                                 "Concurrent Weak References")      \
-  SHENANDOAH_PAR_PHASE_DO(conc_weak_refs_,          "  CWRF: ", f)                     \
-  f(conc_weak_roots,                                "Concurrent Weak Roots")           \
-  f(conc_weak_roots_work,                           "  Roots")                         \
-  SHENANDOAH_PAR_PHASE_DO(conc_weak_roots_work_,    "    CWR: ", f)                    \
-  f(conc_weak_roots_rendezvous,                     "  Rendezvous")                    \
-  f(conc_cleanup_early,                             "Concurrent Cleanup")              \
-  f(conc_class_unload,                              "Concurrent Class Unloading")      \
-  f(conc_class_unload_unlink,                       "  Unlink Stale")                  \
-  f(conc_class_unload_unlink_sd,                    "    System Dictionary")           \
-  f(conc_class_unload_unlink_weak_klass,            "    Weak Class Links")            \
-  f(conc_class_unload_unlink_code_roots,            "    Code Roots")                  \
-  f(conc_class_unload_rendezvous,                   "  Rendezvous")                    \
-  f(conc_class_unload_purge,                        "  Purge Unlinked")                \
-  f(conc_class_unload_purge_coderoots,              "    Code Roots")                  \
-  f(conc_class_unload_purge_cldg,                   "    CLDG")                        \
-  f(conc_class_unload_purge_ec,                     "    Exception Caches")            \
-  f(conc_strong_roots,                              "Concurrent Strong Roots")         \
-  SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
-  f(conc_evac,                                      "Concurrent Evacuation")           \
-  f(conc_update_card_table,                         "Concurrent Update Cards")         \
-  f(conc_final_roots,                               "Concurrent Final Roots")          \
-  f(promote_in_place,                               "  Promote Regions")               \
-  f(final_verify_gross,                             "Pause Final Verify (G)")          \
-  f(final_verify,                                   "Pause Final Verify (N)")          \
-                                                                                       \
-  f(init_update_refs_gross,                         "Pause Init Update Refs (G)")      \
-  f(init_update_refs,                               "Pause Init Update Refs (N)")      \
-  f(init_update_refs_verify,                        "  Verify")                        \
-                                                                                       \
-  f(conc_update_refs_prepare,                       "Concurrent Update Refs Prepare")  \
-  f(conc_update_refs,                               "Concurrent Update Refs")          \
-  f(conc_update_thread_roots,                       "Concurrent Update Thread Roots")  \
-                                                                                       \
-  f(final_update_refs_gross,                        "Pause Final Update Refs (G)")     \
-  f(final_update_refs,                              "Pause Final Update Refs (N)")     \
-  f(final_update_refs_verify,                       "  Verify")                        \
-  f(final_update_refs_update_region_states,         "  Update Region States")          \
-  f(final_update_refs_transfer_satb,                "  Transfer Old From SATB")        \
-  f(final_update_refs_trash_cset,                   "  Trash Collection Set")          \
-  f(final_update_refs_rebuild_freeset,              "  Rebuild Free Set")              \
-  f(final_update_refs_propagate_gc_state,           "  Propagate GC State")            \
-                                                                                       \
-  f(conc_cleanup_complete,                          "Concurrent Cleanup")              \
-  f(conc_coalesce_and_fill,                         "Concurrent Coalesce and Fill")    \
-  SHENANDOAH_PAR_PHASE_DO(conc_coalesce_,           "  CC&F: ", f)                     \
-                                                                                       \
-  f(degen_gc_gross,                                 "Pause Degenerated GC (G)")        \
-  f(degen_gc,                                       "Pause Degenerated GC (N)")        \
-  f(degen_gc_un_self_forward,                       "  Un-Self-Forward")               \
-  f(degen_gc_stw_mark,                              "  Degen STW Mark")                \
-  SHENANDOAH_PAR_PHASE_DO(degen_gc_stw_mark_,       "    DSM: ", f)                    \
-  f(degen_gc_mark,                                  "  Degen Mark")                    \
-  SHENANDOAH_PAR_PHASE_DO(degen_gc_mark_,           "    DM: ", f)                     \
-  f(degen_gc_purge,                                 "    System Purge")                \
-  f(degen_gc_weakrefs,                              "      Weak References")           \
-  SHENANDOAH_PAR_PHASE_DO(degen_gc_weakrefs_p_,     "        WRP: ", f)                \
-  f(degen_gc_purge_class_unload,                    "      Unload Classes")            \
-  SHENANDOAH_PAR_PHASE_DO(degen_gc_purge_cu_par_,   "        DCU: ", f)                \
-  f(degen_gc_purge_weak_par,                        "      Weak Roots")                \
-  SHENANDOAH_PAR_PHASE_DO(degen_gc_purge_weak_p_,   "        DWR: ", f)                \
-  f(degen_gc_purge_cldg,                            "      CLDG")                      \
-  f(degen_gc_final_update_region_states,            "  Update Region States")          \
-  f(degen_gc_final_manage_labs,                     "  Manage GC/TLABs")               \
-  f(degen_gc_choose_cset,                           "  Choose Collection Set")         \
-  f(degen_gc_final_rebuild_freeset,                 "  Rebuild Free Set")              \
-  f(degen_gc_stw_evac,                              "  Evacuation")                    \
-  f(degen_gc_init_update_refs_manage_gclabs,        "  Manage GCLABs")                 \
-  f(degen_gc_update_refs,                           "  Update References")             \
-  f(degen_gc_final_update_refs_update_region_states,"  Update Region States")          \
-  f(degen_gc_final_update_refs_trash_cset,          "  Trash Collection Set")          \
-  f(degen_gc_final_update_refs_rebuild_freeset,     "  Rebuild Free Set")              \
-  f(degen_gc_update_roots,                          "  Degen Update Roots")            \
-  SHENANDOAH_PAR_PHASE_DO(degen_gc_update_,         "    DU: ", f)                     \
-  f(degen_gc_cleanup_complete,                      "  Cleanup")                       \
-  f(degen_gc_promote_regions,                       "  Degen Promote Regions")         \
-  f(degen_gc_coalesce_and_fill,                     "  Degen Coalesce and Fill")       \
-  SHENANDOAH_PAR_PHASE_DO(degen_coalesce_,          "    DC&F", f)                     \
-  f(degen_gc_propagate_gc_state,                    "  Propagate GC State")            \
-                                                                                       \
-  f(full_gc_gross,                                  "Pause Full GC (G)")               \
-  f(full_gc,                                        "Pause Full GC (N)")               \
-  f(full_gc_un_self_forward,                        "  Un-Self-Forward")               \
-  f(full_gc_heapdump_pre,                           "  Pre Heap Dump")                 \
-  f(full_gc_prepare,                                "  Prepare")                       \
-  f(full_gc_update_roots,                           "    Update Roots")                \
-  SHENANDOAH_PAR_PHASE_DO(full_gc_update_roots_,    "      FU: ", f)                   \
-  f(full_gc_mark,                                   "  Mark")                          \
-  SHENANDOAH_PAR_PHASE_DO(full_gc_mark_,            "    FM: ", f)                     \
-  f(full_gc_purge,                                  "    System Purge")                \
-  f(full_gc_weakrefs,                               "      Weak References")           \
-  SHENANDOAH_PAR_PHASE_DO(full_gc_weakrefs_p_,      "        WRP: ", f)                \
-  f(full_gc_purge_class_unload,                     "      Unload Classes")            \
-  SHENANDOAH_PAR_PHASE_DO(full_gc_purge_cu_par_,    "        CU: ", f)                 \
-  f(full_gc_purge_weak_par,                         "      Weak Roots")                \
-  SHENANDOAH_PAR_PHASE_DO(full_gc_purge_weak_p_,    "        WR: ", f)                 \
-  f(full_gc_purge_cldg,                             "      CLDG")                      \
-  f(full_gc_calculate_addresses,                    "  Calculate Addresses")           \
-  f(full_gc_calculate_addresses_regular,            "    Regular Objects")             \
-  f(full_gc_calculate_addresses_humong,             "    Humongous Objects")           \
-  f(full_gc_adjust_pointers,                        "  Adjust Pointers")               \
-  f(full_gc_adjust_roots,                           "  Adjust Roots")                  \
-  SHENANDOAH_PAR_PHASE_DO(full_gc_adjust_roots_,    "    FA: ", f)                     \
-  f(full_gc_copy_objects,                           "  Copy Objects")                  \
-  f(full_gc_copy_objects_regular,                   "    Regular Objects")             \
-  f(full_gc_copy_objects_humong,                    "    Humongous Objects")           \
-  f(full_gc_recompute_generation_usage,             "    Recompute generation usage")  \
-  f(full_gc_copy_objects_reset_complete,            "    Reset Complete Bitmap")       \
-  f(full_gc_copy_objects_rebuild,                   "    Rebuild Region Sets")         \
-  f(full_gc_reconstruct_remembered_set,             "    Reconstruct Remembered Set")  \
-  f(full_gc_heapdump_post,                          "  Post Heap Dump")                \
-  f(full_gc_propagate_gc_state,                     "  Propagate GC State")            \
-                                                                                       \
-  f(heap_iteration_roots,                           "Heap Iteration")                  \
-  SHENANDOAH_PAR_PHASE_DO(heap_iteration_roots_,    "  HI: ", f)                       \
-  // end
+#define SHENANDOAH_SIMPLE_PHASE_DEF(f, NAME, DESC)    \
+  f(NAME, DESC, false)
+
+#define SHENANDOAH_WORKER_PHASE_DEF(f, NAME_PREFIX, MAIN_DESC, DESC_PREFIX)    \
+  f(NAME_PREFIX, MAIN_DESC, true)                                              \
+  SHENANDOAH_WORKER_PHASE_DO(NAME_PREFIX, DESC_PREFIX, f)
+
+#define SHENANDOAH_PHASE_DO(f)                                                                                       \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_reset,                                      "Concurrent Reset")                \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_mark_gross,                                 "Pause Init Mark (G)")             \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_mark,                                       "Pause Init Mark (N)")             \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_mark_verify,                                "  Verify")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_manage_tlabs,                               "  Manage TLABs")                  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_swap_rset,                                  "  Swap Remembered Set")           \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_transfer_satb,                              "  Transfer Old From SATB")        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_update_region_states,                       "  Update Region States")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_propagate_gc_state,                         "  Propagate GC State")            \
+  SHENANDOAH_WORKER_PHASE_DEF(f, init_scan_rset,                                  "Concurrent Scan Remembered Set",  \
+                                                                                  "  RS: ")                          \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_mark_roots,                                 "Concurrent Mark Roots",           \
+                                                                                  "  CMR: ")                         \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_mark,                                       "Concurrent Marking",              \
+                                                                                  "  CM: ")                          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_mark_satb_flush,                            "  Flush SATB")                    \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_mark_gross,                                "Pause Final Mark (G)")            \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_mark,                                      "Pause Final Mark (N)")            \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_mark_verify,                               "  Verify")                        \
+  SHENANDOAH_WORKER_PHASE_DEF(f, finish_mark,                                     "  Finish Mark",                   \
+                                                                                  "    FM: ")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_mark_propagate_gc_state,                   "  Propagate GC State")            \
+  SHENANDOAH_WORKER_PHASE_DEF(f, purge,                                           "  System Purge",                  \
+                                                                                  "      CU: ")                      \
+  SHENANDOAH_WORKER_PHASE_DEF(f, purge_weak_par,                                  "    Weak Roots",                  \
+                                                                                  "      WR: ")                      \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_region_states,                      "  Update Region States")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_manage_labs,                               "  Manage GC/TLABs")               \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, choose_cset,                                     "  Choose Collection Set")         \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_rebuild_freeset,                           "  Rebuild Free Set")              \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_thread_roots,                               "Concurrent Thread Roots",         \
+                                                                                  "  CTR: ")                         \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_weak_refs,                                  "Concurrent Weak References",      \
+                                                                                  "  CWRF: ")                        \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_weak_roots,                                 "Concurrent Weak Roots",           \
+                                                                                  "  CWR: ")                         \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_weak_roots_rendezvous,                      "  Rendezvous")                    \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_cleanup_early,                              "Concurrent Cleanup, Early")       \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload,                               "Concurrent Class Unloading")      \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_unlink,                        "  Unlink Stale")                  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_unlink_sd,                     "    System Dictionary")           \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_unlink_weak_klass,             "    Weak Class Links")            \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_unlink_code_roots,             "    Code Roots")                  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_rendezvous,                    "  Rendezvous")                    \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_purge,                         "  Purge Unlinked")                \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_purge_coderoots,               "    Code Roots")                  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_purge_cldg,                    "    CLDG")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_class_unload_purge_ec,                      "    Exception Caches")            \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_strong_roots,                               "Concurrent Strong Roots",         \
+                                                                                  "  CSR: ")                         \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_evac,                                       "Concurrent Evacuation",           \
+                                                                                  "  CE: ")                          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_update_card_table,                          "Concurrent Update Cards")         \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_final_roots,                                "Concurrent Final Roots")          \
+  SHENANDOAH_WORKER_PHASE_DEF(f, promote_in_place,                                "  Promote Regions",               \
+                                                                                  "    PIP: ")                       \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_verify_gross,                              "Pause Final Verify (G)")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_verify,                                    "Pause Final Verify (N)")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_update_refs_gross,                          "Pause Init Update Refs (G)")      \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_update_refs,                                "Pause Init Update Refs (N)")      \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, init_update_refs_verify,                         "  Verify")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_update_refs_prepare,                        "Concurrent Update Refs Prepare")  \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_update_refs,                                "Concurrent Update Refs",          \
+                                                                                  "  CUR: ")                         \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_update_thread_roots,                        "Concurrent Update Thread Roots")  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_gross,                         "Pause Final Update Refs (G)")     \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs,                               "Pause Final Update Refs (N)")     \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_verify,                        "  Verify")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_update_region_states,          "  Update Region States")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_transfer_satb,                 "  Transfer Old From SATB")        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_trash_cset,                    "  Trash Collection Set")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_rebuild_freeset,               "  Rebuild Free Set")              \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, final_update_refs_propagate_gc_state,            "  Propagate GC State")            \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_cleanup_complete,                           "Concurrent Cleanup, Complete")    \
+  SHENANDOAH_WORKER_PHASE_DEF(f, conc_coalesce_and_fill,                          "Concurrent Coalesce and Fill",    \
+                                                                                  "  CC&F: ")                        \
+                                                                                                                     \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_gross,                                  "Pause Degenerated GC (G)")        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc,                                        "Pause Degenerated GC (N)")        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_un_self_forward,                        "  Un-Self-Forward")               \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_mark,                                   "  Mark",                          \
+                                                                                  "    DM: ")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_purge,                                  "  System Purge")                  \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_weakrefs,                               "    Weak References",             \
+                                                                                  "      WRP: ")                     \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_purge_class_unload,                     "    Unload Classes",              \
+                                                                                  "      DCU: ")                     \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_purge_weak_par,                         "    Weak Roots",                  \
+                                                                                  "      DWR: ")                     \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_purge_cldg,                             "    CLDG")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_final_update_region_states,             "  Update Region States")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_final_manage_labs,                      "  Manage GC/TLABs")               \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_choose_cset,                            "  Choose Collection Set")         \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_final_rebuild_freeset,                  "  Rebuild Free Set")              \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_evac,                                   "  Evacuation",                    \
+                                                                                  "    DE: ")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_init_update_refs_manage_gclabs,         "  Manage GCLABs")                 \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_update_refs,                            "  Update References",             \
+                                                                                  "    DUR: ")                       \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_final_update_refs_update_region_states, "  Update Region States")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_final_update_refs_trash_cset,           "  Trash Collection Set")          \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_final_update_refs_rebuild_freeset,      "  Rebuild Free Set")              \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_update_roots,                           "  Degen Update Roots",            \
+                                                                                  "    DU: ")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_cleanup_complete,                       "  Cleanup")                       \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_promote_regions,                        "  Degen Promote Regions")         \
+  SHENANDOAH_WORKER_PHASE_DEF(f, degen_gc_coalesce_and_fill,                      "  Degen Coalesce and Fill",       \
+                                                                                  "    DC&F")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, degen_gc_propagate_gc_state,                     "  Propagate GC State")            \
+                                                                                                                     \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_gross,                                   "Pause Full GC (G)")               \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc,                                         "Pause Full GC (N)")               \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_un_self_forward,                         "  Un-Self-Forward")               \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_heapdump_pre,                            "  Pre Heap Dump")                 \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_prepare,                                 "  Prepare")                       \
+  SHENANDOAH_WORKER_PHASE_DEF(f, full_gc_update_roots,                            "    Update Roots",                \
+                                                                                  "      FU: ")                      \
+  SHENANDOAH_WORKER_PHASE_DEF(f, full_gc_mark,                                    "  Mark",                          \
+                                                                                  "    FM: ")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_purge,                                   "  System Purge")                  \
+  SHENANDOAH_WORKER_PHASE_DEF(f, full_gc_weakrefs,                                "    Weak References",             \
+                                                                                  "      WRP: ")                     \
+  SHENANDOAH_WORKER_PHASE_DEF(f, full_gc_purge_class_unload,                      "    Unload Classes",              \
+                                                                                  "      CU: ")                      \
+  SHENANDOAH_WORKER_PHASE_DEF(f, full_gc_purge_weak_par,                          "    Weak Roots",                  \
+                                                                                  "      WR: ")                      \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_purge_cldg,                              "    CLDG")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_calculate_addresses,                     "  Calculate Addresses")           \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_calculate_addresses_regular,             "    Regular Objects")             \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_calculate_addresses_humong,              "    Humongous Objects")           \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_adjust_pointers,                         "  Adjust Pointers")               \
+  SHENANDOAH_WORKER_PHASE_DEF(f, full_gc_adjust_roots,                            "  Adjust Roots",                  \
+                                                                                  "    FA: ")                        \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_copy_objects,                            "  Copy Objects")                  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_copy_objects_regular,                    "    Regular Objects")             \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_copy_objects_humong,                     "    Humongous Objects")           \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_recompute_generation_usage,              "    Recompute generation usage")  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_copy_objects_reset_complete,             "    Reset Complete Bitmap")       \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_copy_objects_rebuild,                    "    Rebuild Region Sets")         \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_reconstruct_remembered_set,              "    Reconstruct Remembered Set")  \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_heapdump_post,                           "  Post Heap Dump")                \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, full_gc_propagate_gc_state,                      "  Propagate GC State")            \
+                                                                                                                     \
+  SHENANDOAH_SIMPLE_PHASE_DEF(f, conc_reset_after_collect,                        "Concurrent Reset After Collect")  \
+                                                                                                                     \
+  SHENANDOAH_WORKER_PHASE_DEF(f, heap_iteration_roots,                            "Heap Iteration",                  \
+                                                                                  "  HI: ")                          \
+  // END
 
 typedef WorkerDataArray<double> ShenandoahWorkerData;
 
@@ -212,7 +206,7 @@ class ShenandoahPhaseTimings : public CHeapObj<mtGC> {
   friend class ShenandoahGCPhase;
   friend class ShenandoahWorkerTimingsTracker;
 public:
-#define SHENANDOAH_PHASE_DECLARE_ENUM(type, title)   type,
+#define SHENANDOAH_PHASE_DECLARE_ENUM(name, desc, has_worker_phase) name,
 
   enum Phase {
     SHENANDOAH_PHASE_DO(SHENANDOAH_PHASE_DECLARE_ENUM)
@@ -220,8 +214,8 @@ public:
     _invalid_phase = _num_phases
   };
 
-  enum ParPhase {
-    SHENANDOAH_PAR_PHASE_DO(,, SHENANDOAH_PHASE_DECLARE_ENUM)
+  enum WorkerPhase {
+    SHENANDOAH_WORKER_PHASE_DO(,, SHENANDOAH_PHASE_DECLARE_ENUM)
     _num_par_phases
   };
 
@@ -231,16 +225,16 @@ private:
   uint                _max_workers;
   double              _cycle_data[_num_phases];
   HdrSeq              _global_data[_num_phases];
-  static const char*  _phase_names[_num_phases];
+  static const char*  _desc[_num_phases];
+  static bool         _has_worker_phase[_num_phases];
 
   ShenandoahWorkerData* _worker_data[_num_phases];
   ShenandoahCollectorPolicy* _policy;
 
-  static bool is_worker_phase(Phase phase);
   static bool is_root_work_phase(Phase phase);
 
-  ShenandoahWorkerData* worker_data(Phase phase, ParPhase par_phase);
-  Phase worker_par_phase(Phase phase, ParPhase par_phase);
+  ShenandoahWorkerData* worker_data(Phase phase, WorkerPhase par_phase);
+  static Phase compute_phase_slot(Phase phase, WorkerPhase worker_phase);
 
   void set_cycle_data(Phase phase, double time, bool should_aggregate = false);
   static double uninitialized() { return -1; }
@@ -256,9 +250,14 @@ public:
   void flush_par_workers_to_cycle();
   void flush_cycle_to_global();
 
-  static const char* phase_name(Phase phase) {
+  static const char* phase_desc(Phase phase) {
     assert(phase >= 0 && phase < _num_phases, "Out of bounds: %d", phase);
-    return _phase_names[phase];
+    return _desc[phase];
+  }
+
+  static bool has_worker_phases(Phase phase) {
+    assert(phase >= 0 && phase < _num_phases, "Out of bounds: %d", phase);
+    return _has_worker_phase[phase];
   }
 
   void print_cycle_on(outputStream* out) const;
@@ -269,14 +268,14 @@ class ShenandoahWorkerTimingsTracker : public StackObj {
 private:
   ShenandoahPhaseTimings*          const _timings;
   ShenandoahPhaseTimings::Phase    const _phase;
-  ShenandoahPhaseTimings::ParPhase const _par_phase;
+  ShenandoahPhaseTimings::WorkerPhase const _worker_phase;
   uint const _worker_id;
 
   double _start_time;
   EventGCPhaseParallel _event;
 public:
   ShenandoahWorkerTimingsTracker(ShenandoahPhaseTimings::Phase phase,
-                                 ShenandoahPhaseTimings::ParPhase par_phase,
+                                 ShenandoahPhaseTimings::WorkerPhase worker_phase,
                                  uint worker_id,
                                  bool cumulative = false);
   ~ShenandoahWorkerTimingsTracker();

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -547,11 +547,11 @@ public:
   virtual void work(uint worker_id) {
     if (_concurrent) {
       ShenandoahConcurrentWorkerSession worker_session(worker_id);
-      ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::WeakRefProc, worker_id);
+      ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::Work, worker_id);
       _reference_processor->work();
     } else {
       ShenandoahParallelWorkerSession worker_session(worker_id);
-      ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::WeakRefProc, worker_id);
+      ShenandoahWorkerTimingsTracker x(_phase, ShenandoahPhaseTimings::Work, worker_id);
       _reference_processor->work();
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -49,7 +49,7 @@ uint ShenandoahJavaThreadsIterator::claim() {
 }
 
 void ShenandoahJavaThreadsIterator::threads_do(ThreadClosure* cl, uint worker_id) {
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::ThreadRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::Threads, worker_id);
   for (uint i = claim(); i < _length; i = claim()) {
     for (uint t = i; t < MIN2(_length, i + _stride); t++) {
       cl->do_thread(thread_at(t));
@@ -63,13 +63,13 @@ ShenandoahThreadRoots::ShenandoahThreadRoots(ShenandoahPhaseTimings::Phase phase
   _threads_claim_token_scope() {}
 
 void ShenandoahThreadRoots::oops_do(OopClosure* oops_cl, NMethodClosure* code_cl, uint worker_id) {
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::ThreadRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::Threads, worker_id);
   ResourceMark rm;
   Threads::possibly_parallel_oops_do(_is_par, oops_cl, code_cl);
 }
 
 void ShenandoahThreadRoots::threads_do(ThreadClosure* tc, uint worker_id) {
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::ThreadRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::Threads, worker_id);
   ResourceMark rm;
   Threads::possibly_parallel_threads_do(_is_par, tc);
 }
@@ -78,7 +78,7 @@ ShenandoahCodeCacheRoots::ShenandoahCodeCacheRoots(ShenandoahPhaseTimings::Phase
 }
 
 void ShenandoahCodeCacheRoots::nmethods_do(NMethodClosure* nmethod_cl, uint worker_id) {
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCache, worker_id);
   _coderoots_iterator.possibly_parallel_nmethods_do(nmethod_cl);
 }
 
@@ -153,7 +153,7 @@ void ShenandoahConcurrentRootScanner::roots_do(OopClosure* oops, uint worker_id)
     _cld_roots.cld_do(&clds_cl, worker_id);
 
     {
-      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
+      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCache, worker_id);
       NMethodToOopClosure nmethods(oops, !NMethodToOopClosure::FixRelocations);
       _codecache_snapshot->parallel_nmethods_do(&nmethods);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -46,7 +46,7 @@ ShenandoahVMWeakRoots<CONCURRENT>::ShenandoahVMWeakRoots(ShenandoahPhaseTimings:
 template <bool CONCURRENT>
 template <typename T>
 void ShenandoahVMWeakRoots<CONCURRENT>::oops_do(T* cl, uint worker_id) {
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::VMWeakRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::VMWeaks, worker_id);
   _weak_roots.oops_do(cl);
 }
 
@@ -54,7 +54,7 @@ template <bool CONCURRENT>
 template <typename IsAlive, typename KeepAlive>
 void ShenandoahVMWeakRoots<CONCURRENT>::weak_oops_do(IsAlive* is_alive, KeepAlive* keep_alive, uint worker_id) {
   ShenandoahCleanUpdateWeakOopsClosure<CONCURRENT, IsAlive, KeepAlive> cl(is_alive, keep_alive);
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::VMWeakRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::VMWeaks, worker_id);
   _weak_roots.oops_do(&cl);
 }
 
@@ -71,7 +71,7 @@ ShenandoahVMRoots<CONCURRENT>::ShenandoahVMRoots(ShenandoahPhaseTimings::Phase p
 template <bool CONCURRENT>
 template <typename T>
 void ShenandoahVMRoots<CONCURRENT>::oops_do(T* cl, uint worker_id) {
-  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::VMStrongRoots, worker_id);
+  ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::VMStrongs, worker_id);
   _strong_roots.oops_do(cl);
 }
 
@@ -104,12 +104,12 @@ template <bool CONCURRENT>
 void ShenandoahClassLoaderDataRoots<CONCURRENT>::cld_do_impl(CldDo f, CLDClosure* clds, uint worker_id) {
   if (CONCURRENT) {
     if (_semaphore.try_acquire()) {
-      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
+      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::Classes, worker_id);
       f(clds);
       _semaphore.claim_all();
     }
   } else {
-    ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
+    ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::Classes, worker_id);
     f(clds);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -63,7 +63,7 @@ void ShenandoahSTWMarkTask::work(uint worker_id) {
 
 ShenandoahSTWMark::ShenandoahSTWMark(ShenandoahGeneration* generation, bool full_gc) :
   ShenandoahMark(generation),
-  _root_scanner(full_gc ? ShenandoahPhaseTimings::full_gc_mark : ShenandoahPhaseTimings::degen_gc_stw_mark),
+  _root_scanner(full_gc ? ShenandoahPhaseTimings::full_gc_mark : ShenandoahPhaseTimings::degen_gc_mark),
   _terminator(ShenandoahHeap::heap()->workers()->active_workers(), task_queues()),
   _full_gc(full_gc) {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "Must be at a Shenandoah safepoint");
@@ -151,8 +151,8 @@ void ShenandoahSTWMark::mark_roots(uint worker_id) {
 }
 
 void ShenandoahSTWMark::finish_mark(uint worker_id) {
-  ShenandoahPhaseTimings::Phase phase = _full_gc ? ShenandoahPhaseTimings::full_gc_mark : ShenandoahPhaseTimings::degen_gc_stw_mark;
-  ShenandoahWorkerTimingsTracker timer(phase, ShenandoahPhaseTimings::ParallelMark, worker_id);
+  ShenandoahPhaseTimings::Phase phase = _full_gc ? ShenandoahPhaseTimings::full_gc_mark : ShenandoahPhaseTimings::degen_gc_mark;
+  ShenandoahWorkerTimingsTracker timer(phase, ShenandoahPhaseTimings::Work, worker_id);
   StringDedup::Requests requests;
 
   mark_loop(worker_id, &_terminator, _generation->type(), false /* not cancellable */,

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -808,7 +808,7 @@ void ShenandoahScanRememberedTask::work(uint worker_id) {
 }
 
 void ShenandoahScanRememberedTask::do_work(uint worker_id) {
-  ShenandoahWorkerTimingsTracker x(ShenandoahPhaseTimings::init_scan_rset, ShenandoahPhaseTimings::ScanClusters, worker_id);
+  ShenandoahWorkerTimingsTracker x(ShenandoahPhaseTimings::init_scan_rset, ShenandoahPhaseTimings::Work, worker_id);
 
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
   ShenandoahObjToScanQueue* old = _old_queue_set == nullptr ? nullptr : _old_queue_set->queue(worker_id);

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -143,7 +143,7 @@ bool ShenandoahTimingsTracker::is_current_phase_valid() {
 ShenandoahGCPhase::ShenandoahGCPhase(ShenandoahPhaseTimings::Phase phase) :
   ShenandoahTimingsTracker(phase),
   _timer(ShenandoahHeap::heap()->gc_timer()) {
-  _timer->register_gc_phase_start(ShenandoahPhaseTimings::phase_name(phase), Ticks::now());
+  _timer->register_gc_phase_start(ShenandoahPhaseTimings::phase_desc(phase), Ticks::now());
 }
 
 ShenandoahGCPhase::~ShenandoahGCPhase() {
@@ -164,9 +164,9 @@ ShenandoahWorkerSession::ShenandoahWorkerSession(uint worker_id) {
 }
 
 ShenandoahConcurrentWorkerSession::~ShenandoahConcurrentWorkerSession() {
-  _event.commit(GCId::current(), ShenandoahPhaseTimings::phase_name(ShenandoahGCPhase::current_phase()));
+  _event.commit(GCId::current(), ShenandoahPhaseTimings::phase_desc(ShenandoahGCPhase::current_phase()));
 }
 
 ShenandoahParallelWorkerSession::~ShenandoahParallelWorkerSession() {
-  _event.commit(GCId::current(), WorkerThread::worker_id(), ShenandoahPhaseTimings::phase_name(ShenandoahGCPhase::current_phase()));
+  _event.commit(GCId::current(), WorkerThread::worker_id(), ShenandoahPhaseTimings::phase_desc(ShenandoahGCPhase::current_phase()));
 }


### PR DESCRIPTION
This started by me noticing that we do not have great visibility in per-worker stats for Concurrent Evacuation and Concurrent Update References with -Xlog:gc+stats.

But there are other generic problems with the logging, and those are intertwined. So we want to address in one swing.

The non-exhaustive list of things that were fixed:
 1. There is an obvious problem with "worker-enabled" phases: if you define one, it is supposed to be followed by the special block of "sub-phases" that accept worker-related paraphernalia. If you miss it, the attempt to write worker-related sub-counters would silently overwrite the adjacent phase counters. There is a separate switch to enumerate the worker-related phases, but it desynced as well. This is now re-designed to have a single declaration macro that sets up everything.
 2.  `<total>` sub-phase is the reminiscent of the similar issue. It currently holds no additional meaning, and only clutters the logs.  Some phases are reshuffled to avoid excessive nesting, where `<total>` is actually the same as the "root" phase.
 3. Worker-related sub-phases have several "common" names to be re-used across different "root" counters. That was a reminiscent of pre-`OopStorage` times where we had lots and lots of root classes. Today, we have only a few. It is tempting to add more things there, for example, `ScanClusters`. But it is excessive for a single user. So instead, we now have the pretty generic `Work` that we can use for anything non-root-specific.
 4. As stated for the starter point, at least concurrent evac and concurrent update refs had no worker counters. This is blind-spot in logging: we do not have a good idea what is the worker time distribution / parallelism for those are.
 6. Some phases are straight-up dead and unused. `init_evac`, for example. Those are now removed.
 7. Some phases are sequenced incorrectly. The counter order is roughly the order in which events happen within the cycle. `Concurrent reset after collect` is the most egregious example.

For before/after log snippets, see the comments.

Additional testing:
 - [x] Eyeballing the logs
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385334](https://bugs.openjdk.org/browse/JDK-8385334): Shenandoah: Improve gc+stats logging (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31283/head:pull/31283` \
`$ git checkout pull/31283`

Update a local copy of the PR: \
`$ git checkout pull/31283` \
`$ git pull https://git.openjdk.org/jdk.git pull/31283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31283`

View PR using the GUI difftool: \
`$ git pr show -t 31283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31283.diff">https://git.openjdk.org/jdk/pull/31283.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31283#issuecomment-4546274943)
</details>
