### PR TITLE
8386944: Warning message was not printed on PAC enabled AArch64 Linux

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -298,7 +298,7 @@ static bool core_handle_note(struct ps_prochandle* ph, ELF_PHDR* note_phdr) {
             ph->core->vdso_addr = auxv->a_un.a_val;
 #ifdef __aarch64__
           } else if (auxv->a_type == AT_HWCAP) {
-            ph->pac_enabled = auxv->a_un.a_val & HWCAP_PACA;
+            ph->pac_enabled = (auxv->a_un.a_val & HWCAP_PACA) == HWCAP_PACA;
 #endif
           }
           auxv++;

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -472,7 +472,7 @@ Pgrab(pid_t pid, char* err_buf, size_t err_buf_len) {
   }
 
 #ifdef __aarch64__
-  ph->pac_enabled = HWCAP_PACA & getauxval(AT_HWCAP);
+  ph->pac_enabled = (HWCAP_PACA & getauxval(AT_HWCAP)) == HWCAP_PACA;
 #endif
 
   // initialize ps_prochandle


### PR DESCRIPTION
DWARF parser on AArch64 has been supported since [JDK-8377946](https://bugs.openjdk.org/browse/JDK-8377946) (PR #29731), but warning message would be shown to notice call frames which are the result of mixed jstack might be incorrect if PAC (Pointer Authentication Code) is enabled. However it does not work.

`pac_enabled` is declared as `bool` as a member of `ps_prochandle` in libproc_impl.h. Accessor function is defined in libproc_impl.c. `bool` might not be defined by default in C, so it is defined in libproc.c as following:

```c
// This C bool type must be int for compatibility with Linux calls and
// it would be a mistake to equivalence it to C++ bool on many platforms
#ifndef __cplusplus
typedef int bool;
#define true 1
#define false 0
#endif
```

OTOH `pac_enabled()` would be called in LinuxDebuggerLocal.cpp. C++ has `bool` by default as 1 byte data. `HWCAP_PACA` is defined as 0x40000000, thus it would be `false` even if `HWCAP_PACA` is set because 1st byte of `HWCAP_PACA` is zero.

Hence we need to set the value as boolean to `pac_enabled` explicitly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386944](https://bugs.openjdk.org/browse/JDK-8386944): Warning message was not printed on PAC enabled AArch64 Linux (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31583/head:pull/31583` \
`$ git checkout pull/31583`

Update a local copy of the PR: \
`$ git checkout pull/31583` \
`$ git pull https://git.openjdk.org/jdk.git pull/31583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31583`

View PR using the GUI difftool: \
`$ git pr show -t 31583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31583.diff">https://git.openjdk.org/jdk/pull/31583.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31583#issuecomment-4747030813)
</details>
