### PR TITLE
8385899: G1: G1ConcurrentMarkThread::_state should be Atomic

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -120,10 +120,10 @@ void G1ConcurrentMarkThread::run_service() {
 
     concurrent_cycle_start();
 
-    if (_state == FullCycleMarking) {
+    if (state() == FullCycleMarking) {
       concurrent_mark_cycle_do();
     } else {
-      assert(_state == UndoCycleResetForNextCycle, "Must do undo mark but is %d", _state);
+      assert(state() == UndoCycleResetForNextCycle, "Must do undo mark but is %d", state());
       concurrent_undo_cycle_do();
     }
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1CONCURRENTMARKTHREAD_HPP
 
 #include "gc/shared/concurrentGCThread.hpp"
+#include "runtime/atomic.hpp"
 
 class G1ConcurrentMark;
 class G1Policy;
@@ -47,7 +48,9 @@ class G1ConcurrentMarkThread: public ConcurrentGCThread {
     UndoCycleResetForNextCycle
   };
 
-  volatile ServiceState _state;
+  Atomic<ServiceState> _state;
+
+  ServiceState state() const { return _state.load_relaxed(); }
 
   // Returns whether we are in a "Full" cycle.
   bool is_in_full_concurrent_cycle() const;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
@@ -41,55 +41,55 @@ inline double G1ConcurrentMarkThread::worker_threads_cpu_time_s() {
 }
 
 inline bool G1ConcurrentMarkThread::is_in_full_concurrent_cycle() const {
-  ServiceState state = _state;
-  return (state == FullCycleMarking || state == FullCycleRebuildOrScrub || state == FullCycleResetForNextCycle);
+  ServiceState st = state();
+  return (st == FullCycleMarking || st == FullCycleRebuildOrScrub || st == FullCycleResetForNextCycle);
 }
 
 inline void G1ConcurrentMarkThread::set_idle() {
   // Concurrent cycle may be aborted any time.
   assert(!is_idle(), "must not be idle");
-  _state = Idle;
+  _state.store_relaxed(Idle);
 }
 
 inline void G1ConcurrentMarkThread::start_full_cycle() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
   assert(is_idle(), "cycle in progress");
-  _state = FullCycleMarking;
+  _state.store_relaxed(FullCycleMarking);
 }
 
 inline void G1ConcurrentMarkThread::start_undo_cycle() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
   assert(is_idle(), "cycle in progress");
-  _state = UndoCycleResetForNextCycle;
+  _state.store_relaxed(UndoCycleResetForNextCycle);
 }
 
 inline void G1ConcurrentMarkThread::set_full_cycle_rebuild_and_scrub() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
-  assert(_state == FullCycleMarking, "must be");
-  _state = FullCycleRebuildOrScrub;
+  assert(state() == FullCycleMarking, "must be");
+  _state.store_relaxed(FullCycleRebuildOrScrub);
 }
 
 inline void G1ConcurrentMarkThread::set_full_cycle_reset_for_next_cycle() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
-  assert(_state == FullCycleRebuildOrScrub, "must be");
-  _state = FullCycleResetForNextCycle;
+  assert(state() == FullCycleRebuildOrScrub, "must be");
+  _state.store_relaxed(FullCycleResetForNextCycle);
 }
 
 inline bool G1ConcurrentMarkThread::is_in_marking() const {
-  return _state == FullCycleMarking;
+  return state() == FullCycleMarking;
 }
 
 inline bool G1ConcurrentMarkThread::is_in_rebuild_or_scrub() const {
-  return _state == FullCycleRebuildOrScrub;
+  return state() == FullCycleRebuildOrScrub;
 }
 
 inline bool G1ConcurrentMarkThread::is_in_reset_for_next_cycle() const {
-  ServiceState state = _state;
-  return state == FullCycleResetForNextCycle || state == UndoCycleResetForNextCycle;
+  ServiceState st = state();
+  return st == FullCycleResetForNextCycle || st == UndoCycleResetForNextCycle;
 }
 
 inline bool G1ConcurrentMarkThread::is_idle() const {
-  return _state == Idle;
+  return state() == Idle;
 }
 
 inline bool G1ConcurrentMarkThread::is_in_progress() const {
@@ -97,7 +97,7 @@ inline bool G1ConcurrentMarkThread::is_in_progress() const {
 }
 
 inline bool G1ConcurrentMarkThread::is_in_undo_cycle() const {
-  return _state == UndoCycleResetForNextCycle;
+  return state() == UndoCycleResetForNextCycle;
 }
 
 #endif // SHARE_GC_G1_G1CONCURRENTMARKTHREAD_INLINE_HPP


### PR DESCRIPTION
Hi all,

  please review this change that makes the volatile `G1ConcurrentMarkThread::_state` use the `Atomic` API. No other change.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385899](https://bugs.openjdk.org/browse/JDK-8385899): G1: G1ConcurrentMarkThread::_state should be Atomic (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31461/head:pull/31461` \
`$ git checkout pull/31461`

Update a local copy of the PR: \
`$ git checkout pull/31461` \
`$ git pull https://git.openjdk.org/jdk.git pull/31461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31461`

View PR using the GUI difftool: \
`$ git pr show -t 31461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31461.diff">https://git.openjdk.org/jdk/pull/31461.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31461#issuecomment-4672319800)
</details>
