### PR TITLE
8385557: Shenandoah: Runtime calls from C2 stubs need to be relocatable

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -1111,7 +1111,7 @@ void ShenandoahBarrierStubC2::keepalive(MacroAssembler& masm, Label* L_done) {
 
     // Go to runtime and handle the rest there.
     __ mov(c_rarg0, _obj);
-    __ mov(lr, keepalive_runtime_entry_addr());
+    __ lea(lr, RuntimeAddress(keepalive_runtime_entry_addr()));
     __ blr(lr);
   }
   if (L_done != nullptr) {
@@ -1197,7 +1197,7 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     }
 
     // Go to runtime and handle the rest there.
-    __ mov(lr, lrb_runtime_entry_addr());
+    __ lea(lr, RuntimeAddress(lrb_runtime_entry_addr()));
     __ blr(lr);
 
     // Save the result where needed. Narrow entries return narrowOop (32 bits)

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -985,7 +985,8 @@ void ShenandoahBarrierStubC2::keepalive(MacroAssembler& masm, Label* L_done) {
 
     // Go to runtime and handle the rest there.
     __ mv(c_rarg0, _obj);
-    __ rt_call(keepalive_runtime_entry_addr());
+    __ la(ra, RuntimeAddress(keepalive_runtime_entry_addr()));
+    __ jalr(ra);
   }
   if (L_done != nullptr) {
     __ j(*L_done);
@@ -1056,7 +1057,8 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     }
 
     // Go to runtime and handle the rest there.
-    __ rt_call(lrb_runtime_entry_addr());
+    __ la(ra, RuntimeAddress(lrb_runtime_entry_addr()));
+    __ jalr(ra);
 
     // Save the result where needed. Narrow entries return narrowOop (32 bits)
     // we need to zero the upper 32 bits of x10.

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -1137,7 +1137,8 @@ void ShenandoahBarrierStubC2::keepalive(MacroAssembler& masm, Label* L_done) {
     }
 
     // Go to runtime and handle the rest there.
-    __ call(RuntimeAddress(keepalive_runtime_entry_addr()));
+    // Use rax as scratch, as it will be saved if live.
+    __ call(RuntimeAddress(keepalive_runtime_entry_addr()), rax);
   }
   if (L_done != nullptr) {
     __ jmp(*L_done);
@@ -1260,7 +1261,8 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     }
 
     // Go to runtime and handle the rest there.
-    __ call(RuntimeAddress(lrb_runtime_entry_addr()));
+    // Use rax as scratch, as it will be clobbered by result anyway.
+    __ call(RuntimeAddress(lrb_runtime_entry_addr()), rax);
 
     // Save the result where needed.
     if (_narrow) {


### PR DESCRIPTION
With [JDK-8366041](https://bugs.openjdk.org/browse/JDK-8366041), we have regressed [JDK-8382711](https://bugs.openjdk.org/browse/JDK-8382711) a bit: the new slow calls from C2 stubs are not consistently marked for relocations. So the AOT-generated code misses the updates.

This is not a problem in current mainline, but we get crashes in runtime when AOT code compilation PR is applied.

There is an additional deeper problem that some platforms use `rscratch1` as scratches to figure out the _far_ runtime call target. This is relatively safe, as we save/restore them around the calls, but it pays off maintainability-wise to be more strict about this.

Additional testing:
 - [x] Linux AArch64 server fastdebug, AOT tests no longer fail with AOT Code Cache PR
 - [x] Linux x86_64, AArch64, RISC-V still passes simple smoke tests
 - [x] Regular testing pipelines

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385557](https://bugs.openjdk.org/browse/JDK-8385557): Shenandoah: Runtime calls from C2 stubs need to be relocatable (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31306/head:pull/31306` \
`$ git checkout pull/31306`

Update a local copy of the PR: \
`$ git checkout pull/31306` \
`$ git pull https://git.openjdk.org/jdk.git pull/31306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31306`

View PR using the GUI difftool: \
`$ git pr show -t 31306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31306.diff">https://git.openjdk.org/jdk/pull/31306.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31306#issuecomment-4562469535)
</details>
