### PR TITLE
8376803: Jtreg test compiler/vectorization/TestVectorAlgorithms.java fails after JDK-8373026

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -58,10 +58,6 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
 compiler/vectorapi/VectorRebracket128Test.java 8330538 generic-all
 
-compiler/vectorization/TestVectorAlgorithms.java#noSuperWord 8376803 aix-ppc64,linux-s390x
-compiler/vectorization/TestVectorAlgorithms.java#vanilla 8376803 aix-ppc64,linux-s390x
-compiler/vectorization/TestVectorAlgorithms.java#noOptimizeFill 8376803 aix-ppc64,linux-s390x
-
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 

--- a/test/hotspot/jtreg/compiler/vectorization/VectorAlgorithmsImpl.java
+++ b/test/hotspot/jtreg/compiler/vectorization/VectorAlgorithmsImpl.java
@@ -541,21 +541,34 @@ public class VectorAlgorithmsImpl {
             int next = REVERSE_POWERS_OF_31_STEP_4[0]; // 31^L
             var vcoef = IntVector.fromArray(SPECIES_I, REVERSE_POWERS_OF_31_STEP_4, 1); // W
             var vresult = IntVector.zero(SPECIES_I);
+            final boolean isLE = java.nio.ByteOrder.nativeOrder() == java.nio.ByteOrder.LITTLE_ENDIAN;
             int i;
             for (i = 0; i < SPECIES_B.loopBound(a.length); i += SPECIES_B.length()) {
                 var vb = ByteVector.fromArray(SPECIES_B, a, i);
                 // Add 128 to each byte.
                 var vs = vb.lanewise(VectorOperators.XOR, (byte)0x80)
                            .reinterpretAsShorts();
-                // Each short lane contains 2 bytes, crunch them.
-                var vi = vs.and((short)0xff) // lower byte
-                           .mul((short)31)
-                           .add(vs.lanewise(VectorOperators.LSHR, 8)) // upper byte
-                           .reinterpretAsInts();
-                // Each int contains 2 shorts, crunch them.
-                var v  = vi.and(0xffff) // lower short
-                           .mul(31 * 31)
-                           .add(vi.lanewise(VectorOperators.LSHR, 16)); // upper short
+                // Each short lane contains 2 bytes.
+                // Extract them in logical byte order (b0, b1), independent of platform endianness.
+                ShortVector firstByte = isLE ? vs.and((short)0xff)                    // b0
+                                             : vs.lanewise(VectorOperators.LSHR, 8);  // b0 on BE
+                ShortVector secondByte = isLE ? vs.lanewise(VectorOperators.LSHR, 8)  // b1
+                                             : vs.and((short)0xff);                   // b1 on BE
+                // Combine each byte pair into a pairwise hash value.
+                var vi = firstByte.mul((short)31)
+                                  .add(secondByte)
+                                  .reinterpretAsInts();
+                // Each int lane contains two pairwise hash chunks:
+                // p0 = b0 * 31 + b1
+                // p1 = b2 * 31 + b3
+                // Extract them in logical order, independent of platform endianness.
+                IntVector firstPair = isLE ? vi.and(0xffff)                           // p0
+                                           : vi.lanewise(VectorOperators.LSHR, 16);   // p0 on BE
+                IntVector secondPair = isLE ? vi.lanewise(VectorOperators.LSHR, 16)   // p1
+                                           : vi.and(0xffff);                          // p1 on BE
+                // Crunch the pairwise results into one value.
+                var v = firstPair.mul(31 * 31)
+                                 .add(secondPair);
                 // Add the correction for the 128 additions above.
                 v = v.add(-128 * (31*31*31 + 31*31 + 31 + 1));
                 // Every element of v now contains a crunched int-package of 4 bytes.

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorAlgorithmsImpl.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorAlgorithmsImpl.java
@@ -541,21 +541,34 @@ public class VectorAlgorithmsImpl {
             int next = REVERSE_POWERS_OF_31_STEP_4[0]; // 31^L
             var vcoef = IntVector.fromArray(SPECIES_I, REVERSE_POWERS_OF_31_STEP_4, 1); // W
             var vresult = IntVector.zero(SPECIES_I);
+            final boolean isLE = java.nio.ByteOrder.nativeOrder() == java.nio.ByteOrder.LITTLE_ENDIAN;
             int i;
             for (i = 0; i < SPECIES_B.loopBound(a.length); i += SPECIES_B.length()) {
                 var vb = ByteVector.fromArray(SPECIES_B, a, i);
                 // Add 128 to each byte.
                 var vs = vb.lanewise(VectorOperators.XOR, (byte)0x80)
                            .reinterpretAsShorts();
-                // Each short lane contains 2 bytes, crunch them.
-                var vi = vs.and((short)0xff) // lower byte
-                           .mul((short)31)
-                           .add(vs.lanewise(VectorOperators.LSHR, 8)) // upper byte
-                           .reinterpretAsInts();
-                // Each int contains 2 shorts, crunch them.
-                var v  = vi.and(0xffff) // lower short
-                           .mul(31 * 31)
-                           .add(vi.lanewise(VectorOperators.LSHR, 16)); // upper short
+                // Each short lane contains 2 bytes.
+                // Extract them in logical byte order (b0, b1), independent of platform endianness.
+                ShortVector firstByte = isLE ? vs.and((short)0xff)                          // b0
+                                             : vs.lanewise(VectorOperators.LSHR, 8);        // b0 on BE
+                ShortVector secondByte = isLE ? vs.lanewise(VectorOperators.LSHR, 8)        // b1
+                                              : vs.and((short)0xff);                        // b1 on BE
+                // Combine each byte pair into a pairwise hash value.
+                var vi = firstByte.mul((short)31)
+                                  .add(secondByte)
+                                  .reinterpretAsInts();
+                // Each int lane contains two pairswise hash chunks:
+                // p0 = b0 * 31 + b1
+                // p1 = b2 * 31 + b3
+                // Extract them in logical order, independent of platform endianness.
+                IntVector pair0 = isLE ? vi.and(0xffff)                                    // p0
+                                       : vi.lanewise(VectorOperators.LSHR, 16);            // p0 on BE
+                IntVector pair1 = isLE ? vi.lanewise(VectorOperators.LSHR, 16)             // p1
+                                       : vi.and(0xffff);                                   // p1 on BE
+                // Crunch the pairwise results into one value.
+                var v = pair0.mul(31 * 31)
+                             .add(pair1);
                 // Add the correction for the 128 additions above.
                 v = v.add(-128 * (31*31*31 + 31*31 + 31 + 1));
                 // Every element of v now contains a crunched int-package of 4 bytes.


### PR DESCRIPTION
JDK-8373026  introduced TestVectorAlgorithms. The vectorized hash computations implicitly assumed little-endian lane ordering, causing the test to fail on big-endian platforms. 

This fix updates the hash computation to preserve logical byte order across platforms, making the test endianness-independent and ensuring consistent behaviour on both little-endian and big-endian architectures.

JBS Issue: [JDK-8376803](https://bugs.openjdk.org/browse/JDK-8376803)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376803](https://bugs.openjdk.org/browse/JDK-8376803): Jtreg test compiler/vectorization/TestVectorAlgorithms.java fails after JDK-8373026 (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31375/head:pull/31375` \
`$ git checkout pull/31375`

Update a local copy of the PR: \
`$ git checkout pull/31375` \
`$ git pull https://git.openjdk.org/jdk.git pull/31375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31375`

View PR using the GUI difftool: \
`$ git pr show -t 31375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31375.diff">https://git.openjdk.org/jdk/pull/31375.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31375#issuecomment-4621610875)
</details>
