### PR TITLE
8386669: AArch64: Distinguish ldr and ldrw literal instructions in NativeInstruction

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -128,7 +128,7 @@ public:
 // instruction. Verify that it's really there, so the offsets are not skewed.
 bool NativeNMethodBarrier::check_barrier(err_msg& msg) const {
   NativeInstruction* ni = nativeInstruction_at(instruction_address());
-  if (!ni->is_ldrw_literal()) {
+  if (!ni->is_ldrw_gpr_literal()) {
     msg.print("Nmethod entry barrier did not start with ldrw (literal) as expected. "
               "Addr: " PTR_FORMAT " Code: " UINT32_FORMAT, p2i(instruction_address()), ni->encoding());
     return false;

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -124,14 +124,13 @@ public:
   }
 };
 
-// The first instruction of the nmethod entry barrier is an ldr (literal)
+// The first instruction of the nmethod entry barrier is an ldrw (literal)
 // instruction. Verify that it's really there, so the offsets are not skewed.
 bool NativeNMethodBarrier::check_barrier(err_msg& msg) const {
-  uint32_t* addr = (uint32_t*) instruction_address();
-  uint32_t inst = *addr;
-  if ((inst & 0xff000000) != 0x18000000) {
-    msg.print("Nmethod entry barrier did not start with ldr (literal) as expected. "
-              "Addr: " PTR_FORMAT " Code: " UINT32_FORMAT, p2i(addr), inst);
+  NativeInstruction* ni = nativeInstruction_at(instruction_address());
+  if (!ni->is_ldrw_literal()) {
+    msg.print("Nmethod entry barrier did not start with ldrw (literal) as expected. "
+              "Addr: " PTR_FORMAT " Code: " UINT32_FORMAT, p2i(instruction_address()), ni->encoding());
     return false;
   }
   return true;

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -306,9 +306,13 @@ bool NativeInstruction::is_load_literal_at(address instr) {
   return (Instruction_aarch64::extract(insn, 29, 24) & 0b011011) == 0b00011000;
 }
 
+bool NativeInstruction::is_ldr_gpr_literal_at(address instr) {
+  unsigned insn = *(unsigned*)instr;
+  return Instruction_aarch64::extract(insn, 31, 24) == 0b01011000;
+}
+
 bool NativeInstruction::is_ldrw_gpr_literal_at(address instr) {
   unsigned insn = *(unsigned*)instr;
-  // We only check for GPR literal loads (bit 26, VR bit == 0). SIMD/FP literal loads have VR == 1.
   return Instruction_aarch64::extract(insn, 31, 24) == 0b00011000;
 }
 

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -123,7 +123,7 @@ void NativeCall::insert(address code_pos, address entry) { Unimplemented(); }
 void NativeMovConstReg::verify() {
   if (! (nativeInstruction_at(instruction_address())->is_movz() ||
         is_adrp_at(instruction_address()) ||
-        is_ldr_literal_at(instruction_address())) ) {
+        is_load_literal_at(instruction_address())) ) {
     fatal("should be MOVZ or ADRP or LDR (literal)");
   }
 }
@@ -301,13 +301,12 @@ bool NativeInstruction::is_adrp_at(address instr) {
   return (Instruction_aarch64::extract(insn, 31, 24) & 0b10011111) == 0b10010000;
 }
 
-bool NativeInstruction::is_ldr_literal_at(address instr) {
+bool NativeInstruction::is_load_literal_at(address instr) {
   unsigned insn = *(unsigned*)instr;
-  // We only check for GPR literal loads (bit 26, VR bit == 0). SIMD/FP literal loads have VR == 1.
-  return Instruction_aarch64::extract(insn, 31, 24) == 0b01011000;
+  return (Instruction_aarch64::extract(insn, 29, 24) & 0b011011) == 0b00011000;
 }
 
-bool NativeInstruction::is_ldrw_literal_at(address instr) {
+bool NativeInstruction::is_ldrw_gpr_literal_at(address instr) {
   unsigned insn = *(unsigned*)instr;
   // We only check for GPR literal loads (bit 26, VR bit == 0). SIMD/FP literal loads have VR == 1.
   return Instruction_aarch64::extract(insn, 31, 24) == 0b00011000;

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -270,17 +270,17 @@ bool NativeInstruction::is_safepoint_poll() {
   // a safepoint_poll is implemented in two steps as either
   //
   // adrp(reg, polling_page);
-  // ldr(zr, [reg, #offset]);
+  // ldrw(zr, [reg, #offset]);
   //
   // or
   //
   // mov(reg, polling_page);
-  // ldr(zr, [reg, #offset]);
+  // ldrw(zr, [reg, #offset]);
   //
   // or
   //
   // ldr(reg, [rthread, #offset]);
-  // ldr(zr, [reg, #offset]);
+  // ldrw(zr, [reg, #offset]);
   //
   // however, we cannot rely on the polling page address load always
   // directly preceding the read from the page. C1 does that but C2
@@ -303,7 +303,14 @@ bool NativeInstruction::is_adrp_at(address instr) {
 
 bool NativeInstruction::is_ldr_literal_at(address instr) {
   unsigned insn = *(unsigned*)instr;
-  return (Instruction_aarch64::extract(insn, 29, 24) & 0b011011) == 0b00011000;
+  // We only check for GPR literal loads (bit 26, VR bit == 0). SIMD/FP literal loads have VR == 1.
+  return Instruction_aarch64::extract(insn, 31, 24) == 0b01011000;
+}
+
+bool NativeInstruction::is_ldrw_literal_at(address instr) {
+  unsigned insn = *(unsigned*)instr;
+  // We only check for GPR literal loads (bit 26, VR bit == 0). SIMD/FP literal loads have VR == 1.
+  return Instruction_aarch64::extract(insn, 31, 24) == 0b00011000;
 }
 
 bool NativeInstruction::is_ldrw_to_zr(address instr) {

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -113,6 +113,12 @@ public:
     return is_ldr_literal_at(addr_at(0));
   }
 
+  static bool is_ldrw_literal_at(address instr);
+
+  bool is_ldrw_literal() {
+    return is_ldrw_literal_at(addr_at(0));
+  }
+
   static bool is_ldrw_to_zr(address instr);
 
   static bool is_call_at(address instr) {

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -113,10 +113,16 @@ public:
     return is_load_literal_at(addr_at(0));
   }
 
-  static bool is_ldrw_literal_at(address instr);
+  static bool is_ldr_gpr_literal_at(address instr);
 
-  bool is_ldrw_literal() {
-    return is_ldrw_literal_at(addr_at(0));
+  bool is_ldr_gpr_literal() {
+    return is_ldr_gpr_literal_at(addr_at(0));
+  }
+
+  static bool is_ldrw_gpr_literal_at(address instr);
+
+  bool is_ldrw_gpr_literal() {
+    return is_ldrw_gpr_literal_at(addr_at(0));
   }
 
   static bool is_ldrw_to_zr(address instr);

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -107,10 +107,10 @@ public:
 
   static bool is_adrp_at(address instr);
 
-  static bool is_ldr_literal_at(address instr);
+  static bool is_load_literal_at(address instr);
 
-  bool is_ldr_literal() {
-    return is_ldr_literal_at(addr_at(0));
+  bool is_load_literal() {
+    return is_load_literal_at(addr_at(0));
   }
 
   static bool is_ldrw_literal_at(address instr);
@@ -131,7 +131,7 @@ public:
   }
 
   static bool maybe_cpool_ref(address instr) {
-    return is_adrp_at(instr) || is_ldr_literal_at(instr);
+    return is_adrp_at(instr) || is_load_literal_at(instr);
   }
 
   bool is_Membar() {
@@ -273,7 +273,7 @@ public:
       return addr_at(instruction_size);
     else if (is_adrp_at(instruction_address()))
       return addr_at(2*4);
-    else if (is_ldr_literal_at(instruction_address()))
+    else if (is_load_literal_at(instruction_address()))
       return(addr_at(4));
     assert(false, "Unknown instruction in NativeMovConstReg");
     return nullptr;

--- a/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
@@ -41,7 +41,7 @@ void Relocation::pd_set_data_value(address x, bool verify_only) {
   case relocInfo::oop_type:
     {
       oop_Relocation *reloc = (oop_Relocation *)this;
-      if (NativeInstruction::is_ldr_literal_at(addr())) {
+      if (NativeInstruction::is_load_literal_at(addr())) {
         address constptr = (address)code()->oop_addr_at(reloc->oop_index());
         bytes = MacroAssembler::pd_patch_instruction_size(addr(), constptr);
         assert(*(address*)constptr == x, "error in oop relocation");

--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -488,4 +488,24 @@ TEST_VM(AssemblerAArch64, merge_ldst_after_expand) {
   asm_check((const unsigned int *)code.insts()->start(), insns, sizeof insns / sizeof insns[0]);
 }
 
+TEST_VM(AssemblerAArch64, native_instruction_load_predicates) {
+  static uint32_t insns[] = {
+    0x58000000, // ldr x0, #0
+    0x18000000, // ldr w0, #0
+    0x1C000000, // ldr s0, #0 (VR bit set to 1, enabling SIMD/FP register)
+  };
+
+  NativeInstruction* ni_ldr = nativeInstruction_at(&insns[0]);
+  EXPECT_TRUE(ni_ldr->is_ldr_literal());
+  EXPECT_FALSE(ni_ldr->is_ldrw_literal());
+
+  NativeInstruction* ni_ldrw = nativeInstruction_at(&insns[1]);
+  EXPECT_TRUE(ni_ldrw->is_ldrw_literal());
+  EXPECT_FALSE(ni_ldrw->is_ldr_literal());
+
+  NativeInstruction* ni_ldrs = nativeInstruction_at(&insns[2]);
+  EXPECT_FALSE(ni_ldrs->is_ldrw_literal());
+  EXPECT_FALSE(ni_ldrs->is_ldr_literal());
+}
+
 #endif  // AARCH64

--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -497,15 +497,18 @@ TEST_VM(AssemblerAArch64, native_instruction_load_predicates) {
 
   NativeInstruction* ni_ldr = nativeInstruction_at(&insns[0]);
   EXPECT_TRUE(ni_ldr->is_load_literal());
-  EXPECT_FALSE(ni_ldr->is_ldrw_literal());
+  EXPECT_TRUE(ni_ldr->is_ldr_gpr_literal());
+  EXPECT_FALSE(ni_ldr->is_ldrw_gpr_literal());
 
   NativeInstruction* ni_ldrw = nativeInstruction_at(&insns[1]);
-  EXPECT_TRUE(ni_ldrw->is_ldrw_literal());
-  EXPECT_FALSE(ni_ldrw->is_load_literal());
+  EXPECT_TRUE(ni_ldrw->is_load_literal());
+  EXPECT_FALSE(ni_ldrw->is_ldr_gpr_literal());
+  EXPECT_TRUE(ni_ldrw->is_ldrw_gpr_literal());
 
   NativeInstruction* ni_ldrs = nativeInstruction_at(&insns[2]);
-  EXPECT_FALSE(ni_ldrs->is_ldrw_literal());
-  EXPECT_FALSE(ni_ldrs->is_load_literal());
+  EXPECT_TRUE(ni_ldrs->is_load_literal());
+  EXPECT_FALSE(ni_ldrs->is_ldr_gpr_literal());
+  EXPECT_FALSE(ni_ldrs->is_ldrw_gpr_literal());
 }
 
 #endif  // AARCH64

--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -496,16 +496,16 @@ TEST_VM(AssemblerAArch64, native_instruction_load_predicates) {
   };
 
   NativeInstruction* ni_ldr = nativeInstruction_at(&insns[0]);
-  EXPECT_TRUE(ni_ldr->is_ldr_literal());
+  EXPECT_TRUE(ni_ldr->is_load_literal());
   EXPECT_FALSE(ni_ldr->is_ldrw_literal());
 
   NativeInstruction* ni_ldrw = nativeInstruction_at(&insns[1]);
   EXPECT_TRUE(ni_ldrw->is_ldrw_literal());
-  EXPECT_FALSE(ni_ldrw->is_ldr_literal());
+  EXPECT_FALSE(ni_ldrw->is_load_literal());
 
   NativeInstruction* ni_ldrs = nativeInstruction_at(&insns[2]);
   EXPECT_FALSE(ni_ldrs->is_ldrw_literal());
-  EXPECT_FALSE(ni_ldrs->is_ldr_literal());
+  EXPECT_FALSE(ni_ldrs->is_load_literal());
 }
 
 #endif  // AARCH64


### PR DESCRIPTION
Hello,

The `NativeNMethodBarrier::check_barrier` code in src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp is doing manual verification that the instruction it's seeing is a ldrw (literal) by comparing the highest 8 bits with a known good value. Not only is this hard to read, but it should really be encapsulated inside NativeInstruction instead.

We already have `NativeInstruction::is_ldr_literal_at`, which checks if an instruction is a ldr (literal) instruction, but it does not check the two most significant bits (the "opc" bits), which indicate whether the instruction is using 32-bit or 64-bit registers, i.e., either a ldr (literal) or a ldrw (literal), and it matches for both GPR and SIMD/FP registers. 

I propose we add two new functions: `is_ldr_grp_literal_at` and `is_ldrw_grp_literal_at`, which check the opc bits for the correct 32-bit or 64-bit modes, as well as the VR bit being 0 indicating that general purpose registers are used. These are the most common occurrences and allows us to be specific in our checks.

The implementation of `is_ldr_literal_at` is (IMO) more generally applicable that it's name appears. I suggest we rename this to indicate it's general applicability.

Testing:
* New test-case in the AArch64 assembler GTest suite showcasing the new behavior
* Oracle's tier1-3 linux-aarch64-debug

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386669](https://bugs.openjdk.org/browse/JDK-8386669): AArch64: Distinguish ldr and ldrw literal instructions in NativeInstruction (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31531/head:pull/31531` \
`$ git checkout pull/31531`

Update a local copy of the PR: \
`$ git checkout pull/31531` \
`$ git pull https://git.openjdk.org/jdk.git pull/31531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31531`

View PR using the GUI difftool: \
`$ git pr show -t 31531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31531.diff">https://git.openjdk.org/jdk/pull/31531.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31531#issuecomment-4717583358)
</details>
