### PR TITLE
8386705: Parallel: Allow NUMA with explicit huge pages and adaptive resizing

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4687,20 +4687,6 @@ void os::Linux::numa_init() {
   if (UseNUMA && !UseNUMAInterleaving) {
     FLAG_SET_ERGO_IF_DEFAULT(UseNUMAInterleaving, true);
   }
-
-#if INCLUDE_PARALLELGC
-  if (UseParallelGC && UseNUMA && UseLargePages && !can_commit_large_page_memory()) {
-    // With static large pages we cannot uncommit a page, so there's no way
-    // we can make the adaptive lgrp chunk resizing work. If the user specified both
-    // UseNUMA and UseLargePages on the command line - warn and disable adaptive resizing.
-    if (UseAdaptiveSizePolicy || UseAdaptiveNUMAChunkSizing) {
-      warning("UseNUMA is not fully compatible with +UseLargePages, "
-              "disabling adaptive resizing (-XX:-UseAdaptiveSizePolicy -XX:-UseAdaptiveNUMAChunkSizing)");
-      UseAdaptiveSizePolicy = false;
-      UseAdaptiveNUMAChunkSizing = false;
-    }
-  }
-#endif
 }
 
 void os::Linux::disable_numa(const char* reason, bool warning) {

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -154,7 +154,7 @@ void MutableNUMASpace::bias_region(MemRegion mr, uint lgrp_id) {
   // First we tell the OS which page size we want in the given range. The underlying
   // large page can be broken down if we require small pages.
   os::realign_memory((char*) mr.start(), mr.byte_size(), page_size());
-  // Then we uncommit the pages in the range.
+  // Then we disclaim the pages in the range so they can be faulted in again.
   os::disclaim_memory((char*) mr.start(), mr.byte_size());
   // And make them local/first-touch biased.
   os::numa_make_local((char*)mr.start(), mr.byte_size(), checked_cast<int>(lgrp_id));

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -49,7 +49,7 @@ void MutableSpace::numa_setup_pages(MemRegion mr, bool clear_space) {
   }
 
   if (clear_space) {
-    // Prefer page reallocation to migration.
+    // Prefer page discard and refault under the requested NUMA policy to migration.
     os::disclaim_memory((char*) mr.start(), mr.byte_size());
   }
   os::numa_make_global((char*) mr.start(), mr.byte_size());


### PR DESCRIPTION
Parallel GC still disables adaptive resizing for `UseParallelGC && UseNUMA && UseLargePages` on Linux. Since JDK-8330144 (https://github.com/openjdk/jdk/pull/20080), NUMA rebiasing uses `os::disclaim_memory()` instead of uncommit/recommit, so this restriction is stale.

This patch removes the guard from `os::Linux::numa_init()` and updates comments in `MutableSpace` and `MutableNUMASpace` to describe discard/refault behavior.

Test: tie1-3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386705](https://bugs.openjdk.org/browse/JDK-8386705): Parallel: Allow NUMA with explicit huge pages and adaptive resizing (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @roberttoyonaga (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31524/head:pull/31524` \
`$ git checkout pull/31524`

Update a local copy of the PR: \
`$ git checkout pull/31524` \
`$ git pull https://git.openjdk.org/jdk.git pull/31524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31524`

View PR using the GUI difftool: \
`$ git pr show -t 31524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31524.diff">https://git.openjdk.org/jdk/pull/31524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31524#issuecomment-4716093111)
</details>
