### PR TITLE
8385961: Shenandoah: incorrect assert ordering in ShenandoahFreeSet::allocate_contiguous non-humongous path

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -1745,8 +1745,8 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req, bo
     for (idx_t i = beg; i <= end; i++) {
       ShenandoahHeapRegion* r = _heap->get_region(i);
       assert(i == beg || _heap->get_region(i - 1)->index() + 1 == r->index(), "Should be contiguous");
-      assert(r->is_empty(), "Should be empty");
       r->try_recycle_under_lock();
+      assert(r->is_empty(), "Should be empty");
       r->set_affiliation(req.affiliation());
       r->make_regular_allocation(req.affiliation());
       if ((i == end) && (used_words_in_last_region > 0)) {


### PR DESCRIPTION
Trivial change to fix incorrect assert ordering in ShenandoahFreeSet::allocate_contiguous non-humongous path. In practice this assert never fires: the non-humongous path is only used for CDS archive allocation, which happens during early VM startup before any GC has run. With no prior collection, no regions are in the trash state yet, so the candidate regions are always already empty. The incorrect ordering is therefore latent — it is a correctness/consistency issue rather than an observed failure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385961](https://bugs.openjdk.org/browse/JDK-8385961): Shenandoah: incorrect assert ordering in ShenandoahFreeSet::allocate_contiguous non-humongous path (**Bug** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31383/head:pull/31383` \
`$ git checkout pull/31383`

Update a local copy of the PR: \
`$ git checkout pull/31383` \
`$ git pull https://git.openjdk.org/jdk.git pull/31383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31383`

View PR using the GUI difftool: \
`$ git pr show -t 31383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31383.diff">https://git.openjdk.org/jdk/pull/31383.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31383#issuecomment-4625085206)
</details>
