### PR TITLE
8386460: Report AOT code loading failure before log of AOT code cache content

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -83,11 +83,12 @@ const char* aot_code_entry_kind_name[] = {
 // Print to error channel when -XX:AOTMode is set to "on"
 static LogStream& load_failure_log() {
   static LogStream err_stream(LogLevel::Error, LogTagSetMapping<LOG_TAGS(aot, codecache, init)>::tagset());
-  static LogStream dbg_stream(LogLevel::Debug, LogTagSetMapping<LOG_TAGS(aot, codecache, init)>::tagset());
+  static LogStream inf_stream(LogLevel::Info, LogTagSetMapping<LOG_TAGS(aot, codecache, init)>::tagset());
   if (RequireSharedSpaces || AbortVMOnAOTCodeFailure) {
     return err_stream;
   } else {
-    return dbg_stream;
+    static LogStream aot_stream(LogLevel::Info, LogTagSetMapping<LOG_TAGS(aot)>::tagset());
+    return inf_stream.is_enabled() ? inf_stream : aot_stream;
   }
 }
 
@@ -288,6 +289,20 @@ void AOTCodeCache::init2() {
     return;
   }
 
+  // Report contents of AOT code cache after verification passed
+  Header* header = opened_cache->_load_header;
+  if (header != nullptr) { // Loading AOT code
+    log_info (aot, codecache, init)("Loaded %u AOT code entries from AOT Code Cache", header->entries_count());
+    log_debug(aot, codecache, init)("  Adapters:  total=%u", header->adapters_count());
+    log_debug(aot, codecache, init)("  Shared Blobs: total=%u", header->shared_blobs_count());
+    log_debug(aot, codecache, init)("  StubGen Blobs:  total=%d", header->stubgen_blobs_count());
+    log_debug(aot, codecache, init)("  C1 Blobs: total=%u", header->C1_blobs_count());
+    log_debug(aot, codecache, init)("  C2 Blobs: total=%u", header->C2_blobs_count());
+    log_debug(aot, codecache, init)("  AOT code cache size: %u bytes", header->cache_size());
+
+    // Read strings
+    opened_cache->load_strings();
+  }
   // initialize aot runtime constants as appropriate to this runtime
   AOTRuntimeConstants::initialize_from_runtime();
 
@@ -379,16 +394,6 @@ AOTCodeCache::AOTCodeCache(bool is_dumping, bool is_using) :
       set_failed();
       return;
     }
-    log_info (aot, codecache, init)("Loaded %u AOT code entries from AOT Code Cache", _load_header->entries_count());
-    log_debug(aot, codecache, init)("  Adapters:  total=%u", _load_header->adapters_count());
-    log_debug(aot, codecache, init)("  Shared Blobs: total=%u", _load_header->shared_blobs_count());
-    log_debug(aot, codecache, init)("  StubGen Blobs:  total=%d", _load_header->stubgen_blobs_count());
-    log_debug(aot, codecache, init)("  C1 Blobs: total=%u", _load_header->C1_blobs_count());
-    log_debug(aot, codecache, init)("  C2 Blobs: total=%u", _load_header->C2_blobs_count());
-    log_debug(aot, codecache, init)("  AOT code cache size: %u bytes", _load_header->cache_size());
-
-    // Read strings
-    load_strings();
   }
   if (_for_dump) {
     _C_store_buffer = NEW_C_HEAP_ARRAY(char, max_aot_code_size() + DATA_ALIGNMENT, mtCode);


### PR DESCRIPTION
Currently when some AOT code configuration mismatched in production run we report it and disable AOT code after content of AOT code cache is printed. As result failure report could be missed:
```
> java -XX:AOTCache=JavacBenchApp.aot -Xlog:aot+codecache+init=debug -XX:+UseSerialGC -cp JavacBenchApp.jar JavacBenchApp 50

[0.040s][debug][aot,codecache,init] Mapped 737280 bytes at address 0x000000010379c000 at AOT Code Cache
[0.040s][info ][aot,codecache,init] Loaded 496 AOT code entries from AOT Code Cache
[0.040s][debug][aot,codecache,init] Adapters: total=423
[0.040s][debug][aot,codecache,init] Shared Blobs: total=15
[0.040s][debug][aot,codecache,init] StubGen Blobs: total=4
[0.040s][debug][aot,codecache,init] C1 Blobs: total=34
[0.040s][debug][aot,codecache,init] C2 Blobs: total=20
[0.040s][debug][aot,codecache,init] AOT code cache size: 733216 bytes
[0.040s][debug][aot,codecache,init] Loaded 409 C strings of total length 7948 at offset 697492 from AOT Code Cache
[0.040s][debug][aot,codecache,init] CPU features recorded in AOTCodeCache: fp, asimd, aes, pmull, sha1, sha256, crc32, lse, sha3, sha512, sb
[0.040s][debug][aot,codecache,init] AOT Code Cache disabled: it was created with GC = "g1 gc" vs current "serial gc"
[0.040s][debug][aot,codecache,init] Unable to use AOT Code Cache.
```

Most importantly `-Xlog:aot+codecache+init=info` shows only next line - one can assume that AOT code is used:
```
[0.040s][info ][aot,codecache,init] Loaded 496 AOT code entries from AOT Code Cache
```

I think the failure to load/use AOT code should be reported with `-Xlog:aot+codecache+init=info` and with `-Xlog:aot`
and before printing content of cache. AOT code cache content should be printed after all verifications passed - I moved it (and loading C strings) to `init2()` from constructor:
```
[0.022s][info ][aot,codecache,init] AOT Code Cache disabled: it was created with GC = "g1 gc" vs current "serial gc"
[0.022s][info ][aot,codecache,init] Unable to use AOT Code Cache.
```

Tested tier1-3, hs-aot-stress

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386460](https://bugs.openjdk.org/browse/JDK-8386460): Report AOT code loading failure before log of AOT code cache content (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31492/head:pull/31492` \
`$ git checkout pull/31492`

Update a local copy of the PR: \
`$ git checkout pull/31492` \
`$ git pull https://git.openjdk.org/jdk.git pull/31492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31492`

View PR using the GUI difftool: \
`$ git pr show -t 31492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31492.diff">https://git.openjdk.org/jdk/pull/31492.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31492#issuecomment-4686007258)
</details>
