### PR TITLE
8386334: JdepsTask keeps --system files open

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import static com.sun.tools.jdeps.Module.trace;
 import static java.util.stream.Collectors.*;
 
 import java.io.BufferedInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import java.lang.module.ModuleReader;
 import java.lang.module.ModuleReference;
 import java.lang.module.ResolvedModule;
 import java.net.URI;
+import java.net.URLClassLoader;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -282,6 +284,7 @@ public class JdepsConfiguration implements AutoCloseable {
             archive.close();
         for (Module module : nameToModule.values())
             module.close();
+        system.close();
     }
 
     static class SystemModuleFinder implements ModuleFinder {
@@ -290,6 +293,7 @@ public class JdepsConfiguration implements AutoCloseable {
         private final FileSystem fileSystem;
         private final Path root;
         private final Map<String, ModuleReference> systemModules;
+        private final List<Closeable> closeables = new ArrayList<>();
 
         SystemModuleFinder() {
             if (Files.isRegularFile(Paths.get(JAVA_HOME, "lib", "modules"))) {
@@ -321,6 +325,12 @@ public class JdepsConfiguration implements AutoCloseable {
                 env.put("java.home", javaHome);
                 // a remote run-time image
                 this.fileSystem = FileSystems.newFileSystem(URI.create("jrt:/"), env);
+                closeables.add(fileSystem);
+                ClassLoader cl = fileSystem.provider().getClass().getClassLoader();
+                if (cl != JdepsConfiguration.class.getClassLoader()
+                        && cl instanceof URLClassLoader urlcl) {
+                    closeables.add(urlcl);
+                }
                 this.root = fileSystem.getPath("/modules");
                 this.systemModules = walk(root);
             }
@@ -419,6 +429,23 @@ public class JdepsConfiguration implements AutoCloseable {
                         .isPresent())
                 .map(ModuleDescriptor::name)
                 .collect(Collectors.toSet());
+        }
+
+        public void close() throws IOException {
+            List<IOException> list = new ArrayList<>();
+            closeables.forEach(closeable -> {
+                try {
+                    closeable.close();
+                } catch (IOException ex) {
+                    list.add(ex);
+                }
+            });
+            if (!list.isEmpty()) {
+                IOException ex = new IOException();
+                for (IOException e: list)
+                    ex.addSuppressed(e);
+                throw ex;
+            }
         }
     }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
@@ -327,8 +327,7 @@ public class JdepsConfiguration implements AutoCloseable {
                 this.fileSystem = FileSystems.newFileSystem(URI.create("jrt:/"), env);
                 closeables.add(fileSystem);
                 ClassLoader cl = fileSystem.provider().getClass().getClassLoader();
-                if (cl != JdepsConfiguration.class.getClassLoader()
-                        && cl instanceof URLClassLoader urlcl) {
+                if (cl instanceof URLClassLoader urlcl) {
                     closeables.add(urlcl);
                 }
                 this.root = fileSystem.getPath("/modules");
@@ -432,19 +431,20 @@ public class JdepsConfiguration implements AutoCloseable {
         }
 
         public void close() throws IOException {
-            List<IOException> list = new ArrayList<>();
-            closeables.forEach(closeable -> {
+            IOException ioe = null;
+            for (Closeable closeable : closeables) {
                 try {
                     closeable.close();
                 } catch (IOException ex) {
-                    list.add(ex);
+                    if (ioe == null) {
+                        ioe = ex;
+                    } else {
+                        ioe.addSuppressed(ex);
+                    }
                 }
-            });
-            if (!list.isEmpty()) {
-                IOException ex = new IOException();
-                for (IOException e: list)
-                    ex.addSuppressed(e);
-                throw ex;
+            }
+            if (ioe != null) {
+                throw ioe;
             }
         }
     }

--- a/test/langtools/tools/jdeps/SystemFilesClosed.java
+++ b/test/langtools/tools/jdeps/SystemFilesClosed.java
@@ -34,12 +34,14 @@
  */
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -50,6 +52,17 @@ public class SystemFilesClosed {
 
     @Test
     void testSystemFilesClosed() throws Exception {
+        // Probe lsof availability before doing the jlink/jdeps work
+        try {
+            Process process = new ProcessBuilder("lsof", "-v")
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+            process.waitFor();
+        } catch (IOException ex) {
+            Assumptions.abort("lsof is not available on this system");
+        }
+
         String targetSystem = base.toString();
         int ret = java.util.spi.ToolProvider.findFirst("jlink")
                 .orElseThrow()

--- a/test/langtools/tools/jdeps/SystemFilesClosed.java
+++ b/test/langtools/tools/jdeps/SystemFilesClosed.java
@@ -34,12 +34,14 @@
  */
 
 import java.io.BufferedReader;
-import java.io.IOException;
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,14 +55,8 @@ public class SystemFilesClosed {
     @Test
     void testSystemFilesClosed() throws Exception {
         // Probe lsof availability before doing the jlink/jdeps work
-        try {
-            Process process = new ProcessBuilder("lsof", "-v")
-                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-                    .redirectError(ProcessBuilder.Redirect.DISCARD)
-                    .start();
-            process.waitFor();
-        } catch (IOException ex) {
-            Assumptions.abort("lsof is not available on this system");
+        if (!lsofCommand().isPresent()) {
+            Assumptions.abort("lsof command is not available on this system");
         }
 
         String targetSystem = base.toString();
@@ -76,7 +72,8 @@ public class SystemFilesClosed {
         Assertions.assertEquals(0, jdeps.run(true), "Jdeps task failed");
 
         Process process = new ProcessBuilder()
-                .command("lsof", "-p", String.valueOf(ProcessHandle.current().pid()))
+                .command(lsofCommand().orElseThrow(() -> new RuntimeException("lsof command is not available on this system")),
+                        "-p", String.valueOf(ProcessHandle.current().pid()))
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .start();
@@ -95,5 +92,18 @@ public class SystemFilesClosed {
                     .resolve(info.getTestMethod()
                                  .orElseThrow()
                                  .getName());
+    }
+
+    static Optional<String> lsofCommandCache = Arrays.stream(new String[] {
+            "/usr/bin/lsof",
+            "/usr/sbin/lsof",
+            "/bin/lsof",
+            "/sbin/lsof",
+            "/usr/local/bin/lsof"})
+        .filter(args -> new File(args).exists())
+        .findFirst();
+
+    static Optional<String> lsofCommand() {
+        return lsofCommandCache;
     }
 }

--- a/test/langtools/tools/jdeps/SystemFilesClosed.java
+++ b/test/langtools/tools/jdeps/SystemFilesClosed.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8357249
+ * @bug 8386334
  * @summary Check that `lib/jrt-fs.jar` and `lib/modules` are properly closed while
  *          jdeps is invoked with `--system` option.
  * @requires os.family == "mac" | os.family == "linux"

--- a/test/langtools/tools/jdeps/SystemFilesClosed.java
+++ b/test/langtools/tools/jdeps/SystemFilesClosed.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8357249
+ * @summary Check that `lib/jrt-fs.jar` and `lib/modules` are properly closed while
+ *          jdeps is invoked with `--system` option.
+ * @requires os.family == "mac" | os.family == "linux"
+ * @modules jdk.jdeps
+ * @library lib
+ * @build JdepsRunner
+ * @run junit ${test.main.class}
+ */
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class SystemFilesClosed {
+
+    private Path base;
+
+    @Test
+    void testSystemFilesClosed() throws Exception {
+        String targetSystem = base.toString();
+        int ret = java.util.spi.ToolProvider.findFirst("jlink")
+                .orElseThrow()
+                .run(System.out, System.err, "--add-modules", "java.base", "--output", targetSystem);
+        if (ret != 0) {
+            System.out.println("It is most probably an exploded build. Skip testing.");
+            return;
+        }
+
+        JdepsRunner jdeps = new JdepsRunner("--check", "java.base", "--system", targetSystem);
+        Assertions.assertEquals(0, jdeps.run(true), "Jdeps task failed");
+
+        Process process = new ProcessBuilder()
+                .command("lsof", "-p", String.valueOf(ProcessHandle.current().pid()))
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start();
+        List<String> lines;
+        String realPath = base.toRealPath().toString();
+        try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
+            lines = reader.lines().filter(line -> line.contains(realPath)).toList();
+        }
+        process.waitFor();
+        Assertions.assertEquals(0, lines.size(), "File(s) remain opened: " + lines);
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
When used with the `--system` option to target a different modular JDK image, `JdepsTask` keeps both `lib/jrt-fs.jar` and `lib/modules` open after it completes. This is the `jdeps` counterpart of the issue previously seen with `JavacTask` in JDK-8357249.

For an alternate `java.home`, `JdepsConfiguration.SystemModuleFinder` creates a new `jrt:/` file system using the target image. That file system and the URL class loader used by its provider, are not closed when the jdeps configuration is closed.

The proposal is to modify `JdepsConfiguration.close()` to also close the associated `SystemModuleFinder`, ensuring that these resources are released after the task finishes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386334](https://bugs.openjdk.org/browse/JDK-8386334): JdepsTask keeps --system files open (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31498/head:pull/31498` \
`$ git checkout pull/31498`

Update a local copy of the PR: \
`$ git checkout pull/31498` \
`$ git pull https://git.openjdk.org/jdk.git pull/31498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31498`

View PR using the GUI difftool: \
`$ git pr show -t 31498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31498.diff">https://git.openjdk.org/jdk/pull/31498.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31498#issuecomment-4689968495)
</details>
