### PR TITLE
8385610: Shenandoah: TestSoftMaxHeapSizeAvailableCalc should have more tolerance for other GC triggers

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java
@@ -35,6 +35,7 @@
  *      -XX:ShenandoahGCMode=satb
  *      -XX:+ShenandoahDegeneratedGC
  *      -XX:ShenandoahGCHeuristics=adaptive
+ *      -XX:ShenandoahLearningSteps=0
  *      TestSoftMaxHeapSizeAvailableCalc
  */
 
@@ -60,6 +61,7 @@
  *      -XX:+UseShenandoahGC -Xlog:gc=info
  *      -XX:ShenandoahGCMode=generational
  *      -XX:ShenandoahGCHeuristics=adaptive
+ *      -XX:ShenandoahLearningSteps=0
  *      TestSoftMaxHeapSizeAvailableCalc
  *
  */
@@ -87,12 +89,13 @@ public class TestSoftMaxHeapSizeAvailableCalc {
     // Soft max: 512M, ShenandoahMinFreeThreshold: 10 (default), ShenandoahEvacReserve: 5 (default)
     // Soft max for mutator: 512M * (100.0 - 5) / 100 = 486.4M
     // Threshold to trigger gc: 486.4M - 512 * 10 / 100.0 = 435.2M, just above (300 + 100)M.
-    // Expect gc count to be less than 1 / sec.
+    // Expect gc count to be less than 1 / sec, but to allow for other trigger conditions (like allocation rate),
+    // we bump the max allowed gc count to 35.
     public static class Allocate {
         static final List<byte[]> longLived = new ArrayList<>();
 
         public static void test() throws Exception {
-            final int expectedMaxGcCount = Integer.getInteger("expectedMaxGcCount", 30);
+            final int expectedMaxGcCount = Integer.getInteger("expectedMaxGcCount", 35);
             List<java.lang.management.GarbageCollectorMXBean> collectors = ManagementFactory.getGarbageCollectorMXBeans();
             java.lang.management.GarbageCollectorMXBean cycleCollector = null;
             for (java.lang.management.GarbageCollectorMXBean bean : collectors) {


### PR DESCRIPTION
This test carefully configures the heap and allocation rates to exercise a gc trigger based on the minimum free threshold. However, Shenandoah has other triggers that fire just to learn the characteristics of the GC cycle. We have also made the adaptive heuristic trigger based on the allocation rate slightly more sensitive. These factors combined cause this test to fail intermittently. The fix is two fold:
* For the adaptive heuristic, we disable the learning cycles. This eliminates a whole class of triggers from the test and also inhibits the allocation rate based triggers (by the time the min free threshold fires, the allocation rate for this test has stabilized).
* Increase the tolerance for gc count from 30, to 35 (to accommodate unforeseen changes in the environment that could contribute to gc triggers).
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385610](https://bugs.openjdk.org/browse/JDK-8385610): Shenandoah: TestSoftMaxHeapSizeAvailableCalc should have more tolerance for other GC triggers (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31328/head:pull/31328` \
`$ git checkout pull/31328`

Update a local copy of the PR: \
`$ git checkout pull/31328` \
`$ git pull https://git.openjdk.org/jdk.git pull/31328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31328`

View PR using the GUI difftool: \
`$ git pr show -t 31328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31328.diff">https://git.openjdk.org/jdk/pull/31328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31328#issuecomment-4580695178)
</details>
