### PR TITLE
8233533: Consolidate core file lookup logic in test library

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,9 +58,7 @@ public abstract class CiReplayBase {
     public static final String CLIENT_VM_OPTION = "-client";
     public static final String SERVER_VM_OPTION = "-server";
     public static final String TEST_CORE_FILE_NAME = "test_core";
-    public static final String RUN_SHELL_NO_LIMIT = "ulimit -c unlimited && ";
     private static final String REPLAY_FILE_OPTION = "-XX:ReplayDataFile=" + REPLAY_FILE_NAME;
-    private static final String LOCATIONS_STRING = "location: ";
     private static final String HS_ERR_NAME = "hs_err_pid";
     private static final String RUN_SHELL_ZERO_LIMIT = "ulimit -S -c 0 && ";
     private static final String VERSION_OPTION = "-version";


### PR DESCRIPTION
Removed unused RUN_SHELL_NO_LIMIT and LOCATIONS_STRING constants from CiReplayBase — core file lookup logic is already consolidated in CoreUtils.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8233533](https://bugs.openjdk.org/browse/JDK-8233533): Consolidate core file lookup logic in test library (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31425/head:pull/31425` \
`$ git checkout pull/31425`

Update a local copy of the PR: \
`$ git checkout pull/31425` \
`$ git pull https://git.openjdk.org/jdk.git pull/31425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31425`

View PR using the GUI difftool: \
`$ git pr show -t 31425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31425.diff">https://git.openjdk.org/jdk/pull/31425.diff</a>

</details>
