### PR TITLE
8386656: C2 AVX512: -XX:-UseCountTrailingZerosInstruction causes assert(UseCountTrailingZerosInstruction) failed: tzcnt instruction not supported

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3179,6 +3179,13 @@ bool Matcher::match_rule_supported(int opcode) {
       break;
 
     case Op_VectorCmpMasked:
+      if (!UseCountTrailingZerosInstruction) {
+        return false;
+      }
+      if (UseAVX < 3 || !VM_Version::supports_bmi2()) {
+        return false;
+      }
+      break;
     case Op_VectorMaskGen:
       if (UseAVX < 3 || !VM_Version::supports_bmi2()) {
         return false;

--- a/test/hotspot/jtreg/compiler/cpuflags/Test8386656.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/Test8386656.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8386656 
+ * @bug 8386656
  * @summary Verify no assertions when running with -XX:-UseCountTrailingZerosInstruction
  * @requires vm.cpu.features ~= ".*avx512.*"
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,jdk.internal.util.ArraysSupport::mismatch -XX:-UseCountTrailingZerosInstruction compiler.cpuflags.Test8386656

--- a/test/hotspot/jtreg/compiler/cpuflags/Test8386656.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/Test8386656.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8386656 
+ * @summary Verify no assertions when running with -XX:-UseCountTrailingZerosInstruction
+ * @requires vm.cpu.features ~= ".*avx512.*"
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,jdk.internal.util.ArraysSupport::mismatch -XX:-UseCountTrailingZerosInstruction compiler.cpuflags.Test8386656
+ */
+
+package compiler.cpuflags;
+
+import java.util.Arrays;
+
+public class Test8386656 {
+    public static void main(String[] args) {
+        byte[] a = new byte[32];
+        byte[] b = new byte[32];
+        for (int i = 0; i < 20_000; i++) {
+            Arrays.mismatch(a, b);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/cpuflags/TestUseCountTrailingZerosInstruction.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestUseCountTrailingZerosInstruction.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8386656
  * @summary Verify no assertions when running with -XX:-UseCountTrailingZerosInstruction
+ * @requires os.simpleArch == "x64"
  * @run main/othervm -Xbatch -XX:-UseCountTrailingZerosInstruction compiler.cpuflags.TestUseCountTrailingZerosInstruction
  */
 
@@ -32,6 +33,7 @@
  * @test
  * @bug 8386656
  * @summary Verify no assertions when running with -XX:+UseCountTrailingZerosInstruction
+ * @requires os.simpleArch == "x64"
  * @run main/othervm -Xbatch -XX:+UseCountTrailingZerosInstruction compiler.cpuflags.TestUseCountTrailingZerosInstruction
  */
 

--- a/test/hotspot/jtreg/compiler/cpuflags/TestUseCountTrailingZerosInstruction.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestUseCountTrailingZerosInstruction.java
@@ -25,15 +25,21 @@
  * @test
  * @bug 8386656
  * @summary Verify no assertions when running with -XX:-UseCountTrailingZerosInstruction
- * @requires vm.cpu.features ~= ".*avx512.*"
- * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,jdk.internal.util.ArraysSupport::mismatch -XX:-UseCountTrailingZerosInstruction compiler.cpuflags.Test8386656
+ * @run main/othervm -Xbatch -XX:-UseCountTrailingZerosInstruction compiler.cpuflags.TestUseCountTrailingZerosInstruction
+ */
+
+/**
+ * @test
+ * @bug 8386656
+ * @summary Verify no assertions when running with -XX:+UseCountTrailingZerosInstruction
+ * @run main/othervm -Xbatch -XX:+UseCountTrailingZerosInstruction compiler.cpuflags.TestUseCountTrailingZerosInstruction
  */
 
 package compiler.cpuflags;
 
 import java.util.Arrays;
 
-public class Test8386656 {
+public class TestUseCountTrailingZerosInstruction {
     public static void main(String[] args) {
         byte[] a = new byte[32];
         byte[] b = new byte[32];

--- a/test/hotspot/jtreg/compiler/cpuflags/TestUseCountTrailingZerosInstruction.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestUseCountTrailingZerosInstruction.java
@@ -26,7 +26,7 @@
  * @bug 8386656
  * @summary Verify no assertions when running with -XX:-UseCountTrailingZerosInstruction
  * @requires os.simpleArch == "x64"
- * @run main/othervm -Xbatch -XX:-UseCountTrailingZerosInstruction compiler.cpuflags.TestUseCountTrailingZerosInstruction
+ * @run main/othervm -Xbatch -XX:-UseCountTrailingZerosInstruction ${test.main.class}
  */
 
 /**
@@ -34,7 +34,7 @@
  * @bug 8386656
  * @summary Verify no assertions when running with -XX:+UseCountTrailingZerosInstruction
  * @requires os.simpleArch == "x64"
- * @run main/othervm -Xbatch -XX:+UseCountTrailingZerosInstruction compiler.cpuflags.TestUseCountTrailingZerosInstruction
+ * @run main/othervm -Xbatch -XX:+UseCountTrailingZerosInstruction ${test.main.class}
  */
 
 package compiler.cpuflags;


### PR DESCRIPTION
This patch adds check for `UseCountTrailingZerosInstruction` for  VectorCmpMasked node. This is required because the `vmask_cmp_node` that generates code for `VectorCmpMasked` node generates `tzcntq` instruction which should not be used if `UseCountTrailingZerosInstruction` is false.

Without this patch the compiled code for `ArraySupport.mismatch` generates `vector_mask_cmp` node as part of inlining `vectorizedMismatch`:

```
06b     B7: #   out( B12 B8 ) <- in( B6 )  Freq: 0.999995
06b     cmpl    RCX, #32
06e     jg     B12  P=0.000001 C=-1.000000

074     B8: #   out( B9 ) <- in( B7 )  Freq: 0.999994
074     movl    R10, RCX        # spill
077     # castII of R10
077     movslq  R10, R10        # i2l
07a     vector_mask_gen32 K6, R10       ! vector mask generator
08b     vector_masked_load XMM0, [RSI], K6      ! vector masked copy
091     vector_masked_load XMM1, [RDI], K6      ! vector masked copy
097     vector_mask_cmp XMM1, XMM0, K6  ! vector mask comparison

0be     B9: #   out( B17 B10 ) <- in( B8 B12 )  Freq: 0.999995
        nop     # 2 bytes pad for loops and calls
0c0     testl   R10, R10
0c3     jge     B17  P=0.000000 C=5375.000000

0c9     B10: #  out( B18 B11 ) <- in( B9 )  Freq: 0.999995
0c9     leal    RBP, [RBX + R10]
0cd     incl    RBP     # int
0cf     cmpl    RBP, RBX
0d1     jl     B18  P=0.000000 C=5375.000000
```

With this patch, `vectorizedMismatch` is not inlined and a runtime call to `vectorizedMismatch` is generated:

```
06b     B7: #   out( B14 B8 ) <- in( B6 )  Freq: 0.999995
06b     xorl    RCX, RCX        # int
06d     movl    RDX, RBX        # spill
06f     call_leaf,runtime  vectorizedMismatch
        No JVM State Info
        # 
084     testl   RAX, RAX
086     jge     B14  P=0.000000 C=5375.000000

08c     B8: #   out( B15 B9 ) <- in( B7 )  Freq: 0.999995
08c     leal    RBP, [RBX + RAX]
08f     incl    RBP     # int
091     cmpl    RBP, RBX
093     jl     B15  P=0.000000 C=5375.000000
   
```

Instruction used for compiling and generating above OptoAssembly:
```
java -Xlog:jit+compilation -Xbatch -XX:CompileCommand=compileonly,jdk.internal.util.ArraysSupport::mismatch -XX:CompileCommand=PrintAssembly,jdk.internal.util.ArraysSupport::mismatch -XX:+UseCountTrailingZerosInstruction TestMismatch
```
and the TestMismatch is a test program from the linked JBS issue:
```
import java.util.Arrays;

public class TestMismatch {
    public static void main(String[] args) {
        byte[] a = new byte[32];
        byte[] b = new byte[32];
        for (int i = 0; i < 20_000; i++) {
            Arrays.mismatch(a, b);
        }
    }
}
```

As an alternate I also tried to add `predicate(UseCountTrailingZerosInstruction)` to `vmask_cmp_node` but it triggers following assert in `Matcher::Label_Root()`:
```
    assert( false, "bad AD file" );
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386656](https://bugs.openjdk.org/browse/JDK-8386656): C2 AVX512: -XX:-UseCountTrailingZerosInstruction causes assert(UseCountTrailingZerosInstruction) failed: tzcnt instruction not supported (**Bug** - P3)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer) Review applies to [709853bd](https://git.openjdk.org/jdk/pull/31522/files/709853bda2583cb5909126a9f251640fada78a89)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) Review applies to [709853bd](https://git.openjdk.org/jdk/pull/31522/files/709853bda2583cb5909126a9f251640fada78a89)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31522/head:pull/31522` \
`$ git checkout pull/31522`

Update a local copy of the PR: \
`$ git checkout pull/31522` \
`$ git pull https://git.openjdk.org/jdk.git pull/31522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31522`

View PR using the GUI difftool: \
`$ git pr show -t 31522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31522.diff">https://git.openjdk.org/jdk/pull/31522.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31522#issuecomment-4713081043)
</details>
