### PR TITLE
8386922: Convert TraceRelocator to Unified Logging

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -175,6 +175,7 @@ class outputStream;
   LOG_TAG(refine) \
   LOG_TAG(region) \
   LOG_TAG(reloc) \
+  LOG_TAG(relocator) \
   LOG_TAG(remset) \
   LOG_TAG(resolve) \
   LOG_TAG(safepoint) \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -253,10 +253,6 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TracePcPatching, false,                                     \
           "Trace usage of frame::patch_pc")                                 \
                                                                             \
-  develop(bool, TraceRelocator, false,                                      \
-          "Trace the bytecode relocator")                                   \
-                                                                            \
-                                                                            \
   product(bool, SafepointALot, false, DIAGNOSTIC,                           \
           "Generate a lot of safepoints. This works with "                  \
           "GuaranteedSafepointInterval")                                    \

--- a/src/hotspot/share/runtime/relocator.cpp
+++ b/src/hotspot/share/runtime/relocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 #include "classfile/stackMapTableFormat.hpp"
 #include "interpreter/bytecodes.hpp"
+#include "logging/logTag.hpp"
 #include "memory/metadataFactory.hpp"
 #include "memory/oopFactory.hpp"
 #include "oops/method.inline.hpp"
@@ -50,13 +51,13 @@ class ChangeItem : public ResourceObj {
    virtual bool is_switch_pad() { return false; }
 
    // accessors
-   int bci()    { return _bci; }
+   int bci() const { return _bci; }
    void relocate(int break_bci, int delta) { if (_bci > break_bci) { _bci += delta; } }
 
    virtual bool adjust(int bci, int delta) { return false; }
 
    // debug
-   virtual void print() = 0;
+   virtual void print_on(outputStream* st) const = 0;
 };
 
 class ChangeWiden : public ChangeItem {
@@ -71,7 +72,7 @@ class ChangeWiden : public ChangeItem {
   // Callback to do instruction
   bool handle_code_change(Relocator *r) { return r->handle_widen(bci(), _new_ilen, _inst_buffer); };
 
-  void print()                 { tty->print_cr("ChangeWiden. bci: %d   New_ilen: %d", bci(), _new_ilen); }
+  void print_on(outputStream* st) const { st->print_cr("ChangeWiden. bci: %d   New_ilen: %d", bci(), _new_ilen); }
 };
 
 class ChangeJumpWiden : public ChangeItem {
@@ -94,7 +95,7 @@ class ChangeJumpWiden : public ChangeItem {
     return false;
   }
 
-  void print()                 { tty->print_cr("ChangeJumpWiden. bci: %d   Delta: %d", bci(), _delta); }
+  void print_on(outputStream* st) const { st->print_cr("ChangeJumpWiden. bci: %d   Delta: %d", bci(), _delta); }
 };
 
 class ChangeSwitchPad : public ChangeItem {
@@ -113,7 +114,9 @@ class ChangeSwitchPad : public ChangeItem {
    int  padding()              { return _padding;  }
    bool is_lookup_switch()     { return _is_lookup_switch; }
 
-   void print()                { tty->print_cr("ChangeSwitchPad. bci: %d   Padding: %d  IsLookupSwitch: %d", bci(), _padding, _is_lookup_switch); }
+   void print_on(outputStream* st) const {
+     st->print_cr("ChangeSwitchPad. bci: %d   Padding: %d  IsLookupSwitch: %d", bci(), _padding, _is_lookup_switch);
+   }
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -140,11 +143,10 @@ methodHandle Relocator::insert_space_at(int bci, int size, u_char inst_buffer[],
   _changes = new GrowableArray<ChangeItem*> (10);
   _changes->push(new ChangeWiden(bci, size, inst_buffer));
 
-  if (TraceRelocator) {
-    tty->print_cr("Space at: %d Size: %d", bci, size);
-    _method->print();
-    _method->print_codes();
-    tty->print_cr("-------------------------------------------------");
+  if (const LogTarget(Debug, relocator) out; out.is_enabled()) {
+    LogStream ls(out);
+    ls.print_cr("Space at: %d Size: %d", bci, size);
+    _method->print_value_on(&ls);
   }
 
   if (!handle_code_changes()) return methodHandle();
@@ -160,13 +162,7 @@ methodHandle Relocator::insert_space_at(int bci, int size, u_char inst_buffer[],
   ClassLoaderData* loader_data = method()->method_holder()->class_loader_data();
   loader_data->add_to_deallocate_list(method()());
 
-    set_method(new_method);
-
-  if (TraceRelocator) {
-    tty->print_cr("-------------------------------------------------");
-    tty->print_cr("new method");
-    _method->print_codes();
-  }
+  set_method(new_method);
 
   return new_method;
 }
@@ -179,8 +175,9 @@ bool Relocator::handle_code_changes() {
     // Inv: everything is aligned.
     ChangeItem* ci = _changes->first();
 
-    if (TraceRelocator) {
-      ci->print();
+    if (const LogTarget(Trace, relocator) out; out.is_enabled()) {
+      LogStream ls(out);
+      ci->print_on(&ls);
     }
 
     // Execute operation
@@ -407,13 +404,13 @@ void Relocator::adjust_exception_table(int bci, int delta) {
   }
 }
 
-static void print_linenumber_table(unsigned char* table) {
+static void print_linenumber_table(outputStream* ls, unsigned char* table) {
   CompressedLineNumberReadStream stream(table);
-  tty->print_cr("-------------------------------------------------");
+  ls->print_cr("-------------------------------------------------");
   while (stream.read_pair()) {
-    tty->print_cr("   - line %d: %d", stream.line(), stream.bci());
+    ls->print_cr("   - line %d: %d", stream.line(), stream.bci());
   }
-  tty->print_cr("-------------------------------------------------");
+  ls->print_cr("-------------------------------------------------");
 }
 
 // The width of instruction at "bci" is changing by "delta".  Adjust the line number table.
@@ -433,9 +430,10 @@ void Relocator::adjust_line_no_table(int bci, int delta) {
     writer.write_terminator();
     set_compressed_line_number_table(writer.buffer());
     set_compressed_line_number_table_size(writer.position());
-    if (TraceRelocator) {
-      tty->print_cr("Adjusted line number table");
-      print_linenumber_table(compressed_line_number_table());
+    if (const LogTarget(Trace, relocator) out; out.is_enabled()) {
+      LogStream ls(out);
+      ls.print_cr("Adjusted line number table");
+      print_linenumber_table(&ls, compressed_line_number_table());
     }
   }
 }

--- a/src/hotspot/share/runtime/relocator.cpp
+++ b/src/hotspot/share/runtime/relocator.cpp
@@ -24,6 +24,7 @@
 
 #include "classfile/stackMapTableFormat.hpp"
 #include "interpreter/bytecodes.hpp"
+#include "logging/logStream.hpp"
 #include "logging/logTag.hpp"
 #include "memory/metadataFactory.hpp"
 #include "memory/oopFactory.hpp"

--- a/src/hotspot/share/runtime/relocator.cpp
+++ b/src/hotspot/share/runtime/relocator.cpp
@@ -430,8 +430,8 @@ void Relocator::adjust_line_no_table(int bci, int delta) {
     writer.write_terminator();
     set_compressed_line_number_table(writer.buffer());
     set_compressed_line_number_table_size(writer.position());
-    if (const LogTarget(Trace, relocator) out; out.is_enabled()) {
-      LogStream ls(out);
+    if (LogMessage(relocator) out; out.is_trace()) {
+      NonInterleavingLogStream ls(LogLevelType::Trace, out);
       ls.print_cr("Adjusted line number table");
       print_linenumber_table(&ls, compressed_line_number_table());
     }

--- a/test/hotspot/jtreg/runtime/logging/RelocatorTest.java
+++ b/test/hotspot/jtreg/runtime/logging/RelocatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8197901 8209758
+ * @summary Log relocation in class redefinition.
+ * @library /test/lib
+ * @modules java.compiler
+ *          java.instrument
+ * @requires vm.jvmti
+ * @requires vm.debug
+ * @run main RedefineClassHelper
+ * @run driver RelocatorTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+// package access top-level class to avoid problem with RedefineClassHelper
+// and nested types.
+class RelocatorTest_B {
+    public static void test() {
+        System.out.println("Old class");
+    }
+}
+
+public class RelocatorTest {
+    public static class InternalClass {
+        public static String newB =
+            "class RelocatorTest_B {" +
+            "    public static void test() { " +
+            "       System.out.println(\"New class\");" +
+            "       System.out.println(\"Need more ldc's in this class\");" +
+            "       System.out.println(\"Another ldc\");" +
+            "    }" +
+            "}";
+
+        public static void main(String[] args) throws Exception {
+            RelocatorTest_B.test();
+            RedefineClassHelper.redefineClass(RelocatorTest_B.class, newB);
+            RelocatorTest_B.test();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-javaagent:redefineagent.jar",
+                                                                             "-XX:+StressLdcRewrite",
+                                                                             "-Xlog:relocator=trace,redefine+class+constantpool=trace",
+                                                                             InternalClass.class.getName());
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldContain("Old class");
+        output.shouldMatch("\\[debug\\]\\[relocator *\\] Space at: 3 Size: 3");
+        output.shouldMatch("\\[debug\\]\\[relocator *\\] \\{method\\} .* 'test' '\\(\\)V' in 'RelocatorTest_B'");
+        output.shouldMatch("\\[trace\\]\\[relocator *\\] ChangeWiden. bci: 3   New_ilen: 3");
+        output.shouldMatch("\\[debug\\]\\[relocator *\\] Space at: 12 Size: 3");
+        output.shouldMatch("\\[debug\\]\\[relocator *\\] \\{method\\} .* 'test' '\\(\\)V' in 'RelocatorTest_B'");
+        output.shouldMatch("\\[trace\\]\\[relocator *\\] ChangeWiden. bci: 12   New_ilen: 3");
+        output.shouldMatch("\\[debug\\]\\[relocator *\\] Space at: 21 Size: 3");
+        output.shouldMatch("\\[debug\\]\\[relocator *\\] \\{method\\} .* 'test' '\\(\\)V' in 'RelocatorTest_B'");
+        output.shouldContain("New class");
+        output.shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/logging/RelocatorTest.java
+++ b/test/hotspot/jtreg/runtime/logging/RelocatorTest.java
@@ -29,7 +29,6 @@
  * @modules java.compiler
  *          java.instrument
  * @requires vm.jvmti
- * @requires vm.debug
  * @run main RedefineClassHelper
  * @run driver RelocatorTest
  */
@@ -65,6 +64,7 @@ public class RelocatorTest {
 
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-javaagent:redefineagent.jar",
+                                                                             "-XX:+UnlockDiagnosticVMOptions",
                                                                              "-XX:+StressLdcRewrite",
                                                                              "-Xlog:relocator=trace,redefine+class+constantpool=trace",
                                                                              InternalClass.class.getName());


### PR DESCRIPTION
Please review this simple change to convert TraceRelocator to Unified logging inspired by the change in https://github.com/openjdk/jdk/pull/31527.  The print_codes() before and after insert_space_at is wrong for the constant pool merging for redefinition and the other use with rewriting jsr/ret already has a Method::print_codes_at() call for GenerateOopMap logging, so I removed it. This logging doesn't interact with the valhalla changes in any way.
Tested with tier1 on Oracle platforms and logging tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386922](https://bugs.openjdk.org/browse/JDK-8386922): Convert TraceRelocator to Unified Logging (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**) Review applies to [0636f09a](https://git.openjdk.org/jdk/pull/31578/files/0636f09ac57265ce37431231549e97465ec62afc)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31578/head:pull/31578` \
`$ git checkout pull/31578`

Update a local copy of the PR: \
`$ git checkout pull/31578` \
`$ git pull https://git.openjdk.org/jdk.git pull/31578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31578`

View PR using the GUI difftool: \
`$ git pr show -t 31578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31578.diff">https://git.openjdk.org/jdk/pull/31578.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31578#issuecomment-4746151984)
</details>
