### PR TITLE
8385525: Suggest Metal toolchain download in configure error on Xcode 26+

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -545,7 +545,7 @@ earlier versions may also work.</p>
 no longer comes bundled with Xcode, so it needs to be installed
 separately. This can either be done via the Xcode's Settings/Components
 UI, or in the command line calling
-<code>xcodebuild -downloadComponent metalToolchain</code>.</p>
+<code>xcodebuild -downloadComponent MetalToolchain</code>.</p>
 <p>The standard macOS environment contains the basic tooling needed to
 build, but for external libraries a package manager is recommended. The
 JDK uses <a href="https://brew.sh/">homebrew</a> in the examples, but

--- a/doc/building.md
+++ b/doc/building.md
@@ -355,7 +355,7 @@ earlier versions may also work.
 Starting with Xcode 26, introduced in macOS 26, the Metal toolchain no longer
 comes bundled with Xcode, so it needs to be installed separately. This can
 either be done via the Xcode's Settings/Components UI, or in the command line
-calling `xcodebuild -downloadComponent metalToolchain`.
+calling `xcodebuild -downloadComponent MetalToolchain`.
 
 The standard macOS environment contains the basic tooling needed to build, but
 for external libraries a package manager is recommended. The JDK uses

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -692,6 +692,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_EXTRA],
         AC_MSG_NOTICE([A full XCode is required to build the JDK (not only command line tools)])
         AC_MSG_NOTICE([If you have XCode installed, you might need to reset the Xcode active developer directory])
         AC_MSG_NOTICE([using 'sudo xcode-select -r'])
+        AC_MSG_NOTICE([Starting with Xcode 26, the Metal toolchain is no longer bundled with Xcode.])
+        AC_MSG_NOTICE([Try installing it with 'xcodebuild -downloadComponent MetalToolchain'])
         AC_MSG_ERROR([XCode tool 'metal' neither found in path nor with xcrun])
       else
         AC_MSG_RESULT([yes, will be using '$METAL'])


### PR DESCRIPTION
This makes building much easier to debug on macOS with Xcode 26+

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385525](https://bugs.openjdk.org/browse/JDK-8385525): Suggest Metal toolchain download in configure error on Xcode 26+ (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31293/head:pull/31293` \
`$ git checkout pull/31293`

Update a local copy of the PR: \
`$ git checkout pull/31293` \
`$ git pull https://git.openjdk.org/jdk.git pull/31293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31293`

View PR using the GUI difftool: \
`$ git pr show -t 31293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31293.diff">https://git.openjdk.org/jdk/pull/31293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31293#issuecomment-4555619885)
</details>
