### PR TITLE
8385427: Make unified logging checks in tests tolerant of added spaces

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
@@ -71,7 +71,7 @@ public class PreviewVersion {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("--enable-preview", "-Xlog:class+preview",
             "-cp", "." + File.pathSeparator + System.getProperty("test.classes"), "PVTest");
         oa = new OutputAnalyzer(pb.start());
-        oa.shouldMatch("\\[info *\\]\\[class,preview\\] Loading class PVTest that depends on preview features");
+        oa.shouldMatch("\\[info *\\]\\[class,preview *\\] Loading class PVTest that depends on preview features");
         oa.shouldHaveExitValue(0);
 
         // Subtract 1 from class's major version.  The class should fail to load

--- a/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
@@ -71,7 +71,7 @@ public class PreviewVersion {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("--enable-preview", "-Xlog:class+preview",
             "-cp", "." + File.pathSeparator + System.getProperty("test.classes"), "PVTest");
         oa = new OutputAnalyzer(pb.start());
-        oa.shouldContain("[info][class,preview] Loading class PVTest that depends on preview features");
+        oa.shouldMatch("\\[info *\\]\\[class,preview\\] Loading class PVTest that depends on preview features");
         oa.shouldHaveExitValue(0);
 
         // Subtract 1 from class's major version.  The class should fail to load

--- a/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 SAP SE. All rights reserved.
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
@@ -115,7 +115,7 @@ public class MallocLimitTest {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldMatch("\\[nmt *\\] MallocLimit: total limit: 1024K \\(oom\\)");
-        output.shouldMatch(".*\\[warning\\]\\[nmt *\\] MallocLimit: reached global limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1024K\\)");
+        output.shouldMatch("\\[warning\\]\\[nmt *\\] MallocLimit: reached global limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1024K\\)");
         // The rest is fuzzy. We may get SIGSEGV or a native OOM message, depending on how the failing allocation was handled.
     }
 
@@ -132,7 +132,7 @@ public class MallocLimitTest {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldMatch("\\[nmt *\\] MallocLimit: category \"mtCompiler\" limit: 1234K \\(oom\\)");
-        output.shouldMatch(".*\\[warning\\]\\[nmt *\\] MallocLimit: reached category \"mtCompiler\" limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1234K\\)");
+        output.shouldMatch("\\[warning\\]\\[nmt *\\] MallocLimit: reached category \"mtCompiler\" limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1234K\\)");
         // The rest is fuzzy. We may get SIGSEGV or a native OOM message, depending on how the failing allocation was handled.
     }
 

--- a/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocLimitTest.java
@@ -106,7 +106,7 @@ public class MallocLimitTest {
         ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=1m");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
-        output.shouldContain("[nmt] MallocLimit: total limit: 1024K (fatal)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: total limit: 1024K \\(fatal\\)");
         output.shouldMatch("#  fatal error: MallocLimit: reached global limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1024K\\)");
     }
 
@@ -114,8 +114,8 @@ public class MallocLimitTest {
         ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=1m:oom");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
-        output.shouldContain("[nmt] MallocLimit: total limit: 1024K (oom)");
-        output.shouldMatch(".*\\[warning\\]\\[nmt\\] MallocLimit: reached global limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1024K\\)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: total limit: 1024K \\(oom\\)");
+        output.shouldMatch(".*\\[warning\\]\\[nmt *\\] MallocLimit: reached global limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1024K\\)");
         // The rest is fuzzy. We may get SIGSEGV or a native OOM message, depending on how the failing allocation was handled.
     }
 
@@ -123,7 +123,7 @@ public class MallocLimitTest {
         ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=compiler:1234k", "-Xcomp");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
-        output.shouldContain("[nmt] MallocLimit: category \"mtCompiler\" limit: 1234K (fatal)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: category \"mtCompiler\" limit: 1234K \\(fatal\\)");
         output.shouldMatch("#  fatal error: MallocLimit: reached category \"mtCompiler\" limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1234K\\)");
     }
 
@@ -131,8 +131,8 @@ public class MallocLimitTest {
         ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=compiler:1234k:oom", "-Xcomp");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
-        output.shouldContain("[nmt] MallocLimit: category \"mtCompiler\" limit: 1234K (oom)");
-        output.shouldMatch(".*\\[warning\\]\\[nmt\\] MallocLimit: reached category \"mtCompiler\" limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1234K\\)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: category \"mtCompiler\" limit: 1234K \\(oom\\)");
+        output.shouldMatch(".*\\[warning\\]\\[nmt *\\] MallocLimit: reached category \"mtCompiler\" limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1234K\\)");
         // The rest is fuzzy. We may get SIGSEGV or a native OOM message, depending on how the failing allocation was handled.
     }
 
@@ -140,9 +140,9 @@ public class MallocLimitTest {
         ProcessBuilder pb = processBuilderWithSetting("-XX:MallocLimit=other:2g,compiler:1g:oom,internal:1k");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
-        output.shouldContain("[nmt] MallocLimit: category \"mtCompiler\" limit: 1024M (oom)");
-        output.shouldContain("[nmt] MallocLimit: category \"mtInternal\" limit: 1024B (fatal)");
-        output.shouldContain("[nmt] MallocLimit: category \"mtOther\" limit: 2048M (fatal)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: category \"mtCompiler\" limit: 1024M \\(oom\\)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: category \"mtInternal\" limit: 1024B \\(fatal\\)");
+        output.shouldMatch("\\[nmt *\\] MallocLimit: category \"mtOther\" limit: 2048M \\(fatal\\)");
         output.shouldMatch("#  fatal error: MallocLimit: reached category \"mtInternal\" limit \\(triggering allocation size: \\d+[BKM], allocated so far: \\d+[BKM], limit: 1024B\\)");
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
@@ -59,7 +59,7 @@ public class LambdaProxyClasslist {
     out = TestCommon.dump(appJar,
         TestCommon.list("LambHello",
                         "@lambda-proxy LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()Z"));
-    out.shouldContain("[warning][cds] No invoke dynamic constant pool entry can be found for class LambHello. The classlist is probably out-of-date.")
+    out.shouldMatch("\\[warning\\]\\[cds *\\] No invoke dynamic constant pool entry can be found for class LambHello\\. The classlist is probably out-of-date\\.")
        .shouldHaveExitValue(0);
 
     // 4. More blank spaces in between items should be fine.

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithOldClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithOldClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithOldClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithOldClass.java
@@ -67,7 +67,7 @@ public class LambdaWithOldClass {
             .setUseVersion(false)
             .addSuffix(mainClass);
         OutputAnalyzer output = CDSTestUtils.runWithArchive(runOpts);
-        output.shouldContain("[class,load] LambdaWithOldClassApp source: shared objects file")
+        output.shouldMatch("\\[class,load *\\] LambdaWithOldClassApp source: shared objects file")
               .shouldHaveExitValue(0);
         if (!CDSTestUtils.isAOTClassLinkingEnabled()) {
             // With AOTClassLinking, we don't archive any lambda with old classes in the method

--- a/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
@@ -65,7 +65,7 @@ public class ProhibitedPackage {
                         TestCommon.list("java/lang/Prohibited", "ProhibitedHelper"),
                         "-Xlog:class+load")
             .shouldContain("Dumping")
-            .shouldNotContain("[info][class,load] java.lang.Prohibited source: ")
+            .shouldNotMatch("\\[info *\\]\\[class,load *\\] java.lang.Prohibited source: ")
             .shouldHaveExitValue(0);
 
         // Try loading the class in a prohibited package with various -Xshare

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTLoggingTag.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTLoggingTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTLoggingTag.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTLoggingTag.java
@@ -58,7 +58,7 @@ public class AOTLoggingTag {
             "-cp", appJar, helloClass);
 
         out = CDSTestUtils.executeAndLog(pb, "train");
-        out.shouldContain("[aot] Writing binary AOTConfiguration file:");
+        out.shouldMatch("\\[aot *\\] Writing binary AOTConfiguration file:");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -70,7 +70,7 @@ public class AOTLoggingTag {
             "-Xlog:aot",
             "-cp", appJar);
         out = CDSTestUtils.executeAndLog(pb, "asm");
-        out.shouldContain("[aot] Opened AOT configuration file hello.aotconfig");
+        out.shouldMatch("\\[aot *\\] Opened AOT configuration file hello\\.aotconfig");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -80,7 +80,7 @@ public class AOTLoggingTag {
             "-Xlog:aot",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
-        out.shouldContain("[aot] Opened AOT cache hello.aot");
+        out.shouldMatch("\\[aot *\\] Opened AOT cache hello\\.aot");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -90,7 +90,7 @@ public class AOTLoggingTag {
             "-XX:AOTMode=on",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
-        out.shouldContain("[aot] An error has occurred while processing the AOT cache. Run with -Xlog:aot for details.");
+        out.shouldMatch("\\[aot *\\] An error has occurred while processing the AOT cache\\. Run with -Xlog:aot for details\\.");
         out.shouldNotHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AddOpens.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AddOpens.java
@@ -67,7 +67,7 @@ public class AddOpens {
         {{"-Xlog:cds", "-Xlog:cds"},
          {"--add-opens", addOpensArg}};
     private static String expectedOutput[] =
-        { "[class,load] com.simple.Main source: shared objects file",
+        { "\\[class,load *\\] com\\.simple\\.Main source: shared objects file",
           "method.setAccessible succeeded!"};
 
     public static void buildTestModule() throws Exception {
@@ -103,7 +103,7 @@ public class AddOpens {
                     out.shouldContain("Full module graph = enabled");
                     })
             .setProductionChecker((OutputAnalyzer out) -> {
-                    out.shouldContain(expectedOutput[0]);
+                    out.shouldMatch(expectedOutput[0]);
                     out.shouldContain(expectedOutput[1]);
                     })
             .runStaticWorkflow()
@@ -154,7 +154,7 @@ public class AddOpens {
         @Override
         public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
             if (runMode == RunMode.PRODUCTION) {
-                out.shouldContain(expectedOutput[0]);
+                out.shouldMatch(expectedOutput[0]);
                 out.shouldContain(expectedOutput[1]);
             } else if (runMode == RunMode.ASSEMBLY) {
                 out.shouldMatch("(full module graph: enabled)|(Full module graph = enabled)");
@@ -197,7 +197,7 @@ public class AddOpens {
         @Override
         public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
             if (runMode == RunMode.PRODUCTION) {
-                out.shouldContain(expectedOutput[0]);
+                out.shouldMatch(expectedOutput[0]);
                 out.shouldContain(expectedOutput[1]);
             } else if (runMode == RunMode.ASSEMBLY) {
                 out.shouldMatch("(full module graph: enabled)|(Full module graph = enabled)");

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/OldClassAndInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/OldClassAndInf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/OldClassAndInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/OldClassAndInf.java
@@ -92,7 +92,7 @@ public class OldClassAndInf {
 
         TestCommon.checkExec(output);
         for (String loadee : loadees) {
-            output.shouldContain("[class,load] " + loadee + " source: shared objects file");
+            output.shouldMatch("\\[class,load *\\] " + loadee + " source: shared objects file");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchivedSuperIf.java
@@ -74,7 +74,7 @@ public class ArchivedSuperIf extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 // The interface Bar will be loaded from the archive.
                 // The class (Baz) which implements Bar will be loaded from jar.
-                output.shouldContain("[class,load] pkg.Bar source: shared objects file (top)")
+                output.shouldMatch("\\[class,load *\\] pkg\\.Bar source: shared objects file \\(top\\)")
                       .shouldMatch(".class.load. pkg.Baz source:.*archived_super_if.jar")
                       .shouldHaveExitValue(0);
             });

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/JFRDynamicCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/JFRDynamicCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/JFRDynamicCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/JFRDynamicCDS.java
@@ -62,7 +62,7 @@ public class JFRDynamicCDS extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0)
                       .shouldMatch(".class.load. jdk.jfr.events.*source:.*jrt:/jdk.jfr")
-                      .shouldContain("[class,load] JFRDynamicCDSApp source: shared objects file (top)");
+                      .shouldMatch("\\[class,load *\\] JFRDynamicCDSApp source: shared objects file \\(top\\)");
             });
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java
@@ -76,7 +76,7 @@ public class LambdaContainsOldInf extends DynamicArchiveTestBase {
                 "-Xlog:class+load=debug",
                 "-cp", appJar, mainClass, mainArg)
                 .assertNormalExit(output -> {
-                    output.shouldContain("[class,load] LambdaContainsOldInfApp source: shared objects file (top)")
+                    output.shouldMatch("\\[class,load *\\] LambdaContainsOldInfApp source: shared objects file \\(top\\)")
                           .shouldMatch(".class.load. OldProvider.source:.*lambda_contains_old_inf.jar")
                           .shouldMatch(".class.load. LambdaContainsOldInfApp[$][$]Lambda.*/0x.*source:.*LambdaContainsOldInf")
                           .shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/MainModuleOnly.java
@@ -117,7 +117,7 @@ public class MainModuleOnly extends DynamicArchiveTestBase {
             "--module-path", moduleDir.toString(),
             "-m", TEST_MODULE1)
             .assertNormalExit(output -> {
-                    output.shouldContain("[class,load] com.simple.Main source: shared objects file")
+                    output.shouldMatch("\\[class,load *\\] com\\.simple\\.Main source: shared objects file")
                           .shouldHaveExitValue(0);
                 });
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/classpathtests/BootAppendTests.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/classpathtests/BootAppendTests.java
@@ -205,7 +205,7 @@ public class BootAppendTests {
             "Test #6", BOOT_APPEND_CLASS, "true", "BOOT");
         TestCommon.checkExec(output);
         if (!TestCommon.isUnableToMap(output))
-            output.shouldContain("[class,load] sun.nio.cs.ext1.MyClass source: shared objects file");
+            output.shouldMatch("\\[class,load *\\] sun\\.nio\\.cs\\.ext1\\.MyClass source: shared objects file");
     }
 
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddModules.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddModules.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddModules.java
@@ -118,8 +118,8 @@ public class AddModules {
                                   moduleDir.toString(), // --module-path
                                   MAIN_MODULE1) // -m
             .assertNormalExit(out -> {
-                out.shouldContain("[class,load] com.greetings.Main source: shared objects file")
-                   .shouldContain("[class,load] org.astro.World source: shared objects file");
+                out.shouldMatch("\\[class,load *\\] com\\.greetings\\.Main source: shared objects file")
+                   .shouldMatch("\\[class,load *\\] org\\.astro\\.World source: shared objects file");
             });
 
         // run the com.hello module with the archive with the --module-path
@@ -130,8 +130,8 @@ public class AddModules {
                                   moduleDir.toString(), // --module-path
                                   MAIN_MODULE2) // -m
             .assertNormalExit(out -> {
-                out.shouldContain("[class,load] com.hello.Main source: shared objects file")
-                   .shouldContain("[class,load] org.astro.World source: shared objects file");
+                out.shouldMatch("\\[class,load *\\] com\\.hello\\.Main source: shared objects file")
+                   .shouldMatch("\\[class,load *\\] org\\.astro\\.World source: shared objects file");
             });
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP.java
@@ -115,8 +115,8 @@ public class ModulePathAndCP {
                                   moduleDir.toString(), // --module-path
                                   MAIN_MODULE) // -m
             .assertNormalExit(out -> {
-                out.shouldContain("[class,load] com.greetings.Main source: shared objects file")
-                   .shouldContain("[class,load] org.astro.World source: shared objects file");
+                out.shouldMatch("\\[class,load *\\] com\\.greetings\\.Main source: shared objects file")
+                   .shouldMatch("\\[class,load *\\] org\\.astro\\.World source: shared objects file");
             });
 
         // run with the archive with the --module-path different from the one during
@@ -181,7 +181,7 @@ public class ModulePathAndCP {
                                   jars, // --module-path
                                   MAIN_MODULE) // -m
             .assertNormalExit(out -> {
-                out.shouldContain("[class,load] com.greetings.Main source: shared objects file")
+                out.shouldMatch("\\[class,load *\\] com\\.greetings\\.Main source: shared objects file")
                    .shouldMatch(".class.load. org.astro.World source:.*org.astro.jar");
             });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/OldClassAndRedefineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/OldClassAndRedefineClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/OldClassAndRedefineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/OldClassAndRedefineClass.java
@@ -71,8 +71,8 @@ public class OldClassAndRedefineClass {
                 "-Xlog:cds,class+load",
                 agentCmdArg,
                "OldClassAndRedefineClassApp");
-        out.shouldContain("[class,load] OldSuper source: shared objects file")
-           .shouldContain("[class,load] ChildOldSuper source: shared objects file")
-           .shouldContain("[class,load] Hello source: __VM_RedefineClasses__");
+        out.shouldMatch("\\[class,load *\\] OldSuper source: shared objects file")
+           .shouldMatch("\\[class,load *\\] ChildOldSuper source: shared objects file")
+           .shouldMatch("\\[class,load *\\] Hello source: __VM_RedefineClasses__");
     }
 }

--- a/test/hotspot/jtreg/runtime/jni/mutateFinals/MutateFinalsTest.java
+++ b/test/hotspot/jtreg/runtime/jni/mutateFinals/MutateFinalsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jni/mutateFinals/MutateFinalsTest.java
+++ b/test/hotspot/jtreg/runtime/jni/mutateFinals/MutateFinalsTest.java
@@ -134,7 +134,7 @@ class MutateFinalsTest {
     void testMutateInstanceFinalWithLogging(String methodName) throws Exception {
         String type = methodName.contains("Object") ? "Object" : "<Type>";
         test(methodName, "-Xlog:jni=debug")
-            .shouldContain("[debug][jni] Set" + type + "Field mutated final instance field")
+            .shouldMatch("\\[debug\\]\\[jni *\\] Set" + type + "Field mutated final instance field")
             .shouldHaveExitValue(0);
     }
 
@@ -147,7 +147,7 @@ class MutateFinalsTest {
     void testMutateStaticFinalWithLogging(String methodName) throws Exception {
         String type = methodName.contains("Object") ? "Object" : "<Type>";
         test(methodName, "-Xlog:jni=debug")
-            .shouldContain("[debug][jni] SetStatic" + type + "Field mutated final static field")
+            .shouldMatch("\\[debug\\]\\[jni *\\] SetStatic" + type + "Field mutated final static field")
             .shouldHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/jni/mutateFinals/MutateFinalsTest.java
+++ b/test/hotspot/jtreg/runtime/jni/mutateFinals/MutateFinalsTest.java
@@ -134,7 +134,7 @@ class MutateFinalsTest {
     void testMutateInstanceFinalWithLogging(String methodName) throws Exception {
         String type = methodName.contains("Object") ? "Object" : "<Type>";
         test(methodName, "-Xlog:jni=debug")
-            .shouldMatch("\\[debug\\]\\[jni *\\] Set" + type + "Field mutated final instance field")
+            .shouldMatch("\\[debug *\\]\\[jni *\\] Set" + type + "Field mutated final instance field")
             .shouldHaveExitValue(0);
     }
 
@@ -147,7 +147,7 @@ class MutateFinalsTest {
     void testMutateStaticFinalWithLogging(String methodName) throws Exception {
         String type = methodName.contains("Object") ? "Object" : "<Type>";
         test(methodName, "-Xlog:jni=debug")
-            .shouldMatch("\\[debug\\]\\[jni *\\] SetStatic" + type + "Field mutated final static field")
+            .shouldMatch("\\[debug *\\]\\[jni *\\] SetStatic" + type + "Field mutated final static field")
             .shouldHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -60,7 +60,7 @@ public class ClassInitializationTest {
                                                               "BadMap50");
         out = new OutputAnalyzer(pb.start());
         out.shouldNotHaveExitValue(0);
-        out.shouldNotContain("[class,init]");
+        out.shouldNotMatch("\\[class,init *\\]");
         out.shouldNotContain("Fail over class verification to old verifier for: BadMap50");
 
     }

--- a/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
@@ -44,27 +44,27 @@ public class CondyIndyTest {
                                                                              "CondyIndy");
         OutputAnalyzer o = new OutputAnalyzer(pb.start());
         o.shouldHaveExitValue(0);
-        o.shouldContain("[info][methodhandles");
-        o.shouldNotContain("[debug][methodhandles,indy");
-        o.shouldNotContain("[debug][methodhandles,condy");
+        o.shouldMatch("\\[info *\\]\\[methodhandles");
+        o.shouldNotMatch("\\[debug *\\]\\[methodhandles,indy");
+        o.shouldNotMatch("\\[debug *\\]\\[methodhandles,condy");
 
         // (2) methodhandles+condy=debug only
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:methodhandles+condy=debug",
                                                               "CondyIndy");
         o = new OutputAnalyzer(pb.start());
         o.shouldHaveExitValue(0);
-        o.shouldNotContain("[info ][methodhandles");
-        o.shouldNotContain("[debug][methodhandles,indy");
-        o.shouldContain("[debug][methodhandles,condy");
+        o.shouldNotMatch("\\[info *\\]\\[methodhandles");
+        o.shouldNotMatch("\\[debug *\\]\\[methodhandles,indy");
+        o.shouldMatch("\\[debug *\\]\\[methodhandles,condy");
 
         // (3) methodhandles+indy=debug only
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:methodhandles+indy=debug",
                                                               "CondyIndy");
         o = new OutputAnalyzer(pb.start());
         o.shouldHaveExitValue(0);
-        o.shouldNotContain("[info ][methodhandles");
-        o.shouldContain("[debug][methodhandles,indy");
-        o.shouldNotContain("[debug][methodhandles,condy");
+        o.shouldNotMatch("\\[info *\\]\\[methodhandles");
+        o.shouldMatch("\\[debug *\\]\\[methodhandles,indy");
+        o.shouldNotMatch("\\[debug *\\]\\[methodhandles,condy");
 
         // (4) methodhandles, condy, indy all on
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:methodhandles=info",
@@ -73,8 +73,8 @@ public class CondyIndyTest {
                                                               "CondyIndy");
         o = new OutputAnalyzer(pb.start());
         o.shouldHaveExitValue(0);
-        o.shouldContain("[info ][methodhandles");
-        o.shouldContain("[debug][methodhandles,indy");
-        o.shouldContain("[debug][methodhandles,condy");
+        o.shouldMatch("\\[info *\\]\\[methodhandles");
+        o.shouldMatch("\\[debug *\\]\\[methodhandles,indy");
+        o.shouldMatch("\\[debug *\\]\\[methodhandles,condy");
     };
 }

--- a/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
@@ -68,7 +68,7 @@ public class ExceptionsTest {
 
     static void analyzeOutputOff(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldNotContain("[exceptions]");
+        output.shouldNotMatch("\\[exceptions *\\]");
         output.shouldHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/logging/GenerateOopMapTest.java
+++ b/test/hotspot/jtreg/runtime/logging/GenerateOopMapTest.java
@@ -43,7 +43,7 @@ public class GenerateOopMapTest {
 
     static String infoPattern = "[generateoopmap]";
     static String debugPattern = "[generateoopmap] Basicblock#0 begins at:";
-    static String tracePattern = "[trace][generateoopmap]        5  vars = 'r'      stack = 'v'   monitors = ''  \tifne";
+    static String tracePattern = "\\[trace *\\]\\[generateoopmap\\]        5  vars = 'r'      stack = 'v'   monitors = ''  \tifne";
     static String traceDetailPattern = "[generateoopmap]         0 vars     = ( r  |slot0)    invokestatic()V";
 
     static void test() throws Exception {
@@ -63,7 +63,7 @@ public class GenerateOopMapTest {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:generateoopmap=trace",
                                                               "GenerateOopMapTest", "test");
         o = new OutputAnalyzer(pb.start());
-        o.shouldContain(tracePattern).shouldHaveExitValue(0);
+        o.shouldMatch(tracePattern).shouldHaveExitValue(0);
 
         // Prints extra stuff with detailed. Not sure how useful this is but keep it for now.
         if (Platform.isDebugBuild()) {

--- a/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
@@ -44,7 +44,7 @@ public class StackWalkTest {
 
     static void analyzeOutputOff(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldNotContain("[stackwalk]");
+        output.shouldNotMatch("\\[stackwalk *\\]");
         output.shouldHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
@@ -47,7 +47,7 @@ public class StartupTimeTest {
 
     static void analyzeOutputOff(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldNotContain("[startuptime]");
+        output.shouldNotMatch("\\[startuptime *\\]");
         output.shouldHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/logging/VerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/VerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VerificationTest.java
@@ -39,26 +39,26 @@ public class VerificationTest {
 
     static void analyzeOutputOn(ProcessBuilder pb, boolean isLogLevelInfo) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain("[verification]");
+        output.shouldMatch("\\[verification *\\]");
         output.shouldContain("Verifying class VerificationTest$InternalClass with new format");
         output.shouldContain("Verifying method VerificationTest$InternalClass.<init>()V");
         output.shouldContain("End class verification for: VerificationTest$InternalClass");
 
         if (isLogLevelInfo) {
             // logging level 'info' should not output stack map and opcode data.
-            output.shouldNotContain("[verification] StackMapTable: frame_count");
-            output.shouldNotContain("[verification] offset = 0,  opcode =");
+            output.shouldNotMatch("\\[verification *\\] StackMapTable: frame_count");
+            output.shouldNotMatch("\\[verification *\\] offset = 0,  opcode =");
 
         } else { // log level debug
-            output.shouldMatch("\\[debug *\\]\\[verification\\] StackMapTable: frame_count");
-            output.shouldMatch("\\[debug *\\]\\[verification\\] offset = 0,  opcode =");
+            output.shouldMatch("\\[debug *\\]\\[verification *\\] StackMapTable: frame_count");
+            output.shouldMatch("\\[debug *\\]\\[verification *\\] offset = 0,  opcode =");
         }
         output.shouldHaveExitValue(0);
     }
 
     static void analyzeOutputOff(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldNotContain("[verification]");
+        output.shouldNotMatch("\\[verification *\\]");
         output.shouldHaveExitValue(0);
     }
 

--- a/test/hotspot/jtreg/runtime/logging/VerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VerificationTest.java
@@ -50,8 +50,8 @@ public class VerificationTest {
             output.shouldNotContain("[verification] offset = 0,  opcode =");
 
         } else { // log level debug
-            output.shouldContain("[debug][verification] StackMapTable: frame_count");
-            output.shouldContain("[debug][verification] offset = 0,  opcode =");
+            output.shouldMatch("\\[debug *\\]\\[verification\\] StackMapTable: frame_count");
+            output.shouldMatch("\\[debug *\\]\\[verification\\] offset = 0,  opcode =");
         }
         output.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
@@ -60,11 +60,11 @@ public class PatchModuleTraceCL {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         // "modules" jimage case.
-        output.shouldContain("[class,load] java.lang.Thread source: jrt:/java.base");
+        output.shouldMatch("\\[class,load *\\] java\\.lang\\.Thread source: jrt:/java.base");
         // --patch-module case.
-        output.shouldContain("[class,load] javax.naming.spi.NamingManager source: mods/java.naming");
+        output.shouldMatch("\\[class,load *\\] javax\\.naming\\.spi\\.NamingManager source: mods/java.naming");
         // -cp case.
-        output.shouldContain("[class,load] PatchModuleMain source: file");
+        output.shouldMatch("\\[class,load *\\] PatchModuleMain source: file");
 
         // Test -Xlog:class+load=info output for -Xbootclasspath/a
         source = "package PatchModuleTraceCL_pkg; "                 +
@@ -82,7 +82,7 @@ public class PatchModuleTraceCL {
              "-Xlog:class+load=info", "PatchModuleMain", "PatchModuleTraceCL_pkg.ItIsI");
         output = new OutputAnalyzer(pb.start());
         // -Xbootclasspath/a case.
-        output.shouldContain("[class,load] PatchModuleTraceCL_pkg.ItIsI source: xbcp");
+        output.shouldMatch("\\[class,load *\\] PatchModuleTraceCL_pkg\\.ItIsI source: xbcp");
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -188,7 +188,7 @@ public class THPsInThreadStackPreventionTest {
                 output.shouldHaveExitValue(0);
 
                 // this line indicates the mitigation is active:
-                output.shouldContain("[pagesize] JVM will attempt to prevent THPs in thread stacks.");
+                output.shouldMatch("\\[pagesize *\\] JVM will attempt to prevent THPs in thread stacks\\.");
 
                 ProcSelfStatus status = ProcSelfStatus.parse(output);
                 if (status.numLifeThreads < numThreads) {
@@ -225,7 +225,7 @@ public class THPsInThreadStackPreventionTest {
                 output.shouldHaveExitValue(0);
 
                 // We deliberately switched off mitigation, VM should tell us:
-                output.shouldContain("[pagesize] JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+                output.shouldMatch("\\[pagesize *\\] JVM will \\*not\\* prevent THPs in thread stacks\\. This may cause high RSS\\.");
 
                 // Parse output from self/status
                 ProcSelfStatus status = ProcSelfStatus.parse(output);

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -119,7 +119,7 @@ public class TestHugePageDecisionsAtVMStartup {
         }
 
         if (!useLP) {
-            out.shouldMatch("\\[info\\]\\[pagesize *\\] Large page support disabled");
+            out.shouldMatch("\\[info *\\]\\[pagesize *\\] Large page support disabled");
         } else if (useLP && !useTHP &&
                  (!configuration.supportsExplicitHugePages() || !haveUsableExplicitHugePages)) {
             out.shouldMatch(warningNoLP);
@@ -130,16 +130,16 @@ public class TestHugePageDecisionsAtVMStartup {
             if (configuration.getExplicitAvailableHugePageNumber() == 0) {
                 throw new SkippedException("No usable explicit hugepages configured on the system, skipping test");
             }
-            out.shouldMatch("\\[info\\]\\[pagesize *\\] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
-            out.shouldMatch("\\[info\\]\\[pagesize *\\] UseLargePages=1, UseTransparentHugePages=0");
-            out.shouldMatch("\\[info\\]\\[pagesize *\\] Large page support enabled");
+            out.shouldMatch("\\[info *\\]\\[pagesize *\\] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
+            out.shouldMatch("\\[info *\\]\\[pagesize *\\] UseLargePages=1, UseTransparentHugePages=0");
+            out.shouldMatch("\\[info *\\]\\[pagesize *\\] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {
             long thpPageSize = configuration.getThpPageSizeOrFallback();
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system
             // page size differs, but its always in KB).
-            out.shouldMatch("\\[info\\]\\[pagesize *\\] UseLargePages=1, UseTransparentHugePages=1");
-            out.shouldMatch(".*\\[info\\]\\[pagesize *\\] Large page support enabled\\. Usable page sizes: \\d+[kK], " + thpPageSizeString + "\\. Default large page size: " + thpPageSizeString + ".*");
+            out.shouldMatch("\\[info *\\]\\[pagesize *\\] UseLargePages=1, UseTransparentHugePages=1");
+            out.shouldMatch("\\[info *\\]\\[pagesize *\\] Large page support enabled\\. Usable page sizes: \\d+[kK], " + thpPageSizeString + "\\. Default large page size: " + thpPageSizeString);
         }
     }
 

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -68,8 +68,8 @@ import java.util.Set;
 public class TestHugePageDecisionsAtVMStartup {
 
     // End user warnings, printing with Xlog:pagesize at warning level, should be unconditional
-    static final String warningNoTHP = "[warning][pagesize] UseTransparentHugePages disabled, transparent huge pages are not supported by the operating system.";
-    static final String warningNoLP = "[warning][pagesize] UseLargePages disabled, no large pages configured and available on the system.";
+    static final String warningNoTHP = "\\[warning\\]\\[pagesize *\\] UseTransparentHugePages disabled, transparent huge pages are not supported by the operating system\\.";
+    static final String warningNoLP = "\\[warning\\]\\[pagesize *\\] UseLargePages disabled, no large pages configured and available on the system\\.";
 
     static final String buildSizeString(long l) {
         String units[] = { "K", "M", "G" };
@@ -119,27 +119,27 @@ public class TestHugePageDecisionsAtVMStartup {
         }
 
         if (!useLP) {
-            out.shouldContain("[info][pagesize] Large page support disabled");
+            out.shouldMatch("\\[info\\]\\[pagesize *\\] Large page support disabled");
         } else if (useLP && !useTHP &&
                  (!configuration.supportsExplicitHugePages() || !haveUsableExplicitHugePages)) {
-            out.shouldContain(warningNoLP);
+            out.shouldMatch(warningNoLP);
         } else if (useLP && useTHP && !configuration.supportsTHP()) {
-            out.shouldContain(warningNoTHP);
+            out.shouldMatch(warningNoTHP);
         } else if (useLP && !useTHP &&
                  configuration.supportsExplicitHugePages() && haveUsableExplicitHugePages) {
             if (configuration.getExplicitAvailableHugePageNumber() == 0) {
                 throw new SkippedException("No usable explicit hugepages configured on the system, skipping test");
             }
-            out.shouldContain("[info][pagesize] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
-            out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
-            out.shouldContain("[info][pagesize] Large page support enabled");
+            out.shouldMatch("\\[info\\]\\[pagesize *\\] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
+            out.shouldMatch("\\[info\\]\\[pagesize *\\] UseLargePages=1, UseTransparentHugePages=0");
+            out.shouldMatch("\\[info\\]\\[pagesize *\\] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {
             long thpPageSize = configuration.getThpPageSizeOrFallback();
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system
             // page size differs, but its always in KB).
-            out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=1");
-            out.shouldMatch(".*\\[info]\\[pagesize] Large page support enabled. Usable page sizes: \\d+[kK], " + thpPageSizeString + ". Default large page size: " + thpPageSizeString + ".*");
+            out.shouldMatch("\\[info\\]\\[pagesize *\\] UseLargePages=1, UseTransparentHugePages=1");
+            out.shouldMatch(".*\\[info\\]\\[pagesize *\\] Large page support enabled\\. Usable page sizes: \\d+[kK], " + thpPageSizeString + "\\. Default large page size: " + thpPageSizeString + ".*");
         }
     }
 

--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -322,7 +322,7 @@ public class TestTrimNative {
                 checkExpectedLogMessages(output, false, 0);
                 parseOutputAndLookForNegativeTrim(output, 0, 0, strictTesting);
                 // The following output is expected to be printed with warning level, so it should not need -Xlog
-                output.shouldContain("[warning][trimnative] Native heap trim is not supported on this platform");
+                output.shouldMatch("\\[warning\\]\\[trimnative *\\] Native heap trim is not supported on this platform");
             } break;
 
             case "testOffExplicit": {

--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 SAP SE. All rights reserved.
  * Copyright (c) 2023, 2024, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -55,7 +55,7 @@ public class HeapDumpParallelTest {
         dcmdOut.shouldHaveExitValue(0);
         dcmdOut.shouldContain("Heap dump file created");
         OutputAnalyzer appOut = new OutputAnalyzer(app.getProcessStdout());
-        appOut.shouldContain("[heapdump]");
+        appOut.shouldMatch("\\[heapdump *\\]");
         String opts = Arrays.asList(Utils.getTestJavaOpts()).toString();
         if (opts.contains("-XX:+UseSerialGC") || opts.contains("-XX:+UseEpsilonGC")) {
             System.out.println("UseSerialGC detected.");

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdChangeLogLevel.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdChangeLogLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdChangeLogLevel.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdChangeLogLevel.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import jdk.test.lib.dcmd.JcmdExecutor;
 import jdk.test.lib.dcmd.PidJcmdExecutor;
@@ -46,7 +47,7 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 public class TestJcmdChangeLogLevel {
     public static void main(String[] args) throws Exception {
         final String fileName = "jfr_trace.txt";
-        final String findWhat = "[info][jfr] Flight Recorder initialized";
+        final Pattern findWhat = Pattern.compile("\\[info *\\]\\[jfr\\] Flight Recorder initialized");
         boolean passed = false;
 
         JcmdExecutor je = new PidJcmdExecutor();
@@ -61,7 +62,7 @@ public class TestJcmdChangeLogLevel {
                 throw new Error(e);
             }
             for (String l : lines) {
-                if (l.toString().contains(findWhat)) {
+                if (findWhat.matcher(l).find()) {
                     passed = true;
                     break;
                 }

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdChangeLogLevel.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdChangeLogLevel.java
@@ -47,7 +47,7 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 public class TestJcmdChangeLogLevel {
     public static void main(String[] args) throws Exception {
         final String fileName = "jfr_trace.txt";
-        final Pattern findWhat = Pattern.compile("\\[info *\\]\\[jfr\\] Flight Recorder initialized");
+        final Pattern findWhat = Pattern.compile("\\[info *\\]\\[jfr *\\] Flight Recorder initialized");
         boolean passed = false;
 
         JcmdExecutor je = new PidJcmdExecutor();

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
@@ -128,7 +128,7 @@ public class TestJcmdConfigure {
     }
 
     private static void testRepository(){
-        final Pattern findWhat = Pattern.compile("\\[info *\\]\\[jfr\\] Same base repository path " +
+        final Pattern findWhat = Pattern.compile("\\[info *\\]\\[jfr *\\] Same base repository path " +
                                                  Pattern.quote(REPOSITORYPATH_1) + " is set");
 
         try {

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import jdk.jfr.internal.Repository;
 import jdk.jfr.internal.Options;
@@ -127,7 +128,8 @@ public class TestJcmdConfigure {
     }
 
     private static void testRepository(){
-        final String findWhat = "[info][jfr] Same base repository path " + REPOSITORYPATH_1 + " is set";
+        final Pattern findWhat = Pattern.compile("\\[info *\\]\\[jfr\\] Same base repository path " +
+                                                 Pattern.quote(REPOSITORYPATH_1) + " is set");
 
         try {
             JcmdHelper.jcmd("JFR.configure", REPOSITORYPATH_SETTING_1);
@@ -138,7 +140,7 @@ public class TestJcmdConfigure {
             Asserts.assertTrue(samePath.equals(initialPath));
 
             List<String> lines = Files.readAllLines(Paths.get(JFR_UNIFIED_LOG_FILE));
-            Asserts.assertTrue(lines.stream().anyMatch(l->l.contains(findWhat)));
+            Asserts.assertTrue(lines.stream().anyMatch(l -> findWhat.matcher(l).find()));
 
             JcmdHelper.jcmd("JFR.configure", REPOSITORYPATH_SETTING_2);
             Path changedPath = Repository.getRepository().getRepositoryPath();

--- a/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartupMessage.java
@@ -59,12 +59,12 @@ public class TestStartupMessage {
          // Can't turn off log with -Xlog:jfr+startup=warning
 
          startJfrJvm()
-             .shouldContain("[info][jfr,startup")
+             .shouldMatch("\\[info *\\]\\[jfr,startup")
              .shouldContain("Started recording")
              .shouldContain("Use jcmd");
 
          startJfrJvm("-Xlog:jfr+startup=info")
-             .shouldContain("[info][jfr,startup")
+             .shouldMatch("\\[info *\\]\\[jfr,startup")
              .shouldContain("Started recording")
              .shouldContain("Use jcmd");
     }


### PR DESCRIPTION
Please review this test enhancement.
Implemented the padding-tolerant Unified Logging assertions.
A bunch of  Unified Logging assertions do not account for possible extra padding in the `[<tags>]` section.

Changed short-tag UL assertions from rigid `shouldContain(...)` to `shouldMatch(...)` with patterns like:
```
\\[class,load *\\] ...
```

Covered short categories including `class,load`, `nmt`, `pagesize`, `aot`, `jni`, `cds`, and `trimnative`. I left remaining `shouldContain()` hits alone where the tag set is long enough - `class,resolve`,  `verification`, `gc,heap,coops`, etc.).

Also updated a couple of existing rigid `shouldMatch()` UL regexes for the same padding issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385427](https://bugs.openjdk.org/browse/JDK-8385427): Make unified logging checks in tests tolerant of added spaces (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31338/head:pull/31338` \
`$ git checkout pull/31338`

Update a local copy of the PR: \
`$ git checkout pull/31338` \
`$ git pull https://git.openjdk.org/jdk.git pull/31338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31338`

View PR using the GUI difftool: \
`$ git pr show -t 31338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31338.diff">https://git.openjdk.org/jdk/pull/31338.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31338#issuecomment-4593697028)
</details>
