### PR TITLE
8384251: Test java/lang/instrument/GetObjectSizeIntrinsicsTest.java crashed: fatal error: Not compilable at tier 1: CodeBuffer overflow

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -26,6 +26,7 @@
  * @bug 8253525
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -54,6 +55,7 @@
  * @summary Test for fInst.getObjectSize with zero-based compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -82,6 +84,7 @@
  * @summary Test for fInst.getObjectSize without compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -110,6 +113,7 @@
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -142,6 +146,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -174,6 +179,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -206,6 +212,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -238,6 +245,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -271,6 +279,7 @@
  * @requires vm.bits == 64
  * @requires vm.debug
  * @requires os.maxMemory >= 10G
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest


### PR DESCRIPTION
The test `java/lang/instrument/GetObjectSizeIntrinsicsTest.java` crashed in our CI when run with `-Xcomp` and `-XX:+VerifyOops` on aarch64. On aarch64, `-XX:+VerifyOops` increases the code size by a large amount and since this test creates large object arrays, there are loads of oops to check. However, because this is a test about object size and does nothing interesting with the oops, I propose to disable the test for `-XX:+VerifyOops`. This prevents the failures, but does not detract too much from coverage.

There are alternatives to this, though. #7214 fixed the same kind of failure by restricting the compilation to the test method and thereby saving code cache. However, I still got crashes in testing with this solution, so I took the more heavy-handed route of disabling the test for the flag. The other alternatives listed in #7214, I did not pursue for the same reason.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384251](https://bugs.openjdk.org/browse/JDK-8384251): Test java/lang/instrument/GetObjectSizeIntrinsicsTest.java crashed: fatal error: Not compilable at tier 1: CodeBuffer overflow (**Bug** - P4)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31567/head:pull/31567` \
`$ git checkout pull/31567`

Update a local copy of the PR: \
`$ git checkout pull/31567` \
`$ git pull https://git.openjdk.org/jdk.git pull/31567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31567`

View PR using the GUI difftool: \
`$ git pr show -t 31567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31567.diff">https://git.openjdk.org/jdk/pull/31567.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31567#issuecomment-4739282862)
</details>
