### PR TITLE
8382249: G1: Racy concurrent update of young gen size and revising young gen length

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -186,8 +186,22 @@ void G1Policy::update_young_length_bounds() {
 void G1Policy::update_young_length_bounds(size_t pending_cards, size_t card_rs_length, size_t code_root_rs_length) {
   uint old_young_list_target_length = young_list_target_length();
 
-  uint new_young_list_desired_length = calculate_young_desired_length(pending_cards, card_rs_length, code_root_rs_length);
-  uint new_young_list_target_length = calculate_young_target_length(new_young_list_desired_length);
+  uint min_young_length_by_sizer = _young_gen_sizer.min_desired_young_length();
+  uint max_young_length_by_sizer = _young_gen_sizer.max_desired_young_length();
+
+  if (max_young_length_by_sizer < min_young_length_by_sizer) {
+    // This can happen due to races with heap_size_changed() at mutator time. Do not update the young gen
+    // lengths. Will be updated on the next regular call anyway.
+    assert(!SafepointSynchronize::is_at_safepoint(), "must be");
+    return;
+  }
+
+  uint new_young_list_desired_length = calculate_young_desired_length(pending_cards,
+                                                                      card_rs_length,
+                                                                      code_root_rs_length,
+                                                                      min_young_length_by_sizer,
+                                                                      max_young_length_by_sizer);
+  uint new_young_list_target_length = calculate_young_target_length(new_young_list_desired_length, min_young_length_by_sizer);
 
   log_trace(gc, ergo, heap)("Young list length update: pending cards %zu card_rs_length %zu old target %u desired: %u target: %u",
                             pending_cards,
@@ -224,9 +238,9 @@ void G1Policy::update_young_length_bounds(size_t pending_cards, size_t card_rs_l
 //
 uint G1Policy::calculate_young_desired_length(size_t pending_cards,
                                               size_t card_rs_length,
-                                              size_t code_root_rs_length) const {
-  uint min_young_length_by_sizer = _young_gen_sizer.min_desired_young_length();
-  uint max_young_length_by_sizer = _young_gen_sizer.max_desired_young_length();
+                                              size_t code_root_rs_length,
+                                              uint min_young_length_by_sizer,
+                                              uint max_young_length_by_sizer) const {
 
   assert(min_young_length_by_sizer >= 1, "invariant");
   assert(max_young_length_by_sizer >= min_young_length_by_sizer, "invariant");
@@ -302,7 +316,7 @@ uint G1Policy::calculate_young_desired_length(size_t pending_cards,
 // Limit the desired (wished) young length by current free regions. If the request
 // can be satisfied without using up reserve regions, do so, otherwise eat into
 // the reserve, giving away at most what the heap sizer allows.
-uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
+uint G1Policy::calculate_young_target_length(uint desired_young_length, uint min_young_length_by_sizer) const {
   uint allocated_young_length = _g1h->young_regions_count();
 
   uint receiving_additional_eden;
@@ -319,7 +333,7 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
     // do, we at most eat the sizer's minimum regions into the reserve or half the
     // reserve rounded up (if possible; this is an arbitrary value).
 
-    uint max_to_eat_into_reserve = MIN2(_young_gen_sizer.min_desired_young_length(),
+    uint max_to_eat_into_reserve = MIN2(min_young_length_by_sizer,
                                         (_reserve_regions + 1) / 2);
 
     log_trace(gc, ergo, heap)("Young target length: Common "

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -160,7 +160,7 @@ void G1Policy::record_new_heap_size(uint new_number_of_regions) {
   double reserve_regions_d = (double) new_number_of_regions * _reserve_factor;
   // We use ceiling so that if reserve_regions_d is > 0.0 (but
   // smaller than 1.0) we'll get 1.
-  _reserve_regions = (uint) ceil(reserve_regions_d);
+  _reserve_regions.store_relaxed((uint) ceil(reserve_regions_d));
 
   _young_gen_sizer.heap_size_changed(new_number_of_regions);
 
@@ -333,8 +333,14 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length, uint min
     // do, we at most eat the sizer's minimum regions into the reserve or half the
     // reserve rounded up (if possible; this is an arbitrary value).
 
+    // The heap reserve needs to be snapshotted for consistent use in the following.
+    // It can be concurrently modified by the mutator as it expands the heap. It can
+    // only increase at that time, so this is a conservative snapshot. So at worst this
+    // method will return a too small young gen length in that case.
+    uint reserve_regions = _reserve_regions.load_relaxed();
+
     uint max_to_eat_into_reserve = MIN2(min_young_length_by_sizer,
-                                        (_reserve_regions + 1) / 2);
+                                        (reserve_regions + 1) / 2);
 
     log_trace(gc, ergo, heap)("Young target length: Common "
                               "free regions at end of collection %u "
@@ -343,14 +349,14 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length, uint min
                               "max to eat into reserve %u",
                               _free_regions_at_end_of_collection,
                               desired_young_length,
-                              _reserve_regions,
+                              reserve_regions,
                               max_to_eat_into_reserve);
 
     uint survivor_regions_count = _g1h->survivor_regions_count();
     uint desired_eden_length = desired_young_length - survivor_regions_count;
     uint allocated_eden_length = allocated_young_length - survivor_regions_count;
 
-    if (_free_regions_at_end_of_collection <= _reserve_regions) {
+    if (_free_regions_at_end_of_collection <= reserve_regions) {
       // Fully eat (or already eating) into the reserve, hand back at most absolute_min_length regions.
       uint receiving_eden = MIN3(_free_regions_at_end_of_collection,
                                   desired_eden_length,
@@ -365,9 +371,9 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length, uint min
       log_trace(gc, ergo, heap)("Young target length: Fully eat into reserve "
                                 "receiving eden %u receiving additional eden %u",
                                 receiving_eden, receiving_additional_eden);
-    } else if (_free_regions_at_end_of_collection < (desired_eden_length + _reserve_regions)) {
+    } else if (_free_regions_at_end_of_collection < (desired_eden_length + reserve_regions)) {
       // Partially eat into the reserve, at most max_to_eat_into_reserve regions.
-      uint free_outside_reserve = _free_regions_at_end_of_collection - _reserve_regions;
+      uint free_outside_reserve = _free_regions_at_end_of_collection - reserve_regions;
       assert(free_outside_reserve < desired_eden_length,
              "must be %u %u",
              free_outside_reserve, desired_eden_length);

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -224,9 +224,13 @@ private:
 
   // Calculate desired young length based on current situation without taking actually
   // available free regions into account.
-  uint calculate_young_desired_length(size_t pending_cards, size_t card_rs_length, size_t code_root_rs_length) const;
+  uint calculate_young_desired_length(size_t pending_cards,
+                                      size_t card_rs_length,
+                                      size_t code_root_rs_length,
+                                      uint min_young_length_by_sizer,
+                                      uint max_young_length_by_sizer) const;
   // Limit the given desired young length to available free regions.
-  uint calculate_young_target_length(uint desired_young_length) const;
+  uint calculate_young_target_length(uint desired_young_length, uint min_young_length_by_sizer) const;
 
   double predict_survivor_regions_evac_time() const;
   double predict_retained_regions_evac_time() const;

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -91,9 +91,11 @@ class G1Policy: public CHeapObj<mtGC> {
   G1SurvRateGroup* _survivor_surv_rate_group;
 
   double _reserve_factor;
-  // This will be set when the heap is expanded
-  // for the first time during initialization.
-  uint   _reserve_regions;
+  // The allocation reserve in number of regions that we try to keep free.
+  // G1 allocation of new regions for eden is restrained when allocating into that reserve.
+  // This intentionally slows down the allocation when the heap is close to full to allow
+  // concurrent marking to finish and hopefully avoid a Full GC.
+  Atomic<uint> _reserve_regions;
 
   G1YoungGenSizer _young_gen_sizer;
 

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "runtime/globals_extension.hpp"
 
 G1YoungGenSizer::G1YoungGenSizer() : _sizer_kind(SizerDefaults),
-  _use_adaptive_sizing(true), _min_desired_young_length(0), _max_desired_young_length(0) {
+  _use_adaptive_sizing(true), _min_desired_young_length(), _max_desired_young_length(0) {
 
   precond(!FLAG_IS_ERGO(NewRatio));
   precond(!FLAG_IS_ERGO(NewSize));
@@ -100,16 +100,16 @@ G1YoungGenSizer::G1YoungGenSizer() : _sizer_kind(SizerDefaults),
   }
 
   if (user_specified_NewSize) {
-    _min_desired_young_length = MAX2((uint)(NewSize / G1HeapRegion::GrainBytes), 1U);
+    _min_desired_young_length.store_relaxed(MAX2((uint)(NewSize / G1HeapRegion::GrainBytes), 1U));
   }
 
   if (user_specified_MaxNewSize) {
-    _max_desired_young_length = MAX2((uint)(MaxNewSize / G1HeapRegion::GrainBytes), 1U);
+    _max_desired_young_length.store_relaxed(MAX2((uint)(MaxNewSize / G1HeapRegion::GrainBytes), 1U));
   }
 
   if (user_specified_NewSize && user_specified_MaxNewSize) {
     _sizer_kind = SizerMaxAndNewSize;
-    _use_adaptive_sizing = _min_desired_young_length != _max_desired_young_length;
+    _use_adaptive_sizing = min_desired_young_length() != max_desired_young_length();
   } else if (user_specified_NewSize) {
     _sizer_kind = SizerNewSizeOnly;
   } else {
@@ -159,20 +159,22 @@ void G1YoungGenSizer::recalculate_min_max_young_length(uint number_of_heap_regio
 }
 
 void G1YoungGenSizer::adjust_max_new_size(uint number_of_heap_regions) {
-
   // We need to pass the desired values because recalculation may not update these
   // values in some cases.
-  uint temp = _min_desired_young_length;
-  uint result = _max_desired_young_length;
-  recalculate_min_max_young_length(number_of_heap_regions, &temp, &result);
+  uint temp = min_desired_young_length();
+  uint new_max = max_desired_young_length();
+  recalculate_min_max_young_length(number_of_heap_regions, &temp, &new_max);
 
-  size_t max_young_size = result * G1HeapRegion::GrainBytes;
+  size_t max_young_size = new_max * G1HeapRegion::GrainBytes;
   if (max_young_size != MaxNewSize) {
     FLAG_SET_ERGO(MaxNewSize, max_young_size);
   }
 }
 
 void G1YoungGenSizer::heap_size_changed(uint new_number_of_heap_regions) {
-  recalculate_min_max_young_length(new_number_of_heap_regions, &_min_desired_young_length,
-          &_max_desired_young_length);
+  uint min = min_desired_young_length();
+  uint max = max_desired_young_length();
+  recalculate_min_max_young_length(new_number_of_heap_regions, &min, &max);
+  _min_desired_young_length.store_relaxed(min);
+  _max_desired_young_length.store_relaxed(max);
 }

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
@@ -161,9 +161,9 @@ void G1YoungGenSizer::recalculate_min_max_young_length(uint number_of_heap_regio
 void G1YoungGenSizer::adjust_max_new_size(uint number_of_heap_regions) {
   // We need to pass the desired values because recalculation may not update these
   // values in some cases.
-  uint temp = min_desired_young_length();
+  uint unused_new_min = min_desired_young_length();
   uint new_max = max_desired_young_length();
-  recalculate_min_max_young_length(number_of_heap_regions, &temp, &new_max);
+  recalculate_min_max_young_length(number_of_heap_regions, &unused_new_min, &new_max);
 
   size_t max_young_size = new_max * G1HeapRegion::GrainBytes;
   if (max_young_size != MaxNewSize) {

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1YOUNGGENSIZER_HPP
 #define SHARE_GC_G1_G1YOUNGGENSIZER_HPP
 
+#include "runtime/atomic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 // There are three command line options related to the young gen size:
@@ -78,8 +79,8 @@ private:
   // true otherwise.
   bool _use_adaptive_sizing;
 
-  uint _min_desired_young_length;
-  uint _max_desired_young_length;
+  Atomic<uint> _min_desired_young_length;
+  Atomic<uint> _max_desired_young_length;
 
   uint calculate_default_min_length(uint new_number_of_heap_regions);
   uint calculate_default_max_length(uint new_number_of_heap_regions);
@@ -96,10 +97,10 @@ public:
 
   virtual void heap_size_changed(uint new_number_of_heap_regions);
   uint min_desired_young_length() const {
-    return _min_desired_young_length;
+    return _min_desired_young_length.load_relaxed();
   }
   uint max_desired_young_length() const {
-    return _max_desired_young_length;
+    return _max_desired_young_length.load_relaxed();
   }
 
   bool use_adaptive_young_list_length() const {


### PR DESCRIPTION
Hi all,

  please review this change that avoids a racy update of `young_list_desired/target` length - G1 could change the heap size while `G1Policy::calculate_young_desired_length` (and `G1Policy::calculate_young_target_length`) read min and max young length by the sizer, making them out of sync.

The proposed solution is to detect this case and not continue updating young gen length bounds - after all this can only happen at mutator time, and there is likely another young length revising call in the queue. At most you'll get a slightly off GC.

I did not try to create a reproducer that has a context switch with heap size update right between reading the two variables.

Testing: gha, tier1-4

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382249](https://bugs.openjdk.org/browse/JDK-8382249): G1: Racy concurrent update of young gen size and revising young gen length (**Bug** - P3)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31295/head:pull/31295` \
`$ git checkout pull/31295`

Update a local copy of the PR: \
`$ git checkout pull/31295` \
`$ git pull https://git.openjdk.org/jdk.git pull/31295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31295`

View PR using the GUI difftool: \
`$ git pr show -t 31295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31295.diff">https://git.openjdk.org/jdk/pull/31295.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31295#issuecomment-4561622915)
</details>
