### PR TITLE
8377808: compiler/c2/irTests/TestFloat16ScalarOperations.java is fragile in the presence of special constants

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2025, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -69,9 +69,9 @@ public class TestFloat16ScalarOperations {
     private static final Float16 RANDOM5 = Float16.valueOf(genF.next());
 
     // We have to ensure that the constants are not special values that lead the operations to
-    // constant fold. For example "x + 0" could constant fold to "x", so we need to avoid that
-    // the add constant is zero.
-    private static Generator<Float> genSmallRangeF = G.uniformFloats(0.1f, 0.9f);
+    // constant fold. For example "x + 0" could constant fold to "x" or "x / 0.5" could fold
+    // to "x * 2", so we need to avoid that the constants are zero or a reciprocal power of two.
+    private static Generator<Float> genSmallRangeF = G.uniformFloats(0.6f, 0.9f);
     private static final Float16 RANDOM_CON_ADD = Float16.valueOf(genSmallRangeF.next());
     private static final Float16 RANDOM_CON_SUB = Float16.valueOf(genSmallRangeF.next());
     private static final Float16 RANDOM_CON_MUL = Float16.valueOf(genSmallRangeF.next());

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2025, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,7 +35,6 @@ import compiler.lib.ir_framework.*;
 import compiler.lib.verify.*;
 import jdk.incubator.vector.Float16;
 import static jdk.incubator.vector.Float16.*;
-import java.util.Random;
 
 import compiler.lib.generators.Generator;
 import static compiler.lib.generators.Generators.G;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -98,9 +98,7 @@ public class TestFloat16ScalarOperations {
     private short GOLDEN_QNAN;
 
     public static void main(String args[]) {
-        Scenario s0 = new Scenario(0, "--add-modules=jdk.incubator.vector", "-Xint");
-        Scenario s1 = new Scenario(1, "--add-modules=jdk.incubator.vector");
-        new TestFramework().addScenarios(s1).start();
+        new TestFramework().addFlags("--add-modules=jdk.incubator.vector").start();
     }
 
     public TestFloat16ScalarOperations() {


### PR DESCRIPTION
`TestFlaot16ScalarOperations.java` is fragile when it comes to unexpected constant folding. Previously, #28678 addressed constant folding for addition with zero. This PR addresses the optimization of division by constants that are reciprocals of powers of two. This is done by reducing the range further to 0.6 to 0.9 as this excludes those reciprocals, which are `<= 0.5`. In this test we mainly care about the IR matching, so the further reduction of the input space is fine.

Testing:
 - [ ] Gitub Actions
 - [ ] tier1,tier2 and additional stress testing
 - [x] 250 repetitions of `TestFlaot16ScalarOperations.java` on aarch64

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8377808](https://bugs.openjdk.org/browse/JDK-8377808): compiler/c2/irTests/TestFloat16ScalarOperations.java is fragile in the presence of special constants (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31370/head:pull/31370` \
`$ git checkout pull/31370`

Update a local copy of the PR: \
`$ git checkout pull/31370` \
`$ git pull https://git.openjdk.org/jdk.git pull/31370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31370`

View PR using the GUI difftool: \
`$ git pr show -t 31370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31370.diff">https://git.openjdk.org/jdk/pull/31370.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31370#issuecomment-4613455673)
</details>
