### PR TITLE
8386345: Remove redundant @requires from TestGarbageCollectionEventWithZMinor

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java
@@ -41,7 +41,6 @@ import jdk.test.whitebox.WhiteBox;
  * @test
  * @requires vm.flagless
  * @requires vm.hasJFR & vm.gc.Z
- * @requires vm.flagless
  * @library /test/lib /test/jdk
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Removes redundant @requires.

Ran this through SAPs testing, all green.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386345](https://bugs.openjdk.org/browse/JDK-8386345): Remove redundant @<!---->requires from TestGarbageCollectionEventWithZMinor (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31457/head:pull/31457` \
`$ git checkout pull/31457`

Update a local copy of the PR: \
`$ git checkout pull/31457` \
`$ git pull https://git.openjdk.org/jdk.git pull/31457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31457`

View PR using the GUI difftool: \
`$ git pr show -t 31457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31457.diff">https://git.openjdk.org/jdk/pull/31457.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31457#issuecomment-4671162653)
</details>
