### PR TITLE
8386428: With -UseLSE the Starvation test on Windows ARM64 timeouts

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
@@ -388,8 +388,8 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
             ITEM.set(this, this);
         }
 
-        final Thread getAcqWaiter() {
-            return (Thread)WAITER.getAcquire(this);
+        final Thread getVolatileWaiter() {
+            return (Thread)WAITER.getVolatile(this);
         }
 
         /** The number of times to spin when eligible */
@@ -596,7 +596,7 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
                 q = p.next;
                 if (p.isData != haveData && haveData != (m != null)) {
                     if (p.cmpExItem(m, e) == m) {
-                        Thread w = p.getAcqWaiter(); // matched complementary node
+                        Thread w = p.getVolatileWaiter(); // matched complementary node
                         if (p != h && h == cmpExHead(h, (q == null) ? p : q))
                             h.next = h;     // advance head; self-link old
                         LockSupport.unpark(w);

--- a/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
@@ -388,6 +388,10 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
             ITEM.set(this, this);
         }
 
+        final Thread getAcqWaiter() {
+            return (Thread)WAITER.getAcquire(this);
+        }
+
         /** The number of times to spin when eligible */
         private static final int SPINS = 1 << 7;
 
@@ -486,12 +490,14 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
         // VarHandle mechanics
         static final VarHandle ITEM;
         static final VarHandle NEXT;
+        static final VarHandle WAITER;
         static {
             try {
                 Class<?> tn = DualNode.class;
                 MethodHandles.Lookup l = MethodHandles.lookup();
                 ITEM = l.findVarHandle(tn, "item", Object.class);
                 NEXT = l.findVarHandle(tn, "next", tn);
+                WAITER = l.findVarHandle(tn, "waiter", Thread.class);
             } catch (ReflectiveOperationException e) {
                 throw new ExceptionInInitializerError(e);
             }
@@ -590,7 +596,7 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
                 q = p.next;
                 if (p.isData != haveData && haveData != (m != null)) {
                     if (p.cmpExItem(m, e) == m) {
-                        Thread w = p.waiter; // matched complementary node
+                        Thread w = p.getAcqWaiter(); // matched complementary node
                         if (p != h && h == cmpExHead(h, (q == null) ? p : q))
                             h.next = h;     // advance head; self-link old
                         LockSupport.unpark(w);


### PR DESCRIPTION
With -UseLSE the Starvation test on Windows ARM64 timeouts close to 100% whereas this only happens on Linux ARM64 on larger machines with many cores. The issue is that C2 outputs an LDR following the CAS in LinkedTransferQueue which can execute before the STLXR breaking the Dekker protocol.

Replacing the LDR with LADR by using getAcquire solves the issue as it won't be reordered before the STLXR.  This does impact the +UseLSE case as the LADR was not necessary and is slightly more expensive than LDR.  But to handle this case would require larger changes to Hotspot

Starvation test passes on Windows ARM64 and Linux ARM64, with no regressions on tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386428](https://bugs.openjdk.org/browse/JDK-8386428): With -UseLSE the Starvation test on Windows ARM64 timeouts (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31465/head:pull/31465` \
`$ git checkout pull/31465`

Update a local copy of the PR: \
`$ git checkout pull/31465` \
`$ git pull https://git.openjdk.org/jdk.git pull/31465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31465`

View PR using the GUI difftool: \
`$ git pr show -t 31465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31465.diff">https://git.openjdk.org/jdk/pull/31465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31465#issuecomment-4672809844)
</details>
