### PR TITLE
8385632: ZGC: Incorrect object undo in relocation race for relocation workers

### DIFF
--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -642,7 +642,7 @@ private:
     const zaddress to_addr = _forwarding->insert(from_addr, allocated_addr, &cursor);
     if (to_addr != allocated_addr) {
       // Already relocated, undo allocation
-      _allocator->undo_alloc_object(to_page, to_addr, size);
+      _allocator->undo_alloc_object(to_page, allocated_addr, size);
       increase_other_forwarded(size);
     }
 


### PR DESCRIPTION
Hello,

When a relocation worker races with a mutator and the relocation worker loses, it should attempt to undo its last allocation as a way to potentially save some space.

When the relocation worker loses the race, it passes on the object allocated by the mutator in its call to ZPage::undo_alloc_object, not the object the relocation worker just allocated.

Since relocation workers and mutators have totally separate target pages, we will never end up in a scenario where a mutator allocation can end up on a page that a relocation worker also allocates on. ZPage::undo_alloc_object only undos an allocation if it was the most recent one, by checking if the object's offset into the heap is the same offset as the page's top. This means the undo will never succeed if the object is not on the page also passed to undo_alloc_object. In practice this means that this bug is benign, resulting in one waste relocation worker allocation in the event of a race occurring.

On the mutator side, if the mutator loses the race it calls ZHeap::undo_alloc_object_for_relocation, which gets the correct page for an object via ZHeap::page, so we don't have the same issue there.

The fix is simple, we just make sure we pass the object allocated by the relocation worker in the call to undo_alloc_object.

This might be relevant to backport, so I suggest we add more robustness to the undo-paths in a follow-up RFE, making sure that we're not trying to undo object allocations in a page it doesn't belong to, so we can more easily catch bugs like this in the future.

Testing:
* Running Oracle's tier1-4 ZGC tests

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385632](https://bugs.openjdk.org/browse/JDK-8385632): ZGC: Incorrect object undo in relocation race for relocation workers (**Bug** - P5)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31322/head:pull/31322` \
`$ git checkout pull/31322`

Update a local copy of the PR: \
`$ git checkout pull/31322` \
`$ git pull https://git.openjdk.org/jdk.git pull/31322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31322`

View PR using the GUI difftool: \
`$ git pr show -t 31322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31322.diff">https://git.openjdk.org/jdk/pull/31322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31322#issuecomment-4574399398)
</details>
