### PR TITLE
8341518: TestJcmdWithSideCar.java fails with 'sun.tools.jcmd.JCmd' missing from stdout/stderr

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -440,12 +440,13 @@ static bool is_file_secure(int fd, const char *filename) {
 }
 
 
-// return the user name for the given user id
+// return the user name for the given user id. If the uid cannot be resolved
+// to a passwd entry, return a stable uid-based synthetic name.
 //
 // the caller is expected to free the allocated memory.
 //
 static char* get_user_name(uid_t uid) {
-
+  char* user_name = nullptr;
   struct passwd pwent;
 
   // Determine the max pwbuf size from sysconf, and hardcode
@@ -459,7 +460,14 @@ static char* get_user_name(uid_t uid) {
   struct passwd* p = nullptr;
   int result = getpwuid_r(uid, &pwent, pwbuf, (size_t)bufsize, &p);
 
-  if (result != 0 || p == nullptr || p->pw_name == nullptr || *(p->pw_name) == '\0') {
+  if (result == 0
+      && p != nullptr
+      && p->pw_name != nullptr
+      && *(p->pw_name) != '\0') {
+    user_name = NEW_C_HEAP_ARRAY(char, strlen(p->pw_name) + 1, mtInternal);
+    strcpy(user_name, p->pw_name);
+  }
+  else {
     if (log_is_enabled(Debug, perf)) {
       LogStreamHandle(Debug, perf) log;
       if (result != 0) {
@@ -483,12 +491,19 @@ static char* get_user_name(uid_t uid) {
                      p->pw_name == nullptr ? "pw_name = null" : "pw_name zero length");
       }
     }
-    FREE_C_HEAP_ARRAY(pwbuf);
-    return nullptr;
-  }
 
-  char* user_name = NEW_C_HEAP_ARRAY(char, strlen(p->pw_name) + 1, mtInternal);
-  strcpy(user_name, p->pw_name);
+    // A process can run with a numeric uid that has no passwd entry, for
+    // example in a Docker container started with --user=<uid>:<gid>. Use a
+    // synthetic name so the JVM can still publish hsperfdata.
+    char uid_name[32];
+    jio_snprintf(uid_name, sizeof(uid_name), "uid" UINT64_FORMAT, (uint64_t)uid);
+
+    log_info(perf)("Using synthetic user name %s for unresolved uid " UINT64_FORMAT,
+                   uid_name, (uint64_t)uid);
+
+    user_name = NEW_C_HEAP_ARRAY(char, strlen(uid_name) + 1, mtInternal);
+    strcpy(user_name, uid_name);
+  }
 
   FREE_C_HEAP_ARRAY(pwbuf);
   return user_name;
@@ -1081,10 +1096,6 @@ static char* mmap_create_shared(size_t size) {
   int vmid = os::current_process_id();
 
   char* user_name = get_user_name(geteuid());
-
-  if (user_name == nullptr)
-    return nullptr;
-
   char* dirname = get_user_tmp_dir(user_name, vmid, -1);
   char* filename = get_sharedmem_filename(dirname, vmid, -1);
 

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -440,12 +440,12 @@ static bool is_file_secure(int fd, const char *filename) {
 }
 
 
-// return the user name for the given user id. If the uid cannot be resolved
-// to a passwd entry, return a stable uid-based synthetic name.
+// return the user name for the given user id. If the UID cannot be resolved
+// to a passwd entry, return a stable UID-based synthetic name.
 //
 // the caller is expected to free the allocated memory.
 //
-static char* get_user_name(uid_t uid) {
+[[nodiscard]] static char* get_user_name(uid_t uid) {
   char* user_name = nullptr;
   struct passwd pwent;
 
@@ -496,10 +496,10 @@ static char* get_user_name(uid_t uid) {
     // example in a Docker container started with --user=<uid>:<gid>. Use a
     // synthetic name so the JVM can still publish hsperfdata.
     char uid_name[32];
-    jio_snprintf(uid_name, sizeof(uid_name), "uid" UINT64_FORMAT, (uint64_t)uid);
+    jio_snprintf(uid_name, sizeof(uid_name), "uid" UINT64_FORMAT, static_cast<uint64_t>(uid));
 
     log_info(perf)("Using synthetic user name %s for unresolved uid " UINT64_FORMAT,
-                   uid_name, (uint64_t)uid);
+                   uid_name, static_cast<uint64_t>(uid));
 
     user_name = NEW_C_HEAP_ARRAY(char, strlen(uid_name) + 1, mtInternal);
     strcpy(user_name, uid_name);
@@ -518,8 +518,7 @@ static char* get_user_name(uid_t uid) {
 //
 // the caller is expected to free the allocated memory.
 //
-//
-static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
+[[nodiscard]] static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
 
   // short circuit the directory search if the process doesn't even exist.
   if (kill(vmid, 0) == OS_ERR) {
@@ -659,7 +658,7 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
 
 // return the name of the user that owns the JVM indicated by the given vmid.
 //
-static char* get_user_name(int vmid, int *nspid, TRAPS) {
+[[nodiscard]] static char* get_user_name(int vmid, int *nspid, TRAPS) {
   char *result = get_user_name_slow(vmid, *nspid, CHECK_NULL);
 
 #if defined(LINUX)

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1095,6 +1095,8 @@ static char* mmap_create_shared(size_t size) {
   int vmid = os::current_process_id();
 
   char* user_name = get_user_name(geteuid());
+  assert(user_name != nullptr,
+         "get_user_name() must resolve or synthesize a user name");
   char* dirname = get_user_tmp_dir(user_name, vmid, -1);
   char* filename = get_sharedmem_filename(dirname, vmid, -1);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -105,7 +105,6 @@ runtime/Thread/TestAlwaysPreTouchStacks.java 8383372 macosx-aarch64
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJFREvents.java 8327723 linux-x64
-containers/docker/TestJcmdWithSideCar.java 8341518 linux-all
 
 #############################################################################
 


### PR DESCRIPTION
Please review this serviceability enhancement that makes some Docker containers serviceable.

Docker containers started with `--user=<uid>:<gid>` run the process with  the specified numeric credentials, but they do not necessarily provide matching `/etc/passwd` or `/etc/group` entries. In such environments, user and group name resolution via `getpwuid*()` calls can fail even though the process has valid numeric credentials.

This has a direct impact on JVM serviceability. HotSpot uses the effective user name when creating the perfdata backing file under `/tmp/hsperfdata_<user>/`.  Before this change, `get_user_name(uid_t)` returns `nullptr` when the UID could
not be resolved through `getpwuid_r()`. As a result, `mmap_create_shared()` skips creating the `hsperfdata` file. Tools such as `jcmd` could then neither discover nor attach to JVMs running in such environments.

This PR change adds a fallback for unresolved numeric UIDs. If the UID cannot be resolved to a `passwd` entry, HotSpot now synthesizes a stable UID-based User name as `uid<UID>`.

For example, a JVM running with UID `1000` and no `passwd` entry will create:

```text
/tmp/hsperfdata_uid1000/<pid>
```

JVM serviceability code does wildcard search of perfdata files by scanning `hsperfdata_*` directories.
So the synthetic name schema does not really matter, other than it should be unique per UID.

## Other `getpwuid*()` usages

There are other places in OpenJDK that call `getpwuid()` or `getpwuid_r()`, but
they have different contracts and failure handling. I do not think they need to
be changed as part of this fix.

### `java_props_md.c`: `user.name` and `user.home`

`GetJavaProperties` uses `getpwuid(getuid())` to initialize user-related system properties. If the passwd lookup fails, `user.name` is currently set to `"?"`. For `user.home`, the implementation falls back to `$HOME` and then to `"?"`.

Changing `user.name` to a synthetic value such as `uid<UID>` may be useful, but it is user-visible through:

```java
System.getProperty("user.name")
```

That makes it a separate compatibility decision, not something that should be coupled to this HotSpot perfdata fix.

### `ProcessHandle.Info::user()`

`ProcessHandle.Info::user()` uses `getpwuid_r()` to resolve the process owner.
If the lookup fails, the `user()` accessor returns an empty `Optional<String>`.

That behavior fits the public API shape: process information is optional and may be unavailable. Changing it to return a synthetic name would be externally visible, so this should also be considered separately.

### NIO file owner principals

The Unix NIO filesystem implementation resolves file owner uid/gid values to
`UserPrincipal` and `GroupPrincipal` names. If lookup fails, it already falls
back to the decimal numeric id string.

For example, an unresolved uid `1000` is exposed as `"1000"` through public
APIs such as:

```java
Files.getOwner(path).getName();
Files.readAttributes(path, PosixFileAttributes.class).owner().getName();
```

This looks good to me.

### `com.sun.security.auth.module.UnixSystem`

One place that likely deserves a follow-up is:

```java
var us = new com.sun.security.auth.module.UnixSystem();
```

With an unresolved numeric uid, this public constructor currently fails with:

```text
Exception in thread "main" java.lang.UnsatisfiedLinkError: FFM calls failed
        at jdk.security.auth/com.sun.security.auth.module.UnixSystem.<init>(UnixSystem.java:212)
        at UnixSystemExample.main(UnixSystemExample.java:5)
Caused by: java.lang.RuntimeException: the requested entry is not found
        at jdk.security.auth/com.sun.security.auth.module.UnixSystem.<init>(UnixSystem.java:204)
        ... 1 more
```

Making `UnixSystem` tolerate missing passwd entries would be useful.
This should be handled under a dedicated JBS issue.

### Risks?

I have not found another call sites that need to be changed to keep this perfdata fix consistent.
If necessary, we should reserve the right to change schema for synthetic username in the future.

### Footnote
It's Interesting that Podman does not have this issue and even provides a flag to address this issue [0]. But even without `--passwd` flag being passed, containers start with `/etc/passwd` and `/etc/group` files in order.
There is no such flag available for Docker CE.

* [0] - https://docs.podman.io/en/latest/markdown/podman-run.1.html#passwd

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8341518](https://bugs.openjdk.org/browse/JDK-8341518): TestJcmdWithSideCar.java fails with 'sun.tools.jcmd.JCmd' missing from stdout/stderr (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31404/head:pull/31404` \
`$ git checkout pull/31404`

Update a local copy of the PR: \
`$ git checkout pull/31404` \
`$ git pull https://git.openjdk.org/jdk.git pull/31404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31404`

View PR using the GUI difftool: \
`$ git pr show -t 31404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31404.diff">https://git.openjdk.org/jdk/pull/31404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31404#issuecomment-4989375052)
</details>
