### PR TITLE
8385528: Fix linker alignment warning for libawt on macOS with Xcode 26

### DIFF
--- a/src/java.desktop/share/native/libawt/java2d/loops/AlphaMath.c
+++ b/src/java.desktop/share/native/libawt/java2d/loops/AlphaMath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libawt/java2d/loops/AlphaMath.c
+++ b/src/java.desktop/share/native/libawt/java2d/loops/AlphaMath.c
@@ -26,8 +26,8 @@
 #include "jni.h"
 #include "AlphaMath.h"
 
-JNIEXPORT unsigned char mul8table[256][256];
-JNIEXPORT unsigned char div8table[256][256];
+JNIEXPORT unsigned char mul8table[256][256] = { { 0 } };
+JNIEXPORT unsigned char div8table[256][256] = { { 0 } };
 
 void initAlphaTables()
 {


### PR DESCRIPTION
Building the JDK on macOS with the Xcode 26 linker (ld version 1267) produces:

```
ld: warning: reducing alignment of section __DATA,__common from 0x8000 to 0x4000 because it exceeds segment maximum alignment
```

This comes from libawt, specifically the tentative definitions of `mul8table` and `div8table` in `AlphaMath.c`. These are 64KB uninitialized global arrays that the compiler places in the __common section with 32KB alignment. The Xcode 26 linker caps segment alignment at 16KB (the arm64 page size) and warns when clamping.

The fix is to change the tentative definitions to explicit zero-initialized definitions:

Before:
```c
JNIEXPORT unsigned char mul8table[256][256];
JNIEXPORT unsigned char div8table[256][256];
```

After:
```c
JNIEXPORT unsigned char mul8table[256][256] = { { 0 } };
JNIEXPORT unsigned char div8table[256][256] = { { 0 } };
```

This moves the symbols from __common to __bss, avoiding the alignment warning. Both sections are zero-filled at load time, and `initAlphaTables()` populates the actual values at runtime, so the change is functionally identical. No impact on other platforms.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385528](https://bugs.openjdk.org/browse/JDK-8385528): Fix linker alignment warning for libawt on macOS with Xcode 26 (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31294/head:pull/31294` \
`$ git checkout pull/31294`

Update a local copy of the PR: \
`$ git checkout pull/31294` \
`$ git pull https://git.openjdk.org/jdk.git pull/31294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31294`

View PR using the GUI difftool: \
`$ git pr show -t 31294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31294.diff">https://git.openjdk.org/jdk/pull/31294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31294#issuecomment-4555940523)
</details>
