### PR TITLE
8386289: runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java fails with Should not allocate with exception pending

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -46,6 +46,7 @@
 #include "services/heapDumper.hpp"
 #include "services/writeableFlags.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/exceptions.hpp"
 #include "utilities/formatBuffer.hpp"
 
 
@@ -590,10 +591,14 @@ void AttachListenerThread::thread_entry(JavaThread* thread, TRAPS) {
   assert(thread->stack_base() != nullptr && thread->stack_size() > 0,
          "Should already be setup");
 
-  AttachListener::set_default_streaming(
-      get_bool_sys_prop("jdk.attach.vm.streaming",
-                        AttachListener::get_default_streaming(),
-                        thread));
+  bool is_streaming = get_bool_sys_prop("jdk.attach.vm.streaming",
+                                        AttachListener::get_default_streaming(),
+                                        THREAD);
+  // We try to go on with the attach listener, even though reading jdk.attach.vm.streaming failed.
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+  }
+  AttachListener::set_default_streaming(is_streaming);
   log_debug(attach)("default streaming output: %d", AttachListener::get_default_streaming() ? 1 : 0);
 
   if (AttachListener::pd_init() != 0) {


### PR DESCRIPTION
Hi,

This crash happens because we are not diligent with our exception handling in the `AttachListener` code. The out of memory test ensures that all calls to the JVM will fail because Java is OOM, however we did not check the exception in this call. I've changed it so that the exception is checked, and clear it if we've caught an exception. The idea is that the call failed, but we can continue on with the attach listener anyway.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386289](https://bugs.openjdk.org/browse/JDK-8386289): runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java fails with Should not allocate with exception pending (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31449/head:pull/31449` \
`$ git checkout pull/31449`

Update a local copy of the PR: \
`$ git checkout pull/31449` \
`$ git pull https://git.openjdk.org/jdk.git pull/31449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31449`

View PR using the GUI difftool: \
`$ git pr show -t 31449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31449.diff">https://git.openjdk.org/jdk/pull/31449.diff</a>

</details>
