### PR TITLE
8386707: [BACKOUT] ZGC: Incorrect object undo in relocation race for relocation workers

### DIFF
--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -642,7 +642,7 @@ private:
     const zaddress to_addr = _forwarding->insert(from_addr, allocated_addr, &cursor);
     if (to_addr != allocated_addr) {
       // Already relocated, undo allocation
-      _allocator->undo_alloc_object(to_page, allocated_addr, size);
+      _allocator->undo_alloc_object(to_page, to_addr, size);
       increase_other_forwarded(size);
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cba30170](https://github.com/openjdk/jdk/commit/cba301704701da5b3e92a82d340cce82b0c8c7ea) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Joel Sikström on 16 Jun 2026 and was reviewed by Stefan Karlsson and Axel Boldt-Christmas.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386707](https://bugs.openjdk.org/browse/JDK-8386707): [BACKOUT] ZGC: Incorrect object undo in relocation race for relocation workers (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31536/head:pull/31536` \
`$ git checkout pull/31536`

Update a local copy of the PR: \
`$ git checkout pull/31536` \
`$ git pull https://git.openjdk.org/jdk.git pull/31536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31536`

View PR using the GUI difftool: \
`$ git pr show -t 31536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31536.diff">https://git.openjdk.org/jdk/pull/31536.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31536#issuecomment-4719846141)
</details>
