### PR TITLE
8386659: PPC: cleanup dtrace leftovers part 2

### DIFF
--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -760,22 +760,9 @@ OopMapSet* Runtime1::generate_code_for(StubId id, StubAssembler* sasm) {
       break;
 
     case StubId::c1_dtrace_object_alloc_id:
-      { // O0: object
+      {
         __ unimplemented("stub dtrace_object_alloc_id");
         __ set_info("dtrace_object_alloc", dont_gc_arguments);
-//        // We can't gc here so skip the oopmap but make sure that all
-//        // the live registers get saved.
-//        save_live_registers(sasm);
-//
-//        __ save_thread(L7_thread_cache);
-//        __ call(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)),
-//                relocInfo::runtime_call_type);
-//        __ delayed()->mov(I0, O0);
-//        __ restore_thread(L7_thread_cache);
-//
-//        restore_live_registers(sasm);
-//        __ ret();
-//        __ delayed()->restore();
       }
       break;
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2591,10 +2591,6 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
     __ bind(done);
   }
 
-# if 0
-  // DTrace method exit
-# endif
-
   // Clear "last Java frame" SP and PC.
   // --------------------------------------------------------------------------
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2320,10 +2320,6 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   // Make sure that thread is non-volatile; it crosses a bunch of VM calls below.
   assert(R16_thread->is_nonvolatile(), "thread must be in non-volatile register");
 
-# if 0
-  // DTrace method entry
-# endif
-
   // Lock a synchronized method.
   // --------------------------------------------------------------------------
 


### PR DESCRIPTION
Dtrace is disabled on all ppc builds. This cleans up some more leftovers in the PPC specific code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386659](https://bugs.openjdk.org/browse/JDK-8386659): PPC: cleanup dtrace leftovers part 2 (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31515/head:pull/31515` \
`$ git checkout pull/31515`

Update a local copy of the PR: \
`$ git checkout pull/31515` \
`$ git pull https://git.openjdk.org/jdk.git pull/31515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31515`

View PR using the GUI difftool: \
`$ git pr show -t 31515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31515.diff">https://git.openjdk.org/jdk/pull/31515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31515#issuecomment-4708078701)
</details>
