### PR TITLE
8386130: TestPrintMethodData.java failing with VirtualThread as main thread

### DIFF
--- a/test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java
@@ -64,7 +64,7 @@ public class TestPrintMethodData {
         private static final Generator<Long> GEN_LONG = Generators.G.longs();
         private static final int SIZE = 1024;
 
-        static void main(String[] args) throws Exception {
+        public static void main(String[] args) throws Exception {
             long[] longs = new long[SIZE];
             Generators.G.fill(GEN_LONG, longs);
 


### PR DESCRIPTION
test was failing when run with `JTREG_TEST_THREAD_FACTORY=Virtual`. `public` left out was not intentional, so I am adding it which fixes the testcase : 

```
Note: Command line contains non-control variables:
* JTREG_TEST_THREAD_FACTORY=Virtual
Make sure it is not mistyped, and that you intend to override this variable.
'make help' will list known control variables.

Building target 'test' in configuration 'linux-s390x-server-fastdebug'
Test selection 'jtreg:test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java', will run:
* jtreg:test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java
Clean up dirs for jtreg_test_hotspot_jtreg_compiler_profiling_TestPrintMethodData_java

Running test 'jtreg:test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java'
Passed: compiler/profiling/TestPrintMethodData.java
Test results: passed: 1
Report written to /home/amit/loom/jdk/build/linux-s390x-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_compiler_profiling_TestPrintMethodData_java/html/report.html
Results written to /home/amit/loom/jdk/build/linux-s390x-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_compiler_profiling_TestPrintMethodData_java
Finished running test 'jtreg:test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java'
Test report is stored in build/linux-s390x-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_compiler_profiling_TestPrintMethodData_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/hotspot/jtreg/compiler/profiling/TestPrintMethodData.java
                                                         1     1     0     0     0   
==============================
TEST SUCCESS
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386130](https://bugs.openjdk.org/browse/JDK-8386130): TestPrintMethodData.java failing with VirtualThread as main thread (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31414/head:pull/31414` \
`$ git checkout pull/31414`

Update a local copy of the PR: \
`$ git checkout pull/31414` \
`$ git pull https://git.openjdk.org/jdk.git pull/31414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31414`

View PR using the GUI difftool: \
`$ git pr show -t 31414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31414.diff">https://git.openjdk.org/jdk/pull/31414.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31414#issuecomment-4645949146)
</details>
