### PR TITLE
8385747: Test gc/g1/TestGCLogMessages.java failed:  'Update Derived Pointers' found in stdout

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -747,6 +747,14 @@ WB_ENTRY(void, WB_NMTArenaMalloc(JNIEnv* env, jobject o, jlong arena, jlong size
   a->Amalloc(size_t(size));
 WB_END
 
+WB_ENTRY(jboolean, WB_isC2Included(JNIEnv* env))
+#ifdef COMPILER2
+  return true;
+#else
+  return false;
+#endif
+WB_END
+
 static jmethodID reflected_method_to_jmid(JavaThread* thread, JNIEnv* env, jobject method) {
   assert(method != nullptr, "method should not be null");
   ThreadToNativeFromVM ttn(thread);
@@ -2843,6 +2851,7 @@ static JNINativeMethod methods[] = {
   {CC"NMTNewArena",         CC"(J)J",                 (void*)&WB_NMTNewArena        },
   {CC"NMTFreeArena",        CC"(J)V",                 (void*)&WB_NMTFreeArena       },
   {CC"NMTArenaMalloc",      CC"(JJ)V",                (void*)&WB_NMTArenaMalloc     },
+  {CC"isC2Included",        CC"()Z",                  (void*)&WB_isC2Included       },
   {CC"deoptimizeFrames",   CC"(Z)I",                  (void*)&WB_DeoptimizeFrames  },
   {CC"isFrameDeoptimized", CC"(I)Z",                  (void*)&WB_IsFrameDeoptimized},
   {CC"deoptimizeAll",      CC"()V",                   (void*)&WB_DeoptimizeAll     },

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -86,7 +86,7 @@ public class TestGCLogMessages {
         }
 
         public boolean isAvailable() {
-            return Compiler.isC2Enabled();
+            return Compiler.isC2Included();
         }
     }
 

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -336,6 +336,8 @@ public class WhiteBox {
 
   // Compiler
 
+  public native boolean isC2Included();
+
   public native int     matchesMethod(Executable method, String pattern);
   public native int     matchesInline(Executable method, String pattern);
   public native boolean shouldPrintAssembly(Executable method, int comp_level);

--- a/test/lib/jdk/test/whitebox/code/Compiler.java
+++ b/test/lib/jdk/test/whitebox/code/Compiler.java
@@ -35,6 +35,15 @@ public class Compiler {
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
 
     /**
+     * Check if C2 was included in the VM build
+     *
+     * @return true if C2 was included in the VM build.
+     */
+    public static boolean isC2Included() {
+        return WB.isC2Included();
+    }
+
+    /**
      * Check if C2 is used as JIT compiler.
      *
      * C2 is enabled if following conditions are true:


### PR DESCRIPTION
From the JBS issue:

---
The "Update Derived Pointers'" is a C2 related log message.

The problem is that the main test class is executed as main/othervm and is passed whatever VM flags were passed to jtreg, but the actual tested VMs are exec'd as limited VMs without those jtreg flags. Consequently if a test job passes -XX:TieredStopAtLevel=1, so that C2 is not available to the main test, the actual exec'd VM still has C2 enabled and so produces the unexpected log message.

This problem has arisen because the removal of JVMCI made a change:

```
  public boolean isAvailable() {
-     return Compiler.isC2OrJVMCIIncluded();
+     return Compiler.isC2Enabled();
  }
```

so that now availability is based on the runtime flags (like TieredStopAtLevel=x) not the build-time configuration. 

---

I'm fixing this by introducing and using a `isC2Included()` WhiteBox API, to mimic the old behavior.

Testing: I've performed some smoke testing with and without C2 compiled x with and without C2 enabled. I'll run this through tier1-3 testing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385747](https://bugs.openjdk.org/browse/JDK-8385747): Test gc/g1/TestGCLogMessages.java failed:  'Update Derived Pointers' found in stdout (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31346/head:pull/31346` \
`$ git checkout pull/31346`

Update a local copy of the PR: \
`$ git checkout pull/31346` \
`$ git pull https://git.openjdk.org/jdk.git pull/31346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31346`

View PR using the GUI difftool: \
`$ git pr show -t 31346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31346.diff">https://git.openjdk.org/jdk/pull/31346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31346#issuecomment-4600034964)
</details>
