### PR TITLE
8385989: Remove mention of obsoleted/removed ParallelRefProcEnabled in documentation

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -199,10 +199,9 @@
           range(1, (INT_MAX - 1))                                           \
                                                                             \
   product(size_t, ReferencesPerThread, 1000, EXPERIMENTAL,                  \
-               "Ergonomically start one thread for this amount of "         \
-               "references for reference processing if "                    \
-               "ParallelRefProcEnabled is true. Specify 0 to disable and "  \
-               "use all threads.")                                          \
+          "Ergonomically start one thread for this amount of references "   \
+          "for reference processing for parallel stop-the-world garbage "   \
+          "collectors. Specify 0 to force use of all available threads.")   \
                                                                             \
   product(uint, InitiatingHeapOccupancyPercent, 45,                         \
           "The percent occupancy (IHOP) of the current old generation "     \

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2997,6 +2997,14 @@ they're used.
 :   Enables the use of Java Flight Recorder (JFR) during the runtime of the
     application. Since JDK 8u40 this option has not been required to use JFR.
 
+[`-XX:+ParallelRefProcEnabled`]{#-XX__ParallelRefProcEnabled}
+:   Enables parallel reference processing. By default, collectors employing multiple
+    threads perform parallel reference processing if the number of parallel threads
+    to use is larger than one.
+    The option is available only when the throughput or G1 garbage collector is used
+    (`-XX:+UseParallelGC` or `-XX:+UseG1GC`). Other collectors employing multiple
+    threads always perform reference processing in parallel.
+
 ## Obsolete Java Options
 
 These `java` options are still accepted but ignored, and a warning is issued

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2997,14 +2997,6 @@ they're used.
 :   Enables the use of Java Flight Recorder (JFR) during the runtime of the
     application. Since JDK 8u40 this option has not been required to use JFR.
 
-[`-XX:+ParallelRefProcEnabled`]{#-XX__ParallelRefProcEnabled}
-:   Enables parallel reference processing. By default, collectors employing multiple
-    threads perform parallel reference processing if the number of parallel threads
-    to use is larger than one.
-    The option is available only when the throughput or G1 garbage collector is used
-    (`-XX:+UseParallelGC` or `-XX:+UseG1GC`). Other collectors employing multiple
-    threads always perform reference processing in parallel.
-
 ## Obsolete Java Options
 
 These `java` options are still accepted but ignored, and a warning is issued


### PR DESCRIPTION
Hi all,

  review this trivial cleanup to remove remaining mentions of `-XX:ParallelRefProcEnabled` as the option is about to be expired in this release.

Testing: local compilation, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385989](https://bugs.openjdk.org/browse/JDK-8385989): Remove mention of obsoleted/removed ParallelRefProcEnabled in documentation (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31397/head:pull/31397` \
`$ git checkout pull/31397`

Update a local copy of the PR: \
`$ git checkout pull/31397` \
`$ git pull https://git.openjdk.org/jdk.git pull/31397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31397`

View PR using the GUI difftool: \
`$ git pr show -t 31397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31397.diff">https://git.openjdk.org/jdk/pull/31397.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31397#issuecomment-4629301202)
</details>
