### PR TITLE
Add tls-unique channel binding support (RFC 5929) to JSSE

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
+++ b/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
@@ -273,4 +273,23 @@ public abstract class ExtendedSSLSession implements SSLSession {
         throw new UnsupportedOperationException(
                 "Underlying provider does not implement the method");
     }
+
+    /**
+     * Returns the tls-unique channel binding value for this session, as defined in
+     * RFC 5929.
+     * <P>
+     * Returns null if: Feature not enabled via
+     * sun.security.ssl.enableTlsUniqueChannelBinding, Session uses TLS 1.3+ (use
+     * exportKeyingMaterialData instead), Extended Master Secret (RFC 7627) not
+     * active, Handshake not yet completed.
+     * 
+     * @implSpec The default implementation returns null.
+     * 
+     * @return channel binding bytes (typically 12 bytes for TLS 1.2), or null if
+     *         unavailable
+     * @since 27
+     */
+    public byte[] getTlsUniqueChannelBinding() {
+        return null;
+    }
 }

--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -26,6 +26,7 @@
 package sun.security.ssl;
 
 import java.io.IOException;
+import java.net.Authenticator;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
@@ -41,6 +42,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.HKDFParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.swing.text.Utilities;
 
 import jdk.internal.event.EventHelper;
 import jdk.internal.event.TLSHandshakeEvent;
@@ -406,6 +408,11 @@ final class Finished {
                 chc.conContext.clientVerifyData = fm.verifyData;
             }
 
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
+            }
+
             if (chc.statelessResumption) {
                 chc.handshakeConsumers.put(
                         SSLHandshake.NEW_SESSION_TICKET.id, SSLHandshake.NEW_SESSION_TICKET);
@@ -467,6 +474,11 @@ final class Finished {
              */
             if (shc.conContext.secureRenegotiation) {
                 shc.conContext.serverVerifyData = fm.verifyData;
+            }
+
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
             }
 
             // update the consumers and producers
@@ -551,6 +563,11 @@ final class Finished {
                 chc.conContext.serverVerifyData = fm.verifyData;
             }
 
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
+            }
+
             if (!chc.isResumption) {
                 if (chc.handshakeSession.isRejoinable()) {
                     ((SSLSessionContextImpl)chc.sslContext.
@@ -609,6 +626,11 @@ final class Finished {
 
             if (shc.conContext.secureRenegotiation) {
                 shc.conContext.clientVerifyData = fm.verifyData;
+            }
+
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
             }
 
             if (shc.isResumption) {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -115,6 +115,13 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     private int                 negotiatedMaxFragLen = -1;
     private int                 maximumPacketSize;
 
+    private static final boolean tlsUniqueChannelBindingEnabled = Utilities.getBooleanProperty(
+            "sun.security.ssl.enableTlsUniqueChannelBinding", false);
+    private static final String tlsUniqueChannelBindingMode = System.getProperty(
+            "sun.security.ssl.tlsUniqueChannelBindingMode", "rfc5929");
+    private volatile byte[] clientFinishedVerifyData;
+    private volatile byte[] serverFinishedVerifyData;
+
     private final Queue<SSLSessionImpl> childSessions =
                                         new ConcurrentLinkedQueue<>();
 
@@ -1683,6 +1690,70 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     public byte[] exportKeyingMaterialData(
             String label, byte[] context, int length) throws SSLKeyException {
         return (byte[])exportKeyingMaterial(null, label, context, length);
+    }
+
+    void setClientFinishedVerifyData(byte[] verifyData) {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return;
+        }
+        this.clientFinishedVerifyData = (verifyData != null)
+                ? verifyData.clone()
+                : null;
+    }
+
+    void setServerFinishedVerifyData(byte[] verifyData) {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return;
+        }
+        this.serverFinishedVerifyData = (verifyData != null)
+                ? verifyData.clone()
+                : null;
+    }
+
+    @Override
+    public byte[] getTlsUniqueChannelBinding() {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return null;
+        }
+
+        // Not applicable for TLS 1.3+ (use TLS Exporter / RFC 9266 instead)
+        if (protocolVersion.useTLS13PlusSpec()) {
+            return null;
+        }
+
+        // Require Extended Master Secret (RFC 7627) to prevent renegotiation-based MITM
+        // attacks
+        if (!useExtendedMasterSecret) {
+            return null;
+        }
+
+        byte[] result;
+        if ("client".equalsIgnoreCase(tlsUniqueChannelBindingMode)) {
+            result = getClientFinishedData();
+        } else {
+            result = getFirstFinishedData();
+        }
+
+        return (result != null) ? result.clone() : null;
+    }
+
+    /**
+     * Returns the client's Finished verify_data. Used by authentication protocols
+     * that specifically require the client's Finished message.
+     */
+    private byte[] getClientFinishedData() {
+        return clientFinishedVerifyData;
+    }
+
+    /**
+     * Returns the first Finished verify_data sent per RFC 5929. In a full handshake
+     * the client sends Finished first. In a resumed session the server sends
+     * Finished first.
+     */
+    private byte[] getFirstFinishedData() {
+        return (serverFinishedVerifyData != null && clientFinishedVerifyData == null)
+                ? serverFinishedVerifyData
+                : clientFinishedVerifyData;
     }
 
     /** Returns a string representation of this SSL session */


### PR DESCRIPTION
**Description**:

This patch adds support for the tls-unique channel binding type (RFC 5929) to the JSSE implementation.

**Summary**
The tls-unique channel binding value is derived from the first Finished message's verify_data in a TLS handshake. This is useful for authentication protocols (e.g., SCRAM with channel binding, GS2/SASL) that need to cryptographically bind the authentication exchange to the underlying TLS session, preventing MITM relay attacks.

**Changes**
ExtendedSSLSession.java: Added public getTlsUniqueChannelBinding() method with default null implementation
SSLSessionImpl.java: Stores client/server Finished verify_data; implements getTlsUniqueChannelBinding() with RFC 5929 semantics
Finished.java: Captures verify_data from Finished message producers/consumers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31525/head:pull/31525` \
`$ git checkout pull/31525`

Update a local copy of the PR: \
`$ git checkout pull/31525` \
`$ git pull https://git.openjdk.org/jdk.git pull/31525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31525`

View PR using the GUI difftool: \
`$ git pr show -t 31525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31525.diff">https://git.openjdk.org/jdk/pull/31525.diff</a>

</details>
