### PR TITLE
8357249: Compiler task keeps --system files open

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -75,7 +75,7 @@ public class BasicImageReader implements AutoCloseable {
     private final ByteOrder byteOrder;
     private final String name;
     private final ByteBuffer memoryMap;
-    private final boolean isMappedAll;
+    private final boolean isMemoryMapped;
     private final FileChannel channel;
     private final ImageHeader header;
     private final int indexSize;
@@ -93,11 +93,11 @@ public class BasicImageReader implements AutoCloseable {
         this.byteOrder = Objects.requireNonNull(byteOrder);
         this.name = this.imagePath.toString();
 
-        // Only the runtime image is loaded with the root class-loader.
-        final boolean isRuntimeImage = BasicImageReader.class.getClassLoader() == null;
+        // Only the current runtime image is loaded with the root class-loader.
+        final boolean isCurrentRuntimeImage = BasicImageReader.class.getClassLoader() == null;
         ByteBuffer map = null;
 
-        if (USE_JVM_MAP && isRuntimeImage) {
+        if (USE_JVM_MAP && isCurrentRuntimeImage) {
             // Check to see if the jvm has opened the file using libjimage
             // native entry when loading the image for this runtime
             map = NativeImageBuffer.getNativeMap(name);
@@ -112,7 +112,7 @@ public class BasicImageReader implements AutoCloseable {
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {
-                    if (isRuntimeImage) {
+                    if (isCurrentRuntimeImage) {
                         try {
                             Class<?> fileChannelImpl =
                                 Class.forName("sun.nio.ch.FileChannelImpl");
@@ -133,10 +133,10 @@ public class BasicImageReader implements AutoCloseable {
             });
         }
 
-        isMappedAll = isRuntimeImage && MAP_ALL;
+        isMemoryMapped = isCurrentRuntimeImage && MAP_ALL;
 
         // If no memory map yet, runtime image, and 64 bit jvm then memory map entire file
-        if (map == null && isMappedAll) {
+        if (map == null && isMemoryMapped) {
             map = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
         }
 
@@ -179,7 +179,7 @@ public class BasicImageReader implements AutoCloseable {
     private ByteBuffer readDirectBuffer(int size) throws IOException {
         ByteBuffer buffer = ByteBuffer.allocateDirect(size);
         if (channel.read(buffer, 0L) == size) {
-            buffer.rewind();
+            buffer.flip();
         } else {
             throw new IOException("\"" + name + "\" is not an image file");
         }
@@ -421,7 +421,7 @@ public class BasicImageReader implements AutoCloseable {
         }
         int checkedSize = (int) size;
 
-        if (isMappedAll) {
+        if (isMemoryMapped) {
             ByteBuffer buffer = slice(memoryMap, checkedOffset, checkedSize);
             buffer.order(ByteOrder.BIG_ENDIAN);
 

--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -93,7 +93,8 @@ public class BasicImageReader implements AutoCloseable {
         this.byteOrder = Objects.requireNonNull(byteOrder);
         this.name = this.imagePath.toString();
 
-        // Only the current runtime image is loaded with the root class-loader.
+        // The image reader will be for the current run-time image when the this class
+        // is defined by the boot class loader.
         final boolean isCurrentRuntimeImage = BasicImageReader.class.getClassLoader() == null;
         ByteBuffer map = null;
 

--- a/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/BasicImageReader.java
@@ -75,9 +75,10 @@ public class BasicImageReader implements AutoCloseable {
     private final ByteOrder byteOrder;
     private final String name;
     private final ByteBuffer memoryMap;
+    private final boolean isMappedAll;
     private final FileChannel channel;
     private final ImageHeader header;
-    private final long indexSize;
+    private final int indexSize;
     private final IntBuffer redirect;
     private final IntBuffer offsets;
     private final ByteBuffer locations;
@@ -92,14 +93,14 @@ public class BasicImageReader implements AutoCloseable {
         this.byteOrder = Objects.requireNonNull(byteOrder);
         this.name = this.imagePath.toString();
 
-        ByteBuffer map;
+        // Only the runtime image is loaded with the root class-loader.
+        final boolean isRuntimeImage = BasicImageReader.class.getClassLoader() == null;
+        ByteBuffer map = null;
 
-        if (USE_JVM_MAP && BasicImageReader.class.getClassLoader() == null) {
+        if (USE_JVM_MAP && isRuntimeImage) {
             // Check to see if the jvm has opened the file using libjimage
             // native entry when loading the image for this runtime
             map = NativeImageBuffer.getNativeMap(name);
-         } else {
-            map = null;
         }
 
         // Open the file only if no memory map yet or is 32 bit jvm
@@ -111,7 +112,7 @@ public class BasicImageReader implements AutoCloseable {
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {
-                    if (BasicImageReader.class.getClassLoader() == null) {
+                    if (isRuntimeImage) {
                         try {
                             Class<?> fileChannelImpl =
                                 Class.forName("sun.nio.ch.FileChannelImpl");
@@ -132,10 +133,13 @@ public class BasicImageReader implements AutoCloseable {
             });
         }
 
-        // If no memory map yet and 64 bit jvm then memory map entire file
-        if (MAP_ALL && map == null) {
+        isMappedAll = isRuntimeImage && MAP_ALL;
+
+        // If no memory map yet, runtime image, and 64 bit jvm then memory map entire file
+        if (map == null && isMappedAll) {
             map = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
         }
+
 
         // Assume we have a memory map to read image file header
         ByteBuffer headerBuffer = map;
@@ -143,12 +147,7 @@ public class BasicImageReader implements AutoCloseable {
 
         // If no memory map then read header from image file
         if (headerBuffer == null) {
-            headerBuffer = ByteBuffer.allocateDirect(headerSize);
-            if (channel.read(headerBuffer, 0L) == headerSize) {
-                headerBuffer.rewind();
-            } else {
-                throw new IOException("\"" + name + "\" is not an image file");
-            }
+            headerBuffer = readDirectBuffer(headerSize);
         } else if (headerBuffer.capacity() < headerSize) {
             throw new IOException("\"" + name + "\" is not an image file");
         }
@@ -157,10 +156,9 @@ public class BasicImageReader implements AutoCloseable {
         header = readHeader(intBuffer(headerBuffer, 0, headerSize));
         indexSize = header.getIndexSize();
 
-        // If no memory map yet then must be 32 bit jvm not previously mapped
+        // If no memory map yet then must be 32 bit jvm or not runtime image not previously mapped
         if (map == null) {
-            // Just map the image index
-            map = channel.map(FileChannel.MapMode.READ_ONLY, 0, indexSize);
+            map = readDirectBuffer(indexSize);
         }
 
         memoryMap = map.asReadOnlyBuffer();
@@ -176,6 +174,16 @@ public class BasicImageReader implements AutoCloseable {
 
         stringsReader = new ImageStringsReader(this);
         decompressor = new Decompressor();
+    }
+
+    private ByteBuffer readDirectBuffer(int size) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+        if (channel.read(buffer, 0L) == size) {
+            buffer.rewind();
+        } else {
+            throw new IOException("\"" + name + "\" is not an image file");
+        }
+        return buffer;
     }
 
     protected BasicImageReader(Path imagePath) throws IOException {
@@ -413,7 +421,7 @@ public class BasicImageReader implements AutoCloseable {
         }
         int checkedSize = (int) size;
 
-        if (MAP_ALL) {
+        if (isMappedAll) {
             ByteBuffer buffer = slice(memoryMap, checkedOffset, checkedSize);
             buffer.order(ByteOrder.BIG_ENDIAN);
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1952,13 +1952,19 @@ public class Locations {
                     if (isCurrentPlatform(systemJavaHome)) {
                         jrtfs = FileSystems.getFileSystem(jrtURI);
                     } else {
+                        ClassLoader currentLoader = Locations.class.getClassLoader();
                         try {
                             Map<String, String> attrMap =
                                     Collections.singletonMap("java.home", systemJavaHome.toString());
                             jrtfs = FileSystems.newFileSystem(jrtURI, attrMap);
+                            // Ensure the file system’s class loader is closed so that
+                            // the ${systemJavaHome}/lib/jrt-fs.jar is not left open.
+                            ClassLoader cl = jrtfs.provider().getClass().getClassLoader();
+                            if (cl != currentLoader && cl instanceof URLClassLoader urlcl) {
+                                closeables.add(urlcl);
+                            }
                         } catch (ProviderNotFoundException ex) {
                             URL jfsJar = resolveInJavaHomeLib(systemJavaHome, "jrt-fs.jar").toUri().toURL();
-                            ClassLoader currentLoader = Locations.class.getClassLoader();
                             URLClassLoader fsLoader =
                                     new URLClassLoader(new URL[] {jfsJar}, currentLoader);
 

--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -33,8 +33,6 @@
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -79,8 +77,9 @@ public class SystemFilesClosed {
         };
 
         try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
-            compiler.getTask(null, fileManager, null, List.of("--system", targetSystem), null, List.of(compilationUnit))
-                    .call();
+            Assertions.assertEquals(true,
+                    compiler.getTask(null, fileManager, null, List.of("--system", targetSystem), null, List.of(compilationUnit)).call(),
+                    "Compilation task failed");
         }
 
         Process process = new ProcessBuilder()
@@ -94,7 +93,7 @@ public class SystemFilesClosed {
             lines = reader.lines().filter(line -> line.contains(realPath)).toList();
         }
         process.waitFor();
-        Assertions.assertEquals(0, lines.size());
+        Assertions.assertEquals(0, lines.size(), "File(s) remain opened: " + lines);
     }
 
     @BeforeEach

--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -33,11 +33,11 @@
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
@@ -55,23 +55,16 @@ public class SystemFilesClosed {
 
     @Test
     void testSystemFilesClosed() throws Exception {
-        String javaHome = System.getProperty("java.home");
-        Path jrtfsPath = Path.of(javaHome, "lib", "jrt-fs.jar");
-        Path modulesPath = Path.of(javaHome, "lib", "modules");
-        if (Files.notExists(modulesPath)) {
-            System.out.printf("%s doesn't exist.", modulesPath.toString());
-            System.out.println();
-            System.out.println("It is most probably an exploded build. Skip testing.");
-            return;
-        }
-
-        Path target = base.resolve("lib");
-        if (Files.notExists(target)) {
-            Files.createDirectories(target);
-        }
-        Files.copy(jrtfsPath, target.resolve("jrt-fs.jar"), StandardCopyOption.REPLACE_EXISTING);
-        Files.copy(modulesPath, target.resolve("modules"), StandardCopyOption.REPLACE_EXISTING);
         String targetSystem = base.toString();
+        try (PrintStream err = new PrintStream(OutputStream.nullOutputStream())) {
+            int ret = java.util.spi.ToolProvider.findFirst("jlink")
+                    .orElseThrow()
+                    .run(System.out, err, "--add-modules", "java.base", "--output", targetSystem);
+            if (ret != 0) {
+                System.out.println("It is most probably an exploded build. Skip testing.");
+                return;
+            }
+        }
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         SimpleJavaFileObject compilationUnit = new SimpleJavaFileObject(URI.create("string:///Test.java"), JavaFileObject.Kind.SOURCE) {

--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8357249
+ * @summary Check that `lib/jrt-fs.jar` and `lib/modules` are properly closed while
+ *          javac is invoked with `--system` option.
+ * @requires os.family == "mac" | os.family == "linux"
+ * @run junit ${test.main.class}
+ */
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class SystemFilesClosed {
+
+    private Path base;
+
+    @Test
+    void testSystemFilesClosed() throws Exception {
+        String javaHome = System.getProperty("java.home");
+        Path jrtfsPath = Path.of(javaHome, "lib", "jrt-fs.jar");
+        Path modulesPath = Path.of(javaHome, "lib", "modules");
+        if (Files.notExists(modulesPath)) {
+            System.out.printf("%s doesn't exist.", modulesPath.toString());
+            System.out.println();
+            System.out.println("It is most probably an exploded build. Skip testing.");
+            return;
+        }
+
+        Path target = base.resolve("lib");
+        if (Files.notExists(target)) {
+            Files.createDirectories(target);
+        }
+        Files.copy(jrtfsPath, target.resolve("jrt-fs.jar"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(modulesPath, target.resolve("modules"), StandardCopyOption.REPLACE_EXISTING);
+        String targetSystem = base.toString();
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        SimpleJavaFileObject compilationUnit = new SimpleJavaFileObject(URI.create("string:///Test.java"), JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return """
+               public class Test {
+                    public static void main(String[] args) {
+                        System.out.println("Hello, World!");
+                    }
+               }
+               """;
+            }
+        };
+
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
+            compiler.getTask(null, fileManager, null, List.of("--system", targetSystem), null, List.of(compilationUnit))
+                    .call();
+        }
+
+        Process process = new ProcessBuilder()
+                .command("lsof", "-p", String.valueOf(ProcessHandle.current().pid()))
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start();
+        List<String> lines;
+        try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
+            lines = reader.lines().filter(line -> line.contains(targetSystem)).toList();
+        }
+        process.waitFor();
+        Assertions.assertEquals(0, lines.size());
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}

--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -91,8 +91,9 @@ public class SystemFilesClosed {
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .start();
         List<String> lines;
+        String realPath = base.toRealPath().toString();
         try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
-            lines = reader.lines().filter(line -> line.contains(targetSystem)).toList();
+            lines = reader.lines().filter(line -> line.contains(realPath)).toList();
         }
         process.waitFor();
         Assertions.assertEquals(0, lines.size());

--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -56,14 +56,12 @@ public class SystemFilesClosed {
     @Test
     void testSystemFilesClosed() throws Exception {
         String targetSystem = base.toString();
-        try (PrintStream err = new PrintStream(OutputStream.nullOutputStream())) {
-            int ret = java.util.spi.ToolProvider.findFirst("jlink")
-                    .orElseThrow()
-                    .run(System.out, err, "--add-modules", "java.base", "--output", targetSystem);
-            if (ret != 0) {
-                System.out.println("It is most probably an exploded build. Skip testing.");
-                return;
-            }
+        int ret = java.util.spi.ToolProvider.findFirst("jlink")
+                .orElseThrow()
+                .run(System.out, System.err, "--add-modules", "java.base", "--output", targetSystem);
+        if (ret != 0) {
+            System.out.println("It is most probably an exploded build. Skip testing.");
+            return;
         }
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();


### PR DESCRIPTION
When used with the `--system` option to target a different modularized JDK, `JavacTask` keeps both `lib/jrt-fs.jar` and `lib/modules` open even after it completes.

The `lib/jrt-fs.jar` file remains open because the host-side `JrtFileSystemProvider` creates a `URLClassLoader` to load the target platform's `JrtFileSystemProvider` from `lib/jrt-fs.jar` when creating a `JrtFileSystem`. This `URLClassLoader` is never closed, causing the file to remain open.

The `lib/modules` file remains open because `BasicImageReader` uses a memory-mapped file whose mapping persists until the associated buffer is garbage-collected.

To ensure that `lib/jrt-fs.jar` is properly closed, the proposed solution is to make the client responsible for closing the file system's class loader when "java.home" is passed in the `env` argument to `FileSystems.newFileSystem(...)`.
This approach (currently implemented in the `Locations` class) is simple and works reliably even with older target platform versions. (An alternative approach would be to automatically close the `URLClassLoader` when the `JrtFileSystem` is closed. However, this solution has two significant drawbacks. First, it does not work with older target platform versions because it requires modifications to the target platform's `JrtFileSystem` implementation. Second, it is not reliable. A user may obtain a reference to the provider that created a `JrtFileSystem` instance, close that instance, and then use the same provider to create another `JrtFileSystem`. In that case, the provider's `URLClassLoader` may have already been closed automatically, preventing the creation of the new file system instance).

To ensure that `lib/modules` is properly closed, the proposed solution is to modify `BasicImageReader` so that it uses memory-mapped I/O only for the current runtime and falls back to regular file I/O when accessing a different target system. (An alternative solution would be to explicitly unmap the memory-mapped file when the reader is closed. On JDK 22 and later, the Foreign Function & Memory API could be used for that purpose. However, in that case, `lib/jrt-fs.jar` could no longer be compiled to run on JDK 8). Note that neither of these solutions work for older target platform versions, as both require changes to the target platform's `BasicImageReader` implementation.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8357249](https://bugs.openjdk.org/browse/JDK-8357249): Compiler task keeps --system files open (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31417/head:pull/31417` \
`$ git checkout pull/31417`

Update a local copy of the PR: \
`$ git checkout pull/31417` \
`$ git pull https://git.openjdk.org/jdk.git pull/31417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31417`

View PR using the GUI difftool: \
`$ git pr show -t 31417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31417.diff">https://git.openjdk.org/jdk/pull/31417.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31417#issuecomment-4648023268)
</details>
