### PR TITLE
8386161: RISC-V: Auto-enable Zvkn/Zvkg extension features

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -120,10 +120,10 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZvbb, false, EXPERIMENTAL, "Use Zvbb instructions")           \
   product(bool, UseZvbc, false, EXPERIMENTAL, "Use Zvbc instructions")           \
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
-  product(bool, UseZvkn, false, EXPERIMENTAL,                                    \
+  product(bool, UseZvkn, false, DIAGNOSTIC,                                    \
           "Use Zvkn group extension, Zvkned, Zvknhb, Zvkb, Zvkt")                \
   product(bool, UseCtxFencei, false, EXPERIMENTAL,                               \
           "Use PR_RISCV_CTX_SW_FENCEI_ON to avoid explicit icache flush")        \
-  product(bool, UseZvkg, false, EXPERIMENTAL, "Use Zvkg instructions")
+  product(bool, UseZvkg, false, DIAGNOSTIC, "Use Zvkg instructions")
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -120,7 +120,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZvbb, false, EXPERIMENTAL, "Use Zvbb instructions")           \
   product(bool, UseZvbc, false, EXPERIMENTAL, "Use Zvbc instructions")           \
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
-  product(bool, UseZvkn, false, DIAGNOSTIC,                                    \
+  product(bool, UseZvkn, false, DIAGNOSTIC,                                      \
           "Use Zvkn group extension, Zvkned, Zvknhb, Zvkb, Zvkt")                \
   product(bool, UseCtxFencei, false, EXPERIMENTAL,                               \
           "Use PR_RISCV_CTX_SW_FENCEI_ON to avoid explicit icache flush")        \

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -120,10 +120,10 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZvbb, false, EXPERIMENTAL, "Use Zvbb instructions")           \
   product(bool, UseZvbc, false, EXPERIMENTAL, "Use Zvbc instructions")           \
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
+  product(bool, UseZvkg, false, DIAGNOSTIC, "Use Zvkg instructions")             \
   product(bool, UseZvkn, false, DIAGNOSTIC,                                      \
           "Use Zvkn group extension, Zvkned, Zvknhb, Zvkb, Zvkt")                \
   product(bool, UseCtxFencei, false, EXPERIMENTAL,                               \
-          "Use PR_RISCV_CTX_SW_FENCEI_ON to avoid explicit icache flush")        \
-  product(bool, UseZvkg, false, DIAGNOSTIC, "Use Zvkg instructions")
+          "Use PR_RISCV_CTX_SW_FENCEI_ON to avoid explicit icache flush")
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -249,7 +249,6 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVFH)) {
     VM_Version::ext_Zvfh.enable_feature();
   }
-#ifndef PRODUCT
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNED) &&
       is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNHB) &&
       is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKB)   &&
@@ -259,7 +258,6 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKG)) {
     VM_Version::ext_Zvkg.enable_feature();
   }
-#endif
 
   // ====== non-extensions ======
   //


### PR DESCRIPTION
Hi, 
Can you help to review this patch?
I ran some tests on the SpacemiT Key Stone K3 (which features physical zvkn/zvkg hardware extensions). After enabling Zvkn and UseZvkg, the relevant JMH performance metrics improved significantly. So I propose to auto-enable these features through hwprobe.

auto-enable these features through hwprobe:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk$ build/linux-riscv64-server-release/jdk/bin/java -XX:+PrintFlagsFinal -version | grep UseZvk
     bool UseZvkg                                  = true                              {ARCH diagnostic} {default}
     bool UseZvkn                                  = true                              {ARCH diagnostic} {default}
openjdk version "27-internal" 2026-09-15
OpenJDK Runtime Environment (build 27-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (build 27-internal-adhoc.zifeihan.jdk, mixed mode)
```

cpuinfo like this:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk$ cat /proc/cpuinfo
processor	: 0
hart		: 0
model name	: Spacemit(R) X100
isa		: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
mmu		: sv39
mvendorid	: 0x710
marchid		: 0x8000000058000002
mimpid		: 0x33d8a600
hart isa	: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
```

kernel version like this:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk$ uname -r
6.18.3-generic
zifeihan@riscv-spacemitk3picoitx:~/jdk$ uname -a
Linux riscv-spacemitk3picoitx 6.18.3-generic #1.0.0~rc2.4 SMP PREEMPT_DYNAMIC Thu Apr 16 11:50:58 CST 2026 riscv64 GNU/Linux
zifeihan@riscv-spacemitk3picoitx:~/jdk$ cat /etc/issue
Bianbu 4.0rc2 \n \l
zifeihan@riscv-spacemitk3picoitx:~/jdk$
```


### Testing (SpacemiT Key Stone K3)

- [x] tier1-3 tests (release)
- [x] test/hotspot/jtreg/compiler/codegen/aes/  (release)
- [x] test/jdk/com/sun/crypto/  (release)

jmh testing:
without this patch (SpacemiT Key Stone K3):
```
Benchmark                     (dataSize)  (keyLength)  (provider)   Mode  Cnt       Score      Error  Units
AESGCMBench.decrypt                  128          128              thrpt   40  122929.338 ± 1593.708  ops/s
AESGCMBench.decrypt                  128          192              thrpt   40  115842.352 ±  332.868  ops/s
AESGCMBench.decrypt                  128          256              thrpt   40   98333.644 ±  169.623  ops/s
AESGCMBench.decrypt                  256          128              thrpt   40   71764.800 ±  406.656  ops/s
AESGCMBench.decrypt                  256          192              thrpt   40   68036.150 ±   41.129  ops/s
AESGCMBench.decrypt                  256          256              thrpt   40   59238.070 ±  821.430  ops/s
AESGCMBench.decrypt                  512          128              thrpt   40   41964.913 ±  733.660  ops/s
AESGCMBench.decrypt                  512          192              thrpt   40   35126.170 ± 1974.679  ops/s
AESGCMBench.decrypt                  512          256              thrpt   40   32040.556 ± 1140.475  ops/s
AESGCMBench.decrypt                 1024          128              thrpt   40   20446.893 ± 1154.401  ops/s
AESGCMBench.decrypt                 1024          192              thrpt   40   20097.211 ±  953.756  ops/s
AESGCMBench.decrypt                 1024          256              thrpt   40   16876.627 ±  687.237  ops/s
AESGCMBench.decrypt                 1500          128              thrpt   40   15347.824 ±   16.057  ops/s
AESGCMBench.decrypt                 1500          192              thrpt   40   14390.452 ±   14.003  ops/s
AESGCMBench.decrypt                 1500          256              thrpt   40   11930.619 ±   18.578  ops/s
AESGCMBench.decrypt                 4096          128              thrpt   40    5433.736 ±  321.477  ops/s
AESGCMBench.decrypt                 4096          192              thrpt   40    5516.573 ±    2.304  ops/s
AESGCMBench.decrypt                 4096          256              thrpt   40    4554.365 ±    2.970  ops/s
AESGCMBench.decrypt                16384          128              thrpt   40    1494.981 ±    2.238  ops/s
AESGCMBench.decrypt                16384          192              thrpt   40    1397.171 ±    2.622  ops/s
AESGCMBench.decrypt                16384          256              thrpt   40    1152.100 ±    1.983  ops/s
AESGCMBench.decryptMultiPart         128          128              thrpt   40  117468.282 ±  150.278  ops/s
AESGCMBench.decryptMultiPart         128          192              thrpt   40  113065.071 ± 1919.678  ops/s
AESGCMBench.decryptMultiPart         128          256              thrpt   40   95214.659 ±  194.457  ops/s
AESGCMBench.decryptMultiPart         256          128              thrpt   40   69420.771 ±   50.225  ops/s
AESGCMBench.decryptMultiPart         256          192              thrpt   40   65732.146 ±   82.415  ops/s
AESGCMBench.decryptMultiPart         256          256              thrpt   40   55842.025 ±   67.974  ops/s
AESGCMBench.decryptMultiPart         512          128              thrpt   40   40070.950 ± 1091.115  ops/s
AESGCMBench.decryptMultiPart         512          192              thrpt   40   39807.345 ±   41.373  ops/s
AESGCMBench.decryptMultiPart         512          256              thrpt   40   31472.583 ±  744.763  ops/s
AESGCMBench.decryptMultiPart        1024          128              thrpt   40   21749.733 ±  771.275  ops/s
AESGCMBench.decryptMultiPart        1024          192              thrpt   40   20861.110 ±  147.888  ops/s
AESGCMBench.decryptMultiPart        1024          256              thrpt   40   16981.986 ±  480.962  ops/s
AESGCMBench.decryptMultiPart        1500          128              thrpt   40   13356.320 ±   36.569  ops/s
AESGCMBench.decryptMultiPart        1500          192              thrpt   40   13644.755 ±  526.784  ops/s
AESGCMBench.decryptMultiPart        1500          256              thrpt   40   10926.512 ±  281.043  ops/s
AESGCMBench.decryptMultiPart        4096          128              thrpt   40    5838.058 ±   28.161  ops/s
AESGCMBench.decryptMultiPart        4096          192              thrpt   40    5489.956 ±    3.502  ops/s
AESGCMBench.decryptMultiPart        4096          256              thrpt   40    4536.672 ±    3.911  ops/s
AESGCMBench.decryptMultiPart       16384          128              thrpt   40    1456.255 ±   36.053  ops/s
AESGCMBench.decryptMultiPart       16384          192              thrpt   40    1294.714 ±   45.553  ops/s
AESGCMBench.decryptMultiPart       16384          256              thrpt   40    1040.284 ±    4.185  ops/s
AESGCMBench.encrypt                  128          128              thrpt   40  124415.779 ± 1329.498  ops/s
AESGCMBench.encrypt                  128          192              thrpt   40  116985.215 ± 1345.911  ops/s
AESGCMBench.encrypt                  128          256              thrpt   40   98512.448 ±  194.191  ops/s
AESGCMBench.encrypt                  256          128              thrpt   40   72698.888 ±  163.376  ops/s
AESGCMBench.encrypt                  256          192              thrpt   40   69130.842 ±  855.520  ops/s
AESGCMBench.encrypt                  256          256              thrpt   40   57862.796 ±   82.262  ops/s
AESGCMBench.encrypt                  512          128              thrpt   40   34971.337 ± 1488.244  ops/s
AESGCMBench.encrypt                  512          192              thrpt   40   31976.175 ±   46.420  ops/s
AESGCMBench.encrypt                  512          256              thrpt   40   27499.299 ±   36.304  ops/s
AESGCMBench.encrypt                 1024          128              thrpt   40   18068.394 ±   23.557  ops/s
AESGCMBench.encrypt                 1024          192              thrpt   40   17146.567 ±   16.775  ops/s
AESGCMBench.encrypt                 1024          256              thrpt   40   14682.638 ±   13.441  ops/s
AESGCMBench.encrypt                 1500          128              thrpt   40   14686.756 ±   24.357  ops/s
AESGCMBench.encrypt                 1500          192              thrpt   40   13820.612 ±   11.354  ops/s
AESGCMBench.encrypt                 1500          256              thrpt   40   11538.744 ±   12.498  ops/s
AESGCMBench.encrypt                 4096          128              thrpt   40    4648.193 ±    8.219  ops/s
AESGCMBench.encrypt                 4096          192              thrpt   40    4413.340 ±    7.497  ops/s
AESGCMBench.encrypt                 4096          256              thrpt   40    3766.763 ±    4.459  ops/s
AESGCMBench.encrypt                16384          128              thrpt   40    1178.030 ±    1.007  ops/s
AESGCMBench.encrypt                16384          192              thrpt   40    1115.766 ±    1.208  ops/s
AESGCMBench.encrypt                16384          256              thrpt   40     953.273 ±    1.948  ops/s
AESGCMBench.encryptMultiPart         128          128              thrpt   40  124396.807 ±  251.238  ops/s
AESGCMBench.encryptMultiPart         128          192              thrpt   40  117110.377 ±   98.260  ops/s
AESGCMBench.encryptMultiPart         128          256              thrpt   40   98754.867 ±  885.138  ops/s
AESGCMBench.encryptMultiPart         256          128              thrpt   40   74252.625 ±   79.287  ops/s
AESGCMBench.encryptMultiPart         256          192              thrpt   40   69799.794 ±  112.330  ops/s
AESGCMBench.encryptMultiPart         256          256              thrpt   40   58710.087 ±   83.443  ops/s
AESGCMBench.encryptMultiPart         512          128              thrpt   40   40539.666 ±  463.332  ops/s
AESGCMBench.encryptMultiPart         512          192              thrpt   40   38413.419 ±   62.847  ops/s
AESGCMBench.encryptMultiPart         512          256              thrpt   40   32114.035 ±   81.659  ops/s
AESGCMBench.encryptMultiPart        1024          128              thrpt   40   22471.360 ±   20.197  ops/s
AESGCMBench.encryptMultiPart        1024          192              thrpt   40   21055.493 ±    7.039  ops/s
AESGCMBench.encryptMultiPart        1024          256              thrpt   40   17448.449 ±   12.383  ops/s
AESGCMBench.encryptMultiPart        1500          128              thrpt   40   15144.894 ±   14.817  ops/s
AESGCMBench.encryptMultiPart        1500          192              thrpt   40   14199.589 ±   10.821  ops/s
AESGCMBench.encryptMultiPart        1500          256              thrpt   40   11812.110 ±   12.462  ops/s
AESGCMBench.encryptMultiPart        4096          128              thrpt   40    5901.362 ±    6.703  ops/s
AESGCMBench.encryptMultiPart        4096          192              thrpt   40    5509.484 ±    1.760  ops/s
AESGCMBench.encryptMultiPart        4096          256              thrpt   40    4547.467 ±    3.482  ops/s
AESGCMBench.encryptMultiPart       16384          128              thrpt   40    1491.138 ±    1.788  ops/s
AESGCMBench.encryptMultiPart       16384          192              thrpt   40    1397.373 ±    2.258  ops/s
AESGCMBench.encryptMultiPart       16384          256              thrpt   40    1149.650 ±    1.939  ops/s
Finished running test 'micro:javax.crypto.full.AESGCMBench'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_javax_crypto_full_AESGCMBench

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   micro:javax.crypto.full.AESGCMBench                   1     1     0     0     0   
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'
```

with this patch (SpacemiT Key Stone K3):
```
Benchmark                     (dataSize)  (keyLength)  (provider)   Mode  Cnt       Score      Error  Units
AESGCMBench.decrypt                  128          128              thrpt   40  205614.033 ±  252.466  ops/s
AESGCMBench.decrypt                  128          192              thrpt   40  206757.700 ± 1634.240  ops/s
AESGCMBench.decrypt                  128          256              thrpt   40  202053.857 ±  451.447  ops/s
AESGCMBench.decrypt                  256          128              thrpt   40  128480.495 ±  322.878  ops/s
AESGCMBench.decrypt                  256          192              thrpt   40  128716.093 ± 1264.552  ops/s
AESGCMBench.decrypt                  256          256              thrpt   40  127377.858 ± 1400.679  ops/s
AESGCMBench.decrypt                  512          128              thrpt   40   72065.706 ±  177.452  ops/s
AESGCMBench.decrypt                  512          192              thrpt   40   71496.455 ±  127.001  ops/s
AESGCMBench.decrypt                  512          256              thrpt   40   71142.300 ±   60.454  ops/s
AESGCMBench.decrypt                 1024          128              thrpt   40   38712.567 ±  120.202  ops/s
AESGCMBench.decrypt                 1024          192              thrpt   40   38396.866 ±   61.859  ops/s
AESGCMBench.decrypt                 1024          256              thrpt   40   38276.985 ±   92.632  ops/s
AESGCMBench.decrypt                 1500          128              thrpt   40   27780.452 ±  337.172  ops/s
AESGCMBench.decrypt                 1500          192              thrpt   40   27827.324 ±  369.404  ops/s
AESGCMBench.decrypt                 1500          256              thrpt   40   28220.327 ±   37.000  ops/s
AESGCMBench.decrypt                 4096          128              thrpt   40   10238.352 ±   37.177  ops/s
AESGCMBench.decrypt                 4096          192              thrpt   40   10153.717 ±   15.676  ops/s
AESGCMBench.decrypt                 4096          256              thrpt   40   10147.430 ±   16.926  ops/s
AESGCMBench.decrypt                16384          128              thrpt   40    2600.380 ±    5.060  ops/s
AESGCMBench.decrypt                16384          192              thrpt   40    2652.725 ±   79.355  ops/s
AESGCMBench.decrypt                16384          256              thrpt   40    2640.484 ±   75.305  ops/s
AESGCMBench.decryptMultiPart         128          128              thrpt   40  192717.714 ±   77.968  ops/s
AESGCMBench.decryptMultiPart         128          192              thrpt   40  192467.164 ±  200.754  ops/s
AESGCMBench.decryptMultiPart         128          256              thrpt   40  191219.332 ±  415.036  ops/s
AESGCMBench.decryptMultiPart         256          128              thrpt   40  122780.742 ±  104.153  ops/s
AESGCMBench.decryptMultiPart         256          192              thrpt   40  124347.720 ± 1683.454  ops/s
AESGCMBench.decryptMultiPart         256          256              thrpt   40  120753.570 ±  270.901  ops/s
AESGCMBench.decryptMultiPart         512          128              thrpt   40   72319.600 ± 1229.470  ops/s
AESGCMBench.decryptMultiPart         512          192              thrpt   40   71890.521 ± 1308.499  ops/s
AESGCMBench.decryptMultiPart         512          256              thrpt   40   69761.798 ±  324.036  ops/s
AESGCMBench.decryptMultiPart        1024          128              thrpt   40   39378.952 ±  453.843  ops/s
AESGCMBench.decryptMultiPart        1024          192              thrpt   40   39246.706 ±  472.105  ops/s
AESGCMBench.decryptMultiPart        1024          256              thrpt   40   38113.334 ±   43.514  ops/s
AESGCMBench.decryptMultiPart        1500          128              thrpt   40   27964.298 ±  411.854  ops/s
AESGCMBench.decryptMultiPart        1500          192              thrpt   40   28185.087 ±   39.498  ops/s
AESGCMBench.decryptMultiPart        1500          256              thrpt   40   27281.558 ±  522.403  ops/s
AESGCMBench.decryptMultiPart        4096          128              thrpt   40   10722.929 ±   16.616  ops/s
AESGCMBench.decryptMultiPart        4096          192              thrpt   40   10665.953 ±   19.641  ops/s
AESGCMBench.decryptMultiPart        4096          256              thrpt   40   10633.216 ±   16.775  ops/s
AESGCMBench.decryptMultiPart       16384          128              thrpt   40    2738.883 ±    3.616  ops/s
AESGCMBench.decryptMultiPart       16384          192              thrpt   40    2726.261 ±    5.450  ops/s
AESGCMBench.decryptMultiPart       16384          256              thrpt   40    2714.114 ±    4.469  ops/s
AESGCMBench.encrypt                  128          128              thrpt   40  196883.445 ±  239.521  ops/s
AESGCMBench.encrypt                  128          192              thrpt   40  194850.757 ±  374.908  ops/s
AESGCMBench.encrypt                  128          256              thrpt   40  196031.341 ± 3542.540  ops/s
AESGCMBench.encrypt                  256          128              thrpt   40  126102.053 ± 2571.686  ops/s
AESGCMBench.encrypt                  256          192              thrpt   40  129725.664 ± 3166.982  ops/s
AESGCMBench.encrypt                  256          256              thrpt   40  123926.330 ± 2547.690  ops/s
AESGCMBench.encrypt                  512          128              thrpt   40   71400.871 ±   73.576  ops/s
AESGCMBench.encrypt                  512          192              thrpt   40   70962.677 ±   68.624  ops/s
AESGCMBench.encrypt                  512          256              thrpt   40   70450.701 ±   67.336  ops/s
AESGCMBench.encrypt                 1024          128              thrpt   40   38520.373 ±   56.051  ops/s
AESGCMBench.encrypt                 1024          192              thrpt   40   38274.631 ±   53.891  ops/s
AESGCMBench.encrypt                 1024          256              thrpt   40   38052.493 ±   50.531  ops/s
AESGCMBench.encrypt                 1500          128              thrpt   40   26579.928 ±   94.330  ops/s
AESGCMBench.encrypt                 1500          192              thrpt   40   26424.665 ±   78.952  ops/s
AESGCMBench.encrypt                 1500          256              thrpt   40   26185.179 ±   27.419  ops/s
AESGCMBench.encrypt                 4096          128              thrpt   40   10253.898 ±    9.445  ops/s
AESGCMBench.encrypt                 4096          192              thrpt   40   10207.454 ±   13.510  ops/s
AESGCMBench.encrypt                 4096          256              thrpt   40   10153.146 ±    9.587  ops/s
AESGCMBench.encrypt                16384          128              thrpt   40    2610.626 ±    3.297  ops/s
AESGCMBench.encrypt                16384          192              thrpt   40    2599.030 ±    2.698  ops/s
AESGCMBench.encrypt                16384          256              thrpt   40    2587.418 ±    3.129  ops/s
AESGCMBench.encryptMultiPart         128          128              thrpt   40  202645.116 ± 1947.970  ops/s
AESGCMBench.encryptMultiPart         128          192              thrpt   40  199331.001 ±  325.255  ops/s
AESGCMBench.encryptMultiPart         128          256              thrpt   40  195645.253 ± 1291.251  ops/s
AESGCMBench.encryptMultiPart         256          128              thrpt   40  127618.915 ±  149.053  ops/s
AESGCMBench.encryptMultiPart         256          192              thrpt   40  126422.097 ±  242.387  ops/s
AESGCMBench.encryptMultiPart         256          256              thrpt   40  125252.982 ±  172.989  ops/s
AESGCMBench.encryptMultiPart         512          128              thrpt   40   74095.241 ±  131.793  ops/s
AESGCMBench.encryptMultiPart         512          192              thrpt   40   73302.858 ±   52.420  ops/s
AESGCMBench.encryptMultiPart         512          256              thrpt   40   72825.770 ±   89.104  ops/s
AESGCMBench.encryptMultiPart        1024          128              thrpt   40   40462.924 ±   52.392  ops/s
AESGCMBench.encryptMultiPart        1024          192              thrpt   40   40212.484 ±   53.677  ops/s
AESGCMBench.encryptMultiPart        1024          256              thrpt   40   39994.758 ±   60.691  ops/s
AESGCMBench.encryptMultiPart        1500          128              thrpt   40   26344.872 ±   35.749  ops/s
AESGCMBench.encryptMultiPart        1500          192              thrpt   40   26174.195 ±   40.395  ops/s
AESGCMBench.encryptMultiPart        1500          256              thrpt   40   26010.954 ±   40.821  ops/s
AESGCMBench.encryptMultiPart        4096          128              thrpt   40   10846.896 ±   11.596  ops/s
AESGCMBench.encryptMultiPart        4096          192              thrpt   40   10788.953 ±   11.903  ops/s
AESGCMBench.encryptMultiPart        4096          256              thrpt   40   10716.277 ±   16.043  ops/s
AESGCMBench.encryptMultiPart       16384          128              thrpt   40    2773.879 ±    4.846  ops/s
AESGCMBench.encryptMultiPart       16384          192              thrpt   40    2753.298 ±    3.931  ops/s
AESGCMBench.encryptMultiPart       16384          256              thrpt   40    2742.631 ±    3.066  ops/s
Finished running test 'micro:javax.crypto.full.AESGCMBench'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_javax_crypto_full_AESGCMBench

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:javax.crypto.full.AESGCMBench                   1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386161](https://bugs.openjdk.org/browse/JDK-8386161): RISC-V: Auto-enable Zvkn/Zvkg extension features (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31423/head:pull/31423` \
`$ git checkout pull/31423`

Update a local copy of the PR: \
`$ git checkout pull/31423` \
`$ git pull https://git.openjdk.org/jdk.git pull/31423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31423`

View PR using the GUI difftool: \
`$ git pr show -t 31423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31423.diff">https://git.openjdk.org/jdk/pull/31423.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31423#issuecomment-4655843447)
</details>
