### PR TITLE
8386514: Shenandoah: Wrong object bit size calculation in asserts

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
@@ -109,7 +109,7 @@ typedef struct ShenandoahSharedBitmap {
   }
 
   void set(uint mask) {
-    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
+    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_BIT), "sanity");
     ShenandoahSharedValue mask_val = (ShenandoahSharedValue) mask;
     while (true) {
       ShenandoahSharedValue ov = value.load_acquire();
@@ -128,7 +128,7 @@ typedef struct ShenandoahSharedBitmap {
   }
 
   void unset(uint mask) {
-    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
+    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_BIT), "sanity");
     ShenandoahSharedValue mask_val = (ShenandoahSharedValue) mask;
     while (true) {
       ShenandoahSharedValue ov = value.load_acquire();
@@ -156,14 +156,14 @@ typedef struct ShenandoahSharedBitmap {
 
   // Returns true iff all bits set in mask are set in this.value.
   bool is_set_exactly(uint mask) const {
-    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
+    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_BIT), "sanity");
     uint uvalue = value.load_acquire();
     return (uvalue & mask) == mask;
   }
 
   // Returns true iff all bits set in mask are unset in this.value.
   bool is_unset(uint mask) const {
-    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
+    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_BIT), "sanity");
     return (value.load_acquire() & (ShenandoahSharedValue) mask) == 0;
   }
 
@@ -209,7 +209,7 @@ struct ShenandoahSharedEnumFlag {
 
   void set(T v) {
     assert (v >= 0, "sanity");
-    assert (v < (sizeof(EnumValueType) * CHAR_MAX), "sanity");
+    assert (v < (sizeof(EnumValueType) * CHAR_BIT), "sanity");
     value.release_store_fence((EnumValueType)v);
   }
 
@@ -219,13 +219,13 @@ struct ShenandoahSharedEnumFlag {
 
   T cmpxchg(T new_value, T expected) {
     assert (new_value >= 0, "sanity");
-    assert (new_value < (sizeof(EnumValueType) * CHAR_MAX), "sanity");
+    assert (new_value < (sizeof(EnumValueType) * CHAR_BIT), "sanity");
     return (T)value.compare_exchange((EnumValueType)expected, (EnumValueType)new_value);
   }
 
   T xchg(T new_value) {
     assert (new_value >= 0, "sanity");
-    assert (new_value < (sizeof(EnumValueType) * CHAR_MAX), "sanity");
+    assert (new_value < (sizeof(EnumValueType) * CHAR_BIT), "sanity");
     return (T)value.exchange((EnumValueType)new_value);
   }
 
@@ -250,7 +250,7 @@ typedef struct ShenandoahSharedSemaphore {
   shenandoah_padding(1);
 
   static uint max_tokens() {
-    return sizeof(ShenandoahSharedValue) * CHAR_MAX;
+    return sizeof(ShenandoahSharedValue) * CHAR_BIT;
   }
 
   ShenandoahSharedSemaphore(uint tokens) {


### PR DESCRIPTION
Those asserts intend to compare bit sizes, but use `CHAR_MAX` (max value of char, 127 or 255) instead of `CHAR_BIT` (bit size in a char, usually 8).

GHA pending

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386514](https://bugs.openjdk.org/browse/JDK-8386514): Shenandoah: Wrong object bit size calculation in asserts (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31489/head:pull/31489` \
`$ git checkout pull/31489`

Update a local copy of the PR: \
`$ git checkout pull/31489` \
`$ git pull https://git.openjdk.org/jdk.git pull/31489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31489`

View PR using the GUI difftool: \
`$ git pr show -t 31489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31489.diff">https://git.openjdk.org/jdk/pull/31489.diff</a>

</details>
