### PR TITLE
8382031: Update IANA Language Subtag Registry to Version 2026-05-05

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2025-08-25
+File-Date: 2026-05-05
 %%
 Type: language
 Subtag: aa
@@ -387,6 +387,7 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: ia
+Description: Interlingua (IALA)
 Description: Interlingua (International Auxiliary Language
   Association)
 Added: 2005-10-16
@@ -769,9 +770,9 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: ny
-Description: Nyanja
-Description: Chewa
 Description: Chichewa
+Description: Chewa
+Description: Nyanja
 Added: 2005-10-16
 Suppress-Script: Latn
 %%
@@ -803,6 +804,9 @@ Scope: macrolanguage
 %%
 Type: language
 Subtag: os
+Description: Iron Ossetic
+Description: Iron
+Description: Iron Ossetian
 Description: Ossetian
 Description: Ossetic
 Added: 2005-10-16
@@ -5669,7 +5673,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: boe
-Description: Mundabli
+Description: Mundabli-Mufu
 Added: 2009-07-29
 %%
 Type: language
@@ -9312,7 +9316,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: den
-Description: Slave (Athapascan)
+Description: Slavey
 Added: 2005-10-16
 Scope: macrolanguage
 %%
@@ -10513,6 +10517,11 @@ Type: language
 Subtag: dyi
 Description: Djimini Senoufo
 Added: 2009-07-29
+%%
+Type: language
+Subtag: dyl
+Description: Bhutanese Sign Language
+Added: 2026-04-09
 %%
 Type: language
 Subtag: dym
@@ -15266,6 +15275,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: isu
+Description: Isu
 Description: Isu (Menchum Division)
 Added: 2009-07-29
 %%
@@ -17367,7 +17377,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kjo
-Description: Harijan Kinnauri
+Description: Kinnauri Pahari
 Added: 2009-07-29
 %%
 Type: language
@@ -18804,6 +18814,8 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kut
+Description: Ktunaxa
+Description: Ksanka
 Description: Kutenai
 Added: 2005-10-16
 %%
@@ -20008,6 +20020,11 @@ Description: Lefa
 Added: 2009-07-29
 %%
 Type: language
+Subtag: lfb
+Description: Buu (Cameroon)
+Added: 2026-04-09
+%%
+Type: language
 Subtag: lfn
 Description: Lingua Franca Nova
 Added: 2009-07-29
@@ -21104,7 +21121,7 @@ Macrolanguage: zh
 %%
 Type: language
 Subtag: lui
-Description: Luiseno
+Description: Luiseño
 Added: 2005-10-16
 %%
 Type: language
@@ -21692,6 +21709,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: mdc
+Description: Soq
 Description: Male (Papua New Guinea)
 Added: 2009-07-29
 %%
@@ -21797,6 +21815,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: mdy
+Description: Male
 Description: Male (Ethiopia)
 Added: 2009-07-29
 %%
@@ -23129,6 +23148,7 @@ Added: 2009-07-29
 Type: language
 Subtag: moh
 Description: Mohawk
+Description: Kanien'kéha
 Added: 2005-10-16
 %%
 Type: language
@@ -26262,6 +26282,7 @@ Added: 2010-03-11
 Type: language
 Subtag: nok
 Description: Nooksack
+Description: Lhéchelesem
 Added: 2009-07-29
 %%
 Type: language
@@ -27531,6 +27552,11 @@ Description: Walungge
 Added: 2009-07-29
 %%
 Type: language
+Subtag: olb
+Description: Oli-Bodiman
+Added: 2026-04-09
+%%
+Type: language
 Subtag: old
 Description: Mochi
 Added: 2009-07-29
@@ -27897,6 +27923,13 @@ Type: language
 Subtag: osc
 Description: Oscan
 Added: 2009-07-29
+%%
+Type: language
+Subtag: osd
+Description: Digor Ossetic
+Description: Digor
+Description: Digor Ossetian
+Added: 2026-04-09
 %%
 Type: language
 Subtag: osi
@@ -31532,6 +31565,11 @@ Description: Sicel
 Added: 2009-07-29
 %%
 Type: language
+Subtag: scz
+Description: Shaetlan
+Added: 2026-04-09
+%%
+Type: language
 Subtag: sda
 Description: Toraja-Sa'dan
 Added: 2009-07-29
@@ -33108,6 +33146,7 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: srs
+Description: Tsuut'ina
 Description: Sarsi
 Added: 2009-07-29
 %%
@@ -33852,6 +33891,7 @@ Added: 2017-02-23
 %%
 Type: language
 Subtag: szv
+Description: Isubu
 Description: Isu (Fako Division)
 Added: 2009-07-29
 %%
@@ -36217,6 +36257,13 @@ Description: Te'un
 Added: 2009-07-29
 %%
 Type: language
+Subtag: tvg
+Description: Tugunese
+Description: Batavian Portuguese Creole
+Description: Mardijker Creole
+Added: 2026-05-05
+%%
+Type: language
 Subtag: tvi
 Description: Tulai
 Added: 2023-03-17
@@ -37766,6 +37813,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: wab
+Description: Yote
 Description: Wab
 Added: 2009-07-29
 %%
@@ -41152,6 +41200,7 @@ Added: 2012-08-12
 %%
 Type: language
 Subtag: yko
+Description: Iyasa
 Description: Yasa
 Added: 2009-07-29
 %%
@@ -41431,6 +41480,8 @@ Type: language
 Subtag: yol
 Description: Yola
 Added: 2009-07-29
+Deprecated: 2026-04-09
+Preferred-Value: enm
 %%
 Type: language
 Subtag: yom
@@ -42162,6 +42213,11 @@ Type: language
 Subtag: zhi
 Description: Zhire
 Added: 2009-07-29
+%%
+Type: language
+Subtag: zhk
+Description: Kurdish Sign Language
+Added: 2026-05-05
 %%
 Type: language
 Subtag: zhn
@@ -43491,6 +43547,13 @@ Prefix: ms
 Macrolanguage: ms
 %%
 Type: extlang
+Subtag: dyl
+Description: Bhutanese Sign Language
+Added: 2026-04-09
+Preferred-Value: dyl
+Prefix: sgn
+%%
+Type: extlang
 Subtag: ecs
 Description: Ecuadorian Sign Language
 Added: 2009-07-29
@@ -44806,6 +44869,13 @@ Added: 2009-07-29
 Preferred-Value: yue
 Prefix: zh
 Macrolanguage: zh
+%%
+Type: extlang
+Subtag: zhk
+Description: Kurdish Sign Language
+Added: 2026-05-05
+Preferred-Value: zhk
+Prefix: sgn
 %%
 Type: extlang
 Subtag: zib
@@ -48229,6 +48299,13 @@ Comments: The subtag represents the alphabet codified by Franc Serafin
   Metelko and used from 1825 to 1833.
 %%
 Type: variant
+Subtag: moderat
+Description: The moderate (conservative, i.e. Danish-like) spelling
+  variant of Bokmål
+Added: 2026-04-21
+Prefix: nb
+%%
+Type: variant
 Subtag: monoton
 Description: Monotonic Greek
 Added: 2006-12-11
@@ -48384,6 +48461,12 @@ Comments: Puter is one of the five traditional written standards or
   "idioms" of the Romansh language.
 %%
 Type: variant
+Subtag: radikalt
+Description: Radical (i.e. Nynorsk-like) spelling variant of Bokmål
+Added: 2026-04-21
+Prefix: nb
+%%
+Type: variant
 Subtag: rigik
 Description: Volapük rigik
 Description: Schleyer's Volapük
@@ -48438,6 +48521,13 @@ Description: Simplified form
 Added: 2015-12-29
 %%
 Type: variant
+Subtag: slepe
+Description: Sorbian dialect of Schleife
+Added: 2026-04-09
+Prefix: dsb
+Comments: Spoken in the Free State of Saxony in Germany
+%%
+Type: variant
 Subtag: solba
 Description: The Stolvizza dialect of Resian
 Description: The Solbica dialect of Resian
@@ -48461,6 +48551,13 @@ Added: 2017-02-23
 Prefix: en
 Prefix: es
 Comments: A variety of contact dialects of English and Spanish
+%%
+Type: variant
+Subtag: stadi
+Description: The "Stadin slangi" dialect of Finnish
+Added: 2026-04-09
+Prefix: fi
+Comments: "Stadi" means the city of Helsinki in the dialect.
 %%
 Type: variant
 Subtag: surmiran
@@ -48492,6 +48589,16 @@ Description: Synnejysk
 Description: South Jutish
 Added: 2021-07-17
 Prefix: da
+%%
+Type: variant
+Subtag: taglish
+Description: Tagalog-English code-switching
+Added: 2026-04-09
+Prefix: en
+Prefix: tl
+Prefix: fil
+Comments: This subtag represents Taglish, wherever it is different from
+  straight Tagalog or straight English.
 %%
 Type: variant
 Subtag: tailo

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -44,6 +44,8 @@ public class LanguageSubtagRegistryTest {
 
     static boolean err = false;
 
+    // ACCEPT_LANGUAGE as of 2026-05-05.
+    // Updates to the registry with a "Preferred-Value" should be added
     private static final String ACCEPT_LANGUAGE =
         "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, dyl, ehs, eko, ema,"
         + " en-gb-oed, gti, hnm, iba, ilw, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, luh, lvi, meg, mtm,"

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
- *      8327631 8332424 8334418 8344589 8348328 8362428
+ *      8327631 8332424 8334418 8344589 8348328 8362428 8382031
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2025-08-25) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2026-05-05) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -45,10 +45,10 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, eko, ema,"
+        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, dyl, ehs, eko, ema,"
         + " en-gb-oed, gti, hnm, iba, ilw, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, luh, lvi, meg, mtm,"
         + " ngv, nns, ola, oyb, pat, pcr, phr, plu, pnd, pub, rib, rnb, rsn, scv, sjc, snz, sqm, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
-        + " umi, uss, uth, xia, yos, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
+        + " umi, uss, uth, xia, yol, yos, ysm, zhk, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
     private static final List<LanguageRange> EXPECTED_RANGE_LIST = List.of(
             new LanguageRange("aam", 1.0),
             new LanguageRange("aas", 1.0),
@@ -92,6 +92,8 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("xrq", 1.0),
             new LanguageRange("dsz", 1.0),
             new LanguageRange("sgn-dsz", 1.0),
+            new LanguageRange("dyl", 1.0),
+            new LanguageRange("sgn-dyl", 1.0),
             new LanguageRange("ehs", 1.0),
             new LanguageRange("sgn-ehs", 1.0),
             new LanguageRange("eko", 1.0),
@@ -207,10 +209,14 @@ public class LanguageSubtagRegistryTest {
             new LanguageRange("uth", 1.0),
             new LanguageRange("xia", 1.0),
             new LanguageRange("acn", 1.0),
+            new LanguageRange("yol", 1.0),
+            new LanguageRange("enm", 1.0),
             new LanguageRange("yos", 1.0),
             new LanguageRange("zom", 1.0),
             new LanguageRange("ysm", 1.0),
             new LanguageRange("sgn-ysm", 1.0),
+            new LanguageRange("zhk", 1.0),
+            new LanguageRange("sgn-zhk", 1.0),
             new LanguageRange("zko", 1.0),
             new LanguageRange("xss", 1.0),
             new LanguageRange("wkr", 0.9),


### PR DESCRIPTION
Routine update of the language subtag registry to the latest version.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382031](https://bugs.openjdk.org/browse/JDK-8382031): Update IANA Language Subtag Registry to Version 2026-05-05 (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31285/head:pull/31285` \
`$ git checkout pull/31285`

Update a local copy of the PR: \
`$ git checkout pull/31285` \
`$ git pull https://git.openjdk.org/jdk.git pull/31285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31285`

View PR using the GUI difftool: \
`$ git pr show -t 31285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31285.diff">https://git.openjdk.org/jdk/pull/31285.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31285#issuecomment-4548625481)
</details>
