### PR TITLE
8385728: Serial: Check empty MemRegion in maintain_old_to_young_invariant

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -49,7 +49,14 @@ void CardTableRS::scan_old_to_young_refs(TenuredGeneration* tg, HeapWord* saved_
 void CardTableRS::maintain_old_to_young_invariant(TenuredGeneration* old_gen,
                                                   bool is_young_gen_empty) {
   if (is_young_gen_empty) {
-    clear_MemRegion(old_gen->prev_used_region());
+    MemRegion prev_used_mr = old_gen->prev_used_region();
+    if (!prev_used_mr.is_empty()) {
+      clear_MemRegion(prev_used_mr);
+    }
+    {
+      MemRegion old_gen_committed{old_gen->space()->bottom(), old_gen->space()->end()};
+      verify_region(old_gen_committed, clean_card_val(), true);
+    }
   } else {
     MemRegion used_mr = old_gen->used_region();
     MemRegion prev_used_mr = old_gen->prev_used_region();
@@ -59,7 +66,9 @@ void CardTableRS::maintain_old_to_young_invariant(TenuredGeneration* old_gen,
     }
     // No idea which card contains old-to-young pointer, so dirtying cards for
     // the entire used part of old-gen conservatively.
-    dirty_MemRegion(used_mr);
+    if (!used_mr.is_empty()) {
+      dirty_MemRegion(used_mr);
+    }
   }
 }
 


### PR DESCRIPTION
Add explicit `is_empty()` checks before calling `clear_MemRegion()` and `dirty_MemRegion()` in `maintain_old_to_young_invariant` to avoid passing empty MemRegions.

The alternative would be adding early returns in those two shared methods, but inspecting all existing callers shows they never pass empty regions, so I chose to fix the Serial GC caller rather than modify shared code.

Test: tier1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385728](https://bugs.openjdk.org/browse/JDK-8385728): Serial: Check empty MemRegion in maintain_old_to_young_invariant (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31341/head:pull/31341` \
`$ git checkout pull/31341`

Update a local copy of the PR: \
`$ git checkout pull/31341` \
`$ git pull https://git.openjdk.org/jdk.git pull/31341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31341`

View PR using the GUI difftool: \
`$ git pr show -t 31341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31341.diff">https://git.openjdk.org/jdk/pull/31341.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31341#issuecomment-4595283292)
</details>
