### PR TITLE
8386795: Swing specification needs caveats on L&F rendering behaviors

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/UIManager.java
+++ b/src/java.desktop/share/classes/javax/swing/UIManager.java
@@ -184,7 +184,7 @@ import sun.swing.SwingAccessor;
  * <ul>
  * <li>specified rendering of painted borders may be ignored
  * <li>specified rendering of highlighting effects may be ignored
- * <li>specified rendering of painted backgrounds and foreground may be ignored
+ * <li>specified rendering of painted backgrounds and foregrounds may be ignored
  * <li>specified rendering of selected vs unselected components may be ignored
  * <li>specified rendering of enabled vs disabled components may be ignored
  * </ul>
@@ -192,7 +192,7 @@ import sun.swing.SwingAccessor;
  * <p>
  * These caveats must not be construed as an excuse to arbitrarily ignore these properties.
  * They are intended to support the requirement that the platform Look and Feel be as
- * faithful to the native rendering as is practical.
+ * consistent with the native rendering as is practical.
  *
  * <p>
  * <strong>Warning:</strong>

--- a/src/java.desktop/share/classes/javax/swing/UIManager.java
+++ b/src/java.desktop/share/classes/javax/swing/UIManager.java
@@ -158,6 +158,42 @@ import sun.swing.SwingAccessor;
  * expects certain defaults, so that in general
  * a {@code ComponentUI} provided by one look and feel will not
  * work with another look and feel.
+ *
+ * <h2>System Look and Feels</h2>
+ *
+ * [The terms "System", "Native" and "Platform" may be used interchangeably in this context].
+ * <p>
+ * A System Look And Feel is intended to implement the native Look and Feel of the desktop.
+ * <p>
+ * There is no requirement for the standard Java Look And Feel to be the default,
+ * therefore the System Look and Feel may be the default.
+ * <p>
+ * A desktop may not have a consistent Look and Feel, for example if there are
+ * multiple platform-native toolkits provided to create applications for the desktop.
+ * Swing may elect any one of these to be its native Look and Feel.
+ * <p>
+ * Installation of the native Look and Feel may depend on platform resources being available.
+ * In the event that required resources are not available, Swing may be unable to install
+ * the System Look and Feel.
+ * <p>
+ * Swing's emulation of the native Look and Feel takes precedence over any component-specific
+ * indication of rendering.
+ * This means that a native Look and Feel should render in a way that is consistent with the platform,
+ * even if it contradicts component setting-specific documentation.
+ * Examples include
+ * <ul>
+ * <li>specified rendering of painted borders may be ignored
+ * <li>specified rendering of highlighting effects may be ignored
+ * <li>specified rendering of painted backgrounds and foreground may be ignored
+ * <li>specified rendering of selected vs unselected components may be ignored
+ * <li>specified rendering of enabled vs disabled components may be ignored
+ * </ul>
+ * These are just examples. Not an exhaustive list.
+ * <p>
+ * These caveats must not be construed as an excuse to arbitrarily ignore these properties.
+ * They are intended to support the requirement that the platform Look and Feel be as
+ * faithful to the native rendering as is practical.
+ * 
  * <p>
  * <strong>Warning:</strong>
  * Serialized objects of this class will not be compatible with

--- a/src/java.desktop/share/classes/javax/swing/UIManager.java
+++ b/src/java.desktop/share/classes/javax/swing/UIManager.java
@@ -193,7 +193,7 @@ import sun.swing.SwingAccessor;
  * These caveats must not be construed as an excuse to arbitrarily ignore these properties.
  * They are intended to support the requirement that the platform Look and Feel be as
  * faithful to the native rendering as is practical.
- * 
+ *
  * <p>
  * <strong>Warning:</strong>
  * Serialized objects of this class will not be compatible with


### PR DESCRIPTION
This update to the documentation is motivated by regular bug reports complaining that some case using a platform L&F does not render as the documentation suggests. This is usually because the javadoc was written for L&Fs under the control of Swing. Whereas for platform L&Fs the goal is to render consistently with the platform.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8386797](https://bugs.openjdk.org/browse/JDK-8386797) to be approved
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8386795](https://bugs.openjdk.org/browse/JDK-8386795): Swing specification needs caveats on L&amp;F rendering behaviors (**Bug** - P3)
 * [JDK-8386797](https://bugs.openjdk.org/browse/JDK-8386797): Swing specification needs caveats on L&amp;F rendering behaviors (**CSR**)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31538/head:pull/31538` \
`$ git checkout pull/31538`

Update a local copy of the PR: \
`$ git checkout pull/31538` \
`$ git pull https://git.openjdk.org/jdk.git pull/31538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31538`

View PR using the GUI difftool: \
`$ git pr show -t 31538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31538.diff">https://git.openjdk.org/jdk/pull/31538.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31538#issuecomment-4723037003)
</details>
