### PR TITLE
8386203: Use CRC32C checksum instead of Adler32 for stateless session ticket

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.zip.Adler32;
+import java.util.zip.CRC32C;
 import javax.crypto.KDF;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -610,9 +610,9 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     }
 
     private static int getChecksum(byte[] input) {
-        Adler32 adler32 = new Adler32();
-        adler32.update(input);
-        return (int) adler32.getValue();
+        CRC32C crc32c = new CRC32C();
+        crc32c.update(input);
+        return (int) crc32c.getValue();
     }
 
     void setMasterSecret(SecretKey secret) {


### PR DESCRIPTION
Use CRC32C checksum instead of Adler32 for stateless session ticket to reduce the chance of collision. CRC32C also runs faster on modern hardware (special hardware instructions on Intel, ARM etc).

The checksum is used to fingerprint the local certificate chain: 32bit checksum value is included in the ticket for each certificate in the chain to save space.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386203](https://bugs.openjdk.org/browse/JDK-8386203): Use CRC32C checksum instead of Adler32 for stateless session ticket (**Enhancement** - P5)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31428/head:pull/31428` \
`$ git checkout pull/31428`

Update a local copy of the PR: \
`$ git checkout pull/31428` \
`$ git pull https://git.openjdk.org/jdk.git pull/31428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31428`

View PR using the GUI difftool: \
`$ git pr show -t 31428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31428.diff">https://git.openjdk.org/jdk/pull/31428.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31428#issuecomment-4652323420)
</details>
