### PR TITLE
8386473: DESKeySpec and DESedeKeySpec may throw InvalidKeyException instead of ArrayIndexOutOfBoundsException for Integer.MIN_VALUE offset

### DIFF
--- a/src/java.base/share/classes/javax/crypto/spec/DESKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/DESKeySpec.java
@@ -156,11 +156,11 @@ public class DESKeySpec implements java.security.spec.KeySpec {
         if (key == null) {
             throw new NullPointerException("null key");
         }
-        if (key.length - offset < DES_KEY_LEN) {
-            throw new InvalidKeyException("Wrong key size");
-        }
         if (offset < 0) {
             throw new ArrayIndexOutOfBoundsException("offset is negative");
+        }
+        if (key.length - offset < DES_KEY_LEN) {
+            throw new InvalidKeyException("Wrong key size");
         }
         this.key = new byte[DES_KEY_LEN];
         System.arraycopy(key, offset, this.key, 0, DES_KEY_LEN);
@@ -198,11 +198,11 @@ public class DESKeySpec implements java.security.spec.KeySpec {
             if (key == null) {
                 throw new InvalidKeyException("null key");
             }
-            if (key.length - offset < DES_KEY_LEN) {
-                throw new InvalidKeyException("Wrong key size");
-            }
             if (offset < 0) {
                 throw new ArrayIndexOutOfBoundsException("offset is negative");
+            }
+            if (key.length - offset < DES_KEY_LEN) {
+                throw new InvalidKeyException("Wrong key size");
             }
             for (int i = 0; i < DES_KEY_LEN; i++) {
                 int k = Integer.bitCount(key[offset++] & 0xff);
@@ -235,11 +235,11 @@ public class DESKeySpec implements java.security.spec.KeySpec {
         if (key == null) {
             throw new InvalidKeyException("null key");
         }
-        if (key.length - offset < DES_KEY_LEN) {
-            throw new InvalidKeyException("Wrong key size");
-        }
         if (offset < 0) {
             throw new ArrayIndexOutOfBoundsException("offset is negative");
+        }
+        if (key.length - offset < DES_KEY_LEN) {
+            throw new InvalidKeyException("Wrong key size");
         }
         for (int i = 0; i < WEAK_KEYS.length; i++) {
             boolean found = true;

--- a/src/java.base/share/classes/javax/crypto/spec/DESedeKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/DESedeKeySpec.java
@@ -86,11 +86,11 @@ public class DESedeKeySpec implements java.security.spec.KeySpec {
         if (key == null) {
             throw new NullPointerException("null key");
         }
-        if (key.length - offset < DES_EDE_KEY_LEN) {
-            throw new InvalidKeyException("Wrong key size");
-        }
         if (offset < 0) {
             throw new ArrayIndexOutOfBoundsException("offset is negative");
+        }
+        if (key.length - offset < DES_EDE_KEY_LEN) {
+            throw new InvalidKeyException("Wrong key size");
         }
         this.key = new byte[24];
         System.arraycopy(key, offset, this.key, 0, DES_EDE_KEY_LEN);
@@ -126,11 +126,11 @@ public class DESedeKeySpec implements java.security.spec.KeySpec {
         if (key == null) {
             throw new InvalidKeyException("null key");
         }
-        if (key.length - offset < DES_EDE_KEY_LEN) {
-            throw new InvalidKeyException("Wrong key size");
-        }
         if (offset < 0) {
             throw new ArrayIndexOutOfBoundsException("offset is negative");
+        }
+        if (key.length - offset < DES_EDE_KEY_LEN) {
+            throw new InvalidKeyException("Wrong key size");
         }
         return DESKeySpec.isParityAdjusted(key, offset)
                 && DESKeySpec.isParityAdjusted(key, offset + 8)

--- a/test/jdk/javax/crypto/spec/DESKeySpec/OffsetKey.java
+++ b/test/jdk/javax/crypto/spec/DESKeySpec/OffsetKey.java
@@ -23,14 +23,8 @@
 
 /*
  * @test
- * @bug 8364121
- * @summary DESKeySpec.isWeak should throw aiobe exception if the offset is
- * negative.
- *
- * @test
- * @bug 8386473
- * @summary DESKeySpec and DESedeKeySpec may throw InvalidKeyException instead
- * of ArrayIndexOutOfBoundsException for Integer.MIN_VALUE offset
+ * @bug 8364121 8386473
+ * @summary Test DES[ede]KeySpec for negative and integer overflow offsets
  */
 import java.security.InvalidKeyException;
 import javax.crypto.spec.DESedeKeySpec;

--- a/test/jdk/javax/crypto/spec/DESKeySpec/OffsetKey.java
+++ b/test/jdk/javax/crypto/spec/DESKeySpec/OffsetKey.java
@@ -26,6 +26,11 @@
  * @bug 8364121
  * @summary DESKeySpec.isWeak should throw aiobe exception if the offset is
  * negative.
+ *
+ * @test
+ * @bug 8386473
+ * @summary DESKeySpec and DESedeKeySpec may throw InvalidKeyException instead
+ * of ArrayIndexOutOfBoundsException for Integer.MIN_VALUE offset
  */
 import java.security.InvalidKeyException;
 import javax.crypto.spec.DESedeKeySpec;
@@ -57,6 +62,20 @@ public class OffsetKey {
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
 
+        try {
+            DESKeySpec desKey = new DESKeySpec(strongKey, Integer.MIN_VALUE);
+            throw new Exception("expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException aiobe) {}
+        try {
+            boolean weak = DESKeySpec.isWeak(strongKey, Integer.MIN_VALUE);
+            throw new Exception("expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException aiobe) {}
+        try{
+            boolean parityAdjusted = DESKeySpec.isParityAdjusted(strongKey,
+                    Integer.MIN_VALUE);
+            throw new Exception("expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException aiobe) {}
+
         // Test triple-DES
         try{
             DESedeKeySpec desEdeKey = new DESedeKeySpec(strongKey, -1);
@@ -65,6 +84,17 @@ public class OffsetKey {
         try{
             boolean parityAdjusted = DESedeKeySpec.isParityAdjusted(strongKey,
                     -1);
+            throw new Exception("expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException aiobe) {}
+
+        try{
+            DESedeKeySpec desEdeKey = new DESedeKeySpec(strongKey,
+                    Integer.MIN_VALUE);
+            throw new Exception("expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException aiobe) {}
+        try{
+            boolean parityAdjusted = DESedeKeySpec.isParityAdjusted(strongKey,
+                    Integer.MIN_VALUE);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
     }

--- a/test/jdk/javax/crypto/spec/DESKeySpec/OffsetKey.java
+++ b/test/jdk/javax/crypto/spec/DESKeySpec/OffsetKey.java
@@ -26,7 +26,6 @@
  * @bug 8364121 8386473
  * @summary Test DES[ede]KeySpec for negative and integer overflow offsets
  */
-import java.security.InvalidKeyException;
 import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.DESKeySpec;
 
@@ -51,7 +50,7 @@ public class OffsetKey {
             boolean weak = DESKeySpec.isWeak(strongKey, -1);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
-        try{
+        try {
             boolean parityAdjusted = DESKeySpec.isParityAdjusted(strongKey, -1);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
@@ -64,29 +63,29 @@ public class OffsetKey {
             boolean weak = DESKeySpec.isWeak(strongKey, Integer.MIN_VALUE);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
-        try{
+        try {
             boolean parityAdjusted = DESKeySpec.isParityAdjusted(strongKey,
                     Integer.MIN_VALUE);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
 
         // Test triple-DES
-        try{
+        try {
             DESedeKeySpec desEdeKey = new DESedeKeySpec(strongKey, -1);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
-        try{
+        try {
             boolean parityAdjusted = DESedeKeySpec.isParityAdjusted(strongKey,
                     -1);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
 
-        try{
+        try {
             DESedeKeySpec desEdeKey = new DESedeKeySpec(strongKey,
                     Integer.MIN_VALUE);
             throw new Exception("expected ArrayIndexOutOfBoundsException");
         } catch (ArrayIndexOutOfBoundsException aiobe) {}
-        try{
+        try {
             boolean parityAdjusted = DESedeKeySpec.isParityAdjusted(strongKey,
                     Integer.MIN_VALUE);
             throw new Exception("expected ArrayIndexOutOfBoundsException");


### PR DESCRIPTION
This fix includes throwing the correct exception when an offset for the key length check would cause an integer overflow therefore throwing the wrong exception.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386473](https://bugs.openjdk.org/browse/JDK-8386473): DESKeySpec and DESedeKeySpec may throw InvalidKeyException instead of ArrayIndexOutOfBoundsException for Integer.MIN_VALUE offset (**Bug** - P2)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31494/head:pull/31494` \
`$ git checkout pull/31494`

Update a local copy of the PR: \
`$ git checkout pull/31494` \
`$ git pull https://git.openjdk.org/jdk.git pull/31494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31494`

View PR using the GUI difftool: \
`$ git pr show -t 31494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31494.diff">https://git.openjdk.org/jdk/pull/31494.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31494#issuecomment-4686378393)
</details>
