### PR TITLE
8386204: GenShen: Bootstrap cycles are misidentified in logs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -45,19 +45,19 @@
 #include "runtime/vmThread.hpp"
 #include "utilities/events.hpp"
 
-ShenandoahDegenGC::ShenandoahDegenGC(ShenandoahDegenPoint degen_point, ShenandoahGeneration* generation) :
+ShenandoahDegenGC::ShenandoahDegenGC(ShenandoahDegenPoint degen_point, ShenandoahGeneration* generation, bool do_old_gc_bootstrap) :
   ShenandoahGC(generation),
   _degen_point(degen_point),
-  _abbreviated(false) {
+  _abbreviated(false),
+  _do_old_gc_bootstrap(do_old_gc_bootstrap) {
 }
 
 bool ShenandoahDegenGC::collect(GCCause::Cause cause) {
   vmop_degenerated();
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational()) {
-    bool is_bootstrap_gc = heap->young_generation()->is_bootstrap_cycle();
     FormatBuffer<32> buf("Degenerated %s GC", _generation->name());
-    const char* msg = is_bootstrap_gc ? "Degenerated Bootstrap Old GC" : buf.buffer();
+    const char* msg = _do_old_gc_bootstrap ? "Degenerated Bootstrap Old GC" : buf.buffer();
     heap->mmu_tracker()->record_degenerated(GCId::current(), msg);
     heap->log_heap_status(FormatBuffer<64>("At end of %s", msg));
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -35,9 +35,10 @@ class ShenandoahDegenGC : public ShenandoahGC {
 private:
   const ShenandoahDegenPoint  _degen_point;
   bool _abbreviated;
+  const bool _do_old_gc_bootstrap;
 
 public:
-  ShenandoahDegenGC(ShenandoahDegenPoint degen_point, ShenandoahGeneration* generation);
+  ShenandoahDegenGC(ShenandoahDegenPoint degen_point, ShenandoahGeneration* generation, bool do_old_gc_bootstrap = false);
   bool collect(GCCause::Cause cause) override;
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -53,7 +53,8 @@ ShenandoahGenerationalControlThread::ShenandoahGenerationalControlThread() :
   _requested_generation(nullptr),
   _gc_mode(none),
   _degen_point(ShenandoahGC::_degenerated_unset),
-  _heap(ShenandoahGenerationalHeap::heap()) {
+  _heap(ShenandoahGenerationalHeap::heap()),
+  _do_old_gc_bootstrap(false) {
   shenandoah_assert_generational();
   set_name("ShenControl");
   create_and_start();
@@ -529,12 +530,14 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
 
   assert(!generation->is_old(), "Old GC takes a different control path");
 
+  _do_old_gc_bootstrap = do_old_gc_bootstrap;
   ShenandoahConcurrentGC gc(generation, do_old_gc_bootstrap);
   _heap->increment_total_collections(false);
   if (gc.collect(cause)) {
     // Cycle is complete
     _heap->notify_gc_progress();
     generation->record_success_concurrent(gc.abbreviated());
+    _do_old_gc_bootstrap = false;
   } else {
     assert(_heap->cancelled_gc(), "Must have been cancelled");
     check_cancellation_or_degen(gc.degen_point());
@@ -613,9 +616,10 @@ void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(const Sh
 
   ShenandoahGCSession session(request.cause, request.generation, true,
                               _degen_point == ShenandoahGC::ShenandoahDegenPoint::_degenerated_outside_cycle);
-  ShenandoahDegenGC gc(_degen_point, request.generation);
+  ShenandoahDegenGC gc(_degen_point, request.generation, _do_old_gc_bootstrap);
   gc.collect(request.cause);
   _degen_point = ShenandoahGC::_degenerated_unset;
+  _do_old_gc_bootstrap = false;
 
   assert(_heap->young_generation()->task_queues()->is_empty(), "Unexpected young generation marking tasks");
   if (request.generation->is_global()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -84,6 +84,9 @@ private:
   // preparing for mark).
   ShenandoahSharedFlag _allow_old_preemption;
 
+  // True while the current cycle is the bootstrap of an old GC.
+  bool _do_old_gc_bootstrap;
+
 public:
   ShenandoahGenerationalControlThread();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -596,7 +596,7 @@ bool ShenandoahOldGeneration::validate_idle() {
   assert(!heap->is_concurrent_old_mark_in_progress(), "Cannot be idle during old mark.");
   assert(heap->young_generation()->old_gen_task_queues() == nullptr, "Cannot be idle when still setup for bootstrapping.");
   assert(!is_concurrent_mark_in_progress(), "Cannot be marking in IDLE");
-  assert(!heap->young_generation()->is_bootstrap_cycle(), "Cannot have old mark queues if IDLE");
+  assert(!heap->young_generation()->is_old_marking_active(), "Cannot have old mark queues if IDLE");
   assert(!_old_heuristics->has_coalesce_and_fill_candidates(), "Cannot have coalesce and fill candidates in IDLE");
   assert(_old_heuristics->unprocessed_old_collection_candidates() == 0, "Cannot have mixed collection candidates in IDLE");
   return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -39,7 +39,7 @@ ShenandoahYoungGeneration::ShenandoahYoungGeneration(uint max_queues) :
 void ShenandoahYoungGeneration::set_concurrent_mark_in_progress(bool in_progress) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   heap->set_concurrent_young_mark_in_progress(in_progress);
-  if (is_bootstrap_cycle() && in_progress && !heap->is_prepare_for_old_mark_in_progress()) {
+  if (is_old_marking_active() && in_progress && !heap->is_prepare_for_old_mark_in_progress()) {
     // This is not a bug. When the bootstrapping marking phase is complete,
     // the old generation marking is still in progress, unless it's not.
     // In the case that old-gen preparation for mixed evacuation has been
@@ -79,7 +79,7 @@ bool ShenandoahYoungGeneration::is_concurrent_mark_in_progress() {
 
 void ShenandoahYoungGeneration::reserve_task_queues(uint workers) {
   ShenandoahGeneration::reserve_task_queues(workers);
-  if (is_bootstrap_cycle()) {
+  if (is_old_marking_active()) {
     _old_gen_task_queues->reserve(workers);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -69,7 +69,7 @@ public:
 
   // Returns true if the young generation is configured to enqueue old
   // oops for the old generation mark queues.
-  bool is_bootstrap_cycle() const {
+  bool is_old_marking_active() const {
     return _old_gen_task_queues != nullptr;
   }
 


### PR DESCRIPTION
`ShenandoahDegenGC::collect` uses `ShenandoahYoungGeneration::is_bootstrap_cycle()` to determine whether the current cycle is a bootstrap. This is true for every young cycle that runs while old is concurrently marking, not just the bootstrap cycle. As a result, any degenerated young cycle that happens during ongoing old marking is mislabeled as a bootstrap.

### Fix
Add a boolean `_do_old_gc_bootstrap` to `ShenandoahDegenGC` and `ShenandoahGenerationalControlThread`. It is set true at the start of a bootstrap cycle and cleared after the cycle finishes.

### Small snippet of gc log
  Before:
```
  [119.137s][info][gc,ergo ] GC(33782) At end of Concurrent Old Marking increment:
  [119.138s][info][gc,start] GC(33783) Pause Degenerated GC (Young) (Outside of Cycle)
  [119.140s][info][gc,ergo ] GC(33783) At end of Degenerated Bootstrap Old GC:
```
 Mislabels `Pause Degenerated GC (Young)` as `At end of Degenerated Bootstrap Old GC`.

 After:

```
  [117.102s][info][gc,ergo ] GC(32107) At end of Concurrent Old Marking increment:
  [117.102s][info][gc,start] GC(32108) Pause Degenerated GC (Young) (Outside of Cycle)
  [117.106s][info][gc,ergo ] GC(32108) At end of Degenerated Young GC:
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386204](https://bugs.openjdk.org/browse/JDK-8386204): GenShen: Bootstrap cycles are misidentified in logs (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31445/head:pull/31445` \
`$ git checkout pull/31445`

Update a local copy of the PR: \
`$ git checkout pull/31445` \
`$ git pull https://git.openjdk.org/jdk.git pull/31445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31445`

View PR using the GUI difftool: \
`$ git pr show -t 31445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31445.diff">https://git.openjdk.org/jdk/pull/31445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31445#issuecomment-4665047981)
</details>
