### PR TITLE
8385915: RISC-V: Remove unused cmpxchg* methods

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4176,50 +4176,6 @@ void MacroAssembler::safepoint_poll(Label& slow_path, bool at_return, bool in_nm
   }
 }
 
-void MacroAssembler::cmpxchgptr(Register oldv, Register newv, Register addr, Register tmp,
-                                Label &succeed, Label *fail) {
-  assert_different_registers(addr, tmp, t0);
-  assert_different_registers(newv, tmp, t0);
-  assert_different_registers(oldv, tmp, t0);
-
-  // oldv holds comparison value
-  // newv holds value to write in exchange
-  // addr identifies memory word to compare against/update
-  if (UseZacas) {
-    mv(tmp, oldv);
-    atomic_cas(tmp, newv, addr, Assembler::int64, Assembler::aq, Assembler::rl);
-    beq(tmp, oldv, succeed);
-  } else {
-    Label retry_load, nope;
-    bind(retry_load);
-    // Load reserved from the memory location
-    load_reserved(tmp, addr, int64, Assembler::aqrl);
-    // Fail and exit if it is not what we expect
-    bne(tmp, oldv, nope);
-    // If the store conditional succeeds, tmp will be zero
-    store_conditional(tmp, newv, addr, int64, Assembler::rl);
-    beqz(tmp, succeed);
-    // Retry only when the store conditional failed
-    j(retry_load);
-
-    bind(nope);
-  }
-
-  // neither amocas nor lr/sc have an implied barrier in the failing case
-  membar(AnyAny);
-
-  mv(oldv, tmp);
-  if (fail != nullptr) {
-    j(*fail);
-  }
-}
-
-void MacroAssembler::cmpxchg_obj_header(Register oldv, Register newv, Register obj, Register tmp,
-                                        Label &succeed, Label *fail) {
-  assert(oopDesc::mark_offset_in_bytes() == 0, "assumption");
-  cmpxchgptr(oldv, newv, obj, tmp, succeed, fail);
-}
-
 void MacroAssembler::load_reserved(Register dst,
                                    Register addr,
                                    Assembler::operand_size size,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1203,8 +1203,6 @@ public:
 
 #undef INSN_ENTRY_RELOC
 
-  void cmpxchg_obj_header(Register oldv, Register newv, Register obj, Register tmp, Label &succeed, Label *fail);
-  void cmpxchgptr(Register oldv, Register newv, Register addr, Register tmp, Label &succeed, Label *fail);
   void cmpxchg(Register addr, Register expected,
                Register new_val,
                Assembler::operand_size size,


### PR DESCRIPTION
Hi,Since [JDK-8364570](https://bugs.openjdk.org/browse/JDK-8364570), the RISC-V macroAssembler method `cmpxchg_obj_header` is no longer used. The method `cmpxchgptr` is called by `cmpxchg_obj_header` but is not called by any other methods, so it can be safely removed.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385915](https://bugs.openjdk.org/browse/JDK-8385915): RISC-V: Remove unused cmpxchg* methods (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31373/head:pull/31373` \
`$ git checkout pull/31373`

Update a local copy of the PR: \
`$ git checkout pull/31373` \
`$ git pull https://git.openjdk.org/jdk.git pull/31373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31373`

View PR using the GUI difftool: \
`$ git pr show -t 31373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31373.diff">https://git.openjdk.org/jdk/pull/31373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31373#issuecomment-4614033911)
</details>
