### PR TITLE
8173155: JavacTask should have close() method

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/JavacTask.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/JavacTask.java
@@ -102,6 +102,19 @@ public abstract class JavacTask implements CompilationTask, AutoCloseable {
     public abstract Iterable<? extends JavaFileObject> generate() throws IOException;
 
     /**
+     * Releases any resources opened by this task, either directly or
+     * indirectly. After this method is called, the task becomes unusable,
+     * and subsequent calls to its methods may throw an {@code IllegalStateException}.
+     * Closing a task that has already been closed has no effect.
+     *
+     * @throws IOException if an error occurs while releasing resources.
+     * @throws IllegalStateException if the operation cannot be performed at this time.
+     * @since 28
+     */
+    @Override
+    public abstract void close() throws IOException;
+
+    /**
      * Sets a specified listener to receive notification of events
      * describing the progress of this compilation task.
      *

--- a/src/jdk.compiler/share/classes/com/sun/source/util/JavacTask.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/JavacTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ import com.sun.tools.javac.util.Context;
  * @author Jonathan Gibbons
  * @since 1.6
  */
-public abstract class JavacTask implements CompilationTask {
+public abstract class JavacTask implements CompilationTask, AutoCloseable {
     /**
      * Constructor for subclasses to call.
      */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/BasicJavacTask.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/BasicJavacTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,6 +106,11 @@ public class BasicJavacTask extends JavacTask {
 
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Iterable<? extends JavaFileObject> generate() {
+        throw new IllegalStateException();
+    }
+
+    @Override @DefinedBy(Api.COMPILER_TREE)
+    public void close() {
         throw new IllegalStateException();
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -493,6 +493,11 @@ public class JavacTaskImpl extends BasicJavacTask {
             }
         }
         return results;
+    }
+
+    @Override @DefinedBy(Api.COMPILER_TREE)
+    public void close() {
+        cleanup();
     }
 
     public void ensureEntered() {

--- a/test/langtools/tools/javac/api/TestJavacTask_Close.java
+++ b/test/langtools/tools/javac/api/TestJavacTask_Close.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8173155
  * @summary Cannot release resources after partial compilation
- * @requires os.family == "mac" | os.family == "linux"
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -33,25 +32,21 @@
  * @run junit ${test.main.class}
  */
 
-import java.io.BufferedReader;
-import java.io.File;
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
-import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -66,25 +61,18 @@ public class TestJavacTask_Close {
 
     @Test
     void testClose() throws Exception {
-        if (!lsofCommand().isPresent()) {
-            Assumptions.abort("lsof command is not available on this system");
-        }
-
         Path jar = createJar();
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        SimpleJavaFileObject compilationUnit = new SimpleJavaFileObject(URI.create("string:///Test.java"), JavaFileObject.Kind.SOURCE) {
-            @Override
-            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                return """
-                       public class Test {
-                           private Lib lib;
-                       }
-                       """;
-            }
-        };
+        JavaFileObject compilationUnit = SimpleJavaFileObject.forSource(URI.create("string:///Test.java"),
+                """
+                public class Test {
+                    private Lib lib;
+                }
+                """);
 
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+        boolean[] state = new boolean[] {false, false};
+        try (FM fm = new FM(compiler.getStandardFileManager(null, null, null), state)) {
             com.sun.source.util.JavacTask task = (com.sun.source.util.JavacTask) compiler.getTask(
                     null, fm, null, List.of("-classpath", jar.toString()), null, List.of(compilationUnit));
             Assertions.assertNotNull(task.parse(), "parse() failed");
@@ -92,60 +80,31 @@ public class TestJavacTask_Close {
             Assertions.assertThrows(IllegalStateException.class, () -> task.analyze(), "analyze() on closed task");
         }
 
-        Process process = new ProcessBuilder()
-                .command(lsofCommand().orElseThrow(() -> new RuntimeException("lsof command is not available on this system")),
-                        "-p", String.valueOf(ProcessHandle.current().pid()))
-                .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectError(ProcessBuilder.Redirect.INHERIT)
-                .start();
-        List<String> lines;
-        String realPath = jar.toRealPath().toString();
-        try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
-            lines = reader.lines().filter(line -> line.contains(realPath)).toList();
-        }
-        process.waitFor();
-        Assertions.assertEquals(0, lines.size(), "File(s) remain opened: " + lines);
+        Assertions.assertTrue(state[0], "URLClassLoader not created");
+        Assertions.assertTrue(state[1], "URLClassLoader not closed");
     }
 
     @Test
     void testRepeatedClose() throws Exception {
-        if (!lsofCommand().isPresent()) {
-            Assumptions.abort("lsof command is not available on this system");
-        }
-
         Path jar = createJar();
 
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        SimpleJavaFileObject compilationUnit = new SimpleJavaFileObject(URI.create("string:///Test.java"), JavaFileObject.Kind.SOURCE) {
-            @Override
-            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                return """
-                       public class Test {
-                           private Lib lib;
-                       }
-                       """;
-            }
-        };
+        JavaFileObject compilationUnit = SimpleJavaFileObject.forSource(URI.create("string:///Test.java"),
+                """
+                public class Test {
+                    private Lib lib;
+                }
+                """);
 
-        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null);
+        boolean[] state = new boolean[] {false, false};
+        try (FM fm = new FM(compiler.getStandardFileManager(null, null, null), state);
              com.sun.source.util.JavacTask task = (com.sun.source.util.JavacTask) compiler.getTask(
                      null, fm, null, List.of("-classpath", jar.toString()), null, List.of(compilationUnit))) {
             Assertions.assertEquals(true, task.call(), "Compilation task failed");
         }
 
-        Process process = new ProcessBuilder()
-                .command(lsofCommand().orElseThrow(() -> new RuntimeException("lsof command is not available on this system")),
-                        "-p", String.valueOf(ProcessHandle.current().pid()))
-                .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectError(ProcessBuilder.Redirect.INHERIT)
-                .start();
-        List<String> lines;
-        String realPath = jar.toRealPath().toString();
-        try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
-            lines = reader.lines().filter(line -> line.contains(realPath)).toList();
-        }
-        process.waitFor();
-        Assertions.assertEquals(0, lines.size(), "File(s) remain opened: " + lines);
+        Assertions.assertTrue(state[0], "URLClassLoader not created");
+        Assertions.assertTrue(state[1], "URLClassLoader not closed");
     }
 
     @BeforeEach
@@ -176,16 +135,37 @@ public class TestJavacTask_Close {
         return jar;
     }
 
-    static Optional<String> lsofCommandCache = Arrays.stream(new String[] {
-            "/usr/bin/lsof",
-            "/usr/sbin/lsof",
-            "/bin/lsof",
-            "/sbin/lsof",
-            "/usr/local/bin/lsof"})
-        .filter(args -> new File(args).exists())
-        .findFirst();
+    private static class FM extends ForwardingJavaFileManager {
 
-    static Optional<String> lsofCommand() {
-        return lsofCommandCache;
+        private final boolean[] state;
+
+        private FM(JavaFileManager fileManager, boolean[] state) {
+            super(fileManager);
+            this.state = state;
+        }
+
+        @Override
+        public ClassLoader getClassLoader(Location location) {
+            ClassLoader cl = super.getClassLoader(location);
+            return cl instanceof URLClassLoader urlCl ? new CL(urlCl, state) : cl;
+        }
+    }
+
+    private static class CL extends ClassLoader implements Closeable {
+
+        private final URLClassLoader urlCl;
+        private final boolean[] state;
+
+        private CL(URLClassLoader urlCl, boolean[] state) {
+            this.urlCl = urlCl;
+            this.state = state;
+            this.state[0] = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            state[1] = true;
+            urlCl.close();
+        }
     }
 }

--- a/test/langtools/tools/javac/api/TestJavacTask_Close.java
+++ b/test/langtools/tools/javac/api/TestJavacTask_Close.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8173155
+ * @summary Cannot release resources after partial compilation
+ * @requires os.family == "mac" | os.family == "linux"
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.JarTask toolbox.JavacTask toolbox.ToolBox
+ * @run junit ${test.main.class}
+ */
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.ToolBox;
+import toolbox.JarTask;
+import toolbox.JavacTask;
+
+
+public class TestJavacTask_Close {
+
+    private Path base;
+
+    @Test
+    void testClose() throws Exception {
+        if (!lsofCommand().isPresent()) {
+            Assumptions.abort("lsof command is not available on this system");
+        }
+
+        Path jar = createJar();
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        SimpleJavaFileObject compilationUnit = new SimpleJavaFileObject(URI.create("string:///Test.java"), JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return """
+                       public class Test {
+                           private Lib lib;
+                       }
+                       """;
+            }
+        };
+
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+            com.sun.source.util.JavacTask task = (com.sun.source.util.JavacTask) compiler.getTask(
+                    null, fm, null, List.of("-classpath", jar.toString()), null, List.of(compilationUnit));
+            Assertions.assertNotNull(task.parse(), "parse() failed");
+            task.close();
+            Assertions.assertThrows(IllegalStateException.class, () -> task.analyze(), "analyze() on closed task");
+        }
+
+        Process process = new ProcessBuilder()
+                .command(lsofCommand().orElseThrow(() -> new RuntimeException("lsof command is not available on this system")),
+                        "-p", String.valueOf(ProcessHandle.current().pid()))
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start();
+        List<String> lines;
+        String realPath = jar.toRealPath().toString();
+        try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
+            lines = reader.lines().filter(line -> line.contains(realPath)).toList();
+        }
+        process.waitFor();
+        Assertions.assertEquals(0, lines.size(), "File(s) remain opened: " + lines);
+    }
+
+    @Test
+    void testRepeatedClose() throws Exception {
+        if (!lsofCommand().isPresent()) {
+            Assumptions.abort("lsof command is not available on this system");
+        }
+
+        Path jar = createJar();
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        SimpleJavaFileObject compilationUnit = new SimpleJavaFileObject(URI.create("string:///Test.java"), JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return """
+                       public class Test {
+                           private Lib lib;
+                       }
+                       """;
+            }
+        };
+
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null);
+             com.sun.source.util.JavacTask task = (com.sun.source.util.JavacTask) compiler.getTask(
+                     null, fm, null, List.of("-classpath", jar.toString()), null, List.of(compilationUnit))) {
+            Assertions.assertEquals(true, task.call(), "Compilation task failed");
+        }
+
+        Process process = new ProcessBuilder()
+                .command(lsofCommand().orElseThrow(() -> new RuntimeException("lsof command is not available on this system")),
+                        "-p", String.valueOf(ProcessHandle.current().pid()))
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start();
+        List<String> lines;
+        String realPath = jar.toRealPath().toString();
+        try (InputStream stdout = process.getInputStream(); BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))) {
+            lines = reader.lines().filter(line -> line.contains(realPath)).toList();
+        }
+        process.waitFor();
+        Assertions.assertEquals(0, lines.size(), "File(s) remain opened: " + lines);
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+
+    private Path createJar() throws IOException {
+        Path jarSrc = base.resolve("jarSrc");
+        Path jarClasses = base.resolve("jarClasses");
+        Path jar = base.resolve("jar.jar");
+        Files.createDirectories(jarClasses);
+
+        ToolBox tb = new ToolBox();
+        tb.writeJavaFiles(jarSrc, "public class Lib { }");
+
+        new JavacTask(tb)
+                .outdir(jarClasses)
+                .files(tb.findJavaFiles(jarSrc))
+                .run()
+                .writeAll();
+        new JarTask(tb)
+                .run("cf", jar.toString(), "-C", jarClasses.toString(), ".");
+
+        return jar;
+    }
+
+    static Optional<String> lsofCommandCache = Arrays.stream(new String[] {
+            "/usr/bin/lsof",
+            "/usr/sbin/lsof",
+            "/bin/lsof",
+            "/sbin/lsof",
+            "/usr/local/bin/lsof"})
+        .filter(args -> new File(args).exists())
+        .findFirst();
+
+    static Optional<String> lsofCommand() {
+        return lsofCommandCache;
+    }
+}


### PR DESCRIPTION
When javac is used through the `JavaCompiler` API and a client performs only a partial compilation, for example, by calling `parse()` on `JavacTask`, compiler-created resources may remain open. In particular, annotation processor discovery can create class loaders that keep JAR files open, which is problematic on platforms where open files cannot be removed or replaced. There is no way to close these resources through the API without performing a full compilation by calling `call()`.

The proposal here is to add `close()` to `JavacTask` by making it implement `AutoCloseable`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8386825](https://bugs.openjdk.org/browse/JDK-8386825) to be approved

### Issues
 * [JDK-8173155](https://bugs.openjdk.org/browse/JDK-8173155): JavacTask should have close() method (**Enhancement** - P3)
 * [JDK-8386825](https://bugs.openjdk.org/browse/JDK-8386825): JavacTask should have close() method (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31554/head:pull/31554` \
`$ git checkout pull/31554`

Update a local copy of the PR: \
`$ git checkout pull/31554` \
`$ git pull https://git.openjdk.org/jdk.git pull/31554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31554`

View PR using the GUI difftool: \
`$ git pr show -t 31554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31554.diff">https://git.openjdk.org/jdk/pull/31554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31554#issuecomment-4728676504)
</details>
