### PR TITLE
8386325: The AttachListener does not do proper exception handling

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,12 @@ static bool get_bool_sys_prop(const char* name, bool default_value, TRAPS) {
   HandleMark hm(THREAD);
 
   // setup the arguments to getProperty
-  Handle key_str = java_lang_String::create_from_str(name, CHECK_(default_value));
+  Handle key_str = java_lang_String::create_from_str(name, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+    return default_value;
+  }
+
   // return value
   JavaValue result(T_OBJECT);
   // public static String getProperty(String key, String def);
@@ -189,7 +194,12 @@ static bool get_bool_sys_prop(const char* name, bool default_value, TRAPS) {
                          vmSymbols::getProperty_name(),
                          vmSymbols::string_string_signature(),
                          key_str,
-                         CHECK_(default_value));
+                         THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+    return default_value;
+  }
+
   oop value_oop = result.get_oop();
   if (value_oop != nullptr) {
     // convert Java String to utf8 string


### PR DESCRIPTION
This JDK 28 update clears pending exceptions upon return from Java upcalls that were missed in the fix of:
[8339289](https://bugs.openjdk.org/browse/JDK-8339289) Enhance Attach API to support arbitrary length arguments - Windows .

Testing:
- TBD: Mach5 tiers 1-5

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386325](https://bugs.openjdk.org/browse/JDK-8386325): The AttachListener does not do proper exception handling (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31565/head:pull/31565` \
`$ git checkout pull/31565`

Update a local copy of the PR: \
`$ git checkout pull/31565` \
`$ git pull https://git.openjdk.org/jdk.git pull/31565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31565`

View PR using the GUI difftool: \
`$ git pr show -t 31565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31565.diff">https://git.openjdk.org/jdk/pull/31565.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31565#issuecomment-4736410114)
</details>
