### PR TITLE
8385655: Timeout in java/lang/Thread/virtual/KlassInit.java

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/KlassInit.java
+++ b/test/jdk/java/lang/Thread/virtual/KlassInit.java
@@ -79,7 +79,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
+import jdk.test.lib.thread.VThreadRunner;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
@@ -95,6 +98,12 @@ class KlassInit {
     private static final CountDownLatch finishGetStatic = new CountDownLatch(1);
     private static final CountDownLatch finishPutStatic = new CountDownLatch(1);
     private static final CountDownLatch finishFailedInit = new CountDownLatch(1);
+
+    @BeforeAll
+    static void setup() {
+        // need >=2 carriers for testing pinning
+        VThreadRunner.ensureParallelism(2);
+    }
 
     /**
      * Test that threads blocked waiting for klass to be initialized


### PR DESCRIPTION
Please review this small test fix. We need at least two workers in the test since one of the virtual threads will be pinned in the class initializer. The timeout can be reproduced when running the test with `-XX:ActiveProcessorCount=1`.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385655](https://bugs.openjdk.org/browse/JDK-8385655): Timeout in java/lang/Thread/virtual/KlassInit.java (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31403/head:pull/31403` \
`$ git checkout pull/31403`

Update a local copy of the PR: \
`$ git checkout pull/31403` \
`$ git pull https://git.openjdk.org/jdk.git pull/31403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31403`

View PR using the GUI difftool: \
`$ git pr show -t 31403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31403.diff">https://git.openjdk.org/jdk/pull/31403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31403#issuecomment-4632596924)
</details>
