### PR TITLE
8386852: Lower peak throughput with AOTCache

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -1377,7 +1377,7 @@ CompLevel CompilationPolicy::transition_from_limited_profile(const methodHandle&
 // Determine if a method should be compiled with a normal entry point at a different level.
 CompLevel CompilationPolicy::call_event(const methodHandle& method, CompLevel cur_level, JavaThread* THREAD) {
   CompLevel osr_level = MIN2((CompLevel) method->highest_osr_comp_level(), common<LoopPredicate>(method, cur_level, THREAD, true));
-  CompLevel next_level = common<CallPredicate>(method, cur_level, THREAD, !TrainingData::have_data() && is_old(method));
+  CompLevel next_level = common<CallPredicate>(method, cur_level, THREAD, is_old(method));
 
   // If OSR method level is greater than the regular method level, the levels should be
   // equalized by raising the regular method level in order to avoid OSRs during each


### PR DESCRIPTION
This PR fixes the peak throughput regression seen with AOTCache during benchmarking with a heavy load in a cpu contrained env. Details of the issue are mentioned in the JBS issue https://bugs.openjdk.org/browse/JDK-8386852.
To summarize: when AOTCache is present the C2 queue size feedback mechanism is always turned on. This results in methods getting compiled at tier2, and they remain in tier2 until the C2 queue size goes down again. With this patch the C2 queue size feedback mechanism for a sufficiently hot tier2 methods is disabled. This allows such methods to be added to the C2 queue, irrespective of its size. Eventually if the method is hot enough it may be picked up earlier for compilation.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386852](https://bugs.openjdk.org/browse/JDK-8386852): Lower peak throughput with AOTCache (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31584/head:pull/31584` \
`$ git checkout pull/31584`

Update a local copy of the PR: \
`$ git checkout pull/31584` \
`$ git pull https://git.openjdk.org/jdk.git pull/31584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31584`

View PR using the GUI difftool: \
`$ git pr show -t 31584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31584.diff">https://git.openjdk.org/jdk/pull/31584.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31584#issuecomment-4748077556)
</details>
