### PR TITLE
8386685: CDS load on Windows/ARM64 using base address set to 0x5_0000_0000 causes a JVM crash

### DIFF
--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1990,10 +1990,9 @@ char* AOTMetaspace::reserve_address_space_for_archives(FileMapInfo* static_mapin
       archive_space_size + gap_size + class_space_size;
 
   // Validate that class space base address plus shift can be decoded by aarch64, when restored.
-  const int precomputed_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
-  assert(CompressedKlassPointers::check_klass_decode_mode(base_address, precomputed_shift, total_range_size),
-           "Cannot use SharedBaseAddress: " PTR_FORMAT " with precomputed shift %d.",
-           p2i(base_address), precomputed_shift);
+  assert(shared_base_valid((char*)base_address, total_range_size),
+      "Cannot use SharedBaseAddress " PTR_FORMAT " with precomputed shift %d.",
+      p2i(base_address), ArchiveBuilder::precomputed_narrow_klass_shift());
 
   assert(total_range_size > ccs_begin_offset, "must be");
   if (use_windows_memory_mapping() && use_archive_base_addr) {

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1985,17 +1985,22 @@ char* AOTMetaspace::reserve_address_space_for_archives(FileMapInfo* static_mapin
   const size_t total_range_size =
       archive_space_size + gap_size + class_space_size;
 
-  // Test that class space base address plus shift can be decoded by aarch64, when restored.
-  const int precomputed_narrow_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
-  if (!CompressedKlassPointers::check_klass_decode_mode(base_address, precomputed_narrow_klass_shift,
-                                                        total_range_size)) {
-    aot_log_info(aot)("CDS initialization: Cannot use SharedBaseAddress " PTR_FORMAT
-                  " with precomputed shift %d, will try an alternative address.",
-                  p2i(base_address), precomputed_narrow_klass_shift);
-    // The requested base cannot be used with the archive's precomputed Klass
-    // encoding.  Fail this attempt and let the caller retry at an alternative
-    // address.
-    return nullptr;
+  if (use_archive_base_addr) {
+    const int precomputed_narrow_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
+    if (!CompressedKlassPointers::check_klass_decode_mode(base_address, precomputed_narrow_klass_shift,
+                                                            total_range_size)) {
+      aot_log_info(aot)("CDS initialization: Cannot use SharedBaseAddress " PTR_FORMAT
+                    " with precomputed shift %d, will try an alternative address.",
+                    p2i(base_address), precomputed_narrow_klass_shift);
+      // The requested base cannot be used with the archive's precomputed Klass
+      // encoding.  Fail this attempt and let the caller retry at an alternative
+      // address.
+      return nullptr;
+    }
+  } else {
+    precond(base_address == nullptr);
+    // We will reserve an OS-picked address, which is guaranteed to return an address compatible
+    // with the the archive's precomputed Klass encoding.
   }
 
   assert(total_range_size > ccs_begin_offset, "must be");

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -164,7 +164,7 @@ size_t AOTMetaspace::protection_zone_size() {
   return os::cds_core_region_alignment();
 }
 
-static bool shared_base_valid(char* shared_base) {
+static bool shared_base_valid(char* shared_base, size_t cds_max) {
   // We check user input for SharedBaseAddress at dump time.
 
   // At CDS runtime, "shared_base" will be the (attempted) mapping start. It will also
@@ -175,7 +175,11 @@ static bool shared_base_valid(char* shared_base) {
   // On AARCH64, The "shared_base" may not be later usable as encoding base, depending on the
   // total size of the reserved area and the precomputed_narrow_klass_shift. This is checked
   // before reserving memory.  Here we weed out values already known to be invalid later.
-  return AARCH64_ONLY(is_aligned(shared_base, 4 * G)) NOT_AARCH64(true);
+  // Since the exact reserved size is not yet known, we use the largest possible range.
+  address addr = (address)shared_base;
+  const int shift = ArchiveBuilder::precomputed_narrow_klass_shift();
+  return CompressedKlassPointers::check_klass_decode_mode(addr, shift, cds_max)
+      && AARCH64_ONLY(is_aligned(shared_base, 4 * G)) NOT_AARCH64(true);
 }
 
 class DumpClassListCLDClosure : public CLDClosure {
@@ -273,7 +277,7 @@ static char* compute_shared_base(size_t cds_max) {
     err = "too high";
   } else if (shared_base_too_high(specified_base, aligned_base, cds_max)) {
     err = "too high";
-  } else if (!shared_base_valid(aligned_base)) {
+  } else if (!shared_base_valid(aligned_base, cds_max)) {
     err = "invalid for this platform";
   } else {
     return aligned_base;
@@ -291,7 +295,7 @@ static char* compute_shared_base(size_t cds_max) {
 
   // Make sure the default value of SharedBaseAddress specified in globals.hpp is sane.
   assert(!shared_base_too_high(specified_base, aligned_base, cds_max), "Sanity");
-  assert(shared_base_valid(aligned_base), "Sanity");
+  assert(shared_base_valid(aligned_base, cds_max), "Sanity");
   return aligned_base;
 }
 
@@ -1985,23 +1989,11 @@ char* AOTMetaspace::reserve_address_space_for_archives(FileMapInfo* static_mapin
   const size_t total_range_size =
       archive_space_size + gap_size + class_space_size;
 
-  if (use_archive_base_addr) {
-    const int precomputed_narrow_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
-    if (!CompressedKlassPointers::check_klass_decode_mode(base_address, precomputed_narrow_klass_shift,
-                                                            total_range_size)) {
-      aot_log_info(aot)("CDS initialization: Cannot use SharedBaseAddress " PTR_FORMAT
-                    " with precomputed shift %d, will try an alternative address.",
-                    p2i(base_address), precomputed_narrow_klass_shift);
-      // The requested base cannot be used with the archive's precomputed Klass
-      // encoding.  Fail this attempt and let the caller retry at an alternative
-      // address.
-      return nullptr;
-    }
-  } else {
-    precond(base_address == nullptr);
-    // We will reserve an OS-picked address, which is guaranteed to return an address compatible
-    // with the the archive's precomputed Klass encoding.
-  }
+  // Validate that class space base address plus shift can be decoded by aarch64, when restored.
+  const int precomputed_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
+  assert(CompressedKlassPointers::check_klass_decode_mode(base_address, precomputed_shift, total_range_size),
+           "Cannot use SharedBaseAddress: " PTR_FORMAT " with precomputed shift %d.",
+           p2i(base_address), precomputed_shift);
 
   assert(total_range_size > ccs_begin_offset, "must be");
   if (use_windows_memory_mapping() && use_archive_base_addr) {

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1990,7 +1990,9 @@ char* AOTMetaspace::reserve_address_space_for_archives(FileMapInfo* static_mapin
   const size_t total_range_size =
       archive_space_size + gap_size + class_space_size;
 
-  // Validate that class space base address plus shift can be decoded when restored.
+  // The code for dumping the archive ensures that the base address is valid.
+  // Here we validate that the base address plus shift can be decoded when
+  // restored.
   assert(shared_base_valid((char*)base_address),
       "Cannot use SharedBaseAddress " PTR_FORMAT " with precomputed shift %d.",
       p2i(base_address), ArchiveBuilder::precomputed_narrow_klass_shift());

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1989,9 +1989,13 @@ char* AOTMetaspace::reserve_address_space_for_archives(FileMapInfo* static_mapin
   const int precomputed_narrow_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
   if (!CompressedKlassPointers::check_klass_decode_mode(base_address, precomputed_narrow_klass_shift,
                                                         total_range_size)) {
-    aot_log_info(aot)("CDS initialization: Cannot use SharedBaseAddress " PTR_FORMAT " with precomputed shift %d.",
+    aot_log_info(aot)("CDS initialization: Cannot use SharedBaseAddress " PTR_FORMAT
+                  " with precomputed shift %d, will try an alternative address.",
                   p2i(base_address), precomputed_narrow_klass_shift);
-    use_archive_base_addr = false;
+    // The requested base cannot be used with the archive's precomputed Klass
+    // encoding.  Fail this attempt and let the caller retry at an alternative
+    // address.
+    return nullptr;
   }
 
   assert(total_range_size > ccs_begin_offset, "must be");

--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -164,7 +164,7 @@ size_t AOTMetaspace::protection_zone_size() {
   return os::cds_core_region_alignment();
 }
 
-static bool shared_base_valid(char* shared_base, size_t cds_max) {
+bool AOTMetaspace::shared_base_valid(char* shared_base) {
   // We check user input for SharedBaseAddress at dump time.
 
   // At CDS runtime, "shared_base" will be the (attempted) mapping start. It will also
@@ -172,14 +172,15 @@ static bool shared_base_valid(char* shared_base, size_t cds_max) {
   // the prototype mark words) carry pre-computed narrow Klass IDs that refer to the mapping
   // start as base.
   //
-  // On AARCH64, The "shared_base" may not be later usable as encoding base, depending on the
+  // The "shared_base" may not be later usable as encoding base, depending on the
   // total size of the reserved area and the precomputed_narrow_klass_shift. This is checked
   // before reserving memory.  Here we weed out values already known to be invalid later.
-  // Since the exact reserved size is not yet known, we use the largest possible range.
+  // Since we cannot predict the range, we use the full maximum encoding range
+  // (4G).
+  constexpr size_t range = 4 * G;
   address addr = (address)shared_base;
   const int shift = ArchiveBuilder::precomputed_narrow_klass_shift();
-  return CompressedKlassPointers::check_klass_decode_mode(addr, shift, cds_max)
-      && AARCH64_ONLY(is_aligned(shared_base, 4 * G)) NOT_AARCH64(true);
+  return CompressedKlassPointers::check_klass_decode_mode(addr, shift, range);
 }
 
 class DumpClassListCLDClosure : public CLDClosure {
@@ -277,7 +278,7 @@ static char* compute_shared_base(size_t cds_max) {
     err = "too high";
   } else if (shared_base_too_high(specified_base, aligned_base, cds_max)) {
     err = "too high";
-  } else if (!shared_base_valid(aligned_base, cds_max)) {
+  } else if (!AOTMetaspace::shared_base_valid(aligned_base)) {
     err = "invalid for this platform";
   } else {
     return aligned_base;
@@ -295,7 +296,7 @@ static char* compute_shared_base(size_t cds_max) {
 
   // Make sure the default value of SharedBaseAddress specified in globals.hpp is sane.
   assert(!shared_base_too_high(specified_base, aligned_base, cds_max), "Sanity");
-  assert(shared_base_valid(aligned_base, cds_max), "Sanity");
+  assert(AOTMetaspace::shared_base_valid(aligned_base), "Sanity");
   return aligned_base;
 }
 
@@ -1989,8 +1990,8 @@ char* AOTMetaspace::reserve_address_space_for_archives(FileMapInfo* static_mapin
   const size_t total_range_size =
       archive_space_size + gap_size + class_space_size;
 
-  // Validate that class space base address plus shift can be decoded by aarch64, when restored.
-  assert(shared_base_valid((char*)base_address, total_range_size),
+  // Validate that class space base address plus shift can be decoded when restored.
+  assert(shared_base_valid((char*)base_address),
       "Cannot use SharedBaseAddress " PTR_FORMAT " with precomputed shift %d.",
       p2i(base_address), ArchiveBuilder::precomputed_narrow_klass_shift());
 

--- a/src/hotspot/share/cds/aotMetaspace.hpp
+++ b/src/hotspot/share/cds/aotMetaspace.hpp
@@ -188,6 +188,9 @@ public:
   static bool use_optimized_module_handling() { return NOT_CDS(false) CDS_ONLY(_use_optimized_module_handling); }
   static void disable_optimized_module_handling() { _use_optimized_module_handling = false; }
 
+  // Check if the supplied shared base address can be used as the encoding base.
+  static bool shared_base_valid(char* shared_base);
+
 private:
   static void read_extra_data(JavaThread* current, const char* filename) NOT_CDS_RETURN;
   static void fork_and_dump_final_static_archive(TRAPS);

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -41,6 +41,7 @@
 #include "runtime/vmThread.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 bool CDSConfig::_is_dumping_static_archive = false;
 bool CDSConfig::_is_dumping_preimage_static_archive = false;
@@ -122,6 +123,16 @@ void CDSConfig::ergo_initialize() {
     // limited set of Java code (for module system init, class loading, indy resolution,
     // etc), there is usually no need to attach to this JVM.
     FLAG_SET_ERGO(DisableAttachMechanism, true);
+  }
+
+  constexpr size_t max_encoding_range_size = 4 * G;
+  const int precomputed_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
+  if (!CompressedKlassPointers::check_klass_decode_mode((address) SharedBaseAddress,
+                                                        precomputed_klass_shift,
+                                                        max_encoding_range_size)) {
+     log_warning(cds)("SharedBaseAddress " PTR_FORMAT " is invalid. Reverting to " PTR_FORMAT,
+                 p2i((void*)SharedBaseAddress), p2i((void*)DEFAULT_SHARED_BASE_ADDRESS));
+     FLAG_SET_ERGO(SharedBaseAddress, DEFAULT_SHARED_BASE_ADDRESS);
   }
 }
 

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -125,11 +125,7 @@ void CDSConfig::ergo_initialize() {
     FLAG_SET_ERGO(DisableAttachMechanism, true);
   }
 
-  constexpr size_t max_encoding_range_size = 4 * G;
-  const int precomputed_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift();
-  if (!CompressedKlassPointers::check_klass_decode_mode((address) SharedBaseAddress,
-                                                        precomputed_klass_shift,
-                                                        max_encoding_range_size)) {
+  if (!AOTMetaspace::shared_base_valid((char*)SharedBaseAddress)) {
      log_warning(cds)("SharedBaseAddress " PTR_FORMAT " is invalid. Reverting to " PTR_FORMAT,
                  p2i((void*)SharedBaseAddress), p2i((void*)DEFAULT_SHARED_BASE_ADDRESS));
      FLAG_SET_ERGO(SharedBaseAddress, DEFAULT_SHARED_BASE_ADDRESS);

--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -27,6 +27,9 @@
 
 #include "runtime/globals_shared.hpp"
 
+#define DEFAULT_SHARED_BASE_ADDRESS (LP64_ONLY(32*G) \
+                                    NOT_LP64(LINUX_ONLY(2*G) NOT_LINUX(0)))
+
 //
 // Defines all globals flags used by CDS.
 //
@@ -51,8 +54,7 @@
   product(bool, PrintSharedArchiveAndExit, false,                           \
           "Print shared archive file contents")                             \
                                                                             \
-  product(size_t, SharedBaseAddress, LP64_ONLY(32*G)                        \
-          NOT_LP64(LINUX_ONLY(2*G) NOT_LINUX(0)),                           \
+  product(size_t, SharedBaseAddress, DEFAULT_SHARED_BASE_ADDRESS,           \
           "Address to allocate shared memory region for class data")        \
           range(0, SIZE_MAX)                                                \
                                                                             \


### PR DESCRIPTION
Without this patch, when the requested base address cannot be used to
reserve space, there is an invariant failure in that the callee may fail
to use that address but it never conveys it to the caller.  On
Windows/ARM64, this results in an assertion failure but on other AArch64
platforms, it looks like this failure is being silently ignored.

This patch fixes the problem by conveying to the caller that the callee
couldn't use the desired base address and that the caller should try a
different address instead.  This prevents a JVM crash on Windows/ARM64,
and runtime/cds/{SharedBaseAddress.java,appcds/SharedBaseAddress.java}
tests now pass on Windows/ARM64.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386685](https://bugs.openjdk.org/browse/JDK-8386685): CDS load on Windows/ARM64 using base address set to 0x5_0000_0000 causes a JVM crash (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31520/head:pull/31520` \
`$ git checkout pull/31520`

Update a local copy of the PR: \
`$ git checkout pull/31520` \
`$ git pull https://git.openjdk.org/jdk.git pull/31520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31520`

View PR using the GUI difftool: \
`$ git pr show -t 31520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31520.diff">https://git.openjdk.org/jdk/pull/31520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31520#issuecomment-4712281293)
</details>
