### PR TITLE
8386098: Add empty MemRegion precondition to CardTable methods

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -194,6 +194,7 @@ void CardTable::resize_covered_region(MemRegion new_region) {
 // Note that these versions are precise!  The scanning code has to handle the
 // fact that the write barrier may be either precise or imprecise.
 void CardTable::dirty_MemRegion(MemRegion mr) {
+  assert(!mr.is_empty(), "precondition");
   assert(align_down(mr.start(), HeapWordSize) == mr.start(), "Unaligned start");
   assert(align_up  (mr.end(),   HeapWordSize) == mr.end(),   "Unaligned end"  );
   assert(_covered[0].contains(mr) || _covered[1].contains(mr), "precondition");
@@ -203,6 +204,7 @@ void CardTable::dirty_MemRegion(MemRegion mr) {
 }
 
 void CardTable::clear_MemRegion(MemRegion mr) {
+  assert(!mr.is_empty(), "precondition");
   // Be conservative: only clean cards entirely contained within the
   // region.
   CardValue* cur;

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.inline.hpp
@@ -130,7 +130,10 @@ oop_arraycopy_in_heap(arrayOop src_obj, size_t src_offset_in_bytes, T* src_raw,
         // pointer delta is scaled to number of elements (length field in
         // objArrayOop) which we assume is 32 bit.
         assert(pd == (size_t)(int)pd, "length field overflow");
-        bs->write_ref_array((HeapWord*)dst_raw, pd);
+        if (pd > 0) {
+          // Copied at least one element; call the barrier.
+          bs->write_ref_array((HeapWord*)dst_raw, pd);
+        }
         return OopCopyResult::failed_check_class_cast;
       }
     }


### PR DESCRIPTION
Add empty precondition to`dirty_MemRegion` and `clear_MemRegion` to avoid the "underflow" of `last()`. Inspecting the call chain reveals that one of callers of `write_ref_array` violates the new precondition, hence, the new `if (pd > 0)` in this patch.

Test: tier1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386098](https://bugs.openjdk.org/browse/JDK-8386098): Add empty MemRegion precondition to CardTable methods (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31410/head:pull/31410` \
`$ git checkout pull/31410`

Update a local copy of the PR: \
`$ git checkout pull/31410` \
`$ git pull https://git.openjdk.org/jdk.git pull/31410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31410`

View PR using the GUI difftool: \
`$ git pr show -t 31410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31410.diff">https://git.openjdk.org/jdk/pull/31410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31410#issuecomment-4637900804)
</details>
