### PR TITLE
8355950: hotspot_resourcehogs shouldn't be executed conurrently

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -38,6 +38,9 @@ keys=stress headful intermittent randomness cgroups flag-sensitive external-dep
 
 groups=TEST.groups TEST.quick-groups
 
+# Resource-intensive tests that should not run concurrently with other tests
+exclusiveAccess.dirs=resourcehogs
+
 # Source files for classes that will be used at the beginning of each test suite run,
 # to determine additional characteristics of the system for use with the @requires tag.
 # Note: compiled bootlibs classes will be added to BCP.


### PR DESCRIPTION
Added exclusiveAccess.dirs=resourcehogs to TEST.ROOT so resourcehogs tests don't run concurrently with other tests when executed as part of a larger test suite (tier6, tier7, etc). The existing exclusiveAccess.dirs=. in resourcehogs/TEST.properties only prevents resourcehogs from running parallel with each other.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8355950](https://bugs.openjdk.org/browse/JDK-8355950): hotspot_resourcehogs shouldn't be executed conurrently (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31429/head:pull/31429` \
`$ git checkout pull/31429`

Update a local copy of the PR: \
`$ git checkout pull/31429` \
`$ git pull https://git.openjdk.org/jdk.git pull/31429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31429`

View PR using the GUI difftool: \
`$ git pr show -t 31429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31429.diff">https://git.openjdk.org/jdk/pull/31429.diff</a>

</details>
