### PR TITLE
8386600: Fix comparison checks in DHasKEM

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/DHasKEM.java
+++ b/src/java.base/share/classes/sun/security/ssl/DHasKEM.java
@@ -268,17 +268,17 @@ public class DHasKEM implements KEMSpi {
 
             // RFC 8446 section 7.4.2: checks for all-zero
             // X25519/X448 shared secret.
-            if (kaAlgorithm.equals("X25519") ||
-                    kaAlgorithm.equals("X448")) {
+            if (this == X25519 || this == X448) {
                 byte[] s = secret.getEncoded();
+                byte data = 0;
                 for (byte b : s) {
-                    if (b != 0) {
-                        return secret;
-                    }
+                    data |= b;
                 }
-                // Trigger ILLEGAL_PARAMETER alert
-                throw new IllegalArgumentException(
-                        "All-zero shared secret");
+                if (data == 0) {
+                    // Trigger ILLEGAL_PARAMETER alert
+                    throw new IllegalArgumentException(
+                            "All-zero shared secret");
+                }
             }
 
             return secret;


### PR DESCRIPTION
This fixes comparison check in DHasKEM class.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386600](https://bugs.openjdk.org/browse/JDK-8386600): Fix comparison checks in DHasKEM (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31503/head:pull/31503` \
`$ git checkout pull/31503`

Update a local copy of the PR: \
`$ git checkout pull/31503` \
`$ git pull https://git.openjdk.org/jdk.git pull/31503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31503`

View PR using the GUI difftool: \
`$ git pr show -t 31503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31503.diff">https://git.openjdk.org/jdk/pull/31503.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31503#issuecomment-4692727114)
</details>
