### PR TITLE
8386831: Build fails due to bad copyright header in test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java

### DIFF
--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java
@@ -15,6 +15,10 @@
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 /**


### PR DESCRIPTION
Can I please get a review of this change which addresses a build failure due to an incorrect copyright header in a few file?

I am running a build with this change and will integrate it once it completes.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386831](https://bugs.openjdk.org/browse/JDK-8386831): Build fails due to bad copyright header in test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitPPC64.java (**Bug** - P2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31555/head:pull/31555` \
`$ git checkout pull/31555`

Update a local copy of the PR: \
`$ git checkout pull/31555` \
`$ git pull https://git.openjdk.org/jdk.git pull/31555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31555`

View PR using the GUI difftool: \
`$ git pr show -t 31555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31555.diff">https://git.openjdk.org/jdk/pull/31555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31555#issuecomment-4730381928)
</details>
