### PR TITLE
8355320: FileUtils.copyDirectory() mishandles an existing destination directory

### DIFF
--- a/test/lib-test/jdk/test/lib/FileUtilsTest.java
+++ b/test/lib-test/jdk/test/lib/FileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8285452
+ * @bug 8285452 8355320
  * @summary Unit Test for a common Test API in jdk.test.lib.util.FileUtils
  * @library .. /test/lib
  * @run main FileUtilsTest
@@ -37,6 +37,7 @@ import jdk.test.lib.util.FileUtils;
 public class FileUtilsTest {
 
     public static void main(String[] args) throws Exception {
+        testCopyDirectoryToPWD();
         // Replace with same line
         test("a", 1, 1, null, "a", "a\n");
         // Replace with different line
@@ -120,5 +121,32 @@ public class FileUtilsTest {
             // output is null
         }
         Asserts.assertEQ(output, (expected != null) ? expected.replaceAll("\n", System.lineSeparator()) : null);
+    }
+
+    private static void testCopyDirectoryToPWD() throws IOException {
+        // Create a source directory with a file
+        Path srcDir = Files.createTempDirectory("copyDirTest");
+        Path srcFile = srcDir.resolve("file1.txt");
+        Files.writeString(srcFile, "hello");
+
+        try {
+            // Copy to PWD (current directory)
+            Path pwd = Paths.get(".");
+            System.out.println("copyDirectory(\"" + srcDir + "\", \"" + pwd + "\")");
+            FileUtils.copyDirectory(srcDir, pwd);
+
+            // Verify the file was copied
+            Path copiedFile = pwd.resolve(srcDir.relativize(srcFile));
+            Asserts.assertTrue(Files.exists(copiedFile), "Copied file should exist");
+
+            // Verify we can still write to PWD after copyDirectory
+            Path newFile = Paths.get("file2.txt");
+            Files.writeString(newFile, "world");
+            Asserts.assertTrue(Files.exists(newFile), "Should be able to create files in PWD after copyDirectory");
+            Files.delete(newFile);
+            Files.delete(copiedFile);
+        } finally {
+            FileUtils.deleteFileTreeUnchecked(srcDir);
+        }
     }
 }

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -392,7 +392,7 @@ public final class FileUtils {
             stream.forEach(sourcePath -> {
                 try {
                     Path destPath = dst.resolve(src.relativize(sourcePath));
-                    if (Files.isDirectory(sourcePath)) {
+                    if (Files.isDirectory(sourcePath, LinkOption.NOFOLLOW_LINKS)) {
                         Files.createDirectories(destPath);
                     } else {
                         Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -392,7 +392,11 @@ public final class FileUtils {
             stream.forEach(sourcePath -> {
                 try {
                     Path destPath = dst.resolve(src.relativize(sourcePath));
-                    Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+                    if (Files.isDirectory(sourcePath)) {
+                        Files.createDirectories(destPath);
+                    } else {
+                        Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+                    }
                     destPath.toFile().setWritable(true);
                 } catch (IOException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
FileUtils.copyDirectory() used Files.copy() for all entries including directories. When the destination is an existing directory (like PWD), Files.copy with REPLACE_EXISTING replaces the directory inode, corrupting it. Fixed by using Files.createDirectories() for directory entries and Files.copy() only for files. Added test verifying copyDirectory to PWD works correctly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8355320](https://bugs.openjdk.org/browse/JDK-8355320): FileUtils.copyDirectory() mishandles an existing destination directory (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31444/head:pull/31444` \
`$ git checkout pull/31444`

Update a local copy of the PR: \
`$ git checkout pull/31444` \
`$ git pull https://git.openjdk.org/jdk.git pull/31444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31444`

View PR using the GUI difftool: \
`$ git pr show -t 31444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31444.diff">https://git.openjdk.org/jdk/pull/31444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31444#issuecomment-4663802138)
</details>
