### PR TITLE
8385892: TestResidentSetSizeEvent fails with RuntimeException: Should be non-zero: expected 0 > 0

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2765,7 +2765,34 @@ void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
 
 #if INCLUDE_JFR
 
+// hwm (high water mark) in K for the VM RSS
+static long jfr_rss_hwm_k = -1;
+
 void os::jfr_report_memory_info() {
+  os::Linux::accurate_meminfo_t accurate_info;
+  if (os::Linux::query_accurate_process_memory_info(&accurate_info) && accurate_info.rss != -1) {
+    EventResidentSetSize event;
+    event.set_size(accurate_info.rss * K);
+
+    // unfortunately the smaps_rollup/accurate_info contains no hwm (high water mark) for RSS
+    struct rusage ru;
+    if (getrusage(RUSAGE_SELF, &ru) == 0) {
+      if (ru.ru_maxrss > jfr_rss_hwm_k) {
+        jfr_rss_hwm_k = ru.ru_maxrss;
+      }
+    }
+
+    // do not allow larger current RSS than hwm
+    if (accurate_info.rss > jfr_rss_hwm_k) {
+      jfr_rss_hwm_k = accurate_info.rss;
+    }
+
+    event.set_peak(jfr_rss_hwm_k * K);
+
+    event.commit();
+    return;
+  }
+
   os::Linux::meminfo_t info;
   if (os::Linux::query_process_memory_info(&info)) {
     // Send the RSS JFR event

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2768,12 +2768,16 @@ void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
 // hwm (high water mark) in K for the VM RSS
 static long jfr_rss_hwm_k = -1;
 
+static void send_resident_set_size_event(ssize_t size, ssize_t peak) {
+  EventResidentSetSize event;
+  event.set_size(size * K);
+  event.set_peak(peak * K);
+  event.commit();
+}
+
 void os::jfr_report_memory_info() {
   os::Linux::accurate_meminfo_t accurate_info;
   if (os::Linux::query_accurate_process_memory_info(&accurate_info) && accurate_info.rss != -1) {
-    EventResidentSetSize event;
-    event.set_size(accurate_info.rss * K);
-
     // unfortunately the smaps_rollup/accurate_info contains no hwm (high water mark) for RSS
     struct rusage ru;
     if (getrusage(RUSAGE_SELF, &ru) == 0) {
@@ -2787,19 +2791,13 @@ void os::jfr_report_memory_info() {
       jfr_rss_hwm_k = accurate_info.rss;
     }
 
-    event.set_peak(jfr_rss_hwm_k * K);
-
-    event.commit();
+    send_resident_set_size_event(accurate_info.rss, jfr_rss_hwm_k);
     return;
   }
 
   os::Linux::meminfo_t info;
   if (os::Linux::query_process_memory_info(&info)) {
-    // Send the RSS JFR event
-    EventResidentSetSize event;
-    event.set_size(info.vmrss * K);
-    event.set_peak(info.vmhwm * K);
-    event.commit();
+    send_resident_set_size_event(info.vmrss, info.vmhwm);
   } else {
     // Log a warning
     static bool first_warning = true;


### PR DESCRIPTION
The test jdk/jfr/event/runtime/TestResidentSetSizeEvent.java fails on one of our Linux machines with the exception below.

```
java.lang.RuntimeException: Should be non-zero: expected 0 > 0
at jdk.test.lib.Asserts.fail(Asserts.java:715)
at jdk.test.lib.Asserts.assertGreaterThan(Asserts.java:403)
at jdk.jfr.event.runtime.TestResidentSetSizeEvent.verifyExpectedEventTypes(TestResidentSetSizeEvent.java:81)
at jdk.jfr.event.runtime.TestResidentSetSizeEvent.main(TestResidentSetSizeEvent.java:92)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:583)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1527)
```

The machine is a SLES 15 SP7 and has 128 CPUs, so it is quite large.
The failure occurs because from /proc/self/status, VmRSS (and btw also the other RSS* values) are 0 
```
VmHWM: 0 kB
VmRSS: 0 kB
RssAnon: 0 kB
RssFile: 0 kB
RssShmem: 0 kB
```

Seems those  'fast path' values are sometimes (especially on larger machines) unexpectedly 0.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385892](https://bugs.openjdk.org/browse/JDK-8385892): TestResidentSetSizeEvent fails with RuntimeException: Should be non-zero: expected 0 &gt; 0 (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31401/head:pull/31401` \
`$ git checkout pull/31401`

Update a local copy of the PR: \
`$ git checkout pull/31401` \
`$ git pull https://git.openjdk.org/jdk.git pull/31401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31401`

View PR using the GUI difftool: \
`$ git pr show -t 31401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31401.diff">https://git.openjdk.org/jdk/pull/31401.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31401#issuecomment-4631304514)
</details>
