### PR TITLE
8385628: Typo in jdk.attach comments

### DIFF
--- a/src/jdk.attach/share/classes/com/sun/tools/attach/VirtualMachine.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/VirtualMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.io.IOException;
  * <p> A {@code VirtualMachine} represents a Java virtual machine to which this
  * Java virtual machine has attached. The Java virtual machine to which it is
  * attached is sometimes called the <i>target virtual machine</i>, or <i>target VM</i>.
- * An application (typically a tool such as a managemet console or profiler) uses a
+ * An application (typically a tool such as a management console or profiler) uses a
  * VirtualMachine to load an agent into the target VM. For example, a profiler tool
  * written in the Java Language might attach to a running application and load its
  * profiler agent to profile the running application. </p>

--- a/src/jdk.attach/share/classes/sun/tools/attach/HotSpotAttachProvider.java
+++ b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotAttachProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ public abstract class HotSpotAttachProvider extends AttachProvider {
             mvm = host.getMonitoredVm(vmid);
 
             if (MonitoredVmUtil.isAttachable(mvm)) {
-                // it's attachable; so return false
+                // it's attachable
                 return;
             }
         } catch (Throwable t) {


### PR DESCRIPTION
Trivial typo corrections.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385628](https://bugs.openjdk.org/browse/JDK-8385628): Typo in jdk.attach comments (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31320/head:pull/31320` \
`$ git checkout pull/31320`

Update a local copy of the PR: \
`$ git checkout pull/31320` \
`$ git pull https://git.openjdk.org/jdk.git pull/31320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31320`

View PR using the GUI difftool: \
`$ git pr show -t 31320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31320.diff">https://git.openjdk.org/jdk/pull/31320.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31320#issuecomment-4572915958)
</details>
