### PR TITLE
8386113: Link BigDecimal.toPlainString to Algorithmic Complexity section

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -3500,6 +3500,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * @return a string representation of this {@code BigDecimal}
      * without an exponent field.
      * @since 1.5
+     * @see <a href="#algorithmicComplexity">Algorithmic Complexity</a>
      * @see #toString()
      * @see #toEngineeringString()
      */


### PR DESCRIPTION
BigDecimal has a discussion section about Algorithmic Complexity of toPlainString. However, that is in the class-level notes and somewhat hard to discover; we can add a link in the "See also" section.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386113](https://bugs.openjdk.org/browse/JDK-8386113): Link BigDecimal.toPlainString to Algorithmic Complexity section (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31413/head:pull/31413` \
`$ git checkout pull/31413`

Update a local copy of the PR: \
`$ git checkout pull/31413` \
`$ git pull https://git.openjdk.org/jdk.git pull/31413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31413`

View PR using the GUI difftool: \
`$ git pr show -t 31413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31413.diff">https://git.openjdk.org/jdk/pull/31413.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31413#issuecomment-4641152567)
</details>
