### PR TITLE
8379125: C2: Control of rewired data in Range Check Elimination is not updated when further splitting a main loop leading to a segfault

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2742,28 +2742,29 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
   // Need to find the main-loop zero-trip guard
   Node* const zero_trip_guard_success_proj = cl->skip_assertion_predicates_with_halt();
+  DEBUG_ONLY(ensure_zero_trip_guard_proj(zero_trip_guard_success_proj, true));
   Node* const zero_trip_guard = zero_trip_guard_success_proj->in(0);
-  Node* opqzm = zero_trip_guard->in(1)->in(1)->in(2);
-  assert(opqzm->in(1) == main_limit, "do not understand situation");
+  Node* const opaque_zero_trip_guard = zero_trip_guard->in(1)->in(1)->in(2);
+  assert(opaque_zero_trip_guard->in(1) == main_limit, "unexpected limit node: %s", opaque_zero_trip_guard->in(1)->Name());
 
   // Find the pre-loop limit; we will expand its iterations to
   // not ever trip low tests.
-  Node* p_f = zero_trip_guard->in(0);
+  Node* pre_loop_exit_proj = zero_trip_guard->in(0);
   // pre loop may have been optimized out
-  if (p_f->Opcode() != Op_IfFalse) {
+  if (!pre_loop_exit_proj->is_IfFalse()) {
     return;
   }
-  CountedLoopEndNode *pre_end = p_f->in(0)->as_CountedLoopEnd();
-  assert(pre_end->loopnode()->is_pre_loop(), "");
-  Node *pre_opaq1 = pre_end->limit();
+  CountedLoopEndNode* pre_end = pre_loop_exit_proj->in(0)->as_CountedLoopEnd();
+  assert(pre_end->loopnode()->is_pre_loop(), "not a pre loop");
+  Node* pre_loop_limit = pre_end->limit();
   // Occasionally it's possible for a pre-loop Opaque1 node to be
   // optimized away and then another round of loop opts attempted.
   // We can not optimize this particular loop in that case.
-  if (pre_opaq1->Opcode() != Op_Opaque1) {
+  if (pre_loop_limit->Opcode() != Op_Opaque1) {
     return;
   }
-  Opaque1Node *pre_opaq = (Opaque1Node*)pre_opaq1;
-  Node *pre_limit = pre_opaq->in(1);
+  Opaque1Node* pre_loop_limit_opaque = pre_loop_limit->as_Opaque1();
+  Node* pre_limit = pre_loop_limit_opaque->in(1);
   Node* pre_limit_ctrl = get_ctrl(pre_limit);
 
   // Where do we put new limit calculations
@@ -2777,7 +2778,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
   // Ensure the original loop limit is available from the
   // pre-loop Opaque1 node.
-  Node *orig_limit = pre_opaq->original_loop_limit();
+  Node *orig_limit = pre_loop_limit_opaque->original_loop_limit();
   if (orig_limit == nullptr || _igvn.type(orig_limit) == Type::TOP) {
     return;
   }
@@ -2999,9 +3000,9 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       // Find loads off the surviving projection; remove their control edge
       for (DUIterator_Fast imax, i = dp->fast_outs(imax); i < imax; i++) {
         Node* cd = dp->fast_out(i); // Control-dependent node
-        if (cd->is_Load() && cd->depends_only_on_test()) {   // Loads can now float around in the loop
-          // Allow the load to float around in the loop, or before it (either after Template Assertion Predicates
-          // or when absent after zero trip guard)
+        if (cd->is_Load() && cd->depends_only_on_test()) {
+          // Allow a load to float around in the loop, or before it but after this loop's Template Assertion Predicates
+          // or when absent after the loop's zero trip guard.
           _igvn.replace_input_of(cd, 0, ctrl_target_for_data_rewire);
           --i;
           --imax;
@@ -3023,13 +3024,13 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   }
   // new pre_limit can push Bool/Cmp/Opaque nodes down (when one of the eliminated condition has parameters that are not
   // loop invariant in the pre loop.
-  set_ctrl(pre_opaq, new_limit_ctrl);
+  set_ctrl(pre_loop_limit_opaque, new_limit_ctrl);
   // Can't use new_limit_ctrl for Bool/Cmp because it can be out of loop while they are loop variant. Conservatively set
   // control to latest possible one.
   set_ctrl(pre_end->cmp_node(), pre_end->in(0));
   set_ctrl(pre_end->in(1), pre_end->in(0));
 
-  _igvn.replace_input_of(pre_opaq, 1, pre_limit);
+  _igvn.replace_input_of(pre_loop_limit_opaque, 1, pre_limit);
 
   // Note:: we are making the main loop limit no longer precise;
   // need to round up based on stride.
@@ -3065,11 +3066,11 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
     _igvn.replace_node(final_iv_placeholder, final_iv);
   }
   // The OpaqueNode is unshared by design
-  assert(opqzm->outcnt() == 1, "cannot hack shared node");
-  _igvn.replace_input_of(opqzm, 1, main_limit);
+  assert(opaque_zero_trip_guard->outcnt() == 1, "cannot hack shared node");
+  _igvn.replace_input_of(opaque_zero_trip_guard, 1, main_limit);
   // new main_limit can push opaque node for zero trip guard down (when one of the eliminated condition has parameters
   // that are not loop invariant in the pre loop).
-  set_ctrl(opqzm, new_limit_ctrl);
+  set_ctrl(opaque_zero_trip_guard, new_limit_ctrl);
   // Bool/Cmp nodes for zero trip guard should have been assigned control between the main and pre loop (because zero
   // trip guard depends on induction variable value out of pre loop) so shouldn't need to be adjusted
   assert(is_dominator(new_limit_ctrl, get_ctrl(zero_trip_guard->in(1)->in(1))), "control of cmp should be below control of updated input");

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2937,6 +2937,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
           TemplateAssertionPredicateCreator template_assertion_predicate_creator(cl, scale_con , int_offset, int_limit,
                                                                                  this);
           loop_entry = template_assertion_predicate_creator.create(loop_entry);
+          // Make sure to rewire data dependencies on the removed check to the Template Assertion Predicate in order
+          // to update them correctly when further splitting the main loop later.
           ctrl_target_for_data_rewire = loop_entry;
 
           // Initialized Assertion Predicate for the value of the initial main-loop.

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2741,14 +2741,14 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   }
 
   // Need to find the main-loop zero-trip guard
-  Node *ctrl = cl->skip_assertion_predicates_with_halt();
-  Node *iffm = ctrl->in(0);
-  Node *opqzm = iffm->in(1)->in(1)->in(2);
+  Node* const zero_trip_guard_success_proj = cl->skip_assertion_predicates_with_halt();
+  Node* const zero_trip_guard = zero_trip_guard_success_proj->in(0);
+  Node* opqzm = zero_trip_guard->in(1)->in(1)->in(2);
   assert(opqzm->in(1) == main_limit, "do not understand situation");
 
   // Find the pre-loop limit; we will expand its iterations to
   // not ever trip low tests.
-  Node *p_f = iffm->in(0);
+  Node* p_f = zero_trip_guard->in(0);
   // pre loop may have been optimized out
   if (p_f->Opcode() != Op_IfFalse) {
     return;
@@ -2846,7 +2846,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       // 'limit' maybe pinned below the zero trip test (probably from a
       // previous round of rce), in which case, it can't be used in the
       // zero trip test expression which must occur before the zero test's if.
-      if (is_dominator(ctrl, limit_ctrl)) {
+      if (is_dominator(zero_trip_guard_success_proj, limit_ctrl)) {
         continue;  // Don't rce this check but continue looking for other candidates.
       }
 
@@ -2867,7 +2867,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
       // As above for the 'limit', the 'offset' maybe pinned below the
       // zero trip test.
-      if (is_dominator(ctrl, offset_ctrl)) {
+      if (is_dominator(zero_trip_guard_success_proj, offset_ctrl)) {
         continue; // Don't rce this check but continue looking for other candidates.
       }
 
@@ -2902,16 +2902,15 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       Node* int_limit = limit;
       limit = new ConvI2LNode(limit);
       register_new_node(limit, next_limit_ctrl);
+      Node* ctrl_target_for_data_rewire = zero_trip_guard_success_proj;
 
       // Adjust pre and main loop limits to guard the correct iteration set
       if (cmp->Opcode() == Op_CmpU) { // Unsigned compare is really 2 tests
-        if (b_test._test == BoolTest::lt) { // Range checks always use lt
+        if (b_test._test == BoolTest::lt) {
+          // Range checks always use lt
           // The underflow and overflow limits: 0 <= scale*I+offset < limit
           add_constraint(stride_con, lscale_con, offset, zero, limit, next_limit_ctrl, &pre_limit, &main_limit);
-          Node* init = cl->uncasted_init_trip(true);
 
-          Node* opaque_init = new OpaqueLoopInitNode(C, init);
-          register_new_node(opaque_init, loop_entry);
 
           InitializedAssertionPredicateCreator initialized_assertion_predicate_creator(this);
           if (abs_stride_is_one) {
@@ -2938,12 +2937,13 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
           TemplateAssertionPredicateCreator template_assertion_predicate_creator(cl, scale_con , int_offset, int_limit,
                                                                                  this);
           loop_entry = template_assertion_predicate_creator.create(loop_entry);
+          ctrl_target_for_data_rewire = loop_entry;
 
           // Initialized Assertion Predicate for the value of the initial main-loop.
+          Node* init = cl->uncasted_init_trip(true);
           loop_entry = initialized_assertion_predicate_creator.create(init, loop_entry, stride_con, scale_con,
                                                                       int_offset, int_limit,
                                                                       AssertionPredicateType::InitValue);
-
         } else {
           if (PrintOpto) {
             tty->print_cr("missed RCE opportunity");
@@ -2982,6 +2982,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
           continue;             // Unhandled case
         }
       }
+
       // Only update variable tracking control for new nodes if it's indeed a range check that can be eliminated (and
       // limits are updated)
       new_limit_ctrl = next_limit_ctrl;
@@ -2997,9 +2998,9 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       for (DUIterator_Fast imax, i = dp->fast_outs(imax); i < imax; i++) {
         Node* cd = dp->fast_out(i); // Control-dependent node
         if (cd->is_Load() && cd->depends_only_on_test()) {   // Loads can now float around in the loop
-          // Allow the load to float around in the loop, or before it
-          // but NOT before the pre-loop.
-          _igvn.replace_input_of(cd, 0, ctrl); // ctrl, not null
+          // Allow the load to float around in the loop, or before it (either after Template Assertion Predicates
+          // or when absent after zero trip guard)
+          _igvn.replace_input_of(cd, 0, ctrl_target_for_data_rewire);
           --i;
           --imax;
         }
@@ -3069,7 +3070,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   set_ctrl(opqzm, new_limit_ctrl);
   // Bool/Cmp nodes for zero trip guard should have been assigned control between the main and pre loop (because zero
   // trip guard depends on induction variable value out of pre loop) so shouldn't need to be adjusted
-  assert(is_dominator(new_limit_ctrl, get_ctrl(iffm->in(1)->in(1))), "control of cmp should be below control of updated input");
+  assert(is_dominator(new_limit_ctrl, get_ctrl(zero_trip_guard->in(1)->in(1))), "control of cmp should be below control of updated input");
 
   C->print_method(PHASE_AFTER_RANGE_CHECK_ELIMINATION, 4, cl);
 }

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestAssertionPredicates.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestAssertionPredicates.java
@@ -147,13 +147,25 @@
 /*
  * @test id=DataUpdateZGC
  * @key randomness
- * @bug 8288981 8350577 0360510
+ * @bug 8288981 8350577 8360510
  * @requires vm.compiler2.enabled
  * @requires vm.gc.Z
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+AbortVMOnCompilationFailure -XX:+UseZGC
  *                   -XX:CompileCommand=compileonly,compiler.predicates.assertion.TestAssertionPredicates::*
  *                   -XX:CompileCommand=dontinline,compiler.predicates.assertion.TestAssertionPredicates::*
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-KillPathsReachableByDeadTypeNode
+ *                   compiler.predicates.assertion.TestAssertionPredicates DataUpdate
+ */
+
+/*
+ * @test id=DataUpdateRangeCheckElimination
+ * @key randomness
+ * @bug 8379125
+ * @requires vm.compiler2.enabled
+ * @requires vm.gc.Z
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-UseLoopPredicate
+ *                   -XX:+StressGCM -XX:+UseZGC -XX:+AbortVMOnCompilationFailure -XX:-KillPathsReachableByDeadTypeNode
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.assertion.TestAssertionPredicates::*
  *                   compiler.predicates.assertion.TestAssertionPredicates DataUpdate
  */
 
@@ -350,6 +362,7 @@ public class TestAssertionPredicates {
                     testDataUpdateUnroll();
                     testDataUpdatePeelingUnroll();
                     testPeelingThreeTimesDataUpdate();
+                    testRangeCheckEliminationPeelMainLoopDataUpdate();
                 }
             }
             case "CloneDown" -> {
@@ -1415,6 +1428,71 @@ public class TestAssertionPredicates {
             if (i > 1 && iFld2 == 2) {
                 return;
             }
+        }
+    }
+
+    // JDK-8379125
+    //-Xcomp -XX:CompileCommand=compileonly,Test*::test* -XX:+StressGCM -XX:-UseLoopPredicate -XX:+StressGCM -XX:+UseZGC
+    static void testRangeCheckEliminationPeelMainLoopDataUpdate() {
+        int zero = 34;
+        int x = 2;
+        for (; x < 4; x *= 2);
+        for (int i = 2; i < x; i++) {
+            zero = 0;
+        }
+
+        Foo[] fooArr;
+        int limit;
+        if (flagTrue) {
+            limit = 4;
+            fooArr = new Foo[30_000_001];
+        } else {
+            limit = 5;
+            fooArr = new Foo[40_000_001];
+        }
+
+        // Initialize to prevent null pointers.
+        for (int i = 0; i < limit; i++) {
+            fooArr[10_000_000 * i] = foo;
+        }
+
+
+        // 1) Pre-Main-Post loop created
+        for (int i = 0; i < limit; i++) {
+
+            if (i > 0) { // 4) In main-loop: Always true and folded because of executing pre-loop at least once -> i = [1..5]
+                int k = iFld + i * zero; // 5) Loop variant before CCP, after CCP: folded to k = iFld
+                if (k  == 40) { // 6) After CCP: Loop Invariant -> Triggers Loop Peeling of main loop
+                    return;
+                }
+            }
+
+            // 2) Range Check Elimination (there is no Loop Predication when run with -XX:-UseLoopPredicate):
+            //    - Removes this range check from main loop.
+            //    - Pins the previously pinned LoadP for the fooArr access to the zero-trip-guard of the main loop.
+            //    - Adds a Template Assertion Predicate for the eliminated range check.
+            // 3) Loop is unrolled once. We now have two LoadP for both fooArr accesses at the zero-trip-guard:
+            //    - LoadP 1: fooArr[i * 10^8]
+            //    - LoadP 2: fooArr[(i+1) * 10^8 = i * 10^8 + 10^8]
+            // 7) After peeling the main-loop, we have 4 Load nodes: Two for the peeled iteration and two for
+            //    the remaining loop. Both are pinned at the zero-trip-guard for the main-loop. Here is the bug:
+            //    We should actually update the 2 LoadP pins belonging to the remaining loop to only get executed
+            //    when the zero-trip-guard is true and we are actually enter the remaining loop but forget to do that!
+            //    - LoadP 1: fooArr[i * 10^8]
+            //    - LoadP 2: fooArr[(i+1) * 10^8 = i * 10^8 + 10^8]
+            //    - LoadP 3: fooArr[(i+2) * 10^8 = i * 10^8 + 2*10^8]
+            //    - LoadP 4: fooArr[(i+3) * 10^8 = i * 10^8 + 3*10^8]
+            // 8) During runtime, we have:
+            //    - flagTrue = true
+            //    - limit = 4
+            //    - fooArr = new Foo[30000001]
+            //    We enter the main-loop with i = 1. We execute the peeled iteration but we do not enter the remaining loop
+            //    because i = 3 and we only require one more iteration but the remaining loop ill perform two iterations.
+            //    So, the zero-trip-guard for the remaining loop fails.
+            //    But all LoadP nodes are pinned at the zero-trip-gaurd for the main-loop. When using -XX:+StressGCM, we could
+            //    schedule LoadP 4 before actually checking the zero-trip-guard and we crash with an out-of-bounds-access:
+            //    - LoadP 4: fooArr[(i+3) * 10^8 = i * 10^8 + 3*10^8 = 4*10^8 > 3*10^8 (max-index)] -> crash!
+            fooArr[i * 10_000_000].iFld += 34;
         }
     }
 

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestAssertionPredicates.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestAssertionPredicates.java
@@ -1472,16 +1472,16 @@ public class TestAssertionPredicates {
             //    - Pins the previously pinned LoadP for the fooArr access to the zero-trip-guard of the main loop.
             //    - Adds a Template Assertion Predicate for the eliminated range check.
             // 3) Loop is unrolled once. We now have two LoadP for both fooArr accesses at the zero-trip-guard:
-            //    - LoadP 1: fooArr[i * 10^8]
-            //    - LoadP 2: fooArr[(i+1) * 10^8 = i * 10^8 + 10^8]
+            //    - LoadP 1: fooArr[i * 10^7]
+            //    - LoadP 2: fooArr[(i+1) * 10^7 = i * 10^7 + 10^7]
             // 7) After peeling the main-loop, we have 4 Load nodes: Two for the peeled iteration and two for
             //    the remaining loop. Both are pinned at the zero-trip-guard for the main-loop. Here is the bug:
             //    We should actually update the 2 LoadP pins belonging to the remaining loop to only get executed
             //    when the zero-trip-guard is true and we are actually enter the remaining loop but forget to do that!
-            //    - LoadP 1: fooArr[i * 10^8]
-            //    - LoadP 2: fooArr[(i+1) * 10^8 = i * 10^8 + 10^8]
-            //    - LoadP 3: fooArr[(i+2) * 10^8 = i * 10^8 + 2*10^8]
-            //    - LoadP 4: fooArr[(i+3) * 10^8 = i * 10^8 + 3*10^8]
+            //    - LoadP 1: fooArr[i * 10^7]
+            //    - LoadP 2: fooArr[(i+1) * 10^7 = i * 10^7 + 10^7]
+            //    - LoadP 3: fooArr[(i+2) * 10^7 = i * 10^7 + 2*10^7]
+            //    - LoadP 4: fooArr[(i+3) * 10^7 = i * 10^7 + 3*10^7]
             // 8) During runtime, we have:
             //    - flagTrue = true
             //    - limit = 4
@@ -1489,9 +1489,9 @@ public class TestAssertionPredicates {
             //    We enter the main-loop with i = 1. We execute the peeled iteration but we do not enter the remaining loop
             //    because i = 3 and we only require one more iteration but the remaining loop ill perform two iterations.
             //    So, the zero-trip-guard for the remaining loop fails.
-            //    But all LoadP nodes are pinned at the zero-trip-gaurd for the main-loop. When using -XX:+StressGCM, we could
+            //    But all LoadP nodes are pinned at the zero-trip-guard for the main-loop. When using -XX:+StressGCM, we could
             //    schedule LoadP 4 before actually checking the zero-trip-guard and we crash with an out-of-bounds-access:
-            //    - LoadP 4: fooArr[(i+3) * 10^8 = i * 10^8 + 3*10^8 = 4*10^8 > 3*10^8 (max-index)] -> crash!
+            //    - LoadP 4: fooArr[(i+3) * 10^7 = i * 10^7 + 3*10^7 = 4*10^7 > 3*10^7 (max-index)] -> crash!
             fooArr[i * 10_000_000].iFld += 34;
         }
     }


### PR DESCRIPTION
### Data Rewiring with Template Assertion Predicates

During refactoring and fixing Assertion Predicates [JDK-8288981](https://bugs.openjdk.org/browse/JDK-8288981), we also fixed some data dependency issues: Data that is dependent on a hoisted check was sometimes missed to be updated when further splitting a loop. As a result, cloned data for such a sub loop ended up being pinned before checking the zero trip guard which could lead to a crash (e.g. executing a load for a sub loop that is never actually entered):
```
zero trip guard                                zero trip guard
     |                                                |
     |                                                |  // Peeled Iteration data pinned here -> Okay
     X  // Loop data pinned here                      X  // Remaining Loop data pinned here -> wrong
     |                            Peeling             |  // -> Could be executed before checking zero-trip-guard of Remaining Loop
    Loop                          ------->     Peeled Iteration
                                                      |             
                                                zero trip guard 
                                                      |
                                                Remaining Loop
```

The fix was to always rewire data to the now consistently added Template Assertion Predicates. These nodes are always kept until loop opts are over. It is thus easy to just walk through them when splitting a loop further and rewire all data dependencies to newly established Template Assertion Predicates.

### Missing Case for Range Check Elimination
While the previous fixes cover all the cases for Loop Predication, we miss to update data correctly for Range Check Elimination: We currently just pin the data for the removed checks in Range Check Elimination to the zero trip guard:

https://github.com/openjdk/jdk/blob/006d5ad09e3f5e5e5b1bd737429b4e6cc8f9cb0e/src/hotspot/share/opto/loopTransform.cpp#L2744

https://github.com/openjdk/jdk/blob/006d5ad09e3f5e5e5b1bd737429b4e6cc8f9cb0e/src/hotspot/share/opto/loopTransform.cpp#L2997-L3002

When further splitting the loop, we miss to update the pinned data at the zero trip guard because we only check Template Assertion Predicates for data to be rewired. 

### Triggering a Crash Is Unlikely but Possible
Triggering an actual crash with such a data node that is wrongly executed is quite hard. We need:
- Split a main loop, which does not happen very often (more likely when run with `-XX:+StressLoopPeeling`)
- Executing a wrongly pinned data node (e.g. a load) that normally would not be executed because the zero trip guard fails (more likely when run with `-XX:+StressGCM`).
- Executing the wrongly pinned load and also crash because we are touching unmapped memory.

In practice, this rarely happens. I still managed to find a regression test that intermittently triggers such a crash. A more detailed explanation who it is possible is added as comments in the test.

### Proposed Fix
The fix is straight forward to rewire the data to the added Template Assertion Predicate instead of the zero trip guard.

### Incomplete Fix
The fix is not complete, though: We could also remove `CmpI` nodes with data dependencies in Range Check Elimination. But we currently do not add Assertion Predicates for `CmpI`, only for `CmpU`. As a result, we are also not rewiring data dependencies correctly when further splitting the loop (that only works with Template Assertion Predicates). To handle `CmpI` as well, we would need to add Assertion Predicates (I think that is generally not a bad idea to also have some verification that the main loop range is valid). But that becomes more complicated because we not only need to cover `BoolTest::lt` (only supported case for `CmpU`) but also `gt`, `ge`, and `le`. 

I could not find a reproducer that shows a crash for `CmpI` but I'm sure it could be possible. I therefore suggest to go with this simple fix for `CmpU` for JDK 27 and revisit the problem again for `CmpI` in JDK 28 (I can file a follow-up issue)

Thanks,
Christian 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379125](https://bugs.openjdk.org/browse/JDK-8379125): C2: Control of rewired data in Range Check Elimination is not updated when further splitting a main loop leading to a segfault (**Bug** - P3)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) Review applies to [3126eb37](https://git.openjdk.org/jdk/pull/31290/files/3126eb3785e090f7f2f6c1a88c5986961c654337)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [3126eb37](https://git.openjdk.org/jdk/pull/31290/files/3126eb3785e090f7f2f6c1a88c5986961c654337)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31290/head:pull/31290` \
`$ git checkout pull/31290`

Update a local copy of the PR: \
`$ git checkout pull/31290` \
`$ git pull https://git.openjdk.org/jdk.git pull/31290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31290`

View PR using the GUI difftool: \
`$ git pr show -t 31290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31290.diff">https://git.openjdk.org/jdk/pull/31290.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31290#issuecomment-4553904801)
</details>
