### PR TITLE
8386654: Test tools/javac/SystemFilesClosed.java fails on systems without lsof

### DIFF
--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -31,13 +31,15 @@
  */
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
@@ -56,14 +58,8 @@ public class SystemFilesClosed {
     @Test
     void testSystemFilesClosed() throws Exception {
         // Probe lsof availability before doing the jlink/compile work
-        try {
-            Process process = new ProcessBuilder("lsof", "-v")
-                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-                    .redirectError(ProcessBuilder.Redirect.DISCARD)
-                    .start();
-            process.waitFor();
-        } catch (IOException ex) {
-            Assumptions.abort("lsof is not available on this system");
+        if (!lsofCommand().isPresent()) {
+            Assumptions.abort("lsof command is not available on this system");
         }
 
         String targetSystem = base.toString();
@@ -96,7 +92,8 @@ public class SystemFilesClosed {
         }
 
         Process process = new ProcessBuilder()
-                .command("lsof", "-p", String.valueOf(ProcessHandle.current().pid()))
+                .command(lsofCommand().orElseThrow(() -> new RuntimeException("lsof command is not available on this system")),
+                        "-p", String.valueOf(ProcessHandle.current().pid()))
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .start();
@@ -115,5 +112,18 @@ public class SystemFilesClosed {
                     .resolve(info.getTestMethod()
                                  .orElseThrow()
                                  .getName());
+    }
+
+    static Optional<String> lsofCommandCache = Arrays.stream(new String[] {
+            "/usr/bin/lsof",
+            "/usr/sbin/lsof",
+            "/bin/lsof",
+            "/sbin/lsof",
+            "/usr/local/bin/lsof"})
+        .filter(args -> new File(args).exists())
+        .findFirst();
+
+    static Optional<String> lsofCommand() {
+        return lsofCommandCache;
     }
 }

--- a/test/langtools/tools/javac/SystemFilesClosed.java
+++ b/test/langtools/tools/javac/SystemFilesClosed.java
@@ -33,6 +33,7 @@
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,6 +44,7 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -53,6 +55,17 @@ public class SystemFilesClosed {
 
     @Test
     void testSystemFilesClosed() throws Exception {
+        // Probe lsof availability before doing the jlink/compile work
+        try {
+            Process process = new ProcessBuilder("lsof", "-v")
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+            process.waitFor();
+        } catch (IOException ex) {
+            Assumptions.abort("lsof is not available on this system");
+        }
+
         String targetSystem = base.toString();
         int ret = java.util.spi.ToolProvider.findFirst("jlink")
                 .orElseThrow()


### PR DESCRIPTION
When run on systems without `lsof`, `tools/javac/SystemFilesClosed.java` fails with the following exception:
```
java.io.IOException: Cannot run program "lsof": Exec failed, error: 2 (No such file or directory)
at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1118)
at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1052)
at SystemFilesClosed.testSystemFilesClosed(SystemFilesClosed.java:89)
...
```
The proposal is to probe `lsof` availability at the beginning of the test, before doing the jlink/compile work.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386654](https://bugs.openjdk.org/browse/JDK-8386654): Test tools/javac/SystemFilesClosed.java fails on systems without lsof (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31514/head:pull/31514` \
`$ git checkout pull/31514`

Update a local copy of the PR: \
`$ git checkout pull/31514` \
`$ git pull https://git.openjdk.org/jdk.git pull/31514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31514`

View PR using the GUI difftool: \
`$ git pr show -t 31514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31514.diff">https://git.openjdk.org/jdk/pull/31514.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31514#issuecomment-4707212824)
</details>
