### PR TITLE
8384848: Update JCov for class file version 72

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1192,8 +1192,8 @@ var getJibProfilesDependencies = function (input, common) {
             server: "jpg",
             product: "jcov",
             version: "3.0",
-            build_number: "5",
-            file: "bundles/jcov-3.0+5.zip",
+            build_number: "6",
+            file: "bundles/jcov-3.0+6.zip",
             environment_name: "JCOV_HOME",
         },
 


### PR DESCRIPTION
Switch to newer JCov

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384848](https://bugs.openjdk.org/browse/JDK-8384848): Update JCov for class file version 72 (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31393/head:pull/31393` \
`$ git checkout pull/31393`

Update a local copy of the PR: \
`$ git checkout pull/31393` \
`$ git pull https://git.openjdk.org/jdk.git pull/31393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31393`

View PR using the GUI difftool: \
`$ git pr show -t 31393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31393.diff">https://git.openjdk.org/jdk/pull/31393.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31393#issuecomment-4627203834)
</details>
