### PR TITLE
8385574: JFR: Redaction should check file

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrRedactedEvents.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrRedactedEvents.cpp
@@ -609,6 +609,9 @@ bool JfrRedactedEvents::match_key(StringArray* filters, const char* text) {
 }
 
 bool JfrRedactedEvents::read_file(StringArray* target, const char* filename) {
+  if (!is_valid_redaction_file(filename)) {
+    return false;
+  }
   FILE* file = os::fopen(filename, "r");
   if (file == nullptr) {
     log_error(jfr, redact)("Failed to open redaction file: %s", filename);
@@ -660,4 +663,22 @@ StringArray* JfrRedactedEvents::split(const char* text, char separator) {
     result->add(last, strlen(last));
   }
   return result;
+}
+
+bool JfrRedactedEvents::is_valid_redaction_file(const char* filename) {
+  struct stat st;
+  int ret = os::stat(filename, &st);
+  if (ret != 0) {
+    log_error(jfr, redact)("Failed to access redaction file %s", filename);
+    return false;
+  }
+  if ((st.st_mode & S_IFMT) != S_IFREG) {
+    log_error(jfr, redact)("Redaction file %s is not a regular file", filename);
+    return false;
+  }
+  if (st.st_size > 1024*1024) {
+    log_error(jfr, redact)("Redaction file %s is too large (1024 KB).", filename);
+    return false;
+  }
+  return true;
 }

--- a/src/hotspot/share/jfr/periodic/jfrRedactedEvents.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrRedactedEvents.hpp
@@ -205,6 +205,7 @@ class JfrRedactedEvents: public AllStatic {
   static bool equals_case_insensitive(char a, char b);
   static bool is_redacted_key(const char* key);
   static bool is_separator(char c);
+  static bool is_valid_redaction_file(const char* filename);
   static bool is_whitespace(char c);
   static void ensure_initialized();
   static StringArray* make_java_args_array();


### PR DESCRIPTION
Could I have a review of a PR that checks redaction files before use?

Testing: jdk/dk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385574](https://bugs.openjdk.org/browse/JDK-8385574): JFR: Redaction should check file (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @roberttoyonaga (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31557/head:pull/31557` \
`$ git checkout pull/31557`

Update a local copy of the PR: \
`$ git checkout pull/31557` \
`$ git pull https://git.openjdk.org/jdk.git pull/31557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31557`

View PR using the GUI difftool: \
`$ git pr show -t 31557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31557.diff">https://git.openjdk.org/jdk/pull/31557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31557#issuecomment-4735713553)
</details>
