### PR TITLE
8382879: AOT training run exits with 0 even if assembly subprocess fails

### DIFF
--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1360,6 +1360,7 @@ void AOTMetaspace::fork_and_dump_final_static_archive(TRAPS) {
   int status = exec_jvm_with_java_tool_options(cmd, CHECK);
   if (status != 0) {
     log_error(aot)("Child process failed; status = %d", status);
+    vm_exit(status);
     // We leave the temp config file for debugging
   } else if (CDSConfig::has_temp_aot_config_file()) {
     const char* tmp_config = AOTConfiguration;

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1221,8 +1221,8 @@ void AOTMetaspace::dump_static_archive_impl(StaticArchiveBuilder& builder, TRAPS
   assert(!_output_mapinfo->is_open(), "Must be closed already");
   _output_mapinfo = nullptr;
   if (status && CDSConfig::is_dumping_preimage_static_archive()) {
-    tty->print_cr("%s AOTConfiguration recorded: %s",
-                  CDSConfig::has_temp_aot_config_file() ? "Temporary" : "", AOTConfiguration);
+    tty->print_cr("%sAOTConfiguration recorded: %s",
+                  CDSConfig::has_temp_aot_config_file() ? "Temporary " : "", AOTConfiguration);
     if (CDSConfig::is_single_command_training()) {
       fork_and_dump_final_static_archive(CHECK);
     }
@@ -1359,9 +1359,19 @@ void AOTMetaspace::fork_and_dump_final_static_archive(TRAPS) {
   tty->print_cr("Launching child process %s to assemble AOT cache %s using configuration %s", cmd, AOTCacheOutput, AOTConfiguration);
   int status = exec_jvm_with_java_tool_options(cmd, CHECK);
   if (status != 0) {
+    // We do this in all cases when the child process is launched because:
+    // - the AOT training process is about to exit; or
+    // - jcmd or AOTCacheMXBean is used to end AOT training.
+    //
+    // The child process is just a convenient way to get a fresh JVM state to
+    // assemble the AOT cache. Logically, we consider the AOT assembly to be
+    // executed as part of the current JVM. If the child process has failed,
+    // we should exit the current JVM as well.
+    //
+    // To help debugging, if we have created a temporary AOT config file, do not
+    // delete it.
     log_error(aot)("Child process failed; status = %d", status);
     vm_exit(status);
-    // We leave the temp config file for debugging
   } else if (CDSConfig::has_temp_aot_config_file()) {
     const char* tmp_config = AOTConfiguration;
     // On Windows, need WRITE permission to remove the file.

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
@@ -195,7 +195,7 @@ public class AOTFlags {
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("AOTConfiguration recorded: " + aotConfigFile);
         out.shouldContain("AOTCache creation is complete: hello.aot");
@@ -207,7 +207,7 @@ public class AOTFlags {
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("AOTConfiguration recorded: " + aotConfigFile);
         out.shouldContain("AOTCache creation is complete: hello.aot");
@@ -220,7 +220,7 @@ public class AOTFlags {
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("AOTConfiguration recorded: " + aotConfigFile);
         out.shouldContain("AOTCache creation is complete: hello.aot");
@@ -231,7 +231,7 @@ public class AOTFlags {
             "-XX:AOTCacheOutput=" + aotCacheFile,
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("Temporary AOTConfiguration recorded: " + aotCacheFile + ".config");
         out.shouldContain("AOTCache creation is complete: hello.aot");
@@ -243,7 +243,7 @@ public class AOTFlags {
             "-XX:AOTCacheOutput=" + aotCacheFile,
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("Temporary AOTConfiguration recorded: " + aotCacheFile + ".config");
         out.shouldContain("AOTCache creation is complete: hello.aot");
@@ -255,7 +255,7 @@ public class AOTFlags {
             "-Dmy.prop=My string -Xshare:off here", // -Xshare:off should not be treated as a single VM opt for the child JVM
             "-Xlog:aot=debug",
             "-cp", appJar, helloClass);
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("AOTCache creation is complete: hello.aot");
         out.shouldMatch("Picked up JAVA_TOOL_OPTIONS:.* -Dmy.prop=My' 'string' '-Xshare:off' 'here");

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AssemblySubProcessFailure.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AssemblySubProcessFailure.java
@@ -35,7 +35,6 @@
  */
 
 import java.io.File;
-import java.nio.file.Path;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -49,7 +48,7 @@ public class AssemblySubProcessFailure {
 
     public static void main(String[] args) throws Exception {
         // The main training run process should report the failure if the AOT assembly
-        // sub-processes has failed.
+        // sub-process has failed.
         //
         // The easiest way to trigger a failure is to pass a bad VM option, only to the
         // sub-process using JDK_AOT_VM_OPTIONS.
@@ -58,7 +57,7 @@ public class AssemblySubProcessFailure {
             "-XX:AOTCacheOutput=" + aotCacheFile,
             "-cp", appJar, helloClass);
         pb.environment().put("JDK_AOT_VM_OPTIONS", "-XX:+NoSuchOption");
-        OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "onestep-train");
 
         out.shouldContain("Hello World");
         out.shouldContain("Temporary AOTConfiguration recorded: " + aotConfigFile);
@@ -66,6 +65,7 @@ public class AssemblySubProcessFailure {
         out.shouldContain("Picked up JDK_AOT_VM_OPTIONS: -XX:+NoSuchOption");
         out.shouldContain("Unrecognized VM option 'NoSuchOption'");
         out.shouldContain("Error: Could not create the Java Virtual Machine.");
+        out.shouldNotContain("AOTCache creation is complete");
         out.shouldHaveExitValue(1);
 
         if (!(new File(aotConfigFile)).exists()) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AssemblySubProcessFailure.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AssemblySubProcessFailure.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Handling of assembly sub-process failure in onestep AOT training.
+ * @bug 8382879
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build Hello
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar Hello
+ * @run driver AssemblySubProcessFailure
+ */
+
+import java.io.File;
+import java.nio.file.Path;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class AssemblySubProcessFailure {
+    static String appJar = ClassFileInstaller.getJarPath("hello.jar");
+    static String aotConfigFile = "hello.aot.config";
+    static String aotCacheFile = "hello.aot";
+    static String helloClass = "Hello";
+
+    public static void main(String[] args) throws Exception {
+        // The main training run process should report the failure if the AOT assembly
+        // sub-processes has failed.
+        //
+        // The easiest way to trigger a failure is to pass a bad VM option, only to the
+        // sub-process using JDK_AOT_VM_OPTIONS.
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:AOTMode=record",
+            "-XX:AOTCacheOutput=" + aotCacheFile,
+            "-cp", appJar, helloClass);
+        pb.environment().put("JDK_AOT_VM_OPTIONS", "-XX:+NoSuchOption");
+        OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+
+        out.shouldContain("Hello World");
+        out.shouldContain("Temporary AOTConfiguration recorded: " + aotConfigFile);
+        out.shouldContain("Child process failed; status = 1");
+        out.shouldContain("Picked up JDK_AOT_VM_OPTIONS: -XX:+NoSuchOption");
+        out.shouldContain("Unrecognized VM option 'NoSuchOption'");
+        out.shouldContain("Error: Could not create the Java Virtual Machine.");
+        out.shouldHaveExitValue(1);
+
+        if (!(new File(aotConfigFile)).exists()) {
+          throw new RuntimeException("Should not delete temporary AOT config file when child process fails: " + aotConfigFile);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/JDK_AOT_VM_OPTIONS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/JDK_AOT_VM_OPTIONS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class JDK_AOT_VM_OPTIONS {
         // The "-Xshare:off" below should be treated as part of a property value and not
         // a VM option by itself
         pb.environment().put("JDK_AOT_VM_OPTIONS", "-Dsome.option='foo -Xshare:off ' -Xmx512m -XX:-AOTClassLinking");
-        out = CDSTestUtils.executeAndLog(pb, "ontstep-train");
+        out = CDSTestUtils.executeAndLog(pb, "onestep-train");
         out.shouldContain("Hello World");
         out.shouldContain("AOTCache creation is complete: hello.aot");
         out.shouldContain("Picked up JDK_AOT_VM_OPTIONS: -Dsome.option='foo -Xshare:off '");


### PR DESCRIPTION
If the sub-process that assembles the AOT cache has failed, the main JVM process that executes the training run should also exit immediately with an error code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8382879](https://bugs.openjdk.org/browse/JDK-8382879): AOT training run exits with 0 even if assembly subprocess fails (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31496/head:pull/31496` \
`$ git checkout pull/31496`

Update a local copy of the PR: \
`$ git checkout pull/31496` \
`$ git pull https://git.openjdk.org/jdk.git pull/31496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31496`

View PR using the GUI difftool: \
`$ git pr show -t 31496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31496.diff">https://git.openjdk.org/jdk/pull/31496.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31496#issuecomment-4687117850)
</details>
