### PR TITLE
8385933: GenShen: Remove ShenandoahAgingCyclePeriod

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1203,18 +1203,12 @@ void ShenandoahConcurrentGC::op_final_update_refs() {
     heap->verifier()->verify_roots_in_to_space(_generation);
   }
 
-  // If we are running in generational mode and this is an aging cycle, this will also age active
-  // regions that haven't been used for allocation.
+  // If we are running in generational mode, this will also age active regions that
+  // haven't been used for allocation.
   heap->update_heap_region_states(true /*concurrent*/);
 
   heap->set_update_refs_in_progress(false);
   heap->set_has_forwarded_objects(false);
-
-  if (heap->mode()->is_generational() && heap->is_concurrent_old_mark_in_progress()) {
-    // Aging_cycle is only relevant during evacuation cycle for individual objects and during final mark for
-    // entire regions.  Both of these relevant operations occur before final update refs.
-    ShenandoahGenerationalHeap::heap()->set_aging_cycle(false);
-  }
 
   if (ShenandoahVerify) {
     ShenandoahTimingsTracker v(ShenandoahPhaseTimings::final_update_refs_verify);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -53,8 +53,7 @@ ShenandoahGenerationalControlThread::ShenandoahGenerationalControlThread() :
   _requested_generation(nullptr),
   _gc_mode(none),
   _degen_point(ShenandoahGC::_degenerated_unset),
-  _heap(ShenandoahGenerationalHeap::heap()),
-  _age_period(0) {
+  _heap(ShenandoahGenerationalHeap::heap()) {
   shenandoah_assert_generational();
   set_name("ShenControl");
   create_and_start();
@@ -227,15 +226,6 @@ void ShenandoahGenerationalControlThread::maybe_print_young_region_ages() const 
     ls.print("Young regions: ");
     young_region_ages.print_on(&ls);
     ls.cr();
-  }
-}
-
-void ShenandoahGenerationalControlThread::maybe_set_aging_cycle() {
-  if (_age_period-- == 0) {
-    _heap->set_aging_cycle(true);
-    _age_period = ShenandoahAgingCyclePeriod - 1;
-  } else {
-    _heap->set_aging_cycle(false);
   }
 }
 
@@ -534,9 +524,6 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
   // At this point:
   //  if (generation == YOUNG), this is a normal young cycle or a bootstrap cycle
   //  if (generation == GLOBAL), this is a GLOBAL cycle
-  // In either case, we want to age old objects if this is an aging cycle
-  maybe_set_aging_cycle();
-
   ShenandoahGCSession session(cause, generation);
   TraceCollectorStats tcs(_heap->monitoring_support()->concurrent_collection_counters());
 
@@ -615,7 +602,6 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   _heap->increment_total_collections(true);
   ShenandoahGCSession session(cause, _heap->global_generation());
-  maybe_set_aging_cycle();
   ShenandoahFullGC gc;
   gc.collect(cause);
   _degen_point = ShenandoahGC::_degenerated_unset;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -80,9 +80,6 @@ private:
   // A reference to the heap
   ShenandoahGenerationalHeap* _heap;
 
-  // This is used to keep track of whether to age objects during the current cycle.
-  uint _age_period;
-
   // This is true when the old generation cycle is in an interruptible phase (i.e., marking or
   // preparing for mark).
   ShenandoahSharedFlag _allow_old_preemption;
@@ -141,9 +138,6 @@ private:
   void notify_control_thread(MonitorLocker& ml, GCCause::Cause cause);
   void notify_control_thread(GCCause::Cause cause, ShenandoahGeneration* generation);
   void notify_control_thread(MonitorLocker& ml, GCCause::Cause cause, ShenandoahGeneration* generation);
-
-  // Configure the heap to age objects and regions if the aging period has elapsed.
-  void maybe_set_aging_cycle();
 
   // Take the _control_lock and check for a request to run a gc cycle. If a request is found,
   // the `prepare` methods are used to configure the heap and update heuristics accordingly.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -312,11 +312,7 @@ void ShenandoahPrepareForGenerationalCompactionObjectClosure::do_object(oop p) {
 
     // After full gc compaction, all regions have age 0.  Embed the region's age into the object's age in order to preserve
     // tenuring progress.
-    if (_heap->is_aging_cycle()) {
-      ShenandoahHeap::increase_object_age(p, from_region_age + 1);
-    } else {
-      ShenandoahHeap::increase_object_age(p, from_region_age);
-    }
+    ShenandoahHeap::increase_object_age(p, from_region_age + 1);
 
     if (_young_compact_point + obj_size > _young_to_region->end()) {
       ShenandoahHeapRegion* new_to_region;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -347,7 +347,7 @@ oop ShenandoahGenerationalHeap::try_evacuate_object(oop p, Thread* thread, uint 
   oop copy_val = cast_to_oop(copy);
 
   // Update the age of the evacuated object
-  if (TO_GENERATION == YOUNG_GENERATION && is_aging_cycle()) {
+  if (TO_GENERATION == YOUNG_GENERATION) {
     increase_object_age(copy_val, from_region_age + 1);
   }
 
@@ -975,7 +975,7 @@ public:
         // There have been allocations in this region since the start of the cycle.
         // Any objects new to this region must not assimilate elevated age.
         r->reset_age();
-      } else if (ShenandoahGenerationalHeap::heap()->is_aging_cycle()) {
+      } else {
         r->increment_age();
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -61,21 +61,10 @@ public:
 
 private:
   // ---------- Evacuations and Promotions
-  //
-  // True when regions and objects should be aged during the current cycle
-  ShenandoahSharedFlag  _is_aging_cycle;
   // Age census used for adapting tenuring threshold
   ShenandoahAgeCensus* _age_census;
 
 public:
-  void set_aging_cycle(bool cond) {
-    _is_aging_cycle.set_cond(cond);
-  }
-
-  inline bool is_aging_cycle() const {
-    return _is_aging_cycle.is_set();
-  }
-
   // Return the age census object for young gen
   ShenandoahAgeCensus* age_census() const {
     return _age_census;

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -532,10 +532,6 @@
           "Allow young generation collections to suspend concurrent"        \
           " marking in the old generation.")                                \
                                                                             \
-  product(uintx, ShenandoahAgingCyclePeriod, 1, EXPERIMENTAL,               \
-          "With generational mode, increment the age of objects and"        \
-          "regions each time this many young-gen GC cycles are completed.") \
-                                                                            \
   develop(bool, ShenandoahEnableCardStats, false,                           \
           "Enable statistics collection related to clean & dirty cards")    \
                                                                             \


### PR DESCRIPTION
Removed `ShenandoahAgingCyclePeriod` flag (see the ticket [description](https://bugs.openjdk.org/browse/JDK-8385933) why). With this change, every cycle (other than an old and full cycle) is unconditionally an aging cycle.

### Testing

`gc/shenandoah` with linux-x86_64-server-fastdebug.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385933](https://bugs.openjdk.org/browse/JDK-8385933): GenShen: Remove ShenandoahAgingCyclePeriod (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31427/head:pull/31427` \
`$ git checkout pull/31427`

Update a local copy of the PR: \
`$ git checkout pull/31427` \
`$ git pull https://git.openjdk.org/jdk.git pull/31427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31427`

View PR using the GUI difftool: \
`$ git pr show -t 31427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31427.diff">https://git.openjdk.org/jdk/pull/31427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31427#issuecomment-4652096576)
</details>
