### PR TITLE
8386807: com/sun/jndi/ldap/Connection.java references the wrong exception

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1173,8 +1173,13 @@ public final class Connection implements Runnable {
                 tlsHandshakeCompleted.complete(tlsServerCert);
             } catch (SSLPeerUnverifiedException ex) {
                 CommunicationException ce = new CommunicationException();
-                ce.setRootCause(closureReason);
-                ce.addSuppressed(ex);
+                IOException priorFailure = closureReason;
+                if (priorFailure != null) {
+                    ce.setRootCause(priorFailure);
+                    ce.addSuppressed(ex);
+                } else {
+                    ce.setRootCause(ex);
+                }
                 tlsHandshakeCompleted.completeExceptionally(ce);
             }
         }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1174,7 +1174,8 @@ public final class Connection implements Runnable {
             } catch (SSLPeerUnverifiedException ex) {
                 CommunicationException ce = new CommunicationException();
                 ce.setRootCause(closureReason);
-                tlsHandshakeCompleted.completeExceptionally(ex);
+                ce.addSuppressed(ex);
+                tlsHandshakeCompleted.completeExceptionally(ce);
             }
         }
     }


### PR DESCRIPTION
Instead of discarding the newly created `CommunicationException`
exception and referencing the outer (caught)
`SSLPeerUnverifiedException` exception, this patch adds the
`SSLPeerUnverifiedException` exception as the suppressed exception of
the newly created `CommunicationException` exception.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386807](https://bugs.openjdk.org/browse/JDK-8386807): com/sun/jndi/ldap/Connection.java references the wrong exception (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31545/head:pull/31545` \
`$ git checkout pull/31545`

Update a local copy of the PR: \
`$ git checkout pull/31545` \
`$ git pull https://git.openjdk.org/jdk.git pull/31545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31545`

View PR using the GUI difftool: \
`$ git pr show -t 31545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31545.diff">https://git.openjdk.org/jdk/pull/31545.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31545#issuecomment-4724937267)
</details>
