### PR TITLE
8384512: BMPImageWriter uses integer division before Math.ceil causing incorrect calculation

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
@@ -1111,7 +1111,7 @@ public class BMPImageWriter extends ImageWriter implements BMPConstants {
                         incCompImageSize(1);
                     }
                     // Padding to word align absolute encoding
-                    if ( !isEven((int)Math.ceil((absVal-1)/2.0)) ) {
+                    if (!isEven((absVal - 1) / 2)) {
                         stream.writeByte(0);
                         incCompImageSize(1);
                     }
@@ -1247,7 +1247,7 @@ public class BMPImageWriter extends ImageWriter implements BMPConstants {
                         }
 
                         // Padding
-                        if ( !isEven((int)Math.ceil((absVal+1)/2.0)) ) {
+                        if (!isEven((absVal + 2) / 2)) {
                             stream.writeByte(0);
                             incCompImageSize(1);
                         }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
@@ -1111,7 +1111,7 @@ public class BMPImageWriter extends ImageWriter implements BMPConstants {
                         incCompImageSize(1);
                     }
                     // Padding to word align absolute encoding
-                    if ( !isEven((int)Math.ceil((absVal-1)/2)) ) {
+                    if ( !isEven((int)Math.ceil((absVal-1)/2.0)) ) {
                         stream.writeByte(0);
                         incCompImageSize(1);
                     }
@@ -1247,7 +1247,7 @@ public class BMPImageWriter extends ImageWriter implements BMPConstants {
                         }
 
                         // Padding
-                        if ( !isEven((int)Math.ceil((absVal+1)/2)) ) {
+                        if ( !isEven((int)Math.ceil((absVal+1)/2.0)) ) {
                             stream.writeByte(0);
                             incCompImageSize(1);
                         }

--- a/test/jdk/javax/imageio/plugins/bmp/RLE4PaddingTest.java
+++ b/test/jdk/javax/imageio/plugins/bmp/RLE4PaddingTest.java
@@ -102,7 +102,7 @@ public class RLE4PaddingTest {
 
                 if (srcRgb != dstRgb) {
                     throw new RuntimeException("Test failed due to color" +
-                        "difference: " + Integer.toHexString(dstRgb) +
+                        " difference: " + Integer.toHexString(dstRgb) +
                         " instead of " + Integer.toHexString(srcRgb) +
                         " at [" + x + ", " + y + "]");
                 }

--- a/test/jdk/javax/imageio/plugins/bmp/RLE4PaddingTest.java
+++ b/test/jdk/javax/imageio/plugins/bmp/RLE4PaddingTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8384512
+ * @summary Test verifies that BMP images are encoded correctly with RLE4
+ *          compression and odd number of distinct pixels at the end of
+ *          scanline.
+ */
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class RLE4PaddingTest {
+    static int width = 5;
+    static int height = 2;
+    private static BufferedImage getTestImage() {
+        // create BufferedImage with width 5 and all distinct pixels,
+        // so that it uses absolute mode for RLE.
+        // If we don't add appropriate padding at end of the scanline,
+        // the encoded data of next scanline will be corrupt.
+        int bpp = 4;
+        int size = 16;
+        byte[] r = new byte[16];
+        byte[] g = new byte[16];
+        byte[] b = new byte[16];
+
+        for (int i = 0; i < 16; i++) {
+            r[i] = g[i] = b[i] = (byte)(i * 16);
+        }
+        IndexColorModel icm = new IndexColorModel(bpp, size, r, g, b);
+        BufferedImage src = new BufferedImage(width, height,
+            BufferedImage.TYPE_BYTE_INDEXED, icm);
+
+        int[][] rows = {
+            {1, 2, 3, 4, 5},
+            {6, 7, 8, 9, 10}
+        };
+
+        for (int y = 0; y < src.getHeight(); y++) {
+            for (int x = 0; x < src.getWidth(); x++) {
+                src.getRaster().setSample(x, y, 0, rows[y][x]);
+            }
+        }
+        return src;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedImage src = getTestImage();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
+        ImageWriter writer = ImageIO.getImageWritersByFormatName("BMP").next();
+        writer.setOutput(ios);
+        ImageWriteParam param = writer.getDefaultWriteParam();
+        param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        param.setCompressionType("BI_RLE4");
+        writer.write(null, new IIOImage(src, null, null), param);
+        ios.close();
+        baos.close();
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        BufferedImage dst = ImageIO.read(bais);
+
+        checkResult(src, dst);
+    }
+
+    private static void checkResult(BufferedImage src, BufferedImage dst) {
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                int srcRgb = src.getRGB(x, y);
+                int dstRgb = dst.getRGB(x, y);
+
+                if (srcRgb != dstRgb) {
+                    throw new RuntimeException("Test failed due to color" +
+                        "difference: " + Integer.toHexString(dstRgb) +
+                        " instead of " + Integer.toHexString(srcRgb) +
+                        " at [" + x + ", " + y + "]");
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/javax/imageio/plugins/bmp/RLE4PaddingTest.java
+++ b/test/jdk/javax/imageio/plugins/bmp/RLE4PaddingTest.java
@@ -29,20 +29,21 @@
  *          scanline.
  */
 
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.ImageOutputStream;
 import java.awt.image.BufferedImage;
 import java.awt.image.IndexColorModel;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+
 public class RLE4PaddingTest {
-    static int width = 5;
-    static int height = 2;
+    private static final int width = 5;
+    private static final int height = 2;
     private static BufferedImage getTestImage() {
         // create BufferedImage with width 5 and all distinct pixels,
         // so that it uses absolute mode for RLE.


### PR DESCRIPTION
We use `Math.ceil()` at 2 places in BMPImageWriter and both of them are under encodeRLE4() function. Also they are used only under absolute mode of encoding.

First usage `(int)Math.ceil((absVal-1)/2)` is while encoding data in each scanline. Here absVal always starts with 3 and increments by 2, so `Math.ceil()` is basically a no-op here and its usage can be removed.

Second usage `(int)Math.ceil((absVal+1)/2)` is while encoding end of scanline data. Here absVal can be even and we need to use `Math.ceil()` properly otherwise padding will not be added properly. I have added regression test which actually identifies this issue and it creates a corrupt encoded BMP image. In this regression test we have odd number of distinct pixels at the end of scanline and encoding without proper padding corrupts next scanline of data.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384512](https://bugs.openjdk.org/browse/JDK-8384512): BMPImageWriter uses integer division before Math.ceil causing incorrect calculation (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31447/head:pull/31447` \
`$ git checkout pull/31447`

Update a local copy of the PR: \
`$ git checkout pull/31447` \
`$ git pull https://git.openjdk.org/jdk.git pull/31447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31447`

View PR using the GUI difftool: \
`$ git pr show -t 31447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31447.diff">https://git.openjdk.org/jdk/pull/31447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31447#issuecomment-4666837735)
</details>
