### PR TITLE
Backport ef5b328ce5a8f1a27f87745d6cc19db7baec4c3f

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -1112,6 +1112,9 @@ public final class StackMapGenerator {
                     }
                     locals[localsSize++] = type;
                 }
+            }
+            if (locals != null && localsSize < locals.length) {
+                Arrays.fill(locals, localsSize, locals.length, Type.TOP_TYPE);
             }
             this.localsSize = localsSize;
         }

--- a/test/jdk/jdk/classfile/StackMapsTest.java
+++ b/test/jdk/jdk/classfile/StackMapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Testing Classfile stack maps generator.
- * @bug 8305990 8320222 8320618 8335475 8338623 8338661 8343436
+ * @bug 8305990 8320222 8320618 8335475 8338623 8338661 8343436 8386700
  * @build testdata.*
  * @run junit StackMapsTest
  */
@@ -414,5 +414,30 @@ class StackMapsTest {
         var code = (CodeAttribute) ClassFile.of().parse(bytes).methods().getFirst().code().orElseThrow();
         assertEquals(2, code.maxLocals());
         assertEquals(2, code.maxStack());
+    }
+
+    @Test
+    void testStaleLocals() {
+        byte[] bytes = ClassFile.of().build(ClassDesc.of("Repro"), clb -> clb
+            .withMethodBody("m", MethodTypeDesc.of(CD_void, CD_int), ACC_STATIC, cob -> {
+                var cond = cob.newLabel();
+                var back = cob.newLabel();
+                var fwd = cob.newLabel();
+                cob.iconst_0()
+                   .istore(1) // stale slot 1 holding of a long incorrectly clears slot 0 in the second round
+                   .iload(1)
+                   .ifeq(cond) // conditional branch triggers merge of frames
+                   .goto_(fwd)
+                   .labelBinding(cond)
+                   .iload(0) // invalid stack frame when slot 0 is cleared
+                   .pop()
+                   .labelBinding(back)
+                   .return_()
+                   .labelBinding(fwd)
+                   .lconst_0()
+                   .lstore(0) // long overrides slots 0 and 1
+                   .goto_(back); // back jump with modified locals triggers second round with stale slots
+            }));
+        assertEmpty(ClassFile.of().verify(bytes));
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ef5b328c](https://github.com/openjdk/jdk/commit/ef5b328ce5a8f1a27f87745d6cc19db7baec4c3f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Adam Sotona on 17 Jun 2026 and was reviewed by Chen Liang.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
