### PR TITLE
8385831: Prevent APX instruction being generated on non-APX machines

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -13959,11 +13959,12 @@ instruct orL_rReg_ndd(rRegL dst, rRegL src1, rRegL src2, rFlagsReg cr)
 
 // Use any_RegP to match R15 (TLS register) without spilling.
 instruct orL_rReg_castP2X(rRegL dst, any_RegP src, rFlagsReg cr) %{
+  predicate(!UseAPX);
   match(Set dst (OrL dst (CastP2X src)));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
-  format %{ "orq     $dst, $src\t# orL_rReg_castP2X long" %}
+  format %{ "orq     $dst, $src\t# long" %}
   ins_encode %{
     __ orq($dst$$Register, $src$$Register);
   %}
@@ -13976,7 +13977,7 @@ instruct orL_rReg_castP2X_ndd(rRegL dst, any_RegP src1, any_RegP src2, rFlagsReg
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
-  format %{ "eorq     $dst, $src1, $src2\t# orL_rReg_castP2X_ndd long ndd" %}
+  format %{ "eorq     $dst, $src1, $src2\t# long ndd" %}
   ins_encode %{
     __ eorq($dst$$Register, $src1$$Register, $src2$$Register, false);
   %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -13963,7 +13963,7 @@ instruct orL_rReg_castP2X(rRegL dst, any_RegP src, rFlagsReg cr) %{
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
-  format %{ "orq     $dst, $src\t# long" %}
+  format %{ "orq     $dst, $src\t# orL_rReg_castP2X long" %}
   ins_encode %{
     __ orq($dst$$Register, $src$$Register);
   %}
@@ -13976,7 +13976,7 @@ instruct orL_rReg_castP2X_ndd(rRegL dst, any_RegP src1, any_RegP src2, rFlagsReg
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);
 
-  format %{ "eorq     $dst, $src1, $src2\t# long ndd" %}
+  format %{ "eorq     $dst, $src1, $src2\t# orL_rReg_castP2X_ndd long ndd" %}
   ins_encode %{
     __ eorq($dst$$Register, $src1$$Register, $src2$$Register, false);
   %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -13971,6 +13971,7 @@ instruct orL_rReg_castP2X(rRegL dst, any_RegP src, rFlagsReg cr) %{
 %}
 
 instruct orL_rReg_castP2X_ndd(rRegL dst, any_RegP src1, any_RegP src2, rFlagsReg cr) %{
+  predicate(UseAPX);
   match(Set dst (OrL src1 (CastP2X src2)));
   effect(KILL cr);
   flag(PD::Flag_sets_sign_flag, PD::Flag_sets_zero_flag, PD::Flag_sets_parity_flag, PD::Flag_clears_overflow_flag, PD::Flag_clears_carry_flag);


### PR DESCRIPTION
Guard APX instruction in instruct orL_rReg_castP2X_ndd with UseAPX predicate.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385831](https://bugs.openjdk.org/browse/JDK-8385831): Prevent APX instruction being generated on non-APX machines (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31350/head:pull/31350` \
`$ git checkout pull/31350`

Update a local copy of the PR: \
`$ git checkout pull/31350` \
`$ git pull https://git.openjdk.org/jdk.git pull/31350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31350`

View PR using the GUI difftool: \
`$ git pr show -t 31350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31350.diff">https://git.openjdk.org/jdk/pull/31350.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31350#issuecomment-4605117881)
</details>
