### PR TITLE
8385323: Support capstone on riscv64

### DIFF
--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ ifeq ($(HSDIS_BACKEND), capstone)
     CAPSTONE_MODE := CS_MODE_ARM
   else ifeq ($(call isTargetCpuArch, riscv), true)
     CAPSTONE_ARCH := CS_ARCH_RISCV
-    CAPSTONE_MODE := CS_MODE_RISCV64
+    CAPSTONE_MODE := 'CS_MODE_RISCV64|CS_MODE_RISCVC'
   else
     $(error No support for Capstone on this platform)
   endif

--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -47,6 +47,9 @@ ifeq ($(HSDIS_BACKEND), capstone)
   else ifeq ($(call isTargetCpuArch, arm), true)
     CAPSTONE_ARCH := CS_ARCH_ARM
     CAPSTONE_MODE := CS_MODE_ARM
+  else ifeq ($(call isTargetCpuArch, riscv), true)
+    CAPSTONE_ARCH := CS_ARCH_RISCV
+    CAPSTONE_MODE := CS_MODE_RISCV64
   else
     $(error No support for Capstone on this platform)
   endif


### PR DESCRIPTION
This small change enables support for the with-hsdis=capstone option for the RISC-V target. 
It could be done because libcapstone is available in apt repositories.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385323](https://bugs.openjdk.org/browse/JDK-8385323): Support capstone on riscv64 (**Enhancement** - P4)


### Reviewers
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31424/head:pull/31424` \
`$ git checkout pull/31424`

Update a local copy of the PR: \
`$ git checkout pull/31424` \
`$ git pull https://git.openjdk.org/jdk.git pull/31424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31424`

View PR using the GUI difftool: \
`$ git pr show -t 31424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31424.diff">https://git.openjdk.org/jdk/pull/31424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31424#issuecomment-4650683983)
</details>
