### PR TITLE
GlobalCounter only needs a `release_store_fence` when not nested

### DIFF
--- a/src/hotspot/share/utilities/globalCounter.inline.hpp
+++ b/src/hotspot/share/utilities/globalCounter.inline.hpp
@@ -28,7 +28,6 @@
 #include "utilities/globalCounter.hpp"
 
 #include "runtime/atomic.hpp"
-#include "runtime/javaThread.hpp"
 #include "runtime/safepointVerifiers.hpp"
 
 inline GlobalCounter::CSContext
@@ -40,8 +39,8 @@ GlobalCounter::critical_section_begin(Thread *thread) {
   uintx new_cnt = old_cnt;
   if ((new_cnt & COUNTER_ACTIVE) == 0) {
     new_cnt = _global_counter._counter.load_relaxed() | COUNTER_ACTIVE;
+    thread->get_rcu_counter()->release_store_fence(new_cnt);
   }
-  thread->get_rcu_counter()->release_store_fence(new_cnt);
   return static_cast<CSContext>(old_cnt);
 }
 


### PR DESCRIPTION
Hi,

When entering a CriticalSection, we only need to emit a `release_store_fence` in the unnested case, but we currently do so for all nestings as well. Consider a basic nested CS situation:

```c++
{
  CS a;
  do_foo()
  {
    CS b;
    do_bar();
  }
  do_baz();
}
```

Clearly, it doesn't matter for `do_bar()` if `CS b` executes or not, as it is already protected by `CS a`. Therefore, it is safe to only perform the `release_store_fence()` in `CS a`, as that is what publishes that the thread is in a critical section. It is also fine for any loads and stores to "float" past or before the `CS b` call, as they are still protected by `CS a`.

Technically, we could also skip the `release_store` in the destructor if we are in the nested case, but that requires detecting that we are indeed in the nested case. That would require changing the `CSContext`API, but that makes the PR so much larger that I don't think it's worth to do so (yet).

Testing: tier1-tier3

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31381/head:pull/31381` \
`$ git checkout pull/31381`

Update a local copy of the PR: \
`$ git checkout pull/31381` \
`$ git pull https://git.openjdk.org/jdk.git pull/31381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31381`

View PR using the GUI difftool: \
`$ git pr show -t 31381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31381.diff">https://git.openjdk.org/jdk/pull/31381.diff</a>

</details>
