### PR TITLE
8386273: Some javax/sound/sampled tests fail on systems with high CPU core number and running with high concurrency

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -59,7 +59,7 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
-com/sun/net/httpserver/simpleserver sun/tools/jhsdb
+com/sun/net/httpserver/simpleserver sun/tools/jhsdb javax/sound
 
 # Group definitions
 groups=TEST.groups


### PR DESCRIPTION
Client tests all run in othervm mode. We've also added the sound and headful keywords to many tests.
We can keep doing that as we find specific test problems but one other thing we can do is ask jtreg not to run other tests in parallel with javax/sound tests. There aren't a whole lot of them so it should not make a big difference and if  it helps stability that's what matters.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386273](https://bugs.openjdk.org/browse/JDK-8386273): Some javax/sound/sampled tests fail on systems with high CPU core number and running with high concurrency (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31468/head:pull/31468` \
`$ git checkout pull/31468`

Update a local copy of the PR: \
`$ git checkout pull/31468` \
`$ git pull https://git.openjdk.org/jdk.git pull/31468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31468`

View PR using the GUI difftool: \
`$ git pr show -t 31468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31468.diff">https://git.openjdk.org/jdk/pull/31468.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31468#issuecomment-4673703433)
</details>
