### PR TITLE
8386601: Rename LANGUAGE_MODEL preview feature to PREVIEW_SUPPORT

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -57,6 +57,11 @@ public @interface PreviewFeature {
      */
     public Feature feature();
 
+    /**
+     * A reflective preview API may be used without causing a compilation error
+     * when preview features are disabled (JLS {@jls 1.5.1}), but still causes
+     * a preview warning.
+     */
     public boolean reflective() default false;
 
     /**
@@ -71,7 +76,14 @@ public @interface PreviewFeature {
         @JEP(number=538, title="PEM Encodings of Cryptographic Objects",
             status="Third Preview")
         PEM_API,
-        LANGUAGE_MODEL,
+        /**
+         * Indicates a preview API exists to allow access to the environment
+         * where all preview features of the current Java SE release are enabled.
+         * Such an API is usually {@link #reflective()} and never intended to
+         * become permanent.  This "feature" does not have a JEP and its APIs
+         * are not displayed in the "Preview API" page in Javadoc output.
+         */
+        PREVIEW_SUPPORT,
         /**
          * A key for testing.
          */

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitorPreview.java
@@ -51,7 +51,7 @@ import javax.annotation.processing.ProcessingEnvironment;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public abstract class AbstractAnnotationValueVisitorPreview<R, P> extends AbstractAnnotationValueVisitor14<R, P> {
 
     /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitorPreview.java
@@ -54,7 +54,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public abstract class AbstractElementVisitorPreview<R, P> extends AbstractElementVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses to call.

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitorPreview.java
@@ -54,7 +54,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public abstract class AbstractTypeVisitorPreview<R, P> extends AbstractTypeVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses to call.

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitorPreview.java
@@ -68,7 +68,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public class ElementKindVisitorPreview<R, P> extends ElementKindVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses; uses {@code null} for the

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScannerPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScannerPreview.java
@@ -82,7 +82,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public class ElementScannerPreview<R, P> extends ElementScanner14<R, P> {
     /**
      * Constructor for concrete subclasses; uses {@code null} for the

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitorPreview.java
@@ -59,7 +59,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public class SimpleAnnotationValueVisitorPreview<R, P> extends SimpleAnnotationValueVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses; uses {@code null} for the

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitorPreview.java
@@ -62,7 +62,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public class SimpleElementVisitorPreview<R, P> extends SimpleElementVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses; uses {@code null} for the

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitorPreview.java
@@ -63,7 +63,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public class SimpleTypeVisitorPreview<R, P> extends SimpleTypeVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses; uses {@code null} for the

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitorPreview.java
@@ -67,7 +67,7 @@ import static javax.lang.model.SourceVersion.*;
  * @since 23
  */
 @SupportedSourceVersion(RELEASE_28)
-@PreviewFeature(feature=PreviewFeature.Feature.LANGUAGE_MODEL, reflective=true)
+@PreviewFeature(feature=PreviewFeature.Feature.PREVIEW_SUPPORT, reflective=true)
 public class TypeKindVisitorPreview<R, P> extends TypeKindVisitor14<R, P> {
     /**
      * Constructor for concrete subclasses to call; uses {@code null}

--- a/test/langtools/jdk/javadoc/doclet/testPreview/api/preview/NoPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/api/preview/NoPreview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,6 @@ public class NoPreview {
     public static class T {}
 
     // Preview support feature without JEP should not be listed
-    @PreviewFeature(feature=Feature.LANGUAGE_MODEL)
+    @PreviewFeature(feature=Feature.PREVIEW_SUPPORT)
     public void supportMethod() {}
 }


### PR DESCRIPTION
In `PreviewFeature.Feature`, there is a `LANGUAGE_MODEL` for general support of preview features, currently used by `javax.lang` tree visitors. This is confusing as JEP 401 [incorrectly marked](https://github.com/openjdk/valhalla/pull/2533#discussion_r3391007566) a new language modifier as a `LANGUAGE_MODEL` preview feature API. This "feature" is better renamed `PREVIEW_SUPPORT` to reduce confusions.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386601](https://bugs.openjdk.org/browse/JDK-8386601): Rename LANGUAGE_MODEL preview feature to PREVIEW_SUPPORT (**Enhancement** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) Review applies to [a7d3f718](https://git.openjdk.org/jdk/pull/31504/files/a7d3f718a83b24a6c68c32e07bdb6d53aa7ef16d)
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31504/head:pull/31504` \
`$ git checkout pull/31504`

Update a local copy of the PR: \
`$ git checkout pull/31504` \
`$ git pull https://git.openjdk.org/jdk.git pull/31504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31504`

View PR using the GUI difftool: \
`$ git pr show -t 31504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31504.diff">https://git.openjdk.org/jdk/pull/31504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31504#issuecomment-4693065443)
</details>
