### PR TITLE
8386671: Raster factory methods fail to throw specified exceptions for invalid bandOffsets and bankIndices

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -308,6 +308,13 @@ public class Raster {
         if (bandOffsets == null) {
             throw new NullPointerException("bandOffsets is null");
         }
+        for (int i = 0; i < bandOffsets.length; i++) {
+            int off = bandOffsets[i];
+            if ((off > pixelStride) || (off > scanlineStride)) {
+                throw new IllegalArgumentException("Band offset " + off + " is too large for stride");
+            }
+        }
+
         lsz = (long)w * pixelStride;
         if (lsz > scanlineStride) {
             throw new IllegalArgumentException("w * pixelStride is too large");
@@ -803,6 +810,21 @@ public class Raster {
         if (dataBuffer == null) {
             throw new NullPointerException("DataBuffer cannot be null");
         }
+        if (pixelStride <= 0) {
+            throw new IllegalArgumentException("pixelStride is <= 0");
+        }
+        if (scanlineStride <= 0) {
+            throw new IllegalArgumentException("scanlineStride is <= 0");
+        }
+        if (bandOffsets == null) {
+            throw new NullPointerException("bandOffsets is null");
+        }
+        for (int i = 0; i < bandOffsets.length; i++) {
+            int off = bandOffsets[i];
+            if ((off > pixelStride) || (off > scanlineStride)) {
+                throw new IllegalArgumentException("Band offset " + off + " is too large for stride");
+            }
+        }
 
         if (location == null) {
             location = new Point(0, 0);
@@ -912,6 +934,14 @@ public class Raster {
         if (bandOffsets.length != bands) {
             throw new IllegalArgumentException(
                                    "bankIndices.length != bandOffsets.length");
+        }
+
+        int numBanks = dataBuffer.getNumBanks();
+        for (int i = 0; i < bands; i++) {
+            if (bankIndices[i] >= numBanks) {
+                throw new ArrayIndexOutOfBoundsException("Bank[" + i + "] == " + bankIndices[i] +
+                         " and there are only " + numBanks + " banks.");
+            }
         }
 
         if (location == null) {

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -810,11 +810,11 @@ public class Raster {
         if (dataBuffer == null) {
             throw new NullPointerException("DataBuffer cannot be null");
         }
-        if (pixelStride <= 0) {
-            throw new IllegalArgumentException("pixelStride is <= 0");
+        if (pixelStride < 0) {
+            throw new IllegalArgumentException("pixelStride is < 0");
         }
-        if (scanlineStride <= 0) {
-            throw new IllegalArgumentException("scanlineStride is <= 0");
+        if (scanlineStride < 0) {
+            throw new IllegalArgumentException("scanlineStride is < 0");
         }
         if (bandOffsets == null) {
             throw new NullPointerException("bandOffsets is null");

--- a/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
+++ b/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8255800 8369129 8376297
+ * @bug 8255800 8369129 8376297 8386671
  * @summary verify Raster + SampleModel creation vs spec.
  */
 

--- a/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
+++ b/test/jdk/java/awt/image/Raster/CreateRasterExceptionTest.java
@@ -931,9 +931,10 @@ public class CreateRasterExceptionTest {
             /* @throws ArrayIndexOutOfBoundsException if any element of {@code bankIndices}
              *         is greater or equal to the number of bands in {@code dataBuffer}
              */
+            DataBuffer dBuffer2Bands = new DataBufferByte(15, 2);
             int[] indices = new int[] { 0, 1, 2 };
             int[] offsets = new int[] { 0, 0, 0 };
-            Raster.createBandedRaster(dBuffer, 1, 1, 1,
+            Raster.createBandedRaster(dBuffer2Bands, 1, 1, 1,
                                       indices, offsets, null);
             noException();
         } catch (ArrayIndexOutOfBoundsException t) {
@@ -1198,6 +1199,21 @@ public class CreateRasterExceptionTest {
                    "Got expected exception for bad databuffer type");
             System.out.println(t);
         }
+
+        try {
+             /* @throws IllegalArgumentException if any element of {@code bandOffsets} is greater
+             *  than {@code pixelStride} or the {@code scanlineStride}
+             */
+            int[] offsets = new int[] {2};
+            Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE,
+                                  1, 1, 1, 1, offsets, null);
+            noException();
+        } catch (IllegalArgumentException t) {
+            System.out.println(
+                   "Got expected exception for element too large");
+            System.out.println(t);
+        }
+
     }
 
      /* createInterleavedRaster(DataBuffer dBuffer,
@@ -1344,7 +1360,7 @@ public class CreateRasterExceptionTest {
              /* @throws IllegalArgumentException if any element of {@code bandOffsets} is greater
              *  than {@code pixelStride} or the {@code scanlineStride}
              */
-            int[] offsets = new int[] { 0, 1, 2};
+            int[] offsets = new int[] {2};
             Raster.createInterleavedRaster(dBuffer,
                                   1, 1, 1, 1, offsets, null);
             noException();


### PR DESCRIPTION
In JDK 26 the spec for various methods in Raster were updated under https://bugs.openjdk.org/browse/JDK-8369129

It was discovered that some cases did not actually check an out-of-bounds bank index as specified
There was a test for two of these cases but there was a bug which caused it to get the expected exception for a different reason.

The implementation and the test are fixed.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386671](https://bugs.openjdk.org/browse/JDK-8386671): Raster factory methods fail to throw specified exceptions for invalid bandOffsets and bankIndices (**Bug** - P2)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) Review applies to [abb512a0](https://git.openjdk.org/jdk/pull/31540/files/abb512a0e1c65743358c4c2319b40cb15bb85487)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31540/head:pull/31540` \
`$ git checkout pull/31540`

Update a local copy of the PR: \
`$ git checkout pull/31540` \
`$ git pull https://git.openjdk.org/jdk.git pull/31540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31540`

View PR using the GUI difftool: \
`$ git pr show -t 31540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31540.diff">https://git.openjdk.org/jdk/pull/31540.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31540#issuecomment-4723827859)
</details>
