### PR TITLE
8385830: ForkJoinTask#get may swallow caller thread's interrupt flag

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -418,19 +418,15 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
                 for (;;) {
                     if ((s = status) < 0)
                         break;
-                    else if (interrupts < 0) {
-                        s = ABNORMAL;         // interrupted and not done
-                        break;
-                    }
                     else if (Thread.interrupted()) {
-                        if (!ForkJoinPool.poolIsStopping(pool))
-                            interrupts = interruptible ? -1 : 1;
-                        else {
-                            interrupts = 1;   // re-assert if cleared
+                        if (ForkJoinPool.poolIsStopping(pool)) {
                             try {
                                 cancel(true);
-                            } catch (Throwable ignore) {
-                            }
+                            } catch (Throwable ignore) { }
+                        }
+                        if ((interrupts = interruptible ? -1 : 1) < 0) {
+                            s = ABNORMAL;
+                            break;
                         }
                     }
                     else if (deadline != 0L) {

--- a/test/jdk/java/util/concurrent/tck/ForkJoinPoolTest.java
+++ b/test/jdk/java/util/concurrent/tck/ForkJoinPoolTest.java
@@ -663,6 +663,23 @@ public class ForkJoinPoolTest extends JSR166TestCase {
         }
     }
 
+    public void testCallerInterruptedDuringSubmit() throws InterruptedException, ExecutionException {
+        final Thread submitter = Thread.currentThread();
+        final ExecutorService p = new ForkJoinPool(1);
+        try (PoolCleaner cleaner = cleaner(p)) {
+            for (int i = 0; i < 512; ++i) { // Enough repetitions such that any race condition is bound to materialize
+                try {
+                    p.submit(submitter::interrupt).get();
+                    // If we don't get an InterruptedException, then the current thread should be interrupted
+                    assertTrue(Thread.interrupted());
+                } catch (InterruptedException e) {
+                    // If we do get an InterruptedException, then the current thread should not be interrupted
+                    assertTrue(!Thread.interrupted());
+                }
+            }
+        }
+    }
+
     /**
      * get of submit(callable) throws ExecutionException if callable
      * throws exception


### PR DESCRIPTION
Backport of fix to [JDK-8385830](https://bugs.openjdk.org/browse/JDK-8385830) — "ForkJoinTask#get may swallow caller thread's interrupt flag"


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385830](https://bugs.openjdk.org/browse/JDK-8385830): ForkJoinTask#get may swallow caller thread's interrupt flag (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31419/head:pull/31419` \
`$ git checkout pull/31419`

Update a local copy of the PR: \
`$ git checkout pull/31419` \
`$ git pull https://git.openjdk.org/jdk.git pull/31419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31419`

View PR using the GUI difftool: \
`$ git pr show -t 31419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31419.diff">https://git.openjdk.org/jdk/pull/31419.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31419#issuecomment-4650118912)
</details>
