### PR TITLE
8386107: arm32: libSuspendInCritical jtreg library fails to link

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -69,6 +69,9 @@ ifeq ($(call isTargetOs, linux), true)
   HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit += -ldl
   HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
   HOTSPOT_JTREG_LIBRARIES_LDFLAGS_libfast-math := -ffast-math
+  ifeq ($(call isTargetCpuBits, 32), true)
+    HOTSPOT_JTREG_LIBRARIES_LIBS_libSuspendInCritical += -latomic
+  endif
 else
   HOTSPOT_JTREG_EXCLUDE += libtest-rw.c libtest-rwx.c \
       exeinvoke.c exestack-gap.c exestack-tls.c libAsyncGetCallTraceTest.cpp


### PR DESCRIPTION
The [test/hotspot/jtreg/runtime/jni/critical/libSuspendInCritical.cpp](https://github.com/openjdk/jdk/pull/30936/changes#diff-137899820d5ad5d36c91c879aa09a9678112d4be6718ba8e64ebfe1a20f6dda3) library operates with `jlong` native_counter. 32-bit ARM lacks native 8-byte atomic instructions, so GCC emits calls to __atomic_load_8/__atomic_fetch_add_8 from libatomic, which is not linked, causing a build failure.

The issue is fixed by adding -latomic link flag for the library into JtregNativeHotspot.gmk.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386107](https://bugs.openjdk.org/browse/JDK-8386107): arm32: libSuspendInCritical jtreg library fails to link (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [f2fbe1fb](https://git.openjdk.org/jdk/pull/31411/files/f2fbe1fb16c0baf7ea320bf3980e8522b8fda7b7)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31411/head:pull/31411` \
`$ git checkout pull/31411`

Update a local copy of the PR: \
`$ git checkout pull/31411` \
`$ git pull https://git.openjdk.org/jdk.git pull/31411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31411`

View PR using the GUI difftool: \
`$ git pr show -t 31411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31411.diff">https://git.openjdk.org/jdk/pull/31411.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31411#issuecomment-4639667852)
</details>
