### PR TITLE
8386323: Remove unused MemoryPool allocation availability state

### DIFF
--- a/src/hotspot/share/gc/parallel/psMemoryPool.cpp
+++ b/src/hotspot/share/gc/parallel/psMemoryPool.cpp
@@ -32,7 +32,7 @@ PSOldGenerationPool::PSOldGenerationPool(PSOldGen* old_gen,
 }
 
 MemoryUsage PSOldGenerationPool::get_memory_usage() {
-  size_t maxSize   = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize   = max_size();
   size_t used      = used_in_bytes();
   size_t committed = _old_gen->capacity_in_bytes();
 
@@ -59,7 +59,7 @@ PSEdenSpacePool::PSEdenSpacePool(PSYoungGen* young_gen,
 }
 
 MemoryUsage PSEdenSpacePool::get_memory_usage() {
-  size_t maxSize   = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize   = max_size();
   size_t used = used_in_bytes();
   size_t committed = _space->capacity_in_bytes();
 
@@ -80,7 +80,7 @@ PSSurvivorSpacePool::PSSurvivorSpacePool(PSYoungGen* young_gen,
 }
 
 MemoryUsage PSSurvivorSpacePool::get_memory_usage() {
-  size_t maxSize = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize = max_size();
   size_t used    = used_in_bytes();
   size_t committed = committed_in_bytes();
   return MemoryUsage(initial_size(), used, committed, maxSize);

--- a/src/hotspot/share/gc/serial/serialMemoryPools.cpp
+++ b/src/hotspot/share/gc/serial/serialMemoryPools.cpp
@@ -40,7 +40,7 @@ size_t ContiguousSpacePool::used_in_bytes() {
 }
 
 MemoryUsage ContiguousSpacePool::get_memory_usage() {
-  size_t maxSize   = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize   = max_size();
   size_t used      = used_in_bytes();
   size_t committed = _space->capacity();
 
@@ -64,7 +64,7 @@ size_t SurvivorContiguousSpacePool::committed_in_bytes() {
 }
 
 MemoryUsage SurvivorContiguousSpacePool::get_memory_usage() {
-  size_t maxSize = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize = max_size();
   size_t used    = used_in_bytes();
   size_t committed = committed_in_bytes();
 
@@ -85,7 +85,7 @@ size_t TenuredGenerationPool::used_in_bytes() {
 MemoryUsage TenuredGenerationPool::get_memory_usage() {
   size_t used      = used_in_bytes();
   size_t committed = _gen->capacity();
-  size_t maxSize   = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize   = max_size();
 
   return MemoryUsage(initial_size(), used, committed, maxSize);
 }

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -51,7 +51,6 @@ MemoryPool::MemoryPool(const char* name,
   _type(type),
   _initial_size(init_size),
   _max_size(max_size),
-  _available_for_allocation(true),
   _managers(),
   _num_managers(0),
   _peak_usage(),
@@ -188,7 +187,7 @@ MemoryUsage CodeHeapPool::get_memory_usage() {
   size_t used      = used_in_bytes();
   OrderAccess::acquire(); // ensure possible cache expansion in CodeCache::allocate is seen
   size_t committed = _codeHeap->capacity();
-  size_t maxSize   = (available_for_allocation() ? max_size() : 0);
+  size_t maxSize   = max_size();
 
   return MemoryUsage(initial_size(), used, committed, maxSize);
 }

--- a/src/hotspot/share/services/memoryPool.hpp
+++ b/src/hotspot/share/services/memoryPool.hpp
@@ -61,7 +61,6 @@ class MemoryPool : public CHeapObj<mtInternal> {
   PoolType         _type;
   size_t           _initial_size;
   size_t           _max_size;
-  bool             _available_for_allocation; // Default is true
   MemoryManager*   _managers[max_num_managers];
   int              _num_managers;
   MemoryUsage      _peak_usage;               // Peak memory usage
@@ -97,13 +96,6 @@ class MemoryPool : public CHeapObj<mtInternal> {
   virtual size_t max_size()    const       { return _max_size; }
 
   bool is_pool(instanceHandle pool) const;
-
-  bool available_for_allocation()   { return _available_for_allocation; }
-  bool set_available_for_allocation(bool value) {
-    bool prev = _available_for_allocation;
-    _available_for_allocation = value;
-    return prev;
-  }
 
   MemoryManager* get_memory_manager(int index) {
     assert(index >= 0 && index < _num_managers, "Invalid index");


### PR DESCRIPTION
Trivial removing effectively dead code of `_available_for_allocation` and its related methods.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386323](https://bugs.openjdk.org/browse/JDK-8386323): Remove unused MemoryPool allocation availability state (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31448/head:pull/31448` \
`$ git checkout pull/31448`

Update a local copy of the PR: \
`$ git checkout pull/31448` \
`$ git pull https://git.openjdk.org/jdk.git pull/31448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31448`

View PR using the GUI difftool: \
`$ git pr show -t 31448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31448.diff">https://git.openjdk.org/jdk/pull/31448.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31448#issuecomment-4667981710)
</details>
