### PR TITLE
8386762: C2: Allow inlining cold methods 

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -471,6 +471,11 @@ void CompilerConfig::ergo_initialize() {
     FLAG_SET_CMDLINE(ProfileInterpreter, false);
   }
 
+  // Xcomp has no reasonable profiling information, enable inlining cold methods
+  if (Arguments::is_compiler_only() && FLAG_IS_DEFAULT(InlineColdMethods)) {
+    FLAG_SET_DEFAULT(InlineColdMethods, true);
+  }
+
 #ifdef COMPILER2
   if (!EliminateLocks) {
     EliminateNestedLocks = false;

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -471,12 +471,11 @@ void CompilerConfig::ergo_initialize() {
     FLAG_SET_CMDLINE(ProfileInterpreter, false);
   }
 
+#ifdef COMPILER2
   // Xcomp has no reasonable profiling information, enable inlining cold methods
   if (Arguments::is_compiler_only() && FLAG_IS_DEFAULT(InlineColdMethods)) {
     FLAG_SET_DEFAULT(InlineColdMethods, true);
   }
-
-#ifdef COMPILER2
   if (!EliminateLocks) {
     EliminateNestedLocks = false;
   }

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -383,6 +383,12 @@
           "If compilation is stopped with an error, capture diagnostic "    \
           "information at the bailout point")                               \
                                                                             \
+  product(bool, InlineColdMethods, false, DIAGNOSTIC,                       \
+          "Inline cold methods that would otherwise be rejected due to "    \
+          "cold profile counters. Useful for compiler testing to expose "   \
+          "more code to compilers.")                                        \
+                                                                            \
+
 // end of COMPILER_FLAGS
 
 DECLARE_FLAGS(COMPILER_FLAGS)

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -383,12 +383,6 @@
           "If compilation is stopped with an error, capture diagnostic "    \
           "information at the bailout point")                               \
                                                                             \
-  product(bool, InlineColdMethods, false, DIAGNOSTIC,                       \
-          "Inline cold methods that would otherwise be rejected due to "    \
-          "cold profile counters. Useful for compiler testing to expose "   \
-          "more code to compilers.")                                        \
-                                                                            \
-
 // end of COMPILER_FLAGS
 
 DECLARE_FLAGS(COMPILER_FLAGS)

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -295,32 +295,34 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
     return false;
   }
 
-  // don't use counts with -Xcomp
-  if (UseInterpreter) {
-    if (!callee_method->has_compiled_code() &&
-        !callee_method->was_executed_more_than(0)) {
-      set_msg("never executed");
+  // accept cold methods in CTW or -Xcomp
+  if (InlineColdMethods) {
+    return false;
+  }
+
+  if (!callee_method->has_compiled_code() &&
+      !callee_method->was_executed_more_than(0)) {
+    set_msg("never executed");
+    return true;
+  }
+
+  if (is_init_with_ea(callee_method, caller_method, C)) {
+    // Escape Analysis: inline all executed constructors
+    return false;
+  }
+
+  if (MinInlineFrequencyRatio > 0) {
+    int call_site_count  = caller_method->scale_count(profile.count());
+    int invoke_count     = caller_method->interpreter_invocation_count();
+    assert(invoke_count != 0, "require invocation count greater than zero");
+    double freq = (double)call_site_count / (double)invoke_count;
+    // avoid division by 0, set divisor to at least 1
+    int cp_min_inv = MAX2(1, CompilationPolicy::min_invocations());
+    double min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
+
+    if (freq < min_freq) {
+      set_msg("low call site frequency");
       return true;
-    }
-
-    if (is_init_with_ea(callee_method, caller_method, C)) {
-      // Escape Analysis: inline all executed constructors
-      return false;
-    }
-
-    if (MinInlineFrequencyRatio > 0) {
-      int call_site_count  = caller_method->scale_count(profile.count());
-      int invoke_count     = caller_method->interpreter_invocation_count();
-      assert(invoke_count != 0, "require invocation count greater than zero");
-      double freq = (double)call_site_count / (double)invoke_count;
-      // avoid division by 0, set divisor to at least 1
-      int cp_min_inv = MAX2(1, CompilationPolicy::min_invocations());
-      double min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
-
-      if (freq < min_freq) {
-        set_msg("low call site frequency");
-        return true;
-      }
     }
   }
 
@@ -328,8 +330,8 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
 }
 
 bool InlineTree::is_not_reached(ciMethod* callee_method, ciMethod* caller_method, int caller_bci, ciCallProfile& profile) {
-  if (!UseInterpreter) {
-    return false; // -Xcomp
+  if (InlineColdMethods) {
+    return false; // CTW or -Xcomp
   }
   if (profile.count() > 0) {
     return false; // reachable according to profile
@@ -405,7 +407,7 @@ bool InlineTree::try_to_inline(ciMethod* callee_method, ciMethod* caller_method,
       }
     }
 
-    if (!UseInterpreter &&
+    if (InlineColdMethods &&
         is_init_with_ea(callee_method, caller_method, C)) {
       // Escape Analysis stress testing when running Xcomp:
       // inline constructors even if they are not reached.

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -789,6 +789,11 @@
           "high tier compiler")                                             \
           range(0, max_jint)                                                \
                                                                             \
+  product(bool, InlineColdMethods, false, DIAGNOSTIC,                       \
+          "Inline cold methods that would otherwise be rejected due to "    \
+          "cold profile counters. Useful for compiler testing to expose "   \
+          "more code to compilers.")                                        \
+                                                                            \
   product(bool, IncrementalInline, true,                                    \
           "do post parse inlining")                                         \
                                                                             \


### PR DESCRIPTION
Splitting the internal infrastructure from [JDK-8360557](https://bugs.openjdk.org/browse/JDK-8360557), so we can have the aggressive compilation options available for runtime use. The goal for this PR is to avoid new bugs that would block its integration. We can switch CTW to use this facility later. See the rationale and found bugs in https://github.com/openjdk/jdk/pull/26068 and related JBS entry.

`-Xcomp` already uses a similar mechanism by sensing `!UseInterpreter` in places. This change makes the intent to inline cold methods for the sake of `-Xcomp` more explicit.

C1 does not have the problem of cutting out too cold methods, so this issue is fairly specific to C2.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386762](https://bugs.openjdk.org/browse/JDK-8386762): C2: Allow inlining cold methods (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31537/head:pull/31537` \
`$ git checkout pull/31537`

Update a local copy of the PR: \
`$ git checkout pull/31537` \
`$ git pull https://git.openjdk.org/jdk.git pull/31537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31537`

View PR using the GUI difftool: \
`$ git pr show -t 31537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31537.diff">https://git.openjdk.org/jdk/pull/31537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31537#issuecomment-4720135101)
</details>
