### PR TITLE
8386328: TemporalField.adjustInto Javadoc incorrectly uses 1-argument method signatures

### DIFF
--- a/src/java.base/share/classes/java/time/temporal/Temporal.java
+++ b/src/java.base/share/classes/java/time/temporal/Temporal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -392,8 +392,8 @@ public interface Temporal extends TemporalAccessor {
      * The second is to use {@link TemporalUnit#between(Temporal, Temporal)}:
      * <pre>
      *   // these two lines are equivalent
-     *   temporal = start.until(end, unit);
-     *   temporal = unit.between(start, end);
+     *   amount = start.until(end, unit);
+     *   amount = unit.between(start, end);
      * </pre>
      * The choice should be made based on which makes the code more readable.
      * <p>

--- a/src/java.base/share/classes/java/time/temporal/TemporalAmount.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,9 +145,9 @@ public interface TemporalAmount {
      * <pre>
      *   // These two lines are equivalent, but the second approach is recommended
      *   dateTime = amount.addTo(dateTime);
-     *   dateTime = dateTime.plus(adder);
+     *   dateTime = dateTime.plus(amount);
      * </pre>
-     * It is recommended to use the second approach, {@code plus(TemporalAmount)},
+     * It is recommended to use the second approach, {@code plus(amount)},
      * as it is a lot clearer to read in code.
      *
      * @implSpec
@@ -189,7 +189,7 @@ public interface TemporalAmount {
      *   dateTime = amount.subtractFrom(dateTime);
      *   dateTime = dateTime.minus(amount);
      * </pre>
-     * It is recommended to use the second approach, {@code minus(TemporalAmount)},
+     * It is recommended to use the second approach, {@code minus(amount)},
      * as it is a lot clearer to read in code.
      *
      * @implSpec

--- a/src/java.base/share/classes/java/time/temporal/TemporalField.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,10 +186,10 @@ public interface TemporalField {
      * The second is to use {@link TemporalAccessor#isSupported(TemporalField)}:
      * <pre>
      *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisField.isSupportedBy(temporal);
-     *   temporal = temporal.isSupported(thisField);
+     *   supported = thisField.isSupportedBy(temporal);
+     *   supported = temporal.isSupported(thisField);
      * </pre>
-     * It is recommended to use the second approach, {@code isSupported(TemporalField)},
+     * It is recommended to use the second approach, {@code isSupported(thisField)},
      * as it is a lot clearer to read in code.
      * <p>
      * Implementations should determine whether they are supported using the fields
@@ -216,10 +216,10 @@ public interface TemporalField {
      * The second is to use {@link TemporalAccessor#range(TemporalField)}:
      * <pre>
      *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisField.rangeRefinedBy(temporal);
-     *   temporal = temporal.range(thisField);
+     *   range = thisField.rangeRefinedBy(temporal);
+     *   range = temporal.range(thisField);
      * </pre>
-     * It is recommended to use the second approach, {@code range(TemporalField)},
+     * It is recommended to use the second approach, {@code range(thisField)},
      * as it is a lot clearer to read in code.
      * <p>
      * Implementations should perform any queries or calculations using the fields
@@ -244,10 +244,10 @@ public interface TemporalField {
      * (or {@link TemporalAccessor#get(TemporalField)}):
      * <pre>
      *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisField.getFrom(temporal);
-     *   temporal = temporal.getLong(thisField);
+     *   value = thisField.getFrom(temporal);
+     *   value = temporal.getLong(thisField);
      * </pre>
-     * It is recommended to use the second approach, {@code getLong(TemporalField)},
+     * It is recommended to use the second approach, {@code getLong(thisField)},
      * as it is a lot clearer to read in code.
      * <p>
      * Implementations should perform any queries or calculations using the fields
@@ -281,10 +281,10 @@ public interface TemporalField {
      * The second is to use {@link Temporal#with(TemporalField, long)}:
      * <pre>
      *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisField.adjustInto(temporal);
-     *   temporal = temporal.with(thisField);
+     *   temporal = thisField.adjustInto(temporal, newValue);
+     *   temporal = temporal.with(thisField, newValue);
      * </pre>
-     * It is recommended to use the second approach, {@code with(TemporalField)},
+     * It is recommended to use the second approach, {@code with(thisField, newValue)},
      * as it is a lot clearer to read in code.
      * <p>
      * Implementations should perform any queries or calculations using the fields

--- a/src/java.base/share/classes/java/time/temporal/TemporalQueries.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,10 +94,10 @@ import java.time.chrono.Chronology;
  * The second is to use {@link TemporalAccessor#query(TemporalQuery)}:
  * <pre>
  *   // these two lines are equivalent, but the second approach is recommended
- *   temporal = thisQuery.queryFrom(temporal);
- *   temporal = temporal.query(thisQuery);
+ *   result = thisQuery.queryFrom(temporal);
+ *   result = temporal.query(thisQuery);
  * </pre>
- * It is recommended to use the second approach, {@code query(TemporalQuery)},
+ * It is recommended to use the second approach, {@code query(thisQuery)},
  * as it is a lot clearer to read in code.
  * <p>
  * The most common implementations are method references, such as

--- a/src/java.base/share/classes/java/time/temporal/TemporalQuery.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,10 +81,10 @@ import java.time.DateTimeException;
  * The second is to use {@link TemporalAccessor#query(TemporalQuery)}:
  * <pre>
  *   // these two lines are equivalent, but the second approach is recommended
- *   temporal = thisQuery.queryFrom(temporal);
- *   temporal = temporal.query(thisQuery);
+ *   result = thisQuery.queryFrom(temporal);
+ *   result = temporal.query(thisQuery);
  * </pre>
- * It is recommended to use the second approach, {@code query(TemporalQuery)},
+ * It is recommended to use the second approach, {@code query(thisQuery)},
  * as it is a lot clearer to read in code.
  * <p>
  * The most common implementations are method references, such as
@@ -115,10 +115,10 @@ public interface TemporalQuery<R> {
      * The second is to use {@link TemporalAccessor#query(TemporalQuery)}:
      * <pre>
      *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisQuery.queryFrom(temporal);
-     *   temporal = temporal.query(thisQuery);
+     *   result = thisQuery.queryFrom(temporal);
+     *   result = temporal.query(thisQuery);
      * </pre>
-     * It is recommended to use the second approach, {@code query(TemporalQuery)},
+     * It is recommended to use the second approach, {@code query(thisQuery)},
      * as it is a lot clearer to read in code.
      *
      * @implSpec

--- a/src/java.base/share/classes/java/time/temporal/TemporalUnit.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,10 +203,10 @@ public interface TemporalUnit {
      * The second is to use {@link Temporal#plus(long, TemporalUnit)}:
      * <pre>
      *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisUnit.addTo(temporal);
-     *   temporal = temporal.plus(thisUnit);
+     *   temporal = thisUnit.addTo(temporal, amount);
+     *   temporal = temporal.plus(amount, thisUnit);
      * </pre>
-     * It is recommended to use the second approach, {@code plus(TemporalUnit)},
+     * It is recommended to use the second approach, {@code plus(amount, thisUnit)},
      * as it is a lot clearer to read in code.
      * <p>
      * Implementations should perform any queries or calculations using the units


### PR DESCRIPTION
Clean backport to jdk27 branch

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386328](https://bugs.openjdk.org/browse/JDK-8386328): TemporalField.adjustInto Javadoc incorrectly uses 1-argument method signatures (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31488/head:pull/31488` \
`$ git checkout pull/31488`

Update a local copy of the PR: \
`$ git checkout pull/31488` \
`$ git pull https://git.openjdk.org/jdk.git pull/31488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31488`

View PR using the GUI difftool: \
`$ git pr show -t 31488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31488.diff">https://git.openjdk.org/jdk/pull/31488.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31488#issuecomment-4683929729)
</details>
