### PR TITLE
8386124: Test serviceability/sa/TestG1HeapRegion.java failed: Address of G1HeapRegion does not match

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestG1HeapRegion.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestG1HeapRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,10 @@
  */
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
+import sun.jvm.hotspot.debugger.Address;
 import sun.jvm.hotspot.gc.g1.G1CollectedHeap;
 import sun.jvm.hotspot.gc.g1.G1HeapRegion;
 import sun.jvm.hotspot.HotSpotAgent;
@@ -39,12 +41,15 @@ import jdk.test.lib.Utils;
 
 /**
  * @test
+ * @bug 8194249
  * @library /test/lib
  * @requires vm.hasSA
  * @requires (os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*"))
  * @requires vm.gc.G1
  * @modules jdk.hotspot.agent/sun.jvm.hotspot
+ *          jdk.hotspot.agent/sun.jvm.hotspot.debugger
  *          jdk.hotspot.agent/sun.jvm.hotspot.gc.g1
+ *          jdk.hotspot.agent/sun.jvm.hotspot.gc.shared
  *          jdk.hotspot.agent/sun.jvm.hotspot.memory
  *          jdk.hotspot.agent/sun.jvm.hotspot.runtime
  * @run driver TestG1HeapRegion
@@ -59,12 +64,40 @@ public class TestG1HeapRegion {
 
         try {
             agent.attach(Integer.parseInt(pid));
-            G1CollectedHeap heap = (G1CollectedHeap)VM.getVM().getUniverse().heap();
-            G1HeapRegion hr = heap.hrm().heapRegionIterator().next();
-            G1HeapRegion hrTop = heap.hrm().getByAddress(hr.top());
 
-            Asserts.assertEquals(hr.top(), hrTop.top(),
-                                 "Address of G1HeapRegion does not match.");
+            G1CollectedHeap heap = (G1CollectedHeap)VM.getVM().getUniverse().heap();
+            heap.printOn(System.out);
+
+            // Print each region first.
+            System.out.println();
+            Iterator<G1HeapRegion> hri  = heap.hrm().heapRegionIterator();
+            G1HeapRegion hr = hri.next();
+            while (hr != null) {
+                hr.printOn(System.out);
+                hr = hri.next();
+            }
+            System.out.println();
+
+            // Iterate over each region and confirm that getByAddress(top) returns
+            // the same address as the region being looked at.
+            hri  = heap.hrm().heapRegionIterator();
+            hr = hri.next();
+            while (hr != null) {
+                hr.printOn(System.out);
+                Address top = hr.top();
+                if (top.equals(hr.end())) {
+                    // The end of the region is actually the first address after
+                    // the end, so it points to the start of the next region. We need to
+                    // subtract to avoid getByAddress(top) returning the next region.
+                    top = top.addOffsetTo(-1);
+                }
+                G1HeapRegion hrTop = heap.hrm().getByAddress(top);
+                System.out.format("hr.top():0x%x <--> hrTop.top():0x%x\n",
+                                  hr.top().asLongValue(), hrTop.top().asLongValue());
+                Asserts.assertEquals(hr.top(), hrTop.top(),
+                                     "Address of G1HeapRegion does not match.");
+                hr = hri.next();
+            }
         } finally {
             agent.detach();
         }
@@ -76,7 +109,9 @@ public class TestG1HeapRegion {
         ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
             "--add-modules=jdk.hotspot.agent",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.gc.g1=ALL-UNNAMED",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.gc.shared=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.memory=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.runtime=ALL-UNNAMED",
             "TestG1HeapRegion",

--- a/test/hotspot/jtreg/serviceability/sa/TestG1HeapRegion.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestG1HeapRegion.java
@@ -49,7 +49,6 @@ import jdk.test.lib.Utils;
  * @modules jdk.hotspot.agent/sun.jvm.hotspot
  *          jdk.hotspot.agent/sun.jvm.hotspot.debugger
  *          jdk.hotspot.agent/sun.jvm.hotspot.gc.g1
- *          jdk.hotspot.agent/sun.jvm.hotspot.gc.shared
  *          jdk.hotspot.agent/sun.jvm.hotspot.memory
  *          jdk.hotspot.agent/sun.jvm.hotspot.runtime
  * @run driver TestG1HeapRegion
@@ -111,7 +110,6 @@ public class TestG1HeapRegion {
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.gc.g1=ALL-UNNAMED",
-            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.gc.shared=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.memory=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.runtime=ALL-UNNAMED",
             "TestG1HeapRegion",


### PR DESCRIPTION
This is a test bug.  The gets the first region, gets top() for the that region, and then uses that top() address to get the region that top() is in. It expects it to be the same region. However, when the region is full, top() is actually the next address beyond the end of the region, so marks the start of the next region. The fix is to simply subtract 1 from top() when it equals end(). Note top() is where the next allocation comes from in the region and end() is the end of region space.

I improved the test by adding printing of the G1 heap, including all regions. I also improved the test by making it test every region, not just the first one. During local testing the first region was always free, so did not make for a very good test, and would not reproduce the issue. When I started testing every region, it failed every time. All you need is one full region for failures.

I ran the test 100 times on all supported platforms.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386124](https://bugs.openjdk.org/browse/JDK-8386124): Test serviceability/sa/TestG1HeapRegion.java failed: Address of G1HeapRegion does not match (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.org/census#ysuenaga) (@YaSuenag - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31469/head:pull/31469` \
`$ git checkout pull/31469`

Update a local copy of the PR: \
`$ git checkout pull/31469` \
`$ git pull https://git.openjdk.org/jdk.git pull/31469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31469`

View PR using the GUI difftool: \
`$ git pr show -t 31469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31469.diff">https://git.openjdk.org/jdk/pull/31469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31469#issuecomment-4674215576)
</details>
