### PR TITLE
8385901: G1: G1FullGCPrepareTask::_has_free_compaction_targets should be Atomic

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -60,13 +60,13 @@ G1FullGCPrepareTask::G1FullGCPrepareTask(G1FullCollector* collector) :
 }
 
 void G1FullGCPrepareTask::set_has_free_compaction_targets() {
-  if (!_has_free_compaction_targets) {
-    _has_free_compaction_targets = true;
+  if (!has_free_compaction_targets()) {
+    _has_free_compaction_targets.store_relaxed(true);
   }
 }
 
 bool G1FullGCPrepareTask::has_free_compaction_targets() {
-  return _has_free_compaction_targets;
+  return _has_free_compaction_targets.load_relaxed();
 }
 
 void G1FullGCPrepareTask::work(uint worker_id) {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -28,6 +28,7 @@
 #include "gc/g1/g1FullGCTask.hpp"
 #include "gc/g1/g1HeapRegion.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 
 class G1CollectedHeap;
 class G1CMBitMap;
@@ -61,7 +62,7 @@ public:
 };
 
 class G1FullGCPrepareTask : public G1FullGCTask {
-  volatile bool     _has_free_compaction_targets;
+  Atomic<bool> _has_free_compaction_targets;
   G1HeapRegionClaimer _hrclaimer;
 
   void set_has_free_compaction_targets();


### PR DESCRIPTION
Hi all,

  please review this change to make `G1FullGCPrepareTask::_has_free_compaction_targets` use the `Atomic` API.

The variable is racily set (to the same value) by multiple threads, so make it Atomic as per guidelines.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385901](https://bugs.openjdk.org/browse/JDK-8385901): G1: G1FullGCPrepareTask::_has_free_compaction_targets should be Atomic (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31460/head:pull/31460` \
`$ git checkout pull/31460`

Update a local copy of the PR: \
`$ git checkout pull/31460` \
`$ git pull https://git.openjdk.org/jdk.git pull/31460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31460`

View PR using the GUI difftool: \
`$ git pr show -t 31460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31460.diff">https://git.openjdk.org/jdk/pull/31460.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31460#issuecomment-4672323203)
</details>
