### PR TITLE
8385839: JMX config file correction

### DIFF
--- a/src/jdk.management.agent/share/conf/jmxremote.password.template
+++ b/src/jdk.management.agent/share/conf/jmxremote.password.template
@@ -55,8 +55,6 @@
 #   * com.sun.management.jmxremote.password.toHashes property is set to true in
 #     management.properties file
 #   * the password file is writable
-#   * the system security policy allows writing into the password file, if a
-#     security manager is configured
 #
 # In order to change the password for a role, replace the hashed password entry
 # with a new clear text password or a new hashed password. If the new password
@@ -110,6 +108,6 @@
 # below entries with clear passwords overwritten by their respective 
 # SHA3-512 hash
 #
-#   monitorRole trilby APzBTt34rV2l+OMbuvbnOQ4si8UZmfRCVbIY1+fAofV5CkQzXS/FDMGteQQk/R3q1wtt104qImzJEA7gCwl6dw== 4EeTdSJ7X6Imu0Mb+dWqIns7a7QPIBoM3NB/XlpMQSPSicE7PnlALVWn2pBY3Q3pGDHyAb32Hd8GUToQbUhAjA== SHA3-512
+#   monitorRole APzBTt34rV2l+OMbuvbnOQ4si8UZmfRCVbIY1+fAofV5CkQzXS/FDMGteQQk/R3q1wtt104qImzJEA7gCwl6dw== 4EeTdSJ7X6Imu0Mb+dWqIns7a7QPIBoM3NB/XlpMQSPSicE7PnlALVWn2pBY3Q3pGDHyAb32Hd8GUToQbUhAjA== SHA3-512
 #   controlRole roHEJSbRqSSTII4Z4+NOCV2OJaZVQ/dw153Fy2u4ILDP9XiZ426GwzCzc3RtpoqNMwqYIcfdd74xWXSMrWtGaA== w9qDsekgKn0WOVJycDyU0kLBa081zbStcCjUAVEqlfon5Sgx7XHtaodbmzpLegA1jT7Ag36T0zHaEWRHJe2fdA== SHA3-512
 # 


### PR DESCRIPTION
A mistake from the original commit where the hashed passwords feature was added.

The example at the end of the template file is malformed, some original plaintext is left in when showing the example of how it would be replaced with hashes.

While we are here, removing a line that mentions Security Manager.

This is all comments, no code is changed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385839](https://bugs.openjdk.org/browse/JDK-8385839): JMX config file correction (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31354/head:pull/31354` \
`$ git checkout pull/31354`

Update a local copy of the PR: \
`$ git checkout pull/31354` \
`$ git pull https://git.openjdk.org/jdk.git pull/31354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31354`

View PR using the GUI difftool: \
`$ git pr show -t 31354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31354.diff">https://git.openjdk.org/jdk/pull/31354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31354#issuecomment-4606534329)
</details>
