### PR TITLE
8385738: Javadoc does not produce reproducible output due to the snippet ids

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ import com.sun.source.util.DocTreePath;
 
 import jdk.javadoc.doclet.Taglet;
 import jdk.javadoc.internal.doclets.formats.html.HtmlConfiguration;
+import jdk.javadoc.internal.doclets.formats.html.HtmlDocletWriter;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyles;
 import jdk.javadoc.internal.doclets.formats.html.taglets.snippet.Action;
 import jdk.javadoc.internal.doclets.formats.html.taglets.snippet.ParseException;
@@ -124,7 +125,8 @@ public class SnippetTaglet extends BaseTaglet {
         if (id != null && !id.isBlank()) {
             pre.put(HtmlAttr.ID, id);
         } else {
-            pre.put(HtmlAttr.ID, config.htmlIds.forSnippet(element, ids).name());
+            var set = ids.computeIfAbsent(tagletWriter.htmlWriter, k -> new HashSet<>());
+            pre.put(HtmlAttr.ID, config.htmlIds.forSnippet(element, set).name());
         }
         var code = HtmlTree.CODE()
                 .addUnchecked(Text.EMPTY); // Make sure the element is always rendered
@@ -207,7 +209,7 @@ public class SnippetTaglet extends BaseTaglet {
         return snippetContainer.add(pre.add(code));
     }
 
-    private final Set<String> ids = new HashSet<>();
+    private final HashMap<HtmlDocletWriter, Set<String>> ids = new HashMap<>();
 
     private static final class BadSnippetException extends Exception {
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -125,7 +125,7 @@ public class SnippetTaglet extends BaseTaglet {
         if (id != null && !id.isBlank()) {
             pre.put(HtmlAttr.ID, id);
         } else {
-            var set = ids.computeIfAbsent(tagletWriter.htmlWriter, k -> new HashSet<>());
+            var set = ids.computeIfAbsent(tagletWriter.htmlWriter, _ -> new HashSet<>());
             pre.put(HtmlAttr.ID, config.htmlIds.forSnippet(element, set).name());
         }
         var code = HtmlTree.CODE()

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266666 8275788 8276964 8299080 8276966
+ * @bug 8266666 8275788 8276964 8299080 8276966 8385738
  * @summary Implementation for snippets
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2684,5 +2685,95 @@ public class TestSnippetTag extends SnippetTester {
                         </details>
                         """);
         checkNoCrashes();
+    }
+
+    @Test
+    public void testSnippetIdCounterResetsPerPage(Path base) throws IOException {
+        Path src = base.resolve("src");
+
+        tb.writeJavaFiles(src,
+                """
+                package p;
+                import java.lang.annotation.Target;
+                import java.lang.annotation.ElementType;
+                @Target({ElementType.TYPE, ElementType.METHOD})
+                public @interface ACustomAnnotation {
+                }
+                """,
+                """
+                package p;
+                import java.lang.annotation.Target;
+                import java.lang.annotation.ElementType;
+                @Target({ElementType.TYPE, ElementType.METHOD})
+                public @interface ZCustomAnnotation {
+                }
+                """,
+                """
+                package p;
+                /** Class A. */
+                public class A {
+                    /**
+                     * First snippet on A.foo:
+                     * {@snippet :
+                     *     int x = 1; // first
+                     * }
+                     * Second snippet on A.foo:
+                     * {@snippet :
+                     *     int y = 2; // second
+                     * }
+                     */
+                    @ACustomAnnotation
+                    @ZCustomAnnotation
+                    public void foo() {}
+                }
+                """,
+                """
+                package p;
+                /** Class B. */
+                public class B {
+                    /**
+                     * First snippet on B.foo:
+                     * {@snippet :
+                     *     int x = 1; // first
+                     * }
+                     * Second snippet on B.foo:
+                     * {@snippet :
+                     *     int y = 2; // second
+                     * }
+                     */
+                    @ACustomAnnotation
+                    @ZCustomAnnotation
+                    public void foo() {}
+                }
+                """);
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-use",
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+        for (String cls : new String[] {
+                "A.html",
+                "B.html",
+                "class-use/ACustomAnnotation.html",
+                "class-use/ZCustomAnnotation.html"}) {
+            var file = base
+                .resolve("out")
+                .resolve("p")
+                .resolve(cls);
+            String content = Files.readString(file);
+            for (var snippetId : new String[] {"snippet-foo()1", "snippet-foo()2"}) {
+                checking("id \"" + snippetId + "\" present in " + cls);
+                if (content.contains("id=\"" + snippetId + "\"")) {
+                    passed("found");
+                } else {
+                    failed("" + snippetId + " not found in " +
+                        String.join("\n", Arrays.asList(content.split("\n"))
+                            .stream()
+                            .filter(l -> l.contains("pre class=\"snippet\""))
+                            .toList()));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The top level type generation order is not deterministic due to the directory listing being non-deterministic.
Snippet ids are monotonically incremented during the javadoc run. This means that the generated snippet ids are not reproducible. 
This PR changes Set to the Map so that each page uses a separate snippet id counter. 
Alternatives:
 - reset ids set when tagletWriter.htmlWriter changes
 - list files in sorted order for javadoc generation

```

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/langtools/jdk/javadoc                    398   397     0     0     1   
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-x86_64-server-fastdebug'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385738](https://bugs.openjdk.org/browse/JDK-8385738): Javadoc does not produce reproducible output due to the snippet ids (**Bug** - P4)


### Reviewers
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31345/head:pull/31345` \
`$ git checkout pull/31345`

Update a local copy of the PR: \
`$ git checkout pull/31345` \
`$ git pull https://git.openjdk.org/jdk.git pull/31345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31345`

View PR using the GUI difftool: \
`$ git pr show -t 31345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31345.diff">https://git.openjdk.org/jdk/pull/31345.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31345#issuecomment-4600241973)
</details>
