### PR TITLE
8385408: C2: no reachable node should have no use

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -894,7 +894,8 @@ static Node* mask_and_replace_shift_amount(PhaseGVN* phase, Node* shift_node, ui
     }
 
     if (replace) {
-      shift_node->set_req(2, phase->intcon(masked_shift)); // Replace shift count with masked value.
+      // Replace shift count with masked value and put potential dead nodes on the worklist.
+      shift_node->set_req_X(2, phase->intcon(masked_shift), phase);
 
       // We need to notify the caller that the graph was reshaped, as Ideal needs
       // to return the root of the reshaped graph if any change was made.

--- a/test/hotspot/jtreg/compiler/igvn/TestShiftWorklist.java
+++ b/test/hotspot/jtreg/compiler/igvn/TestShiftWorklist.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8385408
+ * @summary Test that inputs to removed shifts are put on the worklist and cleaned up
+ * @library /test/lib /
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+package compiler.igvn;
+
+import jdk.test.lib.Asserts;
+
+public class TestShiftWorklist {
+    int N = 400;
+    int iArr[] = new int[N];
+
+    public static void main(String[] args) {
+        TestShiftWorklist t = new TestShiftWorklist();
+        for (int i = 0; i < 2_000; i++) {
+            int result = t.test();
+            Asserts.assertEQ(result, 0);
+        }
+    }
+
+    private int test() {
+        long[] lArr = new long[N];
+        long l = 1957; // l % 32 = 5
+        int n = 1;
+        for (int i = 1; i < 30; ++i) {
+            for (double j = 1; j < 12; j++) {
+                iArr[i] = 3;
+                for (long k = 1; k < 2; k++) {
+                    // C2 is able to prove that the effecive shift value for the int n is always 5.
+                    n >>= l;
+                }
+                l = 907436423360901L; // l % 32 = 5
+            }
+        }
+        return (int) checkSum(lArr);
+    }
+
+    private static long checkSum(long[] a) {
+        long sum = 0;
+        for (int j = 0; j < a.length; j++) {
+            sum += (a[j] / (j + 1) + a[j] % (j + 1));
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
The Javafuzzer found an asserting test that reduces to the following code shape:

```java
private int test() {
        long l = 1957; // l % 32 = 5
        int n = 1;
        for (int i = 1; i < 30; ++i) {
            for (double j = 1; j < 12; j++) {
                iArr[i] = 3;
                for (long k = 1; k < 2; k++) {
                    // C2 is able to prove that the effecive shift value for the int n is always 5.
                    n >>= l;
                }
                l = 907436423360901L; // l % 32 = 5
            }
        }
        return n;
}
```
Running this with worklist randomization via `-XX:+StressIGVN -XX:+StressCCP` we get the assert "no node should have no use". This is due to the Phi node for `l`not getting cleaned up when C2 folds the RShiftI to 0 (this is possible since #31017). This is due to `mask_and_replace_shift_amount()` using `set_req()` instead of `set_req_X()`, which puts the Phi on the worklist after the removal. The code without worklist randomization does not fail because the `ConvL2I` get split through that Phi beforehand. The regression test in this PR uses some additional code to force the bad shape.

Testing:
 - [x] Github Actions
 - [x] tier1, tier2, tier3 plus some additional stress testing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385408](https://bugs.openjdk.org/browse/JDK-8385408): C2: no reachable node should have no use (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31323/head:pull/31323` \
`$ git checkout pull/31323`

Update a local copy of the PR: \
`$ git checkout pull/31323` \
`$ git pull https://git.openjdk.org/jdk.git pull/31323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31323`

View PR using the GUI difftool: \
`$ git pr show -t 31323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31323.diff">https://git.openjdk.org/jdk/pull/31323.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31323#issuecomment-4577581213)
</details>
