### PR TITLE
8386150: VtablesTest.java fails when main thread is a Virtual Thread

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/VtablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VtablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class VtablesTest {
         output.shouldContain("NOT overriding with p2.D.nooverride()V");
         output.shouldHaveExitValue(0);
 
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:vtables=trace", "p1/C");
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:vtables=trace", "p1.C");
         output = new OutputAnalyzer(pb.start());
         output.shouldContain("transitive overriding superclass ");
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
Fix for VtablesTest.java test.

Test is now passing with/without `JTREG_TEST_THREAD_FACTORY=Virtual`: 

```
Note: Command line contains non-control variables:
* JTREG_TEST_THREAD_FACTORY=Virtual
Make sure it is not mistyped, and that you intend to override this variable.
'make help' will list known control variables.

Building target 'test' in configuration 'linux-s390x-server-fastdebug'
Test selection 'jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java', will run:
* jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java
Clean up dirs for jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java

Running test 'jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java'
Passed: runtime/logging/VtablesTest.java
Test results: passed: 1
Report written to /home/amit/loom/jdk/build/linux-s390x-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java/html/report.html
Results written to /home/amit/loom/jdk/build/linux-s390x-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java
Finished running test 'jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java'
Test report is stored in build/linux-s390x-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java
                                                         1     1     0     0     0   
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-s390x-server-fastdebug'
```

and without the parameter: 

```
amit@a3560042:~/loom/jdk$ make test TEST=jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java 
Building target 'test' in configuration 'linux-s390x-server-fastdebug'
Test selection 'jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java', will run:
* jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java
Clean up dirs for jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java

Running test 'jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java'
Passed: runtime/logging/VtablesTest.java
Test results: passed: 1
Report written to /home/amit/loom/jdk/build/linux-s390x-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java/html/report.html
Results written to /home/amit/loom/jdk/build/linux-s390x-server-fastdebug/test-support/jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java
Finished running test 'jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java'
Test report is stored in build/linux-s390x-server-fastdebug/test-results/jtreg_test_hotspot_jtreg_runtime_logging_VtablesTest_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/hotspot/jtreg/runtime/logging/VtablesTest.java
                                                         1     1     0     0     0   
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-s390x-server-fastdebug'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386150](https://bugs.openjdk.org/browse/JDK-8386150): VtablesTest.java fails when main thread is a Virtual Thread (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31416/head:pull/31416` \
`$ git checkout pull/31416`

Update a local copy of the PR: \
`$ git checkout pull/31416` \
`$ git pull https://git.openjdk.org/jdk.git pull/31416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31416`

View PR using the GUI difftool: \
`$ git pr show -t 31416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31416.diff">https://git.openjdk.org/jdk/pull/31416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31416#issuecomment-4648886844)
</details>
