### PR TITLE
8386909: Data race on com.sun.tools.jdi.VirtualMachineImpl.shutdown

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
@@ -157,7 +157,7 @@ class VirtualMachineImpl extends MirrorImpl
 
     private Object initMonitor = new Object();
     private boolean initComplete = false;
-    private boolean shutdown = false;
+    private volatile boolean shutdown = false;
 
     private void notifyInitCompletion() {
         synchronized(initMonitor) {


### PR DESCRIPTION
Hi all,

Could anyone review this change contributed by colleague Liz Looney <lizlooney@google.com>, that fixes a long-standing data race on `com.sun.tools.jdi.VirtualMachineImpl.shutdown`?

-Man

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386909](https://bugs.openjdk.org/browse/JDK-8386909): Data race on com.sun.tools.jdi.VirtualMachineImpl.shutdown (**Bug** - P4)


### Contributors
 * Liz Looney `<lizlooney@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31582/head:pull/31582` \
`$ git checkout pull/31582`

Update a local copy of the PR: \
`$ git checkout pull/31582` \
`$ git pull https://git.openjdk.org/jdk.git pull/31582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31582`

View PR using the GUI difftool: \
`$ git pr show -t 31582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31582.diff">https://git.openjdk.org/jdk/pull/31582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31582#issuecomment-4747016912)
</details>
