### PR TITLE
Execute DMB ISH in -UseLSE cmpxchg

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3521,6 +3521,8 @@ void MacroAssembler::cmpxchg(Register addr, Register expected,
       cbnzw(rscratch1, retry_load);
     }
     bind(done);
+    // Prevent memory accesses from floating into the CAS's critical section
+    dmb(ISH);
   }
   BLOCK_COMMENT("} cmpxchg");
 }


### PR DESCRIPTION
Prevent memory accesses from floating into the critical section of the CAS. This brings the `-UseLSE` implementation in line with our other platforms in terms of memory ordering.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31552/head:pull/31552` \
`$ git checkout pull/31552`

Update a local copy of the PR: \
`$ git checkout pull/31552` \
`$ git pull https://git.openjdk.org/jdk.git pull/31552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31552`

View PR using the GUI difftool: \
`$ git pr show -t 31552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31552.diff">https://git.openjdk.org/jdk/pull/31552.diff</a>

</details>
