### PR TITLE
8386254: Parallel: Adjust Pointers should use stripes in young spaces

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1268,8 +1268,7 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
 #endif
 }
 
-template<typename Func>
-void PSParallelCompact::adjust_in_space_helper(SpaceId id, Atomic<uint>* claim_counter, Func&& on_stripe) {
+void PSParallelCompact::adjust_in_space_helper(SpaceId id, Atomic<uint>* claim_counter) {
   MutableSpace* sp = PSParallelCompact::space(id);
   HeapWord* const bottom = sp->bottom();
   HeapWord* const top = sp->top();
@@ -1288,53 +1287,46 @@ void PSParallelCompact::adjust_in_space_helper(SpaceId id, Atomic<uint>* claim_c
       break;
     }
     HeapWord* stripe_end = MIN2(cur_stripe + stripe_size, top);
-    on_stripe(cur_stripe, stripe_end);
+    adjust_in_stripe(cur_stripe, stripe_end);
+  }
+}
+
+size_t PSParallelCompact::adjust_in_obj_with_limit(HeapWord* obj_start, HeapWord* left, HeapWord* right) {
+  precond(mark_bitmap()->is_marked(obj_start));
+  oop obj = cast_to_oop(obj_start);
+  return obj->oop_iterate_size(&pc_adjust_pointer_closure, MemRegion(left, right));
+}
+
+void PSParallelCompact::adjust_in_stripe(HeapWord* stripe_start, HeapWord* stripe_end) {
+  precond(_summary_data.is_region_aligned(stripe_start));
+
+  RegionData* cur_region = _summary_data.addr_to_region_ptr(stripe_start);
+  HeapWord* obj_start;
+  if (cur_region->partial_obj_size() != 0) {
+    obj_start = cur_region->partial_obj_addr();
+    obj_start += adjust_in_obj_with_limit(obj_start, stripe_start, stripe_end);
+  } else {
+    obj_start = stripe_start;
+  }
+
+  while (obj_start < stripe_end) {
+    obj_start = mark_bitmap()->find_obj_beg(obj_start, stripe_end);
+    if (obj_start >= stripe_end) {
+      break;
+    }
+    obj_start += adjust_in_obj_with_limit(obj_start, stripe_start, stripe_end);
   }
 }
 
 void PSParallelCompact::adjust_in_old_space(Atomic<uint>* claim_counter) {
   // Regions in old-space shouldn't be split.
-  assert(!_space_info[old_space_id].split_info().is_valid(), "inv");
+  precond(!_space_info[old_space_id].split_info().is_valid());
 
-  auto scan_obj_with_limit = [&] (HeapWord* obj_start, HeapWord* left, HeapWord* right) {
-    assert(mark_bitmap()->is_marked(obj_start), "inv");
-    oop obj = cast_to_oop(obj_start);
-    return obj->oop_iterate_size(&pc_adjust_pointer_closure, MemRegion(left, right));
-  };
-
-  adjust_in_space_helper(old_space_id, claim_counter, [&] (HeapWord* stripe_start, HeapWord* stripe_end) {
-    assert(_summary_data.is_region_aligned(stripe_start), "inv");
-    RegionData* cur_region = _summary_data.addr_to_region_ptr(stripe_start);
-    HeapWord* obj_start;
-    if (cur_region->partial_obj_size() != 0) {
-      obj_start = cur_region->partial_obj_addr();
-      obj_start += scan_obj_with_limit(obj_start, stripe_start, stripe_end);
-    } else {
-      obj_start = stripe_start;
-    }
-
-    while (obj_start < stripe_end) {
-      obj_start = mark_bitmap()->find_obj_beg(obj_start, stripe_end);
-      if (obj_start >= stripe_end) {
-        break;
-      }
-      obj_start += scan_obj_with_limit(obj_start, stripe_start, stripe_end);
-    }
-  });
+  adjust_in_space_helper(old_space_id, claim_counter);
 }
 
 void PSParallelCompact::adjust_in_young_space(SpaceId id, Atomic<uint>* claim_counter) {
-  adjust_in_space_helper(id, claim_counter, [](HeapWord* stripe_start, HeapWord* stripe_end) {
-    HeapWord* obj_start = stripe_start;
-    while (obj_start < stripe_end) {
-      obj_start = mark_bitmap()->find_obj_beg(obj_start, stripe_end);
-      if (obj_start >= stripe_end) {
-        break;
-      }
-      oop obj = cast_to_oop(obj_start);
-      obj_start += obj->oop_iterate_size(&pc_adjust_pointer_closure);
-    }
-  });
+  adjust_in_space_helper(id, claim_counter);
 }
 
 void PSParallelCompact::adjust_pointers_in_spaces(uint worker_id, Atomic<uint>* claim_counters) {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -760,8 +760,11 @@ public:
   // should_do_max_compaction controls whether all spaces for dead objs should be reclaimed.
   static bool invoke(bool clear_all_soft_refs, bool should_do_max_compaction);
 
-  template<typename Func>
-  static void adjust_in_space_helper(SpaceId id, Atomic<uint>* claim_counter, Func&& on_stripe);
+  static void adjust_in_space_helper(SpaceId id, Atomic<uint>* claim_counter);
+
+  static size_t adjust_in_obj_with_limit(HeapWord* obj_start, HeapWord* left, HeapWord* right);
+
+  static void adjust_in_stripe(HeapWord* stripe_start, HeapWord* stripe_end);
 
   static void adjust_in_old_space(Atomic<uint>* claim_counter);
 


### PR DESCRIPTION
Hi,

Please review this patch to refactor the Parallel GC adjusts pointers phase to use the same stripe based iteration for young spaces similar to what is done for old spaces. 

For large young objects, this allows the adjust pointer workload to be distributed among several workers.

Benchmarking: 

test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java

Before: 
`[0.415s][info ][gc,phases] GC(1) Adjust Pointers 91.393ms`

After:
`[0.371s][info ][gc,phases] GC(1) Adjust Pointers 9.573ms`

Testing: Tiers 1-7

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386254](https://bugs.openjdk.org/browse/JDK-8386254): Parallel: Adjust Pointers should use stripes in young spaces (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31435/head:pull/31435` \
`$ git checkout pull/31435`

Update a local copy of the PR: \
`$ git checkout pull/31435` \
`$ git pull https://git.openjdk.org/jdk.git pull/31435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31435`

View PR using the GUI difftool: \
`$ git pr show -t 31435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31435.diff">https://git.openjdk.org/jdk/pull/31435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31435#issuecomment-4659014644)
</details>
