### PR TITLE
8385974: Update symbol information for jdk-28+0

### DIFF
--- a/src/jdk.compiler/share/data/symbols/java.base-R.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.base-R.sym.txt
@@ -120,11 +120,74 @@ method name parameterModifiers descriptor ()I flags 9 deprecated true runtimeAnn
 class name java/math/BigDecimal
 method name rootn descriptor (ILjava/math/MathContext;)Ljava/math/BigDecimal; flags 1
 
+class name java/security/AsymmetricKey
+header extends java/lang/Object implements java/security/Key,java/security/BinaryEncodable flags 601
+
+class name java/security/BinaryEncodable
+header extends java/lang/Object sealed true permittedSubclasses java/security/AsymmetricKey,java/security/KeyPair,java/security/spec/PKCS8EncodedKeySpec,java/security/spec/X509EncodedKeySpec,javax/crypto/EncryptedPrivateKeyInfo,java/security/cert/X509Certificate,java/security/cert/X509CRL,java/security/PEM flags 601 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+
+-class name java/security/DEREncodable
+
+class name java/security/KeyPair
+header extends java/lang/Object implements java/io/Serializable,java/security/BinaryEncodable flags 31
+
 class name java/security/KeyStore
 method name getCreationInstant descriptor (Ljava/lang/String;)Ljava/time/Instant; thrownTypes java/security/KeyStoreException flags 11
 
 class name java/security/KeyStoreSpi
 method name engineGetCreationInstant descriptor (Ljava/lang/String;)Ljava/time/Instant; flags 1
+
+class name java/security/PEM
+header extends java/lang/Object implements java/security/BinaryEncodable flags 31 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+innerclass innerClass java/lang/ref/Cleaner$Cleanable outerClass java/lang/ref/Cleaner innerClassName Cleanable flags 609
+innerclass innerClass java/util/Base64$Decoder outerClass java/util/Base64 innerClassName Decoder flags 9
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+-method name toString descriptor ()Ljava/lang/String;
+-method name decode descriptor ()[B
+-method name hashCode descriptor ()I
+-method name equals descriptor (Ljava/lang/Object;)Z
+-method name content descriptor ()Ljava/lang/String;
+method name <init> descriptor (Ljava/lang/String;[B[B)V flags 1
+method name <init> descriptor (Ljava/lang/String;[B)V flags 1
+method name content descriptor ()[B flags 1
+method name decode descriptor ()[B flags 1
+method name toString descriptor ()Ljava/lang/String; flags 1
+
+class name java/security/PEMDecoder
+header extends java/lang/Object flags 31 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+innerclass innerClass java/lang/ref/Cleaner$Cleanable outerClass java/lang/ref/Cleaner innerClassName Cleanable flags 609
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+-method name decode descriptor (Ljava/lang/String;)Ljava/security/DEREncodable;
+-method name decode descriptor (Ljava/io/InputStream;)Ljava/security/DEREncodable;
+-method name decode descriptor (Ljava/lang/String;Ljava/lang/Class;)Ljava/security/DEREncodable;
+-method name decode descriptor (Ljava/io/InputStream;Ljava/lang/Class;)Ljava/security/DEREncodable;
+-method name withFactory descriptor (Ljava/security/Provider;)Ljava/security/PEMDecoder;
+method name decode descriptor (Ljava/lang/String;)Ljava/security/BinaryEncodable; flags 1
+method name decode descriptor (Ljava/io/InputStream;)Ljava/security/BinaryEncodable; thrownTypes java/io/IOException flags 1
+method name decode descriptor (Ljava/lang/String;Ljava/lang/Class;)Ljava/security/BinaryEncodable; flags 1 signature <S::Ljava/security/BinaryEncodable;>(Ljava/lang/String;Ljava/lang/Class<TS;>;)TS;
+method name decode descriptor (Ljava/io/InputStream;Ljava/lang/Class;)Ljava/security/BinaryEncodable; thrownTypes java/io/IOException flags 1 signature <S::Ljava/security/BinaryEncodable;>(Ljava/io/InputStream;Ljava/lang/Class<TS;>;)TS;
+method name withFactoriesOf descriptor (Ljava/security/Provider;)Ljava/security/PEMDecoder; flags 1
+
+class name java/security/PEMEncoder
+header extends java/lang/Object flags 31 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+innerclass innerClass java/lang/ref/Cleaner$Cleanable outerClass java/lang/ref/Cleaner innerClassName Cleanable flags 609
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+-method name encodeToString descriptor (Ljava/security/DEREncodable;)Ljava/lang/String;
+-method name encode descriptor (Ljava/security/DEREncodable;)[B
+method name encodeToString descriptor (Ljava/security/BinaryEncodable;)Ljava/lang/String; flags 1
+method name encode descriptor (Ljava/security/BinaryEncodable;)[B flags 1
+
+class name java/security/cert/X509CRL
+header extends java/security/cert/CRL implements java/security/cert/X509Extension,java/security/BinaryEncodable flags 421
+
+class name java/security/cert/X509Certificate
+header extends java/security/cert/Certificate implements java/security/cert/X509Extension,java/security/BinaryEncodable flags 421
+
+class name java/security/spec/PKCS8EncodedKeySpec
+header extends java/security/spec/EncodedKeySpec implements java/security/BinaryEncodable flags 21
+
+class name java/security/spec/X509EncodedKeySpec
+header extends java/security/spec/EncodedKeySpec implements java/security/BinaryEncodable flags 21
 
 class name java/text/AttributedString
 header extends java/lang/Object flags 21
@@ -236,6 +299,27 @@ class name java/util/jar/Attributes$Name
 header extends java/lang/Object nestHost java/util/jar/Attributes flags 21 runtimeAnnotations @Ljdk/internal/vm/annotation/AOTSafeClassInitializer;
 innerclass innerClass java/util/jar/Attributes$Name outerClass java/util/jar/Attributes innerClassName Name flags 9
 
+class name javax/crypto/CryptoException
+header extends java/lang/RuntimeException flags 31 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+method name <init> descriptor ()V flags 1
+method name <init> descriptor (Ljava/lang/String;)V flags 1
+method name <init> descriptor (Ljava/lang/String;Ljava/lang/Throwable;)V flags 1
+method name <init> descriptor (Ljava/lang/Throwable;)V flags 1
+
+class name javax/crypto/EncryptedPrivateKeyInfo
+header extends java/lang/Object implements java/security/BinaryEncodable flags 21
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+-method name encrypt descriptor (Ljava/security/DEREncodable;[CLjava/lang/String;Ljava/security/spec/AlgorithmParameterSpec;Ljava/security/Provider;)Ljavax/crypto/EncryptedPrivateKeyInfo;
+-method name encrypt descriptor (Ljava/security/DEREncodable;[C)Ljavax/crypto/EncryptedPrivateKeyInfo;
+-method name encrypt descriptor (Ljava/security/DEREncodable;Ljava/security/Key;Ljava/lang/String;Ljava/security/spec/AlgorithmParameterSpec;Ljava/security/Provider;Ljava/security/SecureRandom;)Ljavax/crypto/EncryptedPrivateKeyInfo;
+-method name getKey descriptor (Ljava/security/Key;Ljava/security/Provider;)Ljava/security/PrivateKey;
+-method name getKeyPair descriptor (Ljava/security/Key;Ljava/security/Provider;)Ljava/security/KeyPair;
+method name encrypt descriptor (Ljava/security/BinaryEncodable;[CLjava/lang/String;Ljava/security/spec/AlgorithmParameterSpec;Ljava/security/Provider;)Ljavax/crypto/EncryptedPrivateKeyInfo; flags 9 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+method name encrypt descriptor (Ljava/security/BinaryEncodable;[C)Ljavax/crypto/EncryptedPrivateKeyInfo; flags 9 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+method name encrypt descriptor (Ljava/security/BinaryEncodable;Ljava/security/Key;Ljava/lang/String;Ljava/security/spec/AlgorithmParameterSpec;Ljava/security/Provider;Ljava/security/SecureRandom;)Ljavax/crypto/EncryptedPrivateKeyInfo; flags 9 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+method name getKey descriptor (Ljava/security/Key;)Ljava/security/PrivateKey; thrownTypes java/security/NoSuchAlgorithmException,java/security/InvalidKeyException flags 1 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+method name getKeyPair descriptor (Ljava/security/Key;)Ljava/security/KeyPair; thrownTypes java/security/NoSuchAlgorithmException,java/security/InvalidKeyException flags 1 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;PEM_API;)
+
 class name jdk/internal/classfile/impl/AbstractInstruction$UnboundIncrementInstruction
 -method name <init> descriptor (II)V
 method name <init> descriptor (Ljava/lang/classfile/Opcode;II)V flags 1
@@ -328,8 +412,6 @@ innerclass innerClass jdk/internal/foreign/layout/ValueLayouts$OfShortImpl outer
 innerclass innerClass java/lang/foreign/ValueLayout$OfShort outerClass java/lang/foreign/ValueLayout innerClassName OfShort flags 609
 
 class name jdk/internal/lang/LazyConstantImpl
-header extends java/lang/Object implements java/lang/LazyConstant flags 31 signature <T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/lang/LazyConstant<TT;>; runtimeAnnotations @Ljdk/internal/vm/annotation/AOTSafeClassInitializer;
-innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 -method name isInitialized descriptor ()Z
 method name isolateToString descriptor (Ljava/lang/Object;)Ljava/lang/String; flags 9
 

--- a/src/jdk.compiler/share/data/symbols/java.desktop-R.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.desktop-R.sym.txt
@@ -36,6 +36,10 @@ method name getBounds descriptor ()Ljava/awt/Rectangle; flags 1
 class name java/awt/image/DataBufferUShort
 header extends java/awt/image/DataBuffer flags 31 classAnnotations @Ljdk/Profile+Annotation;(value=I4)
 
+class name java/awt/image/PixelInterleavedSampleModel
+header extends java/awt/image/ComponentSampleModel flags 21
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
 class name javax/swing/JEditorPane$AccessibleJEditorPaneHTML
 header extends javax/swing/JEditorPane$AccessibleJEditorPane nestHost javax/swing/JEditorPane flags 21
 innerclass innerClass javax/swing/JEditorPane$AccessibleJEditorPaneHTML outerClass javax/swing/JEditorPane innerClassName AccessibleJEditorPaneHTML flags 4

--- a/src/jdk.compiler/share/data/symbols/jdk.incubator.foreign-R.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/jdk.incubator.foreign-R.sym.txt
@@ -30,6 +30,10 @@ class name jdk/internal/foreign/AbstractMemorySegmentImpl
 method name getString descriptor (JLjava/nio/charset/Charset;J)Ljava/lang/String; flags 1 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
 method name copy descriptor (Ljava/lang/String;Ljava/nio/charset/Charset;ILjava/lang/foreign/MemorySegment;JI)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
 
+class name jdk/internal/foreign/FunctionDescriptorImpl
+header extends java/lang/Object implements java/lang/foreign/FunctionDescriptor flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
 class name jdk/internal/foreign/HeapMemorySegmentImpl$OfByte
 header extends jdk/internal/foreign/HeapMemorySegmentImpl nestHost jdk/internal/foreign/HeapMemorySegmentImpl flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
 innerclass innerClass jdk/internal/foreign/HeapMemorySegmentImpl$OfByte outerClass jdk/internal/foreign/HeapMemorySegmentImpl innerClassName OfByte flags 19


### PR DESCRIPTION
The symbol information for JDK 27 is not updated for the start of JDK 28; in particular, JEP 538 was integrated very close to fork and the symbol file updates shipped with [JDK-8384833](https://bugs.openjdk.org/browse/JDK-8384833) was outdated. This is causing JavaBaseCheckSince to fail.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385974](https://bugs.openjdk.org/browse/JDK-8385974): Update symbol information for jdk-28+0 (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31387/head:pull/31387` \
`$ git checkout pull/31387`

Update a local copy of the PR: \
`$ git checkout pull/31387` \
`$ git pull https://git.openjdk.org/jdk.git pull/31387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31387`

View PR using the GUI difftool: \
`$ git pr show -t 31387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31387.diff">https://git.openjdk.org/jdk/pull/31387.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31387#issuecomment-4625747293)
</details>
