### PR TITLE
8375623: Excessive disk space usage of jpackage and jlink tests in debug builds after JDK-8373246

### DIFF
--- a/src/jdk.jlink/linux/classes/jdk/tools/jlink/internal/plugins/StripNativeDebugSymbolsPlugin.java
+++ b/src/jdk.jlink/linux/classes/jdk/tools/jlink/internal/plugins/StripNativeDebugSymbolsPlugin.java
@@ -104,9 +104,13 @@ public final class StripNativeDebugSymbolsPlugin extends AbstractPlugin {
                                                         stripBin);
         in.transformAndCopy((resource) -> {
             ResourcePoolEntry res = resource;
-            if ((resource.type() == ResourcePoolEntry.Type.NATIVE_LIB &&
-                 resource.path().endsWith(SHARED_LIBS_EXT)) ||
-                resource.type() == ResourcePoolEntry.Type.NATIVE_CMD) {
+            if (!includeDebugSymbols &&
+                (resource.path().endsWith(".debuginfo") ||
+                 resource.path().endsWith(".diz"))) {
+                res = null; // drop pre-existing debug sidecar (NATIVE_LIB or NATIVE_CMD)
+            } else if ((resource.type() == ResourcePoolEntry.Type.NATIVE_LIB &&
+                        resource.path().endsWith(SHARED_LIBS_EXT)) ||
+                       resource.type() == ResourcePoolEntry.Type.NATIVE_CMD) {
                 Optional<StrippedDebugInfoBinary> strippedBin = builder.build(resource);
                 if (strippedBin.isPresent()) {
                     StrippedDebugInfoBinary sb = strippedBin.get();

--- a/test/jdk/tools/jlink/plugins/StripNativeDebugSymbolsPlugin/StripNativeDebugSymbolsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StripNativeDebugSymbolsPlugin/StripNativeDebugSymbolsPluginTest.java
@@ -223,11 +223,10 @@ public class StripNativeDebugSymbolsPluginTest {
         StripNativeDebugSymbolsPlugin plugin = createAndConfigPlugin(config, expectedObjCopy);
         String binFile = "mybin";
         String path = "/fib/bin/" + binFile;
-        // The build system names sidecars as NOSUFFIX.debuginfo (no .so in the middle).
-        // Both NATIVE_LIB and NATIVE_CMD entries can have .debuginfo sidecars.
         String nativeLibDebuginfo = "/fib/lib/libFib.debuginfo";
         String nativeCmdDebuginfo = "/fib/bin/mybin.debuginfo";
-        String dizPath             = "/fib/lib/libFib.diz";
+        String nativeLibDiz       = "/fib/lib/libFib.diz";
+        String nativeCmdDiz       = "/fib/bin/mybin.diz";
         ResourcePoolEntry debugEntry = createMockEntry(path,
                                                        ResourcePoolEntry.Type.NATIVE_CMD);
         ResourcePoolManager inResources = new ResourcePoolManager();
@@ -235,7 +234,8 @@ public class StripNativeDebugSymbolsPluginTest {
         inResources.add(debugEntry);
         inResources.add(createMockEntry(nativeLibDebuginfo, ResourcePoolEntry.Type.NATIVE_LIB));
         inResources.add(createMockEntry(nativeCmdDebuginfo, ResourcePoolEntry.Type.NATIVE_CMD));
-        inResources.add(createMockEntry(dizPath,            ResourcePoolEntry.Type.NATIVE_LIB));
+        inResources.add(createMockEntry(nativeLibDiz,       ResourcePoolEntry.Type.NATIVE_LIB));
+        inResources.add(createMockEntry(nativeCmdDiz,       ResourcePoolEntry.Type.NATIVE_CMD));
         ResourcePool output = plugin.transform(
                                         inResources.resourcePool(),
                                         outResources.resourcePoolBuilder());
@@ -255,9 +255,13 @@ public class StripNativeDebugSymbolsPluginTest {
             throw new AssertionError("Expected pre-existing NATIVE_CMD .debuginfo to be dropped: "
                                      + nativeCmdDebuginfo);
         }
-        if (output.findEntry(dizPath).isPresent()) {
-            throw new AssertionError("Expected pre-existing .diz to be dropped: "
-                                     + dizPath);
+        if (output.findEntry(nativeLibDiz).isPresent()) {
+            throw new AssertionError("Expected pre-existing NATIVE_LIB .diz to be dropped: "
+                                     + nativeLibDiz);
+        }
+        if (output.findEntry(nativeCmdDiz).isPresent()) {
+            throw new AssertionError("Expected pre-existing NATIVE_CMD .diz to be dropped: "
+                                     + nativeCmdDiz);
         }
         verifyFakeObjCopyCalled(binFile);
     }
@@ -279,14 +283,15 @@ public class StripNativeDebugSymbolsPluginTest {
         StripNativeDebugSymbolsPlugin plugin = createAndConfigPlugin(config, expectedObjCopy);
         String sharedLib = "myLib.so";
         String path = "/fib/lib/" + sharedLib;
-        // Pre-existing sidecar from the runtime image (NOSUFFIX.debuginfo form).
         String preExistingDebuginfo = "/fib/lib/myLib.debuginfo";
+        String preExistingLibDiz    = "/fib/lib/myLib.diz";
         ResourcePoolEntry debugEntry = createMockEntry(path,
                                                        ResourcePoolEntry.Type.NATIVE_LIB);
         ResourcePoolManager inResources = new ResourcePoolManager();
         ResourcePoolManager outResources = new ResourcePoolManager();
         inResources.add(debugEntry);
         inResources.add(createMockEntry(preExistingDebuginfo, ResourcePoolEntry.Type.NATIVE_LIB));
+        inResources.add(createMockEntry(preExistingLibDiz,    ResourcePoolEntry.Type.NATIVE_LIB));
         ResourcePool output = plugin.transform(
                                         inResources.resourcePool(),
                                         outResources.resourcePoolBuilder());
@@ -301,10 +306,14 @@ public class StripNativeDebugSymbolsPluginTest {
                                      "{,." + debugExt +"} not present after " +
                                      "stripping!");
         }
-        // pre-existing sidecar must be preserved when keep-debuginfo-files is set
+        // pre-existing sidecars must be preserved when keep-debuginfo-files is set
         if (!output.findEntry(preExistingDebuginfo).isPresent()) {
-            throw new AssertionError("Expected pre-existing .debuginfo to be kept: "
+            throw new AssertionError("Expected pre-existing NATIVE_LIB .debuginfo to be kept: "
                                      + preExistingDebuginfo);
+        }
+        if (!output.findEntry(preExistingLibDiz).isPresent()) {
+            throw new AssertionError("Expected pre-existing NATIVE_LIB .diz to be kept: "
+                                     + preExistingLibDiz);
         }
         verifyFakeObjCopyCalledMultiple(sharedLib, debugExt);
     }

--- a/test/jdk/tools/jlink/plugins/StripNativeDebugSymbolsPlugin/StripNativeDebugSymbolsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StripNativeDebugSymbolsPlugin/StripNativeDebugSymbolsPluginTest.java
@@ -223,20 +223,41 @@ public class StripNativeDebugSymbolsPluginTest {
         StripNativeDebugSymbolsPlugin plugin = createAndConfigPlugin(config, expectedObjCopy);
         String binFile = "mybin";
         String path = "/fib/bin/" + binFile;
+        // The build system names sidecars as NOSUFFIX.debuginfo (no .so in the middle).
+        // Both NATIVE_LIB and NATIVE_CMD entries can have .debuginfo sidecars.
+        String nativeLibDebuginfo = "/fib/lib/libFib.debuginfo";
+        String nativeCmdDebuginfo = "/fib/bin/mybin.debuginfo";
+        String dizPath             = "/fib/lib/libFib.diz";
         ResourcePoolEntry debugEntry = createMockEntry(path,
                                                        ResourcePoolEntry.Type.NATIVE_CMD);
         ResourcePoolManager inResources = new ResourcePoolManager();
         ResourcePoolManager outResources = new ResourcePoolManager();
         inResources.add(debugEntry);
+        inResources.add(createMockEntry(nativeLibDebuginfo, ResourcePoolEntry.Type.NATIVE_LIB));
+        inResources.add(createMockEntry(nativeCmdDebuginfo, ResourcePoolEntry.Type.NATIVE_CMD));
+        inResources.add(createMockEntry(dizPath,            ResourcePoolEntry.Type.NATIVE_LIB));
         ResourcePool output = plugin.transform(
                                         inResources.resourcePool(),
                                         outResources.resourcePoolBuilder());
-        // expect entry to be present
+        // expect binary entry to be present
         if (output.findEntry(path).isPresent()) {
             System.out.println("DEBUG: File " + path + " present as exptected.");
         } else {
             throw new AssertionError("Test failed. Binary " + path +
                                      " not present after stripping!");
+        }
+        // pre-existing debug sidecar files must be dropped regardless of type
+        if (output.findEntry(nativeLibDebuginfo).isPresent()) {
+            throw new AssertionError("Expected pre-existing NATIVE_LIB .debuginfo to be dropped: "
+                                     + nativeLibDebuginfo);
+        }
+        if (output.findEntry(nativeCmdDebuginfo).isPresent()) {
+            throw new AssertionError("Expected pre-existing NATIVE_CMD .debuginfo to be dropped: "
+                                     + nativeCmdDebuginfo);
+        }
+        if (output.findEntry(dizPath).isPresent()) {
+            throw new AssertionError("Expected pre-existing .diz to be dropped: "
+                                     + dizPath);
         }
         verifyFakeObjCopyCalled(binFile);
     }
@@ -258,15 +279,18 @@ public class StripNativeDebugSymbolsPluginTest {
         StripNativeDebugSymbolsPlugin plugin = createAndConfigPlugin(config, expectedObjCopy);
         String sharedLib = "myLib.so";
         String path = "/fib/lib/" + sharedLib;
+        // Pre-existing sidecar from the runtime image (NOSUFFIX.debuginfo form).
+        String preExistingDebuginfo = "/fib/lib/myLib.debuginfo";
         ResourcePoolEntry debugEntry = createMockEntry(path,
                                                        ResourcePoolEntry.Type.NATIVE_LIB);
         ResourcePoolManager inResources = new ResourcePoolManager();
         ResourcePoolManager outResources = new ResourcePoolManager();
         inResources.add(debugEntry);
+        inResources.add(createMockEntry(preExistingDebuginfo, ResourcePoolEntry.Type.NATIVE_LIB));
         ResourcePool output = plugin.transform(
                                         inResources.resourcePool(),
                                         outResources.resourcePoolBuilder());
-        // expect entry + debug info entry to be present
+        // expect entry + newly created debug info entry to be present
         String debugPath = path + "." + debugExt;
         if (output.findEntry(path).isPresent() &&
             output.findEntry(debugPath).isPresent()) {
@@ -276,6 +300,11 @@ public class StripNativeDebugSymbolsPluginTest {
             throw new AssertionError("Test failed. Binary files " + path +
                                      "{,." + debugExt +"} not present after " +
                                      "stripping!");
+        }
+        // pre-existing sidecar must be preserved when keep-debuginfo-files is set
+        if (!output.findEntry(preExistingDebuginfo).isPresent()) {
+            throw new AssertionError("Expected pre-existing .debuginfo to be kept: "
+                                     + preExistingDebuginfo);
         }
         verifyFakeObjCopyCalledMultiple(sharedLib, debugExt);
     }


### PR DESCRIPTION
When jlink --strip-debug (or --strip-native-debug-symbols exclude-debuginfo-files) is used to link from a runtime image, pre-existing native debug symbol sidecar files (.debuginfo, .diz) are incorrectly included in the output image. On a JDK built with external debug symbols, this results in large files such as lib/server/libjvm.debuginfo (often 1 GB) appearing in the linked image despite the explicit request to strip debug information.

StripNativeDebugSymbolsPlugin.transform() only processes entries whose path ends in .so (NATIVE_LIB) or whose type is NATIVE_CMD. Sidecar files have type NATIVE_LIB or NATIVE_CMD but paths ending in .debuginfo or .diz (compressed .debuginfo), so they fall through the filter unchanged.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8375623](https://bugs.openjdk.org/browse/JDK-8375623): Excessive disk space usage of jpackage and jlink tests in debug builds after JDK-8373246 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31534/head:pull/31534` \
`$ git checkout pull/31534`

Update a local copy of the PR: \
`$ git checkout pull/31534` \
`$ git pull https://git.openjdk.org/jdk.git pull/31534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31534`

View PR using the GUI difftool: \
`$ git pr show -t 31534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31534.diff">https://git.openjdk.org/jdk/pull/31534.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31534#issuecomment-4751544365)
</details>
