### PR TITLE
8372442: 2 Null pointer dereference defect groups in jvmtiExport.cpp

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2270,7 +2270,6 @@ void JvmtiExport::post_field_access_by_jni(JavaThread *thread, oop obj,
                       RegisterMap::WalkContinuation::skip);
   javaVFrame *jvf = thread->last_java_vframe(&reg_map);
   assert(jvf != nullptr, "last frame shouldn't be null");
-  assert(jvf->fr().is_java_frame(), "last frame should be a java frame");
 
   Method* method = jvf->method();
   address address = jvf->method()->code_base();
@@ -2371,7 +2370,6 @@ void JvmtiExport::post_field_modification_by_jni(JavaThread *thread, oop obj,
                       RegisterMap::WalkContinuation::skip);
   javaVFrame *jvf = thread->last_java_vframe(&reg_map);
   assert(jvf != nullptr, "last frame shouldn't be null");
-  assert(jvf->fr().is_java_frame(), "last frame should be a java frame");
 
   Method* method = jvf->method();
   address address = jvf->method()->code_base();

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2269,6 +2269,9 @@ void JvmtiExport::post_field_access_by_jni(JavaThread *thread, oop obj,
                       RegisterMap::ProcessFrames::skip,
                       RegisterMap::WalkContinuation::skip);
   javaVFrame *jvf = thread->last_java_vframe(&reg_map);
+  assert(jvf != nullptr, "last frame shouldn't be null");
+  assert(jvf->fr().is_java_frame(), "last frame should be a java frame");
+
   Method* method = jvf->method();
   address address = jvf->method()->code_base();
 
@@ -2367,6 +2370,9 @@ void JvmtiExport::post_field_modification_by_jni(JavaThread *thread, oop obj,
                       RegisterMap::ProcessFrames::skip,
                       RegisterMap::WalkContinuation::skip);
   javaVFrame *jvf = thread->last_java_vframe(&reg_map);
+  assert(jvf != nullptr, "last frame shouldn't be null");
+  assert(jvf->fr().is_java_frame(), "last frame should be a java frame");
+
   Method* method = jvf->method();
   address address = jvf->method()->code_base();
 


### PR DESCRIPTION
The `javaVFrame *jvf = thread->last_java_vframe(&reg_map);`
might be null potentially. Shouldn't be null when called from post_field_modification_by_jni but assert doesn't hurt.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8372442](https://bugs.openjdk.org/browse/JDK-8372442): 2 Null pointer dereference defect groups in jvmtiExport.cpp (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31352/head:pull/31352` \
`$ git checkout pull/31352`

Update a local copy of the PR: \
`$ git checkout pull/31352` \
`$ git pull https://git.openjdk.org/jdk.git pull/31352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31352`

View PR using the GUI difftool: \
`$ git pr show -t 31352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31352.diff">https://git.openjdk.org/jdk/pull/31352.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31352#issuecomment-4606702234)
</details>
