### PR TITLE
8385991: Use StringTable's statistics method in Dictionary

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -31,7 +31,10 @@
 #include "memory/metaspaceClosure.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/instanceKlass.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/timerTrace.hpp"
 #include "utilities/concurrentHashTable.inline.hpp"
+#include "utilities/concurrentHashTableTasks.inline.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/tableStatistics.hpp"
 
@@ -239,10 +242,22 @@ void Dictionary::verify() {
 }
 
 void Dictionary::print_table_statistics(outputStream* st, const char* table_name) {
-  static TableStatistics ts;
+  TableStatistics stats;
   auto sz = [&] (InstanceKlass** val) {
     return sizeof(**val);
   };
-  ts = _table->statistics_get(Thread::current(), sz, ts);
-  ts.print(st, table_name);
+  Thread* thread = Thread::current();
+  ConcurrentTable::StatisticsTask sts(_table);
+  if (sts.prepare(thread)) {
+    TraceTime timer("GetStatistics", TRACETIME_LOG(Debug, perf));
+    while (sts.do_task(thread, sz)) {
+      sts.pause(thread);
+      if (thread->is_Java_thread()) {
+        ThreadBlockInVM tbivm(JavaThread::cast(thread));
+      }
+      sts.cont(thread);
+    }
+    stats = sts.done(thread);
+  }
+  stats.print(st, table_name);
 }

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -248,16 +248,18 @@ void Dictionary::print_table_statistics(outputStream* st, const char* table_name
   };
   Thread* thread = Thread::current();
   ConcurrentTable::StatisticsTask sts(_table);
-  if (sts.prepare(thread)) {
-    TraceTime timer("GetStatistics", TRACETIME_LOG(Debug, perf));
-    while (sts.do_task(thread, sz)) {
-      sts.pause(thread);
-      if (thread->is_Java_thread()) {
-        ThreadBlockInVM tbivm(JavaThread::cast(thread));
-      }
-      sts.cont(thread);
-    }
-    stats = sts.done(thread);
+  if (!sts.prepare(thread)) {
+    st->print_cr("Failed to take statistics");
+    return;
   }
+  TraceTime timer("GetStatistics", TRACETIME_LOG(Debug, perf));
+  while (sts.do_task(thread, sz)) {
+    sts.pause(thread);
+    if (thread->is_Java_thread()) {
+      ThreadBlockInVM tbivm(JavaThread::cast(thread));
+    }
+    sts.cont(thread);
+  }
+  stats = sts.done(thread);
   stats.print(st, table_name);
 }

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -654,17 +654,20 @@ public:
 //   VM.systemdictionary -verbose: for dumping the system dictionary table
 //
 class VM_DumpHashtable : public VM_Operation {
+public:
+  enum DumpKind {
+    DumpSymbols,
+    DumpStrings,
+    DumpSysDict
+  };
+
 private:
   outputStream* _out;
-  int _which;
+  DumpKind _which;
   bool _verbose;
+
 public:
-  enum {
-    DumpSymbols = 1 << 0,
-    DumpStrings = 1 << 1,
-    DumpSysDict = 1 << 2  // not implemented yet
-  };
-  VM_DumpHashtable(outputStream* out, int which, bool verbose) {
+  VM_DumpHashtable(outputStream* out, DumpKind which, bool verbose) {
     _out = out;
     _which = which;
     _verbose = verbose;

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -534,11 +534,6 @@ class ConcurrentHashTable : public CHeapObj<MT> {
   template <typename EVALUATE_FUNC, typename DELETE_FUNC>
   void bulk_delete(Thread* thread, EVALUATE_FUNC& eval_f, DELETE_FUNC& del_f);
 
-  // Gets statistics if available, if not return old one. Item sizes are calculated with
-  // VALUE_SIZE_FUNC.
-  template <typename VALUE_SIZE_FUNC>
-  TableStatistics statistics_get(Thread* thread, VALUE_SIZE_FUNC& vs_f, TableStatistics old);
-
   // Moves all nodes from this table to to_cht with new hash code.
   // Must be done at a safepoint.
   void rehash_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, MT>* to_cht);

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1267,22 +1267,6 @@ inline TableStatistics ConcurrentHashTable<CONFIG, MT>::
 }
 
 template <typename CONFIG, MemTag MT>
-template <typename VALUE_SIZE_FUNC>
-inline TableStatistics ConcurrentHashTable<CONFIG, MT>::
-  statistics_get(Thread* thread, VALUE_SIZE_FUNC& vs_f, TableStatistics old)
-{
-  if (!try_resize_lock(thread)) {
-    return old;
-  }
-  InternalTable* table = get_table();
-  NumberSeq summary;
-  size_t    literal_bytes = 0;
-
-  internal_statistics_range(thread, 0, table->_size, vs_f, summary, literal_bytes);
-  return internal_statistics_epilog(thread, summary, literal_bytes);
-}
-
-template <typename CONFIG, MemTag MT>
 inline void ConcurrentHashTable<CONFIG, MT>::
   rehash_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, MT>* to_cht)
 {


### PR DESCRIPTION
Hi,

- Switch the statistics gathering code to be the same as for the string table (both being based on the statistics gathering in CHT)
- Remove the old `statistics_get` function in CHT, as it's now unused
- Some minor changes to improve clarity in `VM_DumpHashtable` (`DumpSysDict` was actually implemented)

The old `Dictionary` statistics fetching function seemed very broken to me as it would return the statistics to another table if the table's `resize_lock` was already held by another thread. Just using the same mechanism seems reasonable.

Testing: GHA and manually ran `jcmd $PID VM.systemdictionary`

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385991](https://bugs.openjdk.org/browse/JDK-8385991): Use StringTable's statistics method in Dictionary (**Enhancement** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31398/head:pull/31398` \
`$ git checkout pull/31398`

Update a local copy of the PR: \
`$ git checkout pull/31398` \
`$ git pull https://git.openjdk.org/jdk.git pull/31398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31398`

View PR using the GUI difftool: \
`$ git pr show -t 31398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31398.diff">https://git.openjdk.org/jdk/pull/31398.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31398#issuecomment-4630130422)
</details>
