### PR TITLE
8385312: Intermittent assert while running JCK test api/java_util/concurrent/Assorted/SynchronousQueue20.html

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -152,12 +152,6 @@ freeze_result Continuation::try_preempt(JavaThread* current, oop continuation) {
   return res;
 }
 
-#ifndef PRODUCT
-static jlong java_tid(JavaThread* thread) {
-  return java_lang_Thread::thread_id(thread->threadObj());
-}
-#endif
-
 ContinuationEntry* Continuation::get_continuation_entry_for_continuation(JavaThread* thread, oop continuation) {
   if (thread == nullptr || continuation == nullptr) {
     return nullptr;
@@ -387,9 +381,9 @@ frame Continuation::continuation_bottom_sender(JavaThread* thread, const frame& 
   ContinuationEntry* ce = get_continuation_entry_for_sp(thread, callee.sp());
   assert(ce != nullptr, "callee.sp(): " INTPTR_FORMAT, p2i(callee.sp()));
 
-  log_develop_debug(continuations)("continuation_bottom_sender: [" JLONG_FORMAT "] [%d] callee: " INTPTR_FORMAT
+  log_develop_debug(continuations)("continuation_bottom_sender: [" UINT64_FORMAT "] [%d] callee: " INTPTR_FORMAT
     " sender_sp: " INTPTR_FORMAT,
-    java_tid(thread), thread->osthread()->thread_id(), p2i(callee.sp()), p2i(sender_sp));
+    thread->monitor_owner_id(), thread->osthread()->thread_id(), p2i(callee.sp()), p2i(sender_sp));
 
   frame entry = ce->to_frame();
   if (callee.is_interpreted_frame()) {


### PR DESCRIPTION
This PR is a workaround for an `assert` in `OopHandle::resolve()` that failed intermittently during debug logging. The code was trying to read out a thread id from a thread object, but due to a full GC that just moved the thread object an assert failed because we could not resolve the thread object.

We decided to use `monitor_owner_id()` to get the thread id for the debug output, thus avoiding the potential unsafe access to the thread object.

Passes tier1-tier5 without any fails that can be attributed this PR.

Also passes 400 runs of `jck:api/java_util/concurrent/Assorted/SynchronousQueue20.html` (with VM
options: `-Xlog:all=trace:file=vm-%p.log::filecount=1,filesize=1M`).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385312](https://bugs.openjdk.org/browse/JDK-8385312): Intermittent assert while running JCK test api/java_util/concurrent/Assorted/SynchronousQueue20.html (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31339/head:pull/31339` \
`$ git checkout pull/31339`

Update a local copy of the PR: \
`$ git checkout pull/31339` \
`$ git pull https://git.openjdk.org/jdk.git pull/31339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31339`

View PR using the GUI difftool: \
`$ git pr show -t 31339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31339.diff">https://git.openjdk.org/jdk/pull/31339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31339#issuecomment-4600433306)
</details>
