### PR TITLE
8385856: GHA: Consolidate architecture-specific steps in Windows CI workflows

### DIFF
--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -29,6 +29,10 @@ inputs:
   architecture:
     description: 'Architecture'
     required: true
+  install-path:
+    description: 'Custom installation path for MSYS2. If set, a fresh release is downloaded to this location.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -39,10 +43,8 @@ runs:
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal
-        # x86.x64 runners include MSYS2 pre-installed, so release: false reuses it.
-        release: ${{ inputs.architecture == 'ARM64' }}
-        # ARM64 runners don't, so a fresh release is downloaded to a custom location.
-        location: ${{ inputs.architecture == 'ARM64' && format('{0}/msys2', runner.tool_cache) || '' }}
+        release: ${{ inputs.install-path != '' }}
+        location: ${{ inputs.install-path }}
 
       # We can't run bash until this is completed, so stick with pwsh
     - name: 'Set MSYS2 path'

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -33,37 +33,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: 'Install MSYS2 on x86.x64'
-      id: msys2-x64
+    - name: 'Install MSYS2'
+      id: msys2
       uses: msys2/setup-msys2@v2.31.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal
-        release: false
-      if: ${{ inputs.architecture == 'x86.x64' }}
-
-    - name: 'Install MSYS2 on ARM64'
-      id: msys2-arm64
-      uses: msys2/setup-msys2@v2.31.0
-      with:
-        install: 'autoconf tar unzip zip make'
-        path-type: minimal
-        release: true
-        location: ${{ runner.tool_cache }}/msys2
-      if: ${{ inputs.architecture == 'ARM64' }}
+        # x86.x64 runners include MSYS2 pre-installed, so release: false reuses it.
+        release: ${{ inputs.architecture == 'ARM64' }}
+        # ARM64 runners don't, so a fresh release is downloaded to a custom location.
+        location: ${{ inputs.architecture == 'ARM64' && format('{0}/msys2', runner.tool_cache) || '' }}
 
       # We can't run bash until this is completed, so stick with pwsh
-    - name: 'Set MSYS2 path for x64'
+    - name: 'Set MSYS2 path'
       run: |
-        echo "${{ steps.msys2-x64.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
+        echo "${{ steps.msys2.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
       shell: pwsh
-      if: ${{ inputs.architecture == 'x86.x64' }}
-
-    - name: 'Set MSYS2 path for ARM64'
-      run: |
-        echo "${{ steps.msys2-arm64.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
-      shell: pwsh
-      if: ${{ inputs.architecture == 'ARM64' }}
 
     # Remove the default config.site file provided by MSYS2 to ensure config.guess accurately detects the host system.
     - name: 'Remove default config.site'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -51,6 +51,14 @@ on:
       architecture:
         required: true
         type: string
+      vcvars-script:
+        required: false
+        type: string
+        default: 'vcvars64.bat'
+      msys2-install-path:
+        required: false
+        type: string
+        default: ''
       configure-arguments:
         required: false
         type: string
@@ -92,6 +100,7 @@ jobs:
         uses: ./.github/actions/get-msys2
         with:
           architecture: ${{ inputs.architecture }}
+          install-path: ${{ inputs.msys2-install-path }}
 
       - name: 'Get the BootJDK'
         id: bootjdk
@@ -111,8 +120,7 @@ jobs:
         id: toolchain-check
         run: |
           set +e
-          vcvars=${{ inputs.architecture == 'ARM64' && 'vcvarsarm64.bat' || 'vcvars64.bat' }}
-          "/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/${vcvars}" -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          "/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/${{ inputs.vcvars-script }}" -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
             echo "Toolchain is already installed"
             echo "toolchain-installed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -107,49 +107,27 @@ jobs:
         id: gtest
         uses: ./.github/actions/get-gtest
 
-      - name: 'Check toolchain installed for x64'
-        id: toolchain-check-x64
+      - name: 'Check toolchain installed'
+        id: toolchain-check
         run: |
           set +e
-          '/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          vcvars=${{ inputs.architecture == 'ARM64' && 'vcvarsarm64.bat' || 'vcvars64.bat' }}
+          "/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/${vcvars}" -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
-            echo "Toolchain is already installed for x64"
+            echo "Toolchain is already installed"
             echo "toolchain-installed=true" >> $GITHUB_OUTPUT
           else
-            echo "Toolchain is not yet installed for x64"
+            echo "Toolchain is not yet installed"
             echo "toolchain-installed=false" >> $GITHUB_OUTPUT
           fi
-        if: ${{ inputs.architecture == 'x86.x64' }}
 
-      - name: 'Check toolchain installed for ARM64'
-        id: toolchain-check-arm64
-        run: |
-          set +e
-          "/c/Program Files/Microsoft Visual Studio/2022/Enterprise/vc/auxiliary/build/vcvarsarm64.bat" -vcvars_ver=${{ inputs.msvc-toolset-version }}
-          if [ $? -eq 0 ]; then
-            echo "Toolchain is already installed for ARM64"
-            echo "toolchain-installed=true" >> $GITHUB_OUTPUT
-          else
-            echo "Toolchain is not yet installed for ARM64"
-            echo "toolchain-installed=false" >> $GITHUB_OUTPUT
-          fi
-        if: ${{ inputs.architecture == 'ARM64' }}
-
-      - name: 'Install toolchain and dependencies for x64'
+      - name: 'Install toolchain and dependencies'
         run: |
           # Run Visual Studio Installer
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
             modify --quiet --installPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' \
-            --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.x86.x64
-        if: ${{ (inputs.architecture == 'x86.x64') && (steps.toolchain-check-x64.outputs.toolchain-installed != 'true') }}
-
-      - name: 'Install toolchain and dependencies for ARM64'
-        run: |
-          # Run Visual Studio Installer
-          '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
-            modify --quiet --installPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' \
-            --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.ARM64
-        if: ${{ ( inputs.architecture == 'ARM64') && (steps.toolchain-check-arm64.outputs.toolchain-installed != 'true') }}
+            --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.architecture }}
+        if: ${{ steps.toolchain-check.outputs.toolchain-installed != 'true' }}
 
       - name: 'Configure'
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,6 +385,9 @@ jobs:
       platform: windows-aarch64
       runs-on: windows-11-arm
       architecture: 'ARM64'
+      vcvars-script: 'vcvarsarm64.bat'
+      # ARM64 runners don't have MSYS2 pre-installed, so download a fresh release
+      msys2-install-path: 'C:\hostedtoolcache\windows\msys2'
       msvc-toolset-version: '14.44'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -490,6 +493,8 @@ jobs:
       platform: windows-aarch64
       bootjdk-platform: windows-aarch64
       architecture: 'ARM64'
+      # ARM64 runners don't have MSYS2 pre-installed, so download a fresh release
+      msys2-install-path: 'C:\hostedtoolcache\windows\msys2'
       runs-on: windows-11-arm
       dry-run: ${{ needs.prepare.outputs.dry-run == 'true' }}
       debug-suffix: -debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ on:
       architecture:
         required: false
         type: string
+      msys2-install-path:
+        required: false
+        type: string
+        default: ''
       xcode-toolset-version:
         required: false
         type: string
@@ -137,6 +141,7 @@ jobs:
         uses: ./.github/actions/get-msys2
         with:
           architecture: ${{ inputs.architecture }}
+          install-path: ${{ inputs.msys2-install-path }}
         if: runner.os == 'Windows'
 
       - name: 'Get the BootJDK'


### PR DESCRIPTION
Several steps in the Windows CI workflows are duplicated per architecture (x86.x64 / ARM64) where a single step with conditional expressions would suffice.

Changes:

- `action.yml`: Merge the two MSYS2 install steps and two path steps into one of each, using expressions for release and location.
- `build-windows.yml`: Merge the two toolchain check steps into one (conditional on bat file name), and merge the two toolchain install steps into one (component suffix already matches `inputs.architecture`).

This reduces duplication and makes future architecture additions simpler.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385856](https://bugs.openjdk.org/browse/JDK-8385856): GHA: Consolidate architecture-specific steps in Windows CI workflows (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) 🔄 Re-review required (review applies to [8b08dfd7](https://git.openjdk.org/jdk/pull/31364/files/8b08dfd7a27d63e302d79c64986d155300e9bab7))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31364/head:pull/31364` \
`$ git checkout pull/31364`

Update a local copy of the PR: \
`$ git checkout pull/31364` \
`$ git pull https://git.openjdk.org/jdk.git pull/31364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31364`

View PR using the GUI difftool: \
`$ git pr show -t 31364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31364.diff">https://git.openjdk.org/jdk/pull/31364.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31364#issuecomment-4610630905)
</details>
