### PR TITLE
8385873: G1: G1ConcurrentRefineSweepTask::_sweep_completed should be Atomic

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.cpp
@@ -180,11 +180,11 @@ void G1ConcurrentRefineSweepTask::work(uint worker_id) {
   _scan_state->heap_region_iterate_from_worker_offset(&sweep_cl, worker_id, _max_workers);
 
   if (!sweep_cl._completed) {
-    _sweep_completed = false;
+    _sweep_completed.store_relaxed(false);
   }
 
   _stats->inc_sweep_duration(os::elapsed_counter() - start);
   _stats->add_atomic(&sweep_cl._per_worker_refine_data);
 }
 
-bool G1ConcurrentRefineSweepTask::sweep_completed() const { return _sweep_completed; }
+bool G1ConcurrentRefineSweepTask::sweep_completed() const { return _sweep_completed.load_relaxed(); }

--- a/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.hpp
@@ -25,8 +25,8 @@
 #ifndef SHARE_GC_G1_G1CONCURRENTREFINESWEEPTASK_HPP
 #define SHARE_GC_G1_G1CONCURRENTREFINESWEEPTASK_HPP
 
-#include "runtime/atomic.hpp"
 #include "gc/shared/workerThread.hpp"
+#include "runtime/atomic.hpp"
 
 class G1CardTableClaimTable;
 class G1ConcurrentRefineStats;

--- a/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefineSweepTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1CONCURRENTREFINESWEEPTASK_HPP
 #define SHARE_GC_G1_G1CONCURRENTREFINESWEEPTASK_HPP
 
+#include "runtime/atomic.hpp"
 #include "gc/shared/workerThread.hpp"
 
 class G1CardTableClaimTable;
@@ -34,7 +35,7 @@ class G1ConcurrentRefineSweepTask : public WorkerTask {
   G1CardTableClaimTable* _scan_state;
   G1ConcurrentRefineStats* _stats;
   uint _max_workers;
-  bool _sweep_completed;
+  Atomic<bool> _sweep_completed;
 
 public:
 


### PR DESCRIPTION
Hi all,

  please review this change that makes `G1ConcurrentRefineSweepTask::_sweep_completed` and `Atomic` - it is written to by multiple threads, so it should be marked as such. The actual writes are all to the same value, so there is no concurrency issues.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385873](https://bugs.openjdk.org/browse/JDK-8385873): G1: G1ConcurrentRefineSweepTask::_sweep_completed should be Atomic (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31458/head:pull/31458` \
`$ git checkout pull/31458`

Update a local copy of the PR: \
`$ git checkout pull/31458` \
`$ git pull https://git.openjdk.org/jdk.git pull/31458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31458`

View PR using the GUI difftool: \
`$ git pr show -t 31458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31458.diff">https://git.openjdk.org/jdk/pull/31458.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31458#issuecomment-4671572008)
</details>
