### PR TITLE
8385885: Clarify comment in LazyConstantImpl

### DIFF
--- a/src/java.base/share/classes/jdk/internal/lang/LazyConstantImpl.java
+++ b/src/java.base/share/classes/jdk/internal/lang/LazyConstantImpl.java
@@ -92,7 +92,7 @@ public final class LazyConstantImpl<T> implements LazyConstant<T> {
             T t = getAcquire();
             if (t == null) {
                 final Object cf = computingFunctionOrExceptionType;
-                // Don't use pattern matching here in order to improve startup time.
+                // Don't use switch pattern matching here in order to improve startup time.
                 if (cf instanceof Supplier<?> computingFunction) {
                     try {
                         @SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR proposes to add "switch pattern matching"  rather than just "pattern matching".

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385885](https://bugs.openjdk.org/browse/JDK-8385885): Clarify comment in LazyConstantImpl (**Enhancement** - P5)(⚠️ The fixVersion in this issue is [28] but the fixVersion in .jcheck/conf is 27, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31382/head:pull/31382` \
`$ git checkout pull/31382`

Update a local copy of the PR: \
`$ git checkout pull/31382` \
`$ git pull https://git.openjdk.org/jdk.git pull/31382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31382`

View PR using the GUI difftool: \
`$ git pr show -t 31382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31382.diff">https://git.openjdk.org/jdk/pull/31382.diff</a>

</details>
