### PR TITLE
8341144: Java AWT TrayIcon uses the old xembed while most Linux distros switched to SNI

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/SNIDBusConn.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/SNIDBusConn.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt.X11;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.lang.foreign.ValueLayout.*;
+
+import sun.util.logging.PlatformLogger;
+
+/**
+ * Manages a D-Bus session connection for the SNI tray icon implementation.
+ *
+ * Threading model: the dispatch loop must run on a platform thread (not a
+ * virtual thread) because native blocking calls pin the carrier thread in
+ * JDK 24+, and the upcall stub is invoked synchronously from within the
+ * native dispatch call.
+ *
+ * Registration with StatusNotifierWatcher must be fire-and-forget (no blocking
+ * reply wait) to avoid deadlocking with the already-running dispatch loop.
+ */
+final class SNIDBusConn {
+
+    private static final PlatformLogger log =
+        PlatformLogger.getLogger("sun.awt.X11.SNIDBusConn");
+
+    // Passed to dbus_connection_read_write_dispatch as the blocking timeout.
+    // 100 ms gives ~10 iterations/s, keeping CPU idle while remaining
+    // responsive to the closed flag without busy-waiting.
+    private static final int DISPATCH_POLL_MS = 100;
+
+    // Upper bound for the dispatch thread to become ready after start().
+    // A platform thread scheduled by the OS should be runnable within
+    // milliseconds; 2 s is generous enough to survive a loaded CI machine.
+    private static final int DISPATCH_START_TIMEOUT_S = 2;
+
+    // Method handles for the native callback functions, resolved once at
+    // class init. Both have the standard DBusHandleMessageFunction signature
+    // (int)(DBusConnection*, DBusMessage*, void*).
+    private static final MethodHandle DISPATCH_MH;
+    private static final MethodHandle FILTER_MH;
+    static {
+        try {
+            MethodType cb = MethodType.methodType(int.class,
+                MemorySegment.class, MemorySegment.class, MemorySegment.class);
+            DISPATCH_MH = MethodHandles.lookup()
+                .findStatic(SNIDBusConn.class, "dispatchCallback", cb);
+            FILTER_MH = MethodHandles.lookup()
+                .findStatic(SNIDBusConn.class, "filterCallback", cb);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    final MemorySegment conn;      // DBusConnection*
+    private final Arena arena;     // lives for the lifetime of this connection
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final CountDownLatch dispatchReady = new CountDownLatch(1);
+    private final AtomicBoolean filterInstalled = new AtomicBoolean();
+
+    /**
+     * Handler for incoming D-Bus messages on a registered object path.
+     * Invoked synchronously from the dispatch loop on a platform thread.
+     * Implementations must not block indefinitely or propagate checked exceptions.
+     *
+     * @return {@code true} if the message was handled,
+     *         {@code false} to pass it to the next handler
+     */
+    @FunctionalInterface
+    interface MessageHandler {
+        boolean handle(SNIMsg msg);
+    }
+
+    private SNIDBusConn(MemorySegment conn, Arena arena) {
+        this.conn  = conn;
+        this.arena = arena;
+    }
+
+    /**
+     * Connect to the D-Bus session bus using a private connection.
+     * Each call returns a new independent connection, allowing multiple
+     * SNITrayIconPeer instances to register the same object paths concurrently.
+     * Returns null if libdbus-1 is unavailable or the connection fails.
+     */
+    @SuppressWarnings("restricted")
+    static SNIDBusConn connectSession() {
+        if (!SNIDBusLib.AVAILABLE) return null;
+        Arena arena = Arena.ofShared();
+        try {
+            MemorySegment error = arena.allocate(SNIDBusLib.ERROR_LAYOUT);
+            dbus_error_init(error);
+            MemorySegment c = dbus_bus_get_private(SNIDBusLib.DBUS_BUS_SESSION, error);
+            checkError(error, "dbus_bus_get_private");
+            if (c == null || c.equals(MemorySegment.NULL)) {
+                arena.close();
+                return null;
+            }
+            return new SNIDBusConn(c, arena);
+        } catch (Throwable t) {
+            arena.close();
+            return null;
+        }
+    }
+
+    /** Request a well-known bus name. Throws RuntimeException on failure. */
+    void requestName(String name) {
+        try (Arena tmp = Arena.ofConfined()) {
+            MemorySegment error = tmp.allocate(SNIDBusLib.ERROR_LAYOUT);
+            dbus_error_init(error);
+            int result = dbus_bus_request_name(
+                conn,
+                tmp.allocateFrom(name),
+                SNIDBusLib.DBUS_NAME_FLAG_REPLACE_EXISTING | SNIDBusLib.DBUS_NAME_FLAG_DO_NOT_QUEUE,
+                error);
+            checkError(error, "dbus_bus_request_name");
+            if (result != SNIDBusLib.DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER) {
+                throw new RuntimeException("Could not acquire bus name '" + name + "': " + result);
+            }
+        }
+    }
+
+    /**
+     * Register an object path with the given message handler.
+     * The vtable and upcall stub are kept alive by the connection arena.
+     */
+    void registerObject(String path, MessageHandler handler) {
+        HandlerRegistry.register(conn, path, handler);
+
+        @SuppressWarnings("restricted")
+        MemorySegment stub = Linker.nativeLinker().upcallStub(
+            DISPATCH_MH,
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+            arena);
+
+        MemorySegment vtable = arena.allocate(SNIDBusLib.VTABLE_LAYOUT);
+        vtable.set(ADDRESS, 0,  MemorySegment.NULL); // unregister_function
+        vtable.set(ADDRESS, 8,  stub);               // message_function
+        vtable.set(ADDRESS, 16, MemorySegment.NULL);
+        vtable.set(ADDRESS, 24, MemorySegment.NULL);
+        vtable.set(ADDRESS, 32, MemorySegment.NULL);
+        vtable.set(ADDRESS, 40, MemorySegment.NULL);
+
+        int ok = dbus_connection_register_object_path(conn, arena.allocateFrom(path), vtable, MemorySegment.NULL);
+        if (ok == 0) {
+            throw new RuntimeException("dbus_connection_register_object_path failed: " + path);
+        }
+    }
+
+    /** Run the message dispatch loop. Must be called from a platform thread. */
+    void runDispatchLoop() {
+        if (log.isLoggable(PlatformLogger.Level.FINE)) {
+            log.fine("SNI dispatch loop running on: " + Thread.currentThread().getName());
+        }
+        dispatchReady.countDown();
+        try {
+            int ok;
+            do {
+                ok = dbus_connection_read_write_dispatch(conn, DISPATCH_POLL_MS);
+            } while (ok != 0 && !closed.get());
+            log.fine("SNI dispatch loop ended");
+        } catch (Throwable t) {
+            log.severe("SNI dispatch loop crashed: " + t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    /**
+     * Block until the dispatch loop is running, with a 2-second timeout.
+     * Must be called before registering with the SNI watcher to ensure
+     * incoming D-Bus messages can be received immediately after registration.
+     *
+     * @throws RuntimeException if the dispatch loop does not start in time
+     */
+    void awaitDispatch() {
+        try {
+            if (!dispatchReady.await(DISPATCH_START_TIMEOUT_S, TimeUnit.SECONDS)) {
+                throw new RuntimeException("SNI dispatch loop did not start within "
+                        + DISPATCH_START_TIMEOUT_S + " seconds");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for SNI dispatch loop", e);
+        }
+    }
+
+    /**
+     * Unregister object paths, release the bus name, and close the connection.
+     * The dispatch loop will exit naturally when the connection is closed.
+     * Calls after the first one are no-ops.
+     */
+    void close(String busName, String... paths) {
+        if (!closed.compareAndSet(false, true)) return;
+        try (Arena tmp = Arena.ofConfined()) {
+            for (String path : paths) {
+                HandlerRegistry.unregister(conn, path);
+                dbus_connection_unregister_object_path(conn, tmp.allocateFrom(path));
+            }
+            FilterRegistry.unregister(conn);
+            MemorySegment error = tmp.allocate(SNIDBusLib.ERROR_LAYOUT);
+            dbus_error_init(error);
+            dbus_bus_release_name(conn, tmp.allocateFrom(busName), error);
+            dbus_error_free(error);
+            // private connection — must close() before unref()
+            dbus_connection_close(conn);
+            dbus_connection_unref(conn);
+        } catch (Throwable t) {
+            log.warning("SNI close failed: " + t);
+        } finally {
+            arena.close();
+        }
+    }
+
+    /**
+     * Close a private connection that has no registered paths or bus names
+     * (e.g. a one-shot connection used only for a D-Bus query).
+     * Calls after the first one are no-ops.
+     */
+    void closePrivate() {
+        if (!closed.compareAndSet(false, true)) return;
+        try {
+            dbus_connection_close(conn);
+            dbus_connection_unref(conn);
+        } catch (Throwable t) {
+            log.warning("SNI closePrivate failed: " + t);
+        } finally {
+            arena.close();
+        }
+    }
+
+    /** Send fire-and-forget (no reply expected). */
+    void sendNoReply(SNIMsg msg) {
+        dbus_connection_send(conn, msg.ptr, MemorySegment.NULL);
+        dbus_connection_flush(conn);
+    }
+
+    // --- Callback invoked by libdbus for registered paths ---
+
+    @SuppressWarnings("unused")
+    private static int dispatchCallback(MemorySegment conn, MemorySegment msgPtr,
+                                        MemorySegment userData) {
+        try (SNIMsg msg = SNIMsg.borrow(msgPtr)) {
+            if (log.isLoggable(PlatformLogger.Level.FINER)) {
+                log.finer("SNI dispatch: path=" + msg.getPath()
+                    + " iface=" + msg.getIface() + " member=" + msg.getMember());
+            }
+            MessageHandler handler = HandlerRegistry.get(conn, msg.getPath());
+            if (handler != null && handler.handle(msg)) {
+                return SNIDBusLib.DBUS_HANDLER_RESULT_HANDLED;
+            }
+        } catch (Throwable e) {
+            // Must not propagate Throwable across FFM upcall boundary.
+            // Note: malformed D-Bus messages cause libdbus to call abort()
+            // (SIGABRT), which kills the JVM before any Java handler runs.
+            // The only defense is correct message construction.
+            log.severe("SNI dispatch error: " + e);
+        }
+        return SNIDBusLib.DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+    }
+
+    // --- Error checking ---
+
+    @SuppressWarnings("restricted")
+    private static void checkError(MemorySegment error, String context) {
+        int set = dbus_error_is_set(error);
+        if (set != 0) {
+            MemorySegment msgPtr = error.get(ADDRESS, 8);
+            String errMsg = msgPtr.equals(MemorySegment.NULL)
+                ? "(no message)" : msgPtr.reinterpret(SNIDBusLib.DBUS_MAXIMUM_NAME_LENGTH + 1L).getString(0);
+            dbus_error_free(error);
+            throw new RuntimeException(context + " failed: " + errMsg);
+        }
+    }
+
+    /**
+     * Install a match rule and a filter handler for signals received on this
+     * connection. Signals do not flow through registered object paths, so a
+     * filter is the only way to receive them. The handler is called from the
+     * dispatch thread for every incoming message that matches.
+     *
+     * <p>The match rule is added via {@code dbus_bus_add_match} (see the
+     * D-Bus specification for the rule syntax). Only one filter handler is
+     * supported per connection; subsequent calls replace the previous handler
+     * and add the new match rule.
+     *
+     * @param matchRule the D-Bus match rule (e.g.
+     *     {@code "type='signal',interface='org.freedesktop.DBus',member='NameOwnerChanged'"})
+     * @param filter handler invoked for incoming messages matching the rule
+     */
+    @SuppressWarnings("restricted")
+    void installFilter(String matchRule, MessageHandler filter) {
+        try (Arena tmp = Arena.ofConfined()) {
+            MemorySegment error = tmp.allocate(SNIDBusLib.ERROR_LAYOUT);
+            dbus_error_init(error);
+            dbus_bus_add_match(conn, tmp.allocateFrom(matchRule), error);
+            checkError(error, "dbus_bus_add_match");
+        }
+
+        FilterRegistry.register(conn, filter);
+
+        if (filterInstalled.compareAndSet(false, true)) {
+            try {
+                @SuppressWarnings("restricted")
+                MemorySegment stub = Linker.nativeLinker().upcallStub(
+                    FILTER_MH,
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+                    arena);
+
+                int ok = dbus_connection_add_filter(conn, stub, MemorySegment.NULL, MemorySegment.NULL);
+                if (ok == 0) {
+                    throw new RuntimeException("dbus_connection_add_filter failed");
+                }
+            } catch (Throwable t) {
+                // Roll back so a subsequent installFilter() can retry.
+                filterInstalled.set(false);
+                FilterRegistry.unregister(conn);
+                if (t instanceof RuntimeException re) throw re;
+                throw new RuntimeException(t);
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static int filterCallback(MemorySegment conn, MemorySegment msgPtr,
+                                      MemorySegment userData) {
+        try (SNIMsg msg = SNIMsg.borrow(msgPtr)) {
+            MessageHandler filter = FilterRegistry.get(conn);
+            if (filter != null && filter.handle(msg)) {
+                return SNIDBusLib.DBUS_HANDLER_RESULT_HANDLED;
+            }
+        } catch (Throwable e) {
+            log.severe("SNI filter error: " + e);
+        }
+        return SNIDBusLib.DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+    }
+
+    // --- Private MethodHandle wrappers ---
+
+    private static void dbus_error_init(MemorySegment error) {
+        try { SNIDBusLib.dbus_error_init.invoke(error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_error_free(MemorySegment error) {
+        try { SNIDBusLib.dbus_error_free.invoke(error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_error_is_set(MemorySegment error) {
+        try { return (int) SNIDBusLib.dbus_error_is_set.invoke(error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static MemorySegment dbus_bus_get_private(int bus, MemorySegment error) {
+        try { return (MemorySegment) SNIDBusLib.dbus_bus_get_private.invoke(bus, error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_bus_request_name(MemorySegment conn, MemorySegment name, int flags, MemorySegment error) {
+        try { return (int) SNIDBusLib.dbus_bus_request_name.invoke(conn, name, flags, error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_bus_add_match(MemorySegment conn, MemorySegment rule, MemorySegment error) {
+        try { SNIDBusLib.dbus_bus_add_match.invoke(conn, rule, error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_connection_register_object_path(MemorySegment conn, MemorySegment path, MemorySegment vtable, MemorySegment userData) {
+        try { return (int) SNIDBusLib.dbus_connection_register_object_path.invoke(conn, path, vtable, userData); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_connection_read_write_dispatch(MemorySegment conn, int timeout) {
+        try { return (int) SNIDBusLib.dbus_connection_read_write_dispatch.invoke(conn, timeout); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_unregister_object_path(MemorySegment conn, MemorySegment path) {
+        try { SNIDBusLib.dbus_connection_unregister_object_path.invoke(conn, path); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_bus_release_name(MemorySegment conn, MemorySegment name, MemorySegment error) {
+        try { return (int) SNIDBusLib.dbus_bus_release_name.invoke(conn, name, error); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_close(MemorySegment conn) {
+        try { SNIDBusLib.dbus_connection_close.invoke(conn); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_unref(MemorySegment conn) {
+        try { SNIDBusLib.dbus_connection_unref.invoke(conn); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_send(MemorySegment conn, MemorySegment msg, MemorySegment serial) {
+        try { SNIDBusLib.dbus_connection_send.invoke(conn, msg, serial); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_flush(MemorySegment conn) {
+        try { SNIDBusLib.dbus_connection_flush.invoke(conn); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_connection_add_filter(MemorySegment conn, MemorySegment stub, MemorySegment userData, MemorySegment freeData) {
+        try { return (int) SNIDBusLib.dbus_connection_add_filter.invoke(conn, stub, userData, freeData); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    /**
+     * Registry of filter handlers, keyed on connection address so that
+     * multiple connections may install independent filters concurrently.
+     */
+    private static final class FilterRegistry {
+        private static final ConcurrentHashMap<Long, MessageHandler> MAP
+            = new ConcurrentHashMap<>();
+
+        static void register(MemorySegment conn, MessageHandler h) {
+            MAP.put(conn.address(), h);
+        }
+        static void unregister(MemorySegment conn) {
+            MAP.remove(conn.address());
+        }
+        static MessageHandler get(MemorySegment conn) {
+            return MAP.get(conn.address());
+        }
+    }
+
+    /**
+     * Map from (connection address, object path) to handler.
+     * Keyed on connection address so that multiple SNITrayIconPeer instances
+     * (each with their own private connection) can register the same path
+     * concurrently without colliding.
+     */
+    private static final class HandlerRegistry {
+        private static final ConcurrentHashMap<String, MessageHandler> MAP
+            = new ConcurrentHashMap<>();
+
+        static void register(MemorySegment conn, String path, MessageHandler h) {
+            MAP.put(key(conn, path), h);
+        }
+        static void unregister(MemorySegment conn, String path) {
+            MAP.remove(key(conn, path));
+        }
+        static MessageHandler get(MemorySegment conn, String path) {
+            return MAP.get(key(conn, path));
+        }
+        private static String key(MemorySegment conn, String path) {
+            return conn.address() + ":" + path;
+        }
+    }
+}

--- a/src/java.desktop/unix/classes/sun/awt/X11/SNIDBusLib.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/SNIDBusLib.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt.X11;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+import static java.lang.foreign.ValueLayout.*;
+
+/**
+ * Panama FFM bindings for libdbus-1.so, used by the SNI (StatusNotifierItem)
+ * tray icon implementation.
+ *
+ * Struct sizes verified against dbus/dbus-types.h:
+ *   DBusError = 32 bytes, DBusMessageIter = 72 bytes, DBusObjectPathVTable = 48 bytes
+ */
+final class SNIDBusLib {
+
+    // D-Bus type constants (dbus/dbus-protocol.h)
+    static final int DBUS_TYPE_INVALID       = 0;
+    static final int DBUS_TYPE_BOOLEAN       = 'b';
+    static final int DBUS_TYPE_INT32         = 'i';
+    static final int DBUS_TYPE_UINT32        = 'u';
+    static final int DBUS_TYPE_STRING        = 's';
+    static final int DBUS_TYPE_OBJECT_PATH   = 'o';
+    static final int DBUS_TYPE_ARRAY         = 'a';
+    static final int DBUS_TYPE_VARIANT       = 'v';
+    static final int DBUS_TYPE_STRUCT        = 'r';
+    static final int DBUS_TYPE_DICT_ENTRY    = 'e';
+    static final int DBUS_TYPE_BYTE          = 'y';
+
+    static final int DBUS_BUS_SESSION        = 0;
+
+    static final int DBUS_MESSAGE_TYPE_METHOD_CALL   = 1;
+    static final int DBUS_MESSAGE_TYPE_METHOD_RETURN = 2;
+    static final int DBUS_MESSAGE_TYPE_SIGNAL        = 4;
+
+    static final int DBUS_HANDLER_RESULT_HANDLED         = 0;
+    static final int DBUS_HANDLER_RESULT_NOT_YET_HANDLED = 1;
+
+    static final int DBUS_NAME_FLAG_REPLACE_EXISTING  = 0x1;
+    static final int DBUS_NAME_FLAG_DO_NOT_QUEUE      = 0x4;
+    static final int DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER = 1;
+
+    // Maximum length for D-Bus names (bus, interface, member, error names).
+    // Defined as DBUS_MAXIMUM_NAME_LENGTH in dbus/dbus-protocol.h.
+    static final int DBUS_MAXIMUM_NAME_LENGTH = 255;
+
+    // --- Struct layouts ---
+
+    /** DBusError: 32 bytes */
+    static final MemoryLayout ERROR_LAYOUT = MemoryLayout.structLayout(
+        ADDRESS.withName("name"),
+        ADDRESS.withName("message"),
+        JAVA_INT.withName("bits"),
+        JAVA_INT.withName("pad"),
+        ADDRESS.withName("padding1")
+    );
+
+    /** DBusMessageIter: 72 bytes */
+    static final MemoryLayout ITER_LAYOUT = MemoryLayout.structLayout(
+        ADDRESS.withName("dummy1"),
+        ADDRESS.withName("dummy2"),
+        JAVA_INT.withName("dummy3"),
+        JAVA_INT.withName("dummy4"),
+        JAVA_INT.withName("dummy5"),
+        JAVA_INT.withName("dummy6"),
+        JAVA_INT.withName("dummy7"),
+        JAVA_INT.withName("dummy8"),
+        JAVA_INT.withName("dummy9"),
+        JAVA_INT.withName("dummy10"),
+        JAVA_INT.withName("dummy11"),
+        JAVA_INT.withName("pad1"),
+        ADDRESS.withName("pad2"),
+        ADDRESS.withName("pad3")
+    );
+
+    /** DBusObjectPathVTable: 48 bytes — 6 function pointers */
+    static final MemoryLayout VTABLE_LAYOUT = MemoryLayout.structLayout(
+        ADDRESS.withName("unregister_function"),
+        ADDRESS.withName("message_function"),
+        ADDRESS.withName("pad1"),
+        ADDRESS.withName("pad2"),
+        ADDRESS.withName("pad3"),
+        ADDRESS.withName("pad4")
+    );
+
+    // --- FFM plumbing ---
+
+    private static final Linker LINKER = Linker.nativeLinker();
+    private static final SymbolLookup DBUS;
+
+    /** True if libdbus-1.so.3 was successfully loaded; false means SNI is unavailable. */
+    static final boolean AVAILABLE;
+
+    static {
+        SymbolLookup lib = null;
+        boolean ok = false;
+        try {
+            @SuppressWarnings("restricted")
+            SymbolLookup l = SymbolLookup.libraryLookup("libdbus-1.so.3", Arena.global());
+            lib = l;
+            ok = true;
+        } catch (Throwable t) {
+            // libdbus-1.so.3 not present; SNI tray support will be disabled
+        }
+        DBUS = lib;
+        AVAILABLE = ok;
+    }
+
+    @SuppressWarnings("restricted")
+    private static MethodHandle fn(String name, FunctionDescriptor desc) {
+        if (DBUS == null) return null;
+        return LINKER.downcallHandle(DBUS.findOrThrow(name), desc);
+    }
+
+    // --- Function handles ---
+
+    static final MethodHandle dbus_error_init = fn("dbus_error_init",
+        FunctionDescriptor.ofVoid(ADDRESS));
+
+    static final MethodHandle dbus_error_free = fn("dbus_error_free",
+        FunctionDescriptor.ofVoid(ADDRESS));
+
+    static final MethodHandle dbus_error_is_set = fn("dbus_error_is_set",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_bus_get = fn("dbus_bus_get",
+        FunctionDescriptor.of(ADDRESS, JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_bus_get_private = fn("dbus_bus_get_private",
+        FunctionDescriptor.of(ADDRESS, JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_bus_request_name = fn("dbus_bus_request_name",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_bus_get_unique_name = fn("dbus_bus_get_unique_name",
+        FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_bus_add_match = fn("dbus_bus_add_match",
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_connection_add_filter =
+        fn("dbus_connection_add_filter",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_connection_register_object_path =
+        fn("dbus_connection_register_object_path",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_connection_read_write_dispatch =
+        fn("dbus_connection_read_write_dispatch",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT));
+
+    static final MethodHandle dbus_connection_send = fn("dbus_connection_send",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_connection_send_with_reply_and_block =
+        fn("dbus_connection_send_with_reply_and_block",
+        FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_connection_flush = fn("dbus_connection_flush",
+        FunctionDescriptor.ofVoid(ADDRESS));
+
+    static final MethodHandle dbus_message_get_type = fn("dbus_message_get_type",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_message_get_member = fn("dbus_message_get_member",
+        FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_get_path = fn("dbus_message_get_path",
+        FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_get_interface = fn("dbus_message_get_interface",
+        FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_new_method_return =
+        fn("dbus_message_new_method_return",
+        FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_new_method_call =
+        fn("dbus_message_new_method_call",
+        FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_new_signal = fn("dbus_message_new_signal",
+        FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_unref = fn("dbus_message_unref",
+        FunctionDescriptor.ofVoid(ADDRESS));
+
+    static final MethodHandle dbus_message_iter_init = fn("dbus_message_iter_init",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_get_arg_type =
+        fn("dbus_message_iter_get_arg_type",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_get_basic =
+        fn("dbus_message_iter_get_basic",
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_next = fn("dbus_message_iter_next",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_init_append =
+        fn("dbus_message_iter_init_append",
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_append_basic =
+        fn("dbus_message_iter_append_basic",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_open_container =
+        fn("dbus_message_iter_open_container",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_message_iter_close_container =
+        fn("dbus_message_iter_close_container",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_bus_release_name = fn("dbus_bus_release_name",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_connection_unregister_object_path =
+        fn("dbus_connection_unregister_object_path",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+    static final MethodHandle dbus_connection_close = fn("dbus_connection_close",
+        FunctionDescriptor.ofVoid(ADDRESS));
+
+    static final MethodHandle dbus_connection_unref = fn("dbus_connection_unref",
+        FunctionDescriptor.ofVoid(ADDRESS));
+
+    private SNIDBusLib() {}
+}

--- a/src/java.desktop/unix/classes/sun/awt/X11/SNIMsg.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/SNIMsg.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt.X11;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+
+import static java.lang.foreign.ValueLayout.*;
+
+/**
+ * Lightweight wrapper around a DBusMessage* for reading and writing D-Bus arguments.
+ * Used by the SNI (StatusNotifierItem) tray icon implementation.
+ */
+final class SNIMsg implements AutoCloseable {
+
+    final MemorySegment ptr;       // DBusMessage*
+    private final Arena arena;     // for native string allocations
+    private final boolean ownsRef; // true if this SNIMsg is responsible for dbus_message_unref
+    private MemorySegment readIter;
+    private MemorySegment writeIter;
+
+    /** Private constructor. */
+    private SNIMsg(MemorySegment ptr, boolean ownsRef) {
+        this.ptr     = ptr;
+        this.arena   = Arena.ofConfined();
+        this.ownsRef = ownsRef;
+    }
+
+    /** Wrap an existing DBusMessage* taking ownership. */
+    static SNIMsg own(MemorySegment ptr) {
+        return new SNIMsg(ptr, true);
+    }
+
+    /** Wrap an existing DBusMessage* without taking ownership. */
+    static SNIMsg borrow(MemorySegment ptr) {
+        return new SNIMsg(ptr, false);
+    }
+
+    /** Create a new method-return reply. */
+    static SNIMsg newMethodReturn(SNIMsg request) {
+        return SNIMsg.own(dbus_message_new_method_return(request.ptr));
+    }
+
+    /** Create a new method call. */
+    static SNIMsg newMethodCall(Arena arena, String dest, String path,
+                                String iface, String method) {
+        return SNIMsg.own(dbus_message_new_method_call(
+            arena.allocateFrom(dest),
+            arena.allocateFrom(path),
+            arena.allocateFrom(iface),
+            arena.allocateFrom(method)));
+    }
+
+    /** Create a new signal. */
+    static SNIMsg newSignal(Arena arena, String path, String iface, String name) {
+        return SNIMsg.own(dbus_message_new_signal(
+            arena.allocateFrom(path),
+            arena.allocateFrom(iface),
+            arena.allocateFrom(name)));
+    }
+
+    // --- Message metadata ---
+
+    int getType() {
+        return dbus_message_get_type(ptr);
+    }
+
+    String getMember()  { return readCString(SNIDBusLib.dbus_message_get_member, ptr); }
+    String getPath()    { return readCString(SNIDBusLib.dbus_message_get_path,   ptr); }
+    String getIface()   { return readCString(SNIDBusLib.dbus_message_get_interface, ptr); }
+
+    @SuppressWarnings("restricted")
+    private static String readCString(MethodHandle mh, MemorySegment msg) {
+        try {
+            MemorySegment s = (MemorySegment) mh.invoke(msg);
+            if (s == null || s.equals(MemorySegment.NULL)) return null;
+            return s.reinterpret(SNIDBusLib.DBUS_MAXIMUM_NAME_LENGTH + 1L).getString(0);
+        } catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    // --- Reading ---
+
+    private MemorySegment readIter() {
+        if (readIter == null) {
+            readIter = arena.allocate(SNIDBusLib.ITER_LAYOUT);
+            dbus_message_iter_init(ptr, readIter);
+        }
+        return readIter;
+    }
+
+    int readArgType() {
+        return dbus_message_iter_get_arg_type(readIter());
+    }
+
+    @SuppressWarnings("restricted")
+    String readString() {
+        MemorySegment holder = arena.allocate(ADDRESS);
+        dbus_message_iter_get_basic(readIter(), holder);
+        String result = holder.get(ADDRESS, 0).reinterpret(SNIDBusLib.DBUS_MAXIMUM_NAME_LENGTH + 1L).getString(0);
+        dbus_message_iter_next(readIter());
+        return result;
+    }
+
+    int readInt32() {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        dbus_message_iter_get_basic(readIter(), holder);
+        int result = holder.get(JAVA_INT, 0);
+        dbus_message_iter_next(readIter());
+        return result;
+    }
+
+    // --- Writing ---
+
+    private MemorySegment writeIter() {
+        if (writeIter == null) {
+            writeIter = arena.allocate(SNIDBusLib.ITER_LAYOUT);
+            dbus_message_iter_init_append(ptr, writeIter);
+        }
+        return writeIter;
+    }
+
+    void appendString(String value) {
+        appendStringOnIter(writeIter(), value);
+    }
+
+    void appendUInt32(int value) {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        holder.set(JAVA_INT, 0, value);
+        dbus_message_iter_append_basic(writeIter(), SNIDBusLib.DBUS_TYPE_UINT32, holder);
+    }
+
+    void appendInt32(int value) {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        holder.set(JAVA_INT, 0, value);
+        dbus_message_iter_append_basic(writeIter(), SNIDBusLib.DBUS_TYPE_INT32, holder);
+    }
+
+    void appendBool(boolean value) {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        holder.set(JAVA_INT, 0, value ? 1 : 0);
+        dbus_message_iter_append_basic(writeIter(), SNIDBusLib.DBUS_TYPE_BOOLEAN, holder);
+    }
+
+    MemorySegment openContainer(int type, String signature) {
+        MemorySegment sub = arena.allocate(SNIDBusLib.ITER_LAYOUT);
+        MemorySegment sig = signature != null
+            ? arena.allocateFrom(signature) : MemorySegment.NULL;
+        dbus_message_iter_open_container(writeIter(), type, sig, sub);
+        return sub;
+    }
+
+    void closeContainer(MemorySegment sub) {
+        dbus_message_iter_close_container(writeIter(), sub);
+    }
+
+    // --- Static iter helpers (for nested containers) ---
+
+    static MemorySegment openContainerOn(Arena arena, MemorySegment iter,
+                                         int type, String signature) {
+        MemorySegment sub = arena.allocate(SNIDBusLib.ITER_LAYOUT);
+        MemorySegment sig = signature != null
+            ? arena.allocateFrom(signature) : MemorySegment.NULL;
+        dbus_message_iter_open_container(iter, type, sig, sub);
+        return sub;
+    }
+
+    static void closeContainerOn(MemorySegment iter, MemorySegment sub) {
+        dbus_message_iter_close_container(iter, sub);
+    }
+
+    static void appendStringOn(Arena arena, MemorySegment iter, String value) {
+        MemorySegment s = arena.allocateFrom(value);
+        MemorySegment holder = arena.allocate(ADDRESS);
+        holder.set(ADDRESS, 0, s);
+        dbus_message_iter_append_basic(iter, SNIDBusLib.DBUS_TYPE_STRING, holder);
+    }
+
+    static void appendObjectPathOn(Arena arena, MemorySegment iter, String value) {
+        MemorySegment s = arena.allocateFrom(value);
+        MemorySegment holder = arena.allocate(ADDRESS);
+        holder.set(ADDRESS, 0, s);
+        dbus_message_iter_append_basic(iter, SNIDBusLib.DBUS_TYPE_OBJECT_PATH, holder);
+    }
+
+    static void appendInt32On(Arena arena, MemorySegment iter, int value) {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        holder.set(JAVA_INT, 0, value);
+        dbus_message_iter_append_basic(iter, SNIDBusLib.DBUS_TYPE_INT32, holder);
+    }
+
+    static void appendUInt32On(Arena arena, MemorySegment iter, int value) {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        holder.set(JAVA_INT, 0, value);
+        dbus_message_iter_append_basic(iter, SNIDBusLib.DBUS_TYPE_UINT32, holder);
+    }
+
+    static void appendBoolOn(Arena arena, MemorySegment iter, boolean value) {
+        MemorySegment holder = arena.allocate(JAVA_INT);
+        holder.set(JAVA_INT, 0, value ? 1 : 0);
+        dbus_message_iter_append_basic(iter, SNIDBusLib.DBUS_TYPE_BOOLEAN, holder);
+    }
+
+    private void appendStringOnIter(MemorySegment iter, String value) {
+        MemorySegment s = arena.allocateFrom(value);
+        MemorySegment holder = arena.allocate(ADDRESS);
+        holder.set(ADDRESS, 0, s);
+        dbus_message_iter_append_basic(iter, SNIDBusLib.DBUS_TYPE_STRING, holder);
+    }
+
+    /** Send this message and flush. */
+    void send(MemorySegment conn) {
+        dbus_connection_send(conn, ptr, MemorySegment.NULL);
+        dbus_connection_flush(conn);
+    }
+
+    /** Expose the arena for callers that need to allocate native memory. */
+    Arena arena() { return arena; }
+
+    @Override
+    public void close() {
+        if (ownsRef) {
+            dbus_message_unref(ptr);
+        }
+        arena.close();
+    }
+
+    // --- Private MethodHandle wrappers ---
+
+    private static MemorySegment dbus_message_new_method_return(MemorySegment ptr) {
+        try { return (MemorySegment) SNIDBusLib.dbus_message_new_method_return.invoke(ptr); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static MemorySegment dbus_message_new_method_call(MemorySegment dest, MemorySegment path,
+                                                              MemorySegment iface, MemorySegment method) {
+        try { return (MemorySegment) SNIDBusLib.dbus_message_new_method_call.invoke(dest, path, iface, method); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static MemorySegment dbus_message_new_signal(MemorySegment path, MemorySegment iface, MemorySegment name) {
+        try { return (MemorySegment) SNIDBusLib.dbus_message_new_signal.invoke(path, iface, name); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_message_get_type(MemorySegment ptr) {
+        try { return (int) SNIDBusLib.dbus_message_get_type.invoke(ptr); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_init(MemorySegment msg, MemorySegment iter) {
+        try { SNIDBusLib.dbus_message_iter_init.invoke(msg, iter); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static int dbus_message_iter_get_arg_type(MemorySegment iter) {
+        try { return (int) SNIDBusLib.dbus_message_iter_get_arg_type.invoke(iter); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_get_basic(MemorySegment iter, MemorySegment holder) {
+        try { SNIDBusLib.dbus_message_iter_get_basic.invoke(iter, holder); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_next(MemorySegment iter) {
+        try { SNIDBusLib.dbus_message_iter_next.invoke(iter); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_init_append(MemorySegment msg, MemorySegment iter) {
+        try { SNIDBusLib.dbus_message_iter_init_append.invoke(msg, iter); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_append_basic(MemorySegment iter, int type, MemorySegment value) {
+        try { SNIDBusLib.dbus_message_iter_append_basic.invoke(iter, type, value); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_open_container(MemorySegment iter, int type, MemorySegment sig, MemorySegment sub) {
+        try { SNIDBusLib.dbus_message_iter_open_container.invoke(iter, type, sig, sub); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_iter_close_container(MemorySegment iter, MemorySegment sub) {
+        try { SNIDBusLib.dbus_message_iter_close_container.invoke(iter, sub); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_send(MemorySegment conn, MemorySegment msg, MemorySegment serial) {
+        try { SNIDBusLib.dbus_connection_send.invoke(conn, msg, serial); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_connection_flush(MemorySegment conn) {
+        try { SNIDBusLib.dbus_connection_flush.invoke(conn); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+    }
+
+    private static void dbus_message_unref(MemorySegment ptr) {
+        try { SNIDBusLib.dbus_message_unref.invoke(ptr); }
+        catch (Throwable t) { /* ignore */ }
+    }
+}

--- a/src/java.desktop/unix/classes/sun/awt/X11/SNISystemTrayPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/SNISystemTrayPeer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt.X11;
+
+import java.awt.Dimension;
+import java.awt.SystemTray;
+import java.awt.peer.SystemTrayPeer;
+
+/**
+ * {@link java.awt.peer.SystemTrayPeer} implementation for the SNI
+ * (StatusNotifierItem) D-Bus protocol.
+ * Used when {@code org.kde.StatusNotifierWatcher} is present on the session bus
+ * (Ubuntu 24+, KDE Plasma, GNOME with the AppIndicator extension).
+ *
+ * <p>This peer is responsible only for reporting tray availability and the
+ * standard icon size. Each individual {@link SNITrayIconPeer} manages its own
+ * D-Bus service and connection independently.
+ *
+ * See JDK-8035556.
+ */
+public final class SNISystemTrayPeer implements SystemTrayPeer {
+
+    /** Standard SNI icon size recommended by the freedesktop specification. */
+    static final int ICON_SIZE = 22;
+
+    private static volatile SNISystemTrayPeer peerInstance;
+
+    private final boolean available;
+
+    SNISystemTrayPeer(SystemTray target) {
+        peerInstance = this;
+        available = isWatcherPresent();
+    }
+
+    static SNISystemTrayPeer getPeerInstance() {
+        return peerInstance;
+    }
+
+    boolean isAvailable() {
+        return available;
+    }
+
+    void dispose() {
+        peerInstance = null;
+    }
+
+    @Override
+    public Dimension getTrayIconSize() {
+        return new Dimension(ICON_SIZE, ICON_SIZE);
+    }
+
+    /**
+     * Probe the session bus for {@code org.kde.StatusNotifierWatcher}.
+     * Returns {@code true} if and only if the watcher service currently
+     * owns its well-known bus name.
+     *
+     * <p>This performs a synchronous {@code GetNameOwner} round-trip on
+     * the session bus with a short timeout (see
+     * {@code WATCHER_PROBE_TIMEOUT_MS} in {@link SNITrayIconPeer}). Called
+     * from the EDT during {@code SystemTray} initialization, so the probe
+     * must complete quickly enough to keep the UI responsive.
+     */
+    private static boolean isWatcherPresent() {
+        return SNITrayIconPeer.isWatcherAvailable();
+    }
+}

--- a/src/java.desktop/unix/classes/sun/awt/X11/SNITrayIconPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/SNITrayIconPeer.java
@@ -1,0 +1,929 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt.X11;
+
+import java.awt.AWTException;
+import java.awt.CheckboxMenuItem;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Menu;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+import java.awt.TrayIcon;
+import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.image.BufferedImage;
+import java.awt.peer.TrayIconPeer;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import sun.util.logging.PlatformLogger;
+
+/**
+ * TrayIconPeer implementation using the StatusNotifierItem (SNI) D-Bus protocol.
+ * Used on Linux desktops that provide org.kde.StatusNotifierWatcher (Ubuntu 24+,
+ * KDE Plasma, and others running the AppIndicator GNOME extension).
+ *
+ * The icon is exposed as a D-Bus service named
+ * {@code org.kde.StatusNotifierItem-<pid>-<n>} with two object paths:
+ * <ul>
+ *   <li>{@code /StatusNotifierItem} — SNI properties and actions</li>
+ *   <li>{@code /MenuBar} — com.canonical.dbusmenu context menu</li>
+ * </ul>
+ *
+ * <p><b>Known limitation — MouseListener and JPopupMenu workaround:</b><br>
+ * On desktops that use DBusMenu to render the context menu (e.g. GNOME with
+ * ubuntu-appindicators), right-click events are intercepted by the desktop shell
+ * and never delivered as {@code MouseEvent} to the {@code TrayIcon}. The common
+ * workaround of adding a {@code MouseListener} and showing a {@code JPopupMenu}
+ * manually on right-click therefore does not work on those desktops.
+ * The official {@code TrayIcon.setPopupMenu(PopupMenu)} API is fully supported.
+ * On desktops that call {@code ContextMenu(x,y)} directly (e.g. KDE Plasma),
+ * mouse events are delivered normally and the workaround continues to work.
+ * On Windows, mouse events are always delivered regardless of popup menu usage.
+ *
+ * See JDK-8035556.
+ */
+public final class SNITrayIconPeer implements TrayIconPeer {
+
+    private static final PlatformLogger log =
+        PlatformLogger.getLogger("sun.awt.X11.SNITrayIconPeer");
+
+    private static final String SNI_WATCHER_BUS   = "org.kde.StatusNotifierWatcher";
+    private static final String SNI_WATCHER_PATH  = "/StatusNotifierWatcher";
+    private static final String SNI_WATCHER_IFACE = "org.kde.StatusNotifierWatcher";
+
+    private static final String SNI_PATH   = "/StatusNotifierItem";
+    private static final String SNI_IFACE  = "org.kde.StatusNotifierItem";
+    private static final String PROP_IFACE = "org.freedesktop.DBus.Properties";
+    private static final String INTRO_IFACE = "org.freedesktop.DBus.Introspectable";
+
+    private static final String MENU_PATH  = "/MenuBar";
+    private static final String MENU_IFACE = "com.canonical.dbusmenu";
+
+    private static final AtomicInteger counter = new AtomicInteger(1);
+
+    // Timeout for the synchronous D-Bus probe in isWatcherAvailable().
+    // Short enough to keep SystemTray.isSupported() responsive on the EDT,
+    // yet long enough for a healthy session bus to reply.
+    private static final int WATCHER_PROBE_TIMEOUT_MS = 500;
+
+    private final TrayIcon target;
+    private final SNIDBusConn conn;
+    private final String serviceName;
+    private volatile boolean disposed;
+
+    // Current state — updated by updateImage() and setToolTip()
+    private volatile String iconName = "java";
+    private volatile IconData iconData;  // null until first updateImage()
+    private volatile String tooltip = "";
+
+    /** Immutable snapshot of icon pixel data — published atomically via volatile write. */
+    private record IconData(int width, int height, int[] pixels) {}
+
+    SNITrayIconPeer(TrayIcon target) throws AWTException {
+        this.target = target;
+
+        long pid = ProcessHandle.current().pid();
+        int n = counter.getAndIncrement();
+        this.serviceName = "org.kde.StatusNotifierItem-" + pid + "-" + n;
+        log.fine("SNI creating peer: " + serviceName);
+
+        SNIDBusConn c = SNIDBusConn.connectSession();
+        if (c == null) {
+            throw new AWTException("SNI: cannot connect to D-Bus session bus");
+        }
+        this.conn = c;
+
+        try {
+            conn.requestName(serviceName);
+            conn.registerObject(SNI_PATH,  this::handleSNI);
+            conn.registerObject(MENU_PATH, this::handleMenu);
+
+            Thread.ofPlatform().daemon(true)
+                .name("SNI-dispatch-" + n)
+                .start(conn::runDispatchLoop);
+
+            conn.awaitDispatch();
+
+            registerWithWatcher();
+            installWatcherRestartListener();
+            updateImage();
+            log.fine("SNI peer ready: " + serviceName);
+        } catch (RuntimeException e) {
+            log.severe("SNI D-Bus setup failed: " + e.getMessage());
+            conn.close(serviceName, SNI_PATH, MENU_PATH);
+            throw new AWTException("SNI: D-Bus setup failed: " + e.getMessage());
+        }
+    }
+
+    // --- TrayIconPeer ---
+
+    @Override
+    public void dispose() {
+        if (disposed) return;
+        disposed = true;
+        conn.close(serviceName, SNI_PATH, MENU_PATH);
+    }
+
+    @Override
+    public void setToolTip(String tooltip) {
+        this.tooltip = (tooltip != null) ? tooltip : "";
+        emitSignal("NewTitle");
+        emitSignal("NewToolTip");
+    }
+
+    @Override
+    public void updateImage() {
+        Image img = target.getImage();
+        if (img != null) {
+            convertImage(img);
+        }
+        emitSignal("NewIcon");
+    }
+
+    @Override
+    public void displayMessage(String caption, String text, String messageType) {
+        try (Arena tmp = Arena.ofConfined();
+             SNIMsg call = SNIMsg.newMethodCall(tmp,
+                 "org.freedesktop.Notifications",
+                 "/org/freedesktop/Notifications",
+                 "org.freedesktop.Notifications",
+                 "Notify")) {
+            call.appendString("java");           // app_name
+            call.appendUInt32(0);                // replaces_id (0 = new notification)
+            call.appendString("");               // app_icon
+            call.appendString(caption != null ? caption : "");
+            call.appendString(text    != null ? text    : "");
+            // actions: empty array of strings
+            var actions = call.openContainer(SNIDBusLib.DBUS_TYPE_ARRAY, "s");
+            call.closeContainer(actions);
+            // hints: urgency byte
+            var hints = call.openContainer(SNIDBusLib.DBUS_TYPE_ARRAY, "{sv}");
+            appendUrgencyHint(call, hints, urgencyFor(messageType));
+            call.closeContainer(hints);
+            call.appendInt32(notificationTimeout(messageType));
+            conn.sendNoReply(call);
+        } catch (Exception e) {
+            log.warning("SNI displayMessage failed: " + e.getMessage());
+        }
+    }
+
+    private static byte urgencyFor(String messageType) {
+        return switch (messageType != null ? messageType : "") {
+            case "ERROR"   -> (byte) 2;  // critical
+            case "WARNING" -> (byte) 1;  // normal
+            default        -> (byte) 1;  // normal (INFO, NONE)
+        };
+    }
+
+    private static int notificationTimeout(String messageType) {
+        // -1 = server default; ERROR stays until dismissed
+        return "ERROR".equals(messageType) ? 0 : -1;
+    }
+
+    private static void appendUrgencyHint(SNIMsg msg, MemorySegment hintsIter, byte urgency) {
+        Arena a = msg.arena();
+        var entry = SNIMsg.openContainerOn(a, hintsIter, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, "urgency");
+        var variant = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "y");
+        MemorySegment holder = a.allocate(java.lang.foreign.ValueLayout.JAVA_BYTE);
+        holder.set(java.lang.foreign.ValueLayout.JAVA_BYTE, 0, urgency);
+        try { SNIDBusLib.dbus_message_iter_append_basic
+                .invoke(variant, SNIDBusLib.DBUS_TYPE_BYTE, holder); }
+        catch (Throwable t) { throw new RuntimeException(t); }
+        SNIMsg.closeContainerOn(entry, variant);
+        SNIMsg.closeContainerOn(hintsIter, entry);
+    }
+
+    @Override
+    public void showPopupMenu(int x, int y) {
+        // With SNI + DBusMenu the tray host (GNOME Shell, KDE) handles the
+        // popup directly by calling GetLayout on /MenuBar. No X11 popup needed.
+    }
+
+    // --- Watcher registration ---
+
+    private void registerWithWatcher() {
+        try (Arena tmp = Arena.ofConfined();
+             SNIMsg call = SNIMsg.newMethodCall(tmp,
+                 SNI_WATCHER_BUS, SNI_WATCHER_PATH,
+                 SNI_WATCHER_IFACE, "RegisterStatusNotifierItem")) {
+            call.appendString(serviceName);
+            conn.sendNoReply(call);
+            log.fine("SNI RegisterStatusNotifierItem sent");
+        } catch (Exception e) {
+            log.warning("SNI registerWithWatcher failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Subscribe to {@code NameOwnerChanged} signals for the SNI watcher bus
+     * name. If the watcher service disappears and reappears (for example when
+     * the GNOME shell extension is reloaded), the icon is re-registered
+     * automatically so that it stays visible in the tray.
+     */
+    private void installWatcherRestartListener() {
+        String matchRule = "type='signal',sender='org.freedesktop.DBus',"
+            + "interface='org.freedesktop.DBus',member='NameOwnerChanged',"
+            + "arg0='" + SNI_WATCHER_BUS + "'";
+        try {
+            conn.installFilter(matchRule, this::handleNameOwnerChanged);
+        } catch (Exception e) {
+            log.warning("SNI watcher restart listener install failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Filter handler for {@code NameOwnerChanged}. When the watcher's
+     * {@code new_owner} argument is non-empty the service has just appeared
+     * on the bus, so we re-send our {@code RegisterStatusNotifierItem} call.
+     */
+    private boolean handleNameOwnerChanged(SNIMsg msg) {
+        if (disposed) return false;
+        // The libdbus filter sees every message on the connection. Restrict to
+        // the actual NameOwnerChanged signal before parsing arguments — reading
+        // string args from a method call with a different signature would make
+        // libdbus call abort() and kill the JVM.
+        if (msg.getType() != SNIDBusLib.DBUS_MESSAGE_TYPE_SIGNAL) return false;
+        if (!"org.freedesktop.DBus".equals(msg.getIface())) return false;
+        if (!"NameOwnerChanged".equals(msg.getMember())) return false;
+        try {
+            String name = msg.readString();
+            if (!SNI_WATCHER_BUS.equals(name)) return false;
+            msg.readString(); // old_owner, unused
+            String newOwner = msg.readString();
+            if (newOwner != null && !newOwner.isEmpty()) {
+                log.fine("SNI watcher reappeared as " + newOwner + ", re-registering");
+                registerWithWatcher();
+            }
+        } catch (Throwable t) {
+            log.fine("SNI NameOwnerChanged parse failed: " + t);
+        }
+        // Don't consume — the message may be of interest to other handlers.
+        return false;
+    }
+
+    // --- D-Bus message handlers ---
+
+    private boolean handleSNI(SNIMsg msg) {
+        if (disposed) return false;
+        String member = msg.getMember();
+        if (member == null) return false;
+
+        try {
+            return switch (member) {
+                case "Introspect"        -> { replyIntrospect(msg, SNI_INTROSPECT_XML); yield true; }
+                case "Get"               -> { replyGet(msg); yield true; }
+                case "GetAll"            -> { replyGetAll(msg); yield true; }
+                case "Activate"          -> { handleActivate(msg); yield true; }
+                case "SecondaryActivate" -> { replyVoid(msg); yield true; }
+                case "ContextMenu"       -> { replyVoid(msg); yield true; }
+                case "Scroll"            -> { replyVoid(msg); yield true; }
+                default -> false;
+            };
+        } catch (Throwable t) {
+            log.severe("SNI handler failed for member=" + member + ": " + t);
+            return false;
+        }
+    }
+
+    private boolean handleMenu(SNIMsg msg) {
+        if (disposed) return false;
+        String member = msg.getMember();
+        if (member == null) return false;
+
+        try {
+            return switch (member) {
+                case "Introspect"         -> { replyIntrospect(msg, MENU_INTROSPECT_XML); yield true; }
+                case "GetLayout"          -> { replyGetLayout(msg); yield true; }
+                case "AboutToShow"        -> { replyAboutToShow(msg); yield true; }
+                case "GetGroupProperties" -> { replyGetGroupProperties(msg); yield true; }
+                case "Event"              -> { handleMenuEvent(msg); yield true; }
+                case "EventGroup"         -> { replyVoid(msg); yield true; }
+                default -> false;
+            };
+        } catch (Throwable t) {
+            log.severe("SNI menu handler failed for member=" + member + ": " + t);
+            return false;
+        }
+    }
+
+    // --- SNI property replies ---
+
+    private void replyGet(SNIMsg req) {
+        req.readString(); // skip interface arg
+        String prop = req.readString();
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            appendVariantProperty(reply, prop);
+            reply.send(conn.conn);
+        }
+    }
+
+    private void replyGetAll(SNIMsg req) {
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            var arr = reply.openContainer(SNIDBusLib.DBUS_TYPE_ARRAY, "{sv}");
+            appendDictStr(reply, arr,  "Id",       serviceName);
+            appendDictStr(reply, arr,  "Title",    getTitle());
+            appendDictStr(reply, arr,  "Status",   "Active");
+            appendDictStr(reply, arr,  "Category", "ApplicationStatus");
+            appendDictStr(reply, arr,  "IconName", iconName);
+            appendDictObj(reply, arr,  "Menu",     MENU_PATH);
+            appendDictBool(reply, arr, "ItemIsMenu", false);
+            appendIconPixmap(reply, arr);
+            appendToolTip(reply, arr);
+            reply.closeContainer(arr);
+            reply.send(conn.conn);
+        }
+    }
+
+    private void appendVariantProperty(SNIMsg reply, String prop) {
+        Arena a = reply.arena();
+        switch (prop) {
+            case "Id" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+                SNIMsg.appendStringOn(a, v, serviceName);
+                reply.closeContainer(v);
+            }
+            case "Title" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+                SNIMsg.appendStringOn(a, v, getTitle());
+                reply.closeContainer(v);
+            }
+            case "Status" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+                SNIMsg.appendStringOn(a, v, "Active");
+                reply.closeContainer(v);
+            }
+            case "Category" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+                SNIMsg.appendStringOn(a, v, "ApplicationStatus");
+                reply.closeContainer(v);
+            }
+            case "IconName" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+                SNIMsg.appendStringOn(a, v, iconName);
+                reply.closeContainer(v);
+            }
+            case "Menu" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "o");
+                SNIMsg.appendObjectPathOn(a, v, MENU_PATH);
+                reply.closeContainer(v);
+            }
+            case "ItemIsMenu" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "b");
+                SNIMsg.appendBoolOn(a, v, false);
+                reply.closeContainer(v);
+            }
+            case "IconPixmap" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "a(iiay)");
+                appendPixmapArray(a, v);
+                reply.closeContainer(v);
+            }
+            case "ToolTip" -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "(sa(iiay)ss)");
+                appendToolTipStruct(a, v);
+                reply.closeContainer(v);
+            }
+            default -> {
+                var v = reply.openContainer(SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+                SNIMsg.appendStringOn(a, v, "");
+                reply.closeContainer(v);
+            }
+        }
+    }
+
+    private void appendPixmapArray(Arena a, MemorySegment variantIter) {
+        appendPixmapArrayFrom(a, variantIter, iconData);
+    }
+
+    private static void appendPixmapArrayFrom(Arena a, MemorySegment iter, IconData data) {
+        var pixArr = SNIMsg.openContainerOn(a, iter, SNIDBusLib.DBUS_TYPE_ARRAY, "(iiay)");
+        if (data != null) {
+            var pixStruct = SNIMsg.openContainerOn(a, pixArr, SNIDBusLib.DBUS_TYPE_STRUCT, null);
+            SNIMsg.appendInt32On(a, pixStruct, data.width());
+            SNIMsg.appendInt32On(a, pixStruct, data.height());
+            appendPixelBytes(a, pixStruct, data.pixels());
+            SNIMsg.closeContainerOn(pixArr, pixStruct);
+        }
+        SNIMsg.closeContainerOn(iter, pixArr);
+    }
+
+    private void appendToolTipStruct(Arena a, MemorySegment variantIter) {
+        String tt = tooltip;
+        var ttStruct = SNIMsg.openContainerOn(a, variantIter, SNIDBusLib.DBUS_TYPE_STRUCT, null);
+        SNIMsg.appendStringOn(a, ttStruct, "");
+        var emptyArr = SNIMsg.openContainerOn(a, ttStruct, SNIDBusLib.DBUS_TYPE_ARRAY, "(iiay)");
+        SNIMsg.closeContainerOn(ttStruct, emptyArr);
+        SNIMsg.appendStringOn(a, ttStruct, (tt != null) ? tt : "");
+        SNIMsg.appendStringOn(a, ttStruct, "");
+        SNIMsg.closeContainerOn(variantIter, ttStruct);
+    }
+
+    @SuppressWarnings("restricted")
+    private static void appendPixelBytes(Arena a, MemorySegment structIter, int[] pixels) {
+        var byteArr = SNIMsg.openContainerOn(a, structIter, SNIDBusLib.DBUS_TYPE_ARRAY, "y");
+        MemorySegment bHolder = a.allocate(java.lang.foreign.ValueLayout.JAVA_BYTE);
+        for (int argb : pixels) {
+            for (int shift = 24; shift >= 0; shift -= 8) {
+                bHolder.set(java.lang.foreign.ValueLayout.JAVA_BYTE, 0, (byte)((argb >> shift) & 0xff));
+                try { SNIDBusLib.dbus_message_iter_append_basic
+                        .invoke(byteArr, SNIDBusLib.DBUS_TYPE_BYTE, bHolder); }
+                catch (Throwable t) { throw new RuntimeException(t); }
+            }
+        }
+        SNIMsg.closeContainerOn(structIter, byteArr);
+    }
+
+    // --- DBusMenu replies ---
+
+    private void replyGetLayout(SNIMsg req) {
+        // Read and discard input args (parentId, recursionDepth, propertyNames)
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            reply.appendUInt32(1); // revision
+            var root = reply.openContainer(SNIDBusLib.DBUS_TYPE_STRUCT, null);
+            SNIMsg.appendInt32On(reply.arena(), root, 0); // root id
+            // root properties
+            var rootProps = SNIMsg.openContainerOn(reply.arena(), root,
+                SNIDBusLib.DBUS_TYPE_ARRAY, "{sv}");
+            SNIMsg.closeContainerOn(root, rootProps);
+            // children
+            buildMenuChildren(reply, root);
+            reply.closeContainer(root);
+            reply.send(conn.conn);
+        }
+    }
+
+    private void replyAboutToShow(SNIMsg req) {
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            reply.appendBool(false);
+            reply.send(conn.conn);
+        }
+    }
+
+    private void replyGetGroupProperties(SNIMsg req) {
+        // Return empty array — optional method
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            var arr = reply.openContainer(SNIDBusLib.DBUS_TYPE_ARRAY, "(ia{sv})");
+            reply.closeContainer(arr);
+            reply.send(conn.conn);
+        }
+    }
+
+    private void handleMenuEvent(SNIMsg req) {
+        int id       = req.readInt32();
+        String event = req.readString();
+        replyVoid(req);
+
+        if ("clicked".equals(event)) {
+            PopupMenu pm = target.getPopupMenu();
+            if (pm != null) {
+                MenuItem item = findMenuItem(pm, id);
+                if (item != null && item.isEnabled()) {
+                    if (item instanceof CheckboxMenuItem cb) {
+                        boolean newState = !cb.getState();
+                        cb.setState(newState);
+                        ItemEvent ie = new ItemEvent(cb,
+                            ItemEvent.ITEM_STATE_CHANGED,
+                            cb.getLabel(),
+                            newState ? ItemEvent.SELECTED : ItemEvent.DESELECTED);
+                        XToolkit.postEvent(ie);
+                        emitLayoutUpdated();
+                    } else {
+                        ActionEvent ae = new ActionEvent(item,
+                            ActionEvent.ACTION_PERFORMED,
+                            item.getActionCommand());
+                        XToolkit.postEvent(ae);
+                    }
+                }
+            }
+        }
+    }
+
+    private void handleActivate(SNIMsg req) {
+        replyVoid(req);
+        ActionEvent ae = new ActionEvent(target,
+            ActionEvent.ACTION_PERFORMED,
+            target.getActionCommand());
+        XToolkit.postEvent(ae);
+    }
+
+    // --- Menu building from PopupMenu ---
+
+    private void buildMenuChildren(SNIMsg msg, MemorySegment structIter) {
+        var arr = SNIMsg.openContainerOn(msg.arena(), structIter,
+            SNIDBusLib.DBUS_TYPE_ARRAY, "v");
+        PopupMenu pm = target.getPopupMenu();
+        if (pm != null) {
+            appendMenuItems(msg, arr, pm, new int[]{1});
+        }
+        SNIMsg.closeContainerOn(structIter, arr);
+    }
+
+    private void appendMenuItems(SNIMsg msg, MemorySegment arrIter,
+                                 Menu menu, int[] idCounter) {
+        for (MenuItem item : snapshotMenu(menu)) {
+            int id = idCounter[0]++;
+            appendMenuItem(msg, arrIter, id, item, idCounter);
+        }
+    }
+
+    /**
+     * Returns a best-effort snapshot of the items currently in {@code menu}.
+     *
+     * <p>The EDT may mutate the menu concurrently via {@code Menu.add}/
+     * {@code Menu.remove}, which lock on the AWT tree lock
+     * ({@code Component.LOCK}). That lock is package-private to
+     * {@code java.awt} and cannot be acquired from this peer, so iterating
+     * the menu with {@code getItemCount()} + {@code getItem(i)} can race
+     * with a concurrent remove and throw {@code ArrayIndexOutOfBoundsException}.
+     *
+     * <p>We swallow that exception and return whatever we collected so far —
+     * the desktop will see a slightly truncated menu for one call, and a
+     * subsequent {@code LayoutUpdated} signal (or the next {@code GetLayout})
+     * will refresh it with the consistent state.
+     */
+    private static List<MenuItem> snapshotMenu(Menu menu) {
+        int count = menu.getItemCount();
+        List<MenuItem> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            try {
+                result.add(menu.getItem(i));
+            } catch (ArrayIndexOutOfBoundsException ex) {
+                // Menu shrunk concurrently; stop here.
+                break;
+            }
+        }
+        return result;
+    }
+
+    private void appendMenuItem(SNIMsg msg, MemorySegment arrIter,
+                                int id, MenuItem item, int[] idCounter) {
+        Arena a = msg.arena();
+        var variant = SNIMsg.openContainerOn(a, arrIter,
+            SNIDBusLib.DBUS_TYPE_VARIANT, "(ia{sv}av)");
+        var node = SNIMsg.openContainerOn(a, variant, SNIDBusLib.DBUS_TYPE_STRUCT, null);
+        SNIMsg.appendInt32On(a, node, id);
+
+        var props = SNIMsg.openContainerOn(a, node, SNIDBusLib.DBUS_TYPE_ARRAY, "{sv}");
+        if ("-".equals(item.getLabel())) {
+            appendDictEntryStrOn(a, props, "type", "separator");
+        } else {
+            appendDictEntryStrOn(a, props, "label",   item.getLabel());
+            appendDictEntryBoolOn(a, props, "enabled", item.isEnabled());
+            appendDictEntryBoolOn(a, props, "visible", true);
+            if (item instanceof CheckboxMenuItem cb) {
+                appendDictEntryStrOn(a, props, "toggle-type", "checkmark");
+                appendDictEntryInt32On(a, props, "toggle-state", cb.getState() ? 1 : 0);
+            }
+            if (item instanceof Menu) {
+                appendDictEntryStrOn(a, props, "children-display", "submenu");
+            }
+        }
+        SNIMsg.closeContainerOn(node, props);
+
+        var children = SNIMsg.openContainerOn(a, node, SNIDBusLib.DBUS_TYPE_ARRAY, "v");
+        if (item instanceof Menu subMenu) {
+            appendMenuItems(msg, children, subMenu, idCounter);
+        }
+        SNIMsg.closeContainerOn(node, children);
+
+        SNIMsg.closeContainerOn(variant, node);
+        SNIMsg.closeContainerOn(arrIter, variant);
+    }
+
+    // --- MenuItem lookup by DBusMenu id ---
+
+    private MenuItem findMenuItem(PopupMenu pm, int targetId) {
+        return findInMenu(pm, targetId, new int[]{1});
+    }
+
+    private MenuItem findInMenu(Menu menu, int targetId, int[] counter) {
+        for (MenuItem item : snapshotMenu(menu)) {
+            int id = counter[0]++;
+            if (id == targetId) return item;
+            if (item instanceof Menu sub) {
+                MenuItem found = findInMenu(sub, targetId, counter);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    // --- Image conversion ---
+
+    private void convertImage(Image img) {
+        int size = SNISystemTrayPeer.ICON_SIZE;
+        BufferedImage bi = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = bi.createGraphics();
+        try {
+            g.drawImage(img, 0, 0, size, size, null);
+        } finally {
+            g.dispose();
+        }
+        iconData = new IconData(size, size, bi.getRGB(0, 0, size, size, null, 0, size));
+        iconName = "";  // force desktop to use IconPixmap instead of a named icon
+    }
+
+    // --- IconPixmap and ToolTip property appenders ---
+
+    private void appendIconPixmap(SNIMsg msg, MemorySegment arrIter) {
+        IconData data = iconData;
+        if (data == null) return;
+
+        Arena a = msg.arena();
+        var entry = SNIMsg.openContainerOn(a, arrIter, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, "IconPixmap");
+        var variant = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "a(iiay)");
+        appendPixmapArrayFrom(a, variant, data);
+        SNIMsg.closeContainerOn(entry, variant);
+        SNIMsg.closeContainerOn(arrIter, entry);
+    }
+
+    private void appendToolTip(SNIMsg msg, MemorySegment arrIter) {
+        String tt = tooltip;
+        if (tt == null || tt.isEmpty()) return;
+        Arena a = msg.arena();
+        var entry = SNIMsg.openContainerOn(a, arrIter, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, "ToolTip");
+        var variant = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "(sa(iiay)ss)");
+        var ttStruct = SNIMsg.openContainerOn(a, variant, SNIDBusLib.DBUS_TYPE_STRUCT, null);
+        SNIMsg.appendStringOn(a, ttStruct, "");             // icon name (unused)
+        var emptyPixArr = SNIMsg.openContainerOn(a, ttStruct, SNIDBusLib.DBUS_TYPE_ARRAY, "(iiay)");
+        SNIMsg.closeContainerOn(ttStruct, emptyPixArr);
+        SNIMsg.appendStringOn(a, ttStruct, tt);             // title
+        SNIMsg.appendStringOn(a, ttStruct, "");             // description
+        SNIMsg.closeContainerOn(variant, ttStruct);
+        SNIMsg.closeContainerOn(entry, variant);
+        SNIMsg.closeContainerOn(arrIter, entry);
+    }
+
+    // --- Signal emission ---
+
+    private void emitLayoutUpdated() {
+        try (Arena tmp = Arena.ofConfined();
+             SNIMsg sig = SNIMsg.newSignal(tmp, MENU_PATH, MENU_IFACE, "LayoutUpdated")) {
+            sig.appendUInt32(1); // revision
+            sig.appendInt32(0);  // parent id (root)
+            conn.sendNoReply(sig);
+        } catch (Exception e) {
+            log.fine("SNI: failed to emit LayoutUpdated: " + e.getMessage());
+        }
+    }
+
+    private void emitSignal(String signalName) {
+        try (Arena tmp = Arena.ofConfined();
+             SNIMsg sig = SNIMsg.newSignal(tmp, SNI_PATH, SNI_IFACE, signalName)) {
+            conn.sendNoReply(sig);
+        } catch (Exception e) {
+            if (log.isLoggable(PlatformLogger.Level.FINE)) {
+                log.fine("SNI: failed to emit signal " + signalName + ": " + e.getMessage());
+            }
+        }
+    }
+
+    // --- Generic reply helpers ---
+
+    private void replyVoid(SNIMsg req) {
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            reply.send(conn.conn);
+        }
+    }
+
+    private void replyIntrospect(SNIMsg req, String xml) {
+        try (SNIMsg reply = SNIMsg.newMethodReturn(req)) {
+            reply.appendString(xml);
+            reply.send(conn.conn);
+        }
+    }
+
+    // --- Dict-entry appenders for GetAll / openContainer variants ---
+
+    private void appendDictStr(SNIMsg msg, MemorySegment arr, String key, String value) {
+        Arena a = msg.arena();
+        var entry = SNIMsg.openContainerOn(a, arr, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, key);
+        var v = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+        SNIMsg.appendStringOn(a, v, value);
+        SNIMsg.closeContainerOn(entry, v);
+        SNIMsg.closeContainerOn(arr, entry);
+    }
+
+    private void appendDictObj(SNIMsg msg, MemorySegment arr, String key, String value) {
+        Arena a = msg.arena();
+        var entry = SNIMsg.openContainerOn(a, arr, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, key);
+        var v = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "o");
+        SNIMsg.appendObjectPathOn(a, v, value);
+        SNIMsg.closeContainerOn(entry, v);
+        SNIMsg.closeContainerOn(arr, entry);
+    }
+
+    private void appendDictBool(SNIMsg msg, MemorySegment arr, String key, boolean value) {
+        Arena a = msg.arena();
+        var entry = SNIMsg.openContainerOn(a, arr, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, key);
+        var v = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "b");
+        SNIMsg.appendBoolOn(a, v, value);
+        SNIMsg.closeContainerOn(entry, v);
+        SNIMsg.closeContainerOn(arr, entry);
+    }
+
+    private void appendDictEntryStrOn(Arena a, MemorySegment propsArr,
+                                      String key, String value) {
+        var entry = SNIMsg.openContainerOn(a, propsArr, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, key);
+        var v = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "s");
+        SNIMsg.appendStringOn(a, v, value);
+        SNIMsg.closeContainerOn(entry, v);
+        SNIMsg.closeContainerOn(propsArr, entry);
+    }
+
+    private void appendDictEntryBoolOn(Arena a, MemorySegment propsArr,
+                                       String key, boolean value) {
+        var entry = SNIMsg.openContainerOn(a, propsArr, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, key);
+        var v = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "b");
+        SNIMsg.appendBoolOn(a, v, value);
+        SNIMsg.closeContainerOn(entry, v);
+        SNIMsg.closeContainerOn(propsArr, entry);
+    }
+
+    private void appendDictEntryInt32On(Arena a, MemorySegment propsArr,
+                                        String key, int value) {
+        var entry = SNIMsg.openContainerOn(a, propsArr, SNIDBusLib.DBUS_TYPE_DICT_ENTRY, null);
+        SNIMsg.appendStringOn(a, entry, key);
+        var v = SNIMsg.openContainerOn(a, entry, SNIDBusLib.DBUS_TYPE_VARIANT, "i");
+        SNIMsg.appendInt32On(a, v, value);
+        SNIMsg.closeContainerOn(entry, v);
+        SNIMsg.closeContainerOn(propsArr, entry);
+    }
+
+    // --- Utility ---
+
+    private String getTitle() {
+        String tt = tooltip;
+        return (tt != null && !tt.isEmpty()) ? tt : "Java";
+    }
+
+    /**
+     * Probes the session bus for {@code org.kde.StatusNotifierWatcher}.
+     * Opens a temporary private connection, sends a synchronous
+     * {@code GetNameOwner} call with a {@link #WATCHER_PROBE_TIMEOUT_MS}
+     * timeout, and closes the connection immediately afterwards.
+     * Called from the EDT during {@code SystemTray.isSupported()}, so the
+     * timeout must be short enough to keep the UI responsive.
+     *
+     * @return {@code true} if the watcher service is present on the bus
+     */
+    static boolean isWatcherAvailable() {
+        SNIDBusConn c = SNIDBusConn.connectSession();
+        if (c == null) return false;
+        try (Arena tmp = Arena.ofConfined();
+             SNIMsg call = SNIMsg.newMethodCall(tmp,
+                 "org.freedesktop.DBus", "/org/freedesktop/DBus",
+                 "org.freedesktop.DBus", "GetNameOwner")) {
+            call.appendString(SNI_WATCHER_BUS);
+            try (Arena errArena = Arena.ofConfined()) {
+                MemorySegment error = errArena.allocate(SNIDBusLib.ERROR_LAYOUT);
+                SNIDBusLib.dbus_error_init.invoke(error);
+                MemorySegment replyPtr = (MemorySegment)
+                    SNIDBusLib.dbus_connection_send_with_reply_and_block
+                        .invoke(c.conn, call.ptr, WATCHER_PROBE_TIMEOUT_MS, error);
+                int errSet = (int) SNIDBusLib.dbus_error_is_set.invoke(error);
+                if (errSet != 0) {
+                    SNIDBusLib.dbus_error_free.invoke(error);
+                    return false;
+                }
+                if (replyPtr == null || replyPtr.equals(MemorySegment.NULL)) return false;
+                try (SNIMsg _ = SNIMsg.own(replyPtr)) {
+                    return true;
+                }
+            }
+        } catch (Throwable e) {
+            return false;
+        } finally {
+            c.closePrivate();
+        }
+    }
+
+    // --- Introspection XML ---
+
+    private static final String SNI_INTROSPECT_XML = """
+        <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+         "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+        <node>
+          <interface name="org.kde.StatusNotifierItem">
+            <method name="Activate">
+              <arg type="i" direction="in"/><arg type="i" direction="in"/>
+            </method>
+            <method name="SecondaryActivate">
+              <arg type="i" direction="in"/><arg type="i" direction="in"/>
+            </method>
+            <method name="ContextMenu">
+              <arg type="i" direction="in"/><arg type="i" direction="in"/>
+            </method>
+            <method name="Scroll">
+              <arg type="i" direction="in"/><arg type="s" direction="in"/>
+            </method>
+            <property name="Id"          type="s" access="read"/>
+            <property name="Title"       type="s" access="read"/>
+            <property name="Status"      type="s" access="read"/>
+            <property name="Category"    type="s" access="read"/>
+            <property name="IconName"    type="s" access="read"/>
+            <property name="IconPixmap"  type="a(iiay)" access="read"/>
+            <property name="ToolTip"     type="(sa(iiay)ss)" access="read"/>
+            <property name="Menu"        type="o" access="read"/>
+            <property name="ItemIsMenu"  type="b" access="read"/>
+            <signal name="NewIcon"/>
+            <signal name="NewTitle"/>
+            <signal name="NewStatus">  <arg type="s"/></signal>
+            <signal name="NewToolTip"/>
+          </interface>
+          <interface name="org.freedesktop.DBus.Properties">
+            <method name="Get">
+              <arg type="s" direction="in"/><arg type="s" direction="in"/>
+              <arg type="v" direction="out"/>
+            </method>
+            <method name="GetAll">
+              <arg type="s" direction="in"/>
+              <arg type="a{sv}" direction="out"/>
+            </method>
+          </interface>
+          <interface name="org.freedesktop.DBus.Introspectable">
+            <method name="Introspect"><arg type="s" direction="out"/></method>
+          </interface>
+        </node>
+        """;
+
+    private static final String MENU_INTROSPECT_XML = """
+        <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+         "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+        <node>
+          <interface name="com.canonical.dbusmenu">
+            <method name="GetLayout">
+              <arg type="i" direction="in"/>
+              <arg type="i" direction="in"/>
+              <arg type="as" direction="in"/>
+              <arg type="u" direction="out"/>
+              <arg type="(ia{sv}av)" direction="out"/>
+            </method>
+            <method name="GetGroupProperties">
+              <arg type="ai" direction="in"/>
+              <arg type="as" direction="in"/>
+              <arg type="a(ia{sv})" direction="out"/>
+            </method>
+            <method name="Event">
+              <arg type="i" direction="in"/>
+              <arg type="s" direction="in"/>
+              <arg type="v" direction="in"/>
+              <arg type="u" direction="in"/>
+            </method>
+            <method name="EventGroup">
+              <arg type="a(isvu)" direction="in"/>
+              <arg type="ai"      direction="out"/>
+            </method>
+            <method name="AboutToShow">
+              <arg type="i" direction="in"/>
+              <arg type="b" direction="out"/>
+            </method>
+            <signal name="LayoutUpdated">
+              <arg type="u"/><arg type="i"/>
+            </signal>
+            <signal name="ItemsPropertiesUpdated">
+              <arg type="a(ia{sv})"/>
+              <arg type="a(ias)"/>
+            </signal>
+          </interface>
+          <interface name="org.freedesktop.DBus.Introspectable">
+            <method name="Introspect"><arg type="s" direction="out"/></method>
+          </interface>
+        </node>
+        """;
+}

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -1164,19 +1164,46 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
     public TrayIconPeer createTrayIcon(TrayIcon target)
       throws HeadlessException, AWTException
     {
-        TrayIconPeer peer = new XTrayIconPeer(target);
+        TrayIconPeer peer;
+        SNISystemTrayPeer sniTray = SNISystemTrayPeer.getPeerInstance();
+        if (sniTray != null && sniTray.isAvailable()) {
+            peer = new SNITrayIconPeer(target);
+        } else {
+            peer = new XTrayIconPeer(target);
+        }
         targetCreatedPeer(target, peer);
         return peer;
     }
 
     @Override
     public SystemTrayPeer createSystemTray(SystemTray target) throws HeadlessException {
-        SystemTrayPeer peer = new XSystemTrayPeer(target);
-        return peer;
+        // Prefer SNI (StatusNotifierItem) when the session bus has a watcher,
+        // fall back to X11 XEmbed otherwise. The UNIXToolkit.shouldDisableSystemTray()
+        // policy is specifically a workaround for broken xembed rendering on
+        // older GNOME shells (< 45), so the SNI path intentionally does not
+        // consult it — SNI is precisely the protocol that fixes that bug.
+        // The X11 fallback (XSystemTrayPeer constructor) still respects the
+        // policy when SNI is unavailable.
+        SNISystemTrayPeer sniPeer = new SNISystemTrayPeer(target);
+        if (sniPeer.isAvailable()) {
+            return sniPeer;
+        }
+        return new XSystemTrayPeer(target);
     }
 
     @Override
     public boolean isTraySupported() {
+        // SystemTray.isSupported() may be called before SystemTray.getSystemTray()
+        // (the typical "if (isSupported()) ..." pattern), in which case no peer
+        // has been created yet and getPeerInstance() returns null. Probe the
+        // D-Bus session bus directly so we do not falsely report "not supported"
+        // when SNI is in fact available.
+        SNISystemTrayPeer sniPeer = SNISystemTrayPeer.getPeerInstance();
+        if (sniPeer != null) {
+            if (sniPeer.isAvailable()) return true;
+        } else if (SNITrayIconPeer.isWatcherAvailable()) {
+            return true;
+        }
         XSystemTrayPeer peer = XSystemTrayPeer.getPeerInstance();
         if (peer != null) {
             return peer.isAvailable();

--- a/test/jdk/java/awt/TrayIcon/SNIFallbackTest/SNIFallbackTest.java
+++ b/test/jdk/java/awt/TrayIcon/SNIFallbackTest/SNIFallbackTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Field;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8035556
+ * @key headful
+ * @summary Verifies that TrayIcon falls back to XTrayIconPeer when
+ *          org.kde.StatusNotifierWatcher is not available on the session bus,
+ *          and that SystemTray.add() does not throw in that case.
+ * @requires os.family == "linux"
+ * @modules java.desktop/sun.awt.X11:+open
+ *          java.desktop/java.awt:+open
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main/othervm --enable-native-access=ALL-UNNAMED SNIFallbackTest
+ */
+public class SNIFallbackTest {
+
+    public static void main(String[] args) throws Exception {
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray not supported on this desktop");
+        }
+
+        TrayIcon[] iconHolder = new TrayIcon[1];
+        EventQueue.invokeAndWait(() -> {
+            BufferedImage img = new BufferedImage(22, 22, BufferedImage.TYPE_INT_ARGB);
+            iconHolder[0] = new TrayIcon(img, "SNI Fallback Test");
+            try {
+                SystemTray.getSystemTray().add(iconHolder[0]);
+            } catch (AWTException e) {
+                throw new RuntimeException(
+                    "FAIL: SystemTray.add() threw unexpectedly: " + e, e);
+            }
+        });
+
+        TrayIcon icon = iconHolder[0];
+        Field peerField = TrayIcon.class.getDeclaredField("peer");
+        peerField.setAccessible(true);
+        Object peer = peerField.get(icon);
+        String peerClassName = peer.getClass().getName();
+
+        EventQueue.invokeAndWait(() -> SystemTray.getSystemTray().remove(icon));
+
+        if (peerClassName.equals("sun.awt.X11.SNITrayIconPeer")) {
+            throw new SkippedException(
+                "SNI watcher is active on this desktop — X11 fallback not exercised here");
+        }
+        if (!peerClassName.equals("sun.awt.X11.XTrayIconPeer")) {
+            throw new RuntimeException("FAIL: unexpected peer class: " + peerClassName);
+        }
+
+        System.out.println("PASS: X11 fallback peer created when SNI watcher is absent: " + peerClassName);
+    }
+}

--- a/test/jdk/java/awt/TrayIcon/SNITrayIconPropertiesTest/SNITrayIconPropertiesTest.java
+++ b/test/jdk/java/awt/TrayIcon/SNITrayIconPropertiesTest/SNITrayIconPropertiesTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Field;
+
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8035556
+ * @key headful
+ * @summary Verifies SNITrayIconPeer property updates when SNI is active:
+ *          unique service names for multiple icons, setToolTip reflection,
+ *          updateImage populating icon data, and dispose idempotency.
+ * @requires os.family == "linux"
+ * @modules java.desktop/sun.awt.X11:+open
+ *          java.desktop/java.awt:+open
+ * @library /test/lib
+ * @build jdk.test.lib.Platform jtreg.SkippedException
+ * @run main/othervm --enable-native-access=ALL-UNNAMED SNITrayIconPropertiesTest
+ */
+public class SNITrayIconPropertiesTest {
+
+    public static void main(String[] args) throws Exception {
+        if (!Platform.isLinux()) {
+            throw new SkippedException("SNI is Linux-only");
+        }
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray not supported on this desktop");
+        }
+
+        TrayIcon[] icons = new TrayIcon[2];
+        EventQueue.invokeAndWait(() -> {
+            BufferedImage img = new BufferedImage(22, 22, BufferedImage.TYPE_INT_ARGB);
+            icons[0] = new TrayIcon(img, "SNI Props Test 1");
+            icons[1] = new TrayIcon(img, "SNI Props Test 2");
+            try {
+                SystemTray tray = SystemTray.getSystemTray();
+                tray.add(icons[0]);
+                tray.add(icons[1]);
+            } catch (AWTException e) {
+                throw new RuntimeException("FAIL: SystemTray.add() threw: " + e, e);
+            }
+        });
+
+        Field peerField = TrayIcon.class.getDeclaredField("peer");
+        peerField.setAccessible(true);
+        Object peer0 = peerField.get(icons[0]);
+        Object peer1 = peerField.get(icons[1]);
+
+        if (!peer0.getClass().getName().equals("sun.awt.X11.SNITrayIconPeer")) {
+            EventQueue.invokeAndWait(() -> {
+                SystemTray tray = SystemTray.getSystemTray();
+                tray.remove(icons[0]);
+                tray.remove(icons[1]);
+            });
+            throw new SkippedException(
+                "SNI not active on this desktop (peer is " + peer0.getClass().getName() + ") " +
+                "— org.kde.StatusNotifierWatcher may not be running");
+        }
+
+        try {
+            testUniqueServiceNames(peer0, peer1);
+            testSetToolTip(icons[0], peer0);
+            testUpdateImage(icons[0], peer0);
+            testDisposeIdempotency(icons[0], peer0);
+        } finally {
+            // icons[0] may already be removed by testDisposeIdempotency; remove is a no-op if so
+            EventQueue.invokeAndWait(() -> {
+                SystemTray tray = SystemTray.getSystemTray();
+                tray.remove(icons[0]);
+                tray.remove(icons[1]);
+            });
+        }
+
+        System.out.println("All SNI property tests passed.");
+    }
+
+    private static void testUniqueServiceNames(Object peer0, Object peer1) throws Exception {
+        Field f = peer0.getClass().getDeclaredField("serviceName");
+        f.setAccessible(true);
+        String name0 = (String) f.get(peer0);
+        String name1 = (String) f.get(peer1);
+        if (name0.equals(name1)) {
+            throw new RuntimeException(
+                "FAIL: two TrayIcons share the same SNI service name: " + name0);
+        }
+        System.out.println("PASS: unique service names: " + name0 + " / " + name1);
+    }
+
+    private static void testSetToolTip(TrayIcon icon, Object peer) throws Exception {
+        Field f = peer.getClass().getDeclaredField("tooltip");
+        f.setAccessible(true);
+
+        EventQueue.invokeAndWait(() -> icon.setToolTip("hello-sni"));
+        String tooltip = (String) f.get(peer);
+        if (!"hello-sni".equals(tooltip)) {
+            throw new RuntimeException(
+                "FAIL: peer.tooltip expected 'hello-sni', got '" + tooltip + "'");
+        }
+        System.out.println("PASS: setToolTip() updated peer.tooltip");
+    }
+
+    private static void testUpdateImage(TrayIcon icon, Object peer) throws Exception {
+        Field f = peer.getClass().getDeclaredField("iconData");
+        f.setAccessible(true);
+
+        BufferedImage img = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < 32; y++)
+            for (int x = 0; x < 32; x++)
+                img.setRGB(x, y, 0xFF_FF0000);  // opaque red
+
+        EventQueue.invokeAndWait(() -> icon.setImage(img));
+        if (f.get(peer) == null) {
+            throw new RuntimeException("FAIL: peer.iconData is null after setImage()");
+        }
+        System.out.println("PASS: updateImage() populated peer.iconData");
+    }
+
+    private static void testDisposeIdempotency(TrayIcon icon, Object peer) throws Exception {
+        Field f = peer.getClass().getDeclaredField("disposed");
+        f.setAccessible(true);
+
+        EventQueue.invokeAndWait(() -> SystemTray.getSystemTray().remove(icon));
+        if (!(boolean) f.get(peer)) {
+            throw new RuntimeException("FAIL: peer.disposed should be true after remove()");
+        }
+        // Second remove must not throw
+        EventQueue.invokeAndWait(() -> SystemTray.getSystemTray().remove(icon));
+        System.out.println("PASS: dispose() is idempotent");
+    }
+}

--- a/test/jdk/java/awt/TrayIcon/SNITrayIconTest/SNITrayIconTest.java
+++ b/test/jdk/java/awt/TrayIcon/SNITrayIconTest/SNITrayIconTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Field;
+
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8035556
+ * @key headful
+ * @summary On Linux desktops that provide org.kde.StatusNotifierWatcher
+ *          (e.g. Ubuntu 24+ with GNOME and the ubuntu-appindicators extension,
+ *          KDE Plasma), verify that:
+ *          1. The peer created is SNITrayIconPeer, not XTrayIconPeer
+ *          2. SystemTray.remove() disposes the peer cleanly
+ * @requires os.family == "linux"
+ * @modules java.desktop/sun.awt.X11:+open
+ *          java.desktop/java.awt:+open
+ * @library /test/lib
+ * @build jdk.test.lib.Platform jtreg.SkippedException
+ * @run main/othervm --enable-native-access=ALL-UNNAMED SNITrayIconTest
+ */
+public class SNITrayIconTest {
+
+    public static void main(String[] args) throws Exception {
+        if (!Platform.isLinux()) {
+            throw new SkippedException("SNI is Linux-only");
+        }
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray not supported on this desktop");
+        }
+
+        TrayIcon[] iconHolder = new TrayIcon[1];
+        EventQueue.invokeAndWait(() -> {
+            BufferedImage img = new BufferedImage(22, 22, BufferedImage.TYPE_INT_ARGB);
+            iconHolder[0] = new TrayIcon(img, "SNI Test");
+            try {
+                SystemTray.getSystemTray().add(iconHolder[0]);
+            } catch (AWTException e) {
+                throw new RuntimeException("FAIL: SystemTray.add() threw: " + e, e);
+            }
+        });
+
+        TrayIcon icon = iconHolder[0];
+
+        // Access the peer — java.desktop/java.awt is opened via @modules
+        Field peerField = TrayIcon.class.getDeclaredField("peer");
+        peerField.setAccessible(true);
+        Object peer = peerField.get(icon);
+
+        if (peer == null) {
+            throw new RuntimeException("FAIL: TrayIcon peer is null after add()");
+        }
+
+        String peerClassName = peer.getClass().getName();
+        System.out.println("Peer class: " + peerClassName);
+
+        if (!peerClassName.equals("sun.awt.X11.SNITrayIconPeer")) {
+            // SNI watcher not present on this desktop — X11 fallback is correct
+            EventQueue.invokeAndWait(() -> SystemTray.getSystemTray().remove(icon));
+            throw new SkippedException(
+                "SNI not active on this desktop (peer is " + peerClassName + ") " +
+                "— org.kde.StatusNotifierWatcher may not be running");
+        }
+        System.out.println("PASS: peer is SNITrayIconPeer");
+
+        // Verify dispose() removes the icon cleanly
+        EventQueue.invokeAndWait(() -> SystemTray.getSystemTray().remove(icon));
+
+        // Verify disposed state — sun.awt.X11 is opened via @modules
+        Field disposedField = peer.getClass().getDeclaredField("disposed");
+        disposedField.setAccessible(true);
+        boolean disposed = (boolean) disposedField.get(peer);
+
+        if (!disposed) {
+            throw new RuntimeException("FAIL: peer.disposed is false after SystemTray.remove()");
+        }
+        System.out.println("PASS: dispose() completed cleanly");
+
+        System.out.println("All SNI tests passed.");
+    }
+}


### PR DESCRIPTION
Add SNI (org.kde.StatusNotifierItem) D-Bus support to java.awt.TrayIcon on Linux. On Ubuntu 24+ and modern Wayland/GNOME desktops, the legacy X11 XEmbed protocol no longer renders system tray icons; SNI is the de-facto standard used by AppIndicator, KDE Plasma, and the GNOME AppIndicator shell extension.

The D-Bus layer is implemented with Panama FFM (java.lang.foreign) against libdbus-1.so.3 -- no new JNI code, no new native build artifacts in java.desktop. When the org.kde.StatusNotifierWatcher service is present on the session bus, TrayIcon delegates to the new SNI peer; otherwise it falls back to the existing X11 XEmbed peer, which continues to honor UNIXToolkit.shouldDisableSystemTray() for GNOME shells < 45.

New classes (sun.awt.X11):
  - SNIDBusLib        -- Panama FFM bindings for libdbus-1.so.3
  - SNIMsg            -- DBusMessage wrapper with own/borrow ownership
  - SNIDBusConn       -- session connection, dispatch loop, filter API
  - SNITrayIconPeer   -- TrayIconPeer via org.kde.StatusNotifierItem
                         and com.canonical.dbusmenu
  - SNISystemTrayPeer -- SystemTrayPeer; presence check for the watcher

XToolkit createTrayIcon/createSystemTray/isTraySupported now delegate to SNI when the watcher is present, with a lazy session-bus probe so that "if (SystemTray.isSupported())" returns the correct answer on a fresh JVM before any peer has been created.

Robustness features:
  - SNIMsg borrow/own ownership so the dispatch callback closes only the Arena and never unrefs the libdbus-owned message
  - close()/closePrivate() guarded by AtomicBoolean.compareAndSet
  - NameOwnerChanged filter automatically re-registers icons when the SNI watcher restarts (e.g. GNOME shell extension reload)
  - Defensive menu snapshot to tolerate concurrent EDT mutation of the PopupMenu during DBusMenu serialization

Style:
  - Specific imports throughout the new SNI* files (no java.*.*)
  - Private MethodHandle wrappers in SNIMsg and SNIDBusConn centralize the try { mh.invoke() } catch (Throwable) idiom and keep the business logic free of inline try/catch blocks

Tests:
  - test/jdk/java/awt/TrayIcon/SNITrayIconTest           -- basic peer
  - test/jdk/java/awt/TrayIcon/SNITrayIconPropertiesTest -- properties
  - test/jdk/java/awt/TrayIcon/SNIFallbackTest           -- X11 fallback




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8341144](https://bugs.openjdk.org/browse/JDK-8341144): Java AWT TrayIcon uses the old xembed while most Linux distros switched to SNI (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31439/head:pull/31439` \
`$ git checkout pull/31439`

Update a local copy of the PR: \
`$ git checkout pull/31439` \
`$ git pull https://git.openjdk.org/jdk.git pull/31439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31439`

View PR using the GUI difftool: \
`$ git pr show -t 31439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31439.diff">https://git.openjdk.org/jdk/pull/31439.diff</a>

</details>
