### PR TITLE
8385627: Typo in JMXServiceURL.java: misssing

### DIFF
--- a/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,7 +291,7 @@ public class JMXServiceURL implements Serializable {
                          String urlPath)
             throws MalformedURLException {
         if (protocol == null) {
-            throw new MalformedURLException("Misssing protocol name");
+            throw new MalformedURLException("Missing protocol name");
         }
         if (host == null) {
             InetAddress local;


### PR DESCRIPTION
Trivial typo in a message.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385627](https://bugs.openjdk.org/browse/JDK-8385627): Typo in JMXServiceURL.java: misssing (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31319/head:pull/31319` \
`$ git checkout pull/31319`

Update a local copy of the PR: \
`$ git checkout pull/31319` \
`$ git pull https://git.openjdk.org/jdk.git pull/31319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31319`

View PR using the GUI difftool: \
`$ git pr show -t 31319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31319.diff">https://git.openjdk.org/jdk/pull/31319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31319#issuecomment-4572805720)
</details>
