### PR TITLE
8374783: C2 compilation asserts with "slice of address and input slice don't match"

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -732,10 +732,10 @@ void CallGenerator::do_late_inline_helper() {
     // If the specific field accessed by a memory operation is discovered after
     // inlining a method incrementally, request a cleanup so that the
     // corresponding IGVN-recorded address type is updated. This is not just an
-    // optimization: failure update the address type can lead to a slice
+    // optimization: failure to update the address type can lead to a slice
     // mismatch when parsing subsequent accesses to the address, because the
-    // memory slice corresponding to *any* field of a class C is not the same as
-    // the slice corresponding to a specific field of C. This mismatch can in
+    // memory slice corresponding to *any* field of a class K is not the same as
+    // the slice corresponding to a specific field of K. This mismatch can in
     // its turn lead to e.g. incorrect memory graphs.
     if (C->inlining_incrementally() &&
         !result->is_top() && result->is_Con() && result->bottom_type()->isa_intptr_t()) {

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -564,6 +564,34 @@ void LateInlineVirtualCallGenerator::do_late_inline() {
   CallGenerator::do_late_inline_helper();
 }
 
+bool CallGenerator::needs_cleanup(const GraphKit* kit, const CallNode* call, const Node* result) const {
+  if (kit->stopped()) {
+    return true; // Path is dead; needs cleanup
+  }
+  // If the specific field accessed by a memory operation is discovered after
+  // inlining a method incrementally, request a cleanup so that the
+  // corresponding IGVN-recorded address type is updated. This is not just an
+  // optimization: failure to update the address type can lead to a slice
+  // mismatch when parsing subsequent accesses to the address, because the
+  // memory slice corresponding to *any* field of a class K is not the same as
+  // the slice corresponding to a specific field of K. This mismatch can in its
+  // turn lead to e.g. incorrect memory graphs.
+  Compile* C = Compile::current();
+  if (C->inlining_incrementally() &&
+      !result->is_top() && result->is_Con() && result->bottom_type()->isa_intptr_t()) {
+    Node* result_proj = call->proj_out_or_null(TypeFunc::Parms);
+    if (result_proj != nullptr) {
+      for (DUIterator_Fast imax, i = result_proj->fast_outs(imax); i < imax; i++) {
+        Node* use = result_proj->fast_out(i);
+        if (use->is_AddP() && use->in(AddPNode::Offset) == result_proj) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 void CallGenerator::do_late_inline_helper() {
   assert(is_late_inline(), "only late inline allowed");
 
@@ -728,28 +756,7 @@ void CallGenerator::do_late_inline_helper() {
       C->env()->notice_inlined_method(inline_cg()->method());
     }
     C->set_inlining_progress(true);
-    C->set_do_cleanup(kit.stopped()); // path is dead; needs cleanup
-    // If the specific field accessed by a memory operation is discovered after
-    // inlining a method incrementally, request a cleanup so that the
-    // corresponding IGVN-recorded address type is updated. This is not just an
-    // optimization: failure to update the address type can lead to a slice
-    // mismatch when parsing subsequent accesses to the address, because the
-    // memory slice corresponding to *any* field of a class K is not the same as
-    // the slice corresponding to a specific field of K. This mismatch can in
-    // its turn lead to e.g. incorrect memory graphs.
-    if (C->inlining_incrementally() &&
-        !result->is_top() && result->is_Con() && result->bottom_type()->isa_intptr_t()) {
-      Node* result_proj = call->proj_out_or_null(TypeFunc::Parms);
-      if (result_proj != nullptr) {
-        for (DUIterator_Fast imax, i = result_proj->fast_outs(imax); i < imax; i++) {
-          Node* use = result_proj->fast_out(i);
-          if (use->is_AddP() && use->in(AddPNode::Offset) == result_proj) {
-            C->set_do_cleanup(true);
-            break;
-          }
-        }
-      }
-    }
+    C->set_do_cleanup(needs_cleanup(&kit, call, result));
     kit.replace_call(call, result, true, do_asserts);
   }
 }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -738,8 +738,7 @@ void CallGenerator::do_late_inline_helper() {
     // the slice corresponding to a specific field of C. This mismatch can in
     // its turn lead to e.g. incorrect memory graphs.
     if (C->inlining_incrementally() &&
-        !result->is_top() && result->is_Con() && result->bottom_type()->isa_intptr_t() &&
-        UseNewCode) {
+        !result->is_top() && result->is_Con() && result->bottom_type()->isa_intptr_t()) {
       Node* result_proj = call->proj_out_or_null(TypeFunc::Parms);
       if (result_proj != nullptr) {
         for (DUIterator_Fast imax, i = result_proj->fast_outs(imax); i < imax; i++) {

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -729,13 +729,25 @@ void CallGenerator::do_late_inline_helper() {
     }
     C->set_inlining_progress(true);
     C->set_do_cleanup(kit.stopped()); // path is dead; needs cleanup
-    Node* result_proj = call->proj_out_or_null(TypeFunc::Parms);
-    if (C->inlining_incrementally() && result_proj != nullptr && UseNewCode) {
-      for (DUIterator_Fast imax, i = result_proj->fast_outs(imax); i < imax; i++) {
-        Node* use = result_proj->fast_out(i);
-        if (use->is_AddP() && use->in(AddPNode::Offset) == result_proj) {
-          C->set_do_cleanup(true);
-          break;
+    // If the specific field accessed by a memory operation is discovered after
+    // inlining a method incrementally, request a cleanup so that the
+    // corresponding IGVN-recorded address type is updated. This is not just an
+    // optimization: failure update the address type can lead to a slice
+    // mismatch when parsing subsequent accesses to the address, because the
+    // memory slice corresponding to *any* field of a class C is not the same as
+    // the slice corresponding to a specific field of C. This mismatch can in
+    // its turn lead to e.g. incorrect memory graphs.
+    if (C->inlining_incrementally() &&
+        !result->is_top() && result->is_Con() && result->bottom_type()->isa_intptr_t() &&
+        UseNewCode) {
+      Node* result_proj = call->proj_out_or_null(TypeFunc::Parms);
+      if (result_proj != nullptr) {
+        for (DUIterator_Fast imax, i = result_proj->fast_outs(imax); i < imax; i++) {
+          Node* use = result_proj->fast_out(i);
+          if (use->is_AddP() && use->in(AddPNode::Offset) == result_proj) {
+            C->set_do_cleanup(true);
+            break;
+          }
         }
       }
     }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -729,6 +729,16 @@ void CallGenerator::do_late_inline_helper() {
     }
     C->set_inlining_progress(true);
     C->set_do_cleanup(kit.stopped()); // path is dead; needs cleanup
+    Node* result_proj = call->proj_out_or_null(TypeFunc::Parms);
+    if (C->inlining_incrementally() && result_proj != nullptr && UseNewCode) {
+      for (DUIterator_Fast imax, i = result_proj->fast_outs(imax); i < imax; i++) {
+        Node* use = result_proj->fast_out(i);
+        if (use->is_AddP() && use->in(AddPNode::Offset) == result_proj) {
+          C->set_do_cleanup(true);
+          break;
+        }
+      }
+    }
     kit.replace_call(call, result, true, do_asserts);
   }
 }

--- a/src/hotspot/share/opto/callGenerator.hpp
+++ b/src/hotspot/share/opto/callGenerator.hpp
@@ -31,6 +31,8 @@
 #include "opto/type.hpp"
 #include "runtime/deoptimization.hpp"
 
+class GraphKit;
+
 //---------------------------CallGenerator-------------------------------------
 // The subclasses of this class handle generation of ideal nodes for
 // call sites and method entry points.
@@ -42,6 +44,9 @@ class CallGenerator : public ArenaObj {
  protected:
   CallGenerator(ciMethod* method) : _method(method) {}
 
+  // Whether a round of cleanup (see Compile::inline_incrementally_cleanup()) is
+  // required after a late inlining step.
+  bool needs_cleanup(const GraphKit* kit, const CallNode* call, const Node* result) const;
   void do_late_inline_helper();
 
   virtual bool           do_late_inline_check(Compile* C, JVMState* jvms) { ShouldNotReachHere(); return false;  }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -177,7 +177,7 @@ void GraphKit::stop_and_kill_map() {
 
 //--------------------------------stopped--------------------------------------
 // Tell if _map is null, or control is top.
-bool GraphKit::stopped() {
+bool GraphKit::stopped() const {
   if (map() == nullptr)        return true;
   else if (control() == top()) return true;
   else                         return false;

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -192,7 +192,7 @@ class GraphKit : public Phase {
   void stop_and_kill_map();
 
   // Tell if _map is null, or control is top.
-  bool stopped();
+  bool stopped() const;
 
   // Tell if this method or any caller method has exception handlers.
   bool has_exception_handler();

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
@@ -79,10 +79,21 @@ public class TestLateInliningWithSliceNarrowing {
         a.f = 42;
     }
 
+    static int lateLoad(A a) {
+        return a.f;
+    }
+
     static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(A a) {
         long o = lateOffset();
         int val = UNSAFE.getInt(a, o);
         lateStore(a);
+        return val;
+    }
+
+    static int testLoadFromLateDiscoveredOffsetThenLoadFromConstOffset(A a) {
+        long o = lateOffset();
+        int val = UNSAFE.getInt(a, o);
+        lateLoad(a);
         return val;
     }
 
@@ -113,6 +124,11 @@ public class TestLateInliningWithSliceNarrowing {
             {
                 A a = new A();
                 int result = testLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(a);
+                Asserts.assertEquals(0, result);
+            }
+            {
+                A a = new A();
+                int result = testLoadFromLateDiscoveredOffsetThenLoadFromConstOffset(a);
                 Asserts.assertEquals(0, result);
             }
             {

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.inlining;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @bug 8374783
+ * @summary TBD
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:CompileOnly=${test.main.class}::test*
+                     -XX:CompileCommand=dontinline,${test.main.class}::id
+                     -XX:CompileCommand=delayinline,${test.main.class}::offset*
+                     -XX:CompileCommand=delayinline,${test.main.class}::store
+                     ${test.main.class}
+ */
+
+class A {
+    int f;
+}
+
+public class TestLateInliningWithSliceNarrowing {
+
+    private static Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final long F_OFFSET;
+
+    static {
+        try {
+            Field fField = A.class.getDeclaredField("f");
+            F_OFFSET = UNSAFE.objectFieldOffset(fField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Not inlined.
+    static A id(A a) {
+        return a;
+    }
+
+    // Inlined late.
+    static long offset() {
+        return F_OFFSET;
+    }
+
+    // Inlined late.
+    static long offsetMinusFour() {
+        return F_OFFSET - 4;
+    }
+
+    // Inlined late.
+    static long offsetDividedByTwo() {
+        return F_OFFSET / 2;
+    }
+
+    // Inlined late.
+    static void store(A a) {
+        a.f = 42;
+    }
+
+    static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(A a) {
+        long o = offset();
+        int val = UNSAFE.getInt(a, o);
+        store(a);
+        return val;
+    }
+
+    static int testLoadFromLateDiscoveredOffsetPlusFourThenStoreAtConstOffset(A a) {
+        long o = offsetMinusFour();
+        int val = UNSAFE.getInt(a, o + 4);
+        store(a);
+        return val;
+    }
+
+    static int testLoadFromLateDiscoveredOffsetTimesTwoThenStoreAtConstOffset(A a) {
+        long o = offsetDividedByTwo();
+        int val = UNSAFE.getInt(a, o * 2);
+        store(a);
+        return val;
+    }
+
+    static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffsetThenReloadFromConstOffset(A a) {
+        A a2 = id(a);
+        long o = offset();
+        int val = UNSAFE.getInt(a, o);
+        store(a);
+        return a2.f + val;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            {
+                A a = new A();
+                int result = testLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(a);
+                Asserts.assertEquals(0, result);
+            }
+            {
+                A a = new A();
+                int result = testLoadFromLateDiscoveredOffsetPlusFourThenStoreAtConstOffset(a);
+                Asserts.assertEquals(0, result);
+            }
+            {
+                A a = new A();
+                int result = testLoadFromLateDiscoveredOffsetTimesTwoThenStoreAtConstOffset(a);
+                Asserts.assertEquals(0, result);
+            }
+            {
+                A a = new A();
+                int result = testLoadFromLateDiscoveredOffsetThenStoreAtConstOffsetThenReloadFromConstOffset(a);
+                Asserts.assertEquals(42, result);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
@@ -24,7 +24,6 @@
 package compiler.inlining;
 
 import java.lang.reflect.Field;
-import java.util.Objects;
 import jdk.internal.misc.Unsafe;
 import jdk.test.lib.Asserts;
 
@@ -35,10 +34,10 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run main ${test.main.class}
- * @run main/othervm -Xbatch -XX:CompileOnly=${test.main.class}::test*
-                     -XX:CompileCommand=dontinline,${test.main.class}::id
-                     -XX:CompileCommand=delayinline,${test.main.class}::offset*
-                     -XX:CompileCommand=delayinline,${test.main.class}::store
+ * @run main/othervm -Xbatch
+                     -XX:CompileCommand=compileonly,${test.main.class}::test*
+                     -XX:CompileCommand=dontinline,${test.main.class}::notInlined*
+                     -XX:CompileCommand=delayinline,${test.main.class}::late*
                      ${test.main.class}
  */
 
@@ -60,57 +59,52 @@ public class TestLateInliningWithSliceNarrowing {
         }
     }
 
-    // Not inlined.
-    static A id(A a) {
+    static A notInlinedId(A a) {
         return a;
     }
 
-    // Inlined late.
-    static long offset() {
+    static long lateOffset() {
         return F_OFFSET;
     }
 
-    // Inlined late.
-    static long offsetMinusFour() {
+    static long lateOffsetMinusFour() {
         return F_OFFSET - 4;
     }
 
-    // Inlined late.
-    static long offsetDividedByTwo() {
+    static long lateOffsetDividedByTwo() {
         return F_OFFSET / 2;
     }
 
-    // Inlined late.
-    static void store(A a) {
+    static void lateStore(A a) {
         a.f = 42;
     }
 
     static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(A a) {
-        long o = offset();
+        long o = lateOffset();
         int val = UNSAFE.getInt(a, o);
-        store(a);
+        lateStore(a);
         return val;
     }
 
     static int testLoadFromLateDiscoveredOffsetPlusFourThenStoreAtConstOffset(A a) {
-        long o = offsetMinusFour();
+        long o = lateOffsetMinusFour();
         int val = UNSAFE.getInt(a, o + 4);
-        store(a);
+        lateStore(a);
         return val;
     }
 
     static int testLoadFromLateDiscoveredOffsetTimesTwoThenStoreAtConstOffset(A a) {
-        long o = offsetDividedByTwo();
+        long o = lateOffsetDividedByTwo();
         int val = UNSAFE.getInt(a, o * 2);
-        store(a);
+        lateStore(a);
         return val;
     }
 
     static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffsetThenReloadFromConstOffset(A a) {
-        A a2 = id(a);
-        long o = offset();
+        A a2 = notInlinedId(a);
+        long o = lateOffset();
         int val = UNSAFE.getInt(a, o);
-        store(a);
+        lateStore(a);
         return a2.f + val;
     }
 

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
@@ -53,6 +53,7 @@ public class TestLateInliningWithSliceNarrowing {
 
     private static Unsafe UNSAFE = Unsafe.getUnsafe();
     private static final long F_OFFSET;
+    private static final long INT_ARRAY_OFFSET;
 
     static {
         try {
@@ -61,6 +62,7 @@ public class TestLateInliningWithSliceNarrowing {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        INT_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(int[].class);
     }
 
     static A notInlinedId(A a) {
@@ -79,8 +81,16 @@ public class TestLateInliningWithSliceNarrowing {
         return F_OFFSET / 2;
     }
 
+    static long lateArrayOffset() {
+        return INT_ARRAY_OFFSET;
+    }
+
     static void lateStore(A a) {
         a.f = 42;
+    }
+
+    static void lateArrayStore(int[] a) {
+        a[0] = 42;
     }
 
     static int lateLoad(A a) {
@@ -162,6 +172,17 @@ public class TestLateInliningWithSliceNarrowing {
         return val;
     }
 
+    // Test a variation of the first test using an array instead of a class
+    // instance. No slice mismatch occurs because the address types for both
+    // memory accesses lead to the same slice, regardless of whether the offset
+    // is compiler-known.
+    static int testArrayLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(int[] a) {
+        long o = lateArrayOffset();
+        int val = UNSAFE.getInt(a, o);
+        lateArrayStore(a);
+        return val;
+    }
+
     public static void main(String[] args) {
         for (int i = 0; i < 10_000; i++) {
             {
@@ -192,6 +213,11 @@ public class TestLateInliningWithSliceNarrowing {
             {
                 A a = new A();
                 int result = testLoadFromLateDiscoveredBaseThenLoadFromKnownBase(a);
+                Asserts.assertEquals(0, result);
+            }
+            {
+                int[] a = new int[1];
+                int result = testArrayLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(a);
                 Asserts.assertEquals(0, result);
             }
         }

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
@@ -87,6 +87,10 @@ public class TestLateInliningWithSliceNarrowing {
         return a.f;
     }
 
+    static Object lateBase(A a) {
+        return a;
+    }
+
     // Test that when lateStore() is inlined, the IGVN-recorded type of the
     // accessed memory address (captured by an AddP) has been updated to reflect
     // the compiler-known offset discovered by inlining lateOffset(). Failure to
@@ -141,6 +145,23 @@ public class TestLateInliningWithSliceNarrowing {
         return a2.f + val;
     }
 
+    // Test a variation of the first test where the offset is compiler-known
+    // from the beginning, but the unsafe base address is only discovered by
+    // inlining lateBase(). This variation does not require a cleanup between
+    // the late inlining of lateBase() and lateLoad() for correctness: a slice
+    // mismatch cannot occur because the memory access within lateLoad() does
+    // not reuse the same address node (AddP) as the unsafe load. The unsafe
+    // load address node is not reusable by the lateLoad() access because it is
+    // obscured by casts by the time lateLoad() is late inlined. Making the
+    // address node reusable by both loads would require a cleanup round, which
+    // would prevent the mismatch from happening in the first place.
+    static int testLoadFromLateDiscoveredBaseThenLoadFromKnownBase(A a) {
+        Object obj = lateBase(a);
+        int val = UNSAFE.getInt(obj, F_OFFSET);
+        lateLoad(a);
+        return val;
+    }
+
     public static void main(String[] args) {
         for (int i = 0; i < 10_000; i++) {
             {
@@ -167,6 +188,11 @@ public class TestLateInliningWithSliceNarrowing {
                 A a = new A();
                 int result = testLoadFromLateDiscoveredOffsetThenStoreAtConstOffsetThenReloadFromConstOffset(a);
                 Asserts.assertEquals(42, result);
+            }
+            {
+                A a = new A();
+                int result = testLoadFromLateDiscoveredBaseThenLoadFromKnownBase(a);
+                Asserts.assertEquals(0, result);
             }
         }
     }

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInliningWithSliceNarrowing.java
@@ -30,7 +30,11 @@ import jdk.test.lib.Asserts;
 /**
  * @test
  * @bug 8374783
- * @summary TBD
+ * @summary Test that address type refinements after an incremental inlining
+ *          step are propagated by IGVN before the next step. Failing to
+ *          propagate such refinements could lead to slice mismatches between
+ *          field-derived and IGVN-recorded address types when parsing bytecode
+ *          in subsequent inlining steps.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run main ${test.main.class}
@@ -83,6 +87,10 @@ public class TestLateInliningWithSliceNarrowing {
         return a.f;
     }
 
+    // Test that when lateStore() is inlined, the IGVN-recorded type of the
+    // accessed memory address (captured by an AddP) has been updated to reflect
+    // the compiler-known offset discovered by inlining lateOffset(). Failure to
+    // do so leads to a slice mismatch when parsing the inlined store.
     static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffset(A a) {
         long o = lateOffset();
         int val = UNSAFE.getInt(a, o);
@@ -90,6 +98,10 @@ public class TestLateInliningWithSliceNarrowing {
         return val;
     }
 
+    // Test that when lateLoad() is inlined, the IGVN-recorded type of the
+    // accessed memory address (captured by an AddP) has been updated to reflect
+    // the compiler-known offset discovered by inlining lateOffset(). Failure to
+    // do so leads to a slice mismatch when parsing the inlined load.
     static int testLoadFromLateDiscoveredOffsetThenLoadFromConstOffset(A a) {
         long o = lateOffset();
         int val = UNSAFE.getInt(a, o);
@@ -97,6 +109,10 @@ public class TestLateInliningWithSliceNarrowing {
         return val;
     }
 
+    // Test a variation of the above where lateOffsetMinusFour() is not used
+    // directly by an AddP node. This test does not require updating the
+    // IGVN-recorded type of the accessed memory address for correctness,
+    // because lateStore() does not reuse the corresponding AddP node.
     static int testLoadFromLateDiscoveredOffsetPlusFourThenStoreAtConstOffset(A a) {
         long o = lateOffsetMinusFour();
         int val = UNSAFE.getInt(a, o + 4);
@@ -104,6 +120,8 @@ public class TestLateInliningWithSliceNarrowing {
         return val;
     }
 
+    // Test a variation of the above using a different arithmetic operation,
+    // with the same expectations.
     static int testLoadFromLateDiscoveredOffsetTimesTwoThenStoreAtConstOffset(A a) {
         long o = lateOffsetDividedByTwo();
         int val = UNSAFE.getInt(a, o * 2);
@@ -111,6 +129,10 @@ public class TestLateInliningWithSliceNarrowing {
         return val;
     }
 
+    // Test a variation of the first test where failing to update the
+    // IGVN-recorded type of the accessed memory address would result in a slice
+    // mismatch that will lead to an incorrect memory graph (the memory input of
+    // the last load would bypass the memory output of the store).
     static int testLoadFromLateDiscoveredOffsetThenStoreAtConstOffsetThenReloadFromConstOffset(A a) {
         A a2 = notInlinedId(a);
         long o = lateOffset();


### PR DESCRIPTION
This changeset forces an incremental inlining cleanup whenever an incrementally inlined call exposes an address where the offset becomes constant. This is necessary to prevent slice mismatches when parsing subsequent accesses to the address due to outdated IGVN-recorded address type information, see more details in the [JBS issue](https://bugs.openjdk.org/browse/JDK-8374783?focusedId=14886641&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14886641). If not prevented, such mismatches can lead to e.g. incorrect memory graphs, as illustrated in the included test file.

This solution is the most effective and least intrusive one among a few evaluated options, see [JBS issue](https://bugs.openjdk.org/browse/JDK-8374783?focusedId=14886641&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14886641).

#### Testing
- tier1-4, stress test
- original test (`applications/ctw/modules/jdk_jpackage.java`)
- LLM-guided fuzzing (linux-x64 only)

Thanks to @iwanowww for useful discussions and suggestions!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8374783](https://bugs.openjdk.org/browse/JDK-8374783): C2 compilation asserts with "slice of address and input slice don't match" (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31500/head:pull/31500` \
`$ git checkout pull/31500`

Update a local copy of the PR: \
`$ git checkout pull/31500` \
`$ git pull https://git.openjdk.org/jdk.git pull/31500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31500`

View PR using the GUI difftool: \
`$ git pr show -t 31500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31500.diff">https://git.openjdk.org/jdk/pull/31500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31500#issuecomment-4691983938)
</details>
