### PR TITLE
8385833: C2 Vector API: assert(false) failed: infinite loop in PhaseIterGVN::transform_old

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1343,6 +1343,11 @@ Node* VectorNode::reassociate_vector_operation(PhaseGVN* phase) {
     return nullptr;
   }
 
+  // Safety check to ensure we skip useless/redundant reassociations.
+  if (scalar_opcode(Opcode(), vect_type()->element_basic_type()) == 0) {
+    return nullptr;
+  }
+
   Node* in1 = in(1);
   Node* in2 = in(2);
   if (in2->Opcode() == Op_Replicate && in1->Opcode() == Opcode()) {

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1343,6 +1343,9 @@ Node* VectorNode::reassociate_vector_operation(PhaseGVN* phase) {
     return nullptr;
   }
 
+  // Reassociation is beneficial if transformed node with replicate inputs can
+  // subsequently be collapsed by push_through_replicate into Replicate(ScalarOp(..)).
+  // That folding needs a scalar opcode for this operation/element type.
   // Safety check to ensure we skip useless/redundant reassociations.
   if (scalar_opcode(Opcode(), vect_type()->element_basic_type()) == 0) {
     return nullptr;

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorReassociations.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorReassociations.java
@@ -609,8 +609,6 @@ public class TestVectorReassociations {
 
     private static final Generators RD = Generators.G;
 
-    // Random, non-final broadcast values: runtime (non-constant) so the UMaxV/UMinV
-    // nodes are not folded away and survive for the IR checks below.
     static int uA, uB, uC;
 
     static {
@@ -623,7 +621,7 @@ public class TestVectorReassociations {
 
     // UMAX(UMAX(bcast(uA), bcast(uB)), bcast(uC)).
     @Test
-    @IR(counts = { IRNode.UMAX_VI, IRNode.VECTOR_SIZE_ANY, " >0 " },
+    @IR(counts = { IRNode.UMAX_VI, " >0 " },
         applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @Warmup(value = 10000)
     static void test_int_umax_all_broadcast() {
@@ -643,7 +641,7 @@ public class TestVectorReassociations {
 
     // UMIN(UMIN(bcast(uA), bcast(uB)), bcast(uC)).
     @Test
-    @IR(counts = { IRNode.UMIN_VI, IRNode.VECTOR_SIZE_ANY, " >0 " },
+    @IR(counts = { IRNode.UMIN_VI, " >0 " },
         applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @Warmup(value = 10000)
     static void test_int_umin_all_broadcast() {

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorReassociations.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorReassociations.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 8358521
+ * @bug 8358521 8385833
+ * @key randomness
  * @summary Test reassociation of broadcasted inputs across vector operations
  * @modules jdk.incubator.vector
  * @library /test/lib /
@@ -32,7 +33,10 @@
 
 package compiler.vectorapi;
 
+import compiler.lib.generators.Generator;
+import compiler.lib.generators.Generators;
 import compiler.lib.ir_framework.*;
+import compiler.lib.verify.*;
 import jdk.incubator.vector.*;
 import java.util.stream.IntStream;
 
@@ -601,5 +605,59 @@ public class TestVectorReassociations {
                   .lanewise(VectorOperators.MUL,
                             ByteVector.broadcast(BSP, bb))
                   .intoArray(byteOut, 0);
+    }
+
+    private static final Generators RD = Generators.G;
+
+    // Random, non-final broadcast values: runtime (non-constant) so the UMaxV/UMinV
+    // nodes are not folded away and survive for the IR checks below.
+    static int uA, uB, uC;
+
+    static {
+        Generator<Integer> ig = RD.ints();
+        uA = ig.next(); uB = ig.next(); uC = ig.next();
+    }
+
+    static int[] umaxIntOut = new int[ISP.length()];
+    static int[] uminIntOut = new int[ISP.length()];
+
+    // UMAX(UMAX(bcast(uA), bcast(uB)), bcast(uC)).
+    @Test
+    @IR(counts = { IRNode.UMAX_VI, IRNode.VECTOR_SIZE_ANY, " >0 " },
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
+    @Warmup(value = 10000)
+    static void test_int_umax_all_broadcast() {
+        IntVector.broadcast(ISP, uA)
+                 .lanewise(VectorOperators.UMAX, uB)
+                 .lanewise(VectorOperators.UMAX, uC)
+                 .intoArray(umaxIntOut, 0);
+    }
+
+    @Check(test = "test_int_umax_all_broadcast")
+    static void check_int_umax_all_broadcast() {
+        int e = VectorMath.maxUnsigned(VectorMath.maxUnsigned(uA, uB), uC);
+        for (int v : umaxIntOut) {
+            Verify.checkEQ(v, e);
+        }
+    }
+
+    // UMIN(UMIN(bcast(uA), bcast(uB)), bcast(uC)).
+    @Test
+    @IR(counts = { IRNode.UMIN_VI, IRNode.VECTOR_SIZE_ANY, " >0 " },
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
+    @Warmup(value = 10000)
+    static void test_int_umin_all_broadcast() {
+        IntVector.broadcast(ISP, uA)
+                 .lanewise(VectorOperators.UMIN, uB)
+                 .lanewise(VectorOperators.UMIN, uC)
+                 .intoArray(uminIntOut, 0);
+    }
+
+    @Check(test = "test_int_umin_all_broadcast")
+    static void check_int_umin_all_broadcast() {
+        int e = VectorMath.minUnsigned(VectorMath.minUnsigned(uA, uB), uC);
+        for (int v : uminIntOut) {
+            Verify.checkEQ(v, e);
+        }
     }
 }


### PR DESCRIPTION
Hi,

This pull request adds a safety check in the vector reassociation transform to skip over operations
that are not processed by `push_through_replicate`, since for those cases reassociation is not fruitful.
The transform clusters replicated inputs so `push_through_replicate `can strength-reduce them to a scalar
operation, but that folding only works when a scalar opcode exists for the element type. Operations like
`UMinV/UMaxV` have no scalar counterpart, so the reassociation merely reshuffles the graph; IGVN then keeps
reassociating the same IR fragment endlessly, trapping C2 in an infinite loop as shown by the bug reproducer.
The check bails out when no scalar opcode exists, avoiding this dead trap while leaving useful folds intact.

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385833](https://bugs.openjdk.org/browse/JDK-8385833): C2 Vector API: assert(false) failed: infinite loop in PhaseIterGVN::transform_old (**Bug** - P2)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31380/head:pull/31380` \
`$ git checkout pull/31380`

Update a local copy of the PR: \
`$ git checkout pull/31380` \
`$ git pull https://git.openjdk.org/jdk.git pull/31380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31380`

View PR using the GUI difftool: \
`$ git pr show -t 31380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31380.diff">https://git.openjdk.org/jdk/pull/31380.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31380#issuecomment-4620737615)
</details>
