### PR TITLE
8386485: JFR: RecordingFile::write overwrites original file

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.Closeable;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -221,9 +222,10 @@ public final class RecordingFile implements Closeable {
      *
      * @param filter      filter that determines if an event should be included, not
      *                    {@code null}
-     * @throws IOException       if an I/O error occurred, it's not a Flight
-     *                           Recorder file or a version of a JFR file that can't
-     *                           be parsed
+     * @throws IOException if an I/O error occurred, if {@code destination} is the
+     *                     same file as the input file for this
+     *                     {@code RecordingFile}, if it's not a Flight Recorder file
+     *                     or a version of a JFR file that can't be parsed
      *
      * @since 19
      */
@@ -235,6 +237,9 @@ public final class RecordingFile implements Closeable {
 
     // package private
     List<RemovedEvents> write(Path destination, Predicate<RecordedEvent> filter, boolean collectResults) throws IOException {
+        if (Files.exists(destination) && Files.isSameFile(destination, file.toPath())) {
+            throw new IOException("Destination file can't be the same as the input file: " + destination.toAbsolutePath());
+        }
         try (ChunkWriter cw = new ChunkWriter(file.toPath(), destination, filter, collectResults)) {
             try (RecordingFile rf = new RecordingFile(cw)) {
                 while (rf.hasMoreEvents()) {

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordingFileWrite.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordingFileWrite.java
@@ -64,6 +64,15 @@ public class TestRecordingFileWrite {
             throw new AssertionError("Expected at least 50 000 events to be included");
         }
         verify(scrubbed, ids);
+        try {
+            scrubRecording(original, original);
+            throw new AssertionError("Expected IOException when overwriting");
+        } catch (IOException e) {
+            System.out.println(e);
+            if (!e.getMessage().contains("Destination file can't be the same as the input file")) {
+                throw new AssertionError("Unexpected error message " + e);
+            }
+        }
     }
 
     private static void verify(Path scrubbed, Queue<String> events) throws Exception {


### PR DESCRIPTION
Could I get a review of a PR that prevents truncation of the input file for RecordingFile::write?

Testing: jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386485](https://bugs.openjdk.org/browse/JDK-8386485): JFR: RecordingFile::write overwrites original file (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31482/head:pull/31482` \
`$ git checkout pull/31482`

Update a local copy of the PR: \
`$ git checkout pull/31482` \
`$ git pull https://git.openjdk.org/jdk.git pull/31482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31482`

View PR using the GUI difftool: \
`$ git pr show -t 31482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31482.diff">https://git.openjdk.org/jdk/pull/31482.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31482#issuecomment-4681697830)
</details>
