### PR TITLE
8385963: Native Attach API code has unnecessary 'strdup' calls

### DIFF
--- a/src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,11 +96,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_connect
             if (err == ENOENT) {
                 JNU_ThrowByName(env, "java/io/FileNotFoundException", NULL);
             } else {
-                char* msg = strdup(strerror(err));
-                JNU_ThrowIOException(env, msg);
-                if (msg != NULL) {
-                    free(msg);
-                }
+                JNU_ThrowIOException(env, strerror(err));
             }
         }
     }
@@ -171,11 +167,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_checkPermissions
                 JNU_ThrowIOException(env, buf);
             }
         } else {
-            char* msg = strdup(strerror(res));
-            JNU_ThrowIOException(env, msg);
-            if (msg != NULL) {
-                free(msg);
-            }
+            JNU_ThrowIOException(env, strerror(res));
         }
 
         if (isCopy) {

--- a/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,11 +100,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_connect
             if (err == ENOENT) {
                 JNU_ThrowByName(env, "java/io/FileNotFoundException", NULL);
             } else {
-                char* msg = strdup(strerror(err));
-                JNU_ThrowIOException(env, msg);
-                if (msg != NULL) {
-                    free(msg);
-                }
+                JNU_ThrowIOException(env, strerror(err));
             }
         }
     }
@@ -214,11 +210,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_checkPermissions
                 JNU_ThrowIOException(env, buf);
             }
         } else {
-            char* msg = strdup(strerror(res));
-            JNU_ThrowIOException(env, msg);
-            if (msg != NULL) {
-                free(msg);
-            }
+            JNU_ThrowIOException(env, strerror(res));
         }
 
         if (isCopy) {


### PR DESCRIPTION
Native Attach API code e.g. src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
uses strdup before calling JNU_ThrowIOException
```
            char* msg = strdup(strerror(res));
            JNU_ThrowIOException(env, msg);
            if (msg != NULL) {
                free(msg);
            }
```
This gets passed along and into e.g. java_lang_String::create_from_str(message, thread)
which creates a new String object, into which the bytes are copied, so this strdup/malloc and free are unnecessary.

We do this twice in this file, and in macos and aix versions.  I've changed Linux and MacOs here.  The same thing is done in AIX but I have left unchanged as I don't build/test it.  Can update that also if I see any confirmation it's OK.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385963](https://bugs.openjdk.org/browse/JDK-8385963): Native Attach API code has unnecessary 'strdup' calls (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31384/head:pull/31384` \
`$ git checkout pull/31384`

Update a local copy of the PR: \
`$ git checkout pull/31384` \
`$ git pull https://git.openjdk.org/jdk.git pull/31384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31384`

View PR using the GUI difftool: \
`$ git pr show -t 31384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31384.diff">https://git.openjdk.org/jdk/pull/31384.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31384#issuecomment-4631445443)
</details>
