### PR TITLE
8386625: Devkit could not be built on glibc 2.43+

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -253,6 +253,7 @@ $(BUILDDIR)/$(BINUTILS_VER)/Makefile: $(BINUTILS_CFG)
 	      $(LINKER_CONFIG_ENABLE_GOLD) \
 	      --with-sysroot=$(SYSROOT) \
 	      --disable-nls \
+	      --disable-gprofng \
 	      --program-prefix=$(TARGET)- \
 	      --enable-threads \
 	      --enable-plugins \


### PR DESCRIPTION
I saw following error when I tried to build Linux x86_64 devkit on glibc 2.43 system (Fedora 44):

```
/usr/src/jdk/build/devkit/src/binutils-2.43/gprofng/libcollector/iolib.c: In function 'is_not_the_log_
file':
/usr/src/jdk/build/devkit/src/binutils-2.43/gprofng/libcollector/iolib.c:898:18: error: expected ident
ifier before '_Generic'
  898 | if (CALL_UTIL (strstr)(fname, SP_LOG_FILE) == NULL)
      | ^~~~~~
/usr/src/jdk/build/devkit/src/binutils-2.43/gprofng/libcollector/iolib.c:898:7: note: in expansion of
macro 'CALL_UTIL'
  898 | if (CALL_UTIL (strstr)(fname, SP_LOG_FILE) == NULL)
      | ^~~~~~~~~
  GEN doc/strings.1
mv -f .deps/libgp_collector_la-gethrtime.Tpo .deps/libgp_collector_la-gethrtime.Plo
make[7]: *** [Makefile:645: libgp_collector_la-iolib.lo] Error 1
```

According to release notes of glibc 2.43, `_Generic` macro has been introduced as a part of C23, and it might break some packages [1]. It is binutils in devkit.

It is not a bug in OpenJDK and devkit, but it is better if we can avoid the problem with some options. The problem is in gprofng, so we can avoid the problem if we can add `--disable-gprofng` in configure options of binutils. gprofng is a profiler, so it is not required for devkit.


Note that we cannot build Linux x86_64 devkit on Fedora 44 (glibc 2.43 + gcc 16.1) with this change only. We also need to add `-std=gnu17`. I exclude it from this change (so far) because we can add it via `CFLAGS` environment variable and I'm not sure how it affects in older C compilers.

[1] https://sourceware.org/glibc/wiki/Release/2.43#C23_Const-Preserving_Standard_Library_Macros_May_Break_Some_Packages

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386625](https://bugs.openjdk.org/browse/JDK-8386625): Devkit could not be built on glibc 2.43+ (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31511/head:pull/31511` \
`$ git checkout pull/31511`

Update a local copy of the PR: \
`$ git checkout pull/31511` \
`$ git pull https://git.openjdk.org/jdk.git pull/31511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31511`

View PR using the GUI difftool: \
`$ git pr show -t 31511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31511.diff">https://git.openjdk.org/jdk/pull/31511.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31511#issuecomment-4703618740)
</details>
