### PR TITLE
8384869: C2: IR Verification Test failures on x86_64 after JDK-8383881

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2843,6 +2843,10 @@ VM_Version::VM_Features VM_Version::CpuidInfo::feature_flags() const {
   // clflush_size is size in quadwords (8 bytes).
   guarantee(_cpuid_info.std_cpuid1_ebx.bits.clflush_size == ICache::line_size/8, "clflush size is not supported");
 
+  // sse and sse2 are guaranteed to be present
+  vm_features.set_feature(CPU_SSE);
+  vm_features.set_feature(CPU_SSE2);
+
   if (std_cpuid1_edx.bits.cmpxchg8 != 0)
     vm_features.set_feature(CPU_CX8);
   if (std_cpuid1_edx.bits.cmov != 0)

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -383,6 +383,8 @@ protected:
     decl(HT,                ht                )  \
     decl(3DNOW_PREFETCH,    3dnowpref         )  /* Processor supports 3dnow prefetch and prefetchw instructions */ \
                                                  /* may not necessarily support other 3dnow instructions */ \
+    decl(SSE,               sse               )  \
+    decl(SSE2,              sse2              )  \
     decl(SSE3,              sse3              ) /* SSE3 comes from cpuid 1 (ECX) */ \
     decl(SSSE3,             ssse3             ) \
     decl(SSE4A,             sse4a             ) \

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
@@ -107,7 +107,7 @@ public class ClhsdbLongConstant {
             // Expected value obtained from the CPU_SHA definition in vm_version_x86.hpp
             checkLongValue("VM_Version::CPU_SHA ",
                            longConstantOutput,
-                           31L);
+                           33L);
         }
     }
 


### PR DESCRIPTION
This patch adds back enum values and strings in cpu feature strings for `sse` and `sse2` cpu features. JDK-8383881 removed these strings, but there are numerous tests that use these strings as pre-condition for performing IR verification. Instead of fixing all these tests, it is much simpler to just record these features in the cpu feature string.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384869](https://bugs.openjdk.org/browse/JDK-8384869): C2: IR Verification Test failures on x86_64 after JDK-8383881 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31284/head:pull/31284` \
`$ git checkout pull/31284`

Update a local copy of the PR: \
`$ git checkout pull/31284` \
`$ git pull https://git.openjdk.org/jdk.git pull/31284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31284`

View PR using the GUI difftool: \
`$ git pr show -t 31284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31284.diff">https://git.openjdk.org/jdk/pull/31284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31284#issuecomment-4545859771)
</details>
