### PR TITLE
8386247: G1: Cleanup naming and type use of G1CollectionSet class members and methods

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -77,7 +77,7 @@ G1CollectionSet::~G1CollectionSet() {
 }
 
 void G1CollectionSet::prepare_for_collection(uint num_eden_cset_regions,
-                            uint num_survivor_cset_regions) {
+                                             uint num_survivor_cset_regions) {
   assert_at_safepoint_on_vm_thread();
 
   _num_eden_regions     = num_eden_cset_regions;

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -37,13 +37,13 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-uint G1CollectionSet::groups_cur_length() const {
+uint G1CollectionSet::num_groups() const {
   assert(_inc_build_state == CSetBuildType::Inactive, "must be");
   return _groups.length();
 }
 
-uint G1CollectionSet::groups_increment_length() const {
-  return groups_cur_length() - _groups_inc_part_start;
+uint G1CollectionSet::num_groups_in_increment() const {
+  return num_groups() - _groups_inc_part_start;
 }
 
 G1CollectorState* G1CollectionSet::collector_state() const {
@@ -59,12 +59,12 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
   _policy(policy),
   _candidates(),
   _regions(nullptr),
-  _regions_max_length(0),
-  _regions_cur_length(0),
+  _max_regions(0),
+  _num_regions(0),
   _groups(),
-  _eden_region_length(0),
-  _survivor_region_length(0),
-  _initial_old_region_length(0),
+  _eden_region_count(0),
+  _survivor_region_count(0),
+  _initial_old_region_count(0),
   _optional_groups(),
   DEBUG_ONLY(_inc_build_state(CSetBuildType::Inactive) COMMA)
   _regions_inc_part_start(0),
@@ -76,27 +76,27 @@ G1CollectionSet::~G1CollectionSet() {
   abandon_all_candidates();
 }
 
-void G1CollectionSet::init_region_lengths(uint eden_cset_region_length,
-                                          uint survivor_cset_region_length) {
+void G1CollectionSet::init_region_counts(uint eden_cset_region_count,
+                                         uint survivor_cset_region_count) {
   assert_at_safepoint_on_vm_thread();
 
-  _eden_region_length     = eden_cset_region_length;
-  _survivor_region_length = survivor_cset_region_length;
+  _eden_region_count     = eden_cset_region_count;
+  _survivor_region_count = survivor_cset_region_count;
 
-  assert(young_region_length() == regions_cur_length(),
-         "Young region length %u should match collection set length %u", young_region_length(), regions_cur_length());
+  assert(young_region_count() == num_regions(),
+         "Young region length %u should match collection set length %u", young_region_count(), num_regions());
 
-  _initial_old_region_length = 0;
+  _initial_old_region_count = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
   _optional_groups.clear();
 }
 
-void G1CollectionSet::initialize(uint max_region_length) {
+void G1CollectionSet::initialize(uint max_regions) {
   guarantee(_regions == nullptr, "Must only initialize once.");
-  _regions_max_length = max_region_length;
-  _regions = NEW_C_HEAP_ARRAY(uint, max_region_length, mtGC);
+  _max_regions = max_regions;
+  _regions = NEW_C_HEAP_ARRAY(uint, max_regions, mtGC);
 
-  _candidates.initialize(max_region_length);
+  _candidates.initialize(max_regions);
 }
 
 void G1CollectionSet::abandon() {
@@ -109,7 +109,7 @@ void G1CollectionSet::abandon() {
 
 void G1CollectionSet::abandon_all_candidates() {
   _candidates.clear();
-  _initial_old_region_length = 0;
+  _initial_old_region_count = 0;
 }
 
 void G1CollectionSet::prepare_for_scan () {
@@ -128,16 +128,16 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   _g1h->register_old_collection_set_region_with_region_attr(hr);
 
-  assert(regions_cur_length() < _regions_max_length, "Collection set now larger than maximum size.");
-  _regions[_regions_cur_length.] = hr->hrm_index();
-  _initial_old_region_length++;
+  assert(num_regions() < _max_regions, "Collection set now larger than maximum size.");
+  _regions[_num_regions++] = hr->hrm_index();
+  _initial_old_region_count++;
 
   _g1h->old_set_remove(hr);
 }
 
 void G1CollectionSet::start() {
-  assert(regions_cur_length() == 0, "Collection set must be empty before starting a new collection set.");
-  assert(groups_cur_length() == 0, "Collection set groups must be empty before starting a new collection set.");
+  assert(num_regions() == 0, "Collection set must be empty before starting a new collection set.");
+  assert(num_groups() == 0, "Collection set groups must be empty before starting a new collection set.");
   assert(_optional_groups.length() == 0, "Collection set optional gorups must be empty before starting a new collection set.");
 
   continue_incremental_building();
@@ -149,8 +149,8 @@ void G1CollectionSet::start() {
 void G1CollectionSet::continue_incremental_building() {
   assert(_inc_build_state == CSetBuildType::Inactive, "Precondition");
 
-  _regions_inc_part_start = regions_cur_length();
-  _groups_inc_part_start = groups_cur_length();
+  _regions_inc_part_start = num_regions();
+  _groups_inc_part_start = num_groups();
 
   DEBUG_ONLY(_inc_build_state = CSetBuildType::Active;)
 }
@@ -161,13 +161,13 @@ void G1CollectionSet::stop_incremental_building() {
 
 void G1CollectionSet::clear() {
   assert_at_safepoint_on_vm_thread();
-  _regions_cur_length = 0;
+  _num_regions = 0;
   _groups.clear();
   assert(_optional_groups.length() == 0, "must be");
 }
 
 void G1CollectionSet::iterate(G1HeapRegionClosure* cl) const {
-  size_t len = _regions_cur_length;
+  uint len = _num_regions;
   OrderAccess::loadload();
 
   for (uint i = 0; i < len; i++) {
@@ -182,7 +182,7 @@ void G1CollectionSet::iterate(G1HeapRegionClosure* cl) const {
 void G1CollectionSet::par_iterate(G1HeapRegionClosure* cl,
                                   G1HeapRegionClaimer* hr_claimer,
                                   uint worker_id) const {
-  iterate_part_from(cl, hr_claimer, 0, regions_cur_length(), worker_id);
+  iterate_part_from(cl, hr_claimer, 0, num_regions(), worker_id);
 }
 
 void G1CollectionSet::iterate_optional(G1HeapRegionClosure* cl) const {
@@ -197,13 +197,13 @@ void G1CollectionSet::iterate_optional(G1HeapRegionClosure* cl) const {
 void G1CollectionSet::iterate_incremental_part_from(G1HeapRegionClosure* cl,
                                                     G1HeapRegionClaimer* hr_claimer,
                                                     uint worker_id) const {
-  iterate_part_from(cl, hr_claimer, _regions_inc_part_start, regions_cur_increment_length(), worker_id);
+  iterate_part_from(cl, hr_claimer, _regions_inc_part_start, num_regions_in_increment(), worker_id);
 }
 
 void G1CollectionSet::iterate_part_from(G1HeapRegionClosure* cl,
                                         G1HeapRegionClaimer* hr_claimer,
-                                        size_t offset,
-                                        size_t length,
+                                        uint offset,
+                                        uint length,
                                         uint worker_id) const {
   _g1h->par_iterate_regions_array(cl,
                                   hr_claimer,
@@ -223,17 +223,17 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   // Synchronize with the region attribute table.
   _g1h->register_young_region_with_region_attr(hr);
 
-  uint length = regions_cur_length();
+  uint index = num_regions();
   // We use UINT_MAX as "invalid" marker in verification.
-  assert(length < (UINT_MAX - 1), "Collection set is too large with %u entries", length);
-  hr->set_young_index_in_cset(length + 1);
+  assert(index < (UINT_MAX - 1), "Collection set is too large with %u entries", index);
+  hr->set_young_index_in_cset(index + 1);
 
-  assert(length < _regions_max_length, "Collection set larger than maximum allowed.");
-  _regions[length++] = hr->hrm_index();
+  assert(index < _max_regions, "Collection set larger than maximum allowed.");
+  _regions[index++] = hr->hrm_index();
   // Concurrent readers must observe the store of the value in the array before an
-  // update to the length field.
+  // update to the counts field.
   OrderAccess::storestore();
-  _regions_cur_length++;
+  _num_regions++;
 }
 
 void G1CollectionSet::add_survivor_regions(G1HeapRegion* hr) {
@@ -337,7 +337,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 
   uint eden_region_length = _g1h->eden_regions_count();
   uint survivor_region_length = survivors->length();
-  init_region_lengths(eden_region_length, survivor_region_length);
+  init_region_counts(eden_region_length, survivor_region_length);
 
   verify_young_cset_indices();
 
@@ -633,7 +633,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
                             predicted_initial_time_ms, predicted_optional_time_ms, time_remaining_ms, optional_time_remaining_ms);
 }
 
-double G1CollectionSet::select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected) {
+double G1CollectionSet::select_candidates_from_optional_groups(double time_remaining_ms, uint& num_groups_selected) {
 
   assert(_optional_groups.num_regions() > 0,
          "Should only be called when there are optional regions");
@@ -652,14 +652,14 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
     total_prediction_ms += predicted_time_ms;
     time_remaining_ms -= predicted_time_ms;
 
-    num_regions_selected += group->length();
+    num_groups_selected += group->length();
 
     add_group_to_collection_set(group);
     selected.append(group);
   }
 
   log_debug(gc, ergo, cset)("Completed with groups, selected %u region in %u groups",
-                            num_regions_selected, selected.length());
+                            num_groups_selected, selected.length());
   // Remove selected groups from candidate list.
   if (selected.length() > 0) {
     _optional_groups.remove(&selected);
@@ -757,7 +757,7 @@ class G1VerifyYoungCSetIndicesClosure : public G1HeapRegionClosure {
   uint _young_length;
   uint* _heap_region_indices;
 public:
-  G1VerifyYoungCSetIndicesClosure(size_t young_length) : G1HeapRegionClosure(), _young_length(young_length) {
+  G1VerifyYoungCSetIndicesClosure(uint young_length) : G1HeapRegionClosure(), _young_length(young_length) {
     _heap_region_indices = NEW_C_HEAP_ARRAY(uint, young_length + 1, mtGC);
     for (uint i = 0; i < young_length + 1; i++) {
       _heap_region_indices[i] = UINT_MAX;
@@ -786,7 +786,7 @@ public:
 void G1CollectionSet::verify_young_cset_indices() const {
   assert_at_safepoint_on_vm_thread();
 
-  G1VerifyYoungCSetIndicesClosure cl(regions_cur_length());
+  G1VerifyYoungCSetIndicesClosure cl(num_regions());
   iterate(&cl);
 }
 #endif

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -62,9 +62,9 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
   _max_regions(0),
   _num_regions(0),
   _groups(),
-  _eden_region_count(0),
-  _survivor_region_count(0),
-  _initial_old_region_count(0),
+  _num_eden_regions(0),
+  _num_survivor_regions(0),
+  _num_initial_old_regions(0),
   _optional_groups(),
   DEBUG_ONLY(_inc_build_state(CSetBuildType::Inactive) COMMA)
   _regions_inc_part_start(0),
@@ -76,17 +76,17 @@ G1CollectionSet::~G1CollectionSet() {
   abandon_all_candidates();
 }
 
-void G1CollectionSet::init_region_counts(uint eden_cset_region_count,
-                                         uint survivor_cset_region_count) {
+void G1CollectionSet::init_regions_nums(uint num_eden_cset_regions,
+                                        uint num_survivor_cset_regions) {
   assert_at_safepoint_on_vm_thread();
 
-  _eden_region_count     = eden_cset_region_count;
-  _survivor_region_count = survivor_cset_region_count;
+  _num_eden_regions     = num_eden_cset_regions;
+  _num_survivor_regions = num_survivor_cset_regions;
 
-  assert(young_region_count() == num_regions(),
-         "Young region count %u should match collection set region count %u", young_region_count(), num_regions());
+  assert(num_young_regions() == num_regions(),
+         "Young region amount %u should match collection set region amount %u", num_young_regions(), num_regions());
 
-  _initial_old_region_count = 0;
+  _num_initial_old_regions = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
   _optional_groups.clear();
 }
@@ -109,7 +109,7 @@ void G1CollectionSet::abandon() {
 
 void G1CollectionSet::abandon_all_candidates() {
   _candidates.clear();
-  _initial_old_region_count = 0;
+  _num_initial_old_regions = 0;
 }
 
 void G1CollectionSet::prepare_for_scan () {
@@ -130,7 +130,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   assert(num_regions() < _max_regions, "Collection set now larger than maximum size.");
   _regions[_num_regions++] = hr->hrm_index();
-  _initial_old_region_count++;
+  _num_initial_old_regions++;
 
   _g1h->old_set_remove(hr);
 }
@@ -336,9 +336,9 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   // pause are appended to the RHS of the young list, i.e.
   //   [Newly Young Regions ++ Survivors from last pause].
 
-  uint eden_region_count = _g1h->eden_regions_count();
-  uint survivor_region_count = survivors->length();
-  init_region_counts(eden_region_count, survivor_region_count);
+  uint num_eden_regions = _g1h->eden_regions_count();
+  uint num_survivor_regions = survivors->length();
+  init_regions_nums(num_eden_regions, num_survivor_regions);
 
   verify_young_cset_indices();
 
@@ -346,13 +346,13 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   double predicted_base_time_ms = _policy->predict_base_time_ms(pending_cards, card_rs_length);
   // Base time already includes the whole remembered set related time, so do not add that here
   // again.
-  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_region_count) +
-                               _policy->predict_eden_copy_time_ms(eden_region_count);
+  double predicted_eden_time = _policy->predict_young_region_other_time_ms(num_eden_regions) +
+                               _policy->predict_eden_copy_time_ms(num_eden_regions);
   double remaining_time_ms = MAX2(target_pause_time_ms - (predicted_base_time_ms + predicted_eden_time), 0.0);
 
   log_trace(gc, ergo, cset)("Added young regions to CSet. Eden: %u regions, Survivors: %u regions, "
                             "predicted eden time: %1.2fms, predicted base time: %1.2fms, target pause time: %1.2fms, remaining time: %1.2fms",
-                            eden_region_count, survivor_region_count,
+                            num_eden_regions, num_survivor_regions,
                             predicted_eden_time, predicted_base_time_ms, target_pause_time_ms, remaining_time_ms);
 
   // Clear the fields that point to the survivor list - they are all young now.
@@ -670,8 +670,8 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
 }
 
 uint G1CollectionSet::select_optional_groups(double time_remaining_ms) {
-  uint optional_regions_count = num_optional_regions();
-  assert(optional_regions_count > 0,
+  uint total_optional_regions = total_optional_regions();
+  assert(total_optional_regions > 0,
          "Should only be called when there are optional regions");
 
   uint num_regions_selected = 0;
@@ -679,7 +679,7 @@ uint G1CollectionSet::select_optional_groups(double time_remaining_ms) {
   double total_prediction_ms = select_candidates_from_optional_groups(time_remaining_ms, num_regions_selected);
 
   log_debug(gc, ergo, cset)("Prepared %u regions out of %u for optional evacuation. Total predicted time: %.3fms",
-                            num_regions_selected, optional_regions_count, total_prediction_ms);
+                            num_regions_selected, total_optional_regions, total_prediction_ms);
 
   return num_regions_selected;
 }

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -83,8 +83,8 @@ void G1CollectionSet::init_region_lengths(uint eden_cset_region_length,
   _eden_region_length     = eden_cset_region_length;
   _survivor_region_length = survivor_cset_region_length;
 
-  assert((size_t)young_region_length() == _regions_cur_length,
-         "Young region length %u should match collection set length %u", young_region_length(), _regions_cur_length);
+  assert(young_region_length() == regions_cur_length(),
+         "Young region length %u should match collection set length %u", young_region_length(), regions_cur_length());
 
   _initial_old_region_length = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
@@ -128,15 +128,15 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   _g1h->register_old_collection_set_region_with_region_attr(hr);
 
-  assert(_regions_cur_length < _regions_max_length, "Collection set now larger than maximum size.");
-  _regions[_regions_cur_length++] = hr->hrm_index();
+  assert(regions_cur_length() < _regions_max_length, "Collection set now larger than maximum size.");
+  _regions[_regions_cur_length.] = hr->hrm_index();
   _initial_old_region_length++;
 
   _g1h->old_set_remove(hr);
 }
 
 void G1CollectionSet::start() {
-  assert(_regions_cur_length == 0, "Collection set must be empty before starting a new collection set.");
+  assert(regions_cur_length() == 0, "Collection set must be empty before starting a new collection set.");
   assert(groups_cur_length() == 0, "Collection set groups must be empty before starting a new collection set.");
   assert(_optional_groups.length() == 0, "Collection set optional gorups must be empty before starting a new collection set.");
 
@@ -149,7 +149,7 @@ void G1CollectionSet::start() {
 void G1CollectionSet::continue_incremental_building() {
   assert(_inc_build_state == CSetBuildType::Inactive, "Precondition");
 
-  _regions_inc_part_start = _regions_cur_length;
+  _regions_inc_part_start = regions_cur_length();
   _groups_inc_part_start = groups_cur_length();
 
   DEBUG_ONLY(_inc_build_state = CSetBuildType::Active;)
@@ -223,13 +223,13 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   // Synchronize with the region attribute table.
   _g1h->register_young_region_with_region_attr(hr);
 
+  uint length = regions_cur_length();
   // We use UINT_MAX as "invalid" marker in verification.
-  assert(_regions_cur_length < (UINT_MAX - 1),
-         "Collection set is too large with %u entries", _regions_cur_length);
-  hr->set_young_index_in_cset(_regions_cur_length + 1);
+  assert(length < (UINT_MAX - 1), "Collection set is too large with %u entries", length);
+  hr->set_young_index_in_cset(length + 1);
 
-  assert(_regions_cur_length < _regions_max_length, "Collection set larger than maximum allowed.");
-  _regions[_regions_cur_length] = hr->hrm_index();
+  assert(length < _regions_max_length, "Collection set larger than maximum allowed.");
+  _regions[length++] = hr->hrm_index();
   // Concurrent readers must observe the store of the value in the array before an
   // update to the length field.
   OrderAccess::storestore();
@@ -754,13 +754,12 @@ void G1CollectionSet::abandon_optional_collection_set(G1ParScanThreadStateSet* p
 
 #ifdef ASSERT
 class G1VerifyYoungCSetIndicesClosure : public G1HeapRegionClosure {
-private:
-  size_t _young_length;
+  uint _young_length;
   uint* _heap_region_indices;
 public:
   G1VerifyYoungCSetIndicesClosure(size_t young_length) : G1HeapRegionClosure(), _young_length(young_length) {
     _heap_region_indices = NEW_C_HEAP_ARRAY(uint, young_length + 1, mtGC);
-    for (size_t i = 0; i < young_length + 1; i++) {
+    for (uint i = 0; i < young_length + 1; i++) {
       _heap_region_indices[i] = UINT_MAX;
     }
   }
@@ -787,7 +786,7 @@ public:
 void G1CollectionSet::verify_young_cset_indices() const {
   assert_at_safepoint_on_vm_thread();
 
-  G1VerifyYoungCSetIndicesClosure cl(_regions_cur_length);
+  G1VerifyYoungCSetIndicesClosure cl(regions_cur_length());
   iterate(&cl);
 }
 #endif

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -77,7 +77,7 @@ G1CollectionSet::~G1CollectionSet() {
 }
 
 void G1CollectionSet::init_regions_counts(uint eden_cset_regions_count,
-                                         uint survivor_cset_regions_count) {
+                                          uint survivor_cset_regions_count) {
   assert_at_safepoint_on_vm_thread();
 
   _eden_regions_count     = eden_cset_regions_count;

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -62,9 +62,9 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
   _max_regions(0),
   _num_regions(0),
   _groups(),
-  _eden_region_count(0),
-  _survivor_region_count(0),
-  _initial_old_region_count(0),
+  _eden_regions_count(0),
+  _survivor_regions_count(0),
+  _initial_old_regions_count(0),
   _optional_groups(),
   DEBUG_ONLY(_inc_build_state(CSetBuildType::Inactive) COMMA)
   _regions_inc_part_start(0),
@@ -76,17 +76,17 @@ G1CollectionSet::~G1CollectionSet() {
   abandon_all_candidates();
 }
 
-void G1CollectionSet::init_region_counts(uint eden_cset_region_count,
-                                         uint survivor_cset_region_count) {
+void G1CollectionSet::init_regions_counts(uint eden_cset_regions_count,
+                                         uint survivor_cset_regions_count) {
   assert_at_safepoint_on_vm_thread();
 
-  _eden_region_count     = eden_cset_region_count;
-  _survivor_region_count = survivor_cset_region_count;
+  _eden_regions_count     = eden_cset_regions_count;
+  _survivor_regions_count = survivor_cset_regions_count;
 
-  assert(young_region_count() == num_regions(),
-         "Young region count %u should match collection set region count %u", young_region_count(), num_regions());
+  assert(young_regions_count() == num_regions(),
+         "Young region count %u should match collection set region count %u", young_regions_count(), num_regions());
 
-  _initial_old_region_count = 0;
+  _initial_old_regions_count = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
   _optional_groups.clear();
 }
@@ -109,7 +109,7 @@ void G1CollectionSet::abandon() {
 
 void G1CollectionSet::abandon_all_candidates() {
   _candidates.clear();
-  _initial_old_region_count = 0;
+  _initial_old_regions_count = 0;
 }
 
 void G1CollectionSet::prepare_for_scan () {
@@ -130,7 +130,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   assert(num_regions() < _max_regions, "Collection set now larger than maximum size.");
   _regions[_num_regions++] = hr->hrm_index();
-  _initial_old_region_count++;
+  _initial_old_regions_count++;
 
   _g1h->old_set_remove(hr);
 }
@@ -335,9 +335,9 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   // pause are appended to the RHS of the young list, i.e.
   //   [Newly Young Regions ++ Survivors from last pause].
 
-  uint eden_region_count = _g1h->eden_regions_count();
-  uint survivor_region_count = survivors->length();
-  init_region_counts(eden_region_count, survivor_region_count);
+  uint eden_regions_count = _g1h->eden_regions_count();
+  uint survivor_regions_count = survivors->length();
+  init_regions_counts(eden_regions_count, survivor_regions_count);
 
   verify_young_cset_indices();
 
@@ -345,13 +345,13 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   double predicted_base_time_ms = _policy->predict_base_time_ms(pending_cards, card_rs_length);
   // Base time already includes the whole remembered set related time, so do not add that here
   // again.
-  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_region_count) +
-                               _policy->predict_eden_copy_time_ms(eden_region_count);
+  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_regions_count) +
+                               _policy->predict_eden_copy_time_ms(eden_regions_count);
   double remaining_time_ms = MAX2(target_pause_time_ms - (predicted_base_time_ms + predicted_eden_time), 0.0);
 
   log_trace(gc, ergo, cset)("Added young regions to CSet. Eden: %u regions, Survivors: %u regions, "
                             "predicted eden time: %1.2fms, predicted base time: %1.2fms, target pause time: %1.2fms, remaining time: %1.2fms",
-                            eden_region_count, survivor_region_count,
+                            eden_regions_count, survivor_regions_count,
                             predicted_eden_time, predicted_base_time_ms, target_pause_time_ms, remaining_time_ms);
 
   // Clear the fields that point to the survivor list - they are all young now.

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -84,7 +84,7 @@ void G1CollectionSet::init_region_counts(uint eden_cset_region_count,
   _survivor_region_count = survivor_cset_region_count;
 
   assert(young_region_count() == num_regions(),
-         "Young region count %u should match collection set region number %u", young_region_count(), num_regions());
+         "Young region count %u should match collection set region count %u", young_region_count(), num_regions());
 
   _initial_old_region_count = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
@@ -138,7 +138,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 void G1CollectionSet::start() {
   assert(num_regions() == 0, "Collection set must be empty before starting a new collection set.");
   assert(num_groups() == 0, "Collection set groups must be empty before starting a new collection set.");
-  assert(_optional_groups.length() == 0, "Collection set optional gorups must be empty before starting a new collection set.");
+  assert(_optional_groups.length() == 0, "Collection set optional group must be empty before starting a new collection set.");
 
   continue_incremental_building();
 
@@ -231,7 +231,7 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   assert(index < _max_regions, "Collection set larger than maximum allowed.");
   _regions[index++] = hr->hrm_index();
   // Concurrent readers must observe the store of the value in the array before an
-  // update to the counts field.
+  // update to the _num_regions field.
   OrderAccess::storestore();
   _num_regions++;
 }
@@ -754,12 +754,12 @@ void G1CollectionSet::abandon_optional_collection_set(G1ParScanThreadStateSet* p
 
 #ifdef ASSERT
 class G1VerifyYoungCSetIndicesClosure : public G1HeapRegionClosure {
-  uint _young_length;
+  uint _num_young_regions;
   uint* _heap_region_indices;
 public:
-  G1VerifyYoungCSetIndicesClosure(uint young_length) : G1HeapRegionClosure(), _young_length(young_length) {
-    _heap_region_indices = NEW_C_HEAP_ARRAY(uint, young_length + 1, mtGC);
-    for (uint i = 0; i < young_length + 1; i++) {
+  G1VerifyYoungCSetIndicesClosure(uint num_young_regions) : G1HeapRegionClosure(), _num_young_regions(num_young_regions) {
+    _heap_region_indices = NEW_C_HEAP_ARRAY(uint, num_young_regions + 1, mtGC);
+    for (uint i = 0; i < num_young_regions + 1; i++) {
       _heap_region_indices[i] = UINT_MAX;
     }
   }
@@ -770,8 +770,9 @@ public:
   virtual bool do_heap_region(G1HeapRegion* r) {
     const uint idx = r->young_index_in_cset();
 
-    assert(idx > 0, "Young index must be set for all regions in the incremental collection set but is not for region %u.", r->hrm_index());
-    assert(idx <= _young_length, "Young cset index %u too large for region %u", idx, r->hrm_index());
+    assert(r->is_young(), "must be, but region %u is not", r->hrm_index());
+    assert(idx > 0, "Young index must be set for all regions in the collection set but is not for region %u.", r->hrm_index());
+    assert(idx <= _num_young_regions, "Young cset index %u too large for region %u", idx, r->hrm_index());
 
     assert(_heap_region_indices[idx] == UINT_MAX,
            "Index %d used by multiple regions, first use by region %u, second by region %u",

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -182,7 +182,7 @@ void G1CollectionSet::iterate(G1HeapRegionClosure* cl) const {
 void G1CollectionSet::par_iterate(G1HeapRegionClosure* cl,
                                   G1HeapRegionClaimer* hr_claimer,
                                   uint worker_id) const {
-  iterate_part_from(cl, hr_claimer, 0, cur_length(), worker_id);
+  iterate_part_from(cl, hr_claimer, 0, regions_cur_length(), worker_id);
 }
 
 void G1CollectionSet::iterate_optional(G1HeapRegionClosure* cl) const {
@@ -197,7 +197,7 @@ void G1CollectionSet::iterate_optional(G1HeapRegionClosure* cl) const {
 void G1CollectionSet::iterate_incremental_part_from(G1HeapRegionClosure* cl,
                                                     G1HeapRegionClaimer* hr_claimer,
                                                     uint worker_id) const {
-  iterate_part_from(cl, hr_claimer, _regions_inc_part_start, regions_cur_length(), worker_id);
+  iterate_part_from(cl, hr_claimer, _regions_inc_part_start, regions_cur_increment_length(), worker_id);
 }
 
 void G1CollectionSet::iterate_part_from(G1HeapRegionClosure* cl,

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -76,8 +76,8 @@ G1CollectionSet::~G1CollectionSet() {
   abandon_all_candidates();
 }
 
-void G1CollectionSet::init_regions_counts(uint eden_cset_regions_count,
-                                          uint survivor_cset_regions_count) {
+void G1CollectionSet::init_region_counts(uint eden_cset_regions_count,
+                                         uint survivor_cset_regions_count) {
   assert_at_safepoint_on_vm_thread();
 
   _eden_regions_count     = eden_cset_regions_count;
@@ -138,7 +138,8 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 void G1CollectionSet::start() {
   assert(num_regions() == 0, "Collection set must be empty before starting a new collection set.");
   assert(num_groups() == 0, "Collection set groups must be empty before starting a new collection set.");
-  assert(_optional_groups.length() == 0, "Collection set optional group must be empty before starting a new collection set.");
+  assert(_optional_groups.length() == 0,
+         "Collection set optional groups must be empty before starting a new collection set.");
 
   continue_incremental_building();
 
@@ -229,7 +230,7 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   hr->set_young_index_in_cset(index + 1);
 
   assert(index < _max_regions, "Collection set larger than maximum allowed.");
-  _regions[index++] = hr->hrm_index();
+  _regions[index] = hr->hrm_index();
   // Concurrent readers must observe the store of the value in the array before an
   // update to the _num_regions field.
   OrderAccess::storestore();
@@ -337,7 +338,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 
   uint eden_regions_count = _g1h->eden_regions_count();
   uint survivor_regions_count = survivors->length();
-  init_regions_counts(eden_regions_count, survivor_regions_count);
+  init_region_counts(eden_regions_count, survivor_regions_count);
 
   verify_young_cset_indices();
 

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -84,7 +84,7 @@ void G1CollectionSet::init_region_counts(uint eden_cset_region_count,
   _survivor_region_count = survivor_cset_region_count;
 
   assert(young_region_count() == num_regions(),
-         "Young region length %u should match collection set length %u", young_region_count(), num_regions());
+         "Young region count %u should match collection set region number %u", young_region_count(), num_regions());
 
   _initial_old_region_count = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
@@ -335,9 +335,9 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   // pause are appended to the RHS of the young list, i.e.
   //   [Newly Young Regions ++ Survivors from last pause].
 
-  uint eden_region_length = _g1h->eden_regions_count();
-  uint survivor_region_length = survivors->length();
-  init_region_counts(eden_region_length, survivor_region_length);
+  uint eden_region_count = _g1h->eden_regions_count();
+  uint survivor_region_count = survivors->length();
+  init_region_counts(eden_region_count, survivor_region_count);
 
   verify_young_cset_indices();
 
@@ -345,13 +345,13 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   double predicted_base_time_ms = _policy->predict_base_time_ms(pending_cards, card_rs_length);
   // Base time already includes the whole remembered set related time, so do not add that here
   // again.
-  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_region_length) +
-                               _policy->predict_eden_copy_time_ms(eden_region_length);
+  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_region_count) +
+                               _policy->predict_eden_copy_time_ms(eden_region_count);
   double remaining_time_ms = MAX2(target_pause_time_ms - (predicted_base_time_ms + predicted_eden_time), 0.0);
 
   log_trace(gc, ergo, cset)("Added young regions to CSet. Eden: %u regions, Survivors: %u regions, "
                             "predicted eden time: %1.2fms, predicted base time: %1.2fms, target pause time: %1.2fms, remaining time: %1.2fms",
-                            eden_region_length, survivor_region_length,
+                            eden_region_count, survivor_region_count,
                             predicted_eden_time, predicted_base_time_ms, target_pause_time_ms, remaining_time_ms);
 
   // Clear the fields that point to the survivor list - they are all young now.
@@ -633,7 +633,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
                             predicted_initial_time_ms, predicted_optional_time_ms, time_remaining_ms, optional_time_remaining_ms);
 }
 
-double G1CollectionSet::select_candidates_from_optional_groups(double time_remaining_ms, uint& num_groups_selected) {
+double G1CollectionSet::select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected) {
 
   assert(_optional_groups.num_regions() > 0,
          "Should only be called when there are optional regions");
@@ -652,14 +652,14 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
     total_prediction_ms += predicted_time_ms;
     time_remaining_ms -= predicted_time_ms;
 
-    num_groups_selected += group->length();
+    num_regions_selected += group->length();
 
     add_group_to_collection_set(group);
     selected.append(group);
   }
 
   log_debug(gc, ergo, cset)("Completed with groups, selected %u region in %u groups",
-                            num_groups_selected, selected.length());
+                            num_regions_selected, selected.length());
   // Remove selected groups from candidate list.
   if (selected.length() > 0) {
     _optional_groups.remove(&selected);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -59,7 +59,7 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
   _policy(policy),
   _candidates(),
   _regions(nullptr),
-  _max_regions(0),
+  _max_num_regions(0),
   _num_regions(0),
   _groups(),
   _num_eden_regions(0),
@@ -91,12 +91,12 @@ void G1CollectionSet::prepare_for_collection(uint num_eden_cset_regions,
   _optional_groups.clear();
 }
 
-void G1CollectionSet::initialize(uint max_regions) {
+void G1CollectionSet::initialize(uint max_num_regions) {
   guarantee(_regions == nullptr, "Must only initialize once.");
-  _max_regions = max_regions;
-  _regions = NEW_C_HEAP_ARRAY(uint, max_regions, mtGC);
+  _max_num_regions = max_num_regions;
+  _regions = NEW_C_HEAP_ARRAY(uint, max_num_regions, mtGC);
 
-  _candidates.initialize(max_regions);
+  _candidates.initialize(max_num_regions);
 }
 
 void G1CollectionSet::abandon() {
@@ -128,7 +128,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   _g1h->register_old_collection_set_region_with_region_attr(hr);
 
-  assert(num_regions() < _max_regions, "Collection set now larger than maximum size.");
+  assert(num_regions() < _max_num_regions, "Collection set now larger than maximum size.");
   _regions[_num_regions++] = hr->hrm_index();
   _num_initial_old_regions++;
 
@@ -229,7 +229,7 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   assert(index < (UINT_MAX - 1), "Collection set is too large with %u entries", index);
   hr->set_young_index_in_cset(index + 1);
 
-  assert(index < _max_regions, "Collection set larger than maximum allowed.");
+  assert(index < _max_num_regions, "Collection set larger than maximum allowed.");
   _regions[index] = hr->hrm_index();
   // Concurrent readers must observe the store of the value in the array before an
   // update to the _num_regions field.

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -84,7 +84,7 @@ void G1CollectionSet::init_region_counts(uint eden_cset_regions_count,
   _survivor_regions_count = survivor_cset_regions_count;
 
   assert(young_regions_count() == num_regions(),
-         "Young region count %u should match collection set region count %u", young_regions_count(), num_regions());
+         "Young regions count %u should match collection set regions count %u", young_regions_count(), num_regions());
 
   _initial_old_regions_count = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -62,9 +62,9 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
   _max_regions(0),
   _num_regions(0),
   _groups(),
-  _eden_regions_count(0),
-  _survivor_regions_count(0),
-  _initial_old_regions_count(0),
+  _eden_region_count(0),
+  _survivor_region_count(0),
+  _initial_old_region_count(0),
   _optional_groups(),
   DEBUG_ONLY(_inc_build_state(CSetBuildType::Inactive) COMMA)
   _regions_inc_part_start(0),
@@ -76,17 +76,17 @@ G1CollectionSet::~G1CollectionSet() {
   abandon_all_candidates();
 }
 
-void G1CollectionSet::init_region_counts(uint eden_cset_regions_count,
-                                         uint survivor_cset_regions_count) {
+void G1CollectionSet::init_region_counts(uint eden_cset_region_count,
+                                         uint survivor_cset_region_count) {
   assert_at_safepoint_on_vm_thread();
 
-  _eden_regions_count     = eden_cset_regions_count;
-  _survivor_regions_count = survivor_cset_regions_count;
+  _eden_region_count     = eden_cset_region_count;
+  _survivor_region_count = survivor_cset_region_count;
 
-  assert(young_regions_count() == num_regions(),
-         "Young region count %u should match collection set region count %u", young_regions_count(), num_regions());
+  assert(young_region_count() == num_regions(),
+         "Young region count %u should match collection set region count %u", young_region_count(), num_regions());
 
-  _initial_old_regions_count = 0;
+  _initial_old_region_count = 0;
   assert(_optional_groups.length() == 0, "Should not have any optional groups yet");
   _optional_groups.clear();
 }
@@ -109,7 +109,7 @@ void G1CollectionSet::abandon() {
 
 void G1CollectionSet::abandon_all_candidates() {
   _candidates.clear();
-  _initial_old_regions_count = 0;
+  _initial_old_region_count = 0;
 }
 
 void G1CollectionSet::prepare_for_scan () {
@@ -130,7 +130,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   assert(num_regions() < _max_regions, "Collection set now larger than maximum size.");
   _regions[_num_regions++] = hr->hrm_index();
-  _initial_old_regions_count++;
+  _initial_old_region_count++;
 
   _g1h->old_set_remove(hr);
 }
@@ -336,9 +336,9 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   // pause are appended to the RHS of the young list, i.e.
   //   [Newly Young Regions ++ Survivors from last pause].
 
-  uint eden_regions_count = _g1h->eden_regions_count();
-  uint survivor_regions_count = survivors->length();
-  init_region_counts(eden_regions_count, survivor_regions_count);
+  uint eden_region_count = _g1h->eden_regions_count();
+  uint survivor_region_count = survivors->length();
+  init_region_counts(eden_region_count, survivor_region_count);
 
   verify_young_cset_indices();
 
@@ -346,13 +346,13 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   double predicted_base_time_ms = _policy->predict_base_time_ms(pending_cards, card_rs_length);
   // Base time already includes the whole remembered set related time, so do not add that here
   // again.
-  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_regions_count) +
-                               _policy->predict_eden_copy_time_ms(eden_regions_count);
+  double predicted_eden_time = _policy->predict_young_region_other_time_ms(eden_region_count) +
+                               _policy->predict_eden_copy_time_ms(eden_region_count);
   double remaining_time_ms = MAX2(target_pause_time_ms - (predicted_base_time_ms + predicted_eden_time), 0.0);
 
   log_trace(gc, ergo, cset)("Added young regions to CSet. Eden: %u regions, Survivors: %u regions, "
                             "predicted eden time: %1.2fms, predicted base time: %1.2fms, target pause time: %1.2fms, remaining time: %1.2fms",
-                            eden_regions_count, survivor_regions_count,
+                            eden_region_count, survivor_region_count,
                             predicted_eden_time, predicted_base_time_ms, target_pause_time_ms, remaining_time_ms);
 
   // Clear the fields that point to the survivor list - they are all young now.

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -76,8 +76,8 @@ G1CollectionSet::~G1CollectionSet() {
   abandon_all_candidates();
 }
 
-void G1CollectionSet::init_regions_nums(uint num_eden_cset_regions,
-                                        uint num_survivor_cset_regions) {
+void G1CollectionSet::prepare_for_collection(uint num_eden_cset_regions,
+                            uint num_survivor_cset_regions) {
   assert_at_safepoint_on_vm_thread();
 
   _num_eden_regions     = num_eden_cset_regions;
@@ -338,7 +338,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 
   uint num_eden_regions = _g1h->eden_regions_count();
   uint num_survivor_regions = survivors->length();
-  init_regions_nums(num_eden_regions, num_survivor_regions);
+  prepare_for_collection(num_eden_regions, num_survivor_regions);
 
   verify_young_cset_indices();
 
@@ -670,7 +670,7 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
 }
 
 uint G1CollectionSet::select_optional_groups(double time_remaining_ms) {
-  uint total_optional_regions = total_optional_regions();
+  uint total_optional_regions = num_optional_regions();
   assert(total_optional_regions > 0,
          "Should only be called when there are optional regions");
 

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -245,8 +245,8 @@ public:
 
   void prepare_for_scan();
 
-  void init_regions_counts(uint eden_cset_regions_count,
-                           uint survivor_cset_regions_count);
+  void init_region_counts(uint eden_cset_regions_count,
+                          uint survivor_cset_regions_count);
 
   // Total number of regions in the initial collection set.
   uint initial_regions_count() const { return young_regions_count() +

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -283,9 +283,9 @@ public:
   void iterate_incremental_part_from(G1HeapRegionClosure* cl, G1HeapRegionClaimer* hr_claimer, uint worker_id) const;
 
   // Returns the length of the current increment in number of regions.
-  size_t regions_cur_length() const { return _regions_cur_length - _regions_inc_part_start; }
+  size_t regions_cur_increment_length() const { return _regions_cur_length - _regions_inc_part_start; }
   // Returns the length of the whole current collection set in number of regions
-  size_t cur_length() const { return _regions_cur_length; }
+  size_t regions_cur_length() const { return _regions_cur_length; }
 
   // Iterate over the entire collection set (all increments calculated so far), applying
   // the given G1HeapRegionClosure on all of the regions.

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -140,7 +140,7 @@ class G1CollectionSet {
 
   // The actual collection set as a set of region indices.
   //
-  // All regions in _regions below _regions_cur_length are assumed to be part of the
+  // All regions in _regions below _num_regions are assumed to be part of the
   // collection set.
   // We assume that at any time there is at most only one writer and (one or more)
   // concurrent readers. This means synchronization using storestore and loadload
@@ -148,18 +148,18 @@ class G1CollectionSet {
   //
   // This corresponds to the regions referenced by the candidate groups further below.
   uint* _regions;
-  uint _regions_max_length;
+  uint _max_regions;
 
-  uint _regions_cur_length;
+  uint _num_regions;
 
   // Old gen groups selected for evacuation.
   G1CSetCandidateGroupList _groups;
 
-  uint groups_cur_length() const;
+  uint num_groups() const;
 
-  uint _eden_region_length;
-  uint _survivor_region_length;
-  uint _initial_old_region_length;
+  uint _eden_region_count;
+  uint _survivor_region_count;
+  uint _initial_old_region_count;
 
   // When doing mixed collections we can add old regions to the collection set, which
   // will be collected only if there is enough time. We call these optional (old)
@@ -218,8 +218,8 @@ class G1CollectionSet {
   // to allow for more efficient parallel iteration.
   void iterate_part_from(G1HeapRegionClosure* cl,
                          G1HeapRegionClaimer* hr_claimer,
-                         size_t offset,
-                         size_t length,
+                         uint offset,
+                         uint length,
                          uint worker_id) const;
 
   // Adds the given group to the optional groups list (_optional_groups)
@@ -234,7 +234,7 @@ public:
   ~G1CollectionSet();
 
   // Initializes the collection set giving the maximum possible length of the collection set.
-  void initialize(uint max_region_length);
+  void initialize(uint max_regions);
 
   // Drop the collection set and collection set candidates.
   void abandon();
@@ -246,26 +246,26 @@ public:
 
   void prepare_for_scan();
 
-  void init_region_lengths(uint eden_cset_region_length,
-                           uint survivor_cset_region_length);
+  void init_region_counts(uint eden_cset_region_count,
+                          uint survivor_cset_region_count);
 
-  // Total length of the initial collection set in regions.
-  uint initial_region_length() const { return young_region_length() +
-                                              initial_old_region_length(); }
-  uint young_region_length() const { return eden_region_length() +
-                                            survivor_region_length(); }
+  // Total number of regions in the initial collection set.
+  uint initial_region_count() const { return young_region_count() +
+                                             initial_old_region_count(); }
+  uint young_region_count() const { return eden_region_count() +
+                                           survivor_region_count(); }
 
-  uint eden_region_length() const { return _eden_region_length; }
-  uint survivor_region_length() const { return _survivor_region_length; }
-  uint initial_old_region_length() const { return _initial_old_region_length; }
+  uint eden_region_count() const { return _eden_region_count; }
+  uint survivor_region_count() const { return _survivor_region_count; }
+  uint initial_old_region_count() const { return _initial_old_region_count; }
   uint num_optional_regions() const { return _optional_groups.num_regions(); }
 
-  bool only_contains_young_regions() const { return (initial_old_region_length() + num_optional_regions()) == 0; }
+  bool only_contains_young_regions() const { return (initial_old_region_count() + num_optional_regions()) == 0; }
 
   template <class CardOrRangeVisitor>
   inline void merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);
 
-  uint groups_increment_length() const;
+  uint num_groups_in_increment() const;
 
   // Reset the contents of the collection set.
   void clear();
@@ -284,9 +284,9 @@ public:
   void iterate_incremental_part_from(G1HeapRegionClosure* cl, G1HeapRegionClaimer* hr_claimer, uint worker_id) const;
 
   // Returns the length of the current increment in number of regions.
-  uint regions_cur_increment_length() const { return regions_cur_length() - _regions_inc_part_start; }
+  uint num_regions_in_increment() const { return num_regions() - _regions_inc_part_start; }
   // Returns the length of the whole current collection set in number of regions
-  uint regions_cur_length() const { return _regions_cur_length; }
+  uint num_regions() const { return _num_regions; }
 
   // Iterate over the entire collection set (all increments calculated so far), applying
   // the given G1HeapRegionClosure on all of the regions.

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -156,9 +156,9 @@ class G1CollectionSet {
 
   uint num_groups() const;
 
-  uint _eden_regions_count;
-  uint _survivor_regions_count;
-  uint _initial_old_regions_count;
+  uint _eden_region_count;
+  uint _survivor_region_count;
+  uint _initial_old_region_count;
 
   // When doing mixed collections we can add old regions to the collection set, which
   // will be collected only if there is enough time. We call these optional (old)
@@ -245,21 +245,21 @@ public:
 
   void prepare_for_scan();
 
-  void init_region_counts(uint eden_cset_regions_count,
-                          uint survivor_cset_regions_count);
+  void init_region_counts(uint eden_cset_region_count,
+                          uint survivor_cset_region_count);
 
   // Total number of regions in the initial collection set.
-  uint initial_regions_count() const { return young_regions_count() +
-                                              initial_old_regions_count(); }
-  uint young_regions_count() const { return eden_regions_count() +
-                                            survivor_regions_count(); }
+  uint initial_region_count() const { return young_region_count() +
+                                             initial_old_region_count(); }
+  uint young_region_count() const { return eden_region_count() +
+                                           survivor_region_count(); }
 
-  uint eden_regions_count() const { return _eden_regions_count; }
-  uint survivor_regions_count() const { return _survivor_regions_count; }
-  uint initial_old_regions_count() const { return _initial_old_regions_count; }
+  uint eden_region_count() const { return _eden_region_count; }
+  uint survivor_region_count() const { return _survivor_region_count; }
+  uint initial_old_region_count() const { return _initial_old_region_count; }
   uint num_optional_regions() const { return _optional_groups.num_regions(); }
 
-  bool only_contains_young_regions() const { return (initial_old_regions_count() + num_optional_regions()) == 0; }
+  bool only_contains_young_regions() const { return (initial_old_region_count() + num_optional_regions()) == 0; }
 
   template <class CardOrRangeVisitor>
   inline void merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -156,9 +156,9 @@ class G1CollectionSet {
 
   uint num_groups() const;
 
-  uint _eden_region_count;
-  uint _survivor_region_count;
-  uint _initial_old_region_count;
+  uint _num_eden_regions;
+  uint _num_survivor_regions;
+  uint _num_initial_old_regions;
 
   // When doing mixed collections we can add old regions to the collection set, which
   // will be collected only if there is enough time. We call these optional (old)
@@ -245,21 +245,21 @@ public:
 
   void prepare_for_scan();
 
-  void init_region_counts(uint eden_cset_region_count,
-                          uint survivor_cset_region_count);
+  void init_regions_nums(uint num_eden_cset_regions,
+                        uint num_survivor_cset_regions);
 
   // Total number of regions in the initial collection set.
-  uint initial_region_count() const { return young_region_count() +
-                                             initial_old_region_count(); }
-  uint young_region_count() const { return eden_region_count() +
-                                           survivor_region_count(); }
+  uint num_initial_regions() const { return num_young_regions() +
+                                            num_initial_old_regions(); }
+  uint num_young_regions() const { return num_eden_regions() +
+                                          num_survivor_regions(); }
 
-  uint eden_region_count() const { return _eden_region_count; }
-  uint survivor_region_count() const { return _survivor_region_count; }
-  uint initial_old_region_count() const { return _initial_old_region_count; }
+  uint num_eden_regions() const { return _num_eden_regions; }
+  uint num_survivor_regions() const { return _num_survivor_regions; }
+  uint num_initial_old_regions() const { return _num_initial_old_regions; }
   uint num_optional_regions() const { return _optional_groups.num_regions(); }
 
-  bool only_contains_young_regions() const { return (initial_old_region_count() + num_optional_regions()) == 0; }
+  bool only_contains_young_regions() const { return (num_initial_old_regions() + num_optional_regions()) == 0; }
 
   template <class CardOrRangeVisitor>
   inline void merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -188,6 +188,9 @@ class G1CollectionSet {
   // Add the given old region to the current collection set.
   void add_old_region(G1HeapRegion* hr);
 
+  void prepare_for_collection(uint num_eden_cset_regions,
+                              uint num_survivor_cset_regions);
+
   void prepare_optional_group(G1CSetCandidateGroup* gr, uint cur_index);
 
   void add_group_to_collection_set(G1CSetCandidateGroup* gr);
@@ -244,9 +247,6 @@ public:
   const G1CollectionSetCandidates* candidates() const { return &_candidates; }
 
   void prepare_for_scan();
-
-  void init_regions_nums(uint num_eden_cset_regions,
-                        uint num_survivor_cset_regions);
 
   // Total number of regions in the initial collection set.
   uint num_initial_regions() const { return num_young_regions() +

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -26,7 +26,6 @@
 #define SHARE_GC_G1_G1COLLECTIONSET_HPP
 
 #include "gc/g1/g1CollectionSetCandidates.hpp"
-#include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -150,7 +149,7 @@ class G1CollectionSet {
   uint* _regions;
   uint _max_regions;
 
-  uint _num_regions;
+  volatile uint _num_regions;
 
   // Old gen groups selected for evacuation.
   G1CSetCandidateGroupList _groups;
@@ -202,7 +201,7 @@ class G1CollectionSet {
   // Select groups for evacuation from the optional candidates given the remaining time
   // and return the number of actually selected regions.
   uint select_optional_groups(double time_remaining_ms);
-  double select_candidates_from_optional_groups(double time_remaining_ms, uint& num_groups_selected);
+  double select_candidates_from_optional_groups(double time_remaining_ms, uint& num_regions_selected);
 
   // Finalize the young part of the initial collection set. Relabel survivor regions
   // as Eden and calculate a prediction on how long the evacuation of all young regions
@@ -233,7 +232,7 @@ public:
   G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy);
   ~G1CollectionSet();
 
-  // Initializes the collection set giving the maximum possible length of the collection set.
+  // Initializes the collection set giving the maximum possible number of regions in the collection set.
   void initialize(uint max_regions);
 
   // Drop the collection set and collection set candidates.
@@ -283,9 +282,9 @@ public:
   // from a starting position determined by the given worker id.
   void iterate_incremental_part_from(G1HeapRegionClosure* cl, G1HeapRegionClaimer* hr_claimer, uint worker_id) const;
 
-  // Returns the length of the current increment in number of regions.
+  // Returns the number of regions in the collection set current increment.
   uint num_regions_in_increment() const { return num_regions() - _regions_inc_part_start; }
-  // Returns the length of the whole current collection set in number of regions
+  // Returns the total number of regions in the current collection set.
   uint num_regions() const { return _num_regions; }
 
   // Iterate over the entire collection set (all increments calculated so far), applying

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -147,7 +147,7 @@ class G1CollectionSet {
   //
   // This corresponds to the regions referenced by the candidate groups further below.
   uint* _regions;
-  uint _max_regions;
+  uint _max_num_regions;
 
   volatile uint _num_regions;
 
@@ -236,7 +236,7 @@ public:
   ~G1CollectionSet();
 
   // Initializes the collection set giving the maximum possible number of regions in the collection set.
-  void initialize(uint max_regions);
+  void initialize(uint max_num_regions);
 
   // Drop the collection set and collection set candidates.
   void abandon();

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1COLLECTIONSET_HPP
 
 #include "gc/g1/g1CollectionSetCandidates.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -149,7 +150,7 @@ class G1CollectionSet {
   uint* _regions;
   uint _regions_max_length;
 
-  volatile uint _regions_cur_length;
+  uint _regions_cur_length;
 
   // Old gen groups selected for evacuation.
   G1CSetCandidateGroupList _groups;
@@ -174,7 +175,7 @@ class G1CollectionSet {
   CSetBuildType _inc_build_state;
 #endif
   // Index into the _regions indicating the start of the current collection set increment.
-  size_t _regions_inc_part_start;
+  uint _regions_inc_part_start;
   // Index into the _groups indicating the start of the current collection set increment.
   uint _groups_inc_part_start;
 
@@ -283,9 +284,9 @@ public:
   void iterate_incremental_part_from(G1HeapRegionClosure* cl, G1HeapRegionClaimer* hr_claimer, uint worker_id) const;
 
   // Returns the length of the current increment in number of regions.
-  size_t regions_cur_increment_length() const { return _regions_cur_length - _regions_inc_part_start; }
+  uint regions_cur_increment_length() const { return regions_cur_length() - _regions_inc_part_start; }
   // Returns the length of the whole current collection set in number of regions
-  size_t regions_cur_length() const { return _regions_cur_length; }
+  uint regions_cur_length() const { return _regions_cur_length; }
 
   // Iterate over the entire collection set (all increments calculated so far), applying
   // the given G1HeapRegionClosure on all of the regions.

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -282,7 +282,7 @@ public:
   // from a starting position determined by the given worker id.
   void iterate_incremental_part_from(G1HeapRegionClosure* cl, G1HeapRegionClaimer* hr_claimer, uint worker_id) const;
 
-  // Returns the number of regions in the collection set current increment.
+  // Returns the number of regions in the current collection set increment.
   uint num_regions_in_increment() const { return num_regions() - _regions_inc_part_start; }
   // Returns the total number of regions in the current collection set.
   uint num_regions() const { return _num_regions; }

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -156,9 +156,9 @@ class G1CollectionSet {
 
   uint num_groups() const;
 
-  uint _eden_region_count;
-  uint _survivor_region_count;
-  uint _initial_old_region_count;
+  uint _eden_regions_count;
+  uint _survivor_regions_count;
+  uint _initial_old_regions_count;
 
   // When doing mixed collections we can add old regions to the collection set, which
   // will be collected only if there is enough time. We call these optional (old)
@@ -245,21 +245,21 @@ public:
 
   void prepare_for_scan();
 
-  void init_region_counts(uint eden_cset_region_count,
-                          uint survivor_cset_region_count);
+  void init_regions_counts(uint eden_cset_regions_count,
+                           uint survivor_cset_regions_count);
 
   // Total number of regions in the initial collection set.
-  uint initial_region_count() const { return young_region_count() +
-                                             initial_old_region_count(); }
-  uint young_region_count() const { return eden_region_count() +
-                                           survivor_region_count(); }
+  uint initial_regions_count() const { return young_regions_count() +
+                                              initial_old_regions_count(); }
+  uint young_regions_count() const { return eden_regions_count() +
+                                            survivor_regions_count(); }
 
-  uint eden_region_count() const { return _eden_region_count; }
-  uint survivor_region_count() const { return _survivor_region_count; }
-  uint initial_old_region_count() const { return _initial_old_region_count; }
+  uint eden_regions_count() const { return _eden_regions_count; }
+  uint survivor_regions_count() const { return _survivor_regions_count; }
+  uint initial_old_regions_count() const { return _initial_old_regions_count; }
   uint num_optional_regions() const { return _optional_groups.num_regions(); }
 
-  bool only_contains_young_regions() const { return (initial_old_region_count() + num_optional_regions()) == 0; }
+  bool only_contains_young_regions() const { return (initial_old_regions_count() + num_optional_regions()) == 0; }
 
   template <class CardOrRangeVisitor>
   inline void merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,19 +36,19 @@ inline void G1CollectionSet::merge_cardsets_for_collection_groups(CardOrRangeVis
     G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_cset_group()->card_set(), cl);
   }
 
-  uint next_increment_length = num_groups_in_increment();
-  if (next_increment_length == 0) {
+  uint next_group_increment = num_groups_in_increment();
+  if (next_group_increment == 0) {
     return;
   }
 
-  uint start_pos = (worker_id * next_increment_length) / num_workers;
+  uint start_pos = (worker_id * next_group_increment) / num_workers;
   uint cur_pos = start_pos;
   uint count = 0;
   do {
     G1HeapRegionRemSet::iterate_for_merge(_groups.at(offset + cur_pos)->card_set(), cl);
     cur_pos++;
     count++;
-    if (cur_pos == next_increment_length) {
+    if (cur_pos == next_group_increment) {
       cur_pos = 0;
     }
   } while (cur_pos != start_pos);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
@@ -31,7 +31,7 @@
 
 template <class CardOrRangeVisitor>
 inline void G1CollectionSet::merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers) {
-  uint offset =  _groups_inc_part_start;
+  uint offset = _groups_inc_part_start;
   if (offset == 0) {
     G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_cset_group()->card_set(), cl);
   }

--- a/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
@@ -36,18 +36,16 @@ inline void G1CollectionSet::merge_cardsets_for_collection_groups(CardOrRangeVis
     G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_cset_group()->card_set(), cl);
   }
 
-  uint next_group_increment = num_groups_in_increment();
+  const uint next_group_increment = num_groups_in_increment();
   if (next_group_increment == 0) {
     return;
   }
 
   uint start_pos = (worker_id * next_group_increment) / num_workers;
   uint cur_pos = start_pos;
-  uint count = 0;
   do {
     G1HeapRegionRemSet::iterate_for_merge(_groups.at(offset + cur_pos)->card_set(), cl);
     cur_pos++;
-    count++;
     if (cur_pos == next_group_increment) {
       cur_pos = 0;
     }

--- a/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
@@ -36,7 +36,7 @@ inline void G1CollectionSet::merge_cardsets_for_collection_groups(CardOrRangeVis
     G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_cset_group()->card_set(), cl);
   }
 
-  uint next_increment_length = groups_increment_length();
+  uint next_increment_length = num_groups_in_increment();
   if (next_increment_length == 0) {
     return;
   }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -76,7 +76,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _trim_ticks(),
     _surviving_young_words_base(nullptr),
     _surviving_young_words(nullptr),
-    _surviving_words_length(collection_set->young_region_count() + 1),
+    _surviving_words_length(collection_set->young_regions_count() + 1),
     _old_gen_is_full(false),
     _partial_array_splitter(g1h->partial_array_state_manager(), num_workers),
     _string_dedup_requests(),
@@ -717,7 +717,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
     _g1h(g1h),
     _collection_set(collection_set),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, num_workers, mtGC)),
-    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_region_count() + 1, mtGC)),
+    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_regions_count() + 1, mtGC)),
     _num_workers(num_workers),
     _flushed(false),
     _evac_failure_regions(evac_failure_regions)
@@ -725,7 +725,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
   for (uint i = 0; i < num_workers; ++i) {
     _states[i] = nullptr;
   }
-  memset(_surviving_young_words_total, 0, (collection_set->young_region_count() + 1) * sizeof(size_t));
+  memset(_surviving_young_words_total, 0, (collection_set->young_regions_count() + 1) * sizeof(size_t));
 }
 
 G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -76,7 +76,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _trim_ticks(),
     _surviving_young_words_base(nullptr),
     _surviving_young_words(nullptr),
-    _surviving_words_length(collection_set->young_regions_count() + 1),
+    _surviving_words_length(collection_set->young_region_count() + 1),
     _old_gen_is_full(false),
     _partial_array_splitter(g1h->partial_array_state_manager(), num_workers),
     _string_dedup_requests(),
@@ -717,7 +717,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
     _g1h(g1h),
     _collection_set(collection_set),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, num_workers, mtGC)),
-    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_regions_count() + 1, mtGC)),
+    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_region_count() + 1, mtGC)),
     _num_workers(num_workers),
     _flushed(false),
     _evac_failure_regions(evac_failure_regions)
@@ -725,7 +725,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
   for (uint i = 0; i < num_workers; ++i) {
     _states[i] = nullptr;
   }
-  memset(_surviving_young_words_total, 0, (collection_set->young_regions_count() + 1) * sizeof(size_t));
+  memset(_surviving_young_words_total, 0, (collection_set->young_region_count() + 1) * sizeof(size_t));
 }
 
 G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -76,7 +76,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _trim_ticks(),
     _surviving_young_words_base(nullptr),
     _surviving_young_words(nullptr),
-    _surviving_words_length(collection_set->young_region_length() + 1),
+    _surviving_words_length(collection_set->young_region_count() + 1),
     _old_gen_is_full(false),
     _partial_array_splitter(g1h->partial_array_state_manager(), num_workers),
     _string_dedup_requests(),
@@ -717,7 +717,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
     _g1h(g1h),
     _collection_set(collection_set),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, num_workers, mtGC)),
-    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_region_length() + 1, mtGC)),
+    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_region_count() + 1, mtGC)),
     _num_workers(num_workers),
     _flushed(false),
     _evac_failure_regions(evac_failure_regions)
@@ -725,7 +725,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
   for (uint i = 0; i < num_workers; ++i) {
     _states[i] = nullptr;
   }
-  memset(_surviving_young_words_total, 0, (collection_set->young_region_length() + 1) * sizeof(size_t));
+  memset(_surviving_young_words_total, 0, (collection_set->young_region_count() + 1) * sizeof(size_t));
 }
 
 G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -76,7 +76,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _trim_ticks(),
     _surviving_young_words_base(nullptr),
     _surviving_young_words(nullptr),
-    _surviving_words_length(collection_set->young_region_count() + 1),
+    _surviving_words_length(collection_set->num_young_regions() + 1),
     _old_gen_is_full(false),
     _partial_array_splitter(g1h->partial_array_state_manager(), num_workers),
     _string_dedup_requests(),
@@ -717,7 +717,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
     _g1h(g1h),
     _collection_set(collection_set),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, num_workers, mtGC)),
-    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_region_count() + 1, mtGC)),
+    _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->num_young_regions() + 1, mtGC)),
     _num_workers(num_workers),
     _flushed(false),
     _evac_failure_regions(evac_failure_regions)
@@ -725,7 +725,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
   for (uint i = 0; i < num_workers; ++i) {
     _states[i] = nullptr;
   }
-  memset(_surviving_young_words_total, 0, (collection_set->young_region_count() + 1) * sizeof(size_t));
+  memset(_surviving_young_words_total, 0, (collection_set->num_young_regions() + 1) * sizeof(size_t));
 }
 
 G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -855,7 +855,7 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
     // given that humongous object allocations do not really affect
     // either the pause's duration nor when the next pause will take
     // place we can safely ignore them here.
-    uint regions_allocated = _collection_set->eden_region_count();
+    uint regions_allocated = _collection_set->eden_regions_count();
     double alloc_rate_ms = (double) regions_allocated / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
 
@@ -919,14 +919,14 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
       _analytics->report_cost_per_byte_ms(cost_per_byte_ms, is_young_only_pause);
     }
 
-    if (_collection_set->young_region_count() > 0) {
+    if (_collection_set->young_regions_count() > 0) {
       _analytics->report_young_other_cost_per_region_ms(young_other_time_ms() /
-                                                        _collection_set->young_region_count());
+                                                        _collection_set->young_regions_count());
     }
 
-    if (_collection_set->initial_old_region_count() > 0) {
+    if (_collection_set->initial_old_regions_count() > 0) {
       _analytics->report_non_young_other_cost_per_region_ms(non_young_other_time_ms() /
-                                                            _collection_set->initial_old_region_count());
+                                                            _collection_set->initial_old_regions_count());
     }
 
     _analytics->report_constant_other_time_ms(constant_other_time_ms(pause_time_ms));

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -849,8 +849,8 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
   if (update_stats) {
     // We maintain the invariant that all objects allocated by mutator
     // threads will be allocated out of eden regions. So, we can use
-    // the eden region number allocated since the previous GC to
-    // calculate the application's allocate rate. The only exception
+    // the number of eden regions allocated since the previous GC to
+    // calculate the application's allocation rate. The only exception
     // to that is humongous objects that are allocated separately. But
     // given that humongous object allocations do not really affect
     // either the pause's duration nor when the next pause will take

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -855,7 +855,7 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
     // given that humongous object allocations do not really affect
     // either the pause's duration nor when the next pause will take
     // place we can safely ignore them here.
-    uint regions_allocated = _collection_set->eden_regions_count();
+    uint regions_allocated = _collection_set->eden_region_count();
     double alloc_rate_ms = (double) regions_allocated / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
 
@@ -919,14 +919,14 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
       _analytics->report_cost_per_byte_ms(cost_per_byte_ms, is_young_only_pause);
     }
 
-    if (_collection_set->young_regions_count() > 0) {
+    if (_collection_set->young_region_count() > 0) {
       _analytics->report_young_other_cost_per_region_ms(young_other_time_ms() /
-                                                        _collection_set->young_regions_count());
+                                                        _collection_set->young_region_count());
     }
 
-    if (_collection_set->initial_old_regions_count() > 0) {
+    if (_collection_set->initial_old_region_count() > 0) {
       _analytics->report_non_young_other_cost_per_region_ms(non_young_other_time_ms() /
-                                                            _collection_set->initial_old_regions_count());
+                                                            _collection_set->initial_old_region_count());
     }
 
     _analytics->report_constant_other_time_ms(constant_other_time_ms(pause_time_ms));

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -855,7 +855,7 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
     // given that humongous object allocations do not really affect
     // either the pause's duration nor when the next pause will take
     // place we can safely ignore them here.
-    uint regions_allocated = _collection_set->eden_region_count();
+    uint regions_allocated = _collection_set->num_eden_regions();
     double alloc_rate_ms = (double) regions_allocated / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
 
@@ -919,14 +919,14 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
       _analytics->report_cost_per_byte_ms(cost_per_byte_ms, is_young_only_pause);
     }
 
-    if (_collection_set->young_region_count() > 0) {
+    if (_collection_set->num_young_regions() > 0) {
       _analytics->report_young_other_cost_per_region_ms(young_other_time_ms() /
-                                                        _collection_set->young_region_count());
+                                                        _collection_set->num_young_regions());
     }
 
-    if (_collection_set->initial_old_region_count() > 0) {
+    if (_collection_set->num_initial_old_regions() > 0) {
       _analytics->report_non_young_other_cost_per_region_ms(non_young_other_time_ms() /
-                                                            _collection_set->initial_old_region_count());
+                                                            _collection_set->num_initial_old_regions());
     }
 
     _analytics->report_constant_other_time_ms(constant_other_time_ms(pause_time_ms));

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -855,7 +855,7 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
     // given that humongous object allocations do not really affect
     // either the pause's duration nor when the next pause will take
     // place we can safely ignore them here.
-    uint regions_allocated = _collection_set->eden_region_length();
+    uint regions_allocated = _collection_set->eden_region_count();
     double alloc_rate_ms = (double) regions_allocated / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
 
@@ -919,14 +919,14 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
       _analytics->report_cost_per_byte_ms(cost_per_byte_ms, is_young_only_pause);
     }
 
-    if (_collection_set->young_region_length() > 0) {
+    if (_collection_set->young_region_count() > 0) {
       _analytics->report_young_other_cost_per_region_ms(young_other_time_ms() /
-                                                        _collection_set->young_region_length());
+                                                        _collection_set->young_region_count());
     }
 
-    if (_collection_set->initial_old_region_length() > 0) {
+    if (_collection_set->initial_old_region_count() > 0) {
       _analytics->report_non_young_other_cost_per_region_ms(non_young_other_time_ms() /
-                                                            _collection_set->initial_old_region_length());
+                                                            _collection_set->initial_old_region_count());
     }
 
     _analytics->report_constant_other_time_ms(constant_other_time_ms(pause_time_ms));

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1232,7 +1232,7 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
   {
     WorkerThreads* workers = g1h->workers();
 
-    size_t const increment_length = g1h->collection_set()->groups_increment_length();
+    size_t const increment_length = g1h->collection_set()->num_groups_in_increment();
 
     uint const num_workers = initial_evacuation ? workers->active_workers() :
                                                   MIN2(workers->active_workers(), (uint)increment_length);

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1232,14 +1232,14 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
   {
     WorkerThreads* workers = g1h->workers();
 
-    size_t const increment_length = g1h->collection_set()->num_groups_in_increment();
+    uint const num_groups_in_increment = g1h->collection_set()->num_groups_in_increment();
 
     uint const num_workers = initial_evacuation ? workers->active_workers() :
-                                                  MIN2(workers->active_workers(), (uint)increment_length);
+                                                  MIN2(workers->active_workers(), num_groups_in_increment);
 
     G1MergeHeapRootsTask cl(_scan_state, num_workers, initial_evacuation);
-    log_debug(gc, ergo)("Running %s using %u workers for %zu regions",
-                        cl.name(), num_workers, increment_length);
+    log_debug(gc, ergo)("Running %s using %u workers for %u groups",
+                        cl.name(), num_workers, num_groups_in_increment);
     workers->run_task(&cl, num_workers);
   }
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -260,7 +260,7 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
   allocator()->release_mutator_alloc_regions();
 
   collection_set()->finalize_initial_collection_set(target_pause_time_ms, survivor_regions());
-  evacuation_info->set_collection_set_regions(collection_set()->initial_region_count() +
+  evacuation_info->set_collection_set_regions(collection_set()->num_initial_regions() +
                                               collection_set()->num_optional_regions());
 
   concurrent_mark()->verify_no_collection_set_oops();

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -260,7 +260,7 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
   allocator()->release_mutator_alloc_regions();
 
   collection_set()->finalize_initial_collection_set(target_pause_time_ms, survivor_regions());
-  evacuation_info->set_collection_set_regions(collection_set()->initial_region_count() +
+  evacuation_info->set_collection_set_regions(collection_set()->initial_regions_count() +
                                               collection_set()->num_optional_regions());
 
   concurrent_mark()->verify_no_collection_set_oops();

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -260,7 +260,7 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
   allocator()->release_mutator_alloc_regions();
 
   collection_set()->finalize_initial_collection_set(target_pause_time_ms, survivor_regions());
-  evacuation_info->set_collection_set_regions(collection_set()->initial_regions_count() +
+  evacuation_info->set_collection_set_regions(collection_set()->initial_region_count() +
                                               collection_set()->num_optional_regions());
 
   concurrent_mark()->verify_no_collection_set_oops();

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -260,7 +260,7 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
   allocator()->release_mutator_alloc_regions();
 
   collection_set()->finalize_initial_collection_set(target_pause_time_ms, survivor_regions());
-  evacuation_info->set_collection_set_regions(collection_set()->initial_region_length() +
+  evacuation_info->set_collection_set_regions(collection_set()->initial_region_count() +
                                               collection_set()->num_optional_regions());
 
   concurrent_mark()->verify_no_collection_set_oops();

--- a/src/hotspot/share/gc/g1/g1YoungGCAllocationFailureInjector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCAllocationFailureInjector.cpp
@@ -56,7 +56,7 @@ G1YoungGCAllocationFailureInjector::G1YoungGCAllocationFailureInjector()
 void G1YoungGCAllocationFailureInjector::select_allocation_failure_regions() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   _allocation_failure_regions.reinitialize(g1h->max_num_regions());
-  SelectAllocationFailureRegionClosure closure(_allocation_failure_regions, g1h->collection_set()->cur_length());
+  SelectAllocationFailureRegionClosure closure(_allocation_failure_regions, g1h->collection_set()->regions_cur_length());
   g1h->collection_set_iterate_all(&closure);
 }
 

--- a/src/hotspot/share/gc/g1/g1YoungGCAllocationFailureInjector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCAllocationFailureInjector.cpp
@@ -56,7 +56,7 @@ G1YoungGCAllocationFailureInjector::G1YoungGCAllocationFailureInjector()
 void G1YoungGCAllocationFailureInjector::select_allocation_failure_regions() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   _allocation_failure_regions.reinitialize(g1h->max_num_regions());
-  SelectAllocationFailureRegionClosure closure(_allocation_failure_regions, g1h->collection_set()->regions_cur_length());
+  SelectAllocationFailureRegionClosure closure(_allocation_failure_regions, g1h->collection_set()->num_regions());
   g1h->collection_set_iterate_all(&closure);
 }
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -649,9 +649,9 @@ class FreeCSetClosure : public G1HeapRegionClosure {
 
   void assert_tracks_surviving_words(G1HeapRegion* r) {
     assert(r->young_index_in_cset() != 0 &&
-           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_regions_count(),
+           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_region_count(),
            "Young index %u is wrong for region %u of type %s with %u young regions",
-           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_regions_count());
+           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_region_count());
   }
 
   void handle_evacuated_region(G1HeapRegion* r) {
@@ -810,7 +810,7 @@ public:
     p->record_serial_free_cset_time_ms((Ticks::now() - serial_time).seconds() * 1000.0);
   }
 
-  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_regions_count(); }
+  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_region_count(); }
 
   void set_max_workers(uint max_workers) override {
     _active_workers = max_workers;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -649,9 +649,9 @@ class FreeCSetClosure : public G1HeapRegionClosure {
 
   void assert_tracks_surviving_words(G1HeapRegion* r) {
     assert(r->young_index_in_cset() != 0 &&
-           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_region_count(),
+           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_regions_count(),
            "Young index %u is wrong for region %u of type %s with %u young regions",
-           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_region_count());
+           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_regions_count());
   }
 
   void handle_evacuated_region(G1HeapRegion* r) {
@@ -810,7 +810,7 @@ public:
     p->record_serial_free_cset_time_ms((Ticks::now() - serial_time).seconds() * 1000.0);
   }
 
-  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_region_count(); }
+  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_regions_count(); }
 
   void set_max_workers(uint max_workers) override {
     _active_workers = max_workers;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -649,9 +649,9 @@ class FreeCSetClosure : public G1HeapRegionClosure {
 
   void assert_tracks_surviving_words(G1HeapRegion* r) {
     assert(r->young_index_in_cset() != 0 &&
-           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_region_count(),
+           (uint)r->young_index_in_cset() <= _g1h->collection_set()->num_young_regions(),
            "Young index %u is wrong for region %u of type %s with %u young regions",
-           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_region_count());
+           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->num_young_regions());
   }
 
   void handle_evacuated_region(G1HeapRegion* r) {
@@ -810,7 +810,7 @@ public:
     p->record_serial_free_cset_time_ms((Ticks::now() - serial_time).seconds() * 1000.0);
   }
 
-  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_region_count(); }
+  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->num_initial_regions(); }
 
   void set_max_workers(uint max_workers) override {
     _active_workers = max_workers;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -649,9 +649,9 @@ class FreeCSetClosure : public G1HeapRegionClosure {
 
   void assert_tracks_surviving_words(G1HeapRegion* r) {
     assert(r->young_index_in_cset() != 0 &&
-           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_region_length(),
+           (uint)r->young_index_in_cset() <= _g1h->collection_set()->young_region_count(),
            "Young index %u is wrong for region %u of type %s with %u young regions",
-           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_region_length());
+           r->young_index_in_cset(), r->hrm_index(), r->get_type_str(), _g1h->collection_set()->young_region_count());
   }
 
   void handle_evacuated_region(G1HeapRegion* r) {
@@ -810,7 +810,7 @@ public:
     p->record_serial_free_cset_time_ms((Ticks::now() - serial_time).seconds() * 1000.0);
   }
 
-  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_region_length(); }
+  double worker_cost() const override { return G1CollectedHeap::heap()->collection_set()->initial_region_count(); }
 
   void set_max_workers(uint max_workers) override {
     _active_workers = max_workers;


### PR DESCRIPTION
Hi all,

  please review this fix to G1CollectionSet member and method/parameter naming is somewhat different to other G1 code.

E.g.
* uses "length" for region "counts"
* specific problem of G1CollectionSet::cur_length() returning _regions_cur_length which is a violation of Hotspot coding guidelines (getters should be called similarly to the members), but what makes the current code really confusing is that there is a `regions_cur_length()` getter that returns something completely different.
* some use of size_t for uint contents

Improve

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386247](https://bugs.openjdk.org/browse/JDK-8386247): G1: Cleanup naming and type use of G1CollectionSet class members and methods (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) Review applies to [1001fa2c](https://git.openjdk.org/jdk/pull/31433/files/1001fa2ce1fd0f492c96f317a07513f718711b2c)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) Review applies to [27bb9481](https://git.openjdk.org/jdk/pull/31433/files/27bb94815c37bf913ac254d4694b6fea8776ea7b)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31433/head:pull/31433` \
`$ git checkout pull/31433`

Update a local copy of the PR: \
`$ git checkout pull/31433` \
`$ git pull https://git.openjdk.org/jdk.git pull/31433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31433`

View PR using the GUI difftool: \
`$ git pr show -t 31433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31433.diff">https://git.openjdk.org/jdk/pull/31433.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31433#issuecomment-4658539933)
</details>
