### PR TITLE
8385583: RISC-V: Debugger very slow during stepping

### DIFF
--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1230,11 +1230,11 @@ void InterpreterMacroAssembler::notify_method_exit(
     // template interpreter will leave the result on the top of the stack.
     push(state);
 
-    ld(t0, Address(xthread, JavaThread::jvmti_thread_state_offset()));
-    beqz(t0, L);  // if (thread->jvmti_thread_state() == nullptr) exit;
+    ld(t1, Address(xthread, JavaThread::jvmti_thread_state_offset()));
+    beqz(t1, L);  // if (thread->jvmti_thread_state() == nullptr) exit;
 
-    lwu(t0, Address(t0, JvmtiThreadState::frame_pop_cnt_offset()));
-    lwu(t1, Address(xthread, JavaThread::interp_only_mode_offset()));
+    lwu(t1, Address(t1, JvmtiThreadState::frame_pop_cnt_offset()));
+    lwu(t0, Address(xthread, JavaThread::interp_only_mode_offset()));
     orr(t0, t0, t1);
     beqz(t0, L);
 

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1221,6 +1221,7 @@ void InterpreterMacroAssembler::notify_method_exit(
   // track stack depth.  If it is possible to enter interp_only_mode we add
   // the code to check if the event should be sent.
   if (mode == NotifyJVMTI && (JvmtiExport::can_post_interpreter_events() || JvmtiExport::can_post_frame_pop())) {
+    Label L;
     // Note: frame::interpreter_frame_result has a dependency on how the
     // method result is saved across the call to post_method_exit. If this
     // is changed then the interpreter_frame_result implementation will
@@ -1228,8 +1229,18 @@ void InterpreterMacroAssembler::notify_method_exit(
 
     // template interpreter will leave the result on the top of the stack.
     push(state);
+
+    ld(t0, Address(xthread, JavaThread::jvmti_thread_state_offset()));
+    beqz(t0, L);  // if (thread->jvmti_thread_state() == nullptr) exit;
+
+    lwu(t0, Address(t0, JvmtiThreadState::frame_pop_cnt_offset()));
+    lwu(t1, Address(xthread, JavaThread::interp_only_mode_offset()));
+    orr(t0, t0, t1);
+    beqz(t0, L);
+
     call_VM(noreg,
             CAST_FROM_FN_PTR(address, InterpreterRuntime::post_method_exit));
+    bind(L);
     pop(state);
   }
 


### PR DESCRIPTION
Hi, I have implemented the missing implementation from https://bugs.openjdk.org/browse/JDK-6960970.

### Testing
- [x] tier1-3 tests on SOPHON SG2042 (fastdebug)
- [x] test/hotspot/jtreg/serviceability/jvmti/events/NotifyFramePopStressTest/NotifyFramePopStressTest.java 
- [x] test/hotspot/jtreg/serviceability/jvmti/NotifyFramePop/NotifyFramePopTest.java
- [x] test/jdk/java/lang/Thread/ThreadStateTest.java
- [x] test/jdk/com/sun/jdi/EATests.java
- [x] test/jdk/com/sun/jdi/StepOverStressTest.java
- [x] test/hotspot/jtreg/serviceability/jvmti 


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385583](https://bugs.openjdk.org/browse/JDK-8385583): RISC-V: Debugger very slow during stepping (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31310/head:pull/31310` \
`$ git checkout pull/31310`

Update a local copy of the PR: \
`$ git checkout pull/31310` \
`$ git pull https://git.openjdk.org/jdk.git pull/31310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31310`

View PR using the GUI difftool: \
`$ git pr show -t 31310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31310.diff">https://git.openjdk.org/jdk/pull/31310.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31310#issuecomment-4573431835)
</details>
