### PR TITLE
8386287: GenShen: assert(starts_object(card_index)) failed: Can't get last start because no object starts here

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -144,7 +144,7 @@ void ShenandoahGenerationalFullGC::account_for_region(ShenandoahHeapRegion* r, s
 void ShenandoahGenerationalFullGC::maybe_coalesce_and_fill_region(ShenandoahHeapRegion* r) {
   if (r->is_pinned() && r->is_old() && r->is_active() && !r->is_humongous()) {
     r->begin_preemptible_coalesce_and_fill();
-    r->oop_coalesce_and_fill(false);
+    r->oop_coalesce_and_fill(/* cancellable = */ false, /* do_card_table_updates = */ false);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -496,7 +496,7 @@ bool ShenandoahHeapRegion::oop_coalesce_and_fill(bool cancellable, bool do_card_
         // jump straight to a full GC. If this region is pinned when the full GC cycle starts, it will
         // not be compacted. Therefore, if the region is old, we must fill in any unmarked objects. However,
         // promoted objects will not have been registered yet, so we cannot use the card table here.
-        assert(ShenandoahHeap::heap()->is_full_gc_in_progress(), "Can only skip card table updates during a full GC");
+        assert(heap->is_full_gc_in_progress(), "Can only skip card table updates during a full GC");
       }
 
       obj_addr = next_marked_obj;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -452,7 +452,7 @@ void ShenandoahHeapRegion::print_on(outputStream* st) const {
 }
 
 // oop_iterate without closure, return true if completed without cancellation
-bool ShenandoahHeapRegion::oop_coalesce_and_fill(bool cancellable) {
+bool ShenandoahHeapRegion::oop_coalesce_and_fill(bool cancellable, bool do_card_table_updates) {
 
   assert(!is_humongous(), "No need to fill or coalesce humongous regions");
   if (!is_active()) {
@@ -489,7 +489,16 @@ bool ShenandoahHeapRegion::oop_coalesce_and_fill(bool cancellable) {
       size_t fill_size = next_marked_obj - obj_addr;
       assert(fill_size >= ShenandoahHeap::min_fill_size(), "previously allocated object known to be larger than min_size");
       ShenandoahHeap::fill_with_object(obj_addr, fill_size);
-      heap->old_generation()->card_scan()->coalesce_objects(obj_addr, fill_size);
+      if (do_card_table_updates) {
+        heap->old_generation()->card_scan()->coalesce_objects(obj_addr, fill_size);
+      } else {
+        // A humongous object allocation failure during evacuation will skip the degenerated cycle and
+        // jump straight to a full GC. If this region is pinned when the full GC cycle starts, it will
+        // not be compacted. Therefore, if the region is old, we must fill in any unmarked objects. However,
+        // promoted objects will not have been registered yet, so we cannot use the card table here.
+        assert(ShenandoahHeap::heap()->is_full_gc_in_progress(), "Can only skip card table updates during a full GC");
+      }
+
       obj_addr = next_marked_obj;
     }
     if (cancellable && heap->cancelled_gc()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -447,7 +447,7 @@ public:
   // This is used by old-gen GC following concurrent marking to make old-gen HeapRegions parsable. Old regions must be
   // parsable because the mark bitmap is not reliable during the concurrent old mark.
   // Return true iff region is completely coalesced and filled.  Returns false if cancelled before task is complete.
-  bool oop_coalesce_and_fill(bool cancellable);
+  bool oop_coalesce_and_fill(bool cancellable, bool do_card_table_updates = true);
 
   // Invoke closure on every reference contained within the humongous object that spans this humongous
   // region if the reference is contained within a DIRTY card and the reference is no more than words following

--- a/src/hotspot/share/gc/shenandoah/shenandoahPLAB.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPLAB.cpp
@@ -191,10 +191,12 @@ void ShenandoahPLAB::retire() {
     log_debug(gc, plab)("Retire PLAB, unexpend unpromoted: %zu", not_promoted * HeapWordSize);
     _heap->old_generation()->unexpend_promoted(not_promoted);
   }
-  const size_t original_waste = _plab->waste();
-  HeapWord* const top = _plab->top();
 
   // plab->retire() overwrites unused memory between plab->top() and plab->hard_end() with a dummy object to make memory parsable.
-  // It adds the size of this unused memory, in words, to plab->waste().
+  // We do _not_ need to register this remnant object with the card table because all paths where a PLAB object would
+  // be created are covered by a subsequent phase in the cycle. For the concurrent and degenerated cycles, all PLABs
+  // are retired in preparation for update-references. All objects in these PLABs will be registered by update-card-tables.
+  // For a full GC, the entire remembered set will be rebuilt in the final phase. Note also that an empty TLAB will _not_
+  // create a filler object when it is retired. 
   _plab->retire();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPLAB.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPLAB.cpp
@@ -28,8 +28,6 @@
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahPLAB.hpp"
 #include "logging/log.hpp"
-#include "runtime/globals.hpp"
-#include "runtime/javaThread.hpp"
 #include "utilities/copy.hpp"
 
 ShenandoahPLAB::ShenandoahPLAB() :
@@ -46,9 +44,7 @@ ShenandoahPLAB::ShenandoahPLAB() :
 }
 
 ShenandoahPLAB::~ShenandoahPLAB() {
-  if (_plab != nullptr) {
-    delete _plab;
-  }
+  delete _plab;
 }
 
 void ShenandoahPLAB::subtract_from_promoted(size_t increment) {
@@ -119,7 +115,7 @@ HeapWord* ShenandoahPLAB::allocate_slow(size_t size, bool is_promotion) {
   }
 
   if (_plab->words_remaining() < plab_min_size) {
-    // Retire current PLAB. This takes care of any PLAB book-keeping.
+    // Retire current PLAB. This takes care of any PLAB bookkeeping.
     retire();
 
     size_t actual_size = 0;
@@ -197,6 +193,6 @@ void ShenandoahPLAB::retire() {
   // be created are covered by a subsequent phase in the cycle. For the concurrent and degenerated cycles, all PLABs
   // are retired in preparation for update-references. All objects in these PLABs will be registered by update-card-tables.
   // For a full GC, the entire remembered set will be rebuilt in the final phase. Note also that an empty TLAB will _not_
-  // create a filler object when it is retired. 
+  // create a filler object when it is retired.
   _plab->retire();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -388,7 +388,7 @@ public:
      _used(0), _committed(0), _garbage(0), _regions(0), _humongous_waste(0), _trashed_regions(0), _trashed_used(0)
   {
     _region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
-    // Retired regions are not necessarily filled, thouugh their remnant memory is considered used.
+    // Retired regions are not necessarily filled, though their remnant memory is considered used.
     _min_free_size = PLAB::min_size() * HeapWordSize;
   };
 


### PR DESCRIPTION
This was a somewhat exotic bug. After [JDK-8376839](https://bugs.openjdk.org/browse/JDK-8376839), Shenandoah registers the starts for all promoted objects in a separate phase after evacuation completes and all PLABs are retired. The sequence of events in this assertion failure were as follows:
1. evacuation is running
2. a mutator fails to allocate a humongous object
3. evacuation is cancelled
4. because it was a humongous allocation failure, Shenandoah runs a _full_ gc instead of a degenerated cycle
5. an old region holding recently evacuated objects is pinned when the full gc starts
6. the pinned region will not be compacted and will contain unmarked (dead) objects
7. during update refs, the full gc tries to coalesce and fill these dead objects
8. the coalesce and fill for the region also tries to update the card table object registrations
9. this assertion fails because none of the promoted objects have been registered yet

At the end of a full GC, all of the regions are scanned and the remembered set is completely rebuilt, so step `7` above was unnecessary. In this PR, we simply skip it. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386287](https://bugs.openjdk.org/browse/JDK-8386287): GenShen: assert(starts_object(card_index)) failed: Can't get last start because no object starts here (**Bug** - P4)(⚠️ The fixVersion in this issue is [27-pool, 28] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author) Review applies to [c0fdc948](https://git.openjdk.org/jdk/pull/31508/files/c0fdc9481f247a895d0bcaa803e4f85c5e8f2aa2)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31508/head:pull/31508` \
`$ git checkout pull/31508`

Update a local copy of the PR: \
`$ git checkout pull/31508` \
`$ git pull https://git.openjdk.org/jdk.git pull/31508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31508`

View PR using the GUI difftool: \
`$ git pr show -t 31508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31508.diff">https://git.openjdk.org/jdk/pull/31508.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31508#issuecomment-4696573228)
</details>
