### PR TITLE
8375645: C2: NPE in compiled method does not occur with interpreter

### DIFF
--- a/src/hotspot/share/opto/intrinsicnode.cpp
+++ b/src/hotspot/share/opto/intrinsicnode.cpp
@@ -37,25 +37,35 @@ uint StrIntrinsicNode::match_edge(uint idx) const {
   return idx == 2 || idx == 3;
 }
 
+static Node* ideal_mem_intrinsic_node(PhaseGVN* phase, bool can_reshape, Node* n) {
+  if (n->remove_dead_region(phase, can_reshape)) {
+    return n;
+  }
+
+  // Don't bother trying to transform a dead node
+  if (n->in(0) && n->in(0)->is_top()) {
+    return nullptr;
+  }
+
+  // If mem input is a MergeMem, get the desired slice
+  if (const TypePtr* adr_type = n->adr_type(); can_reshape && adr_type != TypePtr::BOTTOM) {
+    Node* mem = n->in(MemNode::Memory);
+    uint alias_idx = phase->C->get_alias_index(adr_type);
+    Node* new_mem = mem->is_MergeMem() ? mem->as_MergeMem()->memory_at(alias_idx) : mem;
+    if (new_mem != mem) {
+      n->set_req_X(MemNode::Memory, new_mem, phase);
+      return n;
+    }
+  }
+
+  return nullptr;
+}
+
 //------------------------------Ideal------------------------------------------
 // Return a node which is more "ideal" than the current node.  Strip out
 // control copies
 Node* StrIntrinsicNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  if (remove_dead_region(phase, can_reshape)) return this;
-  // Don't bother trying to transform a dead node
-  if (in(0) && in(0)->is_top())  return nullptr;
-
-  if (can_reshape) {
-    Node* mem = in(MemNode::Memory);
-    // If mem input is a MergeMem, get the desired slice
-    uint alias_idx = phase->C->get_alias_index(adr_type());
-    mem = mem->is_MergeMem() ? mem->as_MergeMem()->memory_at(alias_idx) : mem;
-    if (mem != in(MemNode::Memory)) {
-      set_req_X(MemNode::Memory, mem, phase);
-      return this;
-    }
-  }
-  return nullptr;
+  return ideal_mem_intrinsic_node(phase, can_reshape, this);
 }
 
 //------------------------------Value------------------------------------------
@@ -64,29 +74,13 @@ const Type* StrIntrinsicNode::Value(PhaseGVN* phase) const {
   return bottom_type();
 }
 
-//=============================================================================
-//------------------------------Ideal------------------------------------------
-// Return a node which is more "ideal" than the current node.  Strip out
-// control copies
-Node* StrCompressedCopyNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
-}
-
-//=============================================================================
-//------------------------------Ideal------------------------------------------
-// Return a node which is more "ideal" than the current node.  Strip out
-// control copies
-Node* StrInflatedCopyNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
-}
-
 uint VectorizedHashCodeNode::match_edge(uint idx) const {
   // Do not match memory edge.
   return idx >= 2 && idx <=  5; // VectorizedHashCodeNode (Binary ary1 cnt1) (Binary result bt)
 }
 
 Node* VectorizedHashCodeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
+  return ideal_mem_intrinsic_node(phase, can_reshape, this);
 }
 
 const Type* VectorizedHashCodeNode::Value(PhaseGVN* phase) const {
@@ -106,7 +100,7 @@ uint EncodeISOArrayNode::match_edge(uint idx) const {
 // Return a node which is more "ideal" than the current node.  Strip out
 // control copies
 Node* EncodeISOArrayNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
+  return ideal_mem_intrinsic_node(phase, can_reshape, this);
 }
 
 //------------------------------Value------------------------------------------

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -147,7 +147,6 @@ public:
   StrIntrinsicNode(control, arymem, s1, s2, c, none), _adr_type(adr_type) {};
   virtual int Opcode() const override;
   virtual const Type* bottom_type() const override { return TypeInt::INT; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
 
 private:
   virtual uint size_of() const override { return sizeof(StrCompressedCopyNode); }
@@ -169,7 +168,6 @@ public:
   StrIntrinsicNode(control, arymem, s1, s2, c, none), _adr_type(adr_type) {};
   virtual int Opcode() const override;
   virtual const Type* bottom_type() const override { return Type::MEMORY; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
 
 private:
   virtual uint size_of() const override { return sizeof(StrInflatedCopyNode); }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -385,22 +385,18 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
     return NodeSentinel; // caller will return null
   }
 
+  if (t_adr->base() == Type::AnyPtr) {
+    // Weird access to null+offset, either is a dead unsafe access that cannot be proved to be so,
+    // or should be folded later
+    assert(t_adr->is_ptr()->ptr() == TypePtr::Null, "must be null");
+    return NodeSentinel; // caller will return null
+  }
+
   // Do NOT remove or optimize the next lines: ensure a new alias index
   // is allocated for an oop pointer type before Escape Analysis.
   // Note: C++ will not remove it since the call has side effect.
   if (t_adr->isa_oopptr()) {
     int alias_idx = phase->C->get_alias_index(t_adr->is_ptr());
-  }
-
-  Node* base = nullptr;
-  if (address->is_AddP()) {
-    base = address->in(AddPNode::Base);
-  }
-  if (base != nullptr && phase->type(base)->higher_equal(TypePtr::NULL_PTR) &&
-      !t_adr->isa_rawptr() && !t_adr->isa_klassptr()) {
-    // Note: non-oop address has TOP base and top->higher_equal(TypePtr::NULL_PTR) is true.
-    // Skip this node optimization if its address has TOP base.
-    return NodeSentinel; // caller will return null
   }
 
   // Avoid independent memory operations

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -397,8 +397,8 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
     base = address->in(AddPNode::Base);
   }
   if (base != nullptr && phase->type(base)->higher_equal(TypePtr::NULL_PTR) &&
-      !t_adr->isa_rawptr()) {
-    // Note: raw address has TOP base and top->higher_equal(TypePtr::NULL_PTR) is true.
+      !t_adr->isa_rawptr() && !t_adr->isa_klassptr()) {
+    // Note: non-oop address has TOP base and top->higher_equal(TypePtr::NULL_PTR) is true.
     // Skip this node optimization if its address has TOP base.
     return NodeSentinel; // caller will return null
   }
@@ -5989,6 +5989,36 @@ void MergeMemNode::set_base_memory(Node *new_base) {
       if (in(i) == new_base)  set_req(i, empty_mem);
     }
   }
+}
+
+// The base_memory of this is a MergeMemNode, collapse it into this, effectively looking through
+// the MergeMem base input of this node
+void MergeMemNode::collapse_mergemem_base(PhaseGVN* phase) {
+  MergeMemNode* base = base_memory()->isa_MergeMem();
+  assert(base != nullptr, "unexpected base_memory %s", base_memory()->Name());
+
+  grow_to_match(base);
+  Node* empty_mem = empty_memory();
+  assert(base->is_empty_memory(empty_mem), "must be compatible");
+
+  Node* base_base = base->base_memory();
+  assert(!is_empty_memory(base_base), "must not be an empty memory");
+  assert(base_base != this, "invalid cycle");
+  assert(!base_base->is_MergeMem(), "should not chain");
+  set_req_X(Compile::AliasIdxBot, base_base, phase);
+
+  for (uint i = Compile::AliasIdxRaw; i < req(); i++) {
+    Node* current_mem = in(i);
+    if (current_mem == base_base) {
+      set_req_X(i, empty_mem, phase);
+    } else if (is_empty_memory(current_mem)) {
+      Node* new_mem = i < base->req() ? base->in(i) : empty_mem;
+      assert(new_mem != this, "invalid cycle");
+      set_req_X(i, new_mem, phase);
+    }
+  }
+
+  assert(verify_sparse(), "MergeMem invariant");
 }
 
 //------------------------------out_RegMask------------------------------------

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1542,6 +1542,9 @@ public:
   void iteration_setup(const MergeMemNode* other = nullptr);
   // push sentinels until I am at least as long as the other (semantic no-op)
   void grow_to_match(const MergeMemNode* other);
+
+  void collapse_mergemem_base(PhaseGVN* phase);
+
   bool verify_sparse() const PRODUCT_RETURN0;
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -24,6 +24,7 @@
 
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
+#include "libadt/vectset.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "opto/addnode.hpp"
@@ -35,11 +36,15 @@
 #include "opto/idealGraphPrinter.hpp"
 #include "opto/loopnode.hpp"
 #include "opto/machnode.hpp"
+#include "opto/memnode.hpp"
+#include "opto/node.hpp"
 #include "opto/opcodes.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/regalloc.hpp"
 #include "opto/rootnode.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/ostream.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 //=============================================================================
@@ -1201,6 +1206,15 @@ void PhaseIterGVN::optimize(bool deep) {
     return;
   }
 
+  split_memory_phis();
+  if (drain_worklist()) {
+    return;
+  }
+  clean_up_memory_phis();
+  if (drain_worklist()) {
+    return;
+  }
+
   if (deep && UseDeepIGVNRevisit) {
     deep_revisit_converged = deep_revisit();
     if (C->failing()) {
@@ -1212,6 +1226,402 @@ void PhaseIterGVN::optimize(bool deep) {
   C->print_method(PHASE_AFTER_ITER_GVN, 3);
 }
 
+// Bottom memory Phis are peculiar. Consider a bottom memory Phi bot_phi and an arbitrary alias
+// class mem.
+//
+// 1. Sometimes, bot_phi does not contain the memory state corresponding to mem, and there is
+// another memory Phi mem_phi at the same region representing the memory state corresponding to
+// mem.
+//
+// if (b) {
+//   Call1();
+//   MemProj1(Call1);
+// } else {
+//   Call2();
+//   MemProj2(Call2);
+//   Store1(_, MemProj2, p, v): mem;
+// }
+// bot_phi = Phi(MemProj1, MemProj2);
+// mem_phi = Phi(MemProj1, Store1);
+//
+// In this example, bot_phi cannot contain the memory state corresponding to mem, because MemProj2
+// does not capture the store into that memory.
+//
+// 2. Sometimes, bot_phi contains the memory state corresponding to mem, even if there is another
+// memory Phi at the same region representing the memory state corresponding to mem.
+//
+// Call1();
+// MemProj1(Call1);
+// Store1(_, MemProj1, p1, v): mem;
+// MergeMem1(MemProj1, Top, Store1);
+// Load1(_, Store1, p2): mem;
+// Load2(_, MergeMem, p3): mem;
+//
+// We somehow want to multiversion some statements:
+//
+// Call1();
+// MemProj1(Call1);
+// if (b) {
+//   Store11(_, MemProj1, p1, v): mem;
+//   MergeMem11(MemProj1, Top, Store11);
+// } else {
+//   Store12(_, MemProj1, p1, v): mem;
+//   MergeMem12(MemProj1, Top, Store12);
+// }
+// bot_phi = Phi(MergeMem11, MergeMem12);
+// mem_phi = Phi(Store11, Store12);
+// Load1(_, mem_phi, p2): mem;
+// Load2(_, bot_phi, p3): mem;
+//
+// In this example, bot_phi must contain the memory state corresponding to mem, because there is a
+// load corresponding to mem from it. This pattern can be eventually simplified after IGVN, but
+// until then, the existence of mem_phi does not mean that bot_phi does not contain the memory
+// state corresponding to mem.
+//
+// 3. Sometimes, bot_phi does not contain the memory state corresponding to mem, even if there is
+// not any memory Phi at the same region representing the memory state corresponding to mem.
+//
+// Call1();
+// MemProj1(Call1);
+// Store1(_, MemProj1, p, v);
+// if (b) {
+//   MergeMem1(MemProj1, Top, Store1);
+// }
+// bot_phi = Phi(MergeMem1, MemProj1);
+//
+// In this case, bot_phi does not contain the memory state corresponding to mem, because in one
+// branch, its input is MemProj1, which does not capture the latest store Store1 of the alias class
+// mem. This situation can be removed if we push the MergeMem down through the Phi, but this
+// transformation is not universally applicable during IGVN because it can lead to infinite loop.
+//
+// This funtion solves the issue above by pushing all MergeMem inputs of bottom memory Phis down
+// through the Phi in a controlled manner. The notable property of the transformation is that,
+// the push effectively splits the bottom memory Phi, so we know for certain the new bottom memory
+// Phi does not contain the memory states corresponding to the other Phis.
+// For example:
+//
+//   Proj1       Store
+//      \       /
+//       MergeMem        Proj2
+//             \       /
+//                Phi
+//                 |
+//                ...
+//
+// Into:
+//
+//   Proj1     Proj2    Store     Proj2(this is the same node as the other Proj2)
+//       \     /            \     /
+//         Phi1              Phi2
+//             \            /
+//                MergeMem
+//                   |
+//                  ...
+//
+// While it is uncertain which memory state the original Phi contains, it is certain that Phi1 (the
+// new bottom memory Phi) does not contain the memory state corresponding to Phi2, because all uses
+// of Phi1 are uses of the new MergeMem, and that MergeMem does not read the memory state
+// corresponding to Phi2 from Phi1.
+//
+// As a result, if we record which alias classes have been split from each bottom memory Phi, it is
+// certain that the transformation will terminate, because if a MergeMem input of a bottom memory
+// Phi has all its non-top inputs being known to be excluded from that Phi, then the Phi does not
+// have to be split anymore (i.e. it can simply skip the MergeMem and is rewired to the MergeMem's
+// base input instead of having the MergeMem pushed through it).
+void PhaseIterGVN::split_memory_phis() {
+  ResourceMark rm;
+  Unique_Node_List control_graph;
+  Unique_Node_List bottom_mem_phis;
+
+  // Collect all reachable RegionNodes and their corresponding bottom memory Phis
+  control_graph.push(C->root());
+  for (uint i = 0; i < control_graph.size(); i++) {
+    Node* n = control_graph.at(i);
+    for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+      Node* out = n->fast_out(i);
+      if (out->is_CFG()) {
+        control_graph.push(out);
+      } else if (out->is_memory_phi() && out->adr_type() == TypePtr::BOTTOM) {
+        bottom_mem_phis.push(out);
+      }
+    }
+  }
+
+  // Map the Phi idx to the VectorSet representing the alias indices that have been split from that
+  // Phi
+  GrowableArray<VectorSet*> excluded_idx_map;
+  bool progress = true;;
+  for (int iter = 0; progress; iter++) {
+    constexpr int iter_limit = 100;
+    if (iter >= iter_limit) {
+      assert(false, "maybe infinite loop in split_memory_phis");
+      break; // Give up in product
+    }
+
+    progress = false;
+    for (uint phi_idx = 0; phi_idx < bottom_mem_phis.size(); phi_idx++) {
+      PhiNode* phi = bottom_mem_phis.at(phi_idx)->as_Phi();
+      int phi_key = phi->_idx;
+      VectorSet* excluded_idx = phi_key < excluded_idx_map.length() ? excluded_idx_map.at(phi_key) : nullptr;
+      MergeMemNode* transformed_phi = try_push_mergemems_down_through_phi(phi, excluded_idx);
+      if (transformed_phi == nullptr) {
+        continue;
+      }
+
+      // Record progress
+      C->print_method(PHASE_AFTER_SPLIT_MEMORY_PHI, 5, phi);
+      progress = true;
+      if (excluded_idx == nullptr) {
+        excluded_idx = new VectorSet();
+        excluded_idx_map.at_put_grow(phi_key, excluded_idx);
+      }
+
+      for (MergeMemStream mms(transformed_phi); mms.next_non_empty();) {
+        if (!mms.at_base_memory()) {
+          excluded_idx->set(mms.alias_idx());
+        }
+      }
+    }
+  }
+}
+
+// Try to push MergeMem inputs of a bottom memory Phi through that Phi. This function is somewhat
+// similar to what PhiNode::Ideal does, but it is used exclusively for this transformation in that
+// it reuses the old Phi as the new Phi, it rewires all uses of phi to the new MergeMemNode, and it
+// eagerly collapses chained MergeMem if the push results in a MergeMem being the base of another
+// MergeMem.
+// If phi has no MergeMem input, or for each of them, all non-top input of the MergeMem has been
+// split from phi before (recorded in excluded_idx), then this function rewires the input of phi as
+// necessary without pushing the MergeMem inputs down.
+MergeMemNode* PhaseIterGVN::try_push_mergemems_down_through_phi(PhiNode* phi, const VectorSet* excluded_idx) {
+  assert(phi->is_memory_phi(), "must be a memory Phi");
+  assert(phi->adr_type() == TypePtr::BOTTOM, "must be a bottom memory Phi");
+
+  MergeMemNode* result = nullptr;
+  bool progress = false;
+  for (uint phi_in_idx = 1; phi_in_idx < phi->req(); phi_in_idx++) {
+    MergeMemNode* phi_in = phi->in(phi_in_idx)->isa_MergeMem();
+    if (phi_in == nullptr) {
+      continue;
+    }
+
+    if (result == nullptr) {
+      result = MergeMemNode::make(phi);
+      register_new_node_with_optimizer(result);
+    }
+
+    result->grow_to_match(phi_in);
+    for (MergeMemStream mms(phi_in); mms.next_non_empty();) {
+      if (mms.at_base_memory()) {
+        continue;
+      }
+
+      int alias_idx = mms.alias_idx();
+      if (excluded_idx != nullptr && excluded_idx->test(alias_idx)) {
+        continue;
+      }
+
+      progress = true;
+      Node* current_mem = result->in(alias_idx);
+      if (result->is_empty_memory(current_mem)) {
+        current_mem = phi->slice_memory(C->get_adr_type(alias_idx));
+        register_new_node_with_optimizer(current_mem);
+        result->set_req(alias_idx, current_mem);
+      }
+      current_mem->set_req(phi_in_idx, mms.memory());
+    }
+
+    Node* phi_in_base = phi_in->base_memory();
+    assert(!phi_in_base->is_MergeMem(), "should not chain");
+    replace_input_of(phi, phi_in_idx, phi_in_base);
+  }
+
+  if (!progress) {
+    if (result != nullptr) {
+      remove_dead_node(result, PhaseIterGVN::NodeOrigin::Speculative);
+    }
+
+    return nullptr;
+  }
+
+  // Self-edges of the original Phi also become self-edges of the split Phis
+  assert(result != nullptr, "must have created new node");
+  for (MergeMemStream mms(result); mms.next_non_empty(); ) {
+    Node* current_mem = mms.memory();
+    assert(current_mem->is_Phi(), "unexpected result input %s", current_mem->Name());
+    assert(current_mem->req() == phi->req(), "unexpected number of input %d - %d", phi->req(), current_mem->req());
+    if (mms.at_base_memory()) {
+      assert(current_mem == phi, "unexpected modification of base memory");
+      continue;
+    }
+
+    for (uint i = 1; i < current_mem->req(); i++) {
+      if (current_mem->in(i) == phi) {
+        current_mem->set_req(i, current_mem);
+      }
+    }
+  }
+
+  // Replace the old Phi with result in the graph
+  for (DUIterator_Fast phi_out_max, phi_out_idx = phi->fast_outs(phi_out_max); phi_out_idx < phi_out_max; phi_out_idx++) {
+    Node* phi_out = phi->fast_out(phi_out_idx);
+    if (phi_out == phi || phi_out == result) {
+      continue;
+    }
+
+    uint del_cnt = 0;
+    for (uint i = 0; i < phi_out->len(); i++) {
+      Node* phi_out_in = phi_out->in(i);
+      if (phi_out_in == phi) {
+        replace_input_of(phi_out, i, result);
+        del_cnt++;
+      }
+    }
+
+    --phi_out_idx;
+    phi_out_max -= del_cnt;
+  }
+
+  // Eagerly collapse MergeMem chains at base_memory
+  for (DUIterator_Fast imax, i = result->fast_outs(imax); i < imax; i++) {
+    Node* out = result->fast_out(i);
+    if (MergeMemNode* mm = out->isa_MergeMem(); mm != nullptr && mm->base_memory() == result) {
+      mm->collapse_mergemem_base(this);
+      --i;
+      --imax;
+    }
+  }
+
+  return result;
+}
+
+// Remove dead memory Phis, handle equal memory Phis. This function solves the cases
+// where local IGVN cannot.
+void PhaseIterGVN::clean_up_memory_phis() {
+  ResourceMark rm;
+  Unique_Node_List control_graph;
+  Unique_Node_List memory_phis;
+
+  control_graph.push(C->root());
+  for (uint i = 0; i < control_graph.size(); i++) {
+    Node* n = control_graph.at(i);
+    for (DUIterator_Fast kmax, k = n->fast_outs(kmax); k < kmax; k++) {
+      Node* out = n->fast_out(k);
+      if (out->is_CFG()) {
+        control_graph.push(out);
+      } else if (out->is_memory_phi()) {
+        memory_phis.push(out);
+      }
+    }
+  }
+
+  // Cannot process at the same time as we collect these nodes because the operations may kill the
+  // nodes in an unexpected manner
+  Unique_Node_List tmp_worklist;
+  Node_Array tmp_node_map;
+  for (uint i = 0; i < memory_phis.size(); i++) {
+    PhiNode* mem_phi = memory_phis.at(i)->as_Phi();
+    if (try_kill_dead_memory_phi(mem_phi, tmp_worklist)) {
+      continue;
+    }
+
+    Node* region = mem_phi->region();
+    for (DUIterator_Fast kmax, k = region->fast_outs(kmax); k < kmax; k++) {
+      Node* other_out = region->fast_out(k);
+      if (mem_phi != other_out && other_out->is_memory_phi() && mem_phi->adr_type() == other_out->adr_type() &&
+          try_replace_identical_memory_phi(mem_phi, other_out->as_Phi(), tmp_worklist, tmp_node_map)) {
+        break;
+      }
+    }
+  }
+}
+
+// If a Phi has no transitive use other than other Phis, then it is dead. Note that the memory Phi
+// of an infinite loop still has a Safepoint use, so the previous statement still holds.
+bool PhaseIterGVN::try_kill_dead_memory_phi(PhiNode* mem_phi, Unique_Node_List& worklist) {
+  worklist.clear();
+  worklist.push(mem_phi);
+  for (uint i = 0; i < worklist.size(); i++) {
+    Node* n = worklist.at(i);
+    for (DUIterator_Fast kmax, k = n->fast_outs(kmax); k < kmax; k++) {
+      Node* out = n->fast_out(k);
+      if (!out->is_Phi()) {
+        return false;
+      }
+
+      worklist.push(out);
+    }
+  }
+
+  remove_globally_dead_node(mem_phi, NodeOrigin::Graph);
+  return true;
+}
+
+// 2 Phi chains may be exactly identical, but IGVN cannot decide that without looking at the whole
+// chain. This function tries to decide whether phi1 and phi2 are actually identical, and replaces
+// all nodes in the phi1 chain with the corresponding node in phi2 chain
+bool PhaseIterGVN:: try_replace_identical_memory_phi(PhiNode* phi1, PhiNode* phi2, Unique_Node_List& worklist, Node_Array& node_map) {
+  worklist.clear();
+  node_map.clear();
+  worklist.push(phi1);
+  node_map.map(phi1->_idx, phi2);
+
+  for (uint worklist_idx = 0; worklist_idx < worklist.size(); worklist_idx++) {
+    Node* n1 = worklist.at(worklist_idx);
+    Node* n2 = node_map[n1->_idx];
+    assert(n2 != nullptr, "must have been recorded");
+    assert(n1->is_memory_phi() && n2->is_memory_phi() && n1->adr_type() == n2->adr_type() && n1->in(0) == n2->in(0), "incompatible");
+    assert(n1->req() == n2->req(), "unexpected input counts");
+    for (uint i = 1; i < n1->req(); i++) {
+      Node* in1 = n1->in(i);
+      Node* in2 = n2->in(i);
+      if (in1 == in2) {
+        continue;
+      }
+
+      if (!in1->is_memory_phi() || !in2->is_memory_phi() || in1->adr_type() != in2->adr_type() || in1->in(0) != in2->in(0)) {
+        // These 2 inputs cannot be identical unless they are both memory Phis at the same Region
+        return false;
+      }
+
+      // Add the input for recursive check
+      worklist.push(in1);
+      node_map.map(in1->_idx, in2);
+    }
+  }
+
+  // Try to replace all nodes in worklist with the corresponding node recorded in node_map
+  Node* top = C->top();
+  for (uint worklist_idx = 0; worklist_idx < worklist.size(); worklist_idx++) {
+    Node* n1 = worklist.at(worklist_idx);
+    Node* n2 = node_map[n1->_idx];
+    assert(n2 != nullptr, "must have been recorded");
+
+    // All uses of n1 are rewired to n2
+    for (DUIterator_Fast imax, i = n1->fast_outs(imax); i < imax; i++) {
+      Node* out = n1->fast_out(i);
+      if (worklist.member(out)) {
+        // This node will be killed now, so no need to rewire its inputs
+        continue;
+      }
+
+      int del_cnt = 0;
+      for (uint j = 0; j < out->len(); j++) {
+        if (out->in(j) == n1) {
+          replace_input_of(out, j, n2);
+          del_cnt++;
+        }
+      }
+
+      --i;
+      imax -= del_cnt;
+    }
+  }
+
+  remove_globally_dead_node(phi1, NodeOrigin::Graph);
+  return true;
+}
+
 #ifdef ASSERT
 void PhaseIterGVN::verify_optimize(bool deep_revisit_converged) {
   assert(_worklist.size() == 0, "igvn worklist must be empty before verify");
@@ -1221,6 +1631,21 @@ void PhaseIterGVN::verify_optimize(bool deep_revisit_converged) {
       is_verify_Identity() ||
       is_verify_invariants()) {
     ResourceMark rm;
+
+    // A CFG is live if it is reachable from root in the CFG graph, some invariants do not hold if
+    // the CFG node is dead
+    Unique_Node_List live_cfgs;
+    live_cfgs.push(C->root());
+    for (uint j = 0; j < live_cfgs.size(); j++) {
+      Node* n = live_cfgs.at(j);
+      for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+        Node* out = n->fast_out(i);
+        if (out->is_CFG()) {
+          live_cfgs.push(out);
+        }
+      }
+    }
+
     Unique_Node_List worklist;
     // BFS all nodes, starting at root
     worklist.push(C->root());
@@ -1241,7 +1666,7 @@ void PhaseIterGVN::verify_optimize(bool deep_revisit_converged) {
         verify_Identity_for(n);
       }
       if (is_verify_invariants()) {
-        verify_node_invariants_for(n);
+        verify_node_invariants_for(n, live_cfgs.member(n));
       }
 
       // traverse all inputs and outputs
@@ -2153,7 +2578,7 @@ void PhaseIterGVN::verify_Identity_for(Node* n) {
 }
 
 // Some other verifications that are not specific to a particular transformation.
-void PhaseIterGVN::verify_node_invariants_for(const Node* n) {
+void PhaseIterGVN::verify_node_invariants_for(const Node* n, bool is_live_cfg) {
   if (n->is_AddP()) {
     if (!n->as_AddP()->address_input_has_same_base()) {
       stringStream ss; // Print as a block without tty lock.
@@ -2163,6 +2588,38 @@ void PhaseIterGVN::verify_node_invariants_for(const Node* n) {
       tty->print_cr("%s", ss.as_string());
 
       assert(false, "Broken node invariant for %s", n->Name());
+    }
+  } else if (n->is_Region() && is_live_cfg) {
+    ResourceMark rm;
+    VectorSet visited_idx;
+    for (DUIterator_Fast n_out_max, n_out_idx = n->fast_outs(n_out_max); n_out_idx < n_out_max; n_out_idx++) {
+      Node* out = n->fast_out(n_out_idx);
+      if (out->is_memory_phi()) {
+        if (out->adr_type() == TypePtr::BOTTOM) {
+          for (uint i = 1; i < out->req(); i++) {
+            if (out->in(i)->is_MergeMem()) {
+              stringStream ss;
+              ss.cr();
+              ss.print_cr("Bottom memory Phi with a MergeMem input");
+              out->dump_bfs(2, nullptr, "", &ss);
+              tty->print_cr("%s", ss.as_string());
+              assert(false, "Broken node invariant for %s", n->Name());
+            }
+          }
+        } else {
+          // Exclude known instances for now, different places disagree about how to walk past
+          // calls, barriers, etc
+          const TypePtr* phi_adr_type = out->adr_type();
+          if (!phi_adr_type->is_known_instance() && visited_idx.test_set(C->get_alias_index(phi_adr_type))) {
+            stringStream ss;
+            ss.cr();
+            ss.print_cr("Ambiguous memory Phi at %s", n->Name());
+            n->dump_bfs(2, nullptr, "-m", &ss);
+            tty->print_cr("%s", ss.as_string());
+            assert(false, "Broken node invariant for %s", n->Name());
+          }
+        }
+      }
     }
   }
 }

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -489,6 +489,12 @@ private:
   // changes happen far away.
   bool needs_deep_revisit(const Node* n) const;
 
+  void split_memory_phis();
+  MergeMemNode* try_push_mergemems_down_through_phi(PhiNode* phi, const VectorSet* excluded_idx);
+  void clean_up_memory_phis();
+  bool try_kill_dead_memory_phi(PhiNode* phi, Unique_Node_List& worklist);
+  bool try_replace_identical_memory_phi(PhiNode* phi1, PhiNode* phi2, Unique_Node_List& worklist, Node_Array& node_map);
+
   // Subsume users of node 'old' into node 'nn'
   void subsume_node( Node *old, Node *nn );
 
@@ -543,7 +549,7 @@ public:
   void verify_Value_for(const Node* n, bool strict = false);
   void verify_Ideal_for(Node* n, bool can_reshape, bool deep_revisit_converged);
   void verify_Identity_for(Node* n);
-  void verify_node_invariants_for(const Node* n);
+  void verify_node_invariants_for(const Node* n, bool is_live_cfg);
   void verify_empty_worklist(Node* n);
 #endif
 

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -37,6 +37,7 @@
   flags(BEFORE_ITER_GVN,                "Before Iter GVN") \
   flags(ITER_GVN1,                      "Iter GVN 1") \
   flags(AFTER_ITER_GVN_STEP,            "After Iter GVN Step") \
+  flags(AFTER_SPLIT_MEMORY_PHI,         "After Splitting Memory Phi") \
   flags(AFTER_ITER_GVN,                 "After Iter GVN") \
   flags(INCREMENTAL_INLINE_STEP,        "Incremental Inline Step") \
   flags(INCREMENTAL_INLINE_CLEANUP,     "Incremental Inline Cleanup") \


### PR DESCRIPTION
Hi,

The underlying issue is the existence of multiple `Phi`s corresponding to the same memory at the same region, which is unexpected and can confuse other components of the compiler regarding which `Phi` does represent the memory state of a particular alias class. This is exaggerated by the peculiarity of bottom memory Phis, please see the comment above `PhaseIterGVN::split_memory_phis` in this PR for more details.

Previous attempts fixing this issue try to reuse existing `Phi` if there is a matching one at the same `Region`. However, this is incorrect, as there is no guarantee that the existing `Phi` is the correct one.

The fix here is to aggressively push all `MergeMemNode`s down through memory `Phi`s, as well as clean up all dead memory `Phi`s.

The test case provided in the JBS issue does not fail anymore, so it is not included in this PR. However, without the fix and with addition verification in `PhaseIterGVN::verify_node_invariants_for`, we have multiple tier1 failures. With this fix, I see no failures.

Testing:

- [x] tier1-7,hs-comp-stress
- [x] tier1-7,hs-comp-stress, `-XX:VerifyIterativeGVN=10000`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8375645](https://bugs.openjdk.org/browse/JDK-8375645): C2: NPE in compiled method does not occur with interpreter (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31451/head:pull/31451` \
`$ git checkout pull/31451`

Update a local copy of the PR: \
`$ git checkout pull/31451` \
`$ git pull https://git.openjdk.org/jdk.git pull/31451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31451`

View PR using the GUI difftool: \
`$ git pr show -t 31451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31451.diff">https://git.openjdk.org/jdk/pull/31451.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31451#issuecomment-4669588079)
</details>
