### PR TITLE
8378049: test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java failing on Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java
@@ -70,7 +70,12 @@ public class NMTPrintMallocSiteOfCorruptedMemory {
             case HEADER_AND_SITE_ARG, FOOTER_AND_SITE_ARG -> output.shouldContain("allocation-site cannot be shown since the marker is also corrupted.");
             case HEADER_ARG, FOOTER_ARG -> {
                 output.shouldContain("allocated from:");
-                output.shouldMatch("\\[.*\\]WB_NMTMalloc\\+0x.*");
+                // We will only have this if NMT can determine the name of the symbols in the stack trace.
+                // This will most likely be true if the platform is Linux and it's a debug build,
+                // so we limit the check to this type of platform.
+                if (Platform.isLinux() && Platform.isDebugBuild()) {
+                    output.shouldMatch("\\[.*\\]WB_NMTMalloc\\+0x.*");
+                }
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  */
 
 import jdk.test.lib.Utils;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.whitebox.WhiteBox;

--- a/test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java
@@ -72,7 +72,7 @@ public class NMTPrintMallocSiteOfCorruptedMemory {
                 output.shouldContain("allocated from:");
                 // We will only have this if NMT can determine the name of the symbols in the stack trace.
                 // This will most likely be true if the platform is Linux and it's a debug build,
-                // so we limit the check to this type of platform.
+                // so we only check it for that platform and build.
                 if (Platform.isLinux() && Platform.isDebugBuild()) {
                     output.shouldMatch("\\[.*\\]WB_NMTMalloc\\+0x.*");
                 }


### PR DESCRIPTION
Hi,

This test looks for the `WN_NMTMalloc` symol in the stack trace produced by NMT when a memory corruption is produced. That's all well and good, but this string only exists on a best effort basis, if the debug symbols are missing then the text will be missing. We're altering the test to only check for this string when it's likely to exist (= Linux debug build). Hopefully, this will let us avoid any more test failures.

Thanks!

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378049](https://bugs.openjdk.org/browse/JDK-8378049): test/hotspot/jtreg/runtime/NMT/NMTPrintMallocSiteOfCorruptedMemory.java failing on Windows (**Bug** - P3)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Author)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31437/head:pull/31437` \
`$ git checkout pull/31437`

Update a local copy of the PR: \
`$ git checkout pull/31437` \
`$ git pull https://git.openjdk.org/jdk.git pull/31437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31437`

View PR using the GUI difftool: \
`$ git pr show -t 31437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31437.diff">https://git.openjdk.org/jdk/pull/31437.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31437#issuecomment-4680692159)
</details>
