### PR TITLE
8386589: Permitting a preview subclass should not produce a preview note

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2525,7 +2525,7 @@ public class Utils {
                     usedInDeclaration.addAll(types2Classes(tpe.getBounds()));
                 }
                 usedInDeclaration.addAll(types2Classes(List.of(te.getSuperclass())));
-                usedInDeclaration.addAll(types2Classes(te.getPermittedSubclasses()));
+                // Intentionally allow preview permitted subclasses
                 usedInDeclaration.addAll(types2Classes(te.getRecordComponents().stream().map(Element::asType).toList())); //TODO: annotations on record components???
             }
             case CONSTRUCTOR, METHOD -> {

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      8250768 8261976 8277300 8282452 8287597 8325325 8325874 8297879
- *           8331947 8281533 8343239 8318416 8346109 8359024
+ *           8331947 8281533 8343239 8318416 8346109 8359024 8386589
  * @summary  test generated docs for items declared using preview
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -239,6 +239,42 @@ public class TestPreview extends JavadocTester {
                 </div>
                 <div class="block">Preview feature</div>
                 </div>
+                """);
+    }
+
+    // 8386589 pre-existing permanent API that is later retrofitted
+    // to permit a @PreviewFeature API should not be flagged as a preview feature
+    @Test
+    public void nonPreviewPermitsPreview(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                public sealed interface Core permits BasicChild, PreviewChild {
+                }
+                """, """
+                package p;
+                public non-sealed interface BasicChild extends Core {
+                }
+                ""","""
+                package p;
+                import jdk.internal.javac.PreviewFeature;
+                @PreviewFeature(feature = PreviewFeature.Feature.TEST)
+                public non-sealed interface PreviewChild extends Core {
+                }
+                """);
+        javadoc("-d", "out-non-preview-permits-preview",
+                "--add-exports", "java.base/jdk.internal.javac=ALL-UNNAMED",
+                "--source-path",
+                src.toString(),
+                "p");
+        checkExit(Exit.OK);
+        checkOutput("p/Core.html", false,
+                """
+                <div class="preview-comment">Programs can only use <code>Core</code> when preview features are enabled.</div>
+                """);
+        checkOutput("p/PreviewChild.html", true,
+                """
+                <div class="preview-comment">Programs can only use <code>PreviewChild</code> when preview features are enabled.</div>
                 """);
     }
 


### PR DESCRIPTION
A class or interface that permits a subclass or subinterface that is part of a preview feature marks the permitting type as preview feature and generates a preview notice for it. No preview message should be generated as the permitted preview subclass does not affect normal use of the type.

This is relevant in the context of JEP 401 where java.lang.classfile.Attribute and java.lang.classfile.ClassElement permit a new preview interface LoadableDescriptorsAttribute, but should not be marked as preview APIs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386589](https://bugs.openjdk.org/browse/JDK-8386589): Permitting a preview subclass should not produce a preview note (**Bug** - P3)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31505/head:pull/31505` \
`$ git checkout pull/31505`

Update a local copy of the PR: \
`$ git checkout pull/31505` \
`$ git pull https://git.openjdk.org/jdk.git pull/31505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31505`

View PR using the GUI difftool: \
`$ git pr show -t 31505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31505.diff">https://git.openjdk.org/jdk/pull/31505.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31505#issuecomment-4694180692)
</details>
