### PR TITLE
8385409: Javap documentation says by default protected and public members are printed but package private members are also printed by default (`-package` behavior, not `-protected`)

### DIFF
--- a/src/jdk.jdeps/share/man/javap.md
+++ b/src/jdk.jdeps/share/man/javap.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1994, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,8 @@ javap - disassemble one or more class files
 
 The `javap` command disassembles one or more class files. The output depends on
 the options used. When no options are used, the `javap` command prints the
-protected and public fields, and methods of the classes passed to it.
+package private, protected and public fields, and methods of the classes passed
+to it.
 
 The `javap` command isn't multirelease JAR aware. Using the class path form of
 the command results in viewing the base entry in all JAR files, multirelease or

--- a/src/jdk.jdeps/share/man/javap.md
+++ b/src/jdk.jdeps/share/man/javap.md
@@ -54,7 +54,7 @@ javap - disassemble one or more class files
 
 The `javap` command disassembles one or more class files. The output depends on
 the options used. When no options are used, the `javap` command prints the
-package private, protected and public fields, and methods of the classes passed
+package private, protected, and public fields and methods declared in the classes passed
 to it.
 
 The `javap` command isn't multirelease JAR aware. Using the class path form of


### PR DESCRIPTION
In the current version of the JDK, there is a small inconsistency in the documentation for the `javap` command.

The description currently states that, when no options are used, `javap` prints only protected and public fields and methods.
```
The javap command disassembles one or more class files. The output depends on the options used.
When no options are used, the javap command prints the protected and public fields, and methods
of the classes passed to it.
```
This contradicts both the documented default for the `-package` option
```
-package
     Shows package/protected/public classes and members (default).
```
and the actual behavior of the tool: package-private members are also printed by default.

The proposed change is to update the wording to state that `javap` prints package-private, protected, and public fields and methods when no access-filtering option is specified.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8385676](https://bugs.openjdk.org/browse/JDK-8385676) to be approved

### Issues
 * [JDK-8385409](https://bugs.openjdk.org/browse/JDK-8385409): Javap documentation says by default protected and public members are printed but package private members are also printed by default (`-package` behavior, not `-protected`) (**Bug** - P4)
 * [JDK-8385676](https://bugs.openjdk.org/browse/JDK-8385676): Javap documentation says by default protected and public members are printed but package private members are also printed by default (`-package` behavior, not `-protected`) (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31321/head:pull/31321` \
`$ git checkout pull/31321`

Update a local copy of the PR: \
`$ git checkout pull/31321` \
`$ git pull https://git.openjdk.org/jdk.git pull/31321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31321`

View PR using the GUI difftool: \
`$ git pr show -t 31321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31321.diff">https://git.openjdk.org/jdk/pull/31321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31321#issuecomment-4573657466)
</details>
