### PR TITLE
8385806: Assert failed when running Skynet.java with continuation trace logging enabled

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1237,9 +1237,6 @@ void frame::interpreter_frame_verify_monitor(BasicObjectLock* value) const {
 
 #ifndef PRODUCT
 
-// Returns true iff the address p is readable and *(intptr_t*)p != errvalue
-extern "C" bool dbg_is_safe(const void* p, intptr_t errvalue);
-
 class FrameValuesOopClosure: public OopClosure, public DerivedOopClosure {
 private:
   GrowableArray<oop*>* _oops;
@@ -1269,17 +1266,13 @@ public:
     _derived->push(derived_loc);
   }
 
-  bool is_good(oop* p) {
-    return *p == nullptr || (dbg_is_safe(*p, -1) && dbg_is_safe((*p)->klass_without_asserts(), -1) && oopDesc::is_oop_or_null(*p));
-  }
   void describe(FrameValues& values, int frame_no) {
     for (int i = 0; i < _oops->length(); i++) {
       oop* p = _oops->at(i);
-      values.describe(frame_no, (intptr_t*)p, err_msg("oop%s for #%d", is_good(p) ? "" : " (BAD)", frame_no));
+      values.describe(frame_no, (intptr_t*)p, err_msg("oop for #%d", frame_no));
     }
     for (int i = 0; i < _narrow_oops->length(); i++) {
       narrowOop* p = _narrow_oops->at(i);
-      // we can't check for bad compressed oops, as decoding them might crash
       values.describe(frame_no, (intptr_t*)p, err_msg("narrow oop for #%d", frame_no));
     }
     assert(_base->length() == _derived->length(), "should be the same");


### PR DESCRIPTION
In `FrameValuesOopClosure::describe` we read the raw value stored at each oop location in the frame and append "(BAD)" to the slot description if the value is not a valid oop. This "bad oop" case can happen for heap frames when the containing stack chunk has already been gc encoded. It can also happen for frames that have just been thawed onto the stack but whose oop slots have not been decoded yet, as is the case when calling `after_thaw_java_frame`. When running with ZGC and `-XX:+ZVerifyOops`, the checks in method `is_good(oop*)` eventually call `check_is_valid_zaddress` which expects the value to be a valid oop. So in the "bad oop" cases this will trigger an assert.

These problematic cases could be fixed by passing around the corresponding `stackChunk` and using `stackChunk::load_oop(oop*)` which already applies the correct GC loading barriers. For collectors that use the bitmap we would also need to use the chunk to verify if it has already been encoded and possibly treat the pointers as `narrowOop*` instead, as we do in `StackChunkVerifyOopsClosure`. The loaded value should always be a valid oop in that case, so "(BAD)" could be appended when the raw value stored in the slot is different. 

Instead of adding this extra complexity, the proposed fix is to remove the load step altogether as this extra "(BAD)" annotation doesn’t add much value to the debugging output. Labeling a value that is logically valid but has some collector specific representation as bad doesn’t look particularly useful, and in a debugging session even encoded oop values can still be analyzed, for example with the `pp` helper from the debug functions.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385806](https://bugs.openjdk.org/browse/JDK-8385806): Assert failed when running Skynet.java with continuation trace logging enabled (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31386/head:pull/31386` \
`$ git checkout pull/31386`

Update a local copy of the PR: \
`$ git checkout pull/31386` \
`$ git pull https://git.openjdk.org/jdk.git pull/31386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31386`

View PR using the GUI difftool: \
`$ git pr show -t 31386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31386.diff">https://git.openjdk.org/jdk/pull/31386.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31386#issuecomment-4625282518)
</details>
