### PR TITLE
8386482: C2 CountedLoopConverter::filtered_type_from_dominators: assert(_base == Int) failed: Not an Int

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3892,7 +3892,16 @@ const TypeInt* CountedLoopConverter::filtered_type_from_dominators(Node* val, No
           if (rtn_t == nullptr) {
             rtn_t = if_t;
           } else {
-            rtn_t = rtn_t->join(if_t)->is_int();
+            const Type* join_t = rtn_t->join(if_t);
+            if (!join_t->isa_int()) {
+              // We may have encountered multiple if conditions, that have no
+              // overlap, and produce an empty/top type. Returning nullptr
+              // is conservative, it means we do not constrain the type, which
+              // will just prevent further optimiziations.
+              assert(join_t->empty(), "top");
+              return nullptr;
+            }
+            rtn_t = join_t->is_int();
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapEmptyType.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapEmptyType.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.loopopts;
+
+/*
+ * @test
+ * @bug 8386482
+ * @summary Test case for CountedLoopConverter::filtered_type_from_dominators/
+ *          CountedLoopConverter::has_truncation_wrap where the type becomes
+ *          empty / top. This used to trigger the assert:
+ *          assert(_base == Int) failed: Not an Int
+ * @library /test/lib /
+ * @run main/othervm -Xcomp
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+public class TestTruncationWrapEmptyType {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test(1);
+        }
+    }
+
+    static int test(int init) {
+        if (init < 1) {
+            return -1;
+        }
+        // if implies: init in [1..max_int]
+
+        int i = init;
+        while (i < 0) {
+            // while implies: init in [min_int .. 0]
+            // That contradicts the "if" above: empty intersection
+            //
+            // See CountedLoopConverter::filtered_type_from_dominators:
+            //   rtn_t = rtn_t->join(if_t)->is_int()
+            // -> top type in join, fails "is_int".
+            i = (short)(i + 1);
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
This fixes another bug in the `CountedLoopConverter::has_truncation_wrap` optimization.

This issue was discovered by the template fuzzer: https://github.com/openjdk/jdk/pull/31501

The issue here: we did not expect an unreachable state. But if we traverse several `if` conditions, their `join` type can become `top`, which means the `phi` type is impossible, the loop unreachable.

Fix: just `return nullptr` if we get an empty type.

Looks like this bug was created by https://github.com/openjdk/jdk/pull/17508. Before that change, we could have `TypeInt` with `lo > hi`, and that would be considered an empty type, `TypeInt::empty() == true`. So it used to make sense to return `TypeInt*` from these kinds of optimizations, and they could return empty type that way. Now that's not possible any more. We would have to return `top`, and change the signatures to `Type*`. That would require a lot of effort, and I don't think that makes sense for a bug-fix. Returning nullptr just means we did not narrow the type, and that should always be safe.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386482](https://bugs.openjdk.org/browse/JDK-8386482): C2 CountedLoopConverter::filtered_type_from_dominators: assert(_base == Int) failed: Not an Int (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31481/head:pull/31481` \
`$ git checkout pull/31481`

Update a local copy of the PR: \
`$ git checkout pull/31481` \
`$ git pull https://git.openjdk.org/jdk.git pull/31481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31481`

View PR using the GUI difftool: \
`$ git pr show -t 31481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31481.diff">https://git.openjdk.org/jdk/pull/31481.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31481#issuecomment-4681946096)
</details>
