### PR TITLE
8384287: java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java fails after JDK-8340987

### DIFF
--- a/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java
@@ -33,7 +33,8 @@ import java.awt.event.ActionListener;
 
 /*
  * @test
- * @bug 4800187
+ * @bug 4800187 8384287
+ * @requires (os.family == "windows")
  * @summary REGRESSION:show the wrong selection when there are \r characters in the text
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame


### PR DESCRIPTION
Test "java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java" fails because the text selected and displayed in the left/right TextArea alternates intermittently between "679" and "567" in linux platform. 

Fix: Similar to the automated test https://github.com/openjdk/jdk/blob/master/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectTest.java this test also has been made Windows specific.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384287](https://bugs.openjdk.org/browse/JDK-8384287): java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java fails after JDK-8340987 (**Bug** - P3)


### Reviewers
 * [Srinivas Mandalika](https://openjdk.org/census#smandalika) (@srmandal - Author)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31547/head:pull/31547` \
`$ git checkout pull/31547`

Update a local copy of the PR: \
`$ git checkout pull/31547` \
`$ git pull https://git.openjdk.org/jdk.git pull/31547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31547`

View PR using the GUI difftool: \
`$ git pr show -t 31547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31547.diff">https://git.openjdk.org/jdk/pull/31547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31547#issuecomment-4726485206)
</details>
