### PR TITLE
8386202: Genshen: Regulator thread reporting hiccup times proportional to safepoint times

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -221,22 +221,22 @@ void ShenandoahControlThread::run_service() {
     // Wait before performing the next action. If allocation happened during this wait,
     // we exit sooner, to let heuristics re-evaluate new conditions. If we are at idle,
     // back off exponentially.
-    const double before_sleep = most_recent_wake_time;
     if (heap->has_changed()) {
       sleep = ShenandoahControlIntervalMin;
-    } else if ((before_sleep - last_sleep_adjust_time) * 1000 > ShenandoahControlIntervalAdjustPeriod){
+    } else if ((most_recent_wake_time - last_sleep_adjust_time) * 1000 > ShenandoahControlIntervalAdjustPeriod){
       sleep = MIN2<int>(ShenandoahControlIntervalMax, MAX2(1, sleep * 2));
-      last_sleep_adjust_time = before_sleep;
+      last_sleep_adjust_time = most_recent_wake_time;
     }
     MonitorLocker ml(&_control_lock, Mutex::_no_safepoint_check_flag);
+    const double before_sleep_time = os::elapsedTime();
     ml.wait(sleep);
+    most_recent_wake_time = os::elapsedTime();
     // Record a conservative estimate of the longest anticipated sleep duration until we sample again.
     double planned_sleep_interval = MIN2<int>(ShenandoahControlIntervalMax, MAX2(1, sleep * 2)) / 1000.0;
-    most_recent_wake_time = os::elapsedTime();
     heuristics->update_should_start_query_times(most_recent_wake_time, planned_sleep_interval);
     if (LogTarget(Debug, gc, thread)::is_enabled()) {
-      double elapsed = most_recent_wake_time - before_sleep;
-      double hiccup = elapsed - double(sleep);
+      double elapsed = most_recent_wake_time - before_sleep_time;
+      double hiccup = elapsed - double(sleep) / 1000.0;
       if (hiccup > 0.001) {
         log_debug(gc, thread)("Control Thread hiccup time: %.3fs", hiccup);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -132,7 +132,7 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   _young_heuristics->update_should_start_query_times(_most_recent_wake_time, double(_sleep) / 1000.0);
   if (LogTarget(Debug, gc, thread)::is_enabled()) {
     double elapsed = _most_recent_wake_time - before_sleep_time;
-    double hiccup = elapsed - double(_sleep);
+    double hiccup = elapsed - double(_sleep) / 1000.0;
     if (hiccup > 0.001) {
       log_debug(gc, thread)("Regulator hiccup time: %.3fs", hiccup);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -124,7 +124,7 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   }
 
   SuspendibleThreadSetLeaver leaver;
-  const double before_sleep_time = os::elapsedTime(); 
+  const double before_sleep_time = os::elapsedTime();
   os::naked_short_sleep(_sleep);
   _most_recent_wake_time = os::elapsedTime();
   _young_heuristics->update_should_start_query_times(_most_recent_wake_time, double(_sleep) / 1000.0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -116,19 +116,17 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   // Wait before performing the next action. If allocation happened during this wait,
   // we exit sooner, to let heuristics re-evaluate new conditions. If we are at idle,
   // back off exponentially.
-  double before_sleep_time = _most_recent_wake_time;
   if (ShenandoahHeap::heap()->has_changed()) {
     _sleep = ShenandoahControlIntervalMin;
-  } else if ((before_sleep_time - _last_sleep_adjust_time) * 1000 > ShenandoahControlIntervalAdjustPeriod){
+  } else if ((_most_recent_wake_time - _last_sleep_adjust_time) * 1000 > ShenandoahControlIntervalAdjustPeriod){
     _sleep = MIN2<uint>(ShenandoahControlIntervalMax, MAX2(1u, _sleep * 2));
-    _last_sleep_adjust_time = before_sleep_time;
+    _last_sleep_adjust_time = _most_recent_wake_time;
   }
 
   SuspendibleThreadSetLeaver leaver;
+  const double before_sleep_time = os::elapsedTime(); 
   os::naked_short_sleep(_sleep);
-  double wake_time = os::elapsedTime();
-  _most_recent_period = wake_time - _most_recent_wake_time;
-  _most_recent_wake_time = wake_time;
+  _most_recent_wake_time = os::elapsedTime();
   _young_heuristics->update_should_start_query_times(_most_recent_wake_time, double(_sleep) / 1000.0);
   if (LogTarget(Debug, gc, thread)::is_enabled()) {
     double elapsed = _most_recent_wake_time - before_sleep_time;

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
@@ -82,7 +82,6 @@ class ShenandoahRegulatorThread: public ConcurrentGCThread {
   // duration of planned regulator sleep period, in ms
   uint _sleep;
   double _most_recent_wake_time;
-  double _most_recent_period;
   double _last_sleep_adjust_time;
 };
 


### PR DESCRIPTION
The reported hiccup value is inaccurate. `sleep` and `_sleep` is measured in milliseconds by the controller and regulator thread. `elapsed` is measured in seconds. We are incorrectly computing the difference of `elapsed` (seconds) and `sleep` and `_sleep` (milliseconds). 

In addition, "The `elapsed` time for the hiccup is using the `before_sleep_time` as the subtrahend, but this is carried over from the previous iteration of the run service loop. The regulator thread participates in safepoints, so this loop will not iterate during pauses. This results in hiccups being reported on the order of safepoint time, rather than the expected value (which is just how much longer the sleep lasted than intended)." - @earthling-amzn 

### Fix
Convert `sleep` and`_sleep` into seconds when calculating hiccup time and sample the `before_sleep_time` right before the thread sleeps. 


### Testing
`gc/shenandoah` with linux-x86_64-server-fastdebug.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386202](https://bugs.openjdk.org/browse/JDK-8386202): Genshen: Regulator thread reporting hiccup times proportional to safepoint times (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31442/head:pull/31442` \
`$ git checkout pull/31442`

Update a local copy of the PR: \
`$ git checkout pull/31442` \
`$ git pull https://git.openjdk.org/jdk.git pull/31442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31442`

View PR using the GUI difftool: \
`$ git pr show -t 31442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31442.diff">https://git.openjdk.org/jdk/pull/31442.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31442#issuecomment-4661859794)
</details>
