### PR TITLE
8385586: Fix race in Windows map_or_reserve_memory_aligned using VirtualAlloc2 and MapViewOfFile3

### DIFF
--- a/src/hotspot/os/windows/gc/z/zSyscall_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zSyscall_windows.cpp
@@ -23,6 +23,7 @@
 
 #include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zSyscall_windows.hpp"
+#include "os_windows.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 
@@ -33,31 +34,9 @@ ZSyscall::VirtualFreeExFn ZSyscall::VirtualFreeEx;
 ZSyscall::MapViewOfFile3Fn ZSyscall::MapViewOfFile3;
 ZSyscall::UnmapViewOfFile2Fn ZSyscall::UnmapViewOfFile2;
 
-static void* lookup_kernelbase_library() {
-  const char* const name = "KernelBase";
-  char ebuf[1024];
-  void* const handle = os::dll_load(name, ebuf, sizeof(ebuf));
-  if (handle == nullptr) {
-    log_error_p(gc)("Failed to load library: %s", name);
-  }
-  return handle;
-}
-
-static void* lookup_kernelbase_symbol(const char* name) {
-  static void* const handle = lookup_kernelbase_library();
-  if (handle == nullptr) {
-    return nullptr;
-  }
-  return os::dll_lookup(handle, name);
-}
-
-static bool has_kernelbase_symbol(const char* name) {
-  return lookup_kernelbase_symbol(name) != nullptr;
-}
-
 template <typename Fn>
 static void install_kernelbase_symbol(Fn*& fn, const char* name) {
-  fn = reinterpret_cast<Fn*>(lookup_kernelbase_symbol(name));
+  fn = reinterpret_cast<Fn*>(os::win32::lookup_kernelbase_symbol(name));
 }
 
 template <typename Fn>
@@ -83,10 +62,10 @@ void ZSyscall::initialize() {
 
 bool ZSyscall::is_supported() {
   // Available in Windows version 1803 and later
-  return has_kernelbase_symbol("VirtualAlloc2");
+  return os::win32::lookup_kernelbase_symbol("VirtualAlloc2") != nullptr;
 }
 
 bool ZSyscall::is_large_pages_supported() {
   // Available in Windows version 1809 and later
-  return has_kernelbase_symbol("CreateFileMapping2");
+  return os::win32::lookup_kernelbase_symbol("CreateFileMapping2") != nullptr;
 }

--- a/src/hotspot/os/windows/gc/z/zSyscall_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zSyscall_windows.cpp
@@ -23,7 +23,6 @@
 
 #include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zSyscall_windows.hpp"
-#include "os_windows.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 
@@ -34,9 +33,31 @@ ZSyscall::VirtualFreeExFn ZSyscall::VirtualFreeEx;
 ZSyscall::MapViewOfFile3Fn ZSyscall::MapViewOfFile3;
 ZSyscall::UnmapViewOfFile2Fn ZSyscall::UnmapViewOfFile2;
 
+static void* lookup_kernelbase_library() {
+  const char* const name = "KernelBase";
+  char ebuf[1024];
+  void* const handle = os::dll_load(name, ebuf, sizeof(ebuf));
+  if (handle == nullptr) {
+    log_error_p(gc)("Failed to load library: %s", name);
+  }
+  return handle;
+}
+
+static void* lookup_kernelbase_symbol(const char* name) {
+  static void* const handle = lookup_kernelbase_library();
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  return os::dll_lookup(handle, name);
+}
+
+static bool has_kernelbase_symbol(const char* name) {
+  return lookup_kernelbase_symbol(name) != nullptr;
+}
+
 template <typename Fn>
 static void install_kernelbase_symbol(Fn*& fn, const char* name) {
-  fn = reinterpret_cast<Fn*>(os::win32::lookup_kernelbase_symbol(name));
+  fn = reinterpret_cast<Fn*>(lookup_kernelbase_symbol(name));
 }
 
 template <typename Fn>
@@ -62,10 +83,10 @@ void ZSyscall::initialize() {
 
 bool ZSyscall::is_supported() {
   // Available in Windows version 1803 and later
-  return os::win32::lookup_kernelbase_symbol("VirtualAlloc2") != nullptr;
+  return has_kernelbase_symbol("VirtualAlloc2");
 }
 
 bool ZSyscall::is_large_pages_supported() {
   // Available in Windows version 1809 and later
-  return os::win32::lookup_kernelbase_symbol("CreateFileMapping2") != nullptr;
+  return has_kernelbase_symbol("CreateFileMapping2");
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -243,6 +243,24 @@ static LPVOID virtualAllocExNuma(HANDLE hProcess, LPVOID lpAddress, SIZE_T dwSiz
   return result;
 }
 
+static void* lookup_kernelbase_library() {
+  const char* const name = "KernelBase";
+  char ebuf[1024];
+  void* const handle = os::dll_load(name, ebuf, sizeof(ebuf));
+  if (handle == nullptr) {
+    log_trace(os)("Failed to load library: %s: %s", name, ebuf);
+  }
+  return handle;
+}
+
+void* os::win32::lookup_kernelbase_symbol(const char* name) {
+  static void* const handle = lookup_kernelbase_library();
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  return os::dll_lookup(handle, name);
+}
+
 // Logging wrapper for MapViewOfFileEx
 static LPVOID mapViewOfFileEx(HANDLE hFileMappingObject, DWORD  dwDesiredAccess, DWORD  dwFileOffsetHigh,
                               DWORD  dwFileOffsetLow, SIZE_T dwNumberOfBytesToMap, LPVOID lpBaseAddress) {
@@ -3251,14 +3269,27 @@ char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, in
   return map_memory_to_file(base, size, fd);
 }
 
+// VirtualAlloc2 / MapViewOfFile3 (Windows 1803+). Resolved in os::init_2() via lookup_kernelbase_symbol.
+os::win32::VirtualAlloc2Fn os::win32::VirtualAlloc2 = nullptr;
+
+os::win32::MapViewOfFile3Fn os::win32::MapViewOfFile3 = nullptr;
+
+static bool is_VirtualAlloc2_supported() {
+  return os::win32::VirtualAlloc2 != nullptr;
+}
+
+static bool is_MapViewOfFile3_supported() {
+  return os::win32::MapViewOfFile3 != nullptr;
+}
+
 // Multiple threads can race in this code but it's not possible to unmap small sections of
 // virtual space to get requested alignment, like posix-like os's.
 // Windows prevents multiple thread from remapping over each other so this loop is thread-safe.
-static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int file_desc, MemTag mem_tag) {
+static char* reserve_memory_aligned(size_t size, size_t alignment, MemTag mem_tag) {
   assert(is_aligned(alignment, os::vm_allocation_granularity()),
-      "Alignment must be a multiple of allocation granularity (page size)");
+      "Alignment must be a multiple of allocation granularity");
   assert(is_aligned(size, os::vm_allocation_granularity()),
-      "Size must be a multiple of allocation granularity (page size)");
+      "Size must be a multiple of allocation granularity");
 
   size_t extra_size = size + alignment;
   assert(extra_size >= size, "overflow, size is too large to allow alignment");
@@ -3267,30 +3298,134 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
   static const int max_attempts = 20;
 
   for (int attempt = 0; attempt < max_attempts && aligned_base == nullptr; attempt ++) {
-    char* extra_base = file_desc != -1 ? os::map_memory_to_file(extra_size, file_desc, mem_tag) :
-                                         os::reserve_memory(extra_size, mem_tag);
+    char* extra_base = os::reserve_memory(extra_size, mem_tag);
     if (extra_base == nullptr) {
       return nullptr;
     }
     // Do manual alignment
     aligned_base = align_up(extra_base, alignment);
+    os::release_memory(extra_base, extra_size);
 
-    if (file_desc != -1) {
-      os::unmap_memory(extra_base, extra_size);
-    } else {
-      os::release_memory(extra_base, extra_size);
+    // Attempt to reserve, into the just vacated space, the slightly smaller aligned area.
+    // Which may fail, hence the loop.
+    aligned_base = os::attempt_reserve_memory_at(aligned_base, size, mem_tag);
+  }
+
+  assert(aligned_base != nullptr,
+      "Did not manage to re-map after %d attempts (size %zu, alignment %zu)", max_attempts, size, alignment);
+
+  return aligned_base;
+}
+
+// Similar to reserve_memory_aligned, multiple threads can race in this code.
+static char* map_memory_aligned(size_t size, size_t alignment, int file_desc, MemTag mem_tag) {
+  assert(is_aligned(alignment, os::vm_allocation_granularity()),
+      "Alignment must be a multiple of allocation granularity");
+  assert(is_aligned(size, os::vm_allocation_granularity()),
+      "Size must be a multiple of allocation granularity");
+
+  size_t extra_size = size + alignment;
+  assert(extra_size >= size, "overflow, size is too large to allow alignment");
+
+  char* aligned_base = nullptr;
+  static const int max_attempts = 20;
+
+  for (int attempt = 0; attempt < max_attempts && aligned_base == nullptr; attempt ++) {
+    char* extra_base = os::map_memory_to_file(extra_size, file_desc, mem_tag);
+    if (extra_base == nullptr) {
+      return nullptr;
     }
+    // Do manual alignment
+    aligned_base = align_up(extra_base, alignment);
+    os::unmap_memory(extra_base, extra_size);
 
     // Attempt to map, into the just vacated space, the slightly smaller aligned area.
     // Which may fail, hence the loop.
-    aligned_base = file_desc != -1 ? os::attempt_map_memory_to_file_at(aligned_base, size, file_desc, mem_tag) :
-                                     os::attempt_reserve_memory_at(aligned_base, size, mem_tag);
+    aligned_base = os::attempt_map_memory_to_file_at(aligned_base, size, file_desc, mem_tag);
   }
 
   assert(aligned_base != nullptr,
       "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
 
   return aligned_base;
+}
+
+// MapViewOfFile3 supports alignment natively.
+static char* map_memory_aligned_va2(size_t size, size_t alignment, int file_desc, MemTag mem_tag) {
+  assert(file_desc != -1,"file descriptor should not be -1");
+  assert(is_aligned(alignment, os::vm_allocation_granularity()),
+         "Alignment must be a multiple of allocation granularity");
+  assert(is_aligned(size, os::vm_allocation_granularity()),
+         "Size must be a multiple of allocation granularity");
+
+  MEM_ADDRESS_REQUIREMENTS requirements = {0};
+  requirements.Alignment = alignment;
+
+  MEM_EXTENDED_PARAMETER param = {0};
+  param.Type = MemExtendedParameterAddressRequirements;
+  param.Pointer = &requirements;
+
+  char* aligned_base = nullptr;
+
+  // File-backed aligned mapping.
+  HANDLE fh = (HANDLE)_get_osfhandle(file_desc);
+  HANDLE fileMapping = CreateFileMapping(fh, nullptr, PAGE_READWRITE,(DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), nullptr);
+  DWORD err = GetLastError();
+  if (fileMapping != nullptr) {
+    aligned_base = (char*)os::win32::MapViewOfFile3(
+            fileMapping,
+            GetCurrentProcess(),
+            nullptr,  // let the system choose an aligned address
+            0,        // offset
+            size,
+            0,        // no special allocation type flags
+            PAGE_READWRITE,
+            &param, 1);
+    err = GetLastError();
+    CloseHandle(fileMapping);
+  }
+
+  if (aligned_base != nullptr) {
+    assert(is_aligned(aligned_base, alignment), "Result must be aligned");
+    MemTracker::record_virtual_memory_reserve_and_commit(aligned_base, size, CALLER_PC, mem_tag);
+    return aligned_base;
+  }
+  log_trace(os)("Aligned allocation via MapViewOfFile3 failed, falling back to retry loop. GetLastError->%lu.", err);
+  return map_memory_aligned(size, alignment, file_desc, mem_tag);
+}
+
+// VirtualAlloc2 supports alignment natively.
+static char* reserve_memory_aligned_va2(size_t size, size_t alignment, MemTag mem_tag) {
+  assert(is_aligned(alignment, os::vm_allocation_granularity()),
+         "Alignment must be a multiple of allocation granularity");
+  assert(is_aligned(size, os::vm_allocation_granularity()),
+         "Size must be a multiple of allocation granularity");
+
+  MEM_ADDRESS_REQUIREMENTS requirements = {0};
+  requirements.Alignment = alignment;
+
+  MEM_EXTENDED_PARAMETER param = {0};
+  param.Type = MemExtendedParameterAddressRequirements;
+  param.Pointer = &requirements;
+
+  char* aligned_base = nullptr;
+
+  // Anonymous aligned reservation.
+  aligned_base = (char*)os::win32::VirtualAlloc2(
+          GetCurrentProcess(),
+          nullptr,  // let the system choose an aligned address
+          size,
+          MEM_RESERVE,
+          PAGE_READWRITE,
+          &param, 1);
+
+  if (aligned_base != nullptr) {
+    assert(is_aligned(aligned_base, alignment), "Result must be aligned");
+    MemTracker::record_virtual_memory_reserve(aligned_base, size, CALLER_PC, mem_tag);
+    return aligned_base;
+  }
+  log_trace(os)("Aligned allocation via VirtualAlloc2 failed, falling back to retry loop. GetLastError->%lu.", GetLastError());
+  return reserve_memory_aligned(size, alignment, mem_tag);
 }
 
 size_t os::commit_memory_limit() {
@@ -3340,11 +3475,17 @@ size_t os::reserve_memory_limit() {
 
 char* os::reserve_memory_aligned(size_t size, size_t alignment, MemTag mem_tag, bool exec) {
   // exec can be ignored
-  return map_or_reserve_memory_aligned(size, alignment, -1/* file_desc */, mem_tag);
+  if (is_VirtualAlloc2_supported()) {
+    return reserve_memory_aligned_va2(size, alignment, mem_tag);
+  }
+  return reserve_memory_aligned(size, alignment, mem_tag);
 }
 
 char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MemTag mem_tag) {
-  return map_or_reserve_memory_aligned(size, alignment, fd, mem_tag);
+  if (is_MapViewOfFile3_supported()) {
+    return map_memory_aligned_va2(size, alignment, fd, mem_tag);
+  }
+  return map_memory_aligned(size, alignment, fd, mem_tag);
 }
 
 char* os::pd_reserve_memory(size_t bytes, bool exec) {
@@ -4561,21 +4702,21 @@ jint os::init_2(void) {
 
   // Lookup SetThreadDescription - the docs state we must use runtime-linking of
   // kernelbase.dll, so that is what we do.
-  HINSTANCE _kernelbase = LoadLibrary(TEXT("kernelbase.dll"));
-  if (_kernelbase != nullptr) {
-    _SetThreadDescription =
-      reinterpret_cast<SetThreadDescriptionFnPtr>(
-                                                  GetProcAddress(_kernelbase,
-                                                                 "SetThreadDescription"));
+  _SetThreadDescription = reinterpret_cast<SetThreadDescriptionFnPtr>(
+      os::win32::lookup_kernelbase_symbol("SetThreadDescription"));
 #ifdef ASSERT
-    _GetThreadDescription =
-      reinterpret_cast<GetThreadDescriptionFnPtr>(
-                                                  GetProcAddress(_kernelbase,
-                                                                 "GetThreadDescription"));
+  _GetThreadDescription = reinterpret_cast<GetThreadDescriptionFnPtr>(
+      os::win32::lookup_kernelbase_symbol("GetThreadDescription"));
 #endif
-  }
   log_info(os, thread)("The SetThreadDescription API is%s available.", _SetThreadDescription == nullptr ? " not" : "");
 
+  // Prepare KernelBase APIs (VirtualAlloc2, MapViewOfFile3) if available (Windows version 1803).
+  os::win32::VirtualAlloc2 = reinterpret_cast<os::win32::VirtualAlloc2Fn>(
+      os::win32::lookup_kernelbase_symbol("VirtualAlloc2"));
+  os::win32::MapViewOfFile3 = reinterpret_cast<os::win32::MapViewOfFile3Fn>(
+      os::win32::lookup_kernelbase_symbol("MapViewOfFile3"));
+  log_debug(os)("VirtualAlloc2 is%s available.", os::win32::VirtualAlloc2 == nullptr ? " not" : "");
+  log_debug(os)("MapViewOfFile3 is%s available.", os::win32::MapViewOfFile3 == nullptr ? " not" : "");
 
   return JNI_OK;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3302,7 +3302,7 @@ static char* reserve_memory_aligned(size_t size, size_t alignment, MemTag mem_ta
   }
 
   assert(aligned_base != nullptr,
-      "Did not manage to re-map after %d attempts (size %zu, alignment %zu)", max_attempts, size, alignment);
+      "Did not manage to reserve after %d attempts (size %zu, alignment %zu)", max_attempts, size, alignment);
 
   return aligned_base;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -243,18 +243,10 @@ static LPVOID virtualAllocExNuma(HANDLE hProcess, LPVOID lpAddress, SIZE_T dwSiz
   return result;
 }
 
-static void* lookup_kernelbase_library() {
-  const char* const name = "KernelBase";
-  char ebuf[1024];
-  void* const handle = os::dll_load(name, ebuf, sizeof(ebuf));
-  if (handle == nullptr) {
-    log_trace(os)("Failed to load library: %s: %s", name, ebuf);
-  }
-  return handle;
-}
-
 void* os::win32::lookup_kernelbase_symbol(const char* name) {
-  static void* const handle = lookup_kernelbase_library();
+  // Pass a small ebuf so dll_load logs failures, but don't use it here to avoid redundancy.
+  char ebuf[1024];
+  static void* const handle = os::dll_load("KernelBase", ebuf, sizeof(ebuf));
   if (handle == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3233,9 +3233,9 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
   assert(fd != -1, "File descriptor is not valid");
 
   HANDLE fh = (HANDLE)_get_osfhandle(fd);
-  HANDLE fileMapping = CreateFileMapping(fh, nullptr, PAGE_READWRITE,
+  HANDLE file_mapping = CreateFileMapping(fh, nullptr, PAGE_READWRITE,
     (DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), nullptr);
-  if (fileMapping == nullptr) {
+  if (file_mapping == nullptr) {
     if (GetLastError() == ERROR_DISK_FULL) {
       vm_exit_during_initialization(err_msg("Could not allocate sufficient disk space for Java heap"));
     }
@@ -3246,9 +3246,9 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
     return nullptr;
   }
 
-  LPVOID addr = mapViewOfFileEx(fileMapping, FILE_MAP_WRITE, 0, 0, size, base);
+  LPVOID addr = mapViewOfFileEx(file_mapping, FILE_MAP_WRITE, 0, 0, size, base);
 
-  CloseHandle(fileMapping);
+  CloseHandle(file_mapping);
 
   return (char*)addr;
 }
@@ -3287,19 +3287,17 @@ static char* reserve_memory_aligned(size_t size, size_t alignment, MemTag mem_ta
   assert(extra_size >= size, "overflow, size is too large to allow alignment");
 
   char* aligned_base = nullptr;
-  static const int max_attempts = 20;
+  constexpr int max_attempts = 20;
 
   for (int attempt = 0; attempt < max_attempts && aligned_base == nullptr; attempt ++) {
     char* extra_base = os::reserve_memory(extra_size, mem_tag);
     if (extra_base == nullptr) {
       return nullptr;
     }
-    // Do manual alignment
     aligned_base = align_up(extra_base, alignment);
     os::release_memory(extra_base, extra_size);
 
-    // Attempt to reserve, into the just vacated space, the slightly smaller aligned area.
-    // Which may fail, hence the loop.
+    // A racing thread may have taken this region instead of us, which is why we loop and retry.
     aligned_base = os::attempt_reserve_memory_at(aligned_base, size, mem_tag);
   }
 
@@ -3309,7 +3307,7 @@ static char* reserve_memory_aligned(size_t size, size_t alignment, MemTag mem_ta
   return aligned_base;
 }
 
-// Similar to reserve_memory_aligned, multiple threads can race in this code.
+// Similar to reserve_memory_aligned, this code is race-prone.
 static char* map_memory_aligned(size_t size, size_t alignment, int file_desc, MemTag mem_tag) {
   assert(is_aligned(alignment, os::vm_allocation_granularity()),
       "Alignment must be a multiple of allocation granularity");
@@ -3320,19 +3318,17 @@ static char* map_memory_aligned(size_t size, size_t alignment, int file_desc, Me
   assert(extra_size >= size, "overflow, size is too large to allow alignment");
 
   char* aligned_base = nullptr;
-  static const int max_attempts = 20;
+  constexpr int max_attempts = 20;
 
   for (int attempt = 0; attempt < max_attempts && aligned_base == nullptr; attempt ++) {
     char* extra_base = os::map_memory_to_file(extra_size, file_desc, mem_tag);
     if (extra_base == nullptr) {
       return nullptr;
     }
-    // Do manual alignment
     aligned_base = align_up(extra_base, alignment);
     os::unmap_memory(extra_base, extra_size);
 
-    // Attempt to map, into the just vacated space, the slightly smaller aligned area.
-    // Which may fail, hence the loop.
+    // A racing thread may have taken this region instead of us, which is why we loop and retry.
     aligned_base = os::attempt_map_memory_to_file_at(aligned_base, size, file_desc, mem_tag);
   }
 
@@ -3344,7 +3340,7 @@ static char* map_memory_aligned(size_t size, size_t alignment, int file_desc, Me
 
 // MapViewOfFile3 supports alignment natively.
 static char* map_memory_aligned_va2(size_t size, size_t alignment, int file_desc, MemTag mem_tag) {
-  assert(file_desc != -1,"file descriptor should not be -1");
+  assert(file_desc != -1, "File descriptor should not be -1");
   assert(is_aligned(alignment, os::vm_allocation_granularity()),
          "Alignment must be a multiple of allocation granularity");
   assert(is_aligned(size, os::vm_allocation_granularity()),
@@ -3361,11 +3357,11 @@ static char* map_memory_aligned_va2(size_t size, size_t alignment, int file_desc
 
   // File-backed aligned mapping.
   HANDLE fh = (HANDLE)_get_osfhandle(file_desc);
-  HANDLE fileMapping = CreateFileMapping(fh, nullptr, PAGE_READWRITE,(DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), nullptr);
+  HANDLE file_mapping = CreateFileMapping(fh, nullptr, PAGE_READWRITE,(DWORD)(size >> 32), (DWORD)(size & 0xFFFFFFFF), nullptr);
   DWORD err = GetLastError();
-  if (fileMapping != nullptr) {
+  if (file_mapping != nullptr) {
     aligned_base = (char*)os::win32::MapViewOfFile3(
-            fileMapping,
+            file_mapping,
             GetCurrentProcess(),
             nullptr,  // let the system choose an aligned address
             0,        // offset
@@ -3374,7 +3370,7 @@ static char* map_memory_aligned_va2(size_t size, size_t alignment, int file_desc
             PAGE_READWRITE,
             &param, 1);
     err = GetLastError();
-    CloseHandle(fileMapping);
+    CloseHandle(file_mapping);
   }
 
   if (aligned_base != nullptr) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3307,7 +3307,7 @@ static char* reserve_memory_aligned(size_t size, size_t alignment, MemTag mem_ta
   return aligned_base;
 }
 
-// Similar to reserve_memory_aligned, this code is race-prone.
+// Similar to reserve_memory_aligned, other reservation/mapping requests can race with this function.
 static char* map_memory_aligned(size_t size, size_t alignment, int file_desc, MemTag mem_tag) {
   assert(is_aligned(alignment, os::vm_allocation_granularity()),
       "Alignment must be a multiple of allocation granularity");

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -109,6 +109,19 @@ class os::win32 {
   // load dll from Windows system directory or Windows directory
   static HINSTANCE load_Windows_dll(const char* name, char *ebuf, int ebuflen);
 
+  // Resolve a symbol from KernelBase.dll, returns nullptr if not found.
+  static void* lookup_kernelbase_symbol(const char* name);
+
+  // VirtualAlloc2 (since Windows version 1803)
+  // Resolved from KernelBase during os::init_2() or nullptr if unavailable.
+  typedef PVOID (WINAPI *VirtualAlloc2Fn)(HANDLE, PVOID, SIZE_T, ULONG, ULONG, MEM_EXTENDED_PARAMETER*, ULONG);
+  static VirtualAlloc2Fn VirtualAlloc2;
+
+  // MapViewOfFile3 (since Windows version 1803)
+  // Resolved from KernelBase during os::init_2() or nullptr if unavailable.
+  typedef PVOID (WINAPI *MapViewOfFile3Fn)(HANDLE, HANDLE, PVOID, ULONG64, SIZE_T, ULONG, ULONG, MEM_EXTENDED_PARAMETER*, ULONG);
+  static MapViewOfFile3Fn MapViewOfFile3;
+
  private:
 
   static void initialize_performance_counter();

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1200,16 +1200,22 @@ TEST_VM(os, map_unmap_memory) {
 
 TEST_VM(os, map_memory_to_file_aligned) {
   const char* letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  const size_t size = strlen(letters) + 1;
+  const size_t content_size = strlen(letters) + 1;
+  const size_t granularity = os::vm_allocation_granularity();
+  const size_t alignments[] = { granularity, 2 * granularity, 4 * granularity, 16 * granularity, 1 * M };
 
   int fd = os::open("map_memory_to_file.txt", O_RDWR | O_CREAT, 0666);
   EXPECT_TRUE(fd > 0);
-  EXPECT_TRUE(os::write(fd, letters, size));
+  ASSERT_TRUE(os::write(fd, letters, content_size));
 
-  char* result = os::map_memory_to_file_aligned(os::vm_allocation_granularity(), os::vm_allocation_granularity(), fd, mtTest);
-  ASSERT_NOT_NULL(result);
-  EXPECT_EQ(strcmp(letters, result), 0);
-  os::unmap_memory(result, os::vm_allocation_granularity());
+  const size_t size = granularity;
+  for (size_t alignment : alignments) {
+    char* result = os::map_memory_to_file_aligned(size, alignment, fd, mtTest);
+    ASSERT_NOT_NULL(result) << "Mapping failed for alignment=" << alignment;
+    EXPECT_TRUE(is_aligned(result, alignment)) << "Failed to aligned to " << alignment;
+    EXPECT_EQ(strcmp(letters, result), 0) << "Text mismatch at alignment=" << alignment;
+    os::unmap_memory(result, size);
+  }
   ::close(fd);
 }
 
@@ -1219,4 +1225,39 @@ TEST_VM(os, dll_load_null_error_buf) {
   // This should not crash.
   void* lib = os::dll_load("NoSuchLib", nullptr, 0);
   ASSERT_NULL(lib);
+}
+
+// --- Aligned allocation tests ---
+
+TEST_VM(os, reserve_memory_aligned_basic) {
+  const size_t granularity = os::vm_allocation_granularity();
+  const size_t alignments[] = { granularity, 2 * granularity, 4 * granularity, 16 * granularity };
+
+  for (size_t alignment : alignments) {
+    const size_t size = alignment;
+    char* result = os::reserve_memory_aligned(size, alignment, mtTest);
+    ASSERT_NE(result, (char*)nullptr) << "reserve_memory_aligned failed for alignment=" << alignment;
+    EXPECT_TRUE(is_aligned(result, alignment)) << "Result " << result << " not aligned to " << alignment;
+
+    ASSERT_TRUE(os::commit_memory(result, size, false));
+    memset(result, 0xCD, size);
+    EXPECT_EQ((unsigned char)result[0], 0xCD);
+
+    os::release_memory(result, size);
+  }
+}
+
+TEST_VM(os, reserve_memory_aligned_large) {
+  const size_t alignment = 1 * M;
+  const size_t size = alignment;
+
+  char* result = os::reserve_memory_aligned(size, alignment, mtTest);
+  ASSERT_NE(result, (char*)nullptr);
+  EXPECT_TRUE(is_aligned(result, alignment));
+
+  ASSERT_TRUE(os::commit_memory(result, size, false));
+  memset(result, 0xEF, size);
+  EXPECT_EQ((unsigned char)result[size - 1], 0xEF);
+
+  os::release_memory(result, size);
 }

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1227,8 +1227,6 @@ TEST_VM(os, dll_load_null_error_buf) {
   ASSERT_NULL(lib);
 }
 
-// --- Aligned allocation tests ---
-
 TEST_VM(os, reserve_memory_aligned_basic) {
   const size_t granularity = os::vm_allocation_granularity();
   const size_t alignments[] = { granularity, 2 * granularity, 4 * granularity, 16 * granularity };


### PR DESCRIPTION
### Summary
Previously on Windows, aligned virtual memory could not be reserved or mapped in a single step. Hotspot used the following race-y pattern on Windows to reserved aligned memory:
 - Reserve a large region in order to get an available address range.
 - Find the first aligned address within the returned range
 - Release the whole region.
 - Quickly re-reserve/map a subregion within the original region at the aligned address found earlier.

`VirtualAlloc2` and `MapViewOfFile3` (available since Windows version 1803) removes the need for this race-y code by supporting alignment natively. I have replaced the race-y part of `map_or_reserve_memory_aligned` with calls to these new APIs. I have also broken up `map_or_reserve_memory_aligned` into two separate functions, one path for mapping and one for reserving. It's awkward to have both code paths sandwiched into the same function.

The Windows API functions are dynamically loaded at startup at the end of `os::init_2` in os_windows.cpp. This is when `os::win32::VirtualAlloc2` and `os::win32::MapViewOfFile3` are prepared. If the loading fails, the Windows implementation falls back to the old racey approach.

`lookup_kernelbase_library` and `lookup_kernelbase_symbol` have been moved from zSyscall_windows.cpp to `os::win32::` to reduce code duplication.

This is a scoped-down version of [JDK-8376561](https://bugs.openjdk.org/browse/JDK-8376561) and [PR](https://github.com/openjdk/jdk/pull/30270) for the sake of easier review.  This is the first change in a series of changes that take advantage of VirtualAlloc2 to replace races in Windows code. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385586](https://bugs.openjdk.org/browse/JDK-8385586): Fix race in Windows map_or_reserve_memory_aligned using VirtualAlloc2 and MapViewOfFile3 (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**) Review applies to [5e76f00a](https://git.openjdk.org/jdk/pull/31311/files/5e76f00ac205859f12081efa3c340b467e8ec72f)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31311/head:pull/31311` \
`$ git checkout pull/31311`

Update a local copy of the PR: \
`$ git checkout pull/31311` \
`$ git pull https://git.openjdk.org/jdk.git pull/31311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31311`

View PR using the GUI difftool: \
`$ git pr show -t 31311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31311.diff">https://git.openjdk.org/jdk/pull/31311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31311#issuecomment-4567634472)
</details>
