### PR TITLE
8386637: PPC64: Implement Thread.onSpinWait() intrinsic and SpinPause() using SMT priority hints

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2717,7 +2717,13 @@ void LIR_Assembler::membar_storeload() {
 }
 
 void LIR_Assembler::on_spin_wait() {
-  Unimplemented();
+  // SMT priority hint: drop to low for the spin, then restore to medium so
+  // subsequent code is not penalised.
+  // Yield (or 27,27,27) is not used because it was never implemented on Power CPUs, see JDK-8201218.
+  __ block_comment("spin_wait {");
+  __ smt_prio_low();
+  __ smt_prio_medium();
+  __ block_comment("}");
 }
 
 void LIR_Assembler::leal(LIR_Opr addr_opr, LIR_Opr dest, LIR_PatchCode patch_code, CodeEmitInfo* info) {

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2138,6 +2138,9 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_CacheWBPreSync:
     case Op_CacheWBPostSync:
       return VM_Version::supports_data_cache_line_flush();
+
+    case Op_OnSpinWait:
+      return VM_Version::supports_on_spin_wait();
   }
 
   return true; // Per default match rules are supported.
@@ -6924,6 +6927,21 @@ instruct membar_CPUOrder() %{
   format %{ " -- \t// MEMBAR-CPUOrder - empty: PPC64 processors are self-consistent." %}
   size(0);
   ins_encode( /*empty*/ );
+  ins_pipe(pipe_class_default);
+%}
+
+instruct onspinwait() %{
+  match(OnSpinWait);
+  ins_cost(DEFAULT_COST);
+
+  format %{ "OnSpinWait (smt_prio_low ; smt_prio_medium)" %}
+  size(8);
+  ins_encode %{
+    __ block_comment("spin_wait {");
+    __ smt_prio_low();
+    __ smt_prio_medium();
+    __ block_comment("}");
+  %}
   ins_pipe(pipe_class_default);
 %}
 

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -67,6 +67,8 @@ public:
 
   static bool supports_float16() { return PowerArchitecturePPC64 >= 9; }
 
+  static bool supports_on_spin_wait() { return true; }
+
   static bool is_determine_features_test_running() { return _is_determine_features_test_running; }
   // CPU instruction support
   static bool has_mfdscr() { return (_features & mfdscr_m) != 0; } // Power8, but may be unavailable (QEMU)

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2026 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -509,7 +509,13 @@ void os::print_register_info(outputStream *st, const void *context, int& continu
 
 extern "C" {
   int SpinPause() {
-    return 0;
+    // Setting prio low, then prio medium results in a pseudo yield.
+    // Yield (or 27,27,27) was never implemented on PPC.
+    //   or 1,1,1 = smt_prio_low
+    //   or 2,2,2 = smt_prio_medium
+    asm volatile ("or 1,1,1\n\t"
+                  "or 2,2,2" : : : "memory");
+    return 1;
   }
 }
 

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java
@@ -145,10 +145,11 @@ public class TestOnSpinWaitPPC64 {
             }
             if (isDisassembled) {
                 // hsdis output: look for `or r1,r1,r1` and `or r2,r2,r2`.
+                // Also the mnemonic mr rx,rx needs to be matched.
                 String norm = line.replaceAll("\\s+", " ");
-                if (norm.contains("or r1,r1,r1"))
+                if (norm.contains("or r1,r1,r1") || norm.contains("mr r1,r1"))
                     sawLow = true;
-                if (norm.contains("or r2,r2,r2"))
+                if (norm.contains("or r2,r2,r2") || norm.contains("mr r2,r2"))
                     sawMed = true;
             } else {
                 // without hsdis output: raw 4-byte instruction words.

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * @test TestOnSpinWaitPPC64
+ * @summary Checks that java.lang.Thread.onSpinWait is intrinsified on PPC64
+ *          and emits the SMT priority-low / priority-medium nop pair.
+ * @library /test/lib
+ *
+ * @requires vm.flagless
+ * @requires os.arch=="ppc64" | os.arch=="ppc64le"
+ * @requires vm.debug
+ *
+ * @run driver compiler.onSpinWait.TestOnSpinWaitPPC64 c2
+ * @run driver compiler.onSpinWait.TestOnSpinWaitPPC64 c1
+ */
+
+package compiler.onSpinWait;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestOnSpinWaitPPC64 {
+
+    public static void main(String[] args) throws Exception {
+        String compiler = args[0];
+        ArrayList<String> command = new ArrayList<String>();
+        command.add("-XX:+IgnoreUnrecognizedVMOptions");
+        command.add("-showversion");
+        command.add("-XX:-BackgroundCompilation");
+        command.add("-XX:+UnlockDiagnosticVMOptions");
+        command.add("-XX:+PrintCompilation");
+        command.add("-XX:+PrintInlining");
+        if (compiler.equals("c2")) {
+            command.add("-XX:-TieredCompilation");
+        } else if (compiler.equals("c1")) {
+            command.add("-XX:+TieredCompilation");
+            command.add("-XX:TieredStopAtLevel=1");
+        } else {
+            throw new RuntimeException("Unknown compiler: " + compiler);
+        }
+        command.add("-Xbatch");
+        command.add("-XX:CompileCommand=compileonly," + Launcher.class.getName() + "::test");
+        command.add("-XX:CompileCommand=print," + Launcher.class.getName() + "::test");
+        command.add(Launcher.class.getName());
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        System.out.println(analyzer.getOutput());
+
+        checkOutput(analyzer);
+    }
+
+    // Hex encoding of the SMT priority-hint instructions emitted by the
+    // PPC `Thread.onSpinWait()` intrinsic.
+    // X-forms used:
+    // or 1,1,1 -> 0x7C21_0B78 (smt_prio_low)
+    // or 2,2,2 -> 0x7C42_1378 (smt_prio_medium)
+    private static String getSpinWaitInstructionHexLE(String name) {
+        if ("smt_prio_low".equals(name))
+            return "780b217c";
+        if ("smt_prio_medium".equals(name))
+            return "7813427c";
+        throw new RuntimeException("Unknown spin wait instruction: " + name);
+    }
+
+    private static String getSpinWaitInstructionHexBE(String name) {
+        if ("smt_prio_low".equals(name))
+            return "7c210b78";
+        if ("smt_prio_medium".equals(name))
+            return "7c421378";
+        throw new RuntimeException("Unknown spin wait instruction: " + name);
+    }
+
+    private static boolean lineContainsInstruction(String compact, String name) {
+        return compact.contains(getSpinWaitInstructionHexLE(name)) ||
+                compact.contains(getSpinWaitInstructionHexBE(name));
+    }
+
+    // The expected output for the spin wait body if the hsdis library is available:
+    //
+    // ;; spin_wait {
+    // 0x...: or r1,r1,r1
+    // 0x...: or r2,r2,r2
+    // ;; }
+    //
+    // When hsdis is absent the disassembler dumps raw bytes which have to matched.
+    private static void checkOutput(OutputAnalyzer output) {
+        Iterator<String> iter = output.asLines().listIterator();
+
+        // 1. Check whether printed instructions are disassembled.
+        boolean isDisassembled = false;
+        while (iter.hasNext()) {
+            String line = iter.next();
+            if (line.contains("[Disassembly]")) {
+                isDisassembled = true;
+                break;
+            }
+            if (line.contains("[MachCode]")) {
+                break;
+            }
+        }
+
+        // 2. Look for the spin_wait block comment.
+        boolean foundHead = false;
+        while (iter.hasNext()) {
+            String line = iter.next().trim();
+            if (line.contains(";; spin_wait {")) {
+                foundHead = true;
+                break;
+            }
+        }
+        if (!foundHead) {
+            throw new RuntimeException("spin_wait block comment not found");
+        }
+
+        // 3. Expect prio low and prio med instructions inside the block.
+        boolean sawLow = false, sawMed = false;
+        while (iter.hasNext()) {
+            String line = iter.next().trim();
+            if (line.startsWith(";; }")) {
+                break;
+            }
+            if (isDisassembled) {
+                // hsdis output: look for `or r1,r1,r1` and `or r2,r2,r2`.
+                String norm = line.replaceAll("\\s+", " ");
+                if (norm.contains("or r1,r1,r1"))
+                    sawLow = true;
+                if (norm.contains("or r2,r2,r2"))
+                    sawMed = true;
+            } else {
+                // without hsdis output: raw 4-byte instruction words.
+                String compact = line.replaceAll("\\s", "").toLowerCase();
+                if (lineContainsInstruction(compact, "smt_prio_low"))
+                    sawLow = true;
+                if (lineContainsInstruction(compact, "smt_prio_medium"))
+                    sawMed = true;
+            }
+        }
+
+        if (!sawLow) {
+            throw new RuntimeException("Did not find smt_prio_low (or r1,r1,r1) inside spin_wait block");
+        }
+        if (!sawMed) {
+            throw new RuntimeException("Did not find smt_prio_medium (or r2,r2,r2) inside spin_wait block");
+        }
+    }
+
+    static class Launcher {
+        public static void main(final String[] args) throws Exception {
+            for (int i = 0; i < 20_000; i++) {
+                test();
+            }
+        }
+
+        static void test() {
+            java.lang.Thread.onSpinWait();
+        }
+    }
+}


### PR DESCRIPTION
Benchmarking with ThreadOnSpinWaitProducerConsumer.java on Power10 with SMT8
have shown the following results:

Pinning the HW threads to the same core via `taskset -c 0,2`:
intrinsic disabled: 1490.2 us/op
intrinsic enabled:  340.3 us/op
=> 4.4x performance

Pinning the HW threads to different cores via `taskset -c 0,8`:
intrinsic disabled: 1047.8 µs/op
intrinsic enabled: 804.4 µs/op
=> 1.3x performance

Single hardware thread (taskset -c 0):
intrinsic disabled: 1614.9 µs/op
intrinsic enabled: 1863.3 µs/op
=> 0.87x performance (slight regression)


The slight regression on 1 HW thread seems negligible since that scenario is highly unlikely on modern processors.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386637](https://bugs.openjdk.org/browse/JDK-8386637): PPC64: Implement Thread.onSpinWait() intrinsic and SpinPause() using SMT priority hints (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31513/head:pull/31513` \
`$ git checkout pull/31513`

Update a local copy of the PR: \
`$ git checkout pull/31513` \
`$ git pull https://git.openjdk.org/jdk.git pull/31513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31513`

View PR using the GUI difftool: \
`$ git pr show -t 31513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31513.diff">https://git.openjdk.org/jdk/pull/31513.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31513#issuecomment-4706605429)
</details>
