### PR TITLE
8385664: Stale comment about JDK-6996415

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -248,9 +248,6 @@ public class TransTypes extends TreeTranslator {
                                                meth.name,
                                                bridgeType,
                                                origin);
-        /* once JDK-6996415 is solved it should be checked if this approach can
-         * be applied to method addOverrideBridgesIfNeeded
-         */
         bridge.params = createBridgeParams(impl, bridge, bridgeType);
         bridge.setAttributes(impl);
 


### PR DESCRIPTION
This change removes an obsolete comment in TransTypes about [JDK-6996415](https://bugs.openjdk.org/browse/JDK-6996415)

> once [JDK-6996415](https://bugs.openjdk.org/browse/JDK-6996415) is solved it should be checked if this approach can be applied to method addOverrideBridgesIfNeeded

[JDK-6996415](https://bugs.openjdk.org/browse/JDK-6996415) was fixed in JDK 7. The fix for [JDK-6996415](https://bugs.openjdk.org/browse/JDK-6996415) disabled the call to `addOverrideBridgesIfNeeded` [here](https://github.com/openjdk/jdk/commit/ac9f97939fad8fc68a19c1edfd96963b98f0adce), and `addOverrideBridgesIfNeeded` was later removed in [JDK-8032188](https://bugs.openjdk.org/browse/JDK-8032188).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385664](https://bugs.openjdk.org/browse/JDK-8385664): Stale comment about JDK-6996415 (**Enhancement** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31332/head:pull/31332` \
`$ git checkout pull/31332`

Update a local copy of the PR: \
`$ git checkout pull/31332` \
`$ git pull https://git.openjdk.org/jdk.git pull/31332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31332`

View PR using the GUI difftool: \
`$ git pr show -t 31332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31332.diff">https://git.openjdk.org/jdk/pull/31332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31332#issuecomment-4586821252)
</details>
