### PR TITLE
8382491: Calling javax.swing.text.html.parser.DTD.getElement(String) with new name is not thread safe

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/DTD.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/DTD.java
@@ -203,13 +203,15 @@ class DTD implements DTDConstants {
      *   <code>name</code>, which may be newly created
      */
     public Element getElement(String name) {
-        Element e = elementHash.get(name);
-        if (e == null) {
-            e = new Element(name, elements.size());
-            elements.addElement(e);
-            elementHash.put(name, e);
+        synchronized (elementHash) {
+            Element e = elementHash.get(name);
+            if (e == null) {
+                e = new Element(name, elements.size());
+                elements.addElement(e);
+                elementHash.put(name, e);
+            }
+            return e;
         }
-        return e;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/DTD.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/DTD.java
@@ -202,16 +202,15 @@ class DTD implements DTDConstants {
      * @return the <code>Element</code> corresponding to
      *   <code>name</code>, which may be newly created
      */
-    public Element getElement(String name) {
-        synchronized (elementHash) {
-            Element e = elementHash.get(name);
-            if (e == null) {
-                e = new Element(name, elements.size());
-                elements.addElement(e);
-                elementHash.put(name, e);
-            }
-            return e;
+    public synchronized Element getElement(String name) {
+        Element e = elementHash.get(name);
+        if (e == null) {
+            e = new Element(name, elements.size());
+            elements.addElement(e);
+            elementHash.put(name, e);
         }
+        return e;
+
     }
 
     /**
@@ -221,7 +220,7 @@ class DTD implements DTDConstants {
      * @return the <code>Element</code> corresponding to
      *   <code>index</code>
      */
-    public Element getElement(int index) {
+    public synchronized Element getElement(int index) {
         return elements.elementAt(index);
     }
 
@@ -237,7 +236,7 @@ class DTD implements DTDConstants {
      * @return the <code>Entity</code> requested or a new <code>Entity</code>
      *   if not found
      */
-    public Entity defineEntity(String name, int type, char[] data) {
+    public synchronized Entity defineEntity(String name, int type, char[] data) {
         Entity ent = entityHash.get(name);
         if (ent == null) {
             ent = new Entity(name, type, data);

--- a/test/jdk/javax/swing/text/html/parser/DTDGetElementRaceTest.java
+++ b/test/jdk/javax/swing/text/html/parser/DTDGetElementRaceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8382491
+ * @summary Verifies DTD.getElement(String) with new name is thread safe
+ * @run main DTDGetElementRaceTest
+ */
+
+import java.util.Hashtable;
+import java.util.Vector;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import javax.swing.text.html.parser.DTD;
+import javax.swing.text.html.parser.Element;
+
+public final class DTDGetElementRaceTest {
+    private static final String ELEMENT_NAME = "race-element";
+
+    public static void main(String[] args) throws Exception {
+        DTD dtd = DTD.getDTD("DTDGetElementRaceTest-" + System.nanoTime());
+
+        dtd.elements = new Vector<Element>();
+        dtd.elementHash = new RacingHashtable();
+
+        CyclicBarrier start = new CyclicBarrier(3);
+        Element[] result = new Element[2];
+        Throwable[] failure = new Throwable[2];
+
+        Thread first = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    start.await();
+                    result[0] = dtd.getElement(ELEMENT_NAME);
+                } catch (Throwable t) {
+                    failure[0] = t;
+                }
+            }
+        });
+
+        Thread second = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    start.await();
+                    result[1] = dtd.getElement(ELEMENT_NAME);
+                } catch (Throwable t) {
+                    failure[1] = t;
+                }
+            }
+        });
+
+        first.start();
+        second.start();
+        start.await();
+        first.join(2000);
+        second.join(2000);
+
+        if (first.isAlive() || second.isAlive()) {
+            throw new RuntimeException("Timed out waiting for getElement calls");
+        }
+        if (failure[0] != null) {
+            throw new RuntimeException(failure[0]);
+        }
+        if (failure[1] != null) {
+            throw new RuntimeException(failure[1]);
+        }
+
+        if (result[0] != result[1]) {
+            throw new RuntimeException("getElement returned two distinct Element instances");
+        }
+
+        int matches = 0;
+        for (Element element : dtd.elements) {
+            if (ELEMENT_NAME.equals(element.getName())) {
+                matches++;
+            }
+        }
+
+        if (matches != 1) {
+            throw new RuntimeException("Expected exactly one element named "
+                    + ELEMENT_NAME + " in DTD.elements, found " + matches);
+        }
+    }
+
+    private static final class RacingHashtable extends Hashtable<String, Element> {
+        private final CountDownLatch bothUnsynchronizedGets = new CountDownLatch(2);
+
+        @Override
+        public Element get(Object key) {
+            boolean callerAlreadyHoldsTableLock = Thread.holdsLock(this);
+            Element element = super.get(key);
+
+            if (!callerAlreadyHoldsTableLock
+                    && element == null
+                    && ELEMENT_NAME.equals(key)) {
+                bothUnsynchronizedGets.countDown();
+                try {
+                    bothUnsynchronizedGets.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(interrupted);
+                }
+            }
+
+            return element;
+        }
+    }
+}
+


### PR DESCRIPTION
`DTD.getElement(String)` is not thread safe. If there are 2 parallel parser threads which call with the same new name then in the Vector there can be 2 identical elements. These unsynchronized elementHash.get(name) calls can both observe null before either thread creates and puts the `Element` which will then have duplicates. The index from elements.size() can also be wrong under races.

The block needs to be synchronized to prevent this

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382491](https://bugs.openjdk.org/browse/JDK-8382491): Calling javax.swing.text.html.parser.DTD.getElement(String) with new name is not thread safe (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31568/head:pull/31568` \
`$ git checkout pull/31568`

Update a local copy of the PR: \
`$ git checkout pull/31568` \
`$ git pull https://git.openjdk.org/jdk.git pull/31568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31568`

View PR using the GUI difftool: \
`$ git pr show -t 31568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31568.diff">https://git.openjdk.org/jdk/pull/31568.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31568#issuecomment-4739684227)
</details>
