### PR TITLE
8385988: Linux devkits does not work with dnf5

### DIFF
--- a/make/devkit/Sysroot.gmk
+++ b/make/devkit/Sysroot.gmk
@@ -109,7 +109,7 @@ endif
 EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
 COMMA := ,
-DNF_ARCHS := $(subst $(SPACE),$(COMMA),$(RPM_ARCHS))
+DNF_ARCHS := $(foreach arch,$(RPM_ARCHS),--arch $(arch))
 
 # Specify a dummy installation root, otherwise dnf will run into
 # problems trying to reconcile with the local/system state
@@ -123,7 +123,7 @@ DNF_DOWNLOAD_FLAGS := \
     --disablerepo='*' \
     $(DNF_REPOS) \
     --resolve \
-    --archlist $(DNF_ARCHS) \
+    $(DNF_ARCHS) \
     --forcearch $(RPM_ARCH) \
     --installroot $(DNF_DUMMY_INSTALL_ROOT) \
     --releasever $(BASE_OS_VERSION) \


### PR DESCRIPTION
I saw following error when I tried to build devkit with dnf5 on Fedora 44:

```
echo filesystem kernel-headers glibc glibc-devel cups-libs cups-devel libX11 libX11-devel libxcb xorg-x11-proto-devel alsa-lib alsa-lib-devel libXext libXext-devel libXtst libXtst-devel libXrender libXrender-devel libXrandr libXrandr-devel freetype freetype-devel libXt libXt-devel libSM libSM-devel libICE libICE-devel libXi libXi-devel libXau libXau-devel libgcc zlib zlib-devel libffi libffi-devel fontconfig fontconfig-devel systemtap-sdt-devel | \
    xargs dnf download --disablerepo='*' --repofrompath base,https://yum.oracle.com/repo/OracleLinux/OL6/4/base/x86_64 --enablerepo base --resolve --archlist x86_64,noarch,i386,i686 --forcearch x86_64 --installroot /usr/src/jdk/build/devkit/x86_64-linux-gnu/x86_64-linux-gnu/dnf-dummy-install-root --releasever 6 --destdir /usr/src/jdk/build/devkit/download/rpms/x86_64-linux-gnu-OL-6
Unknown argument "--archlist" for command "download". Add "--help" for more information about the arguments.
```

We should use multiple `--arch` rather than `--archlist`. `--arch` also works on older dnf.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385988](https://bugs.openjdk.org/browse/JDK-8385988): Linux devkits does not work with dnf5 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31394/head:pull/31394` \
`$ git checkout pull/31394`

Update a local copy of the PR: \
`$ git checkout pull/31394` \
`$ git pull https://git.openjdk.org/jdk.git pull/31394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31394`

View PR using the GUI difftool: \
`$ git pr show -t 31394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31394.diff">https://git.openjdk.org/jdk/pull/31394.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31394#issuecomment-4628731049)
</details>
