### PR TITLE
8385828: The javac benchmarks fail after JDK-8385347

### DIFF
--- a/test/benchmarks/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
+++ b/test/benchmarks/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/benchmarks/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
+++ b/test/benchmarks/micros-javac/src/main/java/org/openjdk/bench/langtools/javac/JavacBenchmark.java
@@ -94,7 +94,7 @@ public class JavacBenchmark {
             try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(JavacBenchmark.class.getResourceAsStream("/src.zip")))) {
                 for (ZipEntry entry; (entry = zis.getNextEntry()) != null;) {
                     final String ename = entry.getName();
-                    if (!ename.startsWith("java.desktop") && !ename.startsWith("jdk.internal.vm.compiler") && !ename.startsWith("jdk.aot") && !ename.startsWith("jdk.accessibility") && !ename.startsWith("jdk.jsobject")) {
+                    if (!ename.startsWith("java.desktop") && !ename.startsWith("jdk.internal.vm.compiler") && !ename.startsWith("jdk.aot") && !ename.startsWith("jdk.accessibility") && !ename.startsWith("jdk.jsobject") && !ename.startsWith("jdk.unsupported.desktop")) {
                         if (!entry.isDirectory() && ename.endsWith(".java")) {
                             Path dst = root.resolve(ename);
                             Files.createDirectories(dst.getParent());


### PR DESCRIPTION
Running the `micros-javac` benchmark on the current JDK fails with the following errors:

```
/tmp/JavacBenchmarkRoot7910357965675411098/jdk.unsupported.desktop/jdk/swing/interop/SwingInterOpUtils.java:45: error: cannot find symbol
        AppContext context = SunToolkit.targetToAppContext(target);
                                       ^
  symbol: method targetToAppContext(Object)
  location: class SunToolkit
/tmp/JavacBenchmarkRoot7910357965675411098/jdk.unsupported.desktop/jdk/swing/interop/SwingInterOpUtils.java:47: error: method postEvent in class SunToolkit cannot be applied to given types;
            SunToolkit.postEvent(context, e);
                      ^
  required: AWTEvent
  found: AppContext,AWTEvent
  reason: actual and formal argument lists differ in length
...
2 errors
100 warnings
<failure>

java.io.IOException: compilation failed
        at org.openjdk.bench.langtools.javac.JavacBenchmark.compile(JavacBenchmark.java:193)
        at org.openjdk.bench.langtools.javac.GroupJavacBenchmark.cold8_Generate(GroupJavacBenchmark.java:141)
        ...
```
The benchmark compiles JDK 11 sources while excluding several modules, `java.desktop` among them. For those excluded modules, the benchmark uses the binary version from the current JDK.

The failure happens because the current JDK's `java.desktop` no longer contains `sun.awt.AppContext`, which was removed by JDK-8385347. The JDK 11 sources for `jdk.unsupported.desktop` still depend on that class, so compiling that module against the current `java.desktop` fails.

The proposal here is to exclude `jdk.unsupported.desktop` from the source set compiled by the benchmark.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385828](https://bugs.openjdk.org/browse/JDK-8385828): The javac benchmarks fail after JDK-8385347 (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31363/head:pull/31363` \
`$ git checkout pull/31363`

Update a local copy of the PR: \
`$ git checkout pull/31363` \
`$ git pull https://git.openjdk.org/jdk.git pull/31363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31363`

View PR using the GUI difftool: \
`$ git pr show -t 31363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31363.diff">https://git.openjdk.org/jdk/pull/31363.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31363#issuecomment-4610530643)
</details>
