### PR TITLE
8379144: serviceability/jvmti/vthread/VThreadTest/VThreadTest.java timed out with --enable-preview

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -56,7 +56,8 @@ public class VThreadTest {
             }
         } catch (Throwable t) {
             t.printStackTrace(System.out);
-            throw new RuntimeException("VThreadTest failed: PRODUCER caught a throwable: " + t);
+            log("VThreadTest failed: PRODUCER caught a throwable: " + t);
+            System.exit(1);
         }
     };
 
@@ -67,7 +68,8 @@ public class VThreadTest {
             }
         } catch (Throwable t) {
             t.printStackTrace(System.out);
-            throw new RuntimeException("VThreadTest failed: CONSUMER caught a throwable: " + t);
+            log("VThreadTest failed: CONSUMER caught a throwable: " + t);
+            System.exit(1);
         }
     };
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -55,8 +55,8 @@ public class VThreadTest {
                 producer("msg: ");
             }
         } catch (Throwable t) {
-            log("Failed: PRODUCER caught a throwable: " + t);
             t.printStackTrace(System.out);
+            throw new RuntimeException("VThreadTest failed: PRODUCER caught a throwable: " + t");
         }
     };
 
@@ -66,8 +66,8 @@ public class VThreadTest {
                 String s = QUEUE.take();
             }
         } catch (Throwable t) {
-            log("Failed: CONSUMER cauoht a throwable: " + t);
             t.printStackTrace(System.out);
+            throw new RuntimeException("VThreadTest failed: CONSUMER caught a throwable: " + t");
         }
     };
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -33,8 +33,6 @@
 import java.util.concurrent.*;
 
 public class VThreadTest {
-    private static final String agentLib = "VThreadTest";
-
     static final int MSG_COUNT = 10*1000;
     static final SynchronousQueue<String> QUEUE = new SynchronousQueue<>();
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -40,6 +40,8 @@ public class VThreadTest {
 
     static native boolean check();
 
+    static void log(String msg) { System.out.println(msg); }
+
     static void producer(String msg) throws InterruptedException {
         int ii = 1;
         long ll = 2*(long)ii;
@@ -54,7 +56,10 @@ public class VThreadTest {
             for (int i = 0; i < MSG_COUNT; i++) {
                 producer("msg: ");
             }
-        } catch (InterruptedException e) { }
+        } catch (Throwable t) {
+            log("Failed: PRODUCER caught a trowable: " + t);
+            t.printStackTrace(System.out);
+        }
     };
 
     static final Runnable CONSUMER = () -> {
@@ -62,7 +67,10 @@ public class VThreadTest {
             for (int i = 0; i < MSG_COUNT; i++) {
                 String s = QUEUE.take();
             }
-        } catch (InterruptedException e) { }
+        } catch (Throwable t) {
+            log("Failed: CONSUMER caught a trowable: " + t);
+            t.printStackTrace(System.out);
+        }
     };
 
     public static void test1() throws Exception {
@@ -80,14 +88,6 @@ public class VThreadTest {
     }
 
     public static void main(String[] args) throws Exception {
-        try {
-            System.loadLibrary(agentLib);
-        } catch (UnsatisfiedLinkError ex) {
-            System.err.println("Failed to load " + agentLib + " lib");
-            System.err.println("java.library.path: " + System.getProperty("java.library.path"));
-            throw ex;
-        }
-
         VThreadTest obj = new VThreadTest();
         obj.runTest();
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -56,7 +56,7 @@ public class VThreadTest {
             }
         } catch (Throwable t) {
             t.printStackTrace(System.out);
-            throw new RuntimeException("VThreadTest failed: PRODUCER caught a throwable: " + t");
+            throw new RuntimeException("VThreadTest failed: PRODUCER caught a throwable: " + t);
         }
     };
 
@@ -67,7 +67,7 @@ public class VThreadTest {
             }
         } catch (Throwable t) {
             t.printStackTrace(System.out);
-            throw new RuntimeException("VThreadTest failed: CONSUMER caught a throwable: " + t");
+            throw new RuntimeException("VThreadTest failed: CONSUMER caught a throwable: " + t);
         }
     };
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java
@@ -57,7 +57,7 @@ public class VThreadTest {
                 producer("msg: ");
             }
         } catch (Throwable t) {
-            log("Failed: PRODUCER caught a trowable: " + t);
+            log("Failed: PRODUCER caught a throwable: " + t);
             t.printStackTrace(System.out);
         }
     };
@@ -68,7 +68,7 @@ public class VThreadTest {
                 String s = QUEUE.take();
             }
         } catch (Throwable t) {
-            log("Failed: CONSUMER caught a trowable: " + t);
+            log("Failed: CONSUMER cauoht a throwable: " + t);
             t.printStackTrace(System.out);
         }
     };

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
@@ -342,17 +342,6 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             if (callbackAborted) break;
 
-            for (int gcCount = 0; gcCount < 5; gcCount++) {
-                NSK_DISPLAY1("Calling ForceGarbageCollection #%d before saving objectCountMax\n", gcCount + 1);
-                if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection())) {
-                    nsk_jvmti_setFailStatus();
-                    break;
-                }
-            }
-            if (nsk_jvmti_getStatus() != NSK_STATUS_PASSED) {
-                break;
-            }
-
             objectCountMax = objectCount;
 
             /* Deallocate last unnecessary descriptor */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
@@ -342,7 +342,6 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             if (callbackAborted) break;
 
-#if 1
             for (int gcCount = 0; gcCount < 5; gcCount++) {
                 NSK_DISPLAY1("Calling ForceGarbageCollection #%d before saving objectCountMax\n", gcCount + 1);
                 if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection())) {
@@ -353,7 +352,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             if (nsk_jvmti_getStatus() != NSK_STATUS_PASSED) {
                 break;
             }
-#endif
+
             objectCountMax = objectCount;
 
             /* Deallocate last unnecessary descriptor */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
@@ -342,6 +342,18 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             if (callbackAborted) break;
 
+#if 1
+            for (int gcCount = 0; gcCount < 5; gcCount++) {
+                NSK_DISPLAY1("Calling ForceGarbageCollection #%d before saving objectCountMax\n", gcCount + 1);
+                if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection())) {
+                    nsk_jvmti_setFailStatus();
+                    break;
+                }
+            }
+            if (nsk_jvmti_getStatus() != NSK_STATUS_PASSED) {
+                break;
+            }
+#endif
             objectCountMax = objectCount;
 
             /* Deallocate last unnecessary descriptor */


### PR DESCRIPTION
The test does not handle exceptions, e.g. `InterruptedException`, in the `Producer` and `Consumer` threads. This can cause deadlocks. This timeout issue is hard to reproduce. This update is to add catch any `Throwable` and log all information needed to understand the root cause.
Also, removed unneeded fragment with the call: `System.loadLibrary(agentLib);`.

Testing:
 - Executed the test locally: `serviceability/jvmti/vthread/VThreadTest/VThreadTest.java`
 - TBD: Submit: mach5 tiers 1-3 to be completely safe


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8379144](https://bugs.openjdk.org/browse/JDK-8379144): serviceability/jvmti/vthread/VThreadTest/VThreadTest.java timed out with --enable-preview (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role) Review applies to [e4ff84e4](https://git.openjdk.org/jdk/pull/31581/files/e4ff84e471741c043a8dd4b4ce6b0118c4ff8d5a)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31581/head:pull/31581` \
`$ git checkout pull/31581`

Update a local copy of the PR: \
`$ git checkout pull/31581` \
`$ git pull https://git.openjdk.org/jdk.git pull/31581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31581`

View PR using the GUI difftool: \
`$ git pr show -t 31581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31581.diff">https://git.openjdk.org/jdk/pull/31581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31581#issuecomment-4746437169)
</details>
