### PR TITLE
8386312: Shenandoah: Incorrect assertion in ShenandoahAllocRate uses is_locked() instead of owned_by_self()

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAllocRate.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAllocRate.hpp
@@ -174,7 +174,7 @@ private:
   void take_sample(jlong now, jlong elapsed, size_t unsampled);
 
   double upper_bound_no_lock(const double standard_deviations) const {
-    assert(_sample_lock.is_locked(), "Caller must hold lock");
+    assert(_sample_lock.owned_by_self(), "Caller must hold lock");
     return _baseline.weighted_average() + standard_deviations * _baseline.weighted_sd();
   }
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahAllocRate.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAllocRate.inline.hpp
@@ -114,7 +114,7 @@ void ShenandoahAllocRate<Clock>::force_update() {
 
 template<typename Clock>
 void ShenandoahAllocRate<Clock>::take_sample(jlong now, jlong elapsed, size_t unsampled) {
-  assert(_sample_lock.is_locked(), "Caller must hold lock");
+  assert(_sample_lock.owned_by_self(), "Caller must hold lock");
 
   _last_sample_time = now;
 


### PR DESCRIPTION
It is a pretty simple fix of the bug, see the details in the ticket JDK-8386312. 

Test:
- [x] MacOS aarch64, hotspot_gc_shenandoah
- [x] GHA, only unrelated failure from TestStackGuardPagesNative.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386312](https://bugs.openjdk.org/browse/JDK-8386312): Shenandoah: Incorrect assertion in ShenandoahAllocRate uses is_locked() instead of owned_by_self() (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31446/head:pull/31446` \
`$ git checkout pull/31446`

Update a local copy of the PR: \
`$ git checkout pull/31446` \
`$ git pull https://git.openjdk.org/jdk.git pull/31446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31446`

View PR using the GUI difftool: \
`$ git pr show -t 31446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31446.diff">https://git.openjdk.org/jdk/pull/31446.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31446#issuecomment-4672303949)
</details>
