### PR TITLE
8376748: Emit runtime warnings for JCE algorithms that will be disabled

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -857,8 +857,8 @@ public class KeyStore {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -867,8 +867,8 @@ public class KeyStore {
      * with the keystore type. This warning is shown once per caller for
      * each legacy keystore type. If the keystore type is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -929,8 +929,8 @@ public class KeyStore {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -939,8 +939,8 @@ public class KeyStore {
      * with the keystore type. This warning is shown once per caller for
      * each legacy keystore type. If the keystore type is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -1010,8 +1010,8 @@ public class KeyStore {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -1020,8 +1020,8 @@ public class KeyStore {
      * with the keystore type. This warning is shown once per caller for
      * each legacy keystore type. If the keystore type is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -1815,8 +1815,9 @@ public class KeyStore {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value. Disallowed type will be skipped.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
+     * Disallowed type will be skipped.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -1825,8 +1826,8 @@ public class KeyStore {
      * with the keystore type. This warning is shown once per caller for
      * each legacy keystore type. If the keystore type is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -1891,8 +1892,9 @@ public class KeyStore {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value. Disallowed type will be skipped.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
+     * Disallowed type will be skipped.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -1901,8 +1903,8 @@ public class KeyStore {
      * with the keystore type. This warning is shown once per caller for
      * each legacy keystore type. If the keystore type is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -896,8 +896,10 @@ public class KeyStore {
             throw new KeyStoreException(type + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("KeyStore", type,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("KeyStore", type)) {
+            CryptoAlgorithmConstraints.warn("KeyStore", type,
+                    Reflection.getCallerClass());
+        }
 
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", (String)null);
@@ -973,8 +975,10 @@ public class KeyStore {
             throw new KeyStoreException(type + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("KeyStore", type,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("KeyStore", type)) {
+            CryptoAlgorithmConstraints.warn("KeyStore", type,
+                    Reflection.getCallerClass());
+        }
 
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", provider);
@@ -1046,8 +1050,10 @@ public class KeyStore {
             throw new KeyStoreException(type + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("KeyStore", type,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("KeyStore", type)) {
+            CryptoAlgorithmConstraints.warn("KeyStore", type,
+                    Reflection.getCallerClass());
+        }
 
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", provider);
@@ -1951,8 +1957,11 @@ public class KeyStore {
                                 String ksAlgo = s.getAlgorithm();
                                 if (CryptoAlgorithmConstraints.permits(
                                         "KEYSTORE", ksAlgo)) {
-                                    CryptoAlgorithmConstraints.warn("KeyStore",
-                                            ksAlgo, callerClass);
+                                    if (CryptoAlgorithmConstraints.isLegacy(
+                                            "KeyStore", ksAlgo)) {
+                                        CryptoAlgorithmConstraints.warn(
+                                                "KeyStore", ksAlgo, callerClass);
+                                    }
                                     keystore = new KeyStore(impl, p, ksAlgo);
                                 } else {
                                     matched = ksAlgo;

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -37,6 +37,9 @@ import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.callback.*;
 
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
+
 import sun.security.util.Debug;
 import sun.security.util.CryptoAlgorithmConstraints;
 
@@ -857,6 +860,13 @@ public class KeyStore {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified keystore type is considered legacy. If so, the
+     * JDK Reference Implementation emits a warning when the keystore type is
+     * requested. If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
      * </ul>
      *
      * @param type the type of keystore.
@@ -876,6 +886,7 @@ public class KeyStore {
      *
      * @see Provider
      */
+    @CallerSensitive
     public static KeyStore getInstance(String type)
         throws KeyStoreException
     {
@@ -884,6 +895,9 @@ public class KeyStore {
         if (!CryptoAlgorithmConstraints.permits("KEYSTORE", type)) {
             throw new KeyStoreException(type + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("KeyStore", type,
+                Reflection.getCallerClass());
 
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", (String)null);
@@ -912,6 +926,14 @@ public class KeyStore {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
+     * security property value.
+     *
      * @param type the type of keystore.
      * See the KeyStore section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#keystore-types">
@@ -937,6 +959,7 @@ public class KeyStore {
      *
      * @see Provider
      */
+    @CallerSensitive
     public static KeyStore getInstance(String type, String provider)
         throws KeyStoreException, NoSuchProviderException
     {
@@ -949,6 +972,9 @@ public class KeyStore {
         if (!CryptoAlgorithmConstraints.permits("KEYSTORE", type)) {
             throw new KeyStoreException(type + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("KeyStore", type,
+                Reflection.getCallerClass());
 
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", provider);
@@ -974,6 +1000,14 @@ public class KeyStore {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
+     * security property value.
+     *
      * @param type the type of keystore.
      * See the KeyStore section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#keystore-types">
@@ -998,6 +1032,7 @@ public class KeyStore {
      *
      * @since 1.4
      */
+    @CallerSensitive
     public static KeyStore getInstance(String type, Provider provider)
         throws KeyStoreException
     {
@@ -1010,6 +1045,9 @@ public class KeyStore {
         if (!CryptoAlgorithmConstraints.permits("KEYSTORE", type)) {
             throw new KeyStoreException(type + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("KeyStore", type,
+                Reflection.getCallerClass());
 
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", provider);
@@ -1760,6 +1798,14 @@ public class KeyStore {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value. Disallowed type will be skipped.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
+     * security property value.
+     *
      * @param  file the keystore file
      * @param  password the keystore password, which may be {@code null}
      *
@@ -1785,10 +1831,12 @@ public class KeyStore {
      *
      * @since 9
      */
+    @CallerSensitive
     public static final KeyStore getInstance(File file, char[] password)
         throws KeyStoreException, IOException, NoSuchAlgorithmException,
             CertificateException {
-        return getInstance(file, password, null, true);
+        return getInstance(file, password, null, true,
+                Reflection.getCallerClass());
     }
 
     /**
@@ -1821,6 +1869,14 @@ public class KeyStore {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value. Disallowed type will be skipped.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
+     * security property value.
+     *
      * @param  file the keystore file
      * @param  param the {@code LoadStoreParameter} that specifies how to load
      *             the keystore, which may be {@code null}
@@ -1847,15 +1903,17 @@ public class KeyStore {
      *
      * @since 9
      */
+    @CallerSensitive
     public static final KeyStore getInstance(File file,
         LoadStoreParameter param) throws KeyStoreException, IOException,
             NoSuchAlgorithmException, CertificateException {
-        return getInstance(file, null, param, false);
+        return getInstance(file, null, param, false,
+                Reflection.getCallerClass());
     }
 
     // Used by getInstance(File, char[]) & getInstance(File, LoadStoreParameter)
     private static final KeyStore getInstance(File file, char[] password,
-        LoadStoreParameter param, boolean hasPassword)
+        LoadStoreParameter param, boolean hasPassword, Class<?> callerClass)
             throws KeyStoreException, IOException, NoSuchAlgorithmException,
                 CertificateException {
 
@@ -1893,6 +1951,8 @@ public class KeyStore {
                                 String ksAlgo = s.getAlgorithm();
                                 if (CryptoAlgorithmConstraints.permits(
                                         "KEYSTORE", ksAlgo)) {
+                                    CryptoAlgorithmConstraints.warn("KeyStore",
+                                            ksAlgo, callerClass);
                                     keystore = new KeyStore(impl, p, ksAlgo);
                                 } else {
                                     matched = ksAlgo;

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -862,8 +862,11 @@ public class KeyStore {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested.
+     * if the specified keystore type is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the keystore type. This warning is shown once per caller for
+     * each legacy keystore type. If the keystore type is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -931,8 +934,11 @@ public class KeyStore {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested.
+     * if the specified keystore type is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the keystore type. This warning is shown once per caller for
+     * each legacy keystore type. If the keystore type is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -1009,8 +1015,11 @@ public class KeyStore {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested.
+     * if the specified keystore type is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the keystore type. This warning is shown once per caller for
+     * each legacy keystore type. If the keystore type is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -1811,8 +1820,11 @@ public class KeyStore {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested.
+     * if the specified keystore type is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the keystore type. This warning is shown once per caller for
+     * each legacy keystore type. If the keystore type is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -1884,8 +1896,11 @@ public class KeyStore {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested.
+     * if the specified keystore type is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the keystore type. This warning is shown once per caller for
+     * each legacy keystore type. If the keystore type is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -862,9 +862,9 @@ public class KeyStore {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified keystore type is considered legacy. If so, the
-     * JDK Reference Implementation emits a warning when the keystore type is
-     * requested. If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * if the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
      * </ul>
@@ -922,19 +922,21 @@ public class KeyStore {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
-     * security property value.
+     * if the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param type the type of keystore.
      * See the KeyStore section in the <a href=
@@ -998,19 +1000,21 @@ public class KeyStore {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
-     * security property value.
+     * if the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param type the type of keystore.
      * See the KeyStore section in the <a href=
@@ -1798,19 +1802,21 @@ public class KeyStore {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value. Disallowed type will be skipped.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
-     * security property value.
+     * if the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param  file the keystore file
      * @param  password the keystore password, which may be {@code null}
@@ -1869,19 +1875,21 @@ public class KeyStore {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified keystore type is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value. Disallowed type will be skipped.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified keystore type is considered legacy. If so, it
-     * emits a warning when the keystore type is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes the
-     * security property value.
+     * if the specified keystore type is considered legacy. If so, it
+     * emits a warning when the keystore type is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param  file the keystore file
      * @param  param the {@code LoadStoreParameter} that specifies how to load

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -176,10 +176,10 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, the
-     * JDK emits a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -249,19 +249,21 @@ public abstract class MessageDigest extends MessageDigestSpi {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, it emits
-     * a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param algorithm the name of the algorithm requested.
      * See the MessageDigest section in the <a href=
@@ -332,19 +334,21 @@ public abstract class MessageDigest extends MessageDigestSpi {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, it emits
-     * a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param algorithm the name of the algorithm requested.
      * See the MessageDigest section in the <a href=

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -176,8 +176,11 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -258,8 +261,11 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -343,8 +349,11 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -171,8 +171,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -181,8 +181,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -256,8 +256,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -266,8 +266,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -344,8 +344,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -354,8 +354,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -211,8 +211,10 @@ public abstract class MessageDigest extends MessageDigestSpi {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("MessageDigest", algorithm)) {
+            CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
+                    Reflection.getCallerClass());
+        }
 
         GetInstance.Instance instance = GetInstance.getInstance("MessageDigest",
                 MessageDigestSpi.class, algorithm);
@@ -301,8 +303,10 @@ public abstract class MessageDigest extends MessageDigestSpi {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("MessageDigest", algorithm)) {
+            CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
+                    Reflection.getCallerClass());
+        }
 
         GetInstance.Instance instance = GetInstance.getInstance("MessageDigest",
                 MessageDigestSpi.class, algorithm, provider);
@@ -382,8 +386,10 @@ public abstract class MessageDigest extends MessageDigestSpi {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("MessageDigest", algorithm)) {
+            CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
+                    Reflection.getCallerClass());
+        }
 
         Object[] objs = Security.getImpl(algorithm, "MessageDigest", provider);
         if (objs[0] instanceof MessageDigest md) {

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,9 @@ import java.util.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
+
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
 
 import sun.security.jca.GetInstance;
 import sun.security.util.Debug;
@@ -171,6 +174,13 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, the
+     * JDK emits a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     * </li>
      * </ul>
      *
      * @param algorithm the name of the algorithm requested.
@@ -191,6 +201,7 @@ public abstract class MessageDigest extends MessageDigestSpi {
      *
      * @see Provider
      */
+    @CallerSensitive
     public static MessageDigest getInstance(String algorithm)
         throws NoSuchAlgorithmException
     {
@@ -199,6 +210,9 @@ public abstract class MessageDigest extends MessageDigestSpi {
         if (!CryptoAlgorithmConstraints.permits("MessageDigest", algorithm)) {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
+                Reflection.getCallerClass());
 
         GetInstance.Instance instance = GetInstance.getInstance("MessageDigest",
                 MessageDigestSpi.class, algorithm);
@@ -239,6 +253,14 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, it emits
+     * a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     *
      * @param algorithm the name of the algorithm requested.
      * See the MessageDigest section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#messagedigest-algorithms">
@@ -265,6 +287,7 @@ public abstract class MessageDigest extends MessageDigestSpi {
      *
      * @see Provider
      */
+    @CallerSensitive
     public static MessageDigest getInstance(String algorithm, String provider)
         throws NoSuchAlgorithmException, NoSuchProviderException
     {
@@ -277,6 +300,9 @@ public abstract class MessageDigest extends MessageDigestSpi {
         if (!CryptoAlgorithmConstraints.permits("MessageDigest", algorithm)) {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
+                Reflection.getCallerClass());
 
         GetInstance.Instance instance = GetInstance.getInstance("MessageDigest",
                 MessageDigestSpi.class, algorithm, provider);
@@ -308,6 +334,14 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, it emits
+     * a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     *
      * @param algorithm the name of the algorithm requested.
      * See the MessageDigest section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#messagedigest-algorithms">
@@ -333,6 +367,7 @@ public abstract class MessageDigest extends MessageDigestSpi {
      *
      * @since 1.4
      */
+    @CallerSensitive
     public static MessageDigest getInstance(String algorithm,
                                             Provider provider)
         throws NoSuchAlgorithmException
@@ -346,6 +381,9 @@ public abstract class MessageDigest extends MessageDigestSpi {
         if (!CryptoAlgorithmConstraints.permits("MessageDigest", algorithm)) {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("MessageDigest", algorithm,
+                Reflection.getCallerClass());
 
         Object[] objs = Security.getImpl(algorithm, "MessageDigest", provider);
         if (objs[0] instanceof MessageDigest md) {

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -277,8 +277,10 @@ public abstract class Signature extends SignatureSpi {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("Signature", algorithm,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("Signature", algorithm)) {
+            CryptoAlgorithmConstraints.warn("Signature", algorithm,
+                    Reflection.getCallerClass());
+        }
 
         Iterator<Service> t = GetInstance.getServices("Signature", algorithm);
         if (!t.hasNext()) {
@@ -423,8 +425,10 @@ public abstract class Signature extends SignatureSpi {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("Signature", algorithm,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("Signature", algorithm)) {
+            CryptoAlgorithmConstraints.warn("Signature", algorithm,
+                    Reflection.getCallerClass());
+        }
 
         Instance instance = GetInstance.getInstance
                 ("Signature", SignatureSpi.class, algorithm, provider);
@@ -488,8 +492,10 @@ public abstract class Signature extends SignatureSpi {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("Signature", algorithm,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("Signature", algorithm)) {
+            CryptoAlgorithmConstraints.warn("Signature", algorithm,
+                    Reflection.getCallerClass());
+        }
 
         Instance instance = GetInstance.getInstance
                 ("Signature", SignatureSpi.class, algorithm, provider);

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ import java.security.Provider.Service;
 
 import jdk.internal.access.JavaSecuritySignatureAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
 
 import sun.security.util.Debug;
 import sun.security.util.CryptoAlgorithmConstraints;
@@ -240,6 +242,13 @@ public abstract class Signature extends SignatureSpi {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, the
+     * JDK emits a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     * </li>
      * </ul>
      *
      * @param algorithm the standard name of the algorithm requested.
@@ -259,6 +268,7 @@ public abstract class Signature extends SignatureSpi {
      *
      * @see Provider
      */
+    @CallerSensitive
     public static Signature getInstance(String algorithm)
             throws NoSuchAlgorithmException {
         Objects.requireNonNull(algorithm, "null algorithm name");
@@ -266,6 +276,9 @@ public abstract class Signature extends SignatureSpi {
         if (!CryptoAlgorithmConstraints.permits("Signature", algorithm)) {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("Signature", algorithm,
+                Reflection.getCallerClass());
 
         Iterator<Service> t = GetInstance.getServices("Signature", algorithm);
         if (!t.hasNext()) {
@@ -368,6 +381,14 @@ public abstract class Signature extends SignatureSpi {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, it emits
+     * a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     *
      * @param algorithm the name of the algorithm requested.
      * See the Signature section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#signature-algorithms">
@@ -393,6 +414,7 @@ public abstract class Signature extends SignatureSpi {
      *
      * @see Provider
      */
+    @CallerSensitive
     public static Signature getInstance(String algorithm, String provider)
             throws NoSuchAlgorithmException, NoSuchProviderException {
         Objects.requireNonNull(algorithm, "null algorithm name");
@@ -400,6 +422,9 @@ public abstract class Signature extends SignatureSpi {
         if (!CryptoAlgorithmConstraints.permits("Signature", algorithm)) {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("Signature", algorithm,
+                Reflection.getCallerClass());
 
         Instance instance = GetInstance.getInstance
                 ("Signature", SignatureSpi.class, algorithm, provider);
@@ -421,6 +446,14 @@ public abstract class Signature extends SignatureSpi {
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
+     * the security property value.
+     *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, it emits
+     * a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
      * the security property value.
      *
      * @param algorithm the name of the algorithm requested.
@@ -446,6 +479,7 @@ public abstract class Signature extends SignatureSpi {
      *
      * @since 1.4
      */
+    @CallerSensitive
     public static Signature getInstance(String algorithm, Provider provider)
             throws NoSuchAlgorithmException {
         Objects.requireNonNull(algorithm, "null algorithm name");
@@ -453,6 +487,9 @@ public abstract class Signature extends SignatureSpi {
         if (!CryptoAlgorithmConstraints.permits("Signature", algorithm)) {
             throw new NoSuchAlgorithmException(algorithm + " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("Signature", algorithm,
+                Reflection.getCallerClass());
 
         Instance instance = GetInstance.getInstance
                 ("Signature", SignatureSpi.class, algorithm, provider);

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -239,8 +239,8 @@ public abstract class Signature extends SignatureSpi {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -249,8 +249,8 @@ public abstract class Signature extends SignatureSpi {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -384,8 +384,8 @@ public abstract class Signature extends SignatureSpi {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -394,8 +394,8 @@ public abstract class Signature extends SignatureSpi {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -458,8 +458,8 @@ public abstract class Signature extends SignatureSpi {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -468,8 +468,8 @@ public abstract class Signature extends SignatureSpi {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -244,10 +244,10 @@ public abstract class Signature extends SignatureSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, the
-     * JDK emits a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -377,19 +377,21 @@ public abstract class Signature extends SignatureSpi {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, it emits
-     * a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param algorithm the name of the algorithm requested.
      * See the Signature section in the <a href=
@@ -446,19 +448,21 @@ public abstract class Signature extends SignatureSpi {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, it emits
-     * a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param algorithm the name of the algorithm requested.
      * See the Signature section in the <a href=

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -244,8 +244,11 @@ public abstract class Signature extends SignatureSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -386,8 +389,11 @@ public abstract class Signature extends SignatureSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -457,8 +463,11 @@ public abstract class Signature extends SignatureSpi {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -517,8 +517,8 @@ public class Cipher {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -527,8 +527,8 @@ public class Cipher {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -645,8 +645,8 @@ public class Cipher {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -655,8 +655,8 @@ public class Cipher {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -741,8 +741,8 @@ public class Cipher {
      * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
-     * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
-     * the security property value.
+     * {@systemProperty jdk.crypto.disabledAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
@@ -751,8 +751,8 @@ public class Cipher {
      * with the algorithm. This warning is shown once per caller for
      * each legacy algorithm. If the algorithm is also disabled,
      * the warning will not be shown.
-     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
-     * it supersedes the security property value.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} system property
+     * is set, it supersedes the security property value.
      * </li>
      * </ul>
      *

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -522,10 +522,10 @@ public class Cipher {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, the
-     * JDK emits a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
      * </li>
      * </ul>
      *
@@ -638,19 +638,21 @@ public class Cipher {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, it emits
-     * a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param transformation the name of the transformation,
      * e.g., <i>AES/CBC/PKCS5Padding</i>.
@@ -729,19 +731,21 @@ public class Cipher {
      *
      * @implNote
      * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.disabledAlgorithms}
+     * <ul>
+     * <li>the {@code jdk.crypto.disabledAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
      * if the specified algorithm is allowed. If the
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
-     *
-     * The JDK Reference Implementation additionally uses
-     * the {@code jdk.crypto.legacyAlgorithms}
+     * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * whether the specified algorithm is considered legacy. If so, it emits
-     * a warning when the algorithm is requested. If the
-     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
-     * the security property value.
+     * if the specified algorithm is considered legacy. If so, it
+     * emits a warning when the algorithm is requested.
+     * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
+     * it supersedes the security property value.
+     * </li>
+     * </ul>
      *
      * @param transformation the name of the transformation,
      * e.g., <i>AES/CBC/PKCS5Padding</i>.

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -564,8 +564,10 @@ public class Cipher {
                     " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("Cipher", transformation,
-                Reflection.getCallerClass());
+        if (CryptoAlgorithmConstraints.isLegacy("Cipher", transformation)) {
+            CryptoAlgorithmConstraints.warn("Cipher", transformation,
+                    Reflection.getCallerClass());
+        }
 
         List<Transform> transforms = getTransforms(transformation);
         List<ServiceId> cipherServices = new ArrayList<>(transforms.size());
@@ -797,7 +799,10 @@ public class Cipher {
                     " is disabled");
         }
 
-        CryptoAlgorithmConstraints.warn("Cipher", transformation, callerClass);
+        if (CryptoAlgorithmConstraints.isLegacy("Cipher", transformation)) {
+            CryptoAlgorithmConstraints.warn("Cipher", transformation,
+                    callerClass);
+        }
 
         Exception failure = null;
         List<Transform> transforms = getTransforms(transformation);

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import javax.crypto.spec.*;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
 import sun.security.util.Debug;
 import sun.security.jca.*;
 import sun.security.util.KnownOIDs;
@@ -518,6 +520,13 @@ public class Cipher {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      * </li>
+     * <li>the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, the
+     * JDK emits a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     * </li>
      * </ul>
      *
      * @param transformation the name of the transformation, e.g.,
@@ -541,6 +550,7 @@ public class Cipher {
      *
      * @see java.security.Provider
      */
+    @CallerSensitive
     public static final Cipher getInstance(String transformation)
             throws NoSuchAlgorithmException, NoSuchPaddingException
     {
@@ -553,6 +563,9 @@ public class Cipher {
             throw new NoSuchAlgorithmException(transformation +
                     " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("Cipher", transformation,
+                Reflection.getCallerClass());
 
         List<Transform> transforms = getTransforms(transformation);
         List<ServiceId> cipherServices = new ArrayList<>(transforms.size());
@@ -629,6 +642,14 @@ public class Cipher {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, it emits
+     * a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     *
      * @param transformation the name of the transformation,
      * e.g., <i>AES/CBC/PKCS5Padding</i>.
      * See the Cipher section in the <a href=
@@ -660,6 +681,7 @@ public class Cipher {
      *
      * @see java.security.Provider
      */
+    @CallerSensitive
     public static final Cipher getInstance(String transformation,
                                            String provider)
             throws NoSuchAlgorithmException, NoSuchProviderException,
@@ -676,7 +698,7 @@ public class Cipher {
             throw new NoSuchProviderException("No such provider: " +
                                               provider);
         }
-        return getInstance(transformation, p);
+        return getInstance(transformation, p, Reflection.getCallerClass());
     }
 
     private String getProviderName() {
@@ -711,6 +733,14 @@ public class Cipher {
      * {@systemProperty jdk.crypto.disabledAlgorithms} is set, it supersedes
      * the security property value.
      *
+     * The JDK Reference Implementation additionally uses
+     * the {@code jdk.crypto.legacyAlgorithms}
+     * {@link Security#getProperty(String) Security} property to determine
+     * whether the specified algorithm is considered legacy. If so, it emits
+     * a warning when the algorithm is requested. If the
+     * {@systemProperty jdk.crypto.legacyAlgorithms} is set, it supersedes
+     * the security property value.
+     *
      * @param transformation the name of the transformation,
      * e.g., <i>AES/CBC/PKCS5Padding</i>.
      * See the Cipher section in the <a href=
@@ -739,6 +769,7 @@ public class Cipher {
      *
      * @see java.security.Provider
      */
+    @CallerSensitive
     public static final Cipher getInstance(String transformation,
                                            Provider provider)
             throws NoSuchAlgorithmException, NoSuchPaddingException
@@ -750,11 +781,23 @@ public class Cipher {
             throw new IllegalArgumentException("Missing provider");
         }
 
+        return getInstance(transformation, provider, Reflection.getCallerClass());
+    }
+
+    private static Cipher getInstance(String transformation, Provider provider,
+            Class<?> callerClass)
+            throws NoSuchAlgorithmException, NoSuchPaddingException {
+        if (provider == null) {
+            throw new IllegalArgumentException("Missing provider");
+        }
+
         // throws NoSuchAlgorithmException if java.security disables it
         if (!CryptoAlgorithmConstraints.permits("Cipher", transformation)) {
             throw new NoSuchAlgorithmException(transformation +
                     " is disabled");
         }
+
+        CryptoAlgorithmConstraints.warn("Cipher", transformation, callerClass);
 
         Exception failure = null;
         List<Transform> transforms = getTransforms(transformation);

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -522,8 +522,11 @@ public class Cipher {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -647,8 +650,11 @@ public class Cipher {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>
@@ -740,8 +746,11 @@ public class Cipher {
      * </li>
      * <li>the {@code jdk.crypto.legacyAlgorithms}
      * {@link Security#getProperty(String) Security} property to determine
-     * if the specified algorithm is considered legacy. If so, it
-     * emits a warning when the algorithm is requested.
+     * if the specified algorithm is considered legacy.
+     * If so, a warning is emitted at runtime when this method is called
+     * with the algorithm. This warning is shown once per caller for
+     * each legacy algorithm. If the algorithm is also disabled,
+     * the warning will not be shown.
      * If the {@systemProperty jdk.crypto.legacyAlgorithms} is set,
      * it supersedes the security property value.
      * </li>

--- a/src/java.base/share/classes/sun/security/util/CryptoAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/CryptoAlgorithmConstraints.java
@@ -59,12 +59,12 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
             "jdk.crypto.legacyAlgorithms";
 
     private static class DisabledHolder {
-        static final CryptoAlgorithmConstraints DISABLED_CONSTRAINTS =
+        private static final CryptoAlgorithmConstraints DISABLED_CONSTRAINTS =
                 new CryptoAlgorithmConstraints(PROPERTY_CRYPTO_DISABLED_ALGS);
     }
 
     private static class LegacyHolder {
-        static final CryptoAlgorithmConstraints LEGACY_CONSTRAINTS =
+        private static final CryptoAlgorithmConstraints LEGACY_CONSTRAINTS =
                 new CryptoAlgorithmConstraints(PROPERTY_CRYPTO_LEGACY_ALGS);
     }
 
@@ -77,6 +77,11 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public static boolean permits(String service, String algo) {
         return DisabledHolder.DISABLED_CONSTRAINTS.cachedCheckAlgorithm(
                 service + "." + algo);
+    }
+
+    public static boolean isLegacy(String service, String alg) {
+        return !LegacyHolder.LEGACY_CONSTRAINTS.cachedCheckAlgorithm(
+                service + "." + alg);
     }
 
     private static class CallersHolder {
@@ -94,8 +99,7 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
         }
         String serviceAndAlg = service + "." + alg;
         Set<String> warnedAlgorithms = CallersHolder.callers.get(callerClass);
-        if (!LegacyHolder.LEGACY_CONSTRAINTS.cachedCheckAlgorithm(
-                serviceAndAlg) && warnedAlgorithms.add(serviceAndAlg)) {
+        if (warnedAlgorithms.add(serviceAndAlg)) {
             URL url = codeSource(callerClass);
             String source = (url == null) ? callerClass.getName() :
                     callerClass.getName() + " (" + url + ")";

--- a/src/java.base/share/classes/sun/security/util/CryptoAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/CryptoAlgorithmConstraints.java
@@ -26,7 +26,9 @@
 package sun.security.util;
 
 import java.lang.ref.SoftReference;
+import java.net.URL;
 import java.security.AlgorithmParameters;
+import java.security.CodeSource;
 import java.security.CryptoPrimitive;
 import java.security.Key;
 import java.util.Arrays;
@@ -36,9 +38,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class implements the algorithm constraints for the
- * "jdk.crypto.disabledAlgorithms" security property. This security property
- * can be overridden by the system property of the same name. See the
- * java.security file for the syntax of the property value.
+ * "jdk.crypto.disabledAlgorithms" and "jdk.crypto.legacyAlgorithms" security
+ * properties. Each security property can be overridden by a system property
+ * of the same name. See the java.security file for the syntax of the property
+ * values.
  */
 public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
     private static final Debug debug = Debug.getInstance("jca");
@@ -51,9 +54,18 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
     private static final String PROPERTY_CRYPTO_DISABLED_ALGS =
             "jdk.crypto.disabledAlgorithms";
 
-    private static class CryptoHolder {
-        static final CryptoAlgorithmConstraints CONSTRAINTS =
+    // Legacy algorithm security property for JCE crypto services
+    private static final String PROPERTY_CRYPTO_LEGACY_ALGS =
+            "jdk.crypto.legacyAlgorithms";
+
+    private static class DisabledHolder {
+        static final CryptoAlgorithmConstraints DISABLED_CONSTRAINTS =
                 new CryptoAlgorithmConstraints(PROPERTY_CRYPTO_DISABLED_ALGS);
+    }
+
+    private static class LegacyHolder {
+        static final CryptoAlgorithmConstraints LEGACY_CONSTRAINTS =
+                new CryptoAlgorithmConstraints(PROPERTY_CRYPTO_LEGACY_ALGS);
     }
 
     private static void debug(String msg) {
@@ -63,11 +75,43 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
     }
 
     public static boolean permits(String service, String algo) {
-        return CryptoHolder.CONSTRAINTS.cachedCheckAlgorithm(
+        return DisabledHolder.DISABLED_CONSTRAINTS.cachedCheckAlgorithm(
                 service + "." + algo);
     }
 
-    private final Set<String> disabledServices; // syntax is <service>.<algo>
+    private static class CallersHolder {
+        static final ClassValue<Set<String>> callers = new ClassValue<>() {
+            @Override
+            protected Set<String> computeValue(Class<?> type) {
+                return ConcurrentHashMap.newKeySet();
+            }
+        };
+    }
+
+    public static void warn(String service, String alg, Class<?> callerClass) {
+        if (callerClass == null) {
+            callerClass = CryptoAlgorithmConstraints.class;
+        }
+        String serviceAndAlg = service + "." + alg;
+        Set<String> warnedAlgorithms = CallersHolder.callers.get(callerClass);
+        if (!LegacyHolder.LEGACY_CONSTRAINTS.cachedCheckAlgorithm(
+                serviceAndAlg) && warnedAlgorithms.add(serviceAndAlg)) {
+            URL url = codeSource(callerClass);
+            String source = (url == null) ? callerClass.getName() :
+                    callerClass.getName() + " (" + url + ")";
+            System.err.printf("""
+                    WARNING: An outdated %s algorithm has been called by %s
+                    WARNING: %s will be disabled by default in a future release
+                    """, service, source, alg);
+        }
+    }
+
+    private static URL codeSource(Class<?> clazz) {
+        CodeSource cs = clazz.getProtectionDomain().getCodeSource();
+        return (cs != null) ? cs.getLocation() : null;
+    }
+
+    private final Set<String> affectedServices; // syntax is <service>.<algo>
     private volatile SoftReference<Map<String, Boolean>> cacheRef =
             new SoftReference<>(null);
 
@@ -76,42 +120,42 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
      * {@code propertyName}. Note that if a system property of the same name
      * is set, it overrides the security property.
      *
-     * @param propertyName the security property name that define the disabled
+     * @param propertyName the security property name that defines the
      *        algorithm constraints
      */
     CryptoAlgorithmConstraints(String propertyName) {
         super(null);
-        disabledServices = getAlgorithms(propertyName, true);
-        String[] entries = disabledServices.toArray(new String[0]);
+        affectedServices = getAlgorithms(propertyName, true);
+        String[] entries = affectedServices.toArray(new String[0]);
         debug("Before " + Arrays.deepToString(entries));
 
-        for (String dk : entries) {
-            int idx = dk.indexOf(".");
-            if (idx < 1 || idx == dk.length() - 1) {
+        for (String k : entries) {
+            int idx = k.indexOf(".");
+            if (idx < 1 || idx == k.length() - 1) {
                 // wrong syntax: missing "." or empty service or algorithm
-                throw new IllegalArgumentException("Invalid entry: " + dk);
+                throw new IllegalArgumentException("Invalid entry: " + k);
             }
-            String service = dk.substring(0, idx);
-            String algo = dk.substring(idx + 1);
+            String service = k.substring(0, idx);
+            String algo = k.substring(idx + 1);
             if (SUPPORTED_SERVICES.stream().anyMatch(e -> e.equalsIgnoreCase
                     (service))) {
                 KnownOIDs oid = KnownOIDs.findMatch(algo);
                 if (oid != null) {
                     debug("Add oid: " + oid.value());
-                    disabledServices.add(service + "." + oid.value());
+                    affectedServices.add(service + "." + oid.value());
                     debug("Add oid stdName: " + oid.stdName());
-                    disabledServices.add(service + "." + oid.stdName());
+                    affectedServices.add(service + "." + oid.stdName());
                     for (String a : oid.aliases()) {
                         debug("Add oid alias: " + a);
-                        disabledServices.add(service + "." + a);
+                        affectedServices.add(service + "." + a);
                     }
                 }
             } else {
                 // unsupported service
-                throw new IllegalArgumentException("Invalid entry: " + dk);
+                throw new IllegalArgumentException("Invalid entry: " + k);
             }
         }
-        debug("After " + Arrays.deepToString(disabledServices.toArray()));
+        debug("After " + Arrays.deepToString(affectedServices.toArray()));
     }
 
     @Override
@@ -131,7 +175,7 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
         throw new UnsupportedOperationException("Unsupported permits() method");
     }
 
-    // Return false if algorithm is found in the disabledServices Set.
+    // Return false if algorithm is found in the affectedServices Set.
     // Otherwise, return true.
     private boolean cachedCheckAlgorithm(String serviceDesc) {
         Map<String, Boolean> cache;
@@ -147,7 +191,7 @@ public class CryptoAlgorithmConstraints extends AbstractAlgorithmConstraints {
         if (result != null) {
             return result;
         }
-        result = checkAlgorithm(disabledServices, serviceDesc, null);
+        result = checkAlgorithm(affectedServices, serviceDesc, null);
         cache.put(serviceDesc, result);
         return result;
     }

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -827,8 +827,8 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 #   jdk.crypto.disabledAlgorithms=Cipher.RSA/ECB/PKCS1Padding, MessageDigest.MD2
 #   jdk.crypto.legacyAlgorithms=Cipher.RSA/ECB/PKCS1Padding, MessageDigest.MD2
 #
-#jdk.crypto.disabledAlgorithms=
 #jdk.crypto.legacyAlgorithms=
+#jdk.crypto.disabledAlgorithms=
 
 #
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -777,8 +777,8 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 # In some environments, certain algorithms may be undesirable for certain
 # cryptographic services. For example, "MD2" is generally no longer considered
 # to be a secure hash algorithm.  This section describes the mechanism for
-# disabling algorithms at the JCA/JCE level based on service name and algorithm
-# name.
+# disabling algorithms and identifying legacy algorithms at the JCA/JCE
+# level based on service name and algorithm name.
 #
 # If a system property of the same name is also specified, it supersedes the
 # security property value defined here.
@@ -786,7 +786,10 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 # The syntax of the disabled services string is described as follows:
 #       "DisabledService {, DisabledService}"
 #
-#   DisabledService:
+# The syntax of the legacy services string is described as follows:
+#       "LegacyService {, LegacyService}"
+#
+#   DisabledService and LegacyService:
 #       Service.AlgorithmName
 #
 # Service:  (one of the following, more services may be added later)
@@ -795,7 +798,7 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 #   AlgorithmName:
 #       (see below)
 #
-# The "AlgorithmName" is the standard algorithm name of the disabled
+# The "AlgorithmName" is the standard algorithm name of the affected
 # service. See the Java Security Standard Algorithm Names Specification
 # for information about Standard Algorithm Names.  Matching is
 # performed using a case-insensitive exact matching rule. For Cipher service,
@@ -805,19 +808,27 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 # unsupported services at the time of checking, an ExceptionInInitializerError
 # with a cause of IllegalArgumentException will be thrown.
 #
-# Note: The restriction is applied in the various getInstance(...) methods
-# of the supported Service classes, i.e. Cipher, KeyStore, MessageDigest,
-# and Signature. If the algorithm is disabled, a NoSuchAlgorithmException will
-# be thrown by the getInstance methods of Cipher, MessageDigest, and Signature
-# and a KeyStoreException by the getInstance methods of KeyStore.
+# Note: The jdk.crypto.disabledAlgorithms property is enforced in the various
+# getInstance(...) methods of the supported Service classes, i.e. Cipher,
+# KeyStore, MessageDigest, and Signature. If the algorithm is disabled, a
+# NoSuchAlgorithmException will be thrown by the getInstance methods of
+# Cipher, MessageDigest, and Signature and a KeyStoreException by the
+# getInstance methods of KeyStore.
 #
-# Note: This property is currently used by the JDK Reference implementation.
-# It is not guaranteed to be examined and used by other implementations.
+# Note: The jdk.crypto.legacyAlgorithms property is checked in the
+# getInstance(...) methods of the supported Service classes, i.e. Cipher,
+# KeyStore, MessageDigest, and Signature. If the algorithm is considered legacy, the
+# JDK emits a warning when the algorithm is requested.
+#
+# Note: These properties are currently used by the JDK Reference implementation.
+# They are not guaranteed to be examined and used by other implementations.
 #
 # Example:
 #   jdk.crypto.disabledAlgorithms=Cipher.RSA/ECB/PKCS1Padding, MessageDigest.MD2
+#   jdk.crypto.legacyAlgorithms=Cipher.RSA/ECB/PKCS1Padding, MessageDigest.MD2
 #
 #jdk.crypto.disabledAlgorithms=
+#jdk.crypto.legacyAlgorithms=
 
 #
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -818,7 +818,9 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 # Note: The jdk.crypto.legacyAlgorithms property is checked in the
 # getInstance(...) methods of the supported Service classes, i.e. Cipher,
 # KeyStore, MessageDigest, and Signature. If the algorithm is considered legacy, the
-# JDK emits a warning when the algorithm is requested.
+# JDK emits a warning at runtime when the algorithm is requested.
+# This warning is shown once per caller for each legacy algorithm.
+# If the algorithm is also disabled, the warning will not be shown.
 #
 # Note: These properties are currently used by the JDK Reference implementation.
 # They are not guaranteed to be examined and used by other implementations.

--- a/test/jdk/java/security/KeyStore/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/KeyStore/TestLegacyAlgorithms.java
@@ -24,11 +24,14 @@
 /**
  * @test
  * @bug 8376748
- * @summary Test JCE layer legacy algorithm warning
+ * @summary Test JCE layer legacy algorithm warning for KeyStore
  * @library /test/lib
  * @run main/othervm TestLegacyAlgorithms KEYSTORE.JKs true
  * @run main/othervm TestLegacyAlgorithms keySTORE.what false
  * @run main/othervm TestLegacyAlgorithms kEYstoRe.jceKS false
+ * @run main/othervm -Djdk.crypto.legacyAlgorithms=KEYSTORE.JKS
+ *      -Djdk.crypto.disabledAlgorithms=KEYSTORE.JKS
+ *      TestLegacyAlgorithms KEYSTORE.JKS false true
  */
 
 import java.io.ByteArrayOutputStream;
@@ -36,16 +39,17 @@ import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.Provider;
 import java.security.Security;
 import java.util.List;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 public class TestLegacyAlgorithms {
 
     private static final String PROP_NAME = "jdk.crypto.legacyAlgorithms";
-
     private static final String DIR = System.getProperty("test.src", ".");
     private static final char[] PASSWD = "passphrase".toCharArray();
     private static final String JKS_FN = "keystore.jks";
@@ -67,88 +71,185 @@ public class TestLegacyAlgorithms {
         return bOut.toString(StandardCharsets.UTF_8);
     }
 
-    private static void test(List<String> algos, Provider p) throws Exception {
-        for (String a : algos) {
-            System.out.println("Testing " + (p != null ?
-                    "provider " + p.getName() : "default provider") +
-                    ": alg " + a);
+    private static int countWarn(String warnS, String msg) {
+        int num = 0;
+        int index = 0;
+        while ((index = warnS.indexOf(msg, index)) >= 0) {
+            num++;
+            index += msg.length();
+        }
+        return num;
+    }
 
-            KeyStore k;
-            if (p == null) {
-                k = KeyStore.getInstance(a);
-                System.out.println("  got KeyStore w/ alg " +
-                        k.getType());
-            } else {
-                k = KeyStore.getInstance(a, p);
-                System.out.println("  provider object: got KeyStore "
-                        + "w/ alg " + k.getType());
-                k = KeyStore.getInstance(a, p.getName());
-                System.out.println("  provider name: got KeyStore w/ "
-                        + "alg " + k.getType());
-            }
+    private static void checkOneWarn(String warnS, String alg) {
+        String warn1 =
+                "WARNING: An outdated KeyStore algorithm has been called by";
+        String warn2 = "WARNING: " + alg
+                + " will be disabled by default in a future release";
+
+        Asserts.assertEQ(countWarn(warnS, warn1), 1,
+                "Expected one legacy warning for KeyStore " + alg
+                        + " but got:\n" + warnS);
+        Asserts.assertEQ(countWarn(warnS, warn2), 1,
+                "Expected one future-disable warning for KeyStore "
+                        + alg + " but got:\n" + warnS);
+        Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                "Expected warning to preserve caller: " + warnS);
+    }
+
+    private static void checkNoWarn(String warnS) {
+        String warn1 =
+                "WARNING: An outdated KeyStore algorithm has been called by";
+        String warn2 =
+                "will be disabled by default in a future release";
+        Asserts.assertFalse(warnS.contains(warn1),
+                "Unexpected legacy warning for KeyStore: " + warnS);
+        Asserts.assertFalse(warnS.contains(warn2),
+                "Unexpected future-disable warning for KeyStore: " + warnS);
+    }
+
+    private static void checkWarn(String label, String alg,
+            boolean shouldWarn, ThrowingRunnable action) throws Exception {
+        System.out.println("Testing " + label);
+        String warnS = saveWarn(action);
+        System.out.println("Warning emitted:\n" + warnS);
+        if (shouldWarn) {
+            checkOneWarn(warnS, alg);
+        } else {
+            checkNoWarn(warnS);
         }
     }
 
-    private static void runTests() throws Exception {
-        test(ALG_LIST, null);
+    // Disable the algorithm and check that a warning is not emitted.
+    private static void warnDisabledTest()
+            throws Exception {
+        File jksFile = new File(DIR, JKS_FN);
+        checkWarn("no warning when the algorithm is disabled",
+                "JKS", false, () -> {
+                    Utils.runAndCheckException(
+                            () -> KeyStore.getInstance("JKS"),
+                            KeyStoreException.class);
+                    Utils.runAndCheckException(
+                            () -> KeyStore.getInstance(jksFile, PASSWD),
+                            KeyStoreException.class);
+                });
+    }
+
+    private static void runTests(boolean shouldWarn) throws Exception {
+        for (String a : ALG_LIST) {
+            checkWarn("default provider: alg " + a, a, shouldWarn,
+                    () -> DefaultKS.run(a));
+        }
 
         File jksFile = new File(DIR, JKS_FN);
 
-        System.out.println("Testing file with password: " + jksFile);
-        KeyStore k = KeyStore.getInstance(jksFile, PASSWD);
-        System.out.println("  file+password: got KeyStore w/ alg " +
-                k.getType());
+        checkWarn("file with password: " + jksFile, "JKS", shouldWarn,
+                () -> PasswordKS.run(jksFile));
 
-        System.out.println("Testing file with LoadStoreParameter: " +
-                jksFile);
-        k = KeyStore.getInstance(jksFile,
-                () -> new KeyStore.PasswordProtection(PASSWD));
-        System.out.println("  file+LoadStoreParameter: got KeyStore "
-                + "w/ alg " + k.getType());
+        checkWarn("file with LoadStoreParameter: " + jksFile, "JKS",
+                shouldWarn, () -> LoadStoreParamKS.run(jksFile));
 
         Provider[] providers = Security.getProviders("KeyStore.JKS");
         for (Provider p : providers) {
-            test(ALG_LIST, p);
+            for (String a : ALG_LIST) {
+                checkWarn("provider object " + p.getName() + ": alg " + a,
+                        a, shouldWarn, () -> ProvObjKS.run(a, p));
+
+                checkWarn("provider name " + p.getName() + ": alg " + a,
+                        a, shouldWarn, () -> ProvNameKS.run(a, p));
+            }
         }
     }
 
     public static void main(String[] args) throws Exception {
         String propValue = args[0];
         boolean shouldWarn = Boolean.parseBoolean(args[1]);
-
+        boolean warnDisabled =
+                args.length > 2 && Boolean.parseBoolean(args[2]);
         System.out.println("Setting Security Prop " + PROP_NAME + " = " +
                 propValue);
         Security.setProperty(PROP_NAME, propValue);
-
-        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
-        System.out.println("Warning emitted:\n" + warnS);
-
-        String warn1 =
-                "WARNING: An outdated KeyStore algorithm has been called by";
-        String warn2 =
-                " will be disabled by default in a future release";
-
-        if (shouldWarn) {
-            Asserts.assertTrue(warnS.contains(warn1),
-                    "Expected legacy warning for KeyStore but not found");
-            for (String a : ALG_LIST) {
-                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
-                        "Expected future-disable warning for KeyStore "
-                        + a + " but not found");
-            }
-            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
-                    "Expected warning not preserve caller: "
-                    + warnS);
+        if (warnDisabled) {
+            warnDisabledTest();
         } else {
-            Asserts.assertFalse(warnS.contains(warn1),
-                    "Unexpected legacy warning for KeyStore: " + warnS);
-            Asserts.assertFalse(warnS.contains(warn2),
-                    "Unexpected future-disable warning for KeyStore: " + warnS);
+            runTests(shouldWarn);
         }
     }
 
     @FunctionalInterface
     private interface ThrowingRunnable {
         void run() throws Exception;
+    }
+
+    private static final class DefaultKS {
+        static void run(String alg) throws Exception {
+            KeyStore k = KeyStore.getInstance(alg);
+            System.out.println("  type lookup: got KeyStore w/ alg "
+                    + k.getType());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            k = KeyStore.getInstance(alg);
+            System.out.println("  type lookup again: got KeyStore w/ alg "
+                    + k.getType());
+        }
+    }
+
+    private static final class PasswordKS {
+        static void run(File jksFile) throws Exception {
+            KeyStore k = KeyStore.getInstance(jksFile, PASSWD);
+            System.out.println("  file+password: got KeyStore w/ alg "
+                    + k.getType());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            k = KeyStore.getInstance(jksFile, PASSWD);
+            System.out.println("  file+password again: got KeyStore "
+                    + "w/ alg " + k.getType());
+        }
+    }
+
+    private static final class LoadStoreParamKS {
+        static void run(File jksFile) throws Exception {
+            KeyStore k = KeyStore.getInstance(jksFile,
+                    () -> new KeyStore.PasswordProtection(PASSWD));
+            System.out.println("  file+LoadStoreParameter: got KeyStore "
+                    + "w/ alg " + k.getType());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            k = KeyStore.getInstance(jksFile,
+                    () -> new KeyStore.PasswordProtection(PASSWD));
+            System.out.println("  file+LoadStoreParameter again: got "
+                    + "KeyStore w/ alg " + k.getType());
+        }
+    }
+
+    private static final class ProvObjKS {
+        static void run(String alg, Provider provider) throws Exception {
+            KeyStore k = KeyStore.getInstance(alg, provider);
+            System.out.println("  provider object: got KeyStore w/ alg "
+                    + k.getType());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            k = KeyStore.getInstance(alg, provider);
+            System.out.println("  provider object again: got KeyStore "
+                    + "w/ alg " + k.getType());
+        }
+    }
+
+    private static final class ProvNameKS {
+        static void run(String alg, Provider provider) throws Exception {
+            KeyStore k = KeyStore.getInstance(alg, provider.getName());
+            System.out.println("  provider name: got KeyStore w/ alg "
+                    + k.getType());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            k = KeyStore.getInstance(alg, provider.getName());
+            System.out.println("  provider name again: got KeyStore "
+                    + "w/ alg " + k.getType());
+        }
     }
 }

--- a/test/jdk/java/security/KeyStore/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/KeyStore/TestLegacyAlgorithms.java
@@ -150,7 +150,11 @@ public class TestLegacyAlgorithms {
                 shouldWarn, () -> LoadStoreParamKS.run(jksFile));
 
         Provider[] providers = Security.getProviders("KeyStore.JKS");
-        for (Provider p : providers) {
+        if (providers.length > 0) {
+            // First provider should warn, and later provider for the same
+            // algorithm will not warn. This is because warning is determined
+            // by caller class and algorithm string, not by provider.
+            Provider p = providers[0];
             for (String a : ALG_LIST) {
                 checkWarn("provider object " + p.getName() + ": alg " + a,
                         a, shouldWarn, () -> ProvObjKS.run(a, p));

--- a/test/jdk/java/security/KeyStore/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/KeyStore/TestLegacyAlgorithms.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8376748
+ * @summary Test JCE layer legacy algorithm warning
+ * @library /test/lib
+ * @run main/othervm TestLegacyAlgorithms KEYSTORE.JKs true
+ * @run main/othervm TestLegacyAlgorithms keySTORE.what false
+ * @run main/othervm TestLegacyAlgorithms kEYstoRe.jceKS false
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.Provider;
+import java.security.Security;
+import java.util.List;
+
+import jdk.test.lib.Asserts;
+
+public class TestLegacyAlgorithms {
+
+    private static final String PROP_NAME = "jdk.crypto.legacyAlgorithms";
+
+    private static final String DIR = System.getProperty("test.src", ".");
+    private static final char[] PASSWD = "passphrase".toCharArray();
+    private static final String JKS_FN = "keystore.jks";
+
+    private static final List<String> ALG_LIST =
+            List.of("JKS", "jkS");
+
+    private static String saveWarn(ThrowingRunnable action) throws Exception {
+        PrintStream origErr = System.err;
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(bOut, true, StandardCharsets.UTF_8);
+        try {
+            System.setErr(ps);
+            action.run();
+        } finally {
+            ps.flush();
+            System.setErr(origErr);
+        }
+        return bOut.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void test(List<String> algos, Provider p) throws Exception {
+        for (String a : algos) {
+            System.out.println("Testing " + (p != null ?
+                    "provider " + p.getName() : "default provider") +
+                    ": alg " + a);
+
+            KeyStore k;
+            if (p == null) {
+                k = KeyStore.getInstance(a);
+                System.out.println("  got KeyStore w/ alg " +
+                        k.getType());
+            } else {
+                k = KeyStore.getInstance(a, p);
+                System.out.println("  provider object: got KeyStore "
+                        + "w/ alg " + k.getType());
+                k = KeyStore.getInstance(a, p.getName());
+                System.out.println("  provider name: got KeyStore w/ "
+                        + "alg " + k.getType());
+            }
+        }
+    }
+
+    private static void runTests() throws Exception {
+        test(ALG_LIST, null);
+
+        File jksFile = new File(DIR, JKS_FN);
+
+        System.out.println("Testing file with password: " + jksFile);
+        KeyStore k = KeyStore.getInstance(jksFile, PASSWD);
+        System.out.println("  file+password: got KeyStore w/ alg " +
+                k.getType());
+
+        System.out.println("Testing file with LoadStoreParameter: " +
+                jksFile);
+        k = KeyStore.getInstance(jksFile,
+                () -> new KeyStore.PasswordProtection(PASSWD));
+        System.out.println("  file+LoadStoreParameter: got KeyStore "
+                + "w/ alg " + k.getType());
+
+        Provider[] providers = Security.getProviders("KeyStore.JKS");
+        for (Provider p : providers) {
+            test(ALG_LIST, p);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String propValue = args[0];
+        boolean shouldWarn = Boolean.parseBoolean(args[1]);
+
+        System.out.println("Setting Security Prop " + PROP_NAME + " = " +
+                propValue);
+        Security.setProperty(PROP_NAME, propValue);
+
+        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
+        System.out.println("Warning emitted:\n" + warnS);
+
+        String warn1 =
+                "WARNING: An outdated KeyStore algorithm has been called by";
+        String warn2 =
+                " will be disabled by default in a future release";
+
+        if (shouldWarn) {
+            Asserts.assertTrue(warnS.contains(warn1),
+                    "Expected legacy warning for KeyStore but not found");
+            for (String a : ALG_LIST) {
+                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
+                        "Expected future-disable warning for KeyStore "
+                        + a + " but not found");
+            }
+            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                    "Expected warning not preserve caller: "
+                    + warnS);
+        } else {
+            Asserts.assertFalse(warnS.contains(warn1),
+                    "Unexpected legacy warning for KeyStore: " + warnS);
+            Asserts.assertFalse(warnS.contains(warn2),
+                    "Unexpected future-disable warning for KeyStore: " + warnS);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/test/jdk/java/security/MessageDigest/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/MessageDigest/TestLegacyAlgorithms.java
@@ -133,7 +133,11 @@ public class TestLegacyAlgorithms {
         }
 
         Provider[] providers = Security.getProviders("MessageDigest.SHA-512");
-        for (Provider p : providers) {
+        if (providers.length > 0) {
+            // First provider should warn, and later provider for the same
+            // algorithm will not warn. This is because warning is determined
+            // by caller class and algorithm string, not by provider.
+            Provider p = providers[0];
             for (String a : ALG_LIST) {
                 checkwarn("provider object " + p.getName() + ": alg " + a,
                         a, shouldWarn, () -> ProvObjMD.run(a, p));

--- a/test/jdk/java/security/MessageDigest/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/MessageDigest/TestLegacyAlgorithms.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8376748
+ * @summary Test JCE layer legacy algorithm warning
+ * @library /test/lib
+ * @run main/othervm TestLegacyAlgorithms MESSAGEdigest.Sha-512 true
+ * @run main/othervm TestLegacyAlgorithms messageDIGest.what false
+ * @run main/othervm TestLegacyAlgorithms meSSagedIgest.sHA-512/224 false
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.security.Security;
+import java.util.List;
+
+import jdk.test.lib.Asserts;
+
+public class TestLegacyAlgorithms {
+
+    private static final String PROP_NAME = "jdk.crypto.legacyAlgorithms";
+    private static final List<String> ALG_LIST =
+            List.of("sHA-512", "shA-512", "2.16.840.1.101.3.4.2.3");
+
+    private static String saveWarn(ThrowingRunnable action) throws Exception {
+        PrintStream origErr = System.err;
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(bOut, true, StandardCharsets.UTF_8);
+        try {
+            System.setErr(ps);
+            action.run();
+        } finally {
+            ps.flush();
+            System.setErr(origErr);
+        }
+        return bOut.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void test(List<String> algos, Provider p) throws Exception {
+        for (String a : algos) {
+            System.out.println("Testing " + (p != null ?
+                    "provider " + p.getName() : "default provider") +
+                    ": alg " + a);
+
+            MessageDigest m;
+            if (p == null) {
+                m = MessageDigest.getInstance(a);
+                System.out.println("  got MessageDigest w/ alg "
+                        + m.getAlgorithm());
+            } else {
+                m = MessageDigest.getInstance(a, p);
+                System.out.println("  provider object: got "
+                        + "MessageDigest w/ alg " + m.getAlgorithm());
+                m = MessageDigest.getInstance(a, p.getName());
+                System.out.println("  provider name: got "
+                        + "MessageDigest w/ alg " + m.getAlgorithm());
+            }
+        }
+    }
+
+    private static void runTests() throws Exception {
+        test(ALG_LIST, null);
+
+        Provider[] providers = Security.getProviders("MessageDigest.SHA-512");
+        for (Provider p : providers) {
+            test(ALG_LIST, p);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String propValue = args[0];
+        boolean shouldWarn = Boolean.parseBoolean(args[1]);
+
+        System.out.println("Setting Security Prop " + PROP_NAME + " = " +
+                propValue);
+        Security.setProperty(PROP_NAME, propValue);
+
+        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
+        System.out.println("Warning emitted:\n" + warnS);
+
+        String warn1 =
+                "WARNING: An outdated MessageDigest algorithm has been called by";
+        String warn2 =
+                " will be disabled by default in a future release";
+
+        if (shouldWarn) {
+            Asserts.assertTrue(warnS.contains(warn1),
+                    "Expected legacy warning for MessageDigest but not found");
+            for (String a : ALG_LIST) {
+                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
+                        "Expected future-disable warning for MessageDigest "
+                        + a + " but not found");
+            }
+            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                    "Expected warning not preserve caller: "
+                    + warnS);
+        } else {
+            Asserts.assertFalse(warnS.contains(warn1),
+                    "Unexpected legacy warning for MessageDigest: " + warnS);
+            Asserts.assertFalse(warnS.contains(warn2),
+                    "Unexpected future-disable warning for MessageDigest: " + warnS);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/test/jdk/java/security/MessageDigest/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/MessageDigest/TestLegacyAlgorithms.java
@@ -24,22 +24,27 @@
 /**
  * @test
  * @bug 8376748
- * @summary Test JCE layer legacy algorithm warning
+ * @summary Test JCE layer legacy algorithm warning for MessageDigest
  * @library /test/lib
  * @run main/othervm TestLegacyAlgorithms MESSAGEdigest.Sha-512 true
  * @run main/othervm TestLegacyAlgorithms messageDIGest.what false
  * @run main/othervm TestLegacyAlgorithms meSSagedIgest.sHA-512/224 false
+ * @run main/othervm -Djdk.crypto.legacyAlgorithms=MESSAGEdigest.Sha-512
+ *      -Djdk.crypto.disabledAlgorithms=MESSAGEdigest.Sha-512
+ *      TestLegacyAlgorithms MESSAGEdigest.Sha-512 false true
  */
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 import java.util.List;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 public class TestLegacyAlgorithms {
 
@@ -61,74 +66,143 @@ public class TestLegacyAlgorithms {
         return bOut.toString(StandardCharsets.UTF_8);
     }
 
-    private static void test(List<String> algos, Provider p) throws Exception {
-        for (String a : algos) {
-            System.out.println("Testing " + (p != null ?
-                    "provider " + p.getName() : "default provider") +
-                    ": alg " + a);
+    private static int countWarn(String warnS, String msg) {
+        int num = 0;
+        int index = 0;
+        while ((index = warnS.indexOf(msg, index)) >= 0) {
+            num++;
+            index += msg.length();
+        }
+        return num;
+    }
 
-            MessageDigest m;
-            if (p == null) {
-                m = MessageDigest.getInstance(a);
-                System.out.println("  got MessageDigest w/ alg "
-                        + m.getAlgorithm());
-            } else {
-                m = MessageDigest.getInstance(a, p);
-                System.out.println("  provider object: got "
-                        + "MessageDigest w/ alg " + m.getAlgorithm());
-                m = MessageDigest.getInstance(a, p.getName());
-                System.out.println("  provider name: got "
-                        + "MessageDigest w/ alg " + m.getAlgorithm());
-            }
+    private static void checkOneWarn(String warnS, String alg) {
+        String warn1 =
+                "WARNING: An outdated MessageDigest algorithm has been called by";
+        String warn2 = "WARNING: " + alg
+                + " will be disabled by default in a future release";
+
+        Asserts.assertEQ(countWarn(warnS, warn1), 1,
+                "Expected one legacy warning for MessageDigest " + alg
+                        + " but got:\n" + warnS);
+        Asserts.assertEQ(countWarn(warnS, warn2), 1,
+                "Expected one future-disable warning for MessageDigest "
+                        + alg + " but got:\n" + warnS);
+        Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                "Expected warning to preserve caller: " + warnS);
+    }
+
+    private static void checkNoWarn(String warnS) {
+        String warn1 =
+                "WARNING: An outdated MessageDigest algorithm has been called by";
+        String warn2 =
+                "will be disabled by default in a future release";
+        Asserts.assertFalse(warnS.contains(warn1),
+                "Unexpected legacy warning for MessageDigest: " + warnS);
+        Asserts.assertFalse(warnS.contains(warn2),
+                "Unexpected future-disable warning for MessageDigest: " + warnS);
+    }
+
+    private static void checkwarn(String label, String alg,
+            boolean shouldWarn, ThrowingRunnable action) throws Exception {
+        System.out.println("Testing " + label);
+        String warnS = saveWarn(action);
+        System.out.println("Warning emitted:\n" + warnS);
+        if (shouldWarn) {
+            checkOneWarn(warnS, alg);
+        } else {
+            checkNoWarn(warnS);
         }
     }
 
-    private static void runTests() throws Exception {
-        test(ALG_LIST, null);
+    // Disable the algorithm and check that a warning is not emitted.
+    private static void warnDisabledTest()
+            throws Exception {
+        checkwarn("no warning when the algorithm is disabled",
+                "SHA-512", false, () -> {
+                    Utils.runAndCheckException(
+                            () -> MessageDigest.getInstance("SHA-512"),
+                            NoSuchAlgorithmException.class);
+                });
+    }
+
+    private static void runTests(boolean shouldWarn) throws Exception {
+        for (String a : ALG_LIST) {
+            checkwarn("default provider: alg " + a, a, shouldWarn,
+                    () -> DefaultMD.run(a));
+        }
 
         Provider[] providers = Security.getProviders("MessageDigest.SHA-512");
         for (Provider p : providers) {
-            test(ALG_LIST, p);
+            for (String a : ALG_LIST) {
+                checkwarn("provider object " + p.getName() + ": alg " + a,
+                        a, shouldWarn, () -> ProvObjMD.run(a, p));
+
+                checkwarn("provider name " + p.getName() + ": alg " + a,
+                        a, shouldWarn, () -> ProvNameMD.run(a, p));
+            }
         }
     }
 
     public static void main(String[] args) throws Exception {
         String propValue = args[0];
         boolean shouldWarn = Boolean.parseBoolean(args[1]);
-
+        boolean warnDisabled =
+                args.length > 2 && Boolean.parseBoolean(args[2]);
         System.out.println("Setting Security Prop " + PROP_NAME + " = " +
                 propValue);
         Security.setProperty(PROP_NAME, propValue);
-
-        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
-        System.out.println("Warning emitted:\n" + warnS);
-
-        String warn1 =
-                "WARNING: An outdated MessageDigest algorithm has been called by";
-        String warn2 =
-                " will be disabled by default in a future release";
-
-        if (shouldWarn) {
-            Asserts.assertTrue(warnS.contains(warn1),
-                    "Expected legacy warning for MessageDigest but not found");
-            for (String a : ALG_LIST) {
-                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
-                        "Expected future-disable warning for MessageDigest "
-                        + a + " but not found");
-            }
-            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
-                    "Expected warning not preserve caller: "
-                    + warnS);
+        if (warnDisabled) {
+            warnDisabledTest();
         } else {
-            Asserts.assertFalse(warnS.contains(warn1),
-                    "Unexpected legacy warning for MessageDigest: " + warnS);
-            Asserts.assertFalse(warnS.contains(warn2),
-                    "Unexpected future-disable warning for MessageDigest: " + warnS);
+            runTests(shouldWarn);
         }
     }
 
     @FunctionalInterface
     private interface ThrowingRunnable {
         void run() throws Exception;
+    }
+
+    private static final class DefaultMD {
+        static void run(String alg) throws Exception {
+            MessageDigest m = MessageDigest.getInstance(alg);
+            System.out.println("  type lookup: got MessageDigest w/ alg "
+                    + m.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            m = MessageDigest.getInstance(alg);
+            System.out.println("  type lookup again: got MessageDigest w/ alg "
+                    + m.getAlgorithm());
+        }
+    }
+
+    private static final class ProvObjMD {
+        static void run(String alg, Provider provider) throws Exception {
+            MessageDigest m = MessageDigest.getInstance(alg, provider);
+            System.out.println("  provider object: got MessageDigest w/ alg "
+                    + m.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            m = MessageDigest.getInstance(alg, provider);
+            System.out.println("  provider object again: got MessageDigest "
+                    + "w/ alg " + m.getAlgorithm());
+        }
+    }
+
+    private static final class ProvNameMD {
+        static void run(String alg, Provider provider) throws Exception {
+            MessageDigest m = MessageDigest.getInstance(alg, provider.getName());
+            System.out.println("  provider name: got MessageDigest w/ alg "
+                    + m.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            m = MessageDigest.getInstance(alg, provider.getName());
+            System.out.println("  provider name again: got MessageDigest "
+                    + "w/ alg " + m.getAlgorithm());
+        }
     }
 }

--- a/test/jdk/java/security/Signature/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/Signature/TestLegacyAlgorithms.java
@@ -133,7 +133,11 @@ public class TestLegacyAlgorithms {
         }
 
         Provider[] providers = Security.getProviders("Signature.SHA512withRSA");
-        for (Provider p : providers) {
+        if (providers.length > 0) {
+            // First provider should warn, and later provider for the same
+            // algorithm will not warn. This is because warning is determined
+            // by caller class and algorithm string, not by provider.
+            Provider p = providers[0];
             for (String a : ALG_LIST) {
                 checkWarn("provider object " + p.getName() + ": alg " + a,
                         a, shouldWarn, () -> ProvObjSig.run(a, p));

--- a/test/jdk/java/security/Signature/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/Signature/TestLegacyAlgorithms.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8376748
+ * @summary Test JCE layer legacy algorithm warning
+ * @library /test/lib
+ * @run main/othervm TestLegacyAlgorithms SIGNATURe.sha512withRSA true
+ * @run main/othervm TestLegacyAlgorithms signaturE.what false
+ * @run main/othervm TestLegacyAlgorithms SiGnAtUrE.SHa512/224withRSA false
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import java.util.List;
+
+import jdk.test.lib.Asserts;
+
+public class TestLegacyAlgorithms {
+
+    private static final String PROP_NAME = "jdk.crypto.legacyAlgorithms";
+    private static final List<String> ALG_LIST =
+            List.of("sha512withRsa", "1.2.840.113549.1.1.13");
+
+    private static String saveWarn(ThrowingRunnable action) throws Exception {
+        PrintStream origErr = System.err;
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(bOut, true, StandardCharsets.UTF_8);
+        try {
+            System.setErr(ps);
+            action.run();
+        } finally {
+            ps.flush();
+            System.setErr(origErr);
+        }
+        return bOut.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void test(List<String> algos, Provider p) throws Exception {
+        for (String a : algos) {
+            System.out.println("Testing " + (p != null ?
+                    "provider " + p.getName() : "default provider") +
+                    ": alg " + a);
+
+            Signature s;
+            if (p == null) {
+                s = Signature.getInstance(a);
+                System.out.println("  got Signature w/ alg " +
+                        s.getAlgorithm());
+            } else {
+                s = Signature.getInstance(a, p);
+                System.out.println("  provider object: got Signature "
+                        + "w/ alg " + s.getAlgorithm());
+                s = Signature.getInstance(a, p.getName());
+                System.out.println("  provider name: got Signature w/ "
+                        + "alg " + s.getAlgorithm());
+            }
+        }
+    }
+
+    private static void runTests() throws Exception {
+        test(ALG_LIST, null);
+
+        Provider[] providers = Security.getProviders("Signature.SHA512withRSA");
+        for (Provider p : providers) {
+            test(ALG_LIST, p);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String propValue = args[0];
+        boolean shouldWarn = Boolean.parseBoolean(args[1]);
+
+        System.out.println("Setting Security Prop " + PROP_NAME + " = " +
+                propValue);
+        Security.setProperty(PROP_NAME, propValue);
+
+        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
+        System.out.println("Warning emitted:\n" + warnS);
+
+        String warn1 =
+                "WARNING: An outdated Signature algorithm has been called by";
+        String warn2 =
+                " will be disabled by default in a future release";
+
+        if (shouldWarn) {
+            Asserts.assertTrue(warnS.contains(warn1),
+                    "Expected legacy warning for Signature but not found");
+            for (String a : ALG_LIST) {
+                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
+                        "Expected future-disable warning for Signature "
+                        + a + " but not found");
+            }
+            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                    "Expected warning not preserve caller: "
+                    + warnS);
+        } else {
+            Asserts.assertFalse(warnS.contains(warn1),
+                    "Unexpected legacy warning for Signature: " + warnS);
+            Asserts.assertFalse(warnS.contains(warn2),
+                    "Unexpected future-disable warning for Signature: " + warnS);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/test/jdk/java/security/Signature/TestLegacyAlgorithms.java
+++ b/test/jdk/java/security/Signature/TestLegacyAlgorithms.java
@@ -24,22 +24,27 @@
 /**
  * @test
  * @bug 8376748
- * @summary Test JCE layer legacy algorithm warning
+ * @summary Test JCE layer legacy algorithm warning for Signature
  * @library /test/lib
  * @run main/othervm TestLegacyAlgorithms SIGNATURe.sha512withRSA true
  * @run main/othervm TestLegacyAlgorithms signaturE.what false
  * @run main/othervm TestLegacyAlgorithms SiGnAtUrE.SHa512/224withRSA false
+ * @run main/othervm -Djdk.crypto.legacyAlgorithms=SIGNATURe.sha512withRSA
+ *      -Djdk.crypto.disabledAlgorithms=SIGNATURe.sha512withRSA
+ *      TestLegacyAlgorithms SIGNATURe.sha512withRSA false true
  */
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 import java.security.Signature;
 import java.util.List;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 public class TestLegacyAlgorithms {
 
@@ -61,74 +66,143 @@ public class TestLegacyAlgorithms {
         return bOut.toString(StandardCharsets.UTF_8);
     }
 
-    private static void test(List<String> algos, Provider p) throws Exception {
-        for (String a : algos) {
-            System.out.println("Testing " + (p != null ?
-                    "provider " + p.getName() : "default provider") +
-                    ": alg " + a);
+    private static int countWarn(String warnS, String msg) {
+        int num = 0;
+        int index = 0;
+        while ((index = warnS.indexOf(msg, index)) >= 0) {
+            num++;
+            index += msg.length();
+        }
+        return num;
+    }
 
-            Signature s;
-            if (p == null) {
-                s = Signature.getInstance(a);
-                System.out.println("  got Signature w/ alg " +
-                        s.getAlgorithm());
-            } else {
-                s = Signature.getInstance(a, p);
-                System.out.println("  provider object: got Signature "
-                        + "w/ alg " + s.getAlgorithm());
-                s = Signature.getInstance(a, p.getName());
-                System.out.println("  provider name: got Signature w/ "
-                        + "alg " + s.getAlgorithm());
-            }
+    private static void checkOneWarn(String warnS, String alg) {
+        String warn1 =
+                "WARNING: An outdated Signature algorithm has been called by";
+        String warn2 = "WARNING: " + alg
+                + " will be disabled by default in a future release";
+
+        Asserts.assertEQ(countWarn(warnS, warn1), 1,
+                "Expected one legacy warning for Signature " + alg
+                        + " but got:\n" + warnS);
+        Asserts.assertEQ(countWarn(warnS, warn2), 1,
+                "Expected one future-disable warning for Signature "
+                        + alg + " but got:\n" + warnS);
+        Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                "Expected warning to preserve caller: " + warnS);
+    }
+
+    private static void checkNoWarn(String warnS) {
+        String warn1 =
+                "WARNING: An outdated Signature algorithm has been called by";
+        String warn2 =
+                "will be disabled by default in a future release";
+        Asserts.assertFalse(warnS.contains(warn1),
+                "Unexpected legacy warning for Signature: " + warnS);
+        Asserts.assertFalse(warnS.contains(warn2),
+                "Unexpected future-disable warning for Signature: " + warnS);
+    }
+
+    private static void checkWarn(String label, String alg,
+            boolean shouldWarn, ThrowingRunnable action) throws Exception {
+        System.out.println("Testing " + label);
+        String warnS = saveWarn(action);
+        System.out.println("Warning emitted:\n" + warnS);
+        if (shouldWarn) {
+            checkOneWarn(warnS, alg);
+        } else {
+            checkNoWarn(warnS);
         }
     }
 
-    private static void runTests() throws Exception {
-        test(ALG_LIST, null);
+    // Disable the algorithm and check that a warning is not emitted.
+    private static void warnDisabledTest()
+            throws Exception {
+        checkWarn("no warning when the algorithm is disabled",
+                "sha512withRSA", false, () -> {
+                    Utils.runAndCheckException(
+                            () -> Signature.getInstance("sha512withRSA"),
+                            NoSuchAlgorithmException.class);
+                });
+    }
+
+    private static void runTests(boolean shouldWarn) throws Exception {
+        for (String a : ALG_LIST) {
+            checkWarn("default provider: alg " + a, a, shouldWarn,
+                    () -> DefaultSig.run(a));
+        }
 
         Provider[] providers = Security.getProviders("Signature.SHA512withRSA");
         for (Provider p : providers) {
-            test(ALG_LIST, p);
+            for (String a : ALG_LIST) {
+                checkWarn("provider object " + p.getName() + ": alg " + a,
+                        a, shouldWarn, () -> ProvObjSig.run(a, p));
+
+                checkWarn("provider name " + p.getName() + ": alg " + a,
+                        a, shouldWarn, () -> ProvNameSig.run(a, p));
+            }
         }
     }
 
     public static void main(String[] args) throws Exception {
         String propValue = args[0];
         boolean shouldWarn = Boolean.parseBoolean(args[1]);
-
+        boolean warnDisabled =
+                args.length > 2 && Boolean.parseBoolean(args[2]);
         System.out.println("Setting Security Prop " + PROP_NAME + " = " +
                 propValue);
         Security.setProperty(PROP_NAME, propValue);
-
-        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
-        System.out.println("Warning emitted:\n" + warnS);
-
-        String warn1 =
-                "WARNING: An outdated Signature algorithm has been called by";
-        String warn2 =
-                " will be disabled by default in a future release";
-
-        if (shouldWarn) {
-            Asserts.assertTrue(warnS.contains(warn1),
-                    "Expected legacy warning for Signature but not found");
-            for (String a : ALG_LIST) {
-                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
-                        "Expected future-disable warning for Signature "
-                        + a + " but not found");
-            }
-            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
-                    "Expected warning not preserve caller: "
-                    + warnS);
+        if (warnDisabled) {
+            warnDisabledTest();
         } else {
-            Asserts.assertFalse(warnS.contains(warn1),
-                    "Unexpected legacy warning for Signature: " + warnS);
-            Asserts.assertFalse(warnS.contains(warn2),
-                    "Unexpected future-disable warning for Signature: " + warnS);
+            runTests(shouldWarn);
         }
     }
 
     @FunctionalInterface
     private interface ThrowingRunnable {
         void run() throws Exception;
+    }
+
+    private static final class DefaultSig {
+        static void run(String alg) throws Exception {
+            Signature s = Signature.getInstance(alg);
+            System.out.println("  type lookup: got Signature w/ alg "
+                    + s.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            s = Signature.getInstance(alg);
+            System.out.println("  type lookup again: got Signature w/ alg "
+                    + s.getAlgorithm());
+        }
+    }
+
+    private static final class ProvObjSig {
+        static void run(String alg, Provider provider) throws Exception {
+            Signature s = Signature.getInstance(alg, provider);
+            System.out.println("  provider object: got Signature w/ alg "
+                    + s.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            s = Signature.getInstance(alg, provider);
+            System.out.println("  provider object again: got Signature "
+                    + "w/ alg " + s.getAlgorithm());
+        }
+    }
+
+    private static final class ProvNameSig {
+        static void run(String alg, Provider provider) throws Exception {
+            Signature s = Signature.getInstance(alg, provider.getName());
+            System.out.println("  provider name: got Signature w/ alg "
+                    + s.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            s = Signature.getInstance(alg, provider.getName());
+            System.out.println("  provider name again: got Signature "
+                    + "w/ alg " + s.getAlgorithm());
+        }
     }
 }

--- a/test/jdk/javax/crypto/Cipher/TestLegacyAlgorithms.java
+++ b/test/jdk/javax/crypto/Cipher/TestLegacyAlgorithms.java
@@ -133,18 +133,26 @@ public class TestLegacyAlgorithms {
                     () -> DefaultCipher.run(a));
         }
 
-        Provider[] providers = Security.getProviders();
-        for (Provider p : providers) {
+        Provider provider = null;
+        for (Provider p : Security.getProviders()) {
+            // First provider should warn, and later provider for the same
+            // algorithm will not warn. This is because warning is determined
+            // by caller class and algorithm string, not by provider.
             if (p.getService("Cipher", "RSA") != null) {
-                for (String a : ALG_LIST) {
-                    checkWarn("provider object " + p.getName() +
-                            ": alg " + a, a, shouldWarn,
-                            () -> ProvObjCipher.run(a, p));
+                provider = p;
+                break;
+            }
+        }
+        if (provider != null) {
+            final Provider fp = provider;
+            for (String a : ALG_LIST) {
+                checkWarn("provider object " + fp.getName() +
+                        ": alg " + a, a, shouldWarn,
+                        () -> ProvObjCipher.run(a, fp));
 
-                    checkWarn("provider name " + p.getName() +
-                            ": alg " + a, a, shouldWarn,
-                            () -> ProvNameCipher.run(a, p));
-                }
+                checkWarn("provider name " + fp.getName() +
+                        ": alg " + a, a, shouldWarn,
+                        () -> ProvNameCipher.run(a, fp));
             }
         }
     }

--- a/test/jdk/javax/crypto/Cipher/TestLegacyAlgorithms.java
+++ b/test/jdk/javax/crypto/Cipher/TestLegacyAlgorithms.java
@@ -30,17 +30,23 @@
  * @run main/othervm TestLegacyAlgorithms cipheR.rsA true
  * @run main/othervm TestLegacyAlgorithms CIPher.what false
  * @run main/othervm TestLegacyAlgorithms cipHER.RSA/ECB/PKCS1Padding2 false
+ * @run main/othervm -Djdk.crypto.legacyAlgorithms=CIPHER.RSA
+ *      -Djdk.crypto.disabledAlgorithms=CIPHER.RSA
+ *      TestLegacyAlgorithms CIPHER.RSA false true
+
  */
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 import java.util.List;
 import javax.crypto.Cipher;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 public class TestLegacyAlgorithms {
 
@@ -62,35 +68,83 @@ public class TestLegacyAlgorithms {
         return bOut.toString(StandardCharsets.UTF_8);
     }
 
-    private static void test(List<String> algos, Provider p) throws Exception {
-        for (String a : algos) {
-            System.out.println("Testing " + (p != null ?
-                    "provider " + p.getName() : "default provider") +
-                    ": alg " + a);
+    private static int countWarn(String warnS, String msg) {
+        int num = 0;
+        int index = 0;
+        while ((index = warnS.indexOf(msg, index)) >= 0) {
+            num++;
+            index += msg.length();
+        }
+        return num;
+    }
 
-            Cipher c;
-            if (p == null) {
-                c = Cipher.getInstance(a);
-                System.out.println("  got cipher w/ alg " +
-                        c.getAlgorithm());
-            } else {
-                c = Cipher.getInstance(a, p);
-                System.out.println("  provider object: got cipher w/ "
-                        + "alg " + c.getAlgorithm());
-                c = Cipher.getInstance(a, p.getName());
-                System.out.println("  provider name: got cipher w/ "
-                        + "alg " + c.getAlgorithm());
-            }
+    private static void checkOneWarn(String warnS, String alg) {
+        String warn1 =
+                "WARNING: An outdated Cipher algorithm has been called by";
+        String warn2 = "WARNING: " + alg
+                + " will be disabled by default in a future release";
+
+        Asserts.assertEQ(countWarn(warnS, warn1), 1,
+                "Expected one legacy warning for Cipher " + alg
+                        + " but got:\n" + warnS);
+        Asserts.assertEQ(countWarn(warnS, warn2), 1,
+                "Expected one future-disable warning for Cipher "
+                        + alg + " but got:\n" + warnS);
+        Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                "Expected warning to preserve caller: " + warnS);
+    }
+
+    private static void checkNoWarn(String warnS) {
+        String warn1 =
+                "WARNING: An outdated Cipher algorithm has been called by";
+        String warn2 =
+                "will be disabled by default in a future release";
+        Asserts.assertFalse(warnS.contains(warn1),
+                "Unexpected legacy warning for Cipher: " + warnS);
+        Asserts.assertFalse(warnS.contains(warn2),
+                "Unexpected future-disable warning for Cipher: " + warnS);
+    }
+
+    private static void checkWarn(String label, String alg,
+            boolean shouldWarn, ThrowingRunnable action) throws Exception {
+        System.out.println("Testing " + label);
+        String warnS = saveWarn(action);
+        System.out.println("Warning emitted:\n" + warnS);
+        if (shouldWarn) {
+            checkOneWarn(warnS, alg);
+        } else {
+            checkNoWarn(warnS);
         }
     }
 
-    private static void runTests() throws Exception {
-        test(ALG_LIST, null);
+    private static void warnDisabledTest()
+            throws Exception {
+        checkWarn("no warning when the algorithm is disabled",
+                "RSA", false, () -> {
+                    Utils.runAndCheckException(
+                            () -> Cipher.getInstance("RSA"),
+                            NoSuchAlgorithmException.class);
+                });
+    }
+
+    private static void runTests(boolean shouldWarn) throws Exception {
+        for (String a : ALG_LIST) {
+            checkWarn("default provider: alg " + a, a, shouldWarn,
+                    () -> DefaultCipher.run(a));
+        }
 
         Provider[] providers = Security.getProviders();
         for (Provider p : providers) {
             if (p.getService("Cipher", "RSA") != null) {
-                test(ALG_LIST, p);
+                for (String a : ALG_LIST) {
+                    checkWarn("provider object " + p.getName() +
+                            ": alg " + a, a, shouldWarn,
+                            () -> ProvObjCipher.run(a, p));
+
+                    checkWarn("provider name " + p.getName() +
+                            ": alg " + a, a, shouldWarn,
+                            () -> ProvNameCipher.run(a, p));
+                }
             }
         }
     }
@@ -98,40 +152,62 @@ public class TestLegacyAlgorithms {
     public static void main(String[] args) throws Exception {
         String propValue = args[0];
         boolean shouldWarn = Boolean.parseBoolean(args[1]);
-
+        boolean warnDisabled =
+                args.length > 2 && Boolean.parseBoolean(args[2]);
         System.out.println("Setting Security Prop " + PROP_NAME + " = " +
                 propValue);
         Security.setProperty(PROP_NAME, propValue);
-
-        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
-        System.out.println("Warning emitted:\n" + warnS);
-
-        String warn1 =
-                "WARNING: An outdated Cipher algorithm has been called by";
-        String warn2 =
-                " will be disabled by default in a future release";
-
-        if (shouldWarn) {
-            Asserts.assertTrue(warnS.contains(warn1),
-                    "Expected legacy warning for Cipher but not found");
-            for (String a : ALG_LIST) {
-                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
-                        "Expected future-disable warning for Cipher "
-                        + a + " but not found");
-            }
-            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
-                    "Expected warning not preserve caller: "
-                    + warnS);
+        if (warnDisabled) {
+            warnDisabledTest();
         } else {
-            Asserts.assertFalse(warnS.contains(warn1),
-                    "Unexpected legacy warning for Cipher: " + warnS);
-            Asserts.assertFalse(warnS.contains(warn2),
-                    "Unexpected future-disable warning for Cipher: " + warnS);
+            runTests(shouldWarn);
         }
     }
 
     @FunctionalInterface
     private interface ThrowingRunnable {
         void run() throws Exception;
+    }
+
+    private static final class DefaultCipher {
+        static void run(String alg) throws Exception {
+            Cipher c = Cipher.getInstance(alg);
+            System.out.println("  type lookup: got Cipher w/ alg "
+                    + c.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            c = Cipher.getInstance(alg);
+            System.out.println("  type lookup again: got Cipher w/ alg "
+                    + c.getAlgorithm());
+        }
+    }
+
+    private static final class ProvObjCipher {
+        static void run(String alg, Provider provider) throws Exception {
+            Cipher c = Cipher.getInstance(alg, provider);
+            System.out.println("  provider object: got Cipher w/ alg "
+                    + c.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            c = Cipher.getInstance(alg, provider);
+            System.out.println("  provider object again: got Cipher "
+                    + "w/ alg " + c.getAlgorithm());
+        }
+    }
+
+    private static final class ProvNameCipher {
+        static void run(String alg, Provider provider) throws Exception {
+            Cipher c = Cipher.getInstance(alg, provider.getName());
+            System.out.println("  provider name: got Cipher w/ alg "
+                    + c.getAlgorithm());
+
+            // Call the method twice, and make sure that only get one
+            // warning per caller.
+            c = Cipher.getInstance(alg, provider.getName());
+            System.out.println("  provider name again: got Cipher "
+                    + "w/ alg " + c.getAlgorithm());
+        }
     }
 }

--- a/test/jdk/javax/crypto/Cipher/TestLegacyAlgorithms.java
+++ b/test/jdk/javax/crypto/Cipher/TestLegacyAlgorithms.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8376748
+ * @summary Test JCE layer legacy algorithm warning for Cipher
+ * @library /test/lib
+ * @run main/othervm TestLegacyAlgorithms CIPHEr.Rsa/ECB/PKCS1Padding true
+ * @run main/othervm TestLegacyAlgorithms cipheR.rsA true
+ * @run main/othervm TestLegacyAlgorithms CIPher.what false
+ * @run main/othervm TestLegacyAlgorithms cipHER.RSA/ECB/PKCS1Padding2 false
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.security.Provider;
+import java.security.Security;
+import java.util.List;
+import javax.crypto.Cipher;
+
+import jdk.test.lib.Asserts;
+
+public class TestLegacyAlgorithms {
+
+    private static final String PROP_NAME = "jdk.crypto.legacyAlgorithms";
+    private static final List<String> ALG_LIST =
+            List.of("Rsa/ECB/PKCS1Padding", "rSA");
+
+    private static String saveWarn(ThrowingRunnable action) throws Exception {
+        PrintStream origErr = System.err;
+        ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(bOut, true, StandardCharsets.UTF_8);
+        try {
+            System.setErr(ps);
+            action.run();
+        } finally {
+            ps.flush();
+            System.setErr(origErr);
+        }
+        return bOut.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void test(List<String> algos, Provider p) throws Exception {
+        for (String a : algos) {
+            System.out.println("Testing " + (p != null ?
+                    "provider " + p.getName() : "default provider") +
+                    ": alg " + a);
+
+            Cipher c;
+            if (p == null) {
+                c = Cipher.getInstance(a);
+                System.out.println("  got cipher w/ alg " +
+                        c.getAlgorithm());
+            } else {
+                c = Cipher.getInstance(a, p);
+                System.out.println("  provider object: got cipher w/ "
+                        + "alg " + c.getAlgorithm());
+                c = Cipher.getInstance(a, p.getName());
+                System.out.println("  provider name: got cipher w/ "
+                        + "alg " + c.getAlgorithm());
+            }
+        }
+    }
+
+    private static void runTests() throws Exception {
+        test(ALG_LIST, null);
+
+        Provider[] providers = Security.getProviders();
+        for (Provider p : providers) {
+            if (p.getService("Cipher", "RSA") != null) {
+                test(ALG_LIST, p);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String propValue = args[0];
+        boolean shouldWarn = Boolean.parseBoolean(args[1]);
+
+        System.out.println("Setting Security Prop " + PROP_NAME + " = " +
+                propValue);
+        Security.setProperty(PROP_NAME, propValue);
+
+        String warnS = saveWarn(TestLegacyAlgorithms::runTests);
+        System.out.println("Warning emitted:\n" + warnS);
+
+        String warn1 =
+                "WARNING: An outdated Cipher algorithm has been called by";
+        String warn2 =
+                " will be disabled by default in a future release";
+
+        if (shouldWarn) {
+            Asserts.assertTrue(warnS.contains(warn1),
+                    "Expected legacy warning for Cipher but not found");
+            for (String a : ALG_LIST) {
+                Asserts.assertTrue(warnS.contains("WARNING: " + a + warn2),
+                        "Expected future-disable warning for Cipher "
+                        + a + " but not found");
+            }
+            Asserts.assertTrue(warnS.contains("TestLegacyAlgorithms"),
+                    "Expected warning not preserve caller: "
+                    + warnS);
+        } else {
+            Asserts.assertFalse(warnS.contains(warn1),
+                    "Unexpected legacy warning for Cipher: " + warnS);
+            Asserts.assertFalse(warnS.contains(warn2),
+                    "Unexpected future-disable warning for Cipher: " + warnS);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}


### PR DESCRIPTION
This change adds the `jdk.crypto.legacyAlgorithms` security property to `java.security`. At the JCE layer, the JDK checks this property and emits a runtime warning when a configured legacy algorithm is requested.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8386355](https://bugs.openjdk.org/browse/JDK-8386355) to be approved

### Issues
 * [JDK-8376748](https://bugs.openjdk.org/browse/JDK-8376748): Emit runtime warnings for JCE algorithms that will be disabled (**Enhancement** - P3)
 * [JDK-8386355](https://bugs.openjdk.org/browse/JDK-8386355): Emit runtime warnings for JCE algorithms that will be disabled (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31472/head:pull/31472` \
`$ git checkout pull/31472`

Update a local copy of the PR: \
`$ git checkout pull/31472` \
`$ git pull https://git.openjdk.org/jdk.git pull/31472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31472`

View PR using the GUI difftool: \
`$ git pr show -t 31472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31472.diff">https://git.openjdk.org/jdk/pull/31472.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31472#issuecomment-4676129977)
</details>
