### PR TITLE
8385430: Shenandoah: Compact heuristic runs continuously when allocation is idle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -32,7 +32,8 @@
 #include "logging/logTag.hpp"
 
 ShenandoahCompactHeuristics::ShenandoahCompactHeuristics(ShenandoahSpaceInfo* space_info) :
-  ShenandoahHeuristics(space_info) {
+  ShenandoahHeuristics(space_info),
+  _bytes_used_at_end_of_gc(0) {
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahUncommit);
@@ -46,9 +47,10 @@ ShenandoahCompactHeuristics::ShenandoahCompactHeuristics(ShenandoahSpaceInfo* sp
 }
 
 bool ShenandoahCompactHeuristics::should_start_gc() {
+  const size_t used = _space_info->used();
   const size_t capacity = ShenandoahHeap::heap()->soft_max_capacity();
   const size_t available = _space_info->soft_mutator_available();
-  const size_t bytes_allocated = estimate_bytes_allocated_since_gc_start();
+  const size_t bytes_allocated = used > _bytes_used_at_end_of_gc ? used - _bytes_used_at_end_of_gc : 0;
 
   log_debug(gc, ergo)("should_start_gc calculation: available: " PROPERFMT ", soft_max_capacity: "  PROPERFMT ", "
                 "allocated_since_gc_start: "  PROPERFMT,
@@ -74,6 +76,11 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   return ShenandoahHeuristics::should_start_gc();
 }
 
+void ShenandoahCompactHeuristics::record_cycle_end() {
+  ShenandoahHeuristics::record_cycle_end();
+  _bytes_used_at_end_of_gc = _space_info->used();
+}
+
 void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(ShenandoahCollectionSet* cset,
                                                                         RegionData* data, size_t size,
                                                                         size_t actual_free) {
@@ -93,12 +100,4 @@ void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(Shenando
       cset->add_region(r);
     }
   }
-}
-
-size_t ShenandoahCompactHeuristics::estimate_bytes_allocated_since_gc_start() const {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  const double average_allocation_rate = heap->alloc_rate().weighted_average();
-  const double now = os::elapsedTime();
-  const double elapsed_seconds = now - cycle_start_time_seconds();
-  return shenandoah_safe_size_cast(average_allocation_rate * elapsed_seconds);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.hpp
@@ -41,13 +41,15 @@ public:
   bool is_diagnostic() override   { return false; }
   bool is_experimental() override { return false; }
 
+  void record_cycle_end() override;
+
 protected:
   void choose_collection_set_from_regiondata(ShenandoahCollectionSet* cset,
                                              RegionData* data, size_t size,
                                              size_t actual_free) override;
 
 private:
-  size_t estimate_bytes_allocated_since_gc_start() const;
+  size_t _bytes_used_at_end_of_gc;
 };
 
 #endif // SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHCOMPACTHEURISTICS_HPP


### PR DESCRIPTION
The recent changes to allocation rate sampling [JDK-8383892](https://bugs.openjdk.org/browse/JDK-8383892) left the compact heuristic with an incorrectly high estimation of bytes allocated since GC. Though the general fix applies to the new allocation rate sampling, this is a specific fix to the compact heuristic to trigger off changes in `used` instead of attempting to replicate the `bytes allocated since gc` concept using the estimated allocation rate.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385430](https://bugs.openjdk.org/browse/JDK-8385430): Shenandoah: Compact heuristic runs continuously when allocation is idle (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31298/head:pull/31298` \
`$ git checkout pull/31298`

Update a local copy of the PR: \
`$ git checkout pull/31298` \
`$ git pull https://git.openjdk.org/jdk.git pull/31298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31298`

View PR using the GUI difftool: \
`$ git pr show -t 31298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31298.diff">https://git.openjdk.org/jdk/pull/31298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31298#issuecomment-4557022419)
</details>
