### PR TITLE
8385987: CheckReleaseFile.java fails for the build using the source code without .git

### DIFF
--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -112,13 +112,17 @@ public class CheckReleaseFile {
         }
         String valueString = valueMatcher.group(1);
 
+        if (valueString == "") {
+            throw new RuntimeException("The test failed, SOURCE value was empty." +
+                " JDK Repository used for building might not have .git directory." + 
+                " Verify that .git was removed from the repository intentionally.");
+        }
 
         String[] values = valueString.split(" ");
 
-        // First value should start with ".:" or SOURCE value should be empty,
-        // regardless of Oracle or OpenJDK.
+        // First value MUST start with ".:" regardless of Oracle or OpenJDK
         String rootRegexp = "\\." + SRC_HASH_REGEXP;
-        if (values[0] != "" && !values[0].matches(rootRegexp)) {
+        if (!values[0].matches(rootRegexp)) {
             throw new RuntimeException("The test failed, first element did not match regexp: " + rootRegexp);
         }
 
@@ -128,7 +132,7 @@ public class CheckReleaseFile {
         String vendor = System.getProperty("java.vendor");
         if (runtime.contains("OpenJDK") && vendor.contains("Oracle Corporation")) {
             System.out.println("Oracle built OpenJDK, verifying SOURCE format");
-            if (values.length != 1 || values[0] == "") {
+            if (values.length != 1) {
                 throw new RuntimeException("The test failed, wrong number of elements in SOURCE list." +
                                            " Should be 1 for Oracle built OpenJDK.");
             }

--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -114,7 +114,7 @@ public class CheckReleaseFile {
 
         if (valueString == "") {
             throw new RuntimeException("The test failed, SOURCE value was empty." +
-                " JDK Repository used for building might not have .git directory." + 
+                " JDK Repository used for building might not have .git directory." +
                 " Verify that .git was removed from the repository intentionally.");
         }
 

--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -114,8 +114,8 @@ public class CheckReleaseFile {
 
         if ("".equals(valueString)) {
             throw new RuntimeException("The test failed, SOURCE value was empty." +
-                " JDK Repository used for building might not have .git directory." +
-                " Verify that .git was removed from the repository intentionally.");
+                " The JDK workspace used for building might not have a .git directory or generated .src-rev file." +
+                " Verify that either .git was removed intentionally or generating .src-rev was intentionally omitted");
         }
 
         String[] values = valueString.split(" ");

--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,9 +115,10 @@ public class CheckReleaseFile {
 
         String[] values = valueString.split(" ");
 
-        // First value MUST start with ".:" regardless of Oracle or OpenJDK
+        // First value should start with ".:" or SOURCE value should be empty,
+        // regardless of Oracle or OpenJDK.
         String rootRegexp = "\\." + SRC_HASH_REGEXP;
-        if (!values[0].matches(rootRegexp)) {
+        if (values[0] != "" && !values[0].matches(rootRegexp)) {
             throw new RuntimeException("The test failed, first element did not match regexp: " + rootRegexp);
         }
 
@@ -127,7 +128,7 @@ public class CheckReleaseFile {
         String vendor = System.getProperty("java.vendor");
         if (runtime.contains("OpenJDK") && vendor.contains("Oracle Corporation")) {
             System.out.println("Oracle built OpenJDK, verifying SOURCE format");
-            if (values.length != 1) {
+            if (values.length != 1 || values[0] == "") {
                 throw new RuntimeException("The test failed, wrong number of elements in SOURCE list." +
                                            " Should be 1 for Oracle built OpenJDK.");
             }

--- a/test/jdk/build/releaseFile/CheckReleaseFile.java
+++ b/test/jdk/build/releaseFile/CheckReleaseFile.java
@@ -112,7 +112,7 @@ public class CheckReleaseFile {
         }
         String valueString = valueMatcher.group(1);
 
-        if (valueString == "") {
+        if ("".equals(valueString)) {
             throw new RuntimeException("The test failed, SOURCE value was empty." +
                 " JDK Repository used for building might not have .git directory." +
                 " Verify that .git was removed from the repository intentionally.");


### PR DESCRIPTION
**Overview:**

This test primarily focuses on the verifying the SOURCE value in the Oracle provided OpenJDK build. In the cases except these, in order for the SOURCE value to be more flexible, there have been process added where the SOURCE value is empty.

**Confirmation of the program after the fix:**

After Fix CheckReleaseFile.java was verified against various SOURCE values, including both empty and non-empty cases, to ensure that it processes them correctly. The verification was performed using both internally built OpenJDK  and Oracle's OpenJDK build.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385987](https://bugs.openjdk.org/browse/JDK-8385987): CheckReleaseFile.java fails for the build using the source code without .git (**Bug** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31399/head:pull/31399` \
`$ git checkout pull/31399`

Update a local copy of the PR: \
`$ git checkout pull/31399` \
`$ git pull https://git.openjdk.org/jdk.git pull/31399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31399`

View PR using the GUI difftool: \
`$ git pr show -t 31399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31399.diff">https://git.openjdk.org/jdk/pull/31399.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31399#issuecomment-4629774633)
</details>
