### PR TITLE
8385817: Headless jdk still contains bin/jconsole

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -49,11 +49,6 @@ include $(TOPDIR)/make/conf/build-module-sets.conf
 # Depending on the configuration, we might need to filter out some modules that
 # normally should have been included
 
-# the headless-only build does not have jconsole
-ifeq ($(ENABLE_HEADLESS_ONLY), true)
-  MODULES_FILTER += jdk.jconsole
-endif
-
 # Some platforms don't have the serviceability agent
 ifeq ($(INCLUDE_SA), false)
   MODULES_FILTER += jdk.hotspot.agent

--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -49,6 +49,11 @@ include $(TOPDIR)/make/conf/build-module-sets.conf
 # Depending on the configuration, we might need to filter out some modules that
 # normally should have been included
 
+# the headless-only build does not have jconsole
+ifeq ($(ENABLE_HEADLESS_ONLY), true)
+  MODULES_FILTER += jdk.jconsole
+endif
+
 # Some platforms don't have the serviceability agent
 ifeq ($(INCLUDE_SA), false)
   MODULES_FILTER += jdk.hotspot.agent

--- a/make/modules/jdk.jconsole/Launcher.gmk
+++ b/make/modules/jdk.jconsole/Launcher.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/jdk.jconsole/Launcher.gmk
+++ b/make/modules/jdk.jconsole/Launcher.gmk
@@ -31,16 +31,14 @@ include LauncherCommon.gmk
 ## Build jconsole
 ################################################################################
 ifneq ($(ENABLE_HEADLESS_ONLY), true)
-
-$(eval $(call SetupBuildLauncher, jconsole, \
-    MAIN_CLASS := sun.tools.jconsole.JConsole, \
-    JAVA_ARGS := \
-        --add-opens java.base/java.io=jdk.jconsole \
-        --add-modules ALL-DEFAULT \
-        -Djconsole.showOutputViewer \
-        -Djdk.attach.allowAttachSelf=true, \
-    WINDOWS_JAVAW := true, \
-))
-
+  $(eval $(call SetupBuildLauncher, jconsole, \
+      MAIN_CLASS := sun.tools.jconsole.JConsole, \
+      JAVA_ARGS := \
+          --add-opens java.base/java.io=jdk.jconsole \
+          --add-modules ALL-DEFAULT \
+          -Djconsole.showOutputViewer \
+          -Djdk.attach.allowAttachSelf=true, \
+      WINDOWS_JAVAW := true, \
+  ))
 endif
 ################################################################################

--- a/make/modules/jdk.jconsole/Launcher.gmk
+++ b/make/modules/jdk.jconsole/Launcher.gmk
@@ -30,6 +30,7 @@ include LauncherCommon.gmk
 ################################################################################
 ## Build jconsole
 ################################################################################
+ifneq ($(ENABLE_HEADLESS_ONLY), true)
 
 $(eval $(call SetupBuildLauncher, jconsole, \
     MAIN_CLASS := sun.tools.jconsole.JConsole, \
@@ -41,4 +42,5 @@ $(eval $(call SetupBuildLauncher, jconsole, \
     WINDOWS_JAVAW := true, \
 ))
 
+endif
 ################################################################################


### PR DESCRIPTION
When building a headless JDK on Linux (configure option `--enable-headless-only`) there is still the tool bin/jconsole in the resulting JDK image.
However the tool seems not to work, so probably it could be removed.
Also the jdk.jconsole classes can be found in the lib/modules file (probably they are not very useful in a headless jdk).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385817](https://bugs.openjdk.org/browse/JDK-8385817): Headless jdk still contains bin/jconsole (**Enhancement** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [9429de75](https://git.openjdk.org/jdk/pull/31499/files/9429de7574514a8d4eb1ea035241b2124f44fb51)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31499/head:pull/31499` \
`$ git checkout pull/31499`

Update a local copy of the PR: \
`$ git checkout pull/31499` \
`$ git pull https://git.openjdk.org/jdk.git pull/31499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31499`

View PR using the GUI difftool: \
`$ git pr show -t 31499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31499.diff">https://git.openjdk.org/jdk/pull/31499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31499#issuecomment-4690697627)
</details>
