### PR TITLE
8385906: DirPermissionDenied.java uses chmod instead of Java APIs for changing permissions

### DIFF
--- a/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
+++ b/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
@@ -23,23 +23,33 @@
 
 /**
  * @test
- * @bug 6977851
+ * @bug 6977851 8385906
  * @summary NPE from FileURLConnection.connect
  * @library /test/lib
- * @build DirPermissionDenied jdk.test.lib.process.*
- *        jdk.test.lib.util.FileUtils
+ * @build DirPermissionDenied jdk.test.lib.util.FileUtils jtreg.SkippedException
  * @run junit ${test.main.class}
  */
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.FileUtils;
+import jtreg.SkippedException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -51,6 +61,8 @@ public class DirPermissionDenied {
     private static final Path TEST_DIR = Paths.get(
             "DirPermissionDeniedDirectory");
     private static URL url;
+    private static List<AclEntry> aclEntries;
+    private static Set<PosixFilePermission> posixPermissions;
 
     @Test
     public void connectTest() throws IOException {
@@ -73,21 +85,88 @@ public class DirPermissionDenied {
     @BeforeAll
     public static void setup() throws Throwable {
         url = new URL(TEST_DIR.toUri().toString());
-        // mkdir and chmod "333"
         Files.createDirectories(TEST_DIR);
-        ProcessTools.executeCommand("chmod", "333", TEST_DIR.toString())
-                    .outputTo(System.out)
-                    .errorTo(System.out)
-                    .shouldHaveExitValue(0);
+        try {
+            makeDirectoryUnreadable();
+            if (TEST_DIR.toFile().list() != null) {
+                throw new SkippedException("Could not make directory inaccessible");
+            }
+        } catch (Throwable exception) {
+            restorePermissions();
+            throw exception;
+        }
     }
 
     @AfterAll
     public static void tearDown() throws Throwable {
-        // add read permission to ensure the dir removable
-        ProcessTools.executeCommand("chmod", "733", TEST_DIR.toString())
-                    .outputTo(System.out)
-                    .errorTo(System.out)
-                    .shouldHaveExitValue(0);
+        restorePermissions();
         FileUtils.deleteFileIfExistsWithRetry(TEST_DIR);
+    }
+
+    private static void makeDirectoryUnreadable() throws IOException {
+        FileStore store = Files.getFileStore(TEST_DIR);
+        if (store.supportsFileAttributeView("posix")) {
+            posixPermissions = Files.getPosixFilePermissions(TEST_DIR);
+            Set<PosixFilePermission> perms = EnumSet.of(
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                    PosixFilePermission.GROUP_WRITE,
+                    PosixFilePermission.GROUP_EXECUTE);
+            Files.setPosixFilePermissions(TEST_DIR, perms);
+        } else if (store.supportsFileAttributeView("acl")) {
+            AclFileAttributeView view = Files.getFileAttributeView(TEST_DIR,
+                    AclFileAttributeView.class);
+            if (view == null) {
+                throw new IOException("ACL view not available");
+            }
+            aclEntries = new ArrayList<>(view.getAcl());
+            List<AclEntry> entries = new ArrayList<>();
+            entries.add(AclEntry.newBuilder()
+                    .setType(AclEntryType.DENY)
+                    .setPrincipal(getCurrentUserPrincipal(view))
+                    .setPermissions(AclEntryPermission.READ_DATA,
+                            AclEntryPermission.LIST_DIRECTORY)
+                    .build());
+            entries.addAll(aclEntries);
+            view.setAcl(entries);
+        } else {
+            throw new SkippedException("Required file attribute view not supported");
+        }
+    }
+
+    private static UserPrincipal getCurrentUserPrincipal(
+            AclFileAttributeView view) throws IOException {
+        String userName = System.getProperty("user.name");
+        try {
+            return TEST_DIR.getFileSystem().getUserPrincipalLookupService()
+                    .lookupPrincipalByName(userName);
+        } catch (IOException e) {
+            for (AclEntry entry : view.getAcl()) {
+                UserPrincipal principal = entry.principal();
+                String name = principal.getName();
+                if (name.equalsIgnoreCase(userName)
+                        || name.endsWith("\\" + userName)) {
+                    return principal;
+                }
+            }
+            throw e;
+        }
+    }
+
+    private static void restorePermissions() throws IOException {
+        if (Files.notExists(TEST_DIR)) {
+            return;
+        }
+
+        FileStore store = Files.getFileStore(TEST_DIR);
+        if (posixPermissions != null
+                && store.supportsFileAttributeView("posix")) {
+            Files.setPosixFilePermissions(TEST_DIR, posixPermissions);
+        } else if (aclEntries != null
+                && store.supportsFileAttributeView("acl")) {
+            AclFileAttributeView view = Files.getFileAttributeView(TEST_DIR,
+                    AclFileAttributeView.class);
+            view.setAcl(aclEntries);
+        }
     }
 }

--- a/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
+++ b/test/jdk/sun/net/www/protocol/file/DirPermissionDenied.java
@@ -26,7 +26,7 @@
  * @bug 6977851 8385906
  * @summary NPE from FileURLConnection.connect
  * @library /test/lib
- * @build DirPermissionDenied jdk.test.lib.util.FileUtils jtreg.SkippedException
+ * @build DirPermissionDenied jdk.test.lib.util.FileUtils
  * @run junit ${test.main.class}
  */
 
@@ -49,8 +49,8 @@ import java.util.List;
 import java.util.Set;
 
 import jdk.test.lib.util.FileUtils;
-import jtreg.SkippedException;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -88,9 +88,8 @@ public class DirPermissionDenied {
         Files.createDirectories(TEST_DIR);
         try {
             makeDirectoryUnreadable();
-            if (TEST_DIR.toFile().list() != null) {
-                throw new SkippedException("Could not make directory inaccessible");
-            }
+            Assumptions.assumeTrue(TEST_DIR.toFile().list() == null,
+                    "Could not make directory inaccessible");
         } catch (Throwable exception) {
             restorePermissions();
             throw exception;
@@ -130,7 +129,8 @@ public class DirPermissionDenied {
             entries.addAll(aclEntries);
             view.setAcl(entries);
         } else {
-            throw new SkippedException("Required file attribute view not supported");
+            Assumptions.assumeTrue(false,
+                    "Required file attribute view not supported");
         }
     }
 


### PR DESCRIPTION
Prior to this change, the DirPermissionDenied.java test used chmod to
change directory permissions, which can fail on Windows either because
chmod is not a native Windows program/command or because MSys2's
implementation of chmod does not work well with Access Control Entries
in Windows.  Consequently, the DirPermissionDenied.java test fails on
Windows, except in specific restrictive cases such as when the test is
run using the most recent version of Cygwin.

This patch updates the test so that instead of shelling out to chmod,
the test now uses Java APIs to change the directory permission.  Key to
this change is that depending on whether the filesystem supports POSIX
or Access Control Lists, the test decides whether to use the Unix-style
file permissions or ACL entries.  In the unlikely case that the test is
unable to change the directory access as is required by the test, the
test bails out with a `SkippedException`.  This is required on older
versions of Windows, where Administrator accounts implictly have
unconditional access to all files, even when there is an attempt to deny
them access.

I've validated that this test now passes on macOS, Windows 11, and
Windows Server 2022 Datacenter.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385906](https://bugs.openjdk.org/browse/JDK-8385906): DirPermissionDenied.java uses chmod instead of Java APIs for changing permissions (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Arno Zeller](https://openjdk.org/census#azeller) (@ArnoZeller - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31372/head:pull/31372` \
`$ git checkout pull/31372`

Update a local copy of the PR: \
`$ git checkout pull/31372` \
`$ git pull https://git.openjdk.org/jdk.git pull/31372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31372`

View PR using the GUI difftool: \
`$ git pr show -t 31372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31372.diff">https://git.openjdk.org/jdk/pull/31372.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31372#issuecomment-4613593173)
</details>
