### PR TITLE
8385661: jvmti/vthread/ThreadStateTest/ThreadStateTest.java triggers assert(f.pc() == _chunk->pc()) failed

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1371,16 +1371,10 @@ JvmtiEnvBase::set_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth
       return JVMTI_ERROR_OPAQUE_FRAME;
     }
 
-    if (state->is_virtual() && (thread == nullptr || !thread->is_vthread_mounted())) { // unmounted virtual thread
-      assert(fr.is_heap_frame(), "sanity check");
-      fr = jvf->stack_chunk()->derelativize(fr);
-      jvf->stack_chunk()->force_slow_path();
-      fr.deoptimize(nullptr);
-    } else { // platform thread or mounted virtual thread
-      if (fr.is_heap_frame()) {
-        fr = jvf->stack_chunk()->derelativize(fr);
-        jvf->stack_chunk()->force_slow_path();
-      }
+    if (fr.is_heap_frame()) {
+      assert(state->is_virtual(), "invariant");
+      fr.deoptimize(nullptr, jvf->stack_chunk());
+    } else {
       Deoptimization::deoptimize(thread, fr);
     }
   }

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -387,6 +387,22 @@ void frame::deoptimize(JavaThread* thread) {
 #endif // ASSERT
 }
 
+void frame::deoptimize(JavaThread* thread, stackChunkOop chunk) {
+  assert(is_heap_frame() && _frame_index >= 0, "wrong frame type");
+
+  // Fast path does not expect deopted frames
+  chunk->force_slow_path();
+
+  frame fr = chunk->derelativize(*this);
+  fr.deoptimize(nullptr);
+
+  // Fix chunk pc if deopted frame is the top one
+  bool is_top = fr.sp() == chunk->sp_address();
+  if (is_top) {
+    chunk->set_pc(fr.raw_pc());
+  }
+}
+
 frame frame::java_sender() const {
   RegisterMap map(JavaThread::current(),
                   RegisterMap::UpdateMap::skip,

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -282,6 +282,7 @@ class frame {
 
   // Support for deoptimization
   void deoptimize(JavaThread* thread);
+  void deoptimize(JavaThread* thread, stackChunkOop chunk);
 
   // The frame's original SP, before any extension by an interpreted callee;
   // used for packing debug info into vframeArray objects and vframeArray lookup.


### PR DESCRIPTION
Please review this small fix. After JDK-6960970, a `NotifyFramePop` request targeting a virtual thread can lead to deoptimizing a compiled frame that is currently in the heap. When the frame deoptimized is the top frame in the `stackChunk`, the chunk’s `pc` field must be updated as well.

I refactored `JvmtiEnvBase::set_frame_pop` to separate between the heap vs stack frame cases, instead of the current logic which is based on mounted vs unmounted. Also helper `frame::deoptimize(JavaThread*, stackChunkOop)` is added to encapsulate the deopt logic.

I verified the test doesn’t crash anymore and also tested in mach5 tiers1-6.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385661](https://bugs.openjdk.org/browse/JDK-8385661): jvmti/vthread/ThreadStateTest/ThreadStateTest.java triggers assert(f.pc() == _chunk-&gt;pc()) failed (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31456/head:pull/31456` \
`$ git checkout pull/31456`

Update a local copy of the PR: \
`$ git checkout pull/31456` \
`$ git pull https://git.openjdk.org/jdk.git pull/31456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31456`

View PR using the GUI difftool: \
`$ git pr show -t 31456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31456.diff">https://git.openjdk.org/jdk/pull/31456.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31456#issuecomment-4671344082)
</details>
