### PR TITLE
8386252: Shenandoah: Polish LRB argument preparation

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -976,12 +976,9 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     if (c_rarg0 == _obj) {
       __ lea(c_rarg1, _addr);
     } else if (c_rarg1 == _obj) {
-      // Set up arguments in reverse, and then flip them
-      __ lea(c_rarg0, _addr);
-      // flip them
-      __ mov(_tmp1, c_rarg0);
-      __ mov(c_rarg0, c_rarg1);
-      __ mov(c_rarg1, _tmp1);
+      __ mov(_tmp1, c_rarg1);
+      __ lea(c_rarg1, _addr);
+      __ mov(c_rarg0, _tmp1);
     } else {
       assert_different_registers(c_rarg1, _obj);
       __ lea(c_rarg1, _addr);

--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
@@ -1210,12 +1210,9 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     if (c_rarg0 == _obj) {
       __ addi(c_rarg1, _addr.base(), _addr.disp());
     } else if (c_rarg1 == _obj) {
-      // Set up arguments in reverse, and then flip them
-      __ addi(c_rarg0, _addr.base(), _addr.disp());
-      // flip them
-      __ mr(_tmp1, c_rarg0);
-      __ mr(c_rarg0, c_rarg1);
-      __ mr(c_rarg1, _tmp1);
+      __ mr(_tmp1, c_rarg1);
+      __ addi(c_rarg1, _addr.base(), _addr.disp());
+      __ mr(c_rarg0, _tmp1);
     } else {
       assert_different_registers(c_rarg1, _obj);
       __ addi(c_rarg1, _addr.base(), _addr.disp());

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -912,12 +912,9 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     if (c_rarg0 == _obj) {
       __ la(c_rarg1, _addr);
     } else if (c_rarg1 == _obj) {
-      // Set up arguments in reverse, and then flip them
-      __ la(c_rarg0, _addr);
-      // flip them
-      __ mv(_tmp1, c_rarg0);
-      __ mv(c_rarg0, c_rarg1);
-      __ mv(c_rarg1, _tmp1);
+      __ mv(_tmp1, c_rarg1);
+      __ la(c_rarg1, _addr);
+      __ mv(c_rarg0, _tmp1);
     } else {
       assert_different_registers(c_rarg1, _obj);
       __ la(c_rarg1, _addr);


### PR DESCRIPTION
We had the comment about this during the initial LBE reviews. x86 uses the xchg trick to put the registers where needed:

```
    } else if (_obj == c_rarg1) {
      // Set up arguments in reverse, and then flip them
      __ lea(c_rarg0, _addr);
      __ xchgptr(c_rarg0, c_rarg1);
```

This is handy because x86 has the reg-reg xchg that costs almost nothing. non-x86 ports have copied this by using 3 moves. There is a little more efficient scheme to achieve this without emulating the swap. 

Additional testing:
 - [x] Linux AArch64, RISC-V, PPC64 cross-compilation and light testing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386252](https://bugs.openjdk.org/browse/JDK-8386252): Shenandoah: Polish LRB argument preparation (**Enhancement** - P5)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31434/head:pull/31434` \
`$ git checkout pull/31434`

Update a local copy of the PR: \
`$ git checkout pull/31434` \
`$ git pull https://git.openjdk.org/jdk.git pull/31434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31434`

View PR using the GUI difftool: \
`$ git pr show -t 31434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31434.diff">https://git.openjdk.org/jdk/pull/31434.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31434#issuecomment-4658740409)
</details>
