### PR TITLE
8386288: GenShen: assert(region->get_top_before_promote() == nullptr) failed: Cannot add region scheduled for in-place-promotion to the collection set

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -153,7 +153,7 @@ void ShenandoahInPlacePromoter::maybe_promote_region(ShenandoahHeapRegion* r) co
       if (!obj->is_typeArray()) {
         promote_humongous(r);
       }
-    } else if (r->is_regular() && (r->get_top_before_promote() != nullptr)) {
+    } else if (r->is_regular_or_regular_pinned() && (r->get_top_before_promote() != nullptr)) {
       // Likewise, we cannot put promote-in-place regions into the collection set because that would also trigger
       // the LRB to copy on reference fetch.
       //
@@ -181,7 +181,7 @@ void ShenandoahInPlacePromoter::promote(ShenandoahHeapRegion* region) const {
     assert(region->garbage_before_padded_for_promote() < old_garbage_threshold,
            "Region %zu has too much garbage for promotion", region->index());
     assert(region->is_young(), "Only young regions can be promoted");
-    assert(region->is_regular(), "Use different service to promote humongous regions");
+    assert(region->is_regular_or_regular_pinned(), "Use different service to promote humongous regions");
     assert(_heap->is_tenurable(region), "Only promote regions that are sufficiently aged");
     assert(region->get_top_before_promote() == tams, "Region %zu has been used for allocations before promotion", region->index());
   }


### PR DESCRIPTION
A region that is scheduled to be promoted in place, should always be promoted. However, when a region that is planned to be promoted in place gets pinned, `maybe_promote_region` skips the region, which leaves the region in a state where it was planned to be promoted but it never was. The subsequent cycle that starts will see `region->get_top_before_promote() != nullptr` and crash. The fix is to allow pinned regions to be promoted in place.

### Testing
`TEST=gc/shenandoah` with linux-x86_64-server-fastdebug

Reproduced the crash from hs_err file using these additional flags on my x86 debug build (100 runs, no crash with the assertion):
 `-XX:ShenandoahGuaranteedOldGCInterval=100 -XX:ShenandoahGarbageThreshold=15`


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386288](https://bugs.openjdk.org/browse/JDK-8386288): GenShen: assert(region-&gt;get_top_before_promote() == nullptr) failed: Cannot add region scheduled for in-place-promotion to the collection set (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31485/head:pull/31485` \
`$ git checkout pull/31485`

Update a local copy of the PR: \
`$ git checkout pull/31485` \
`$ git pull https://git.openjdk.org/jdk.git pull/31485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31485`

View PR using the GUI difftool: \
`$ git pr show -t 31485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31485.diff">https://git.openjdk.org/jdk/pull/31485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31485#issuecomment-4683470689)
</details>
