### PR TITLE
8386138: Problem-list JvmtiGetAllModulesTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -139,6 +139,8 @@ serviceability/sa/ClhsdbThreadContext.java        8356704 windows-x64
 
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 
+serviceability/jvmti/GetModulesInfo/JvmtiGetAllModulesTest.java 8385679 generic-all
+
 #############################################################################
 
 # :hotspot_misc


### PR DESCRIPTION
Please review this change to exclude `serviceability/jvmti/GetModulesInfo/JvmtiGetAllModulesTest.java` in preparation of the upcoming jtreg 8.3 integration in main-line.

This commit

- https://github.com/openjdk/jdk/commit/2acf0dc98a8caacbdae72e801d500def9efbeabc

removed the following lines from the `JvmtiGetAllModulesTest.java` file:
```java
// jdk.proxy1 and jdk.proxy2 modules are dynamically initialized by Graal code in case Graal VM is used.
// We need to filter them out because they are not part of boot modules. See more details in JDK-8195156.
modules.removeIf(mod -> mod.getName().startsWith("jdk.proxy"));
```

Changes in how jtreg 8.3 searches and finds an entry-point in tests, also make those `jdk.proxy` modules appear. Instead of restoring those brittle filter lines above, the test should be refactored to be more robust. Find more details in:

- https://bugs.openjdk.org/browse/JDK-8385679

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386138](https://bugs.openjdk.org/browse/JDK-8386138): Problem-list JvmtiGetAllModulesTest.java (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31415/head:pull/31415` \
`$ git checkout pull/31415`

Update a local copy of the PR: \
`$ git checkout pull/31415` \
`$ git pull https://git.openjdk.org/jdk.git pull/31415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31415`

View PR using the GUI difftool: \
`$ git pr show -t 31415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31415.diff">https://git.openjdk.org/jdk/pull/31415.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31415#issuecomment-4647025423)
</details>
