### PR TITLE
8382063: Jtreg test javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java fails

### DIFF
--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -39,7 +39,7 @@ import jdk.test.lib.Utils;
 
 public class TestDoneBeforeDoInBackground {
 
-    private static final int WAIT_TIME = (int)Utils.adjustTimeout(200);
+    private static final long WAIT_TIME = Utils.adjustTimeout(200);
     private static final long CLEANUP_TIME = 1000;
 
     private static final AtomicBoolean doInBackgroundStarted = new AtomicBoolean(false);

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -53,7 +53,6 @@ public class TestDoneBeforeDoInBackground {
             @Override
             protected String doInBackground() throws Exception {
                 try {
-                    workerStarted.countDown();
                     while (true) {
                         System.out.println("Working...");
                         Thread.sleep(WAIT_TIME);
@@ -90,6 +89,12 @@ public class TestDoneBeforeDoInBackground {
         worker.addPropertyChangeListener(
             new PropertyChangeListener() {
                 public void propertyChange(PropertyChangeEvent evt) {
+                    if (worker.getState() == SwingWorker.StateValue.STARTED) {
+                        // Now the worker has started and we got a STARTED
+                        // notification. It should be save to cancel now.
+                        workerStarted.countDown();
+                    }
+
                     System.out.println("doInBackgroundStarted: " +
                                         doInBackgroundStarted.get() +
                                         " doInBackgroundFinished: " +

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -43,13 +43,15 @@ public class TestDoneBeforeDoInBackground {
     private static final AtomicBoolean doInBackgroundFinished = new AtomicBoolean(false);
     private static final AtomicBoolean doneFinished = new AtomicBoolean(false);
     private static final CountDownLatch doneLatch = new CountDownLatch(1);
+    private static final CountDownLatch workerStarted = new CountDownLatch(1);
 
     public static void main(String[] args) throws InterruptedException {
         SwingWorker<String, String> worker = new SwingWorker<>() {
             @Override
             protected String doInBackground() throws Exception {
                 try {
-                    while (!Thread.currentThread().isInterrupted()) {
+                    while (true) {
+                        workerStarted.countDown();
                         System.out.println("Working...");
                         Thread.sleep(WAIT_TIME);
                     }
@@ -121,7 +123,7 @@ public class TestDoneBeforeDoInBackground {
                 }
             });
         worker.execute();
-        Thread.sleep(WAIT_TIME * 3);
+        workerStarted.await();
 
         final long start = System.currentTimeMillis();
         worker.cancel(true);

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -53,8 +53,8 @@ public class TestDoneBeforeDoInBackground {
             @Override
             protected String doInBackground() throws Exception {
                 try {
+                    workerStarted.countDown();
                     while (true) {
-                        workerStarted.countDown();
                         System.out.println("Working...");
                         Thread.sleep(WAIT_TIME);
                     }

--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 8081474
+ * @library /test/lib
  * @summary  Verifies if SwingWorker calls 'done'
  *           before the 'doInBackground' is finished
  * @run main TestDoneBeforeDoInBackground
@@ -34,9 +35,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jdk.test.lib.Utils;
+
 public class TestDoneBeforeDoInBackground {
 
-    private static final int WAIT_TIME = 200;
+    private static final int WAIT_TIME = (int)Utils.adjustTimeout(200);
     private static final long CLEANUP_TIME = 1000;
 
     private static final AtomicBoolean doInBackgroundStarted = new AtomicBoolean(false);
@@ -123,7 +126,9 @@ public class TestDoneBeforeDoInBackground {
                 }
             });
         worker.execute();
-        workerStarted.await();
+        if (!workerStarted.await(5 * WAIT_TIME, TimeUnit.MILLISECONDS)) {
+            throw new RuntimeException("worker didn't start in time");
+        }
 
         final long start = System.currentTimeMillis();
         worker.cancel(true);


### PR DESCRIPTION
The doInBackground working loop is left because of the loop condition (!Thread.currentThread().isInterrupted()) - this will not clear the interrupted status of the thread and the Thread.sleep at line 63 will throw an InterruptedException directly.
I suggest to change two things:
No longer check the !Thread.currentThread().isInterrupted() but rely only on the Thread.sleep to throw an InterrutedException.
And using a countdown latch instead of a sleep to ensure that we really entered the loop before we do cancel the worker.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382063](https://bugs.openjdk.org/browse/JDK-8382063): Jtreg test javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java fails (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [0208eb91](https://git.openjdk.org/jdk/pull/31348/files/0208eb917f836ebf0c0221e3a9a8eccc4f323360)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [7c9851a1](https://git.openjdk.org/jdk/pull/31348/files/7c9851a11e8e3c3ad7869eed78352709db8201d4)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31348/head:pull/31348` \
`$ git checkout pull/31348`

Update a local copy of the PR: \
`$ git checkout pull/31348` \
`$ git pull https://git.openjdk.org/jdk.git pull/31348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31348`

View PR using the GUI difftool: \
`$ git pr show -t 31348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31348.diff">https://git.openjdk.org/jdk/pull/31348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31348#issuecomment-4600911024)
</details>
