### PR TITLE
8386805: Drop ICF optimization from MSVC compilation flags

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -93,7 +93,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     BASIC_LDFLAGS="-opt:ref"
     BASIC_LDFLAGS_JDK_ONLY="-incremental:no"
-    BASIC_LDFLAGS_JVM_ONLY="-opt:icf,8 -subsystem:windows"
+    BASIC_LDFLAGS_JVM_ONLY="-opt:noicf -subsystem:windows"
     LDFLAGS_LTO="-LTCG:INCREMENTAL"
   fi
 


### PR DESCRIPTION
The assertion in src/hotspot/share/code/aotCodeCache.cpp requires that
all functions are mapped to distinct addresses, but this assumption
breaks when we enable the Identical COMDAT Folding optimization in MSVC.
Indeed, the MSVC documentation points to this exact issue being a
potential problem:

> Because /OPT:ICF can cause the same address to be assigned to
> different functions or read-only data members (that is, const
> variables when compiled by using /Gy), it can break a program that
> depends on unique addresses for functions or read-only data members.

To avoid future problems with AOT failing because of ICF, this patch
disables ICF when compiling the JVM.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386805](https://bugs.openjdk.org/browse/JDK-8386805): Drop ICF optimization from MSVC compilation flags (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31544/head:pull/31544` \
`$ git checkout pull/31544`

Update a local copy of the PR: \
`$ git checkout pull/31544` \
`$ git pull https://git.openjdk.org/jdk.git pull/31544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31544`

View PR using the GUI difftool: \
`$ git pr show -t 31544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31544.diff">https://git.openjdk.org/jdk/pull/31544.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31544#issuecomment-4724472204)
</details>
