### PR TITLE
8385655: Timeout in java/lang/Thread/virtual/KlassInit.java

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/KlassInit.java
+++ b/test/jdk/java/lang/Thread/virtual/KlassInit.java
@@ -79,7 +79,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
+import jdk.test.lib.thread.VThreadRunner;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
@@ -95,6 +98,12 @@ class KlassInit {
     private static final CountDownLatch finishGetStatic = new CountDownLatch(1);
     private static final CountDownLatch finishPutStatic = new CountDownLatch(1);
     private static final CountDownLatch finishFailedInit = new CountDownLatch(1);
+
+    @BeforeAll
+    static void setup() {
+        // need >=2 carriers for testing pinning
+        VThreadRunner.ensureParallelism(2);
+    }
 
     /**
      * Test that threads blocked waiting for klass to be initialized


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [286f7bbc](https://github.com/openjdk/jdk/commit/286f7bbc81cad42357f6a7840c0cde44a6103063) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Patricio Chilano Mateo on 8 Jun 2026 and was reviewed by Alan Bateman and Aleksey Shipilev.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8385655](https://bugs.openjdk.org/browse/JDK-8385655): Timeout in java/lang/Thread/virtual/KlassInit.java (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31431/head:pull/31431` \
`$ git checkout pull/31431`

Update a local copy of the PR: \
`$ git checkout pull/31431` \
`$ git pull https://git.openjdk.org/jdk.git pull/31431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31431`

View PR using the GUI difftool: \
`$ git pr show -t 31431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31431.diff">https://git.openjdk.org/jdk/pull/31431.diff</a>

</details>
