### PR TITLE
8371504: Support Markdown link syntax in Markdown @see tags

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2198,6 +2198,14 @@ public class DocCommentParser {
                             List<DCTree> html = blockContent();
                             if (html != null)
                                 return m.at(pos).newSeeTree(html);
+                        }
+
+                        case '[' -> {
+                            if (textKind == DocTree.Kind.MARKDOWN) {
+                                List<DCTree> html = blockContent();
+                                if (html != null)
+                                    return m.at(pos).newSeeTree(html);
+                            }
                         }
 
                         case '@' -> {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SeeTaglet.java
@@ -184,6 +184,8 @@ public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
             }
 
             case LINK, LINK_PLAIN -> {
+                // @see [String]
+                // @see [Map class][Map]
                 // Markdown reference links to program elements are covered by @see reference label form.
                 return invalidSeeTagOutput(element, seeTag);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SeeTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,14 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.RawTextTree;
 import com.sun.source.doctree.SeeTree;
 import com.sun.source.doctree.TextTree;
 
+import jdk.internal.org.commonmark.node.Link;
+import jdk.internal.org.commonmark.node.Node;
+import jdk.internal.org.commonmark.node.Paragraph;
+import jdk.internal.org.commonmark.parser.Parser;
 import jdk.javadoc.doclet.Taglet;
 import jdk.javadoc.internal.doclets.formats.html.ClassWriter;
 import jdk.javadoc.internal.doclets.formats.html.Contents;
@@ -158,10 +163,29 @@ public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
         assert !ref.isEmpty();
         DocTree ref0 = ref.get(0);
         switch (ref0.getKind()) {
-            case TEXT, MARKDOWN, START_ELEMENT -> {
+            case TEXT, START_ELEMENT -> {
                 // @see "Reference"
                 // @see <a href="...">...</a>
                 return htmlWriter.commentTagsToContent(element, ref, false, false);
+            }
+
+            case MARKDOWN -> {
+                // @see [label](url)
+                if (ref.size() != 1 || !(ref.getFirst() instanceof RawTextTree raw)) {
+                    return htmlWriter.commentTagsToContent(element, ref, false, false);
+                }
+                String source = raw.getContent().strip();
+                if (!source.startsWith("[")) {
+                    return htmlWriter.commentTagsToContent(element, ref, false, false);
+                }
+                return isSingleMarkdownLink(source)
+                        ? htmlWriter.commentTagsToContent(element, ref, false, false)
+                        : invalidSeeTagOutput(element, seeTag);
+            }
+
+            case LINK, LINK_PLAIN -> {
+                // Markdown reference links to program elements are covered by @see reference label form.
+                return invalidSeeTagOutput(element, seeTag);
             }
 
             case REFERENCE -> {
@@ -190,6 +214,35 @@ public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
 
             default -> throw new IllegalStateException(ref0.getKind().toString());
         }
+    }
+
+    private boolean isSingleMarkdownLink(String source) {
+        Node document = Parser.builder().build().parse(source);
+        Node paragraph = document.getFirstChild();
+        if (!(paragraph instanceof Paragraph) || paragraph.getNext() != null) {
+            return false;
+        }
+
+        Node link = paragraph.getFirstChild();
+        if (!(link instanceof Link l) || link.getNext() != null
+                || l.getDestination() == null || l.getDestination().isBlank()) {
+            return false;
+        }
+
+        String title = l.getTitle();
+        return title == null || title.isEmpty();
+    }
+
+    private Content invalidSeeTagOutput(Element element, SeeTree seeTag) {
+        CommentHelper ch = utils.getCommentHelper(element);
+        var path = ch.getDocTreePath(seeTag);
+        if (path != null) {
+            messages.error(path, "doclet.tag.invalid_usage", "@see");
+        } else {
+            messages.error("doclet.tag.invalid_usage", "@see");
+        }
+        return tagletWriter.invalidTagOutput(resources.getText("doclet.tag.invalid", "see"),
+                Optional.of(seeTag.toString()));
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownLinks.java
@@ -358,7 +358,7 @@ public class TestMarkdownLinks extends JavadocTester {
                     /// text
                     /// @see [Example](https://example.com)
                     public void simple() { }
-                
+
                     /// text
                     /// @see [Example with *markup*](https://example.com/markup)
                     public void markup() { }
@@ -391,11 +391,11 @@ public class TestMarkdownLinks extends JavadocTester {
                     /// text
                     /// @see [Example](https://example.com) trailing text
                     public void trailing() { }
-                
+
                     /// text
                     /// @see [One](https://a) [Two](https://b)
                     public void multiple() { }
-                
+
                     /// text
                     /// @see [String]
                     public void shorthand() { }

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownLinks.java
@@ -411,7 +411,10 @@ public class TestMarkdownLinks extends JavadocTester {
         checkExit(Exit.ERROR);
 
         checkOutput(Output.OUT, true,
-                "error: invalid usage of tag @see");
+                "error: invalid usage of tag @see",
+                "/// @see [Example](https://example.com) trailing text",
+                "/// @see [One](https://a) [Two](https://b)",
+                "/// @see [String]");
         checkOutput(Output.OUT, false,
                 "IllegalStateException: LINK");
         checkOutput("p/C.html", false,

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8298405
+ * @bug      8298405 8371504
  * @summary  Markdown support in the standard doclet
  * @library  /tools/lib ../../lib
  * @modules  jdk.javadoc/jdk.javadoc.internal.tool
@@ -323,6 +323,7 @@ public class TestMarkdownLinks extends JavadocTester {
                     /// First sentence.
                     /// @see "A reference"
                     /// @see <a href="http://www.example.com">Example</a>
+                    /// @see [Example site](https://example.com/)
                     /// @see D a _Markdown_ description
                     public class C { }
                     """,
@@ -341,9 +342,82 @@ public class TestMarkdownLinks extends JavadocTester {
                     <ul class="tag-list">
                     <li>"A reference"</li>
                     <li><a href="http://www.example.com">Example</a></li>
+                    <li><a href="https://example.com/">Example site</a></li>
                     <li><a href="D.html" title="class in p">a <em>Markdown</em> description</a></li>
                     </ul>
                     </dd>""");
 
+    }
+
+    @Test
+    public void testSeeTagLinks(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                public class C {
+                    /// text
+                    /// @see [Example](https://example.com)
+                    public void simple() { }
+                
+                    /// text
+                    /// @see [Example with *markup*](https://example.com/markup)
+                    public void markup() { }
+                }
+                """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "--source-path",
+                src.toString(),
+                "p");
+
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                """
+                <ul class="tag-list">
+                <li><a href="https://example.com">Example</a></li>
+                </ul>""", """
+                <li><a href="https://example.com/markup">Example with <em>markup</em></a></li>""");
+
+    }
+
+    @Test
+    public void testInvalidSeeTagLinks(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                public class C {
+                    /// text
+                    /// @see [Example](https://example.com) trailing text
+                    public void trailing() { }
+                
+                    /// text
+                    /// @see [One](https://a) [Two](https://b)
+                    public void multiple() { }
+                
+                    /// text
+                    /// @see [String]
+                    public void shorthand() { }
+                }
+                """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "--source-path",
+                src.toString(),
+                "p");
+
+        checkExit(Exit.ERROR);
+
+        checkOutput(Output.OUT, true,
+                "error: invalid usage of tag @see");
+        checkOutput(Output.OUT, false,
+                "IllegalStateException: LINK");
+        checkOutput("p/C.html", false,
+                """
+                <a href="https://example.com">Example</a> trailing text""", """
+                <a href="https://a">One</a>""", """
+                <a href="https://b">Two</a>""");
     }
 }


### PR DESCRIPTION
Please review this patch to support markdown link syntax in `@see`tags.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8371504](https://bugs.openjdk.org/browse/JDK-8371504): Support Markdown link syntax in Markdown @<!---->see tags (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) Review applies to [d3eca5ca](https://git.openjdk.org/jdk/pull/31532/files/d3eca5ca3dc2664d0466f0675ae01ceebf0e3a96)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31532/head:pull/31532` \
`$ git checkout pull/31532`

Update a local copy of the PR: \
`$ git checkout pull/31532` \
`$ git pull https://git.openjdk.org/jdk.git pull/31532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31532`

View PR using the GUI difftool: \
`$ git pr show -t 31532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31532.diff">https://git.openjdk.org/jdk/pull/31532.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31532#issuecomment-4741028662)
</details>
