### PR TITLE
8385723: Intermittent failure of serviceability/sa/ClhsdbInspect.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -33,8 +33,6 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-all
 
-serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
-
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_a/TestDescription.java 8308367 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_b/TestDescription.java 8308367 generic-all

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -643,6 +643,8 @@ public class LingeredApp {
                         crasher.run();
                     }
                 }
+                // Force a GC now to reduce the risk of one happening during the loop below.
+                System.gc();
                 while (Files.exists(path)) {
                     // Touch the lock to indicate our readiness
                     setLastModified(theLockFileName, epoch());


### PR DESCRIPTION
This is a clean backport of commit [4ff29cbd](https://github.com/openjdk/jdk/commit/4ff29cbde4670e2ab0dae2a023285055e4fc343d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Chris Plummer on 5 Jun 2026 and was reviewed by Kevin Walls, Albert Mingkun Yang, Leonid Mesnik and SendaoYan.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385723](https://bugs.openjdk.org/browse/JDK-8385723): Intermittent failure of serviceability/sa/ClhsdbInspect.java (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31466/head:pull/31466` \
`$ git checkout pull/31466`

Update a local copy of the PR: \
`$ git checkout pull/31466` \
`$ git pull https://git.openjdk.org/jdk.git pull/31466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31466`

View PR using the GUI difftool: \
`$ git pr show -t 31466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31466.diff">https://git.openjdk.org/jdk/pull/31466.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31466#issuecomment-4672983245)
</details>
