### PR TITLE
8385017: Null pointer dereference in java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java:204

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,6 +201,9 @@ public final class ModelByteBuffer {
     public void writeTo(OutputStream out) throws IOException {
         if (root.file != null && root.buffer == null) {
             try (InputStream is = getInputStream()) {
+                if (is == null) {
+                   throw new IOException("null stream");
+                }
                 is.transferTo(out);
             }
         } else
@@ -321,6 +324,8 @@ public final class ModelByteBuffer {
             buffer = new byte[(int) capacity()];
             offset = 0;
             dis.readFully(buffer);
+        } catch (NullPointerException npe) {
+            throw new IOException("input stream is null", npe);
         }
 
     }

--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBufferWavetable.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBufferWavetable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,8 +195,9 @@ public final class ModelByteBufferWavetable implements ModelWavetable {
 
     @Override
     public AudioFloatInputStream openStream() {
-        if (buffer == null)
+        if (buffer == null) {
             return null;
+        }
         if (format == null) {
             InputStream is = buffer.getInputStream();
             AudioInputStream ais = null;
@@ -209,8 +210,12 @@ public final class ModelByteBufferWavetable implements ModelWavetable {
             return AudioFloatInputStream.getInputStream(ais);
         }
         if (buffer.array() == null) {
+            InputStream is = buffer.getInputStream();
+            if (is == null) {
+                return null;
+            }
             return AudioFloatInputStream.getInputStream(new AudioInputStream(
-                    buffer.getInputStream(), format,
+                    is, format,
                     buffer.capacity() / format.getFrameSize()));
         }
         if (buffer8 != null) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBufferWavetable.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBufferWavetable.java
@@ -200,6 +200,9 @@ public final class ModelByteBufferWavetable implements ModelWavetable {
         }
         if (format == null) {
             InputStream is = buffer.getInputStream();
+            if (is == null) {
+                return null;
+            }
             AudioInputStream ais = null;
             try {
                 ais = AudioSystem.getAudioInputStream(is);

--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBufferWavetable.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBufferWavetable.java
@@ -245,7 +245,8 @@ public final class ModelByteBufferWavetable implements ModelWavetable {
 
     @Override
     public int getChannels() {
-        return getFormat().getChannels();
+        AudioFormat format = getFormat();
+        return (format != null) ? format.getChannels() : 1;
     }
 
     @Override

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftAbstractResampler.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftAbstractResampler.java
@@ -96,6 +96,9 @@ public abstract class SoftAbstractResampler implements SoftResampler {
             }
 
             stream = osc.openStream();
+            if (stream == null) {
+                throw new IOException("null stream");
+            }
             streampos = 0;
             stream_eof = false;
             pitchcorrection = osc.getPitchcorrection();

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftVoice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftVoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -662,7 +662,9 @@ public final class SoftVoice extends VoiceStatus {
             for (int i = 0; i < performer.ctrl_connections.length; i++)
                 processConnection(performer.ctrl_connections[i]);
 
-            osc_stream.setPitch((float)co_osc_pitch[0]);
+            if (osc_stream != null) {
+                osc_stream.setPitch((float)co_osc_pitch[0]);
+            }
 
             int filter_type = (int)co_filter_type[0];
             double filter_freq;
@@ -829,7 +831,10 @@ public final class SoftVoice extends VoiceStatus {
             osc_buff[0] = buffer[SoftMainMixer.CHANNEL_LEFT_DRY].array();
             if (nrofchannels != 1)
                 osc_buff[1] = buffer[SoftMainMixer.CHANNEL_RIGHT_DRY].array();
-            int ret = osc_stream.read(osc_buff, 0, bufferlen);
+            int ret = -1;
+            if (osc_stream != null) {
+                ret = osc_stream.read(osc_buff, 0, bufferlen);
+            }
             if (ret == -1) {
                 stopping = true;
                 return;


### PR DESCRIPTION
A fix for a theoretical NPE because a method might return null and it is used.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385017](https://bugs.openjdk.org/browse/JDK-8385017): Null pointer dereference in java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java:204 (**Bug** - P3)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) 🔄 Re-review required (review applies to [89acf694](https://git.openjdk.org/jdk/pull/31299/files/89acf6942696c047de2d212bac90d8108844ae39))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31299/head:pull/31299` \
`$ git checkout pull/31299`

Update a local copy of the PR: \
`$ git checkout pull/31299` \
`$ git pull https://git.openjdk.org/jdk.git pull/31299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31299`

View PR using the GUI difftool: \
`$ git pr show -t 31299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31299.diff">https://git.openjdk.org/jdk/pull/31299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31299#issuecomment-4557037464)
</details>
