### PR TITLE
8386591: C2: wrong result because of broken truncation check in CountedLoopConverter::TruncatedIncrement::build

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3129,25 +3129,12 @@ Node* LoopLimitNode::Identity(PhaseGVN* phase) {
   return this;
 }
 
-// Match increment with optional truncation:
-// BYTE:
-//   signed 8-bit truncation
-//   ((i+1) << 24) >> 24
-// SHORT:
-//   signed 16-bit truncation
-//   ((i+1) << 16) >> 16
-// CHAR:
-//   unsigned 16-bit truncation
-//   (char)(i+1)
-//   ((i+1) & 0xffff)
+// CHAR: (i+1)&0x7fff      Note: does NOT work for char cast (0xffff)
+// BYTE: ((i+1)<<8)>>8     Note: does NOT work for byte cast (<< 24 >> 24)
+// SHORT: ((i+1)<<16)>>16
 //
-// For historical reasons:
-//   unsigned 15-bit truncation
-//   ((i+1) & 0x7fff)
-// This pattern was previously wrongly categorized as
-// CHAR truncation, and we keep it to avoid performance
-// regressions.
-//
+// Note: in the future, we should fix both the BYTE and the CHAR case,
+//       to allow proper optimization of byte/char cast truncation.
 void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
   _is_valid = false;
 
@@ -3170,7 +3157,6 @@ void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
       jint mask = n1->in(2)->bottom_type()->is_int()->get_con();
       switch (mask) {
         case 0x7fff: // Unsigned 15-bit truncation. For historical reasons.
-        case 0xffff: // Unsigned 16-bit truncation. Char cast.
           t1 = n1;
           n1 = t1->in(1);
           n1op = n1->Opcode();
@@ -3182,22 +3168,18 @@ void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
                n1->in(1)->Opcode() == Op_LShiftI &&
                n1->in(2) == n1->in(1)->in(2) &&
                n1->in(2)->is_Con()) {
-      // Signed truncation.
-      // Pattern: ((i+1) << shift) >> shift
       jint shift = n1->in(2)->bottom_type()->is_int()->get_con();
-      switch (shift) {
-        case 16: // Signed 16-bit truncation. Short cast.
-        case 24: // Signed 8-bit truncation. Byte cast.
-          t1 = n1;
-          t2 = t1->in(1);
-          n1 = t2->in(1);
-          n1op = n1->Opcode();
-          // We remove "shift" bits, and a sign bit.
-          jint bits = 32 - shift - 1;
-          jint lo = - (1 << bits);
-          jint hi =   (1 << bits) - 1;
-          trunc_t = TypeInt::make(lo, hi, 0);
-          break;
+      // %%% This check should match any shift in [1..31].
+      if (shift == 16 || shift == 8) {
+        t1 = n1;
+        t2 = t1->in(1);
+        n1 = t2->in(1);
+        n1op = n1->Opcode();
+        if (shift == 16) {
+          trunc_t = TypeInt::SHORT;
+        } else if (shift == 8) {
+          trunc_t = TypeInt::BYTE;
+        }
       }
     }
   }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3155,6 +3155,13 @@ void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
       n1 = t1->in(1);
       n1op = n1->Opcode();
       trunc_t = TypeInt::CHAR;
+      // TODO: fix bug
+      // Problem: we accept mask 0x7fff which produces range [0..32767].
+      // But we return CHAR, which will check for wrap in [0..65535].
+      // This leads to wrong results, because we ignore wrap.
+      // Matching 0x7fff is also a bit silly. I would assume users are
+      // more likely to want to use "(char)" cast truncation, which
+      // would lead to a 0xffff mask, with range [0..65535].
     } else if (n1op == Op_RShiftI &&
                n1->in(1) != nullptr &&
                n1->in(1)->Opcode() == Op_LShiftI &&
@@ -3171,6 +3178,15 @@ void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
           trunc_t = TypeInt::SHORT;
         } else if (shift == 8) {
           trunc_t = TypeInt::BYTE;
+          // TODO: maybe fix missing optimization
+          // shift == 8 means this pattern:
+          // ((x << 8) >> 8), which only removes the uppermost
+          // 8 bits, so leaves a 24-bit value. But we probably
+          // wanted to match ((x << 24) >> 24), which would be
+          // 8-bit signed truncation. Since we return BYTE, we
+          // will apply strict signed-bit overflow checks, so
+          // this just means we get missing optimizations, we
+          // don't actually manage to allow "(byte)" cast truncation.
         }
       }
     }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3130,7 +3130,24 @@ Node* LoopLimitNode::Identity(PhaseGVN* phase) {
 }
 
 // Match increment with optional truncation:
-// CHAR: (i+1)&0x7fff, BYTE: ((i+1)<<8)>>8, or SHORT: ((i+1)<<16)>>16
+// BYTE:
+//   signed 8-bit truncation
+//   ((i+1) << 24) >> 24
+// SHORT:
+//   signed 16-bit truncation
+//   ((i+1) << 16) >> 16
+// CHAR:
+//   unsigned 16-bit truncation
+//   (char)(i+1)
+//   ((i+1) & 0xffff)
+//
+// For historical reasons:
+//   unsigned 15-bit truncation
+//   ((i+1) & 0x7fff)
+// This pattern was previously wrongly categorized as
+// CHAR truncation, and we keep it to avoid performance
+// regressions.
+//
 void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
   _is_valid = false;
 
@@ -3146,48 +3163,41 @@ void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
   const TypeInteger* trunc_t = TypeInteger::bottom(_bt);
 
   if (_bt == T_INT) {
-    // Try to strip (n1 & M) or (n1 << N >> N) from n1.
     if (n1op == Op_AndI &&
-        n1->in(2)->is_Con() &&
-        n1->in(2)->bottom_type()->is_int()->get_con() == 0x7fff) {
-      // %%% This check should match any mask of 2**K-1.
-      t1 = n1;
-      n1 = t1->in(1);
-      n1op = n1->Opcode();
-      trunc_t = TypeInt::CHAR;
-      // TODO: fix bug
-      // Problem: we accept mask 0x7fff which produces range [0..32767].
-      // But we return CHAR, which will check for wrap in [0..65535].
-      // This leads to wrong results, because we ignore wrap.
-      // Matching 0x7fff is also a bit silly. I would assume users are
-      // more likely to want to use "(char)" cast truncation, which
-      // would lead to a 0xffff mask, with range [0..65535].
+        n1->in(2)->is_Con()) {
+      // Unsigned truncation.
+      // Pattern: ((i+1) & mask)
+      jint mask = n1->in(2)->bottom_type()->is_int()->get_con();
+      switch (mask) {
+        case 0x7fff: // Unsigned 15-bit truncation. For historical reasons.
+        case 0xffff: // Unsigned 16-bit truncation. Char cast.
+          t1 = n1;
+          n1 = t1->in(1);
+          n1op = n1->Opcode();
+          trunc_t = TypeInt::make_unsigned(0, mask, 0);
+          break;
+      }
     } else if (n1op == Op_RShiftI &&
                n1->in(1) != nullptr &&
                n1->in(1)->Opcode() == Op_LShiftI &&
                n1->in(2) == n1->in(1)->in(2) &&
                n1->in(2)->is_Con()) {
+      // Signed truncation.
+      // Pattern: ((i+1) << shift) >> shift
       jint shift = n1->in(2)->bottom_type()->is_int()->get_con();
-      // %%% This check should match any shift in [1..31].
-      if (shift == 16 || shift == 8) {
-        t1 = n1;
-        t2 = t1->in(1);
-        n1 = t2->in(1);
-        n1op = n1->Opcode();
-        if (shift == 16) {
-          trunc_t = TypeInt::SHORT;
-        } else if (shift == 8) {
-          trunc_t = TypeInt::BYTE;
-          // TODO: maybe fix missing optimization
-          // shift == 8 means this pattern:
-          // ((x << 8) >> 8), which only removes the uppermost
-          // 8 bits, so leaves a 24-bit value. But we probably
-          // wanted to match ((x << 24) >> 24), which would be
-          // 8-bit signed truncation. Since we return BYTE, we
-          // will apply strict signed-bit overflow checks, so
-          // this just means we get missing optimizations, we
-          // don't actually manage to allow "(byte)" cast truncation.
-        }
+      switch (shift) {
+        case 16: // Signed 16-bit truncation. Short cast.
+        case 24: // Signed 8-bit trunction. Byte cast.
+          t1 = n1;
+          t2 = t1->in(1);
+          n1 = t2->in(1);
+          n1op = n1->Opcode();
+          // We remove "shift" bits, and a sign bit.
+          jint bits = 32 - shift - 1;
+          jint lo = - (1 << bits);
+          jint hi =   (1 << bits) - 1;
+          trunc_t = TypeInt::make(lo, hi, 0);
+          break;
       }
     }
   }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3187,7 +3187,7 @@ void CountedLoopConverter::TruncatedIncrement::build(Node* expr) {
       jint shift = n1->in(2)->bottom_type()->is_int()->get_con();
       switch (shift) {
         case 16: // Signed 16-bit truncation. Short cast.
-        case 24: // Signed 8-bit trunction. Byte cast.
+        case 24: // Signed 8-bit truncation. Byte cast.
           t1 = n1;
           t2 = t1->in(1);
           n1 = t2->in(1);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -2105,7 +2105,6 @@ class CountedLoopConverter {
     bool is_valid() const { return _is_valid; }
     Node* incr() const { return _incr; }
 
-    // Optional truncation for: CHAR: (i+1)&0x7fff, BYTE: ((i+1)<<8)>>8, or SHORT: ((i+1)<<16)>>16
     Node* outer_trunc() const { return _outer_trunc; } // the outermost truncating node (either the & or the final >>)
     Node* inner_trunc() const { return _inner_trunc; } // the inner truncating node, if applicable (the << in a <</>> pair)
     const TypeInteger* trunc_type() const { return _trunc_type; }

--- a/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
@@ -23,7 +23,7 @@
 
 /*
  * @test id=vanilla
- * @bug 8385855
+ * @bug 8385855 8386591
  * @summary Test CountedLoopConverter::has_truncation_wrap logic that checks if
  *          a truncated iv (e.g. byte or char iv) is still a valid counted loop.
  * @library /test/lib /
@@ -32,7 +32,7 @@
 
 /*
  * @test id=Xcomp
- * @bug 8385855
+ * @bug 8385855 8386591
  * @library /test/lib /
  * @run main ${test.main.class} -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,${test.main.class}::test*
  */
@@ -784,8 +784,8 @@ public class TestHasTruncationWrap {
     }
 
     // testIRByte4: byte loop, with a CmpI, but the limit ranges are bad.
-    // And: "byte i++" goes through "<< 24 >> 24" truncation with signed extension,
-    //      and that's not recognized by TruncatedIncrement::build.
+    // Byte cast -> "<< 24 >> 24" 8-bit signed truncation.
+    // But: we could have wrap, because 1_000 is outside byte type.
     public static int testIRByte4_gold = testIRByte4();
 
     @Run(test = "testIRByte4")
@@ -927,7 +927,8 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar4: char loop, with a CmpI, but the limit ranges are bad.
-    // And: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
+    // Char cast -> "& 0xffff"
+    // But: 100_000 outside char range.
     public static int testIRChar4_gold = testIRChar4();
 
     @Run(test = "testIRChar4")
@@ -1044,9 +1045,8 @@ public class TestHasTruncationWrap {
     }
 
     // testIRShift8: 24-bit loop, and range in 24-bit range via CmpI before loop (for loop limit).
-    // Note: this shift value is strange, we probably wanted to implement byte truncation
-    //       with shift=24, but instead we have 24-bit signed truncation.
-    // Note2: this pattern would have been supported by TruncatedIncrement::build, but it gets
+    // Note: before JDK-8386591, we used to confuxe 24-bit truncation with byte truncation,
+    //       but it didn't produce a CountedLoop anyway, because of some idealization.
     //        modified by LShiftINode::Ideal:
     //          RShiftI(AddI(LShiftI(Phi, 8), 256), 8)
     //        The same is explicitly excluded for shift 16, to preserve short/byte idioms.
@@ -1080,11 +1080,6 @@ public class TestHasTruncationWrap {
 
     // testIRShift8BadBounds: 24-bit loop, with a CmpI, but the limit ranges are bad.
     // Note: same issues as for testIRShift8.
-    // Note2: the range argument seems a bit strange here, but it turns out that
-    //        TruncatedIncrement::build maps shift=8 to BYTE, which just shows that
-    //        the implementation confused the shift=24 with shift=8.
-    //        Since we map to BYTE, 1_000 would be out of bounds, that's why this
-    //        is still a bad bounds example.
     public static int testIRShift8BadBounds_gold = testIRShift8BadBounds();
 
     @Run(test = "testIRShift8BadBounds")

--- a/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
@@ -731,8 +731,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRByte1: byte loop, but values are trivially in byte range.
-    // But: "byte i++" goes through "<< 24 >> 24" truncation with signed extension,
-    //      and that's not recognized by TruncatedIncrement::build.
+    // Byte cast -> "<< 24 >> 24" 8-bit signed truncation.
     public static int testIRByte1_gold = testIRByte1();
 
     @Run(test = "testIRByte1")
@@ -742,7 +741,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
     static int testIRByte1() {
         byte init  = (byte)lo;
         byte limit = (byte)hi;
@@ -754,8 +753,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRByte2: byte loop, ranges proved in byte range via CmpI before loop.
-    // But: "byte i++" goes through "<< 24 >> 24" truncation with signed extension,
-    //      and that's not recognized by TruncatedIncrement::build.
+    // Byte cast -> "<< 24 >> 24" 8-bit signed truncation.
     public static int testIRByte2_gold = testIRByte2();
 
     @Run(test = "testIRByte2")
@@ -765,7 +763,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
     static int testIRByte2() {
         int init  = Math.max(lo, 0);   // init  in [0..max_int]
         int limit = Math.min(hi, 100); // limit in [min_int..100]
@@ -817,7 +815,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar1: char loop, but values are trivially in char range.
-    // But: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
+    // Char cast -> "& 0xffff"
     public static int testIRChar1_gold = testIRChar1();
 
     @Run(test = "testIRChar1")
@@ -827,7 +825,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
     static int testIRChar1() {
         char init  = (char)lo;
         char limit = (char)hi;
@@ -839,7 +837,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar2: char loop, ranges proved in char range via CmpI before loop.
-    // But: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
+    // Char cast -> "& 0xffff"
     public static int testIRChar2_gold = testIRChar2();
 
     @Run(test = "testIRChar2")
@@ -849,7 +847,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
     static int testIRChar2() {
         int init  = Math.max(lo, 0);   // init  in [0..max_int]
         int limit = Math.min(hi, 100); // limit in [min_int..100]
@@ -870,7 +868,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar3: char loop, and range in char range via CmpI before loop (for loop limit).
-    // But: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
+    // Char cast -> "& 0xffff"
     public static int testIRChar3_gold = testIRChar3();
 
     @Run(test = "testIRChar3")
@@ -880,7 +878,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
     static int testIRChar3() {
         int init  = Math.max(lo, 0);   // init  in [0..max_int]
         int limit = Math.min(hi, 100); // limit in [min_int..100]

--- a/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
@@ -23,7 +23,7 @@
 
 /*
  * @test id=vanilla
- * @bug 8385855 8386591
+ * @bug 8385855
  * @summary Test CountedLoopConverter::has_truncation_wrap logic that checks if
  *          a truncated iv (e.g. byte or char iv) is still a valid counted loop.
  * @library /test/lib /
@@ -32,7 +32,7 @@
 
 /*
  * @test id=Xcomp
- * @bug 8385855 8386591
+ * @bug 8385855
  * @library /test/lib /
  * @run main ${test.main.class} -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,${test.main.class}::test*
  */
@@ -731,7 +731,8 @@ public class TestHasTruncationWrap {
     }
 
     // testIRByte1: byte loop, but values are trivially in byte range.
-    // Byte cast -> "<< 24 >> 24" 8-bit signed truncation.
+    // But: "byte i++" goes through "<< 24 >> 24" truncation with signed extension,
+    //      and that's not recognized by TruncatedIncrement::build.
     public static int testIRByte1_gold = testIRByte1();
 
     @Run(test = "testIRByte1")
@@ -741,7 +742,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
     static int testIRByte1() {
         byte init  = (byte)lo;
         byte limit = (byte)hi;
@@ -753,7 +754,8 @@ public class TestHasTruncationWrap {
     }
 
     // testIRByte2: byte loop, ranges proved in byte range via CmpI before loop.
-    // Byte cast -> "<< 24 >> 24" 8-bit signed truncation.
+    // But: "byte i++" goes through "<< 24 >> 24" truncation with signed extension,
+    //      and that's not recognized by TruncatedIncrement::build.
     public static int testIRByte2_gold = testIRByte2();
 
     @Run(test = "testIRByte2")
@@ -763,7 +765,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
     static int testIRByte2() {
         int init  = Math.max(lo, 0);   // init  in [0..max_int]
         int limit = Math.min(hi, 100); // limit in [min_int..100]
@@ -784,8 +786,8 @@ public class TestHasTruncationWrap {
     }
 
     // testIRByte4: byte loop, with a CmpI, but the limit ranges are bad.
-    // Byte cast -> "<< 24 >> 24" 8-bit signed truncation.
-    // But: we could have wrap, because 1_000 is outside byte type.
+    // And: "byte i++" goes through "<< 24 >> 24" truncation with signed extension,
+    //      and that's not recognized by TruncatedIncrement::build.
     public static int testIRByte4_gold = testIRByte4();
 
     @Run(test = "testIRByte4")
@@ -815,7 +817,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar1: char loop, but values are trivially in char range.
-    // Char cast -> "& 0xffff"
+    // But: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
     public static int testIRChar1_gold = testIRChar1();
 
     @Run(test = "testIRChar1")
@@ -825,7 +827,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
     static int testIRChar1() {
         char init  = (char)lo;
         char limit = (char)hi;
@@ -837,7 +839,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar2: char loop, ranges proved in char range via CmpI before loop.
-    // Char cast -> "& 0xffff"
+    // But: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
     public static int testIRChar2_gold = testIRChar2();
 
     @Run(test = "testIRChar2")
@@ -847,7 +849,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
     static int testIRChar2() {
         int init  = Math.max(lo, 0);   // init  in [0..max_int]
         int limit = Math.min(hi, 100); // limit in [min_int..100]
@@ -868,7 +870,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar3: char loop, and range in char range via CmpI before loop (for loop limit).
-    // Char cast -> "& 0xffff"
+    // But: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
     public static int testIRChar3_gold = testIRChar3();
 
     @Run(test = "testIRChar3")
@@ -878,7 +880,7 @@ public class TestHasTruncationWrap {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTED_LOOP, "> 0"})
+    @IR(counts = {IRNode.COUNTED_LOOP, "= 0"})
     static int testIRChar3() {
         int init  = Math.max(lo, 0);   // init  in [0..max_int]
         int limit = Math.min(hi, 100); // limit in [min_int..100]
@@ -927,8 +929,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRChar4: char loop, with a CmpI, but the limit ranges are bad.
-    // Char cast -> "& 0xffff"
-    // But: 100_000 outside char range.
+    // And: "char i++" lowers through mask "& 0xffff", not recognized by TruncatedIncrement::build.
     public static int testIRChar4_gold = testIRChar4();
 
     @Run(test = "testIRChar4")
@@ -1045,8 +1046,9 @@ public class TestHasTruncationWrap {
     }
 
     // testIRShift8: 24-bit loop, and range in 24-bit range via CmpI before loop (for loop limit).
-    // Note: before JDK-8386591, we used to confuse 24-bit truncation with byte truncation,
-    //       but it didn't produce a CountedLoop anyway, because of some idealization.
+    // Note: this shift value is strange, we probably wanted to implement byte truncation
+    //       with shift=24, but instead we have 24-bit signed truncation.
+    // Note2: this pattern would have been supported by TruncatedIncrement::build, but it gets
     //        modified by LShiftINode::Ideal:
     //          RShiftI(AddI(LShiftI(Phi, 8), 256), 8)
     //        The same is explicitly excluded for shift 16, to preserve short/byte idioms.
@@ -1080,6 +1082,11 @@ public class TestHasTruncationWrap {
 
     // testIRShift8BadBounds: 24-bit loop, with a CmpI, but the limit ranges are bad.
     // Note: same issues as for testIRShift8.
+    // Note2: the range argument seems a bit strange here, but it turns out that
+    //        TruncatedIncrement::build maps shift=8 to BYTE, which just shows that
+    //        the implementation confused the shift=24 with shift=8.
+    //        Since we map to BYTE, 1_000 would be out of bounds, that's why this
+    //        is still a bad bounds example.
     public static int testIRShift8BadBounds_gold = testIRShift8BadBounds();
 
     @Run(test = "testIRShift8BadBounds")

--- a/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestHasTruncationWrap.java
@@ -1045,7 +1045,7 @@ public class TestHasTruncationWrap {
     }
 
     // testIRShift8: 24-bit loop, and range in 24-bit range via CmpI before loop (for loop limit).
-    // Note: before JDK-8386591, we used to confuxe 24-bit truncation with byte truncation,
+    // Note: before JDK-8386591, we used to confuse 24-bit truncation with byte truncation,
     //       but it didn't produce a CountedLoop anyway, because of some idealization.
     //        modified by LShiftINode::Ideal:
     //          RShiftI(AddI(LShiftI(Phi, 8), 256), 8)

--- a/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapBadCharWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapBadCharWrap.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.loopopts;
+
+/*
+ * @test
+ * @bug 8386591
+ * @summary Test case for TruncatedIncrement::build /
+ *          CountedLoopConverter::has_truncation_wrap where we got wrong
+ *          results, because we confused "& 0x7fff" as range [0..65535]
+ *          instead of [0..32767].
+ * @library /test/lib /
+ * @run main/othervm -Xcomp
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+public class TestTruncationWrapBadCharWrap {
+    interface TestMethod {
+        int call();
+    }
+
+    public static void main(String[] args) {
+        int failures = 0;
+
+        failures += run("test1", () -> test1(), 1402);
+        failures += run("test2", () -> test2(), 2037);
+        failures += run("test3", () -> test3(), 171761184);
+
+        if (failures > 0) {
+            throw new RuntimeException("failures: " + failures);
+        }
+    }
+
+    static int run(String name, TestMethod t, int expected) {
+        for (int i = 0; i < 10_000; i++) {
+            int result = t.call();
+            if (result != expected) {
+                System.out.println(name + " wrong result: " + result + " vs " + expected);
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+
+    static int test1() {
+        int sum = 0;
+        int i = (char)-27131;
+        while (32 < i) {
+            sum++;
+            i = (i - 4) & 0x7fff;
+        }
+        return sum;
+    }
+
+    static int test2() {
+        int sum = 0;
+        for (int i = 519; i < 32758; i = (i + 48) & 0x7fff) {
+            sum++;
+        }
+        return sum;
+    }
+
+    static int opaqueCounter;
+
+    static boolean opaqueCheck() {
+        return opaqueCounter++ > 10448;
+    }
+
+    static int test3() {
+        opaqueCounter = 0;
+        int sum = 0;
+        int i;
+        for (i = 2046; i <= 32766; i = (i + 50) & 0x7fff) {
+            sum += i + 1;
+            if (opaqueCheck()) { break; }
+        }
+        return sum + i;
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapBadCharWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapBadCharWrap.java
@@ -74,7 +74,7 @@ public class TestTruncationWrapBadCharWrap {
         while (32 < i) {
             sum++;
             // Ignoring truncation would require values to be in range [0..32767].
-            // But unfortunately, we classify this as CHAR, and check for [0..65535].
+            // But unfortunately, we classified this as CHAR, and checked for [0..65535].
             i = (i - 4) & 0x7fff;
         }
         return sum;
@@ -83,8 +83,8 @@ public class TestTruncationWrapBadCharWrap {
     static int test2() {
         int sum = 0;
         // We have 32767 - 32758 = 9 < 48, so the limit is too close to the wrap
-        // limit, and wrap is possible. But since 0x7fff gets mapped to CHAR,
-        // we accidentally check 65535 - 32758 < 48, and conclude wrap is not
+        // limit, and wrap is possible. But since 0x7fff got mapped to CHAR,
+        // we accidentally checked 65535 - 32758 < 48, and conclude wrap is not
         // possible.
         for (int i = 519; i < 32758; i = (i + 48) & 0x7fff) {
             sum++;
@@ -104,8 +104,8 @@ public class TestTruncationWrapBadCharWrap {
         int i;
         // Similar as with test2:
         // We should check 32767 - 32766 = 1 < 50, so wrap possible. But we
-        // wrongly classify it as CHAR and check 65535 - 32766 < 50, and
-        // conclude there is no wrap.
+        // wrongly classified it as CHAR and checked 65535 - 32766 < 50, and
+        // concluded there is no wrap.
         for (i = 2046; i <= 32766; i = (i + 50) & 0x7fff) {
             sum += i + 1;
             if (opaqueCheck()) { break; }

--- a/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapBadCharWrap.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestTruncationWrapBadCharWrap.java
@@ -69,9 +69,12 @@ public class TestTruncationWrapBadCharWrap {
 
     static int test1() {
         int sum = 0;
-        int i = (char)-27131;
+        // The entry value is outside the range [0..32767], but inside [0..65535].
+        int i = (char)38405;
         while (32 < i) {
             sum++;
+            // Ignoring truncation would require values to be in range [0..32767].
+            // But unfortunately, we classify this as CHAR, and check for [0..65535].
             i = (i - 4) & 0x7fff;
         }
         return sum;
@@ -79,6 +82,10 @@ public class TestTruncationWrapBadCharWrap {
 
     static int test2() {
         int sum = 0;
+        // We have 32767 - 32758 = 9 < 48, so the limit is too close to the wrap
+        // limit, and wrap is possible. But since 0x7fff gets mapped to CHAR,
+        // we accidentally check 65535 - 32758 < 48, and conclude wrap is not
+        // possible.
         for (int i = 519; i < 32758; i = (i + 48) & 0x7fff) {
             sum++;
         }
@@ -95,6 +102,10 @@ public class TestTruncationWrapBadCharWrap {
         opaqueCounter = 0;
         int sum = 0;
         int i;
+        // Similar as with test2:
+        // We should check 32767 - 32766 = 1 < 50, so wrap possible. But we
+        // wrongly classify it as CHAR and check 65535 - 32766 < 50, and
+        // conclude there is no wrap.
         for (i = 2046; i <= 32766; i = (i + 50) & 0x7fff) {
             sum += i + 1;
             if (opaqueCheck()) { break; }


### PR DESCRIPTION
The third bug covered by https://github.com/openjdk/jdk/pull/31501.

As we have seen in https://github.com/openjdk/jdk/pull/31395, the `CountedLoopConverter::has_truncation_wrap` algorithm had some peculiarities, specifically this one:

> For `char`, we recognize `& 0x7fff`, and not the actual char truncation (`& 0xffff`). So we don't actually turn `(char)` truncation into `CountedLoops`.

So here we are. The issue is that we recognized `0x7fff` as `char` truncation, and accordingly only check that we cannot overflow/wrap the range `CHAR = [0 .. 0xffff]`, so if we got a value in range `0x8000 .. 0xffff`, that ends up overflowing/wrapping, but since we only checked for overflow outside the `CHAR` range, we wrongly decide there is no wrap/overflow.

I map mask `0x7fff` to range `0..0x7fff`, so overflow checks have the right range.

Note: we currently don't properly optimize `(byte)` and `(char)` truncation, I left a note for that.
I had a previous "fix", that also addressed that: https://github.com/openjdk/jdk/pull/31502.
But I decided I'll do this "extension" work in a separate RFE:
https://bugs.openjdk.org/browse/JDK-8386838

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386591](https://bugs.openjdk.org/browse/JDK-8386591): C2: wrong result because of broken truncation check in CountedLoopConverter::TruncatedIncrement::build (**Bug** - P3)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31560/head:pull/31560` \
`$ git checkout pull/31560`

Update a local copy of the PR: \
`$ git checkout pull/31560` \
`$ git pull https://git.openjdk.org/jdk.git pull/31560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31560`

View PR using the GUI difftool: \
`$ git pr show -t 31560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31560.diff">https://git.openjdk.org/jdk/pull/31560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31560#issuecomment-4738539855)
</details>
