### PR TITLE
8386344: runtime/StackGuardPages/TestStackGuardPages build failure after JDK-8303612

### DIFF
--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -51,7 +51,7 @@
 
 JavaVM* _jvm;
 
-static jmp_buf  context;
+static sigjmp_buf  context;
 
 static volatile int _last_si_code = -1;
 static volatile int _failures = 0;


### PR DESCRIPTION
JDK-8303612 changes from `longjmp()`/`setjmp()` to `siglongjmp()`/`sigsetjmp()`, but does not change the context type to `sigjmp_buf`, causing an incompatible type warning when building the TestStackGuardPages test.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386344](https://bugs.openjdk.org/browse/JDK-8386344): runtime/StackGuardPages/TestStackGuardPages build failure after JDK-8303612 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31455/head:pull/31455` \
`$ git checkout pull/31455`

Update a local copy of the PR: \
`$ git checkout pull/31455` \
`$ git pull https://git.openjdk.org/jdk.git pull/31455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31455`

View PR using the GUI difftool: \
`$ git pr show -t 31455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31455.diff">https://git.openjdk.org/jdk/pull/31455.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31455#issuecomment-4670937708)
</details>
