### PR TITLE
8385622: [s390x] Debugger very slow during stepping

### DIFF
--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -2003,9 +2003,23 @@ void InterpreterMacroAssembler::notify_method_exit(bool native_method,
   // depth. If it is possible to enter interp_only_mode we add
   // the code to check if the event should be sent.
   if (mode == NotifyJVMTI && (JvmtiExport::can_post_interpreter_events() || JvmtiExport::can_post_frame_pop())) {
+    NearLabel jvmti_post_done;
+
+    // if (thread->jvmti_thread_state() == nullptr) exit;
+    z_ltg(Z_R1_scratch, Address(Z_thread, JavaThread::jvmti_thread_state_offset()));
+    z_brz(jvmti_post_done);
+
+    // if (interp_only_mode() == false && frame_pop_cnt() == 0) exit;
+    z_lg(Z_R0_scratch, Address(Z_R1_scratch, JvmtiThreadState::frame_pop_cnt_offset()));
+    z_lg(Z_R1_scratch, Address(Z_thread, JavaThread::interp_only_mode_offset()));
+    z_ogr(Z_R1_scratch, Z_R0_scratch);
+    z_brz(jvmti_post_done);
+
     if (!native_method) push(state); // see frame::interpreter_frame_result()
     call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_method_exit));
     if (!native_method) pop(state);
+
+    bind(jvmti_post_done);
   }
 }
 

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -2010,9 +2010,9 @@ void InterpreterMacroAssembler::notify_method_exit(bool native_method,
     z_brz(jvmti_post_done);
 
     // if (interp_only_mode() == false && frame_pop_cnt() == 0) exit;
-    z_lg(Z_R0_scratch, Address(Z_R1_scratch, JvmtiThreadState::frame_pop_cnt_offset()));
-    z_lg(Z_R1_scratch, Address(Z_thread, JavaThread::interp_only_mode_offset()));
-    z_ogr(Z_R1_scratch, Z_R0_scratch);
+    z_lgf(Z_R0_scratch, Address(Z_R1_scratch, JvmtiThreadState::frame_pop_cnt_offset()));
+    z_lgf(Z_R1_scratch, Address(Z_thread, JavaThread::interp_only_mode_offset()));
+    z_or(Z_R1_scratch, Z_R0_scratch);
     z_brz(jvmti_post_done);
 
     if (!native_method) push(state); // see frame::interpreter_frame_result()

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -2010,9 +2010,8 @@ void InterpreterMacroAssembler::notify_method_exit(bool native_method,
     z_brz(jvmti_post_done);
 
     // if (interp_only_mode() == false && frame_pop_cnt() == 0) exit;
-    z_lgf(Z_R0_scratch, Address(Z_R1_scratch, JvmtiThreadState::frame_pop_cnt_offset()));
-    z_lgf(Z_R1_scratch, Address(Z_thread, JavaThread::interp_only_mode_offset()));
-    z_or(Z_R1_scratch, Z_R0_scratch);
+    z_lgf(Z_R1_scratch, Address(Z_R1_scratch, JvmtiThreadState::frame_pop_cnt_offset()));
+    z_o(Z_R1_scratch, Address(Z_thread, JavaThread::interp_only_mode_offset()));
     z_brz(jvmti_post_done);
 
     if (!native_method) push(state); // see frame::interpreter_frame_result()


### PR DESCRIPTION
I have implemented the missing implementation from https://bugs.openjdk.org/browse/JDK-6960970. 

Testing (fastdebug/s390x z16): 

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/hotspot/jtreg/serviceability/jvmti       248   191     0     0    57   
==============================
TEST SUCCESS
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385622](https://bugs.openjdk.org/browse/JDK-8385622): [s390x] Debugger very slow during stepping (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31317/head:pull/31317` \
`$ git checkout pull/31317`

Update a local copy of the PR: \
`$ git checkout pull/31317` \
`$ git pull https://git.openjdk.org/jdk.git pull/31317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31317`

View PR using the GUI difftool: \
`$ git pr show -t 31317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31317.diff">https://git.openjdk.org/jdk/pull/31317.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31317#issuecomment-4572144185)
</details>
