### PR TITLE
8385454: Provide more NUMA related information in hsinfo/hserr files

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2639,30 +2639,31 @@ static size_t read_sysfs_file(const char *path, char *buf, size_t sz) {
 }
 
 static void print_numa_memory_info(outputStream* st, int node) {
-  char path[256], line[256];
-  long long mem_total = -1, mem_free = -1;
+  char path[256];
+  char line[256];
+  long long mem_total = -1;
+  long long mem_free = -1;
   os::snprintf_checked(path, sizeof(path), SYS_DEVICES_NODE "/node%d/meminfo", node);
   FILE* f = os::fopen(path, "r");
   if (f == nullptr) {
     return;
   }
 
-  while (fgets(line, sizeof(line), f)) {
+  while (fgets(line, sizeof(line), f) != nullptr) {
     long long mval;
     if (sscanf(line, "Node %*d MemTotal: %lld kB", &mval) == 1) mem_total = mval;
     if (sscanf(line, "Node %*d MemFree: %lld kB",  &mval) == 1) mem_free  = mval;
   }
   fclose(f);
 
-  StreamIndentor si(st);
   if (mem_total >= 0) { st->print_cr("mem size: %lld kB", mem_total); }
   if (mem_free >= 0) { st->print_cr("mem free: %lld kB", mem_free); }
 }
 
 static void print_numa_cpu_list(outputStream* st, int node) {
-  char path[256], buf[1024];
+  char path[256];
+  char buf[1024];
   os::snprintf_checked(path, sizeof(path), SYS_DEVICES_NODE "/node%d/cpulist", node);
-  StreamIndentor si(st);
   if (read_sysfs_file(path, buf, sizeof(buf)) > 0) {
     st->print_cr("cpus: %s", buf);
   } else {
@@ -2677,14 +2678,13 @@ bool os::Linux::print_numa_info(outputStream* st) {
   }
 
   DIR* dirp = os::opendir(SYS_DEVICES_NODE);
-  int node_count = 0;
-
   if (dirp == nullptr) {
     return false;
   }
 
   struct dirent* e;
   bool first = true;
+  int node_count = 0;
 
   while ((e = os::readdir(dirp)) != nullptr) {
     if (strncmp(e->d_name, "node", 4) != 0 || !isdigit((unsigned char)e->d_name[4])) continue;
@@ -2694,6 +2694,7 @@ bool os::Linux::print_numa_info(outputStream* st) {
       first = false;
     }
     st->print_cr("NUMA node %d", node);
+    StreamIndentor si(st);
     print_numa_cpu_list(st, node);
     print_numa_memory_info(st, node);
     node_count++;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2183,6 +2183,10 @@ void os::print_os_info(outputStream* st) {
     st->cr();
   }
 
+  if (os::Linux::print_numa_info(st)) {
+    st->cr();
+  }
+
   VM_Version::print_platform_virtualization_info(st);
 
   os::Linux::print_steal_info(st);
@@ -2620,6 +2624,82 @@ bool os::Linux::print_container_info(outputStream* st) {
   }
 
   return true;
+}
+
+#define SYS_DEVICES_NODE "/sys/devices/system/node"
+
+static size_t read_sysfs_file(const char *path, char *buf, size_t sz) {
+  FILE* f = os::fopen(path, "r");
+  if (f == nullptr) return 0;
+  size_t n = fread(buf, 1, sz - 1, f);
+  fclose(f);
+  buf[n] = '\0';
+  while (n > 0 && (buf[n-1] == '\n' || buf[n-1] == '\r')) buf[--n] = '\0';
+  return n;
+}
+
+static void print_numa_memory_info(outputStream* st, int node) {
+  char path[256], line[256];
+  long long mem_total = -1, mem_free = -1;
+  os::snprintf_checked(path, sizeof(path), SYS_DEVICES_NODE "/node%d/meminfo", node);
+  FILE* f = os::fopen(path, "r");
+  if (f == nullptr) {
+    return;
+  }
+
+  while (fgets(line, sizeof(line), f)) {
+    long long mval;
+    if (sscanf(line, "Node %*d MemTotal: %lld kB", &mval) == 1) mem_total = mval;
+    if (sscanf(line, "Node %*d MemFree: %lld kB",  &mval) == 1) mem_free  = mval;
+  }
+  fclose(f);
+
+  if (mem_total >= 0) { st->print_cr("  mem size: %lld kB", mem_total); }
+  if (mem_free >= 0) { st->print_cr("  mem free: %lld kB", mem_free); }
+}
+
+static void print_numa_cpu_list(outputStream* st, int node) {
+  char path[256], buf[1024];
+  os::snprintf_checked(path, sizeof(path), SYS_DEVICES_NODE "/node%d/cpulist", node);
+  if (read_sysfs_file(path, buf, sizeof(buf)) > 0) {
+    st->print_cr("  cpus: %s", buf);
+  } else {
+    st->print_cr("  cpus: (unavailable)");
+  }
+}
+
+bool os::Linux::print_numa_info(outputStream* st) {
+  if (UseNUMA) {
+    DIR* dirp = os::opendir(SYS_DEVICES_NODE);
+    int node_count = 0;
+    struct dirent *e;
+    bool first = true;
+
+    if (dirp == nullptr) {
+      return false;
+    }
+
+    while ((e = os::readdir(dirp)) != nullptr) {
+      // must be 'node<digit>'
+      if (strncmp(e->d_name, "node", 4) != 0 || !isdigit((unsigned char)e->d_name[4])) continue;
+      int node = atoi(e->d_name + 4);
+      if (first) {
+        st->print_cr(""); first = false;
+      }
+      st->print_cr("NUMA node %d", node);
+      print_numa_cpu_list(st, node);
+      print_numa_memory_info(st, node);
+      node_count++;
+    }
+    os::closedir(dirp);
+
+    if (node_count == 0) {
+      return false;
+    }
+    st->print_cr("Total NUMA node count: %d", node_count);
+    return true;
+  }
+  return false;
 }
 
 void os::Linux::print_steal_info(outputStream* st) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2654,52 +2654,57 @@ static void print_numa_memory_info(outputStream* st, int node) {
   }
   fclose(f);
 
-  if (mem_total >= 0) { st->print_cr("  mem size: %lld kB", mem_total); }
-  if (mem_free >= 0) { st->print_cr("  mem free: %lld kB", mem_free); }
+  StreamIndentor si(st);
+  if (mem_total >= 0) { st->print_cr("mem size: %lld kB", mem_total); }
+  if (mem_free >= 0) { st->print_cr("mem free: %lld kB", mem_free); }
 }
 
 static void print_numa_cpu_list(outputStream* st, int node) {
   char path[256], buf[1024];
   os::snprintf_checked(path, sizeof(path), SYS_DEVICES_NODE "/node%d/cpulist", node);
+  StreamIndentor si(st);
   if (read_sysfs_file(path, buf, sizeof(buf)) > 0) {
-    st->print_cr("  cpus: %s", buf);
+    st->print_cr("cpus: %s", buf);
   } else {
-    st->print_cr("  cpus: (unavailable)");
+    st->print_cr("cpus: (unavailable)");
   }
 }
 
 bool os::Linux::print_numa_info(outputStream* st) {
-  if (UseNUMA) {
-    DIR* dirp = os::opendir(SYS_DEVICES_NODE);
-    int node_count = 0;
-    struct dirent *e;
-    bool first = true;
-
-    if (dirp == nullptr) {
-      return false;
-    }
-
-    while ((e = os::readdir(dirp)) != nullptr) {
-      // must be 'node<digit>'
-      if (strncmp(e->d_name, "node", 4) != 0 || !isdigit((unsigned char)e->d_name[4])) continue;
-      int node = atoi(e->d_name + 4);
-      if (first) {
-        st->print_cr(""); first = false;
-      }
-      st->print_cr("NUMA node %d", node);
-      print_numa_cpu_list(st, node);
-      print_numa_memory_info(st, node);
-      node_count++;
-    }
-    os::closedir(dirp);
-
-    if (node_count == 0) {
-      return false;
-    }
-    st->print_cr("Total NUMA node count: %d", node_count);
-    return true;
+  if (!UseNUMA) {
+    // If NUMA optimizations are not enabled we don't print anything
+    return false;
   }
-  return false;
+
+  DIR* dirp = os::opendir(SYS_DEVICES_NODE);
+  int node_count = 0;
+
+  if (dirp == nullptr) {
+    return false;
+  }
+
+  struct dirent* e;
+  bool first = true;
+
+  while ((e = os::readdir(dirp)) != nullptr) {
+    if (strncmp(e->d_name, "node", 4) != 0 || !isdigit((unsigned char)e->d_name[4])) continue;
+    int node = atoi(e->d_name + 4);
+    if (first) {
+      st->cr();
+      first = false;
+    }
+    st->print_cr("NUMA node %d", node);
+    print_numa_cpu_list(st, node);
+    print_numa_memory_info(st, node);
+    node_count++;
+  }
+  os::closedir(dirp);
+
+  if (node_count == 0) {
+    return false;
+  }
+  st->print_cr("Total NUMA node count: %d", node_count);
+  return true;
 }
 
 void os::Linux::print_steal_info(outputStream* st) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2682,17 +2682,47 @@ bool os::Linux::print_numa_info(outputStream* st) {
     return false;
   }
 
+  char buf[1024];
+  if (read_sysfs_file("/sys/devices/system/node/online", buf, sizeof(buf)) > 0) {
+    st->print_cr("online nodes : %s", buf);
+  } else {
+    os::closedir(dirp);
+    return false;
+  }
+
+  char *p = buf;
+  int low_node_number  = INT_MAX;
+  int high_node_number = INT_MIN;
+  while (*p) {
+    int a, b;
+    if (sscanf(p, "%d", &a) != 1) break;
+    b = a;
+    while (isdigit((unsigned char)*p)) p++;
+    if (*p == '-') {
+      p++;
+      if (sscanf(p, "%d", &b) != 1) break;
+      while (isdigit((unsigned char)*p)) p++;
+    }
+    if (a < low_node_number) low_node_number = a;
+    if (b > high_node_number) high_node_number = b;
+    if (*p == ',') p++; else break;
+  }
+
   struct dirent* e;
   bool first = true;
   int node_count = 0;
 
-  while ((e = os::readdir(dirp)) != nullptr) {
-    if (strncmp(e->d_name, "node", 4) != 0 || !isdigit((unsigned char)e->d_name[4])) continue;
-    int node = atoi(e->d_name + 4);
+  for (int node = low_node_number; node <= high_node_number; node++) {
+    char nodepath[256];
+    os::snprintf_checked(nodepath, sizeof(nodepath), SYS_DEVICES_NODE "/node%d", node);
+    DIR* currd = os::opendir(nodepath);
+    if (currd == nullptr) continue;
     if (first) {
       st->cr();
       first = false;
     }
+    os::closedir(currd);
+
     st->print_cr("NUMA node %d", node);
     StreamIndentor si(st);
     print_numa_cpu_list(st, node);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2690,30 +2690,11 @@ bool os::Linux::print_numa_info(outputStream* st) {
     return false;
   }
 
-  char *p = buf;
-  int low_node_number  = INT_MAX;
-  int high_node_number = INT_MIN;
-  while (*p != '\0') {
-    int a, b;
-    if (sscanf(p, "%d", &a) != 1) break;
-    b = a;
-    while (isdigit((unsigned char)*p)) p++;
-    if (*p == '-') {
-      p++;
-      if (sscanf(p, "%d", &b) != 1) break;
-      while (isdigit((unsigned char)*p)) p++;
-    }
-    if (a < low_node_number) low_node_number = a;
-    if (b > high_node_number) high_node_number = b;
-    if (*p == ',') p++; else break;
-  }
-
-  struct dirent* e;
   bool first = true;
   int node_count = 0;
 
   // in case of node 0,2,5 gaps are still iterated
-  for (int node = low_node_number; node <= high_node_number; node++) {
+  for (int node: *nindex_to_node()) {
     char nodepath[256];
     os::snprintf_checked(nodepath, sizeof(nodepath), SYS_DEVICES_NODE "/node%d", node);
     DIR* currd = os::opendir(nodepath);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2628,7 +2628,7 @@ bool os::Linux::print_container_info(outputStream* st) {
 
 #define SYS_DEVICES_NODE "/sys/devices/system/node"
 
-static size_t read_sysfs_file(const char *path, char *buf, size_t sz) {
+static size_t read_sysfs_file(const char* path, char* buf, size_t sz) {
   FILE* f = os::fopen(path, "r");
   if (f == nullptr) return 0;
   size_t n = fread(buf, 1, sz - 1, f);
@@ -2677,23 +2677,20 @@ bool os::Linux::print_numa_info(outputStream* st) {
     return false;
   }
 
-  DIR* dirp = os::opendir(SYS_DEVICES_NODE);
-  if (dirp == nullptr) {
-    return false;
-  }
-
   char buf[1024];
   if (read_sysfs_file("/sys/devices/system/node/online", buf, sizeof(buf)) > 0) {
     st->print_cr("NUMA nodes online: %s", buf);
   } else {
-    os::closedir(dirp);
     return false;
   }
 
   bool first = true;
   int node_count = 0;
 
-  // in case of node 0,2,5 gaps are still iterated
+  if (nindex_to_node() == nullptr) {
+    return false;
+  }
+
   for (int node: *nindex_to_node()) {
     char nodepath[256];
     os::snprintf_checked(nodepath, sizeof(nodepath), SYS_DEVICES_NODE "/node%d", node);
@@ -2711,11 +2708,11 @@ bool os::Linux::print_numa_info(outputStream* st) {
     print_numa_memory_info(st, node);
     node_count++;
   }
-  os::closedir(dirp);
 
   if (node_count == 0) {
     return false;
   }
+
   st->print_cr("Total NUMA node count: %d", node_count);
   return true;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2684,7 +2684,7 @@ bool os::Linux::print_numa_info(outputStream* st) {
 
   char buf[1024];
   if (read_sysfs_file("/sys/devices/system/node/online", buf, sizeof(buf)) > 0) {
-    st->print_cr("online nodes : %s", buf);
+    st->print_cr("NUMA nodes online: %s", buf);
   } else {
     os::closedir(dirp);
     return false;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2693,7 +2693,7 @@ bool os::Linux::print_numa_info(outputStream* st) {
   char *p = buf;
   int low_node_number  = INT_MAX;
   int high_node_number = INT_MIN;
-  while (*p) {
+  while (*p != '\0') {
     int a, b;
     if (sscanf(p, "%d", &a) != 1) break;
     b = a;
@@ -2712,6 +2712,7 @@ bool os::Linux::print_numa_info(outputStream* st) {
   bool first = true;
   int node_count = 0;
 
+  // in case of node 0,2,5 gaps are still iterated
   for (int node = low_node_number; node <= high_node_number; node++) {
     char nodepath[256];
     os::snprintf_checked(nodepath, sizeof(nodepath), SYS_DEVICES_NODE "/node%d", node);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -77,6 +77,7 @@ class os::Linux {
   static void print_proc_sys_info(outputStream* st);
   static bool print_ld_preload_file(outputStream* st);
   static void print_uptime_info(outputStream* st);
+  static bool print_numa_info(outputStream* st);
 
  public:
   struct CPUPerfTicks {


### PR DESCRIPTION
Currently we have very limited NUMA related information in e.g. hsinfo/hserr files. This should be enhanced.
The node numbers are printed and associated cpus and some memory details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385454](https://bugs.openjdk.org/browse/JDK-8385454): Provide more NUMA related information in hsinfo/hserr files (**Enhancement** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31292/head:pull/31292` \
`$ git checkout pull/31292`

Update a local copy of the PR: \
`$ git checkout pull/31292` \
`$ git pull https://git.openjdk.org/jdk.git pull/31292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31292`

View PR using the GUI difftool: \
`$ git pr show -t 31292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31292.diff">https://git.openjdk.org/jdk/pull/31292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31292#issuecomment-4555239181)
</details>
