### PR TITLE
8340088: Stack tracing tests of sleeping thread should be more resilient to code changes

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -467,17 +467,19 @@ abstract class BaseThread extends Thread {
     public boolean checkStackTrace(StackTraceElement[] elements) {
         boolean res = true;
 
-        logger.trace(controller.THREAD_TRACE_LEVEL, "trace elements: "
-                + elements.length);
+        int length = stackTraceLength(elements);
 
-        if (elements.length > expectedLength) {
+        logger.trace(controller.THREAD_TRACE_LEVEL, "trace elements: "
+                + length);
+
+        if (length > expectedLength) {
             res = false;
-            logger.complain("Contains " + elements.length + ", more then "
+            logger.complain("Contains " + length + ", more then "
                     + expectedLength + " elements");
         }
 
         for (int j = 0; j < elements.length; j++) {
-            if (!checkElement(elements[j])) {
+            if (!checkElement(elements, j)) {
                 logger.complain("Unexpected method name: "
                                 + elements[j].getMethodName()
                                 + " at " + j + " position");
@@ -504,6 +506,14 @@ abstract class BaseThread extends Thread {
         logger.trace(controller.THREAD_TRACE_LEVEL, "\"" + name + "\""
                 + " is not expected method name");
         return false;
+    }
+
+    protected boolean checkElement(StackTraceElement[] elements, int index) {
+        return checkElement(elements[index]);
+    }
+
+    protected int stackTraceLength(StackTraceElement[] elements) {
+        return elements.length;
     }
 
     protected void recursiveMethod() {
@@ -653,21 +663,6 @@ class SleepingThread extends BaseThread {
 
         this.threadsGroupLocks = threadsGroupLocks;
 
-        expectedLength += 4;
-
-        expectedMethods.add(Thread.class.getName() + ".sleep");
-        expectedMethods.add(Thread.class.getName() + ".sleepNanos");
-        expectedMethods.add(Thread.class.getName() + ".sleepNanos0");
-        expectedMethods.add(Thread.class.getName() + ".beforeSleep");
-        expectedMethods.add(Thread.class.getName() + ".afterSleep");
-        expectedMethods.add(Thread.class.getName() + ".currentCarrierThread");
-        expectedMethods.add(Thread.class.getName() + ".currentThread");
-        // jdk.internal.event.ThreadSleepEvent not accessible
-        expectedMethods.add("java.lang.Object.<init>");
-        expectedMethods.add("jdk.internal.event.Event.<init>");
-        expectedMethods.add("jdk.internal.event.ThreadSleepEvent.<init>");
-        expectedMethods.add("jdk.internal.event.ThreadSleepEvent.<clinit>");
-        expectedMethods.add("jdk.internal.event.ThreadSleepEvent.isEnabled");
         expectedMethods.add(SleepingThread.class.getName() + ".run");
 
         switch (controller.invocationType) {
@@ -696,6 +691,27 @@ class SleepingThread extends BaseThread {
 
     public boolean checkState(Thread.State state) {
         return state == Thread.State.TIMED_WAITING;
+    }
+
+    protected boolean checkElement(StackTraceElement[] elements, int index) {
+        return super.checkElement(elements, index) ||
+               isJdkImplementationFrame(elements[index]);
+    }
+
+    protected int stackTraceLength(StackTraceElement[] elements) {
+        int count = 0;
+        for (StackTraceElement element : elements) {
+            if (!isJdkImplementationFrame(element))
+                count++;
+        }
+        return count;
+    }
+
+    private static boolean isJdkImplementationFrame(StackTraceElement element) {
+        String className = element.getClassName();
+        return className.startsWith("java.") ||
+               className.startsWith("jdk.") ||
+               className.startsWith("sun.");
     }
 
     public void run() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
@@ -34,6 +34,7 @@ import nsk.share.ClassUnloader;
 import nsk.share.TestFailure;
 import nsk.share.gc.ThreadedGCTest;
 import nsk.share.gc.gp.GarbageUtils;
+import nsk.share.gc.OOMStress;
 import nsk.share.test.ExecutionController;
 import nsk.share.test.LocalRandom;
 
@@ -99,7 +100,7 @@ public abstract class SysDictTest extends ThreadedGCTest {
     }
     volatile ClassLoader[] currentClassLoaders;
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private ClassLoader loader;
         private String[] names;

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import nsk.share.ClassUnloader;
 import nsk.share.TestFailure;
 import nsk.share.gc.ThreadedGCTest;
 import nsk.share.gc.gp.GarbageUtils;


### PR DESCRIPTION
SleepingThread in ThreadController had a hardcoded list of JDK method names for stack trace checking every Thread.sleep change (JFR events, virtual threads, etc) required updating this list. Replaced with a generic JDK frame filter (java.*/jdk.*/sun.*) that works at any stack position, matching the approach already used in strace001.java and SleepingThread.java. Also added overridable checkElement/stackTraceLength methods to BaseThread so only SleepingThread behavior changes.



---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8340088](https://bugs.openjdk.org/browse/JDK-8340088): Stack tracing tests of sleeping thread should be more resilient to code changes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31356/head:pull/31356` \
`$ git checkout pull/31356`

Update a local copy of the PR: \
`$ git checkout pull/31356` \
`$ git pull https://git.openjdk.org/jdk.git pull/31356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31356`

View PR using the GUI difftool: \
`$ git pr show -t 31356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31356.diff">https://git.openjdk.org/jdk/pull/31356.diff</a>

</details>
