### PR TITLE
8385656: Misplaced comment on enum value in jdk.internal.util.Architecture

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,15 +37,15 @@ import java.util.Locale;
  * architecture values.
  */
 public enum Architecture {
-    /*
-     * An unknown architecture not specifically named.
-     * The addrSize and ByteOrder values are those of the current architecture.
-     */
     AARCH64(64, ByteOrder.LITTLE_ENDIAN),
     ARM(32, ByteOrder.LITTLE_ENDIAN),
     LOONGARCH64(64, ByteOrder.LITTLE_ENDIAN),
     MIPSEL(32, ByteOrder.LITTLE_ENDIAN),
     MIPS64EL(64, ByteOrder.LITTLE_ENDIAN),
+    /*
+     * An unknown architecture not specifically named.
+     * The addrSize and ByteOrder values are those of the current architecture.
+     */
     OTHER(is64bit() ? 64 : 32, ByteOrder.nativeOrder()),
     PPC(32, ByteOrder.BIG_ENDIAN),
     PPC64(64, ByteOrder.BIG_ENDIAN),


### PR DESCRIPTION
Can I please get a review of this trivial change which moves the code comment to the correct enum value in `jdk.internal.util.Architecture`? The comment is currently misplaced on `AARCH64` instead of `OTHER` and seems to be an oversight when https://bugs.openjdk.org/browse/JDK-8315942 was integrated. 




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8385656](https://bugs.openjdk.org/browse/JDK-8385656): Misplaced comment on enum value in jdk.internal.util.Architecture (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31329/head:pull/31329` \
`$ git checkout pull/31329`

Update a local copy of the PR: \
`$ git checkout pull/31329` \
`$ git pull https://git.openjdk.org/jdk.git pull/31329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31329`

View PR using the GUI difftool: \
`$ git pr show -t 31329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31329.diff">https://git.openjdk.org/jdk/pull/31329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31329#issuecomment-4582039713)
</details>
