### PR TITLE
8001150: [TEST_BUG] Improve instructions for java/awt/xembed/server/TestXEmbedServerJava.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -661,6 +661,7 @@ javax/swing/JInternalFrame/bug4134077.java 8184985 windows-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_1.java 7131438,8022539 generic-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_2.java 7131438,8022539 generic-all
 java/awt/Modal/WsDisabledStyle/CloseBlocker/CloseBlocker.java 7187741 linux-all,macosx-all
+java/awt/xembed/server/TestXEmbedServerJava.java 8001150,8004031 generic-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/Frame/FrameStateTest/FrameStateTest.java 8203920 macosx-all,linux-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -661,7 +661,6 @@ javax/swing/JInternalFrame/bug4134077.java 8184985 windows-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_1.java 7131438,8022539 generic-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_2.java 7131438,8022539 generic-all
 java/awt/Modal/WsDisabledStyle/CloseBlocker/CloseBlocker.java 7187741 linux-all,macosx-all
-java/awt/xembed/server/TestXEmbedServerJava.java 8001150,8004031 generic-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/Frame/FrameStateTest/FrameStateTest.java 8203920 macosx-all,linux-all

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServer.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServer.java
@@ -34,7 +34,7 @@ import java.awt.datatransfer.*;
 
 public abstract class TestXEmbedServer {
     // vertical position of server AND client windows
-    private static final int VERTICAL_POSITION = 360;
+    private static final int VERTICAL_POSITION = 200;
 
     private static final Logger log = Logger.getLogger("test.xembed");
     Frame f;
@@ -169,7 +169,7 @@ public abstract class TestXEmbedServer {
         dummy.setBounds(0, VERTICAL_POSITION, 100, 100);
         dummy.setVisible(true);
 
-        f.setBounds(540, VERTICAL_POSITION, 700, 300);
+        f.setBounds(300, VERTICAL_POSITION, 800, 300);
         f.setVisible(true);
     }
 

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServer.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServer.java
@@ -34,7 +34,7 @@ import java.awt.datatransfer.*;
 
 public abstract class TestXEmbedServer {
     // vertical position of server AND client windows
-    private static final int VERTICAL_POSITION = 200;
+    private static final int VERTICAL_POSITION = 360;
 
     private static final Logger log = Logger.getLogger("test.xembed");
     Frame f;
@@ -169,7 +169,7 @@ public abstract class TestXEmbedServer {
         dummy.setBounds(0, VERTICAL_POSITION, 100, 100);
         dummy.setVisible(true);
 
-        f.setBounds(300, VERTICAL_POSITION, 800, 300);
+        f.setBounds(540, VERTICAL_POSITION, 700, 300);
         f.setVisible(true);
     }
 

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -55,7 +55,7 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
             "  - Drag the text in the client text field and drop it to the left or right of the existing text within the same text field.\n" +
             "  - Drag the text from the client text field to the server text field.\n" +
             "  - Drag the text from the server text field to the client text field.\n";
-	Frame f = new Frame("Instructions");
+	    Frame f = new Frame("Instructions");
         f.setLayout(new BorderLayout());
         f.add(new TextArea(instruction), BorderLayout.CENTER);
         f.pack();

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -48,9 +48,14 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
             "You may start XEmbed client by pressing 'Add client' button.\n" +
             "Check that focus transfer with mouse works, that focus traversal with Tab/Shift-Tab works.\n" +
             "Check that XEmbed server client's growing and shrinking.\n" +
-            "Check that Drag&Drop works in all combinations.\n" +
-            "Check the keyboard input works in both text fields.\n";
-        Frame f = new Frame("Instructions");
+            "Check the keyboard input works in both text fields.\n" +
+            "  - Input some sample text into the server text field.\n" +
+            "  - Drag the text in the server text field and drop it to the left or right of the existing text within the same text field.\n" +
+            "  - Input some sample text into the client text field.\n" +
+            "  - Drag the text in the client text field and drop it to the left or right of the existing text within the same text field.\n" +
+            "  - Drag the text from the client text field to the server text field.\n" +
+            "  - Drag the text from the server text field to the client text field.\n";
+	Frame f = new Frame("Instructions");
         f.setLayout(new BorderLayout());
         f.add(new TextArea(instruction), BorderLayout.CENTER);
         f.pack();

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -55,7 +55,7 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
             "  - Drag the text in the client text field and drop it to the left or right of the existing text within the same text field.\n" +
             "  - Drag the text from the client text field to the server text field.\n" +
             "  - Drag the text from the server text field to the client text field.\n";
-	    Frame f = new Frame("Instructions");
+        Frame f = new Frame("Instructions");
         f.setLayout(new BorderLayout());
         f.add(new TextArea(instruction), BorderLayout.CENTER);
         f.pack();

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4931668
+ * @bug 4931668 8001150
  * @summary Tests XEmbed server/client functionality
  * @author denis mikhalkin: area=awt.xembed
  * @requires (!(os.family=="mac") & !(os.family=="windows"))

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -59,8 +59,7 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
             "  - Drag the text from the client text field to the server text field and verify it is dropped to the right of the existing text.\n" +
             "  - Drag the text from the server text field to the client text field and verify it is dropped to the right of the existing text.\n";
         Frame f = new Frame("Instructions");
-        TextArea instructionArea =
-                new TextArea(instruction, 16, 72, TextArea.SCROLLBARS_VERTICAL_ONLY);
+        TextArea instructionArea = new TextArea(instruction, 16, 104);
         instructionArea.setEditable(false);
         f.setLayout(new BorderLayout());
         f.add(instructionArea, BorderLayout.CENTER);
@@ -69,6 +68,7 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
         f.setVisible(true);
 
         TestXEmbedServerJava lock = new TestXEmbedServerJava();
+        lock.f.setLocation(260, lock.f.getY());
         try {
             synchronized(lock) {
                 lock.wait();

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -48,18 +48,24 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
             "You may start XEmbed client by pressing 'Add client' button.\n" +
             "Check that focus transfer with mouse works, that focus traversal with Tab/Shift-Tab works.\n" +
             "Check that XEmbed server client's growing and shrinking.\n" +
+            "  - Click the Increase size button in the embedded client and verify the client area grows.\n" +
+            "  - Click the Decrease size button in the embedded client and verify the client area shrinks.\n" +
+            "  - Repeat the grow and shrink actions a few times and verify the embedded client resizes correctly each time.\n" +
             "Check the keyboard input works in both text fields.\n" +
             "  - Input some sample text into the server text field.\n" +
-            "  - Drag the text in the server text field and drop it to the left or right of the existing text within the same text field.\n" +
+            "  - Drag the entire text in the server text field and verify it is dropped to the right of the existing text within the same text field.\n" +
             "  - Input some sample text into the client text field.\n" +
-            "  - Drag the text in the client text field and drop it to the left or right of the existing text within the same text field.\n" +
-            "  - Drag the text from the client text field to the server text field.\n" +
-            "  - Drag the text from the server text field to the client text field.\n";
+            "  - Drag the entire text in the client text field and verify it is dropped to the right of the existing text within the same text field.\n" +
+            "  - Drag the text from the client text field to the server text field and verify it is dropped to the right of the existing text.\n" +
+            "  - Drag the text from the server text field to the client text field and verify it is dropped to the right of the existing text.\n";
         Frame f = new Frame("Instructions");
+        TextArea instructionArea =
+                new TextArea(instruction, 16, 72, TextArea.SCROLLBARS_VERTICAL_ONLY);
+        instructionArea.setEditable(false);
         f.setLayout(new BorderLayout());
-        f.add(new TextArea(instruction), BorderLayout.CENTER);
+        f.add(instructionArea, BorderLayout.CENTER);
         f.pack();
-        f.setLocation(0, 400);
+        f.setLocation(20, 20);
         f.setVisible(true);
 
         TestXEmbedServerJava lock = new TestXEmbedServerJava();

--- a/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
+++ b/test/jdk/java/awt/xembed/server/TestXEmbedServerJava.java
@@ -64,11 +64,12 @@ public class TestXEmbedServerJava extends TestXEmbedServer {
         f.setLayout(new BorderLayout());
         f.add(instructionArea, BorderLayout.CENTER);
         f.pack();
-        f.setLocation(20, 20);
+        f.setLocation(120, 60);
         f.setVisible(true);
 
         TestXEmbedServerJava lock = new TestXEmbedServerJava();
-        lock.f.setLocation(260, lock.f.getY());
+        lock.f.setLocation(f.getX() + f.getWidth() + 20,
+                           f.getY() + f.getHeight() + 40);
         try {
             synchronized(lock) {
                 lock.wait();


### PR DESCRIPTION
 Please review this change that updates test instructions and adjusts the ProblemList entry.

**Summary:**
JDK-8001150: Fixed instruction ambiguity and added clearer test instructions.

  Tested Platform:
  Linux

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8001150](https://bugs.openjdk.org/browse/JDK-8001150): [TEST_BUG] Improve instructions for java/awt/xembed/server/TestXEmbedServerJava.java (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31546/head:pull/31546` \
`$ git checkout pull/31546`

Update a local copy of the PR: \
`$ git checkout pull/31546` \
`$ git pull https://git.openjdk.org/jdk.git pull/31546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31546`

View PR using the GUI difftool: \
`$ git pr show -t 31546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31546.diff">https://git.openjdk.org/jdk/pull/31546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31546#issuecomment-4803612107)
</details>
