### PR TITLE
8385355: NullPointerException in jdk.tools.jlink.internal.ImageResourcesTree after JDK-8377070

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -235,22 +235,40 @@ public final class ImageResourcesTree {
                 return;
             }
             String modName = fullPath.substring(1, modEnd);
-            String pkgPath = fullPath.substring(modEnd + 1);
+            String resPath = fullPath.substring(modEnd + 1);
+            int pathEnd = resPath.lastIndexOf('/');
 
             Node parentNode = getDirectoryNode(modName, modulesRoot);
             boolean isPreviewPath = false;
-            if (pkgPath.startsWith(PREVIEW_PREFIX)) {
+            if (resPath.startsWith("META-INF/")) {
+                parentNode = getDirectoryNode("META-INF", parentNode);
+                if (!resPath.startsWith(PREVIEW_PREFIX)) {
+                    // Non-preview META-INF paths are resources, not package
+                    // hierarchies, so directory and file names may contain dots.
+                    for (int i = "META-INF".length(), j; i != pathEnd; i = j) {
+                        j = resPath.indexOf('/', i + 1);
+                        parentNode = getDirectoryNode(resPath.substring(i + 1, j), parentNode);
+                    }
+                    new ResourceNode(resPath.substring(pathEnd + 1), parentNode);
+                    return;
+                }
                 // For preview paths, process nodes relative to the preview directory.
-                pkgPath = pkgPath.substring(PREVIEW_PREFIX.length());
-                Node metaInf = getDirectoryNode("META-INF", parentNode);
-                parentNode = getDirectoryNode("preview", metaInf);
+                parentNode = getDirectoryNode("preview", parentNode);
+                resPath = resPath.substring(PREVIEW_PREFIX.length());
+                pathEnd -= PREVIEW_PREFIX.length();
                 isPreviewPath = true;
             }
 
-            int pathEnd = pkgPath.lastIndexOf('/');
             // From invariants tested above, this must now be well-formed.
-            String fullPkgName = (pathEnd == -1) ? "" : pkgPath.substring(0, pathEnd).replace('/', '.');
-            String resourceName = pkgPath.substring(pathEnd + 1);
+            String pkgPath = (pathEnd == -1) ? "" : resPath.substring(0, pathEnd);
+            if (pkgPath.contains(".")) {
+                // Non META-INF entries are package paths. Dots in path segment
+                // names would otherwise be confused with package separators.
+                System.err.println("Invalid package path, skipping " + pkgPath);
+                return;
+            }
+            String fullPkgName = pkgPath.replace('/', '.');
+            String resourceName = resPath.substring(pathEnd + 1);
             // Intermediate packages are marked "empty" (no resources). This might
             // later be merged with a non-empty link for the same package.
             ModuleLink emptyLink = ModuleLink.forEmptyPackage(modName, isPreviewPath);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -249,7 +249,13 @@ public final class ImageResourcesTree {
                         j = resPath.indexOf('/', i + 1);
                         parentNode = getDirectoryNode(resPath.substring(i + 1, j), parentNode);
                     }
-                    new ResourceNode(resPath.substring(pathEnd + 1), parentNode);
+                    String resourceName = resPath.substring(pathEnd + 1);
+                    Node resourceNode = parentNode.getChildren(resourceName);
+                    if (resourceNode == null) {
+                        new ResourceNode(resourceName, parentNode);
+                    } else if (!(resourceNode instanceof ResourceNode)) {
+                        throw new InvalidTreeException(resourceNode);
+                    }
                     return;
                 }
                 // For preview paths, process nodes relative to the preview directory.

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -37,6 +37,7 @@ import tests.Helper;
 import tests.JImageGenerator;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -58,6 +59,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 /*
  * @test
+ * @bug 8385355
  * @summary Tests for ImageReader.
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
@@ -72,13 +74,16 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 /// There is no mutable test instance state to worry about.
 @TestInstance(PER_CLASS)
 public class ImageReaderTest {
-    // The '@' prefix marks the entry as a preview entry which will be placed in
-    // the '/modules/<module>/META-INF/preview/...' namespace.
+    // The '@' prefix marks the entry as a preview class entry which will be placed in
+    // the '/modules/<module>/META-INF/preview/...' namespace. The '!' prefix marks
+    // the entry as a non-class resource path.
     private static final Map<String, List<String>> IMAGE_ENTRIES = Map.of(
             "modfoo", Arrays.asList(
                     "com.foo.HasPreviewVersion",
                     "com.foo.NormalFoo",
                     "com.foo.bar.NormalBar",
+                    "!META-INF/maven/com.google.code.findbugs/jsr305/pom.properties",
+                    "!META-INF/z",
                     // Replaces original class in preview mode.
                     "@com.foo.HasPreviewVersion",
                     // New class in existing package in preview mode.
@@ -135,6 +140,21 @@ public class ImageReaderTest {
             assertNonPreviewVersion(loader, "modfoo", "com.foo.NormalFoo");
             assertNonPreviewVersion(loader, "modfoo", "com.foo.bar.NormalBar");
             assertNonPreviewVersion(loader, "modbar", "com.bar.One");
+        }
+    }
+
+    @Test
+    public void testMetaInfResourcesAreNotPackagePaths() throws IOException {
+        for (PreviewMode mode : List.of(PreviewMode.ENABLED, PreviewMode.DISABLED)) {
+            try (ImageReader reader = ImageReader.open(image, mode)) {
+                assertResource(reader, "modfoo", "META-INF/maven/com.google.code.findbugs/jsr305/pom.properties");
+                assertResource(reader, "modfoo", "META-INF/z");
+                assertDirContents(reader, "/modules/modfoo/META-INF", "MANIFEST.MF", "maven", "z");
+                assertDirContents(reader, "/modules/modfoo/META-INF/maven", "com.google.code.findbugs");
+                assertDirContents(reader, "/modules/modfoo/META-INF/maven/com.google.code.findbugs", "jsr305");
+                assertDirContents(reader, "/modules/modfoo/META-INF/maven/com.google.code.findbugs/jsr305", "pom.properties");
+                assertAbsent(reader, "/modules/modfoo/META-INF/maven/com/google/code/findbugs/jsr305/pom.properties");
+            }
         }
     }
 
@@ -416,6 +436,10 @@ public class ImageReaderTest {
             jar.addEntry("module-info.class", InMemoryJavaCompiler.compile("module-info", moduleInfo));
 
             classes.forEach(fqn -> {
+                if (fqn.startsWith("!")) {
+                    jar.addEntry(fqn.substring(1), "resource".getBytes(StandardCharsets.UTF_8));
+                    return;
+                }
                 boolean isPreviewEntry = fqn.startsWith("@");
                 if (isPreviewEntry) {
                     fqn = fqn.substring(1);

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -84,6 +84,8 @@ public class ImageReaderTest {
                     "com.foo.bar.NormalBar",
                     "!META-INF/maven/com.google.code.findbugs/jsr305/pom.properties",
                     "!META-INF/z",
+                    "!META-INF/collision/child.properties",
+                    "!META-INF/collision",
                     // Replaces original class in preview mode.
                     "@com.foo.HasPreviewVersion",
                     // New class in existing package in preview mode.
@@ -149,7 +151,9 @@ public class ImageReaderTest {
             try (ImageReader reader = ImageReader.open(image, mode)) {
                 assertResource(reader, "modfoo", "META-INF/maven/com.google.code.findbugs/jsr305/pom.properties");
                 assertResource(reader, "modfoo", "META-INF/z");
-                assertDirContents(reader, "/modules/modfoo/META-INF", "MANIFEST.MF", "maven", "z");
+                assertResource(reader, "modfoo", "META-INF/collision/child.properties");
+                assertDirContents(reader, "/modules/modfoo/META-INF", "MANIFEST.MF", "collision", "maven", "z");
+                assertDirContents(reader, "/modules/modfoo/META-INF/collision", "child.properties");
                 assertDirContents(reader, "/modules/modfoo/META-INF/maven", "com.google.code.findbugs");
                 assertDirContents(reader, "/modules/modfoo/META-INF/maven/com.google.code.findbugs", "jsr305");
                 assertDirContents(reader, "/modules/modfoo/META-INF/maven/com.google.code.findbugs/jsr305", "pom.properties");


### PR DESCRIPTION
This fixes a regression from JDK-8377070 where `ImageResourcesTree` treated every image entry path as a package hierarchy. That implicitly assumes directory path segments cannot contain `.`, which is true for package paths but not for ordinary resources such as `META-INF/maven/com.google.code.findbugs/...`.

The fix handles non-preview `META-INF/` entries as resource paths, preserving their directory names as-is and avoiding package inference for those resources. `META-INF/preview/` continues to use the existing package-oriented handling because those entries represent preview class/package content.

A regression test was added to `ImageReaderTest` with `META-INF` resources containing dotted path segments, verifying resource lookup and directory contents in both preview-enabled and preview-disabled modes.

This change was developed by @david-beaumont.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385355](https://bugs.openjdk.org/browse/JDK-8385355): NullPointerException in jdk.tools.jlink.internal.ImageResourcesTree after JDK-8377070 (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Contributors
 * David Beaumont `<dbeaumont@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31318/head:pull/31318` \
`$ git checkout pull/31318`

Update a local copy of the PR: \
`$ git checkout pull/31318` \
`$ git pull https://git.openjdk.org/jdk.git pull/31318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31318`

View PR using the GUI difftool: \
`$ git pr show -t 31318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31318.diff">https://git.openjdk.org/jdk/pull/31318.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31318#issuecomment-4597837954)
</details>
