### PR TITLE
8381235: TestCompileTaskTimeout intermittently fails due to unexpected exit code 1

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileTaskTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ package compiler.arguments;
 
 /*
  * @test TestCompileTaskTimeout
- * @bug 8308094 8365909 8366875
+ * @bug 8308094 8365909 8366875 8381235
  * @requires vm.debug & vm.flagless & os.name == "Linux"
  * @summary Check functionality of CompileTaskTimeout
  * @library /test/lib
@@ -44,15 +44,15 @@ public class TestCompileTaskTimeout {
 
         // Short timeouts crash the VM.
         ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=1", "--version")
-                    .shouldHaveExitValue(134)
+                    .shouldNotHaveExitValue(0)
                     .shouldContain("timed out after");
 
         ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=1", "-XX:TieredStopAtLevel=3", "--version")
-                    .shouldHaveExitValue(134)
+                    .shouldNotHaveExitValue(0)
                     .shouldContain("timed out after");
 
         ProcessTools.executeTestJava("-Xcomp", "-XX:CompileTaskTimeout=1", "-XX:-TieredCompilation", "--version")
-                    .shouldHaveExitValue(134)
+                    .shouldNotHaveExitValue(0)
                     .shouldContain("timed out after");
 
         // A long enough timeout succeeds.


### PR DESCRIPTION
`TestCompileTaskTimeout.java` fails when core dumps are disabled as asserts will then exit with exit code 1 instead of 134. This PR addresses this by only requiring a non-zero exit code. That is sufficient because the succeeding check ensures that there was an assert with the expected text. 

Testing:
 - [x] Github Actions
 - [x] tier1,tier2 plus additional stress testing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381235](https://bugs.openjdk.org/browse/JDK-8381235): TestCompileTaskTimeout intermittently fails due to unexpected exit code 1 (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31374/head:pull/31374` \
`$ git checkout pull/31374`

Update a local copy of the PR: \
`$ git checkout pull/31374` \
`$ git pull https://git.openjdk.org/jdk.git pull/31374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31374`

View PR using the GUI difftool: \
`$ git pr show -t 31374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31374.diff">https://git.openjdk.org/jdk/pull/31374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31374#issuecomment-4614133699)
</details>
