### PR TITLE
8385506: Fix some remaining CSS issues

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -82,6 +82,8 @@
     /* Search input colors */
     --search-input-background-color: #ffffff;
     --search-input-text-color: #000000;
+    --search-border-light-color: #eaeaea;
+    --search-border-dark-color: #a6a6a6;
     --search-input-placeholder-color: #757575;
     --overlay-background: rgba(153, 169, 183, 0.3);
     /* Highlight color for active search tag target */
@@ -107,23 +109,23 @@
 :root[data-theme="theme-dark"] {
     --body-text-color: #e8e8e8;
     --block-text-color: #e8e8e8;
-    --body-background-color: #1f2124;
+    --body-background-color: #202226;
     --section-background-color: var(--body-background-color);
     --detail-background-color: var(--body-background-color);
     --code-background-color: #303940;
     --mark-background-color: #313131;
     --detail-block-color: #31363c;
-    --navbar-background-color: #395A6F;
+    --navbar-background-color: #406074;
     --navbar-text-color: #ffffff;
-    --subnav-background-color: #3d454d;
+    --subnav-background-color: #434c54;
     --subnav-link-color: #d8dcdf;
     --member-heading-background-color: var(--subnav-background-color);
     --selected-background-color: #f8981d;
     --selected-text-color: #253441;
     --selected-link-color: #4a698a;
     --table-header-color: #38444d;
-    --even-row-color: #222528;
-    --odd-row-color: #2d3135;
+    --even-row-color: #282c2f;
+    --odd-row-color: #33383b;
     --title-color: #fff;
     --link-color: #94badb;
     --link-color-active: #e8a351;
@@ -138,8 +140,10 @@
     --border-color: #444444;
     --table-border-color: #717171;
     --tab-border-radius: 2px 2px 0 0;
-    --search-input-background-color: #303030;
+    --search-input-background-color: #202224;
     --search-input-text-color: #d0d0d0;
+    --search-border-light-color: #505050;
+    --search-border-dark-color: #000000;
     --search-input-placeholder-color: #979797;
     --overlay-background: rgba(0, 0, 0, 0.45);
     --search-tag-background-color: #c6c61e;
@@ -245,6 +249,9 @@ h1, h2, h3, h4, h5, h6, div.member-signature, div.member-signature > span {
 }
 ul {
     list-style-type:disc;
+}
+main li {
+    margin-top: 4px;
 }
 tt {
     font-family:var(--code-font-family);
@@ -522,6 +529,9 @@ section.class-description > div.horizontal-scroll > :is(dl, ol, ul, p, div, bloc
 section.class-description > div.horizontal-scroll > :last-child > :is(li, dd):last-child {
     margin-bottom:4px;
 }
+dl.notes {
+    margin-top: 14.2px;
+}
 dl.notes > dt {
     font-family: var(--body-font-family);
     font-size:0.856em;
@@ -737,10 +747,12 @@ ul.tag-list li {
     display: inline;
 }
 ul.tag-list li:not(:last-child):after,
-ul.tag-list-long li:not(:last-child):after
-{
+ul.tag-list-long li:not(:last-child):after {
     content: ", ";
     white-space: pre-wrap;
+}
+ul.tag-list-long > li {
+    margin-top: 1px;
 }
 ul.preview-feature-list {
     list-style: none;
@@ -957,6 +969,12 @@ div.block {
     font-size:var(--block-font-size);
     font-family:var(--block-font-family);
     line-height:var(--block-line-height);
+    display: block;
+    margin:0 10px 5px 0;
+    color:var(--block-text-color);
+}
+section.detail div.block {
+    margin-bottom: 14.4px;
 }
 .module-signature,
 .package-signature,
@@ -1005,11 +1023,6 @@ div.block {
     /* Color of line numbers in source pages can be set via custom property below */
     color:var(--source-linenumber-color, green);
     padding:0 30px 0 0;
-}
-.block {
-    display:block;
-    margin:0 10px 5px 0;
-    color:var(--block-text-color);
 }
 .deprecated-label, .description-from-type-label, .implementation-label, .member-name-link,
 .package-hierarchy-label, .type-name-label, .type-name-link, .search-tag-link, .preview-label,
@@ -1075,15 +1088,16 @@ input[type="text"] {
     background-image:var(--glass-svg);
     background-size:13px;
     background-repeat:no-repeat;
-    background-position:3px 4px;
+    background-position:3px 5px;
     background-color: var(--search-input-background-color);
     color: var(--search-input-text-color);
-    border-color: var(--border-color);
+    border-style:solid;
+    border-color: var(--search-border-dark-color) var(--search-border-light-color) var(--search-border-light-color) var(--search-border-dark-color);
     border-radius: 4px;
     padding-left:20px;
     padding-right: 18px;
     font-size: var(--nav-font-size);
-    height: 19px;
+    height: 20px;
 }
 input#page-search-input {
     width: calc(180px + 10vw);
@@ -1585,8 +1599,7 @@ button.snippet-copy span {
 table.borderless,
 table.plain,
 table.striped {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 14px 0;
 }
 table.borderless > caption,
 table.plain > caption,


### PR DESCRIPTION
Please review a change to the javadoc default stylesheet to fix some CSS issues. The changes are described in detail in the JBS issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385506](https://bugs.openjdk.org/browse/JDK-8385506): Fix some remaining CSS issues (**Enhancement** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31291/head:pull/31291` \
`$ git checkout pull/31291`

Update a local copy of the PR: \
`$ git checkout pull/31291` \
`$ git pull https://git.openjdk.org/jdk.git pull/31291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31291`

View PR using the GUI difftool: \
`$ git pr show -t 31291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31291.diff">https://git.openjdk.org/jdk/pull/31291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31291#issuecomment-4554147852)
</details>
