### PR TITLE
8385964: AttachProvider docs update: 'doors' to 'socket'

### DIFF
--- a/src/jdk.attach/share/classes/com/sun/tools/attach/spi/AttachProvider.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/spi/AttachProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,8 @@ import java.util.ServiceLoader;
  * for example, ships with attach providers that use the package name <i>"sun"</i>
  * (for historical reasons). The
  * <i>type</i> typically corresponds to the attach mechanism. For example, an
- * implementation that uses the Doors inter-process communication mechanism
- * might use the type <i>"doors"</i>. The purpose of the name and type is to
+ * implementation that uses the UNIX Domain Socket inter-process communication mechanism
+ * might use the type <i>"socket"</i>. The purpose of the name and type is to
  * identify providers in environments where there are multiple providers
  * installed.
  *


### PR DESCRIPTION
The com.sun.tools.attach.spi.AttachProvider API docs give an example which is out of date for the JDK and therefore confusing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385964](https://bugs.openjdk.org/browse/JDK-8385964): AttachProvider docs update: 'doors' to 'socket' (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31385/head:pull/31385` \
`$ git checkout pull/31385`

Update a local copy of the PR: \
`$ git checkout pull/31385` \
`$ git pull https://git.openjdk.org/jdk.git pull/31385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31385`

View PR using the GUI difftool: \
`$ git pr show -t 31385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31385.diff">https://git.openjdk.org/jdk/pull/31385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31385#issuecomment-4630555981)
</details>
