### PR TITLE
8386466: DESedeKeySpec.isParityAdjusted spec permits 8-byte key but RI throws InvalidKeyException

### DIFF
--- a/src/java.base/share/classes/javax/crypto/spec/DESedeKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/DESedeKeySpec.java
@@ -117,7 +117,7 @@ public class DESedeKeySpec implements java.security.spec.KeySpec {
      *
      * @exception InvalidKeyException if the given key material is
      * <code>null</code>, or starting at <code>offset</code> inclusive, is
-     * shorter than 8 bytes.
+     * shorter than 24 bytes.
      * @exception ArrayIndexOutOfBoundsException if <code>offset</code> is
      * negative.
      */


### PR DESCRIPTION
Fixes cut-and-paste error introduced in JDK-8379375.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8386788](https://bugs.openjdk.org/browse/JDK-8386788) to be approved

### Issues
 * [JDK-8386466](https://bugs.openjdk.org/browse/JDK-8386466): DESedeKeySpec.isParityAdjusted spec permits 8-byte key but RI throws InvalidKeyException (**Bug** - P2)
 * [JDK-8386788](https://bugs.openjdk.org/browse/JDK-8386788): DESedeKeySpec.isParityAdjusted spec permits 8-byte key but RI throws InvalidKeyException (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31509/head:pull/31509` \
`$ git checkout pull/31509`

Update a local copy of the PR: \
`$ git checkout pull/31509` \
`$ git pull https://git.openjdk.org/jdk.git pull/31509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31509`

View PR using the GUI difftool: \
`$ git pr show -t 31509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31509.diff">https://git.openjdk.org/jdk/pull/31509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31509#issuecomment-4697313657)
</details>
