### PR TITLE
8386707: [BACKOUT] ZGC: Incorrect object undo in relocation race for relocation workers

### DIFF
--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -642,7 +642,7 @@ private:
     const zaddress to_addr = _forwarding->insert(from_addr, allocated_addr, &cursor);
     if (to_addr != allocated_addr) {
       // Already relocated, undo allocation
-      _allocator->undo_alloc_object(to_page, allocated_addr, size);
+      _allocator->undo_alloc_object(to_page, to_addr, size);
       increase_other_forwarded(size);
     }
 


### PR DESCRIPTION
Hello,

The fix for the original issue ([JDK-8385632](https://bugs.openjdk.org/browse/JDK-8385632)) solves a real bug and is not inherently wrong by itself. However, by fixing the faulty undo-logic in the relocation code of ZGC, another bug pops up ([JDK-8386128](https://bugs.openjdk.org/browse/JDK-8386128)) in an interaction between undoing object allocations on Medium pages that are shared among GC workers.

Given other priorities and to make sure that JDK 27 stabilizes, we think the best approach is to backout the fix for [JDK-8385632](https://bugs.openjdk.org/browse/JDK-8385632) and follow-up at a later time.

I plan on backporting this backout to the JDK 27 stabilization branch once this PR is integrated.

Testing:
* Running through Oracle's tier 1-3 ZGC tests
* Local reproducer that now passes with the fix backed out:
  ```
  make --no-print-directory -C ../build/fastdebug test TEST=open/test/hotspot/jtreg/vmTestbase/nsk/monitoring/ThreadMXBean/GetThreadAllocatedBytes/stressTest_directly/TestDescription.java JTREG=JAVA_OPTIONS="-XX:+UseZGC -XX:+ZStressFastMediumPageAllocation -XX:-TieredCompilation -XX:+ZVerifyForwarding -Xmx924M" JTREG_REPEAT_COUNT=5 
  ```




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386707](https://bugs.openjdk.org/browse/JDK-8386707): [BACKOUT] ZGC: Incorrect object undo in relocation race for relocation workers (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31526/head:pull/31526` \
`$ git checkout pull/31526`

Update a local copy of the PR: \
`$ git checkout pull/31526` \
`$ git pull https://git.openjdk.org/jdk.git pull/31526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31526`

View PR using the GUI difftool: \
`$ git pr show -t 31526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31526.diff">https://git.openjdk.org/jdk/pull/31526.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31526#issuecomment-4716320808)
</details>
