### PR TITLE
8385552: Improve devkit/sysroot creation

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -394,11 +394,11 @@ to date at the time of writing.</p>
 <tbody>
 <tr class="odd">
 <td>Linux/x64</td>
-<td>Oracle Enterprise Linux 6.4 / 8.x</td>
+<td>Oracle Linux 6.4 / 8.x</td>
 </tr>
 <tr class="even">
 <td>Linux/aarch64</td>
-<td>Oracle Enterprise Linux 7.6 / 8.x</td>
+<td>Oracle Linux 7.6 / 8.x</td>
 </tr>
 <tr class="odd">
 <td>macOS</td>
@@ -1495,26 +1495,24 @@ following targets are known to work:</p>
 </tr>
 </tbody>
 </table>
-<p><code>BASE_OS</code> must be one of <code>OL</code> for Oracle
-Enterprise Linux or <code>Fedora</code>. If the base OS is
-<code>Fedora</code> the corresponding Fedora release can be specified
-with the help of the <code>BASE_OS_VERSION</code> option. If the build
-is successful, the new devkits can be found in the
+<p><code>BASE_OS</code> must be one of <code>OL</code> for Oracle Linux
+or <code>Fedora</code>. The release/version of the base OS can be
+specified using the <code>BASE_OS_VERSION</code> option. If the build is
+successful, the new devkits can be found in the
 <code>build/devkit/result</code> subdirectory:</p>
 <pre><code>cd make/devkit
-make TARGETS=&quot;ppc64le-linux-gnu aarch64-linux-gnu&quot; BASE_OS=Fedora BASE_OS_VERSION=21
+make TARGETS=&quot;ppc64le-linux-gnu aarch64-linux-gnu&quot; BASE_OS=Fedora
 ls -1 ../../build/devkit/result/
 x86_64-linux-gnu-to-aarch64-linux-gnu
 x86_64-linux-gnu-to-ppc64le-linux-gnu</code></pre>
 <p>Notice that devkits are not only useful for targeting different build
 platforms. Because they contain the full build dependencies for a system
-(i.e. compiler and root file system), they can easily be used to build
-well-known, reliable and reproducible build environments. You can for
-example create and use a devkit with GCC 7.3 and a Fedora 12 sysroot
-environment (with glibc 2.11) on Ubuntu 14.04 (which doesn't have GCC
-7.3 by default) to produce JDK binaries which will run on all Linux
-systems with runtime libraries newer than the ones from Fedora 12 (e.g.
-Ubuntu 16.04, SLES 11 or RHEL 6).</p>
+(i.e., compiler and root file system/sysroot), they can easily be used
+to build well-known, reliable, and reproducible build environments. You
+can, for example, create and use a devkit with a version of the GCC
+compiler not provided by the host OS, using a sysroot from an older
+Linux distribution to produce JDK binaries which will run on all Linux
+systems with newer runtime libraries.</p>
 <h4 id="using-debian-debootstrap">Using Debian debootstrap</h4>
 <p>On Debian (or a derivative like Ubuntu), you can create sysroots for
 foreign architectures with tools provided by the OS. You can use

--- a/doc/building.md
+++ b/doc/building.md
@@ -195,8 +195,8 @@ time of writing.
 
 | Operating system  | Vendor/version used                |
 | ----------------- | ---------------------------------- |
-| Linux/x64         | Oracle Enterprise Linux 6.4 / 8.x  |
-| Linux/aarch64     | Oracle Enterprise Linux 7.6 / 8.x  |
+| Linux/x64         | Oracle Linux 6.4 / 8.x             |
+| Linux/aarch64     | Oracle Linux 7.6 / 8.x             |
 | macOS             | macOS 14.x                         |
 | Windows           | Windows Server 2016                |
 
@@ -1288,27 +1288,26 @@ at least the following targets are known to work:
 | riscv64-linux-gnu        |
 | s390x-linux-gnu          |
 
-`BASE_OS` must be one of `OL` for Oracle Enterprise Linux or `Fedora`. If the
-base OS is `Fedora` the corresponding Fedora release can be specified with the
-help of the `BASE_OS_VERSION` option. If the build is successful, the new
-devkits can be found in the `build/devkit/result` subdirectory:
+`BASE_OS` must be one of `OL` for Oracle Linux or `Fedora`. The release/version
+of the base OS can be specified using the `BASE_OS_VERSION` option. If the build
+is successful, the new devkits can be found in the `build/devkit/result`
+subdirectory:
 
 ```
 cd make/devkit
-make TARGETS="ppc64le-linux-gnu aarch64-linux-gnu" BASE_OS=Fedora BASE_OS_VERSION=21
+make TARGETS="ppc64le-linux-gnu aarch64-linux-gnu" BASE_OS=Fedora
 ls -1 ../../build/devkit/result/
 x86_64-linux-gnu-to-aarch64-linux-gnu
 x86_64-linux-gnu-to-ppc64le-linux-gnu
 ```
 
 Notice that devkits are not only useful for targeting different build
-platforms. Because they contain the full build dependencies for a system (i.e.
-compiler and root file system), they can easily be used to build well-known,
-reliable and reproducible build environments. You can for example create and
-use a devkit with GCC 7.3 and a Fedora 12 sysroot environment (with glibc 2.11)
-on Ubuntu 14.04 (which doesn't have GCC 7.3 by default) to produce JDK binaries
-which will run on all Linux systems with runtime libraries newer than the ones
-from Fedora 12 (e.g. Ubuntu 16.04, SLES 11 or RHEL 6).
+platforms. Because they contain the full build dependencies for a system (i.e.,
+compiler and root file system/sysroot), they can easily be used to build
+well-known, reliable, and reproducible build environments. You can, for example,
+create and use a devkit with a version of the GCC compiler not provided by the
+host OS, using a sysroot from an older Linux distribution to produce JDK
+binaries which will run on all Linux systems with newer runtime libraries.
 
 #### Using Debian debootstrap
 

--- a/make/devkit/Common.gmk
+++ b/make/devkit/Common.gmk
@@ -50,14 +50,23 @@ ifeq ($(BASE_OS), OL)
     $(error Only "aarch64 x86_64" architectures are supported for OL, but "$(ARCH)" was requested)
   endif
   BASE_OS_VERSION ?= 7
-  ifeq ($(BASE_OS_VERSION), 7)
+  ifeq ($(BASE_OS_VERSION), 6)
+    ifeq ($(filter x86_64, $(ARCH)), )
+      $(error Only "x86_64" architectures are supported for OL6, but "$(ARCH)" was requested)
+    endif
+    BASE_OS_DESCRIPTION_VERSION := 6.4
+    REPO_BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL6/4
+    BASE_OS_REPOS := base,$(REPO_BASE_URL)/base/$(ARCH)
+  else ifeq ($(BASE_OS_VERSION), 7)
+    BASE_OS_DESCRIPTION_VERSION := 7.6
     REPO_BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL7/6
     BASE_OS_REPOS := base,$(REPO_BASE_URL)/base/$(ARCH)
   else
     REPO_BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL$(BASE_OS_VERSION)
     BASE_OS_REPOS := baseos,$(REPO_BASE_URL)/baseos/latest/$(ARCH) appstream,$(REPO_BASE_URL)/appstream/$(ARCH)
+    BASE_OS_DESCRIPTION_VERSION := $(BASE_OS_VERSION)
   endif
-  BASE_OS_DESCRIPTION := OL$(BASE_OS_VERSION)
+  BASE_OS_DESCRIPTION := OL$(BASE_OS_DESCRIPTION_VERSION)
 else ifeq ($(BASE_OS), Fedora)
   ifeq ($(filter aarch64 armhfp ppc64le riscv64 s390x x86_64, $(ARCH)), )
     $(error Only "aarch64 armhfp ppc64le riscv64 s390x x86_64" architectures are supported for Fedora, but "$(ARCH)" was requested)

--- a/make/devkit/Common.gmk
+++ b/make/devkit/Common.gmk
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+ARCH := $(word 1,$(subst -, ,$(TARGET)))
+
+ifeq ($(TARGET), arm-linux-gnueabihf)
+  ARCH=armhfp
+endif
+
+$(info ARCH=$(ARCH))
+
+ifeq ($(PREFIX),)
+  $(error PREFIX not set)
+endif
+
+BUILDDIR := $(OUTPUT_ROOT)/$(HOST)/$(TARGET)
+TARGETDIR := $(PREFIX)/$(TARGET)
+SYSROOT := $(TARGETDIR)/sysroot
+
+# Base OS information and repositories
+#
+# BASE_OS_REPOS is a space-separated set of repositories. Each entry
+# is of the format <repo_name>,<url> where <repo_name> is a unique
+# identifier across the set of repositories.
+
+ifeq ($(BASE_OS), OL)
+  ifeq ($(filter aarch64 x86_64, $(ARCH)), )
+    $(error Only "aarch64 x86_64" architectures are supported for OL, but "$(ARCH)" was requested)
+  endif
+  BASE_OS_VERSION ?= 7
+  ifeq ($(BASE_OS_VERSION), 7)
+    REPO_BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL7/6
+    BASE_OS_REPOS := base,$(REPO_BASE_URL)/base/$(ARCH)
+  else
+    REPO_BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL$(BASE_OS_VERSION)
+    BASE_OS_REPOS := baseos,$(REPO_BASE_URL)/baseos/latest/$(ARCH) appstream,$(REPO_BASE_URL)/appstream/$(ARCH)
+  endif
+  BASE_OS_DESCRIPTION := OL$(BASE_OS_VERSION)
+else ifeq ($(BASE_OS), Fedora)
+  ifeq ($(filter aarch64 armhfp ppc64le riscv64 s390x x86_64, $(ARCH)), )
+    $(error Only "aarch64 armhfp ppc64le riscv64 s390x x86_64" architectures are supported for Fedora, but "$(ARCH)" was requested)
+  endif
+  ifeq ($(ARCH), riscv64)
+    BASE_OS_VERSION ?= 43
+    BASE_OS_BUILD := 6640
+    REPO_BASE_URL := https://riscv-koji.fedoraproject.org/repos-dist/f$(BASE_OS_VERSION)/$(BASE_OS_BUILD)/riscv64
+    BASE_OS_REPOS := riscv64,$(REPO_BASE_URL)
+  else
+    ifeq ($(ARCH), armhfp)
+      BASE_OS_VERSION ?= 36
+    else
+      BASE_OS_VERSION ?= 41
+    endif
+    ifeq ($(ARCH), armhfp)
+      ifneq ($(BASE_OS_VERSION), 36)
+        $(error Fedora 36 is the last release supporting "armhfp", but $(BASE_OS_VERSION) was requested)
+      endif
+    endif
+    LATEST_ARCHIVED_OS_VERSION := 41
+    ifeq ($(filter aarch64 x86_64 armhfp, $(ARCH)), )
+      FEDORA_TYPE := fedora-secondary
+    else
+      FEDORA_TYPE := fedora/linux
+    endif
+    NOT_ARCHIVED := $(shell [ $(BASE_OS_VERSION) -gt $(LATEST_ARCHIVED_OS_VERSION) ] && echo true)
+    ifeq ($(NOT_ARCHIVED),true)
+      RPM_REPO_URL := https://dl.fedoraproject.org/pub/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os
+    else
+      RPM_REPO_URL := https://archives.fedoraproject.org/pub/archive/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os
+    endif
+    BASE_OS_REPOS := os,$(RPM_REPO_URL)
+  endif
+  BASE_OS_DESCRIPTION := Fedora_$(BASE_OS_VERSION)
+else
+  $(error Unknown base OS $(BASE_OS))
+endif

--- a/make/devkit/Makefile
+++ b/make/devkit/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@
 #
 # make TARGETS="aarch64-linux-gnu" BASE_OS=Fedora
 # or
-# make TARGETS="arm-linux-gnueabihf ppc64le-linux-gnu" BASE_OS=Fedora BASE_OS_VERSION=17
+# make TARGETS="aarch64-linux-gnu ppc64le-linux-gnu" BASE_OS=Fedora BASE_OS_VERSION=41
 #
 # to build several devkits for a specific OS version at once.
 # You can find the final results under ../../build/devkit/result/<host>-to-<target>
@@ -50,7 +50,7 @@
 # makefile again for cross compilation. Ex:
 #
 # PATH=$PWD/../../build/devkit/result/x86_64-linux-gnu-to-x86_64-linux-gnu/bin:$PATH \
-#    make TARGETS="arm-linux-gnueabihf ppc64le-linux-gnu" BASE_OS=Fedora
+#    make TARGETS="aarch64-linux-gnu ppc64le-linux-gnu" BASE_OS=Fedora
 #
 # This is the makefile which iterates over all host and target platforms.
 #
@@ -79,10 +79,10 @@ TARGET_PLATFORMS := $(PLATFORMS)
 $(info HOST_PLATFORMS $(HOST_PLATFORMS))
 $(info TARGET_PLATFORMS $(TARGET_PLATFORMS))
 
-all compile : $(PLATFORMS)
+all compile: $(PLATFORMS)
 
 ifeq ($(SKIP_ME), )
-  $(foreach p,$(filter-out $(ME),$(PLATFORMS)),$(eval $(p) : $$(ME)))
+  $(foreach p,$(filter-out $(ME),$(PLATFORMS)),$(eval $(p): $$(ME)))
 endif
 
 OUTPUT_ROOT = $(abspath ../../build/devkit)
@@ -90,38 +90,39 @@ RESULT = $(OUTPUT_ROOT)/result
 
 SUBMAKEVARS = HOST=$@ BUILD=$(ME) RESULT=$(RESULT) OUTPUT_ROOT=$(OUTPUT_ROOT)
 
-$(HOST_PLATFORMS) :
+$(HOST_PLATFORMS):
 	@echo 'Building compilers for $@'
 	@echo 'Targets: $(TARGET_PLATFORMS)'
 	for p in $(filter $@, $(TARGET_PLATFORMS)) $(filter-out $@, $(TARGET_PLATFORMS)); do \
-	  $(MAKE) -f Tools.gmk download-rpms $(SUBMAKEVARS) \
+	  $(MAKE) -f Sysroot.gmk sysroot $(SUBMAKEVARS) \
               TARGET=$$p PREFIX=$(RESULT)/$@-to-$$p && \
 	  $(MAKE) -f Tools.gmk all $(SUBMAKEVARS) \
               TARGET=$$p PREFIX=$(RESULT)/$@-to-$$p && \
 	  $(MAKE) -f Tools.gmk ccache $(SUBMAKEVARS) \
               TARGET=$@ PREFIX=$(RESULT)/$@-to-$$p || exit 1 ; \
 	done
-	@echo 'All done"'
+	@echo 'All done'
 
 TODAY := $(shell date +%Y%m%d)
 
 define Mktar
   $(1)-to-$(2)_tar = $$(RESULT)/sdk-$(1)-to-$(2)-$$(TODAY).tar.gz
-  $$($(1)-to-$(2)_tar) : PLATFORM = $(1)-to-$(2)
+  $$($(1)-to-$(2)_tar): PLATFORM = $(1)-to-$(2)
   TARFILES += $$($(1)-to-$(2)_tar)
 endef
 
 $(foreach p,$(HOST_PLATFORMS),$(foreach t,$(TARGET_PLATFORMS),$(eval $(call Mktar,$(p),$(t)))))
 
-tars : all $(TARFILES)
-onlytars : $(TARFILES)
-%.tar.gz :
+tars: all $(TARFILES)
+onlytars: $(TARFILES)
+
+%.tar.gz:
 	$(MAKE) -r -f Tars.gmk SRC_DIR=$(RESULT)/$(PLATFORM) TAR_FILE=$@
 
-clean :
+clean:
 	rm -rf $(addprefix ../../build/devkit/, result $(HOST_PLATFORMS))
+
 dist-clean: clean
 	rm -rf $(addprefix ../../build/devkit/, src download)
 
-FORCE :
-.PHONY : all compile tars $(HOST_PLATFORMS) clean dist-clean
+.PHONY: all compile tars $(HOST_PLATFORMS) clean dist-clean

--- a/make/devkit/Makefile
+++ b/make/devkit/Makefile
@@ -99,7 +99,7 @@ $(HOST_PLATFORMS):
 	  $(MAKE) -f Tools.gmk all $(SUBMAKEVARS) \
               TARGET=$$p PREFIX=$(RESULT)/$@-to-$$p && \
 	  $(MAKE) -f Tools.gmk ccache $(SUBMAKEVARS) \
-              TARGET=$@ PREFIX=$(RESULT)/$@-to-$$p || exit 1 ; \
+              TARGET=$@ PREFIX=$(RESULT)/$@-to-$$p || exit 1; \
 	done
 	@echo 'All done'
 

--- a/make/devkit/Sysroot.gmk
+++ b/make/devkit/Sysroot.gmk
@@ -1,0 +1,207 @@
+#
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+include Common.gmk
+
+$(info TARGET=$(TARGET))
+$(info HOST=$(HOST))
+$(info BUILD=$(BUILD))
+
+ifeq ($(BASE_OS)-$(BASE_OS_VERSION)-$(ARCH), OL-7-aarch64)
+  KERNEL_HEADERS_RPM := kernel-uek-headers
+else
+  KERNEL_HEADERS_RPM := kernel-headers
+endif
+
+ZLIB_RPMS := zlib zlib-devel
+ifeq ($(BASE_OS), Fedora)
+  ifneq ($(ARCH), armhfp)
+    ZLIB_RPMS := zlib-ng zlib-ng-devel
+  endif
+endif
+
+
+################################################################################
+
+# RPMs to include
+RPM_LIST := \
+    filesystem \
+    $(KERNEL_HEADERS_RPM) \
+    glibc glibc-devel \
+    cups-libs cups-devel \
+    libX11 libX11-devel \
+    libxcb xorg-x11-proto-devel \
+    alsa-lib alsa-lib-devel \
+    libXext libXext-devel \
+    libXtst libXtst-devel \
+    libXrender libXrender-devel \
+    libXrandr libXrandr-devel \
+    freetype freetype-devel \
+    libXt libXt-devel \
+    libSM libSM-devel \
+    libICE libICE-devel \
+    libXi libXi-devel \
+    libXau libXau-devel \
+    libgcc \
+    $(ZLIB_RPMS) \
+    libffi libffi-devel \
+    fontconfig fontconfig-devel \
+    systemtap-sdt-devel \
+    wayland-devel wayland-protocols-devel \
+    #
+
+################################################################################
+# Define common directories and files
+
+DOWNLOAD := $(OUTPUT_ROOT)/download
+DOWNLOAD_RPMS := $(DOWNLOAD)/rpms/$(TARGET)-$(BASE_OS)-$(BASE_OS_VERSION)
+SRCDIR := $(OUTPUT_ROOT)/src
+
+################################################################################
+# Marker files
+
+DOWNLOAD_RPMS_MARKER := $(BUILDDIR)/download-rpms.marker
+RPMS_UNPACKED_MARKER := $(BUILDDIR)/rpms_unpacked.marker
+UNPATCHED_SYSROOT_MARKER := $(BUILDDIR)/sysroot_unpatched.marker
+PATCHED_SYSROOT_MARKER := $(BUILDDIR)/sysroot_patched.marker
+
+################################################################################
+# Download RPMs
+
+ifeq ($(ARCH), armhfp)
+  RPM_ARCH := armv7hl
+else
+  RPM_ARCH := $(ARCH)
+endif
+
+RPM_ARCHS := $(RPM_ARCH) noarch
+ifeq ($(ARCH), x86_64)
+  # Enable mixed mode.
+  RPM_ARCHS += i386 i686
+endif
+
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
+COMMA := ,
+DNF_ARCHS := $(subst $(SPACE),$(COMMA),$(RPM_ARCHS))
+
+# Specify a dummy installation root, otherwise dnf will run into
+# problems trying to reconcile with the local/system state
+DNF_DUMMY_INSTALL_ROOT := $(BUILDDIR)/dnf-dummy-install-root
+
+DNF_REPOS := $(foreach repo, $(BASE_OS_REPOS), \
+    --repofrompath $(repo) \
+    --enablerepo $(word 1,$(subst $(COMMA),$(SPACE),$(repo))))
+
+DNF_DOWNLOAD_FLAGS := \
+    --disablerepo='*' \
+    $(DNF_REPOS) \
+    --resolve \
+    --archlist $(DNF_ARCHS) \
+    --forcearch $(RPM_ARCH) \
+    --installroot $(DNF_DUMMY_INSTALL_ROOT) \
+    --releasever $(BASE_OS_VERSION) \
+    #
+
+$(DOWNLOAD_RPMS_MARKER):
+	@mkdir -p $(@D)
+	mkdir -p $(DOWNLOAD_RPMS)
+        # Only run this if rpm dir is empty.
+        ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
+	  echo $(RPM_LIST) | \
+	      xargs dnf download $(DNF_DOWNLOAD_FLAGS) --destdir $(DOWNLOAD_RPMS)
+        endif
+	ls $(DOWNLOAD_RPMS)/*.rpm > /dev/null 2>&1 || \
+	    { echo "Failed to download rpms"; exit 1; }
+	touch $@
+
+################################################################################
+# Unpack RPMS
+
+RPM_PATTERNS := $(foreach arch,$(RPM_ARCHS),$(DOWNLOAD_RPMS)/*.$(arch).rpm)
+
+CPIO_EXCLUDES := \
+    "./usr/share/doc/*" \
+    "./usr/share/man/*" \
+    "./usr/X11R6/man/*" \
+    "*/X11/locale/*" \
+    #
+
+$(RPMS_UNPACKED_MARKER): $(DOWNLOAD_RPMS_MARKER)
+	$(info Unpacking target rpms and libraries)
+	mkdir -p $(SYSROOT)
+        # The -e test below is needed to skip unmatched glob patterns
+	( \
+	    cd $(SYSROOT); \
+	    for rpm in $(RPM_PATTERNS); do \
+	        if [ ! -e "$$rpm" ]; then continue; fi; \
+	        echo Extracting $$rpm...; \
+	        rpm2cpio $$rpm | \
+	            cpio --extract --make-directories -f $(CPIO_EXCLUDES) \
+	            || exit 1; \
+	    done \
+	)
+	touch $@
+
+################################################################################
+
+$(UNPATCHED_SYSROOT_MARKER): $(RPMS_UNPACKED_MARKER)
+	touch $@
+
+################################################################################
+# Patch sysroot
+
+# Note: MUST create a <sysroot>/usr/lib even if not really needed.
+# gcc will use a path relative to it to resolve lib64. (x86_64).
+# we're creating multi-lib compiler with 32bit libc as well, so we should
+# have it anyway, but just to make sure...
+# Patch GNU ld scripts to force linking against libraries in the sysroot
+# and not the ones installed on the build machine.
+
+LD_SCRIPT_PATCHES := \
+    -e 's|/usr/lib64/||g' \
+    -e 's|/usr/lib/||g' \
+    -e 's|/lib64/||g' \
+    -e 's|/lib/||g' \
+    #
+
+$(PATCHED_SYSROOT_MARKER): $(UNPATCHED_SYSROOT_MARKER)
+	@echo Patching GNU ld scripts
+	@(for f in $$(find $(SYSROOT) -name "*.so" -type f 2>/dev/null); do \
+	    if grep -Iq 'GNU ld script' "$$f"; then \
+	        sed $(LD_SCRIPT_PATCHES) "$$f" > "$$f.tmp" && \
+	        mv "$$f.tmp" "$$f"; \
+	    fi; \
+	done)
+	@mkdir -p $(SYSROOT)/usr/lib
+	@touch $@
+
+################################################################################
+
+download-rpms: $(DOWNLOAD_RPMS_MARKER)
+unpatched-sysroot: $(UNPATCHED_SYSROOT_MARKER)
+sysroot: $(PATCHED_SYSROOT_MARKER)
+
+.PHONY: download-rpms unpatched-sysroot sysroot

--- a/make/devkit/Sysroot.gmk
+++ b/make/devkit/Sysroot.gmk
@@ -133,8 +133,6 @@ $(DOWNLOAD_RPMS_MARKER):
 	  echo $(RPM_LIST) | \
 	      xargs dnf download $(DNF_DOWNLOAD_FLAGS) --destdir $(DOWNLOAD_RPMS)
         endif
-	ls $(DOWNLOAD_RPMS)/*.rpm > /dev/null 2>&1 || \
-	    { echo "Failed to download rpms"; exit 1; }
 	touch $@
 
 ################################################################################
@@ -150,18 +148,18 @@ CPIO_EXCLUDES := \
     #
 
 $(RPMS_UNPACKED_MARKER): $(DOWNLOAD_RPMS_MARKER)
-	$(info Unpacking target rpms and libraries)
-	mkdir -p $(SYSROOT)
+	if [ -d $(SYSROOT) ]; then echo "WARNING: Sysroot directory ($(SYSROOT)) already exists, proceeding anyway..."; fi
+	@mkdir -p $(SYSROOT)
         # The -e test below is needed to skip unmatched glob patterns
 	( \
-	    cd $(SYSROOT); \
-	    for rpm in $(RPM_PATTERNS); do \
-	        if [ ! -e "$$rpm" ]; then continue; fi; \
-	        echo Extracting $$rpm...; \
-	        rpm2cpio $$rpm | \
-	            cpio --extract --make-directories -f $(CPIO_EXCLUDES) \
+	  cd $(SYSROOT); \
+	  for rpm in $(RPM_PATTERNS); do \
+	    if [ ! -e "$$rpm" ]; then continue; fi; \
+	    echo Extracting $$rpm...; \
+	    rpm2cpio $$rpm | \
+	        cpio --extract --make-directories -f $(CPIO_EXCLUDES) \
 	            || exit 1; \
-	    done \
+	  done \
 	)
 	touch $@
 
@@ -189,12 +187,14 @@ LD_SCRIPT_PATCHES := \
 
 $(PATCHED_SYSROOT_MARKER): $(UNPATCHED_SYSROOT_MARKER)
 	@echo Patching GNU ld scripts
-	@(for f in $$(find $(SYSROOT) -name "*.so" -type f 2>/dev/null); do \
+	@( \
+	  for f in $$(find $(SYSROOT) -name "*.so" -type f 2>/dev/null); do \
 	    if grep -Iq 'GNU ld script' "$$f"; then \
-	        sed $(LD_SCRIPT_PATCHES) "$$f" > "$$f.tmp" && \
-	        mv "$$f.tmp" "$$f"; \
+	      sed $(LD_SCRIPT_PATCHES) "$$f" > "$$f.tmp" && \
+	      mv "$$f.tmp" "$$f"; \
 	    fi; \
-	done)
+	  done \
+	)
 	@mkdir -p $(SYSROOT)/usr/lib
 	@touch $@
 

--- a/make/devkit/Sysroot.gmk
+++ b/make/devkit/Sysroot.gmk
@@ -35,6 +35,10 @@ else
   KERNEL_HEADERS_RPM := kernel-headers
 endif
 
+ifneq ($(BASE_OS)-$(BASE_OS_VERSION), OL-6)
+  WAYLAND_RPMS := wayland-devel wayland-protocols-devel
+endif
+
 ZLIB_RPMS := zlib zlib-devel
 ifeq ($(BASE_OS), Fedora)
   ifneq ($(ARCH), armhfp)
@@ -69,7 +73,7 @@ RPM_LIST := \
     libffi libffi-devel \
     fontconfig fontconfig-devel \
     systemtap-sdt-devel \
-    wayland-devel wayland-protocols-devel \
+    $(WAYLAND_RPMS) \
     #
 
 ################################################################################
@@ -128,11 +132,8 @@ DNF_DOWNLOAD_FLAGS := \
 $(DOWNLOAD_RPMS_MARKER):
 	@mkdir -p $(@D)
 	mkdir -p $(DOWNLOAD_RPMS)
-        # Only run this if rpm dir is empty.
-        ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
-	  echo $(RPM_LIST) | \
-	      xargs dnf download $(DNF_DOWNLOAD_FLAGS) --destdir $(DOWNLOAD_RPMS)
-        endif
+	echo $(RPM_LIST) | \
+	    xargs dnf download $(DNF_DOWNLOAD_FLAGS) --destdir $(DOWNLOAD_RPMS)
 	touch $@
 
 ################################################################################

--- a/make/devkit/Tars.gmk
+++ b/make/devkit/Tars.gmk
@@ -41,7 +41,7 @@ default: tars
 
 tars: $(TAR_FILE)
 
-$(TAR_FILE): $(shell find $(SRC_DIR) -type f)
+$(TAR_FILE): $(shell find $(SRC_DIR) -type f | sed 's/ /\\ /g')
 	@echo 'Creating compiler package $@'
 	cd $(dir $(SRC_DIR)) && tar -czf $@ $(notdir $(SRC_DIR))/*
 	touch $@

--- a/make/devkit/Tars.gmk
+++ b/make/devkit/Tars.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ endif
 
 default: tars
 
-tars : $(TAR_FILE)
+tars: $(TAR_FILE)
 
 $(TAR_FILE): $(shell find $(SRC_DIR) -type f)
 	@echo 'Creating compiler package $@'

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -143,8 +143,8 @@ define DownloadVerify
 	mkdir -p $$(SRCDIR)
 	tar -C $$(SRCDIR) -xf $$<
 	$$(foreach p,$$(abspath $$(wildcard patches/$$(ARCH)-$$(notdir $$($(1)_DIR)).patch)), \
-	    echo PATCHING $$(p) ; \
-	    patch -d $$($(1)_DIR) -p1 -i $$(p) ; \
+	  echo PATCHING $$(p); \
+	  patch -d $$($(1)_DIR) -p1 -i $$(p); \
 	)
 	touch $$@
 
@@ -153,10 +153,10 @@ define DownloadVerify
 	wget -O - $$($(1)_URL) > $$@.tmp
 	sha512_actual="$$$$(sha512sum $$@.tmp | awk '{ print $$$$1; }')"; \
 	if [ x"$$$${sha512_actual}" != x"$$($(1)_SHA512)" ]; then \
-	    echo "Checksum mismatch for $$@.tmp"; \
-	    echo "    Expected: $$($(1)_SHA512)"; \
-	    echo "    Actual:   $$$${sha512_actual}"; \
-	    exit 1; \
+	  echo "Checksum mismatch for $$@.tmp"; \
+	  echo "    Expected: $$($(1)_SHA512)"; \
+	  echo "    Actual:   $$$${sha512_actual}"; \
+	  exit 1; \
 	fi
 	mv $$@.tmp $$@
 endef
@@ -173,7 +173,8 @@ $(foreach dep,$(DEPENDENCIES),$(eval $(dep) = $(TARGETDIR)/$($(dep)_VER).done))
 CONFIG = \
     --target=$(TARGET) \
     --host=$(HOST) --build=$(BUILD) \
-    --prefix=$(PREFIX)
+    --prefix=$(PREFIX) \
+    #
 
 CMAKE_CONFIG = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX)
 
@@ -266,17 +267,17 @@ $(BUILDDIR)/$(BINUTILS_VER)/Makefile: $(BINUTILS_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) CFLAGS="-O2 $(CFLAGS)" \
-	        $(BINUTILS_CFG) \
-	        $(CONFIG) \
-	        $(LINKER_CONFIG_ENABLE_GOLD) \
-	        --with-sysroot=$(SYSROOT) \
-	        --disable-nls \
-	        --program-prefix=$(TARGET)- \
-	        $(ENABLE_MULTILIB) \
-	        --enable-threads \
-	        --enable-plugins \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) CFLAGS="-O2 $(CFLAGS)" \
+	      $(BINUTILS_CFG) \
+	      $(CONFIG) \
+	      $(LINKER_CONFIG_ENABLE_GOLD) \
+	      --with-sysroot=$(SYSROOT) \
+	      --disable-nls \
+	      --program-prefix=$(TARGET)- \
+	      $(ENABLE_MULTILIB) \
+	      --enable-threads \
+	      --enable-plugins \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -284,13 +285,13 @@ $(BUILDDIR)/$(MPFR_VER)/Makefile: $(MPFR_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
-	        $(MPFR_CFG) \
-	        $(CONFIG) \
-	        --program-prefix=$(TARGET)- \
-	        --enable-shared=no \
-	        --with-gmp=$(PREFIX) \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
+	      $(MPFR_CFG) \
+	      $(CONFIG) \
+	      --program-prefix=$(TARGET)- \
+	      --enable-shared=no \
+	      --with-gmp=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -298,15 +299,15 @@ $(BUILDDIR)/$(GMP_VER)/Makefile: $(GMP_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
-	        $(GMP_CFG) \
-	        --host=$(HOST) --build=$(BUILD) \
-	        --prefix=$(PREFIX) \
-	        --disable-nls \
-	        --program-prefix=$(TARGET)- \
-	        --enable-shared=no \
-	        --with-mpfr=$(PREFIX) \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
+	      $(GMP_CFG) \
+	      --host=$(HOST) --build=$(BUILD) \
+	      --prefix=$(PREFIX) \
+	      --disable-nls \
+	      --program-prefix=$(TARGET)- \
+	      --enable-shared=no \
+	      --with-mpfr=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -314,14 +315,14 @@ $(BUILDDIR)/$(MPC_VER)/Makefile: $(MPC_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
-	        $(MPC_CFG) \
-	        $(CONFIG) \
-	        --program-prefix=$(TARGET)- \
-	        --enable-shared=no \
-	        --with-mpfr=$(PREFIX) \
-	        --with-gmp=$(PREFIX) \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
+	      $(MPC_CFG) \
+	      $(CONFIG) \
+	      --program-prefix=$(TARGET)- \
+	      --enable-shared=no \
+	      --with-mpfr=$(PREFIX) \
+	      --with-gmp=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -355,19 +356,19 @@ $(BUILDDIR)/$(GCC_VER)/Makefile: $(GCC_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	mkdir -p $(@D)
 	( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) $(GCC_CFG) $(EXTRA_CFLAGS) \
-	        $(CONFIG) \
-	        --with-sysroot=$(SYSROOT) \
-	        --with-debug-prefix-map=$(OUTPUT_ROOT)=devkit \
-	        --enable-languages=c,c++ \
-	        --enable-shared \
-	        --disable-nls \
-	        --with-gnu-as \
-	        --with-gnu-ld \
-	        --with-mpfr=$(PREFIX) \
-	        --with-gmp=$(PREFIX) \
-	        --with-mpc=$(PREFIX) \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) $(GCC_CFG) $(EXTRA_CFLAGS) \
+	      $(CONFIG) \
+	      --with-sysroot=$(SYSROOT) \
+	      --with-debug-prefix-map=$(OUTPUT_ROOT)=devkit \
+	      --enable-languages=c,c++ \
+	      --enable-shared \
+	      --disable-nls \
+	      --with-gnu-as \
+	      --with-gnu-ld \
+	      --with-mpfr=$(PREFIX) \
+	      --with-gmp=$(PREFIX) \
+	      --with-mpc=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -386,12 +387,12 @@ ifeq ($(HOST), $(TARGET))
 	$(info Configuring $@. Log in $(@D)/log.config)
 	mkdir -p $(@D)
 	( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" $(GDB_CFG) \
-	        $(CONFIG) \
-	        --with-sysroot=$(SYSROOT) \
-	        --with-mpfr=$(PREFIX) \
-	        --with-gmp=$(PREFIX) \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" $(GDB_CFG) \
+	      $(CONFIG) \
+	      --with-sysroot=$(SYSROOT) \
+	      --with-mpfr=$(PREFIX) \
+	      --with-gmp=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -410,9 +411,8 @@ $(BUILDDIR)/$(CCACHE_VER)/Makefile: $(CCACHE_SRC_MARKER)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	@( \
-	    cd $(@D) ; \
-	    $(PATHPRE) $(ENVS) $(CCACHE_CFG) \
-	        $(CCACHE_CONFIG) \
+	  cd $(@D); \
+	  $(PATHPRE) $(ENVS) $(CCACHE_CFG) $(CCACHE_CONFIG) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -424,11 +424,10 @@ ifeq ($(HOST),$(TARGET))
   $(GCC_PATCHED): $(LINK_LIBS_MARKER)
 	@echo -n 'Creating compiler symlinks...'
 	@for f in cpp; do \
-	    if [ ! -e $(PREFIX)/bin/$(TARGET)-$$f ]; \
-	    then \
-	        cd $(PREFIX)/bin && \
-	        ln -fs $$f $(TARGET)-$$f ; \
-	    fi \
+	  if [ ! -e $(PREFIX)/bin/$(TARGET)-$$f ]; then \
+	    cd $(PREFIX)/bin && \
+	    ln -fs $$f $(TARGET)-$$f; \
+	  fi \
 	done
 	@touch $@
 	@echo 'done'
@@ -440,13 +439,13 @@ ifeq ($(HOST),$(TARGET))
   $(LINK_LIBS_MARKER): $(GCC)
 	@echo -n 'Creating library symlinks...'
 	@for l in $(LIBDIRS); do \
-	    for f in `cd $(PREFIX)/$$l && ls`; do \
-	        if [ ! -e $(TARGETDIR)/$$l/$$f ]; then \
-	            mkdir -p $(TARGETDIR)/$$l && \
-	            cd $(TARGETDIR)/$$l/ && \
-	            ln -fs ../../$$l/$$f $$f; \
-	        fi \
-	    done; \
+	  for f in `cd $(PREFIX)/$$l && ls`; do \
+	    if [ ! -e $(TARGETDIR)/$$l/$$f ]; then \
+	      mkdir -p $(TARGETDIR)/$$l && \
+	      cd $(TARGETDIR)/$$l/ && \
+	      ln -fs ../../$$l/$$f $$f; \
+	    fi \
+	  done \
 	done
 	@touch $@
 	@echo 'done'

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -39,67 +39,13 @@
 # Fix this...
 #
 
+include Common.gmk
+
 lowercase = $(shell echo $1 | tr A-Z a-z)
 
 $(info TARGET=$(TARGET))
 $(info HOST=$(HOST))
 $(info BUILD=$(BUILD))
-
-ARCH := $(word 1,$(subst -, ,$(TARGET)))
-
-ifeq ($(TARGET), arm-linux-gnueabihf)
-  ARCH=armhfp
-endif
-
-$(info ARCH=$(ARCH))
-
-KERNEL_HEADERS_RPM := kernel-headers
-
-ifeq ($(BASE_OS), OL)
-  ifeq ($(ARCH), aarch64)
-    BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL7/6/base/$(ARCH)/
-    LINUX_VERSION := OL7.6
-    KERNEL_HEADERS_RPM := kernel-uek-headers
-  else
-    BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL6/4/base/$(ARCH)/
-    LINUX_VERSION := OL6.4
-  endif
-else ifeq ($(BASE_OS), Fedora)
-  DEFAULT_OS_VERSION := 41
-  ifeq ($(BASE_OS_VERSION), )
-    BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
-  endif
-  ifeq ($(filter aarch64 armhfp ppc64le riscv64 s390x x86_64, $(ARCH)), )
-    $(error Only "aarch64 armhfp ppc64le riscv64 s390x x86_64" architectures are supported for Fedora, but "$(ARCH)" was requested)
-  endif
-  ifeq ($(ARCH), riscv64)
-    ifeq ($(filter 38 39 40 41, $(BASE_OS_VERSION)), )
-      $(error Only Fedora 38-41 are supported for "$(ARCH)", but Fedora $(BASE_OS_VERSION) was requested)
-    endif
-    BASE_URL := http://fedora.riscv.rocks/repos-dist/f$(BASE_OS_VERSION)/latest/$(ARCH)/Packages/
-  else
-    LATEST_ARCHIVED_OS_VERSION := 41
-    ifeq ($(filter aarch64 armhfp x86_64, $(ARCH)), )
-      FEDORA_TYPE := fedora-secondary
-    else
-      FEDORA_TYPE := fedora/linux
-    endif
-    ifeq ($(ARCH), armhfp)
-      ifneq ($(BASE_OS_VERSION), 36)
-        $(error Fedora 36 is the last release supporting "armhfp", but $(BASE_OS) was requested)
-      endif
-    endif
-    NOT_ARCHIVED := $(shell [ $(BASE_OS_VERSION) -gt $(LATEST_ARCHIVED_OS_VERSION) ] && echo true)
-    ifeq ($(NOT_ARCHIVED),true)
-      BASE_URL := https://dl.fedoraproject.org/pub/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os/Packages/
-    else
-      BASE_URL := https://archives.fedoraproject.org/pub/archive/$(FEDORA_TYPE)/releases/$(BASE_OS_VERSION)/Everything/$(ARCH)/os/Packages/
-    endif
-  endif
-  LINUX_VERSION := Fedora_$(BASE_OS_VERSION)
-else
-  $(error Unknown base OS $(BASE_OS))
-endif
 
 ################################################################################
 # Define external dependencies
@@ -156,32 +102,6 @@ ifneq ($(REQUIRED_MIN_MAKE_MAJOR_VERSION),)
   endif
 endif
 
-# RPMs used by all BASE_OS
-RPM_LIST := \
-    $(KERNEL_HEADERS_RPM) \
-    glibc glibc-headers glibc-devel \
-    cups-libs cups-devel \
-    libX11 libX11-devel \
-    libxcb xorg-x11-proto-devel \
-    alsa-lib alsa-lib-devel \
-    libXext libXext-devel \
-    libXtst libXtst-devel \
-    libXrender libXrender-devel \
-    libXrandr libXrandr-devel \
-    freetype freetype-devel \
-    libXt libXt-devel \
-    libSM libSM-devel \
-    libICE libICE-devel \
-    libXi libXi-devel \
-    libXdmcp libXdmcp-devel \
-    libXau libXau-devel \
-    libgcc libxcrypt \
-    zlib zlib-devel \
-    libffi libffi-devel \
-    fontconfig fontconfig-devel \
-    systemtap-sdt-devel \
-    #
-
 ################################################################################
 # Define common directories and files
 
@@ -194,28 +114,11 @@ else
 endif
 
 # Define directories
-BUILDDIR := $(OUTPUT_ROOT)/$(HOST)/$(TARGET)
-TARGETDIR := $(PREFIX)/$(TARGET)
-SYSROOT := $(TARGETDIR)/sysroot
 DOWNLOAD := $(OUTPUT_ROOT)/download
-DOWNLOAD_RPMS := $(DOWNLOAD)/rpms/$(TARGET)-$(LINUX_VERSION)
 SRCDIR := $(OUTPUT_ROOT)/src
 
-# Marker file for unpacking rpms
-RPMS := $(SYSROOT)/rpms_unpacked
-
-# Need to patch libs that are linker scripts to use non-absolute paths
-LIBS := $(SYSROOT)/libs_patched
-
-################################################################################
-# Download RPMs
-download-rpms:
-	mkdir -p $(DOWNLOAD_RPMS)
-        # Only run this if rpm dir is empty.
-        ifeq ($(wildcard $(DOWNLOAD_RPMS)/*.rpm), )
-	  cd $(DOWNLOAD_RPMS) && \
-	      wget -r -np -nd $(patsubst %, -A "*%*.rpm", $(RPM_LIST)) $(BASE_URL)
-        endif
+# Marker files
+LINK_LIBS_MARKER := $(BUILDDIR)/link_libs.marker
 
 ################################################################################
 # Unpack source packages
@@ -236,16 +139,16 @@ define DownloadVerify
   endif
   $(1)_FILE = $(DOWNLOAD)/$(notdir $($(1)_URL))
 
-  $$($(1)_SRC_MARKER) : $$($(1)_FILE)
+  $$($(1)_SRC_MARKER): $$($(1)_FILE)
 	mkdir -p $$(SRCDIR)
 	tar -C $$(SRCDIR) -xf $$<
 	$$(foreach p,$$(abspath $$(wildcard patches/$$(ARCH)-$$(notdir $$($(1)_DIR)).patch)), \
-	  echo PATCHING $$(p) ; \
-	  patch -d $$($(1)_DIR) -p1 -i $$(p) ; \
+	    echo PATCHING $$(p) ; \
+	    patch -d $$($(1)_DIR) -p1 -i $$(p) ; \
 	)
 	touch $$@
 
-  $$($(1)_FILE) :
+  $$($(1)_FILE):
 	mkdir -p $$(@D)
 	wget -O - $$($(1)_URL) > $$@.tmp
 	sha512_actual="$$$$(sha512sum $$@.tmp | awk '{ print $$$$1; }')"; \
@@ -261,87 +164,14 @@ endef
 # Download and unpack all source packages
 $(foreach dep,$(DEPENDENCIES),$(eval $(call DownloadVerify,$(dep))))
 
-################################################################################
-# Unpack RPMS
-
-RPM_ARCHS := $(ARCH) noarch
-ifeq ($(ARCH),x86_64)
-  # Enable mixed mode.
-  RPM_ARCHS += i386 i686
-else ifeq ($(ARCH),i686)
-  RPM_ARCHS += i386
-else ifeq ($(ARCH), armhfp)
-  RPM_ARCHS += armv7hl
-endif
-
-RPM_FILE_LIST := $(sort $(foreach a, $(RPM_ARCHS), \
-  $(wildcard $(patsubst %,$(DOWNLOAD_RPMS)/%*$a.rpm,$(RPM_LIST))) \
-))
-
-# Note. For building linux you should install rpm2cpio.
-define unrpm
-  $(SYSROOT)/$(notdir $(1)).unpacked : $(1)
-  $$(RPMS) : $(SYSROOT)/$(notdir $(1)).unpacked
-endef
-
-%.unpacked :
-	$(info Unpacking target rpms and libraries from $<)
-	@(mkdir -p $(@D); \
-	cd $(@D); \
-	rpm2cpio $< | \
-	    cpio --extract --make-directories \
-	        -f \
-	        "./usr/share/doc/*" \
-	        "./usr/share/man/*" \
-	        "./usr/X11R6/man/*" \
-	        "*/X11/locale/*" \
-	    || die ; )
-	touch $@
-
-$(foreach p,$(RPM_FILE_LIST),$(eval $(call unrpm,$(p))))
-
-################################################################################
-
-# Note: MUST create a <sysroot>/usr/lib even if not really needed.
-# gcc will use a path relative to it to resolve lib64. (x86_64).
-# we're creating multi-lib compiler with 32bit libc as well, so we should
-# have it anyway, but just to make sure...
-# Patch libc.so and libpthread.so to force linking against libraries in sysroot
-# and not the ones installed on the build machine.
-$(LIBS) : $(RPMS)
-	@echo Patching libc and pthreads
-	@(for f in `find $(SYSROOT) -name libc.so -o -name libpthread.so`; do \
-	  (cat $$f | sed -e 's|/usr/lib64/||g' \
-	      -e 's|/usr/lib/||g' \
-	      -e 's|/lib64/||g' \
-	      -e 's|/lib/||g' ) > $$f.tmp ; \
-	  mv $$f.tmp $$f ; \
-	done)
-	@mkdir -p $(SYSROOT)/usr/lib
-	@touch $@
-
-################################################################################
-# Create links for ffi header files so that they become visible by default when using the
-# devkit.
-ifeq ($(ARCH), x86_64)
-  $(SYSROOT)/usr/include/ffi.h: $(RPMS)
-	cd $(@D) && rm -f $(@F) && ln -s ../lib/libffi-*/include/$(@F) .
-
-  $(SYSROOT)/usr/include/ffitarget.h: $(RPMS)
-	cd $(@D) && rm -f $(@F) && ln -s ../lib/libffi-*/include/$(@F) .
-
-  SYSROOT_LINKS += $(SYSROOT)/usr/include/ffi.h $(SYSROOT)/usr/include/ffitarget.h
-endif
-
-################################################################################
-
 # Define marker files for each source package to be compiled
 $(foreach dep,$(DEPENDENCIES),$(eval $(dep) = $(TARGETDIR)/$($(dep)_VER).done))
 
 ################################################################################
 
 # Default base config
-CONFIG = --target=$(TARGET) \
+CONFIG = \
+    --target=$(TARGET) \
     --host=$(HOST) --build=$(BUILD) \
     --prefix=$(PREFIX)
 
@@ -356,7 +186,6 @@ BUILDPAR = -j$(NUM_CORES)
 # Default commands to when making
 MAKECMD =
 INSTALLCMD = install
-
 
 declare_tools = CC$(1)=$(2)gcc LD$(1)=$(2)ld AR$(1)=$(2)ar AS$(1)=$(2)as RANLIB$(1)=$(2)ranlib CXX$(1)=$(2)g++ OBJDUMP$(1)=$(2)objdump
 
@@ -376,10 +205,10 @@ TOOLS ?= $(call declare_tools,_FOR_TARGET,$(TARGET)-)
 # CFLAG_<name> to most likely -m32.
 define mk_bfd
   $$(info Libs for $(1))
-  $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile \
-      : CFLAGS += $$(CFLAGS_$(1))
-  $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile \
-      : LIBDIRS = --libdir=$(TARGETDIR)/$(1)
+  $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile: \
+      CFLAGS += $$(CFLAGS_$(1))
+  $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile: \
+      LIBDIRS = --libdir=$(TARGETDIR)/$(1)
 
   BFDLIB += $$(TARGETDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1)).done
   BFDMAKES += $$(BUILDDIR)/$$(BINUTILS_VER)-$(subst /,-,$(1))/Makefile
@@ -389,18 +218,18 @@ endef
 $(foreach l,$(LIBDIRS),$(eval $(call mk_bfd,$(l))))
 
 # Only build these two libs.
-$(BFDLIB) : MAKECMD = all-libiberty all-bfd
-$(BFDLIB) : INSTALLCMD = install-libiberty install-bfd
+$(BFDLIB): MAKECMD = all-libiberty all-bfd
+$(BFDLIB): INSTALLCMD = install-libiberty install-bfd
 
 # Building targets libbfd + libiberty. HOST==TARGET, i.e not
 # for a cross env.
-$(BFDMAKES) : CONFIG = --target=$(TARGET) \
+$(BFDMAKES): CONFIG = --target=$(TARGET) \
     --host=$(TARGET) --build=$(BUILD) \
     --prefix=$(TARGETDIR) \
     --with-sysroot=$(SYSROOT) \
     $(LIBDIRS)
 
-$(BFDMAKES) : TOOLS = $(call declare_tools,_FOR_TARGET,$(TARGET)-) $(call declare_tools,,$(TARGET)-)
+$(BFDMAKES): TOOLS = $(call declare_tools,_FOR_TARGET,$(TARGET)-) $(call declare_tools,,$(TARGET)-)
 
 ################################################################################
 
@@ -410,103 +239,107 @@ $(GCC) \
     $(MPFR) \
     $(MPC) \
     $(BFDMAKES) \
-    $(CCACHE) : ENVS += $(TOOLS)
+    $(CCACHE): ENVS += $(TOOLS)
 
 # libdir to work around hateful bfd stuff installing into wrong dirs...
 # ensure we have 64 bit bfd support in the HOST library. I.e our
 # compiler on i686 will know 64 bit symbols, BUT later
 # we build just the libs again for TARGET, then with whatever the arch
 # wants.
-$(BUILDDIR)/$(BINUTILS_VER)/Makefile : CONFIG += --enable-64-bit-bfd --libdir=$(PREFIX)/$(word 1,$(LIBDIRS))
+$(BUILDDIR)/$(BINUTILS_VER)/Makefile: CONFIG += --enable-64-bit-bfd --libdir=$(PREFIX)/$(word 1,$(LIBDIRS))
 
 ifeq ($(filter $(ARCH), s390x riscv64 ppc64le), )
   # gold compiles but cannot link properly on s390x @ gcc 13.2 and Fedore 41
   # gold is not available for riscv64 and ppc64le,
   # and subsequent linking will fail if we try to enable it.
-  LINKER_CONFIG := --enable-gold=default
+  LINKER_CONFIG_ENABLE_GOLD := --enable-gold=default
+endif
+
+ifeq ($(filter riscv64 ppc64le s390x armhfp, $(ARCH)), )
+  ENABLE_MULTILIB := --enable-multilib
 endif
 
 # Makefile creation. Simply run configure in build dir.
 # Setting CFLAGS to -O2 generates a much faster ld.
 $(BFDMAKES) \
-$(BUILDDIR)/$(BINUTILS_VER)/Makefile \
-    : $(BINUTILS_CFG)
+$(BUILDDIR)/$(BINUTILS_VER)/Makefile: $(BINUTILS_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) CFLAGS="-O2 $(CFLAGS)" \
-	      $(BINUTILS_CFG) \
-	      $(CONFIG) \
-	      $(LINKER_CONFIG) \
-	      --with-sysroot=$(SYSROOT) \
-	      --disable-nls \
-	      --program-prefix=$(TARGET)- \
-	      --enable-multilib \
-	      --enable-threads \
-	      --enable-plugins \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) CFLAGS="-O2 $(CFLAGS)" \
+	        $(BINUTILS_CFG) \
+	        $(CONFIG) \
+	        $(LINKER_CONFIG_ENABLE_GOLD) \
+	        --with-sysroot=$(SYSROOT) \
+	        --disable-nls \
+	        --program-prefix=$(TARGET)- \
+	        $(ENABLE_MULTILIB) \
+	        --enable-threads \
+	        --enable-plugins \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-$(BUILDDIR)/$(MPFR_VER)/Makefile \
-    : $(MPFR_CFG)
+$(BUILDDIR)/$(MPFR_VER)/Makefile: $(MPFR_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
-	      $(MPFR_CFG) \
-	      $(CONFIG) \
-	      --program-prefix=$(TARGET)- \
-	      --enable-shared=no \
-	      --with-gmp=$(PREFIX) \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
+	        $(MPFR_CFG) \
+	        $(CONFIG) \
+	        --program-prefix=$(TARGET)- \
+	        --enable-shared=no \
+	        --with-gmp=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-$(BUILDDIR)/$(GMP_VER)/Makefile \
-    : $(GMP_CFG)
+$(BUILDDIR)/$(GMP_VER)/Makefile: $(GMP_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
-	      $(GMP_CFG) \
-	      --host=$(HOST) --build=$(BUILD) \
-	      --prefix=$(PREFIX) \
-	      --disable-nls \
-	      --program-prefix=$(TARGET)- \
-	      --enable-shared=no \
-	      --with-mpfr=$(PREFIX) \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
+	        $(GMP_CFG) \
+	        --host=$(HOST) --build=$(BUILD) \
+	        --prefix=$(PREFIX) \
+	        --disable-nls \
+	        --program-prefix=$(TARGET)- \
+	        --enable-shared=no \
+	        --with-mpfr=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
-$(BUILDDIR)/$(MPC_VER)/Makefile \
-    : $(MPC_CFG)
+$(BUILDDIR)/$(MPC_VER)/Makefile: $(MPC_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
-	      $(MPC_CFG) \
-	      $(CONFIG) \
-	      --program-prefix=$(TARGET)- \
-	      --enable-shared=no \
-	      --with-mpfr=$(PREFIX) \
-	      --with-gmp=$(PREFIX) \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" \
+	        $(MPC_CFG) \
+	        $(CONFIG) \
+	        --program-prefix=$(TARGET)- \
+	        --enable-shared=no \
+	        --with-mpfr=$(PREFIX) \
+	        --with-gmp=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
 # Only valid if glibc target -> linux
 # proper destructor handling for c++
 ifneq (,$(findstring linux,$(TARGET)))
-  $(BUILDDIR)/$(GCC_VER)/Makefile : CONFIG += --enable-__cxa_atexit
+  $(BUILDDIR)/$(GCC_VER)/Makefile: CONFIG += --enable-__cxa_atexit
 endif
 
+$(BUILDDIR)/$(GCC_VER)/Makefile: CONFIG += --disable-libgomp
 ifeq ($(ARCH), armhfp)
-  $(BUILDDIR)/$(GCC_VER)/Makefile : CONFIG +=  --with-float=hard
+  $(BUILDDIR)/$(GCC_VER)/Makefile: CONFIG +=  --with-float=hard
+endif
+ifeq ($(ARCH), riscv64)
+  $(BUILDDIR)/$(GCC_VER)/Makefile: CONFIG += --disable-libsanitizer
 endif
 
-ifneq ($(filter riscv64 ppc64le s390x, $(ARCH)), )
+ifneq ($(filter riscv64 ppc64le s390x armhfp, $(ARCH)), )
   # We only support 64-bit on these platforms anyway
   CONFIG += --disable-multilib
 endif
@@ -518,34 +351,33 @@ endif
 # skip native language.
 # and link and assemble with the binutils we created
 # earlier, so --with-gnu*
-$(BUILDDIR)/$(GCC_VER)/Makefile \
-    : $(GCC_CFG)
+$(BUILDDIR)/$(GCC_VER)/Makefile: $(GCC_CFG)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	mkdir -p $(@D)
 	( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) $(GCC_CFG) $(EXTRA_CFLAGS) \
-	      $(CONFIG) \
-	      --with-sysroot=$(SYSROOT) \
-	      --with-debug-prefix-map=$(OUTPUT_ROOT)=devkit \
-	      --enable-languages=c,c++ \
-	      --enable-shared \
-	      --disable-nls \
-	      --with-gnu-as \
-	      --with-gnu-ld \
-	      --with-mpfr=$(PREFIX) \
-	      --with-gmp=$(PREFIX) \
-	      --with-mpc=$(PREFIX) \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) $(GCC_CFG) $(EXTRA_CFLAGS) \
+	        $(CONFIG) \
+	        --with-sysroot=$(SYSROOT) \
+	        --with-debug-prefix-map=$(OUTPUT_ROOT)=devkit \
+	        --enable-languages=c,c++ \
+	        --enable-shared \
+	        --disable-nls \
+	        --with-gnu-as \
+	        --with-gnu-ld \
+	        --with-mpfr=$(PREFIX) \
+	        --with-gmp=$(PREFIX) \
+	        --with-mpc=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
 # need binutils for gcc
-$(GCC) : $(BINUTILS)
+$(GCC): $(BINUTILS)
 
 # as of 4.3 or so need these for doing config
-$(BUILDDIR)/$(GCC_VER)/Makefile : $(GMP) $(MPFR) $(MPC)
-$(MPFR) : $(GMP)
-$(MPC) : $(GMP) $(MPFR)
+$(BUILDDIR)/$(GCC_VER)/Makefile: $(GMP) $(MPFR) $(MPC)
+$(MPFR): $(GMP)
+$(MPC): $(GMP) $(MPFR)
 
 ################################################################################
 # Build gdb but only where host and target match
@@ -554,12 +386,12 @@ ifeq ($(HOST), $(TARGET))
 	$(info Configuring $@. Log in $(@D)/log.config)
 	mkdir -p $(@D)
 	( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" $(GDB_CFG) \
-	      $(CONFIG) \
-	      --with-sysroot=$(SYSROOT) \
-	      --with-mpfr=$(PREFIX) \
-	      --with-gmp=$(PREFIX) \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS)" $(GDB_CFG) \
+	        $(CONFIG) \
+	        --with-sysroot=$(SYSROOT) \
+	        --with-mpfr=$(PREFIX) \
+	        --with-gmp=$(PREFIX) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -574,14 +406,13 @@ endif
 
 ################################################################################
 # very straightforward. just build a ccache. it is only for host.
-$(BUILDDIR)/$(CCACHE_VER)/Makefile \
-    : $(CCACHE_SRC_MARKER)
+$(BUILDDIR)/$(CCACHE_VER)/Makefile: $(CCACHE_SRC_MARKER)
 	$(info Configuring $@. Log in $(@D)/log.config)
 	@mkdir -p $(@D)
 	@( \
-	  cd $(@D) ; \
-	  $(PATHPRE) $(ENVS) $(CCACHE_CFG) \
-	      $(CCACHE_CONFIG) \
+	    cd $(@D) ; \
+	    $(PATHPRE) $(ENVS) $(CCACHE_CFG) \
+	        $(CCACHE_CONFIG) \
 	) > $(@D)/log.config 2>&1
 	@echo 'done'
 
@@ -590,14 +421,14 @@ GCC_PATCHED = $(TARGETDIR)/gcc-patched
 ################################################################################
 # For some reason cpp is not created as a target-compiler
 ifeq ($(HOST),$(TARGET))
-  $(GCC_PATCHED) : $(GCC) link_libs
+  $(GCC_PATCHED): $(LINK_LIBS_MARKER)
 	@echo -n 'Creating compiler symlinks...'
 	@for f in cpp; do \
-	  if [ ! -e $(PREFIX)/bin/$(TARGET)-$$f ]; \
-	  then \
-	    cd $(PREFIX)/bin && \
-	    ln -fs $$f $(TARGET)-$$f ; \
-	  fi \
+	    if [ ! -e $(PREFIX)/bin/$(TARGET)-$$f ]; \
+	    then \
+	        cd $(PREFIX)/bin && \
+	        ln -fs $$f $(TARGET)-$$f ; \
+	    fi \
 	done
 	@touch $@
 	@echo 'done'
@@ -606,19 +437,21 @@ ifeq ($(HOST),$(TARGET))
   # Ugly at best. Seems that when we compile host->host compiler, that are NOT
   # the BUILD compiler, the result will not try searching for libs in package root.
   # "Solve" this by create links from the target libdirs to where they are.
-  link_libs:
+  $(LINK_LIBS_MARKER): $(GCC)
 	@echo -n 'Creating library symlinks...'
-	@$(foreach l,$(LIBDIRS), \
-	for f in `cd $(PREFIX)/$(l) && ls`; do \
-	  if [ ! -e $(TARGETDIR)/$(l)/$$f ]; then \
-	    mkdir -p $(TARGETDIR)/$(l) && \
-	    cd $(TARGETDIR)/$(l)/ && \
-	    ln -fs $(if $(findstring /,$(l)),../,)../../$(l)/$$f $$f; \
-	  fi \
-	done;)
+	@for l in $(LIBDIRS); do \
+	    for f in `cd $(PREFIX)/$$l && ls`; do \
+	        if [ ! -e $(TARGETDIR)/$$l/$$f ]; then \
+	            mkdir -p $(TARGETDIR)/$$l && \
+	            cd $(TARGETDIR)/$$l/ && \
+	            ln -fs ../../$$l/$$f $$f; \
+	        fi \
+	    done; \
+	done
+	@touch $@
 	@echo 'done'
 else
-  $(GCC_PATCHED) :
+  $(GCC_PATCHED):
 	@echo 'done'
 endif
 
@@ -628,7 +461,7 @@ endif
 # make install.
 # Use path to our build hosts cross tools
 # Always need to build cross tools for build host self.
-$(TARGETDIR)/%.done : $(BUILDDIR)/%/Makefile
+$(TARGETDIR)/%.done: $(BUILDDIR)/%/Makefile
 	$(info Building $(basename $@). Log in $(<D)/log.build)
 	$(PATHPRE) $(ENVS) $(MAKE) $(BUILDPAR) -f $< -C $(<D) $(MAKECMD) $(MAKECMD.$(notdir $@)) > $(<D)/log.build 2>&1
 	@echo -n 'installing...'
@@ -646,26 +479,20 @@ $(PREFIX)/devkit.info:
 	echo '# This file describes to configure how to interpret the contents of this' >> $@
 	echo '# devkit' >> $@
 	echo '' >> $@
-	echo 'DEVKIT_NAME="$(GCC_VER) - $(LINUX_VERSION)"' >> $@
+	echo 'DEVKIT_NAME="$(GCC_VER) - $(BASE_OS_DESCRIPTION)"' >> $@
 	echo 'DEVKIT_TOOLCHAIN_PATH="$$DEVKIT_ROOT/bin"' >> $@
 	echo 'DEVKIT_SYSROOT="$$DEVKIT_ROOT/$(TARGET)/sysroot"' >> $@
 	echo 'DEVKIT_EXTRA_PATH="$$DEVKIT_ROOT/bin"' >> $@
 
 ################################################################################
 # Copy these makefiles into the root of the kit
-$(PREFIX)/Makefile: ./Makefile
-	rm -rf $@
-	cp $< $@
 
-$(PREFIX)/Tools.gmk: ./Tools.gmk
-	rm -rf $@
-	cp $< $@
+THESE_MAKEFILES := Makefile $(wildcard *.gmk) patches
+COPIED_MAKEFILES := $(addprefix $(PREFIX)/, $(THESE_MAKEFILES))
 
-$(PREFIX)/Tars.gmk: ./Tars.gmk
+$(PREFIX)/%: ./%
 	rm -rf $@
-	cp $< $@
-
-THESE_MAKEFILES := $(PREFIX)/Makefile $(PREFIX)/Tools.gmk $(PREFIX)/Tars.gmk
+	cp -r $< $@
 
 ################################################################################
 
@@ -682,9 +509,14 @@ ifeq ($(TARGET), $(HOST))
 	@echo 'Creating missing $* soft link'
 	ln -s $(TARGET)-$* $@
 
-  MISSING_LINKS := $(addprefix $(PREFIX)/bin/, \
+  MISSING_LINK_NAMES = \
       addr2line ar as c++ c++filt dwp elfedit g++ gcc gcc-$(GCC_VER_ONLY) gprof ld ld.bfd \
-      ld.gold nm objcopy objdump ranlib readelf size strings strip)
+      nm objcopy objdump ranlib readelf size strings strip
+  ifneq ($(LINKER_CONFIG_ENABLE_GOLD), )
+    MISSING_LINK_NAMES += ld.gold
+  endif
+
+  MISSING_LINKS := $(addprefix $(PREFIX)/bin/, $(MISSING_LINK_NAMES))
 endif
 
 # Add link to work around "plugin needed to handle lto object" (JDK-8344272)
@@ -697,17 +529,14 @@ MISSING_LINKS += $(PREFIX)/lib/bfd-plugins/liblto_plugin.so
 
 ################################################################################
 
-bfdlib : $(BFDLIB)
-binutils : $(BINUTILS)
-rpms : $(RPMS)
-libs : $(LIBS)
-sysroot : rpms libs
-gcc : sysroot $(GCC) $(GCC_PATCHED)
-gdb : $(GDB)
-all : binutils gcc bfdlib $(PREFIX)/devkit.info $(MISSING_LINKS) $(SYSROOT_LINKS) \
-    $(THESE_MAKEFILES) gdb
+bfdlib: $(BFDLIB)
+binutils: $(BINUTILS)
+gcc: $(GCC) $(GCC_PATCHED)
+gdb: $(GDB)
+all: binutils gcc bfdlib gdb \
+    $(MISSING_LINKS) $(COPIED_MAKEFILES) $(PREFIX)/devkit.info
 
 # this is only built for host. so separate.
-ccache : $(CCACHE)
+ccache: $(CCACHE)
 
-.PHONY : gcc all binutils bfdlib link_libs rpms libs sysroot
+.PHONY: bfdlib binutils gcc gdb all ccache


### PR DESCRIPTION
### Background (from JBS)

The devkit creation makefiles under make/devkit have been more or less untouched since they were first introduced. While they have served us well there are some key challenges which are slowly becoming more urgent to address.

One such issue relates to the logic for creating the sysroot. Currently, it is implemented using wget with a set of pattern to download packages directly from the upstream yum repo. One problem with this is that it will download all packages which happen to match the pattern, no matter if those packages are actually needed or not. More problematically though, using wget like this does not (necessarily) work for more recent linux distribution versions/repositories.

The dnf tool is the native solution for downloading packages, including dependencies etc.

The sysroot logic could also benefit from being split out into its own file, making the fairly involved Tools.gmk slightly less complex.

A secondary goal of this cleanup is to make it possible to reuse the logic (especially the sysroot logic) for creating devkit equivalents for building project Detroit.

### About the change

The goal of this change was, initially, to change the sysroot logic to use dnf. In making the required changes I relatively quickly I realized that the Tools.gmk file was long overdue for cleanup. I chose to split out the sysroot logic to a separate file but couldn't resist making some fairly significant, (_mostly_) cosmetic changes to Tools.gmk while at it, moving it closer to the general style of the JDK build system. That said, a lot of the logic in Tools.gmk remains "old-style" even after this change.

Some specific things worth highlighting:

- I've tried to adjust formatting to closer match the JDK build system style, but I'm sure there are places/cases where it's off.
- I updated versions and URLs to reflect the latest reality, and adjusted the documentation in Makefile accordingly.
- To avoid having to call the Sysroot.gmk file twice (first to download packages and then to create the actual sysroot) I updated the logic to not depend on parse time globing. Specifically, what used to be `RPM_FILE_LIST` is now handled in the recipe instead.
- I fixed some missing dependencies which were most likely not actual problems, unless running with parallelism (which is not needed - Tools.gmk sets BUILDPAR where relevant). Even with these fixes parallelism is unlikely to work well.
- I dropped some packages which no longer exist (assuming they did in the first place, many years ago). Specifying invalid/non-existent packages to wget would just result in no packages being downloaded. With dnf it's a hard failure, which I argue is a good thing.
- I dropped the ffi header links - AFAICT that is no longer a problem in any of the distributions/versions we use.
- I added `--disable-libgomp` for GCC. I see that others have run into the same issue and I have no reason to believe it's needed for the JDK.
- I also added `--disable-libsanitizer` for riscv64 to work around a GCC issue. If somebody else things it's important and wants to have a look I'd appreciate the help.

### Testing

I generated devkits for aarch64, x64 (OL) and armhfp, ppc64le, riscv64, s390x (Fedora). I then used those devkits to build the (mainline) JDK. All worked with two exceptions:

- I ran into a build problem with armhfp but AFAICT it is pre-existing, unrelated to my changes. As a matter of fact, I was unable to build the armhfp devkit using the mainline devkit version (without my changes)
- On the same general note, the mainline version is broken for riscv64 (the repo URL is dead). I located an alternative version which works.

I will want to do additional testing but would appreciate a review or two first. TYIA!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385552](https://bugs.openjdk.org/browse/JDK-8385552): Improve devkit/sysroot creation (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31303/head:pull/31303` \
`$ git checkout pull/31303`

Update a local copy of the PR: \
`$ git checkout pull/31303` \
`$ git pull https://git.openjdk.org/jdk.git pull/31303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31303`

View PR using the GUI difftool: \
`$ git pr show -t 31303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31303.diff">https://git.openjdk.org/jdk/pull/31303.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31303#issuecomment-4559915863)
</details>
