### PR TITLE
8385584: CAInterop.java#buypassclass3ca fails with Intermediate Root CA not found in the chain

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -607,8 +607,8 @@ public class CAInterop {
                     new CATestURLs("https://valid.business.ca22.ssl.buypass.no",
                     "https://revoked.business.ca22.ssl.buypass.no");
             case "buypassclass3ca" ->
-                    new CATestURLs("https://valid.qcevident.ca23.ssl.buypass.no",
-                    "https://revoked.qcevident.ca23.ssl.buypass.no");
+                    new CATestURLs("https://valid.evident.ca23.ssl.buypass.no",
+                    "https://revoked.evident.ca23.ssl.buypass.no");
 
             case "comodorsaca" ->
                     new CATestURLs("https://comodorsacertificationauthority-ev.comodoca.com",


### PR DESCRIPTION
Updated CAInterop.java#buypassclass3ca to use Buypass CA's current Class 3 SSL test endpoints:

  - valid.evident.ca23.ssl.buypass.no
  - revoked.evident.ca23.ssl.buypass.no

The previous qcevident.ca23 endpoints were serving a Class 2 certificate chain.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385584](https://bugs.openjdk.org/browse/JDK-8385584): CAInterop.java#buypassclass3ca fails with Intermediate Root CA not found in the chain (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31312/head:pull/31312` \
`$ git checkout pull/31312`

Update a local copy of the PR: \
`$ git checkout pull/31312` \
`$ git pull https://git.openjdk.org/jdk.git pull/31312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31312`

View PR using the GUI difftool: \
`$ git pr show -t 31312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31312.diff">https://git.openjdk.org/jdk/pull/31312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31312#issuecomment-4566895012)
</details>
