### PR TITLE
8385051: C2: Factor the shared lane-wise binary op out of VectorBlendNode

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -1151,6 +1151,14 @@ instruct vmulI_sve(vReg dst_src1, vReg src2) %{
 instruct vmulL_neon(vReg dst, vReg src1, vReg src2) %{
   predicate(UseSVE == 0);
   match(Set dst (MulVL src1 src2));
+  // TEMP_DEF dst: NEON has no T2D mul, so we lower MulVL to per-lane GPR
+  // extract-mul-insert. The "mov dst.D[0]" inherits a partial-write merge
+  // dependency on the old dst, and if dst aliases src1 or src2 the subsequent
+  // "umov ..., src.D[1]" must wait for that merge to retire, serialising the
+  // two scalar muls within an iteration and across unrolled iterations.
+  // Forcing dst into a fresh register breaks the chain and exposes lane-level
+  // parallelism.
+  effect(TEMP_DEF dst);
   format %{ "vmulL_neon $dst, $src1, $src2\t# 2L" %}
   ins_encode %{
     uint length_in_bytes = Matcher::vector_length_in_bytes(this);

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -730,6 +730,14 @@ BINARY_OP_NEON_SVE_PAIRWISE(vmulI, MulVI, mulv, sve_mul, S)
 instruct vmulL_neon(vReg dst, vReg src1, vReg src2) %{
   predicate(UseSVE == 0);
   match(Set dst (MulVL src1 src2));
+  // TEMP_DEF dst: NEON has no T2D mul, so we lower MulVL to per-lane GPR
+  // extract-mul-insert. The "mov dst.D[0]" inherits a partial-write merge
+  // dependency on the old dst, and if dst aliases src1 or src2 the subsequent
+  // "umov ..., src.D[1]" must wait for that merge to retire, serialising the
+  // two scalar muls within an iteration and across unrolled iterations.
+  // Forcing dst into a fresh register breaks the chain and exposes lane-level
+  // parallelism.
+  effect(TEMP_DEF dst);
   format %{ "vmulL_neon $dst, $src1, $src2\t# 2L" %}
   ins_encode %{
     uint length_in_bytes = Matcher::vector_length_in_bytes(this);

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -42,6 +42,7 @@
 #include "opto/regmask.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/type.hpp"
+#include "opto/vectornode.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -1244,6 +1245,10 @@ bool Node::has_special_unique_user() const {
     return true;
   } else if (n->Opcode() == Op_XorV || n->Opcode() == Op_XorVMask) {
     // Condition for XorVMask(VectorMaskCmp(x,y,cond), MaskAll(true)) ==> VectorMaskCmp(x,y,ncond)
+    return true;
+  } else if (n->Opcode() == Op_VectorBlend &&
+             VectorNode::is_lanewise_binary_op(this)) {
+    // Condition for VectorBlend(op(A,C), op(B,C), m) ==> op(VectorBlend(A,B,m), C)
     return true;
   } else {
     return false;

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -2764,6 +2764,101 @@ Node* XorVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   return VectorNode::Ideal(phase, can_reshape);
 }
 
+// Per-lane, pure binary vector ops. Used by VectorBlendNode::Ideal to factor:
+//   (VectorBlend (op A C) (op B C) M) => (op (VectorBlend A B M) C)
+bool VectorNode::is_lanewise_binary_op(const Node* n) {
+  if (is_commutative_vector_operation(n->Opcode())) {
+    return true;
+  }
+  switch (n->Opcode()) {
+    case Op_SubVB:
+    case Op_SubVS:
+    case Op_SubVI:
+    case Op_SubVL:
+    case Op_SubVF:
+    case Op_SubVD:
+    case Op_DivVF:
+    case Op_DivVD:
+    case Op_LShiftVB:
+    case Op_LShiftVS:
+    case Op_LShiftVI:
+    case Op_LShiftVL:
+    case Op_RShiftVB:
+    case Op_RShiftVS:
+    case Op_RShiftVI:
+    case Op_RShiftVL:
+    case Op_URShiftVB:
+    case Op_URShiftVS:
+    case Op_URShiftVI:
+    case Op_URShiftVL:
+    case Op_RotateLeftV:
+    case Op_RotateRightV:
+    case Op_CompressBitsV:
+    case Op_ExpandBitsV:
+    case Op_SaturatingSubV:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Factoring out a shared operand from two matching lane-wise binary ops, see
+// is_lanewise_binary_op for the list of supported ops. For commutative ops the
+// common operand may be in either position; for non-commutative ops it must
+// appear in the same slot in both inner ops, and the rebuilt op puts it back in
+// that slot. Predicated inner ops are not supported yet. This rewrite
+// synthesizes a new op node, so we must avoid leaving both original inner ops
+// alive afterwards, that would net +1 node.
+Node* VectorBlendNode::Ideal_VectorBlend_lanewise_binary_op(PhaseGVN* phase, bool can_reshape) {
+  Node* in1 = in(1);
+  Node* in2 = in(2);
+  Node* mask = in(3);
+  int op = in1->Opcode();
+  if (!VectorNode::is_lanewise_binary_op(in1) ||
+      in2->Opcode() != op ||
+      in1->is_predicated_vector() ||
+      in2->is_predicated_vector() ||
+      (in1->outcnt() != 1 && in2->outcnt() != 1)) {
+    return nullptr;
+  }
+  bool commutative = is_commutative_vector_operation(op);
+  bool is_shift = in1->is_ShiftV();
+  // For shifts and rotates, putting a VectorBlend into slot 2 turns a
+  // constant shift/rotate amount into a non-constant one, which is not
+  // guaranteed to be a win in codegen. Skip the rewrite in that case.
+  bool slot2_sensitive = is_shift || op == Op_RotateLeftV || op == Op_RotateRightV;
+  Node* common = nullptr;
+  Node* a = nullptr;            // operand of in1 that is not common
+  Node* b = nullptr;            // operand of in2 that is not common
+  bool common_on_left = false;  // position of common in the rebuilt op
+  if (in1->in(2) == in2->in(2)) {
+    // (VectorBlend (op A C) (op B C) M) => (op (VectorBlend A B M) C)
+    common = in1->in(2); a = in1->in(1); b = in2->in(1);
+    common_on_left = false;
+  } else if (in1->in(1) == in2->in(1) && !slot2_sensitive) {
+    // (VectorBlend (op C A) (op C B) M) => (op C (VectorBlend A B M))
+    common = in1->in(1); a = in1->in(2); b = in2->in(2);
+    common_on_left = true;
+  } else if (commutative && in1->in(1) == in2->in(2)) {
+    // (VectorBlend (op C A) (op B C) M) => (op (VectorBlend A B M) C)
+    common = in1->in(1); a = in1->in(2); b = in2->in(1);
+    common_on_left = false;
+  } else if (commutative && in1->in(2) == in2->in(1)) {
+    // (VectorBlend (op A C) (op C B) M) => (op (VectorBlend A B M) C)
+    common = in1->in(2); a = in1->in(1); b = in2->in(2);
+    common_on_left = false;
+  }
+  if (common == nullptr) {
+    return nullptr;
+  }
+  Node* blend = phase->transform(new VectorBlendNode(a, b, mask));
+  Node* lhs = common_on_left ? common : blend;
+  Node* rhs = common_on_left ? blend  : common;
+  bool is_var_shift = is_shift && in1->as_ShiftV()->is_var_shift();
+  return VectorNode::make(op, lhs, rhs, vect_type(),
+                          false /*is_mask*/, is_var_shift);
+}
+
 Node* VectorBlendNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* in1 = in(1);
   Node* in2 = in(2);
@@ -2793,6 +2888,11 @@ Node* VectorBlendNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     if (m != nullptr) {
       return new VectorBlendNode(in2, in1, m);
     }
+  }
+
+  Node* res = Ideal_VectorBlend_lanewise_binary_op(phase, can_reshape);
+  if (res != nullptr) {
+    return res;
   }
 
   return VectorNode::Ideal(phase, can_reshape);
@@ -2825,6 +2925,22 @@ static bool is_replicate_uint_constant(const Node* n) {
          n->in(1)->bottom_type()->is_long()->get_con() <= 0xFFFFFFFFL;
 }
 
+// Extract the two vector inputs of a VectorBlend node. The matcher rewrites
+// VectorBlend to (VectorBlend (Binary vec1 vec2) mask) during post-visit (see
+// Matcher::find_shared_post_visit), so by the time match-rule predicates run
+// the Binary wrapper is in place. Handle both forms transparently.
+static void vector_blend_vec_inputs(const Node* n, Node*& vec1, Node*& vec2) {
+  assert(n->Opcode() == Op_VectorBlend, "expected VectorBlend");
+  Node* in1 = n->in(1);
+  if (in1 != nullptr && in1->Opcode() == Op_Binary) {
+    vec1 = in1->in(1);
+    vec2 = in1->in(2);
+  } else {
+    vec1 = in1;
+    vec2 = n->in(2);
+  }
+}
+
 static bool has_vector_elements_fit_uint(Node* n) {
   auto is_lower_doubleword_mask_pattern = [](const Node* n) {
     return n->Opcode() == Op_AndV &&
@@ -2838,6 +2954,16 @@ static bool has_vector_elements_fit_uint(Node* n) {
            n->in(2)->in(1)->bottom_type()->isa_int() &&
            n->in(2)->in(1)->bottom_type()->is_int()->get_con() >= 32;
   };
+
+  // (VectorBlend A B M): each output lane is taken from either A or B, so
+  // the result fits when both branches independently fit.
+  if (n->Opcode() == Op_VectorBlend) {
+    Node* vec1; Node* vec2;
+    vector_blend_vec_inputs(n, vec1, vec2);
+    return has_vector_elements_fit_uint(vec1) &&
+           has_vector_elements_fit_uint(vec2);
+  }
+
   return is_lower_doubleword_mask_pattern(n) ||             // (AndV     SRC (Replicate C)) where C <= 0xFFFFFFFF
          is_clear_upper_doubleword_uright_shift_pattern(n); // (URShiftV SRC S) where S >= 32
 }
@@ -2853,6 +2979,15 @@ static bool has_vector_elements_fit_int(Node* n) {
            n->in(2)->in(1)->bottom_type()->isa_int() &&
            n->in(2)->in(1)->bottom_type()->is_int()->get_con() >= 32;
   };
+
+  // (VectorBlend A B M): each output lane is taken from either A or B, so
+  // the result fits when both branches independently fit.
+  if (n->Opcode() == Op_VectorBlend) {
+    Node* vec1; Node* vec2;
+    vector_blend_vec_inputs(n, vec1, vec2);
+    return has_vector_elements_fit_int(vec1) &&
+           has_vector_elements_fit_int(vec2);
+  }
 
   return is_cast_integer_to_long_pattern(n) ||             // (VectorCastI2X SRC)
          is_clear_upper_doubleword_right_shift_pattern(n); // (RShiftV SRC S) where S >= 32

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -215,6 +215,8 @@ class VectorNode : public TypeNode {
     }
 #endif
   }
+
+  static bool is_lanewise_binary_op(const Node* n);
 };
 
 //===========================Vector=ALU=Operations=============================
@@ -1801,6 +1803,8 @@ class VectorBlendNode : public VectorNode {
   Node* vec1() const { return in(1); }
   Node* vec2() const { return in(2); }
   Node* vec_mask() const { return in(3); }
+ private:
+  Node* Ideal_VectorBlend_lanewise_binary_op(PhaseGVN* phase, bool can_reshape);
 };
 
 // Rearrange lane elements from a source vector under the control of a shuffle

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorBlendTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorBlendTest.java
@@ -28,9 +28,13 @@ import compiler.lib.generators.*;
 import jdk.incubator.vector.*;
 import jdk.test.lib.Asserts;
 
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.IntBinaryOperator;
+import java.util.function.LongBinaryOperator;
+
 /**
  * @test
- * @bug 8384571
+ * @bug 8384571 8385051
  * @key randomness
  * @library /test/lib /
  * @summary Test Ideal/Identity transformations for VectorBlendNode
@@ -42,6 +46,8 @@ import jdk.test.lib.Asserts;
 public class VectorBlendTest {
     private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_MAX;
     private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_MAX;
+    private static final VectorSpecies<Float> F_SPECIES = FloatVector.SPECIES_MAX;
+    private static final VectorSpecies<Double> D_SPECIES = DoubleVector.SPECIES_MAX;
 
     private static final int LENGTH = 128;
     private static final Generators RD = Generators.G;
@@ -50,10 +56,20 @@ public class VectorBlendTest {
     private static int[] ib;
     private static int[] ic;
     private static int[] ir;
+    private static int[] ir2;
+    private static int[] ir3;
     private static long[] la;
     private static long[] lb;
     private static long[] lc;
     private static long[] lr;
+    private static float[] fa;
+    private static float[] fb;
+    private static float[] fc;
+    private static float[] fr;
+    private static double[] da;
+    private static double[] db;
+    private static double[] dc;
+    private static double[] dr;
     private static boolean[] m;
 
     static {
@@ -61,23 +77,43 @@ public class VectorBlendTest {
         ib = new int[LENGTH];
         ic = new int[LENGTH];
         ir = new int[LENGTH];
+        ir2 = new int[LENGTH];
+        ir3 = new int[LENGTH];
         la = new long[LENGTH];
         lb = new long[LENGTH];
         lc = new long[LENGTH];
         lr = new long[LENGTH];
+        fa = new float[LENGTH];
+        fb = new float[LENGTH];
+        fc = new float[LENGTH];
+        fr = new float[LENGTH];
+        da = new double[LENGTH];
+        db = new double[LENGTH];
+        dc = new double[LENGTH];
+        dr = new double[LENGTH];
         m = new boolean[LENGTH];
 
         Generator<Integer> iGen = RD.ints();
         Generator<Long> lGen = RD.longs();
+        Generator<Float> fGen = RD.floats();
+        Generator<Double> dGen = RD.doubles();
         RD.fill(iGen, ia);
         RD.fill(iGen, ib);
         RD.fill(iGen, ic);
         RD.fill(lGen, la);
         RD.fill(lGen, lb);
         RD.fill(lGen, lc);
+        RD.fill(fGen, fa);
+        RD.fill(fGen, fb);
+        RD.fill(fGen, fc);
+        RD.fill(dGen, da);
+        RD.fill(dGen, db);
+        RD.fill(dGen, dc);
 
         for (int i = 0; i < LENGTH; i++) {
             m[i] = (i & 1) == 1;
+            // Keep shift counts in [0, 31] so LShiftVI is well-defined.
+            ic[i] &= 31;
         }
     }
 
@@ -106,6 +142,71 @@ public class VectorBlendTest {
     public static void verifyAllLong(long[] expected) {
         for (int i = 0; i < L_SPECIES.length(); i++) {
             Asserts.assertEquals(expected[i], lr[i]);
+        }
+    }
+
+    @DontInline
+    public static void verifyBlendFactor(int[] result,
+                                         int[] lhs1, int[] rhs1,
+                                         int[] lhs2, int[] rhs2,
+                                         IntBinaryOperator op) {
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            int x1 = op.applyAsInt(lhs1[i], rhs1[i]);
+            int x2 = op.applyAsInt(lhs2[i], rhs2[i]);
+            Asserts.assertEquals(m[i] ? x2 : x1, result[i]);
+        }
+    }
+
+    @DontInline
+    public static void verifyBlendFactor(int[] result,
+                                         int[] lhs1, int rhs1,
+                                         int[] lhs2, int rhs2,
+                                         IntBinaryOperator op) {
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            int x1 = op.applyAsInt(lhs1[i], rhs1);
+            int x2 = op.applyAsInt(lhs2[i], rhs2);
+            Asserts.assertEquals(m[i] ? x2 : x1, result[i]);
+        }
+    }
+
+    @DontInline
+    public static void verifyBlendFactor(long[] result,
+                                         long[] lhs1, long[] rhs1,
+                                         long[] lhs2, long[] rhs2,
+                                         LongBinaryOperator op) {
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            long x1 = op.applyAsLong(lhs1[i], rhs1[i]);
+            long x2 = op.applyAsLong(lhs2[i], rhs2[i]);
+            Asserts.assertEquals(m[i] ? x2 : x1, result[i]);
+        }
+    }
+
+    @FunctionalInterface
+    private interface FloatBinaryOperator {
+        float applyAsFloat(float a, float b);
+    }
+
+    @DontInline
+    public static void verifyBlendFactor(float[] result,
+                                         float[] lhs1, float[] rhs1,
+                                         float[] lhs2, float[] rhs2,
+                                         FloatBinaryOperator op) {
+        for (int i = 0; i < F_SPECIES.length(); i++) {
+            float x1 = op.applyAsFloat(lhs1[i], rhs1[i]);
+            float x2 = op.applyAsFloat(lhs2[i], rhs2[i]);
+            Asserts.assertEquals(m[i] ? x2 : x1, result[i]);
+        }
+    }
+
+    @DontInline
+    public static void verifyBlendFactor(double[] result,
+                                         double[] lhs1, double[] rhs1,
+                                         double[] lhs2, double[] rhs2,
+                                         DoubleBinaryOperator op) {
+        for (int i = 0; i < D_SPECIES.length(); i++) {
+            double x1 = op.applyAsDouble(lhs1[i], rhs1[i]);
+            double x2 = op.applyAsDouble(lhs2[i], rhs2[i]);
+            Asserts.assertEquals(m[i] ? x2 : x1, result[i]);
         }
     }
 
@@ -179,6 +280,392 @@ public class VectorBlendTest {
         // lanes. After the swap, the equivalent VectorBlend selects:
         // m=true -> av, m=false -> bv.
         verifyInt(ia, ib);
+    }
+
+    // VectorBlend(AndV(a, c), AndV(b, c), m) => AndV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.AND_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorAndInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.AND, cv)
+          .blend(bv.lanewise(VectorOperators.AND, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, (a, b) -> a & b);
+    }
+
+    // VectorBlend(OrV(a, c), OrV(b, c), m) => OrV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.OR_VL, "1", IRNode.VECTOR_BLEND_L, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorOrLong() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
+        LongVector cv = LongVector.fromArray(L_SPECIES, lc, 0);
+        av.lanewise(VectorOperators.OR, cv)
+          .blend(bv.lanewise(VectorOperators.OR, cv), mask)
+          .intoArray(lr, 0);
+
+        verifyBlendFactor(lr, la, lc, lb, lc, (a, b) -> a | b);
+    }
+
+    // VectorBlend(XorV(a, c), XorV(b, c), m) => XorV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.XOR_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorXorInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.XOR, cv)
+          .blend(bv.lanewise(VectorOperators.XOR, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, (a, b) -> a ^ b);
+    }
+
+    // Common operand on the left side of one inner op and right side of the
+    // other -- exercises the commutative-match path of the optimization.
+    @Test
+    @IR(counts = {IRNode.XOR_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorXorCommutedInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        cv.lanewise(VectorOperators.XOR, av)
+          .blend(bv.lanewise(VectorOperators.XOR, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ic, ia, ib, ic, (a, b) -> a ^ b);
+    }
+
+    // VectorBlend(AddV(a, c), AddV(b, c), m) => AddV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.ADD_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorAddInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.ADD, cv)
+          .blend(bv.lanewise(VectorOperators.ADD, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, Integer::sum);
+    }
+
+    // VectorBlend(MulV(a, c), MulV(b, c), m) => MulV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.MUL_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorMulInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.MUL, cv)
+          .blend(bv.lanewise(VectorOperators.MUL, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, (a, b) -> a * b);
+    }
+
+    // VectorBlend(SubV(a, c), SubV(b, c), m) => SubV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.SUB_VL, "1", IRNode.VECTOR_BLEND_L, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorSubLong() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
+        LongVector cv = LongVector.fromArray(L_SPECIES, lc, 0);
+        av.lanewise(VectorOperators.SUB, cv)
+          .blend(bv.lanewise(VectorOperators.SUB, cv), mask)
+          .intoArray(lr, 0);
+
+        verifyBlendFactor(lr, la, lc, lb, lc, (a, b) -> a - b);
+    }
+
+    // VectorBlend(SubV(c, a), SubV(c, b), m) => SubV(c, VectorBlend(a, b, m))
+    @Test
+    @IR(counts = {IRNode.SUB_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorSubLeftInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        cv.lanewise(VectorOperators.SUB, av)
+          .blend(cv.lanewise(VectorOperators.SUB, bv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ic, ia, ic, ib, (a, b) -> a - b);
+    }
+
+    // Negative test: non-commutative op with the common operand in different
+    // positions in the two inner ops must NOT factor; both SubV nodes survive.
+    @Test
+    @IR(counts = {IRNode.SUB_VI, "2", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorSubNegative() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.SUB, cv)
+          .blend(cv.lanewise(VectorOperators.SUB, bv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ic, ib, (a, b) -> a - b);
+    }
+
+    // VectorBlend(LShiftV(a, c), LShiftV(b, c), m)
+    //   => LShiftV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.LSHIFT_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorLShiftInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.LSHL, cv)
+          .blend(bv.lanewise(VectorOperators.LSHL, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, (a, b) -> a << b);
+    }
+
+    // Negative test: shift with the common operand on the left must NOT factor.
+    // Folding the two counts into a VectorBlend would force is_var_shift=true
+    // on the rebuilt shift and regress codegen on ISAs that have cheaper
+    // constant-count shifts.
+    @Test
+    @IR(counts = {IRNode.LSHIFT_VI, "2", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorLShiftNegative() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        IntVector av = IntVector.broadcast(I_SPECIES, 3);
+        IntVector bv = IntVector.broadcast(I_SPECIES, 5);
+        cv.lanewise(VectorOperators.LSHL, av)
+          .blend(cv.lanewise(VectorOperators.LSHL, bv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ic, 3, ic, 5, (a, b) -> a << b);
+    }
+
+    // VectorBlend(RotateLeftV(a, c), RotateLeftV(b, c), m)
+    //   => RotateLeftV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true"})
+    public static void testBlendFactorRolInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.ROL, cv)
+          .blend(bv.lanewise(VectorOperators.ROL, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, Integer::rotateLeft);
+    }
+
+    // Negative test: rotate with the common operand on the left must NOT factor
+    //  -- folding the two counts would fall off the const-count rotate match
+    // (e.g. x86 vprotate_immI8), or trigger the degenerate shift-OR fallback
+    // on ISAs that do not support per-lane variable rotates.
+    @Test
+    @IR(counts = {IRNode.ROTATE_LEFT_V, "2", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"avx512f", "true", "zvbb", "true"})
+    public static void testBlendFactorRolNegative() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        IntVector av = IntVector.broadcast(I_SPECIES, 3);
+        IntVector bv = IntVector.broadcast(I_SPECIES, 5);
+        cv.lanewise(VectorOperators.ROL, av)
+          .blend(cv.lanewise(VectorOperators.ROL, bv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ic, 3, ic, 5, Integer::rotateLeft);
+    }
+
+    // VectorBlend(CompressBitsV(a, c), CompressBitsV(b, c), m)
+    //   => CompressBitsV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureAnd = {"sve2", "true", "svebitperm", "true"})
+    public static void testBlendFactorCompressBitsInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.COMPRESS_BITS, cv)
+          .blend(bv.lanewise(VectorOperators.COMPRESS_BITS, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, Integer::compress);
+    }
+
+    // VectorBlend(ExpandBitsV(a, c), ExpandBitsV(b, c), m)
+    //   => ExpandBitsV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS_VL, "1", IRNode.VECTOR_BLEND_L, "1"},
+        applyIfCPUFeatureAnd = {"sve2", "true", "svebitperm", "true"})
+    public static void testBlendFactorExpandBitsLong() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
+        LongVector cv = LongVector.fromArray(L_SPECIES, lc, 0);
+        av.lanewise(VectorOperators.EXPAND_BITS, cv)
+          .blend(bv.lanewise(VectorOperators.EXPAND_BITS, cv), mask)
+          .intoArray(lr, 0);
+
+        verifyBlendFactor(lr, la, lc, lb, lc, Long::expand);
+    }
+
+    // VectorBlend(MinV(a, c), MinV(b, c), m) => MinV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.MIN_VF, "1", IRNode.VECTOR_BLEND_F, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorMinFloat() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, 0);
+        FloatVector cv = FloatVector.fromArray(F_SPECIES, fc, 0);
+        av.lanewise(VectorOperators.MIN, cv)
+          .blend(bv.lanewise(VectorOperators.MIN, cv), mask)
+          .intoArray(fr, 0);
+
+        verifyBlendFactor(fr, fa, fc, fb, fc, Math::min);
+    }
+
+    // VectorBlend(MaxV(a, c), MaxV(b, c), m) => MaxV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.MAX_VD, "1", IRNode.VECTOR_BLEND_D, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorMaxDouble() {
+        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, 0);
+        DoubleVector cv = DoubleVector.fromArray(D_SPECIES, dc, 0);
+        av.lanewise(VectorOperators.MAX, cv)
+          .blend(bv.lanewise(VectorOperators.MAX, cv), mask)
+          .intoArray(dr, 0);
+
+        verifyBlendFactor(dr, da, dc, db, dc, Math::max);
+    }
+
+    // VectorBlend(AddVF(a, c), AddVF(b, c), m) => AddVF(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.ADD_VF, "1", IRNode.VECTOR_BLEND_F, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorAddFloat() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, 0);
+        FloatVector cv = FloatVector.fromArray(F_SPECIES, fc, 0);
+        av.lanewise(VectorOperators.ADD, cv)
+          .blend(bv.lanewise(VectorOperators.ADD, cv), mask)
+          .intoArray(fr, 0);
+
+        verifyBlendFactor(fr, fa, fc, fb, fc, Float::sum);
+    }
+
+    // VectorBlend(SubVD(a, c), SubVD(b, c), m) => SubVD(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.SUB_VD, "1", IRNode.VECTOR_BLEND_D, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorSubDouble() {
+        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, 0);
+        DoubleVector cv = DoubleVector.fromArray(D_SPECIES, dc, 0);
+        av.lanewise(VectorOperators.SUB, cv)
+          .blend(bv.lanewise(VectorOperators.SUB, cv), mask)
+          .intoArray(dr, 0);
+
+        verifyBlendFactor(dr, da, dc, db, dc, (a, b) -> a - b);
+    }
+
+    // VectorBlend(DivVF(a, c), DivVF(b, c), m) => DivVF(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.DIV_VF, "1", IRNode.VECTOR_BLEND_F, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"})
+    public static void testBlendFactorDivFloat() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, m, 0);
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, 0);
+        FloatVector cv = FloatVector.fromArray(F_SPECIES, fc, 0);
+        av.lanewise(VectorOperators.DIV, cv)
+          .blend(bv.lanewise(VectorOperators.DIV, cv), mask)
+          .intoArray(fr, 0);
+
+        verifyBlendFactor(fr, fa, fc, fb, fc, (a, b) -> a / b);
+    }
+
+    // VectorBlend(SaturatingAddV(a, c), SaturatingAddV(b, c), m)
+    //   => SaturatingAddV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.SATURATING_ADD_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorSAddInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.SADD, cv)
+          .blend(bv.lanewise(VectorOperators.SADD, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, VectorMath::addSaturating);
+    }
+
+    // VectorBlend(SaturatingSubV(a, c), SaturatingSubV(b, c), m)
+    //   => SaturatingSubV(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.SATURATING_SUB_VI, "1", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorSSubInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        av.lanewise(VectorOperators.SSUB, cv)
+          .blend(bv.lanewise(VectorOperators.SSUB, cv), mask)
+          .intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, VectorMath::subSaturating);
+    }
+
+    // Negative test for the use-count guard on the rule:
+    // VectorBlend(OP(a, c), OP(b, c), m) => OP(VectorBlend(a, b, m), c)
+    @Test
+    @IR(counts = {IRNode.AND_VI, "2", IRNode.VECTOR_BLEND_I, "1"},
+        applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"})
+    public static void testBlendFactorMultiUsed() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        IntVector and1 = av.lanewise(VectorOperators.AND, cv);
+        IntVector and2 = bv.lanewise(VectorOperators.AND, cv);
+        // Force both inner ops to be multi-used.
+        and1.intoArray(ir2, 0);
+        and2.intoArray(ir3, 0);
+        and1.blend(and2, mask).intoArray(ir, 0);
+
+        verifyBlendFactor(ir, ia, ic, ib, ic, (a, b) -> a & b);
     }
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.lang.reflect.Array;
 
 /**
  * @test
- * @bug 8341137
+ * @bug 8341137 8385051
  * @key randomness
  * @summary Optimize long vector multiplication using x86 VPMUL[U]DQ instruction.
  * @modules jdk.incubator.vector
@@ -43,9 +43,11 @@ public class VectorMultiplyOpt {
 
     public static int[] isrc1;
     public static int[] isrc2;
+    public static int[] isrc3;
     public static long[] lsrc1;
     public static long[] lsrc2;
     public static long[] res;
+    public static boolean[] mskArr;
 
     public static final int SIZE = 1024;
     public static final Random r = jdk.test.lib.Utils.getRandomInstance();
@@ -71,10 +73,14 @@ public class VectorMultiplyOpt {
         res  = new long[SIZE];
         isrc1 = new int[SIZE + 16];
         isrc2 = new int[SIZE + 16];
+        isrc3 = new int[SIZE + 16];
+        mskArr = new boolean[SIZE + 16];
         IntStream.range(0, SIZE).forEach(i -> { lsrc1[i] = Long.MAX_VALUE * r.nextLong(); });
         IntStream.range(0, SIZE).forEach(i -> { lsrc2[i] = Long.MAX_VALUE * r.nextLong(); });
         IntStream.range(0, SIZE).forEach(i -> { isrc1[i] = Integer.MAX_VALUE * r.nextInt(); });
         IntStream.range(0, SIZE).forEach(i -> { isrc2[i] = Integer.MAX_VALUE * r.nextInt(); });
+        IntStream.range(0, SIZE).forEach(i -> { isrc3[i] = Integer.MAX_VALUE * r.nextInt(); });
+        IntStream.range(0, SIZE).forEach(i -> { mskArr[i] = (i & 1) == 1; });
     }
 
 
@@ -245,6 +251,53 @@ public class VectorMultiplyOpt {
     @Check(test = "test_pattern6")
     public void test_pattern6_validate() {
         validate("pattern6 ", res, lsrc1, lsrc2, (l1, l2) -> (l1 >> shift5) * (l2 >> shift5));
+    }
+
+    // Verifies that the VectorBlend(MulVL(I2L(a), I2L(c)), MulVL(I2L(b), I2L(c)), m)
+    //  => MulVL(VectorBlend(I2L(a), I2L(b), m), I2L(c))
+    // factoring (in VectorBlendNode::Ideal) does not regress the MulVL ->
+    // vmuldq narrowing.
+    @Test
+    @IR(counts = {IRNode.MUL_VL, " >0 ",
+                  IRNode.VECTOR_BLEND_L, " >0 ",
+                  IRNode.VECTOR_CAST_I2L, " >0 "},
+        applyIfCPUFeature = {"avx2", "true"})
+    @IR(counts = {"vmuldq", " >0 "},
+        applyIfCPUFeature = {"avx2", "true"},
+        phase = CompilePhase.FINAL_CODE)
+    @Warmup(value = 10000)
+    public static void test_pattern7() {
+        int i = 0;
+        for (; i < LSP.loopBound(res.length); i += LSP.length()) {
+            VectorMask<Long> mask = VectorMask.fromArray(LSP, mskArr, i);
+            LongVector va = IntVector.fromArray(ISP, isrc1, i)
+                                     .convert(VectorOperators.I2L, 0)
+                                     .reinterpretAsLongs();
+            LongVector vb = IntVector.fromArray(ISP, isrc2, i)
+                                     .convert(VectorOperators.I2L, 0)
+                                     .reinterpretAsLongs();
+            LongVector vc = IntVector.fromArray(ISP, isrc3, i)
+                                     .convert(VectorOperators.I2L, 0)
+                                     .reinterpretAsLongs();
+            va.lanewise(VectorOperators.MUL, vc)
+              .blend(vb.lanewise(VectorOperators.MUL, vc), mask)
+              .intoArray(res, i);
+        }
+        for (; i < res.length; i++) {
+            res[i] = mskArr[i] ? Math.multiplyFull(isrc2[i], isrc3[i])
+                               : Math.multiplyFull(isrc1[i], isrc3[i]);
+        }
+    }
+
+    @Check(test = "test_pattern7")
+    public void test_pattern7_validate() {
+        for (int i = 0; i < res.length; i++) {
+            long expected = mskArr[i] ? Math.multiplyFull(isrc2[i], isrc3[i])
+                                      : Math.multiplyFull(isrc1[i], isrc3[i]);
+            if (res[i] != expected) {
+                throw new AssertionError("pattern7 index " + i + ": actual=" + res[i] + " expected=" + expected);
+            }
+        }
     }
 
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorBlendOpts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorBlendOpts.java
@@ -36,6 +36,8 @@ import java.util.concurrent.TimeUnit;
 public class VectorBlendOpts {
     private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_MAX;
     private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_MAX;
+    private static final VectorSpecies<Float> F_SPECIES = FloatVector.SPECIES_MAX;
+    private static final VectorSpecies<Double> D_SPECIES = DoubleVector.SPECIES_MAX;
 
     @Param({"1024"})
     private int ARRAYLEN;
@@ -46,6 +48,8 @@ public class VectorBlendOpts {
     private boolean[] mask_arr;
     private int[] ia, ib, ic, ir;
     private long[] la, lb, lc, lr;
+    private float[] fa, fb, fc, fr;
+    private double[] da, db, dc, dr;
 
     @Setup(Level.Trial)
     public void init() {
@@ -59,6 +63,14 @@ public class VectorBlendOpts {
         lb = new long[ARRAYLEN];
         lc = new long[ARRAYLEN];
         lr = new long[ARRAYLEN];
+        fa = new float[ARRAYLEN];
+        fb = new float[ARRAYLEN];
+        fc = new float[ARRAYLEN];
+        fr = new float[ARRAYLEN];
+        da = new double[ARRAYLEN];
+        db = new double[ARRAYLEN];
+        dc = new double[ARRAYLEN];
+        dr = new double[ARRAYLEN];
         for (int i = 0; i < ARRAYLEN; i++) {
             mask_arr[i] = r.nextBoolean();
             ia[i] = r.nextInt();
@@ -67,6 +79,12 @@ public class VectorBlendOpts {
             la[i] = r.nextLong();
             lb[i] = r.nextLong();
             lc[i] = r.nextLong();
+            fa[i] = r.nextFloat();
+            fb[i] = r.nextFloat();
+            fc[i] = r.nextFloat();
+            da[i] = r.nextDouble();
+            db[i] = r.nextDouble();
+            dc[i] = r.nextDouble();
         }
     }
 
@@ -129,5 +147,252 @@ public class VectorBlendOpts {
             VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, j);
             av.blend(bv, mask.not()).intoArray(ir, j);
         }
+    }
+
+    // VectorBlend(AndV(a, c), AndV(b, c), m) => AndV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorAndInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.AND, cv)
+                   .blend(bv.lanewise(VectorOperators.AND, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(OrV(a, c), OrV(b, c), m) => OrV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorOrLong() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, mask_arr, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
+        LongVector cv = LongVector.fromArray(L_SPECIES, lc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.OR, cv)
+                   .blend(bv.lanewise(VectorOperators.OR, cv), mask);
+        }
+        cv.intoArray(lr, 0);
+    }
+
+    // VectorBlend(XorV(a, c), XorV(b, c), m) => XorV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorXorInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.XOR, cv)
+                   .blend(bv.lanewise(VectorOperators.XOR, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(AddV(a, c), AddV(b, c), m) => AddV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorAddInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.ADD, cv)
+                   .blend(bv.lanewise(VectorOperators.ADD, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(MulV(a, c), MulV(b, c), m) => MulV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorMulLong() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, mask_arr, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
+        LongVector cv = LongVector.fromArray(L_SPECIES, lc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.MUL, cv)
+                   .blend(bv.lanewise(VectorOperators.MUL, cv), mask);
+        }
+        cv.intoArray(lr, 0);
+    }
+
+    // VectorBlend(SubV(a, c), SubV(b, c), m) => SubV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorSubInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.SUB, cv)
+                   .blend(bv.lanewise(VectorOperators.SUB, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(LShiftV(a, c), LShiftV(b, c), m)
+    //   => LShiftV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorLShiftInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.LSHL, cv)
+                   .blend(bv.lanewise(VectorOperators.LSHL, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(RotateLeftV(a, c), RotateLeftV(b, c), m)
+    //   => RotateLeftV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorRolInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.ROL, cv)
+                   .blend(bv.lanewise(VectorOperators.ROL, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(CompressBitsV(a, c), CompressBitsV(b, c), m)
+    //   => CompressBitsV(VectorBlend(a, b, m), c)
+    // Only intrinsified on AArch64 SVE2 + svebitperm; elsewhere VectorAPI falls
+    // back to a scalar Integer.compress loop and the optimization is moot.
+    @Benchmark
+    public void factorCompressBitsInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.COMPRESS_BITS, cv)
+                   .blend(bv.lanewise(VectorOperators.COMPRESS_BITS, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(ExpandBitsV(a, c), ExpandBitsV(b, c), m)
+    //   => ExpandBitsV(VectorBlend(a, b, m), c)
+    // Same AArch64 SVE2 + svebitperm caveat as factorCompressBitsInt.
+    @Benchmark
+    public void factorExpandBitsLong() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, mask_arr, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
+        LongVector cv = LongVector.fromArray(L_SPECIES, lc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.EXPAND_BITS, cv)
+                   .blend(bv.lanewise(VectorOperators.EXPAND_BITS, cv), mask);
+        }
+        cv.intoArray(lr, 0);
+    }
+
+    // VectorBlend(MinV(a, c), MinV(b, c), m) => MinV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorMinFloat() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, mask_arr, 0);
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, 0);
+        FloatVector cv = FloatVector.fromArray(F_SPECIES, fc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.MIN, cv)
+                   .blend(bv.lanewise(VectorOperators.MIN, cv), mask);
+        }
+        cv.intoArray(fr, 0);
+    }
+
+    // VectorBlend(MaxV(a, c), MaxV(b, c), m) => MaxV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorMaxDouble() {
+        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, mask_arr, 0);
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, 0);
+        DoubleVector cv = DoubleVector.fromArray(D_SPECIES, dc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.MAX, cv)
+                   .blend(bv.lanewise(VectorOperators.MAX, cv), mask);
+        }
+        cv.intoArray(dr, 0);
+    }
+
+    // VectorBlend(AddVF(a, c), AddVF(b, c), m) => AddVF(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorAddFloat() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, mask_arr, 0);
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, 0);
+        FloatVector cv = FloatVector.fromArray(F_SPECIES, fc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.ADD, cv)
+                   .blend(bv.lanewise(VectorOperators.ADD, cv), mask);
+        }
+        cv.intoArray(fr, 0);
+    }
+
+    // VectorBlend(SubVD(a, c), SubVD(b, c), m) => SubVD(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorSubDouble() {
+        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, mask_arr, 0);
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        DoubleVector bv = DoubleVector.fromArray(D_SPECIES, db, 0);
+        DoubleVector cv = DoubleVector.fromArray(D_SPECIES, dc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.SUB, cv)
+                   .blend(bv.lanewise(VectorOperators.SUB, cv), mask);
+        }
+        cv.intoArray(dr, 0);
+    }
+
+    // VectorBlend(DivVF(a, c), DivVF(b, c), m) => DivVF(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorDivFloat() {
+        VectorMask<Float> mask = VectorMask.fromArray(F_SPECIES, mask_arr, 0);
+        FloatVector av = FloatVector.fromArray(F_SPECIES, fa, 0);
+        FloatVector bv = FloatVector.fromArray(F_SPECIES, fb, 0);
+        FloatVector cv = FloatVector.fromArray(F_SPECIES, fc, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.DIV, cv)
+                   .blend(bv.lanewise(VectorOperators.DIV, cv), mask);
+        }
+        cv.intoArray(fr, 0);
+    }
+
+    // VectorBlend(SaturatingAddV(a, c), SaturatingAddV(b, c), m)
+    //   => SaturatingAddV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorSAddInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.SADD, cv)
+                   .blend(bv.lanewise(VectorOperators.SADD, cv), mask);
+        }
+        cv.intoArray(ir, 0);
+    }
+
+    // VectorBlend(SaturatingSubV(a, c), SaturatingSubV(b, c), m)
+    //   => SaturatingSubV(VectorBlend(a, b, m), c)
+    @Benchmark
+    public void factorSSubInt() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, mask_arr, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
+        IntVector cv = IntVector.fromArray(I_SPECIES, ic, 0);
+        for (int j = 0; j < COUNT; j++) {
+            cv = av.lanewise(VectorOperators.SSUB, cv)
+                   .blend(bv.lanewise(VectorOperators.SSUB, cv), mask);
+        }
+        cv.intoArray(ir, 0);
     }
 }


### PR DESCRIPTION
This PR continues the JDK-8384571 [1] work by further optimizing Blend-related IR patterns. It adds the factoring optimization that pulls a shared operand out of two matching lane-wise binary ops fed into a `VectorBlend`:
```
  (VectorBlend (op A C) (op B C) M) => (op (VectorBlend A B M) C)
```

For commutative ops the common operand may be in either position; for non-commutative ops it must appear in the same slot in both inner ops.

Shifts and rotates are not factored when the common operand sits in the count slot, since that turns a constant shift/rotate amount into a non-constant one which is not guaranteed to be a win in codegen.

Also extends `MulVLNode::has_int_inputs` / `has_uint_inputs` to peek through `VectorBlend` so the `MulVL -> vmuldq/vmuludq` narrowing on x86 keeps working after the factoring runs.

The `factorMulLong` benchmark exposed a performance issue with the rule `vmulL_neon`: The encoder lowers `MulVL` to per-lane `GPR extract -> scalar mul -> mov dst.D[i]`. The first `mov` inherits a partial-write merge dependency on the old `dst`, and if the register allocator coalesces `dst` with `src1/src2` the subsequent `umov` for lane 1 must wait for that merge to retire. This serialises the two scalar `muls` within an iteration and across unrolled iterations. This PR fix the issue by forcing `dst` into a fresh register to breaks the chain.

This PR also extends the existing JTReg and JMH tests for `VectorBlend`. All tests (tier1, tier2, and tier3) passed on AArch64 and X86 platforms.

JMH benchmark test results:

On a Nvidia Grace (Neoverse-V2) machine with 128-bit SVE2:
```
Benchmark		        Unit	Before	Err	After	Err	    Uplift
factorAddFloat		    ops/ms	2726.9	1.1	7790.8	12.1	2.9
factorAddInt		    ops/ms	3383.4	3.9	7778.3	19.7	2.3
factorAndInt		    ops/ms	3386.8	2.1	436377	4806.1	128.8
factorCompressBitsInt	ops/ms	1455.7	1.0	2244.7	0.7	    1.5
factorDivFloat		    ops/ms	1084.9	1.2	1777.4	0.8	    1.6
factorExpandBitsLong	ops/ms	1455.6	1.7	2237.7	1.4	    1.5
factorLShiftInt		    ops/ms	1923.7	2.4	3518.7	3.6	    1.8
factorMaxDouble		    ops/ms	2712.8	1.6	7718.3	4.9	    2.8
factorMinFloat		    ops/ms	2725.0	4.7	7778.5	13.5	2.9
factorMulLong		    ops/ms	1427.3	0.6	2773.2	3.4	    1.9
factorOrLong		    ops/ms	3377.3	3.0	472138	2687.2	139.8
factorRolInt		    ops/ms	1188.0	1.7	1187.9	0.4	    1.0
factorSAddInt		    ops/ms	3384.8	3.3	7769.1	4.1	    2.3
factorSSubInt		    ops/ms	3387.4	8.2	7790.4	12.5	2.3
factorSubDouble		    ops/ms	2717.7	3.1	7711.4	2.6	    2.8
factorSubInt		    ops/ms	3384.8	5.7	7767.4	3.4	    2.3
factorXorInt		    ops/ms	3386.7	1.9	15017.2	20.5	4.4
```

On an AWS Graviton3 (Neoverse-V1) machine with 256-bit SVE1:
```
Benchmark		        Unit	Before	Err	After	Err	    Uplift
factorAddFloat		    ops/ms	2105.1	0.6	5779.4	0.1	    2.7
factorAddInt		    ops/ms	2624.2	0.5	5778.5	0.4	    2.2
factorAndInt		    ops/ms	2623.8	0.6	293407	4459.5	111.8
factorCompressBitsInt	ops/ms	22.0	0.0	22.1	0.0	    1.0
factorDivFloat		    ops/ms	605.1	0.0	1301.6	0.0	    2.2
factorExpandBitsLong	ops/ms	17.0	0.0	17.0	0.0	    1.0
factorLShiftInt		    ops/ms	1481.8	0.4	2580.5	0.0	    1.7
factorMaxDouble		    ops/ms	1965.9	1.1	5223.3	1.9	    2.7
factorMinFloat		    ops/ms	1957.6	2.3	5247.9	1.0	    2.7
factorMulLong		    ops/ms	1046.7	0.0	2109.6	0.1	    2.0
factorOrLong		    ops/ms	2615.6	0.0	307047	867.7	117.4
factorRolInt		    ops/ms	885.4	0.1	885.6	0.1	    1.0
factorSAddInt		    ops/ms	2623.8	0.5	5778.6	0.2	    2.2
factorSSubInt		    ops/ms	2623.7	0.6	5778.1	0.2	    2.2
factorSubDouble		    ops/ms	2094.9	0.1	5768.0	0.2	    2.8
factorSubInt		    ops/ms	2624.4	0.4	5778.4	0.2	    2.2
factorXorInt		    ops/ms	2624.0	0.3	5778.4	0.2	    2.2
```

On a Nvidia Grace (Neoverse-V2) machine with `-XX:UseSVE=0`:
```
Benchmark		        Unit	Before	Err	After	Err	    Uplift
factorAddFloat		    ops/ms	2207.6	1.4	7764.8	5.2	    3.5
factorAddInt		    ops/ms	2983.3	27	7775.5	16.8	2.6
factorAndInt		    ops/ms	2960.1	82	436311	5503.8	147.4
factorCompressBitsInt	ops/ms	50.5	0.1	50.6	0.1	    1.0
factorDivFloat		    ops/ms	1078.3	0.5	1781.4	1.5	    1.7
factorExpandBitsLong	ops/ms	36.7	0.1	36.7	0.1	    1.0
factorLShiftInt		    ops/ms	1902.4	4.8	3534.5	10.7	1.9
factorMaxDouble		    ops/ms	2236.8	1.0	7697.7	15.2	3.4
factorMinFloat		    ops/ms	2212.7	8.8	7787.0	11.7	3.5
factorMulLong		    ops/ms	728.6	1.1	1037.8	1.7	    1.4
factorOrLong		    ops/ms	3209.2	5.8	465766	3478.5	145.1
factorRolInt		    ops/ms	1005.9	1.7	1003.8	0.7	    1.0
factorSAddInt		    ops/ms	2922.7	64	7776.3	15.2	2.7
factorSSubInt		    ops/ms	2975.3	55	7787.1	20.7	2.6
factorSubDouble	    	ops/ms	2235.8	0.9	7682.0	2.1	    3.4
factorSubInt		    ops/ms	2905.3	28	7797.8	12.0	2.7
factorXorInt		    ops/ms	2921.3	46	15076.5	38.0	5.2
```

On an AMD EPYC 9124 16-Core Processor with option `-XX:UseAVX=3`:
```
Benchmark		        Unit	Before	Err	After	Err	    Uplift
factorAddFloat		    ops/ms	3646.2	0.7	6110.9	0.3	    1.7
factorAddInt		    ops/ms	4938.5	0.3	14243.0	0.8	    2.9
factorAndInt		    ops/ms	4938.5	0.2	296063	1510.5	59.9
factorCompressBitsInt	ops/ms	83.8	0.5	77.3	0.4	    0.9
factorDivFloat		    ops/ms	876.8	0.0	1664.3	0.1	    1.9
factorExpandBitsLong	ops/ms	96.6	0.2	91.5	0.3	    0.9
factorLShiftInt		    ops/ms	4540.6	1.3	6821.2	1.2	    1.5
factorMaxDouble		    ops/ms	884.2	0.1	1231.5	0.4	    1.4
factorMinFloat		    ops/ms	1085.9	0.2	1730.4	0.7	    1.6
factorMulLong		    ops/ms	3642.3	0.2	6112.1	0.5	    1.7
factorOrLong		    ops/ms	4938.3	0.3	290656	6077.9	58.9
factorRolInt		    ops/ms	3404.6	1.3	4978.0	0.2	    1.5
factorSAddInt		    ops/ms	698.3	0.1	1166.3	0.2	    1.7
factorSSubInt		    ops/ms	708.8	0.1	1189.2	0.1	    1.7
factorSubDouble		    ops/ms	3646.7	0.2	6110.0	1.4	    1.7
factorSubInt		    ops/ms	4937.7	1.1	14242.8	0.6	    2.9
factorXorInt		    ops/ms	4938.6	0.3	68699.2	202.2	13.9
```

On an AMD EPYC 9124 16-Core Processor with option `-XX:UseAVX=2`:
```
Benchmark		        Unit	Before	Err	After	Err	    Uplift
factorAddFloat		    ops/ms	2920.3	1.3	11216.8	3.3	    3.8
factorAddInt		    ops/ms	5282.7	3.5	18689.1	39.4	3.5
factorAndInt		    ops/ms	5284.6	1.6	426993	2099.4	80.8
factorCompressBitsInt	ops/ms	103.8	1.8	103.1	1.8	    1.0
factorDivFloat		    ops/ms	873.3	1.0	2063.6	0.7	    2.4
factorExpandBitsLong	ops/ms	101.7	1.4	102.0	1.5	    1.0
factorLShiftInt		    ops/ms	3479.5	5.7	8532.7	2.5	    2.5
factorMaxDouble		    ops/ms	885.7	0.3	1265.2	0.4	    1.4
factorMinFloat		    ops/ms	971.8	0.6	1384.1	2.0	    1.4
factorMulLong		    ops/ms	787.3	0.3	1009.9	1.6	    1.3
factorOrLong		    ops/ms	5284.6	1.8	425419	789.9	80.5
factorRolInt		    ops/ms	2201.4	0.7	2201.5	2.5	    1.0
factorSAddInt		    ops/ms	1343.0	0.4	2245.6	2.2	    1.7
factorSSubInt		    ops/ms	1345.2	0.6	2248.6	1.9	    1.7
factorSubDouble		    ops/ms	2920.4	0.8	11215.9	3.7	    3.8
factorSubInt		    ops/ms	5284.1	1.7	18719.1	5.1	    3.5
factorXorInt		    ops/ms	5284.3	3.7	18720.1	6.1	    3.5
```

[1] https://bugs.openjdk.org/browse/JDK-8384571




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Dependency #31333 must be integrated first

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-BoldItalic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Italic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif.woff)

### Issue
 * [JDK-8385051](https://bugs.openjdk.org/browse/JDK-8385051): C2: Factor the shared lane-wise binary op out of VectorBlendNode (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31379/head:pull/31379` \
`$ git checkout pull/31379`

Update a local copy of the PR: \
`$ git checkout pull/31379` \
`$ git pull https://git.openjdk.org/jdk.git pull/31379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31379`

View PR using the GUI difftool: \
`$ git pr show -t 31379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31379.diff">https://git.openjdk.org/jdk/pull/31379.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31379#issuecomment-4620359964)
</details>
