### PR TITLE
8385836: Update comment in SourceVersion for language evolution history for changes in 27

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -87,7 +87,8 @@ public enum SourceVersion {
      *      third preview)
      *  26: no changes (primitive Types in Patterns, instanceof, and
      *      switch in fourth preview)
-     *  27: tbd
+     *  27: no changes (primitive Types in Patterns, instanceof, and
+     *      switch in fifth preview)
      */
 
     /**


### PR DESCRIPTION
Include source-level comments about per-release language changes, or lack thereof.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385836](https://bugs.openjdk.org/browse/JDK-8385836): Update comment in SourceVersion for language evolution history for changes in 27 (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31360/head:pull/31360` \
`$ git checkout pull/31360`

Update a local copy of the PR: \
`$ git checkout pull/31360` \
`$ git pull https://git.openjdk.org/jdk.git pull/31360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31360`

View PR using the GUI difftool: \
`$ git pr show -t 31360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31360.diff">https://git.openjdk.org/jdk/pull/31360.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31360#issuecomment-4608235949)
</details>
