### PR TITLE
8386592: Gtest os.trim_native_heap_vm sometimes fails in subtest os.trim_native_heap_vm

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5520,22 +5520,22 @@ int os::Linux::malloc_info(FILE* stream) {
 
 bool os::trim_native_heap(os::size_change_t* rss_change) {
 #ifdef __GLIBC__
-  os::Linux::accurate_meminfo_t info1;
-  os::Linux::accurate_meminfo_t info2;
+  os::Linux::meminfo_t info1;
+  os::Linux::meminfo_t info2;
 
   bool have_info1 = rss_change != nullptr &&
-                    os::Linux::query_accurate_process_memory_info(&info1);
+                    os::Linux::query_process_memory_info(&info1);
   ::malloc_trim(0);
   bool have_info2 = rss_change != nullptr && have_info1 &&
-                    os::Linux::query_accurate_process_memory_info(&info2);
-
+                    os::Linux::query_process_memory_info(&info2);
+  ssize_t delta = (ssize_t) -1;
   if (rss_change != nullptr) {
     if (have_info1 && have_info2 &&
-        info1.rss != -1 && info2.rss != -1 &&
-        info1.swap != -1 && info2.swap != -1) {
-      // Note: query_process_memory_info/query_accurate_process_memory_info return values in K
-      rss_change->before = (info1.rss + info1.swap) * K;
-      rss_change->after = (info2.rss + info2.swap) * K;
+        info1.vmrss != -1 && info2.vmrss != -1 &&
+        info1.vmswap != -1 && info2.vmswap != -1) {
+      // Note: query_process_memory_info returns values in K
+      rss_change->before = (info1.vmrss + info1.vmswap) * K;
+      rss_change->after = (info2.vmrss + info2.vmswap) * K;
     } else {
       rss_change->after = rss_change->before = SIZE_MAX;
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5520,22 +5520,22 @@ int os::Linux::malloc_info(FILE* stream) {
 
 bool os::trim_native_heap(os::size_change_t* rss_change) {
 #ifdef __GLIBC__
-  os::Linux::meminfo_t info1;
-  os::Linux::meminfo_t info2;
+  os::Linux::accurate_meminfo_t info1;
+  os::Linux::accurate_meminfo_t info2;
 
   bool have_info1 = rss_change != nullptr &&
-                    os::Linux::query_process_memory_info(&info1);
+                    os::Linux::query_accurate_process_memory_info(&info1);
   ::malloc_trim(0);
   bool have_info2 = rss_change != nullptr && have_info1 &&
-                    os::Linux::query_process_memory_info(&info2);
-  ssize_t delta = (ssize_t) -1;
+                    os::Linux::query_accurate_process_memory_info(&info2);
+
   if (rss_change != nullptr) {
     if (have_info1 && have_info2 &&
-        info1.vmrss != -1 && info2.vmrss != -1 &&
-        info1.vmswap != -1 && info2.vmswap != -1) {
-      // Note: query_process_memory_info returns values in K
-      rss_change->before = (info1.vmrss + info1.vmswap) * K;
-      rss_change->after = (info2.vmrss + info2.vmswap) * K;
+        info1.rss != -1 && info2.rss != -1 &&
+        info1.swap != -1 && info2.swap != -1) {
+      // Note: query_process_memory_info/query_accurate_process_memory_info return values in K
+      rss_change->before = (info1.rss + info1.swap) * K;
+      rss_change->after = (info2.rss + info2.swap) * K;
     } else {
       rss_change->after = rss_change->before = SIZE_MAX;
     }

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1062,17 +1062,26 @@ TEST_VM(os, is_first_C_frame) {
 TEST_VM(os, trim_native_heap) {
   EXPECT_TRUE(os::can_trim_native_heap());
   os::size_change_t sc;
-  sc.before = sc.after = (size_t)-1;
-  EXPECT_TRUE(os::trim_native_heap(&sc));
-  tty->print_cr("%zu->%zu", sc.before, sc.after);
-  // Regardless of whether we freed memory, both before and after
-  // should be somewhat believable numbers (RSS).
-  const size_t min = 5 * M;
-  const size_t max = LP64_ONLY(20 * G) NOT_LP64(3 * G);
-  ASSERT_LE(min, sc.before);
-  ASSERT_GT(max, sc.before);
-  ASSERT_LE(min, sc.after);
-  ASSERT_GT(max, sc.after);
+  os::Linux::accurate_meminfo_t info1;
+  os::Linux::accurate_meminfo_t info2;
+  bool have_info1 = os::Linux::query_accurate_process_memory_info(&info1);
+  EXPECT_TRUE(os::trim_native_heap(nullptr));
+  bool have_info2 = os::Linux::query_accurate_process_memory_info(&info2);
+
+  if (have_info1 && have_info2) {
+    sc.before = (info1.rss + info1.swap) * K;
+    sc.after = (info2.rss + info2.swap) * K;
+    tty->print_cr("%zu->%zu", sc.before, sc.after);
+
+    // Regardless of whether we freed memory, both before and after
+    // should be somewhat believable numbers (RSS).
+    const size_t min = 5 * M;
+    const size_t max = LP64_ONLY(20 * G) NOT_LP64(3 * G);
+    ASSERT_LE(min, sc.before);
+    ASSERT_GT(max, sc.before);
+    ASSERT_LE(min, sc.after);
+    ASSERT_GT(max, sc.after);
+  }
   // Should also work
   EXPECT_TRUE(os::trim_native_heap());
 }


### PR DESCRIPTION
We run into this gtest failure on a machine with rather large core number (128 cores). Seems the vmrss values used in the coding are by definition somewhat inaccurate. Failure is

```
[ RUN ] os.trim_native_heap_vm
0->0
test/hotspot/gtest/runtime/test_os.cpp:1072: Failure
Expected: (min) <= (sc.before), actual: 5242880 vs 0
```

We use there

`os::trim_native_heap `on Linux and this uses` os::Linux::query_process_memory_info`
which uses vmrss .

I see this in also in those tests
```
gtest/GTestWrapper.java and gtest/LargePageGtests.java (HS :tier1) 
gtest/NativeHeapTrimmerGtest.java (HS :tier4)
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386592](https://bugs.openjdk.org/browse/JDK-8386592): Gtest os.trim_native_heap_vm sometimes fails in subtest os.trim_native_heap_vm (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31559/head:pull/31559` \
`$ git checkout pull/31559`

Update a local copy of the PR: \
`$ git checkout pull/31559` \
`$ git pull https://git.openjdk.org/jdk.git pull/31559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31559`

View PR using the GUI difftool: \
`$ git pr show -t 31559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31559.diff">https://git.openjdk.org/jdk/pull/31559.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31559#issuecomment-4739498717)
</details>
