### PR TITLE
8386200: ListFormat incorrectly escapes single quotes

### DIFF
--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -498,15 +498,18 @@ public final class ListFormat extends Format {
                         midIndex += mbLength;
                     }
                 }
-                parsed = new MessageFormat(createMessageFormatString(count), locale).parseObject(source, parsePos);
+                parsed = new MessageFormat(listToMessageFormatPattern(createMessageFormatString(count)),
+                        locale).parseObject(source, parsePos);
             }
         }
 
         if (parsed == null) {
             // now try exact number patterns
-            parsed = new MessageFormat(patterns[TWO], locale).parseObject(source, parsePos);
+            parsed = new MessageFormat(listToMessageFormatPattern(patterns[TWO]),
+                    locale).parseObject(source, parsePos);
             if (parsed == null) {
-                parsed = new MessageFormat(patterns[THREE], locale).parseObject(source, parsePos);
+                parsed = new MessageFormat(listToMessageFormatPattern(patterns[THREE]),
+                        locale).parseObject(source, parsePos);
             }
         }
 
@@ -584,9 +587,9 @@ public final class ListFormat extends Format {
         var len = input.length;
         return switch (len) {
             case 0 -> throw new IllegalArgumentException("There should at least be one input string");
-            case 1 -> new MessageFormat("{0}", locale);
-            case 2, 3 -> new MessageFormat(patterns[len + 1], locale);
-            default -> new MessageFormat(createMessageFormatString(len), locale);
+            case 1 -> new MessageFormat(listToMessageFormatPattern("{0}"), locale);
+            case 2, 3 -> new MessageFormat(listToMessageFormatPattern(patterns[len + 1]), locale);
+            default -> new MessageFormat(listToMessageFormatPattern(createMessageFormatString(len)), locale);
         };
     }
 
@@ -741,5 +744,19 @@ public final class ListFormat extends Format {
 
         return prefixPos < suffixPos ?
             new int[] {prefixPos, suffixPos + suffix.length()} : null;
+    }
+
+    /**
+     * {@return the MessageFormat pattern corresponding to the passed ListFormat pattern}
+     *
+     * Single quotes must be escaped so they are interpreted as literal text
+     * as opposed to escaping delimiters when passed to MessageFormat. Everything
+     * else remains the same; ListFormat already handles other validation on its own.
+     *
+     * @param pattern list pattern to use
+     */
+    private static String listToMessageFormatPattern(String pattern) {
+        return pattern.indexOf('\'') < 0 ? pattern :
+                pattern.replace("'", "''");
     }
 }

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8041488 8316974 8318569 8306116 8385736 8385834
+ * @bug 8041488 8316974 8318569 8306116 8385736 8385834 8386200
  * @summary Tests for ListFormat class
  * @run junit TestListFormat
  */
@@ -71,6 +71,14 @@ public class TestListFormat {
             ". {0} * {1}",
             "{0} + {1}",
             "{0} | {1} [",
+            "",
+            "",
+    };
+    // Ensures MessageFormat single quotes in custom patterns are treated as literals.
+    private static final String[] CUSTOM_PATTERNS_SINGLE_QUOTE = {
+            "' {0} ' {1}",
+            "{0} '' {1}",
+            "{0} ''' {1} '''",
             "",
             "",
     };
@@ -142,6 +150,10 @@ public class TestListFormat {
                 arguments(CUSTOM_PATTERNS_METACHAR, SAMPLE2, ". foo | bar ["),
                 arguments(CUSTOM_PATTERNS_METACHAR, SAMPLE3, ". foo * bar | baz ["),
                 arguments(CUSTOM_PATTERNS_METACHAR, SAMPLE4, ". foo * bar + baz | qux ["),
+                arguments(CUSTOM_PATTERNS_SINGLE_QUOTE, SAMPLE1, "foo"),
+                arguments(CUSTOM_PATTERNS_SINGLE_QUOTE, SAMPLE2, "' foo ''' bar '''"),
+                arguments(CUSTOM_PATTERNS_SINGLE_QUOTE, SAMPLE3, "' foo ' bar ''' baz '''"),
+                arguments(CUSTOM_PATTERNS_SINGLE_QUOTE, SAMPLE4, "' foo ' bar '' baz ''' qux '''")
         };
     }
 


### PR DESCRIPTION
ListFormat validates patterns before passing them to MessageFormat, but it currently allows single quotes as is. MessageFormat interprets these as escaping syntax, which can lead to incorrect output. For example, given the end pattern  `"{0}'{1}'"` and an empty two pattern, a `ListFormat` formats `List.of("foo", "bar")` as `"foo{1}"` instead of `"foo'bar'"`.

This behavior violates the specification, as ListFormat does not define any escaping mechanisms. This PR converts ListFormat patterns to the corresponding MessageFormat pattern by ensuring all single quotes are doubled, such that they are always treated literally by the MessageFormat. I intentionally handle the replacement logic at the MessageFormat creation site instead of the existing ListFormat validation, because the patterns should remain exactly the same as the input given by the user.

I am treating this as a normal bug fix since the current behavior violates the specification and is incorrect. No one should be relying on this type of behavior. However, I can file a CSR if deemed necessary.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386200](https://bugs.openjdk.org/browse/JDK-8386200): ListFormat incorrectly escapes single quotes (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31430/head:pull/31430` \
`$ git checkout pull/31430`

Update a local copy of the PR: \
`$ git checkout pull/31430` \
`$ git pull https://git.openjdk.org/jdk.git pull/31430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31430`

View PR using the GUI difftool: \
`$ git pr show -t 31430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31430.diff">https://git.openjdk.org/jdk/pull/31430.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31430#issuecomment-4653535170)
</details>
