### PR TITLE
8386810: Improve debuggability of test/jdk/sun/nio/cs/TestStringCodingUTF8.java

### DIFF
--- a/test/jdk/sun/nio/cs/TestStringCodingUTF8.java
+++ b/test/jdk/sun/nio/cs/TestStringCodingUTF8.java
@@ -196,16 +196,20 @@ public class TestStringCodingUTF8 {
             printStartIdx = 0;
         }
         for (int i = printStartIdx; i < firstMismatchIndex + 20; i++) {
+            if (i >= expected.length && i >= actual.length) {
+                // no more elements in either arrays, we are done
+                break;
+            }
             final StringBuilder sb = new StringBuilder();
             sb.append("Index=").append(i).append(", expected=");
-            if (i > expected.length) {
+            if (i >= expected.length) {
                 // "expected" array isn't that big
                 sb.append("<no element>");
             } else {
                 sb.append(expected[i]);
             }
             sb.append(", actual=");
-            if (i > actual.length) {
+            if (i >= actual.length) {
                 // "actual" array isn't that big
                 sb.append("<no element>");
             } else {

--- a/test/jdk/sun/nio/cs/TestStringCodingUTF8.java
+++ b/test/jdk/sun/nio/cs/TestStringCodingUTF8.java
@@ -112,15 +112,13 @@ public class TestStringCodingUTF8 {
 
         //getBytes(csn);
         byte[] baStr = str.getBytes(cs.name());
-        if (!Arrays.equals(ba, baStr))
-            throw new RuntimeException("getBytes(csn) failed for charset " + cs
-                    + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
+        failIfMismatch(ba, baStr, "getBytes(csn) failed for charset " + cs
+                + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
 
         //getBytes(cs);
         baStr = str.getBytes(cs);
-        if (!Arrays.equals(ba, baStr))
-            throw new RuntimeException("getBytes(cs) failed for charset " + cs
-                    + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
+        failIfMismatch(ba, baStr, "getBytes(cs) failed for charset " + cs
+                + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
 
         //new String(csn);
         if (!new String(ba, cs.name()).equals(new String(decode(cs, ba, 0, ba.length))))
@@ -182,5 +180,42 @@ public class TestStringCodingUTF8 {
             throw new Error(x);
         }
         return Arrays.copyOf(ba, bb.position());
+    }
+
+    private static void failIfMismatch(final byte[] expected, final byte[] actual,
+                                       final String failureMsg) {
+        final int firstMismatchIndex = Arrays.mismatch(expected, actual);
+        if (firstMismatchIndex == -1) {
+            // no mismatch
+            return;
+        }
+        System.err.println("Arrays mismatch starts at index: " + firstMismatchIndex);
+        System.err.println("Printing few indexes before and after the mismatch:");
+        int printStartIdx = firstMismatchIndex - 20;
+        if (printStartIdx < 0) {
+            printStartIdx = 0;
+        }
+        for (int i = printStartIdx; i < firstMismatchIndex + 20; i++) {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("Index=").append(i).append(", expected=");
+            if (i > expected.length) {
+                // "expected" array isn't that big
+                sb.append("<no element>");
+            } else {
+                sb.append(expected[i]);
+            }
+            sb.append(", actual=");
+            if (i > actual.length) {
+                // "actual" array isn't that big
+                sb.append("<no element>");
+            } else {
+                sb.append(actual[i]);
+            }
+            if (i == firstMismatchIndex) {
+                sb.append(" <--- first mismatch");
+            }
+            System.err.println(sb.toString());
+        }
+        throw new RuntimeException(failureMsg);
     }
 }

--- a/test/jdk/sun/nio/cs/TestStringCodingUTF8.java
+++ b/test/jdk/sun/nio/cs/TestStringCodingUTF8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,26 @@
  * questions.
  */
 
-/* @test
-   @bug 7040220 8054307
-   @summary Test if StringCoding and NIO result have the same de/encoding result for UTF-8
- * @run main/othervm/timeout=2000 TestStringCodingUTF8
+/*
+ * @test
+ * @bug 7040220 8054307
+ * @summary Test if StringCoding and NIO result have the same de/encoding result for UTF-8
  * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main/othervm/timeout=2000 TestStringCodingUTF8
  */
 
 import java.util.*;
 import java.nio.*;
 import java.nio.charset.*;
 
+import jdk.test.lib.RandomFactory;
+
 public class TestStringCodingUTF8 {
+
+    private static final Random rnd = RandomFactory.getRandom();
+
     public static void main(String[] args) throws Throwable {
         test("UTF-8");
         test("CESU-8");
@@ -62,7 +70,7 @@ public class TestStringCodingUTF8 {
         for (int i = 0; i < 0x20000; i++) {
             list.add(i, i);
         }
-        Collections.shuffle(list);
+        Collections.shuffle(list, rnd);
         int j = 0;
         char[] bmpsupp = new char[0x30000];
         for (int i = 0; i < 0x20000; i++) {
@@ -72,7 +80,6 @@ public class TestStringCodingUTF8 {
         test(cs, bmpsupp, 0, bmpsupp.length);
 
         // randomed "off" and "len" on shuffled data
-        Random rnd = new Random();
         int maxlen = 1000;
         int itr = 5000;
         for (int i = 0; i < itr; i++) {
@@ -88,11 +95,13 @@ public class TestStringCodingUTF8 {
             //new String(csn);
             if (!new String(ba, cs.name()).equals(
                  new String(decode(cs, ba, 0, ba.length))))
-                throw new RuntimeException("new String(csn) failed");
+                throw new RuntimeException("new String(csn) failed for charset " + cs
+                        + " for byte array of length " + ba.length);
             //new String(cs);
             if (!new String(ba, cs).equals(
                  new String(decode(cs, ba, 0, ba.length))))
-                throw new RuntimeException("new String(cs) failed");
+                throw new RuntimeException("new String(cs) failed for charset " + cs
+                        + " for byte array of length " + ba.length);
         }
         System.out.println("done!");
     }
@@ -104,20 +113,24 @@ public class TestStringCodingUTF8 {
         //getBytes(csn);
         byte[] baStr = str.getBytes(cs.name());
         if (!Arrays.equals(ba, baStr))
-            throw new RuntimeException("getBytes(csn) failed");
+            throw new RuntimeException("getBytes(csn) failed for charset " + cs
+                    + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
 
         //getBytes(cs);
         baStr = str.getBytes(cs);
         if (!Arrays.equals(ba, baStr))
-            throw new RuntimeException("getBytes(cs) failed");
+            throw new RuntimeException("getBytes(cs) failed for charset " + cs
+                    + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
 
         //new String(csn);
         if (!new String(ba, cs.name()).equals(new String(decode(cs, ba, 0, ba.length))))
-            throw new RuntimeException("new String(csn) failed");
+            throw new RuntimeException("new String(csn) failed for charset " + cs
+                    + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
 
         //new String(cs);
         if (!new String(ba, cs).equals(new String(decode(cs, ba, 0, ba.length))))
-            throw new RuntimeException("new String(cs) failed");
+            throw new RuntimeException("new String(cs) failed for charset " + cs
+                    + ", character array length=" + ca.length + ", offset=" + off + ", len=" + len);
     }
 
     // copy/paste of the StringCoding.decode()


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to improve the debuggability of the `test/jdk/sun/nio/cs/TestStringCodingUTF8.java` test?

This test fails intermittently in our CI in older update releases with errors like:
```
java.lang.RuntimeException: getBytes(csn) failed
    at TestStringCodingUTF8.test(TestStringCodingUTF8.java:111)
    at TestStringCodingUTF8.test(TestStringCodingUTF8.java:85)
    at TestStringCodingUTF8.main(TestStringCodingUTF8.java:41) 
```

It's not clear from the failures whether this is a test specific issue or some genuine issue in some specific release of the JDK. Since the test uses a `Random` instance to generate the data to test, it isn't easy to reproduce it either.

The change in this PR proposes to use the `RandomFactory` test library which is equipped with printing the seed used by the `Random` instance. If the test fails in future, the seed should help reproduce the test data that ran into the failure. The change also improves the error messages in the test and updates the `Collections.shuffle()` call to pass it the same `Random` instance that's being used in the test.

The test continues to pass with this change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386810](https://bugs.openjdk.org/browse/JDK-8386810): Improve debuggability of test/jdk/sun/nio/cs/TestStringCodingUTF8.java (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [4a264f71](https://git.openjdk.org/jdk/pull/31548/files/4a264f71b84f40c627740a49629dc0767c9d6134)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31548/head:pull/31548` \
`$ git checkout pull/31548`

Update a local copy of the PR: \
`$ git checkout pull/31548` \
`$ git pull https://git.openjdk.org/jdk.git pull/31548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31548`

View PR using the GUI difftool: \
`$ git pr show -t 31548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31548.diff">https://git.openjdk.org/jdk/pull/31548.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31548#issuecomment-4727137937)
</details>
