### PR TITLE
add support for pinning all objects returned from invoker or allocation apis

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package com.sun.tools.jdi;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
-import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -124,9 +124,8 @@ class VirtualMachineImpl extends MirrorImpl
     // "objectsByID" protected by "synchronized(this)".
     private final Map<Long, SoftObjectReference> objectsByID = new HashMap<>();
     private final ReferenceQueue<ObjectReferenceImpl> referenceQueue = new ReferenceQueue<>();
-    private static final int DISPOSE_THRESHOLD = 50;
     private final List<SoftObjectReference> batchedDisposeRequests =
-            Collections.synchronizedList(new ArrayList<>(DISPOSE_THRESHOLD + 10));
+            Collections.synchronizedList(new ArrayList<>(10));
 
     // These are cached once for the life of the VM
     private JDWP.VirtualMachine.Version versionInfo;
@@ -1321,7 +1320,7 @@ class VirtualMachineImpl extends MirrorImpl
         JDWP.VirtualMachine.DisposeObjects.Request[] requests = null;
         synchronized(batchedDisposeRequests) {
             int size = batchedDisposeRequests.size();
-            if (size >= DISPOSE_THRESHOLD) {
+            if (size >= 1) {
                 if ((traceFlags & TRACE_OBJREFS) != 0) {
                     printTrace("Dispose threshold reached. Will dispose "
                                + size + " object references...");
@@ -1541,7 +1540,7 @@ class VirtualMachineImpl extends MirrorImpl
         return threadGroupForJDI;
     }
 
-   private static class SoftObjectReference extends SoftReference<ObjectReferenceImpl> {
+   private static class SoftObjectReference extends WeakReference<ObjectReferenceImpl> {
        int count;
        Long key;
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/ArrayTypeImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ArrayTypeImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ writeNewObjectArray(JNIEnv *env, PacketOutputStream *out,
                 outStream_setError(out, JDWP_ERROR(OUT_OF_MEMORY));
             } else {
                 (void)outStream_writeByte(out, specificTypeKey(env, array));
-                (void)outStream_writeObjectRef(env, out, array);
+                (void)outStream_writeObjectRefPin(env, out, array);
             }
 
         }
@@ -197,8 +197,8 @@ writeNewPrimitiveArray(JNIEnv *env, PacketOutputStream *out,
             outStream_setError(out, JDWP_ERROR(OUT_OF_MEMORY));
         } else {
             (void)outStream_writeByte(out, specificTypeKey(env, array));
-            (void)outStream_writeObjectRef(env, out, array);
-        }
+            (void)outStream_writeObjectRefPin(env, out, array);
+       }
 
     } END_WITH_LOCAL_REFS(env);
 }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/VirtualMachineImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -717,7 +717,7 @@ createString(PacketInputStream *in, PacketOutputStream *out)
         if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             outStream_setError(out, JDWP_ERROR(OUT_OF_MEMORY));
         } else {
-            (void)outStream_writeObjectRef(env, out, string);
+            (void)outStream_writeObjectRefPin(env, out, string);
         }
 
     } END_WITH_LOCAL_REFS(env);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -814,9 +814,15 @@ invoker_completeInvokeRequest(jthread thread)
 
     if (!detached) {
         outStream_initReply(&out, id);
-        (void)outStream_writeValue(env, &out, tag, returnValue);
+        if (isObjectTag(tag)) {
+            (void)outStream_writeObjectTag(env, &out, returnValue.l);
+            (void)outStream_writeObjectRefPin(env, &out, returnValue.l);
+        } else {
+            (void)outStream_writeValue(env, &out, tag, returnValue);
+        }
         (void)outStream_writeObjectTag(env, &out, exc);
-        (void)outStream_writeObjectRef(env, &out, exc);
+        (void)outStream_writeObjectRefPin(env, &out, exc);
+        
         /*
          * Delete potentially saved global references for return value
          * and exception. This must be done before sending the reply or

--- a/src/jdk.jdwp.agent/share/native/libjdwp/outStream.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/outStream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,8 +202,8 @@ outStream_writeModuleRef(JNIEnv *env, PacketOutputStream *stream, jobject val)
     return outStream_writeObjectRef(env, stream, val);
 }
 
-jdwpError
-outStream_writeObjectRef(JNIEnv *env, PacketOutputStream *stream, jobject val)
+static jdwpError
+outStream_writeObjectRefCommon(JNIEnv *env, PacketOutputStream *stream, jobject val, jboolean pin)
 {
     jlong id;
     jlong *idPtr;
@@ -222,6 +222,17 @@ outStream_writeObjectRef(JNIEnv *env, PacketOutputStream *stream, jobject val)
             return stream->error;
         }
 
+        /* Pin if requested */
+        if (pin) {
+            //tty_message("pinning: %ld", id);
+            jvmtiError error = commonRef_pin(id);
+            if (error != JVMTI_ERROR_NONE) {
+                commonRef_release(env, id);
+                outStream_setError(stream, map2jdwpError(error));
+                return stream->error;
+            }
+        }
+
         /* Track the common ref in case we need to release it on a future error */
         idPtr = bagAdd(stream->ids);
         if (idPtr == NULL) {
@@ -237,6 +248,18 @@ outStream_writeObjectRef(JNIEnv *env, PacketOutputStream *stream, jobject val)
     }
 
     return writeBytes(stream, &id, sizeof(id));
+}
+
+jdwpError
+outStream_writeObjectRef(JNIEnv *env, PacketOutputStream *stream, jobject val)
+{
+    return outStream_writeObjectRefCommon(env, stream, val, JNI_FALSE);
+}
+
+jdwpError
+outStream_writeObjectRefPin(JNIEnv *env, PacketOutputStream *stream, jobject val)
+{
+    return outStream_writeObjectRefCommon(env, stream, val, JNI_TRUE);
 }
 
 jdwpError

--- a/src/jdk.jdwp.agent/share/native/libjdwp/outStream.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/outStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,7 @@ jdwpError outStream_writeFloat(PacketOutputStream *stream, jfloat val);
 jdwpError outStream_writeDouble(PacketOutputStream *stream, jdouble val);
 jdwpError outStream_writeModuleRef(JNIEnv *env, PacketOutputStream *stream, jobject val);
 jdwpError outStream_writeObjectRef(JNIEnv *env, PacketOutputStream *stream, jobject val);
+jdwpError outStream_writeObjectRefPin(JNIEnv *env, PacketOutputStream *stream, jobject val);
 jdwpError outStream_writeObjectTag(JNIEnv *env, PacketOutputStream *stream, jobject val);
 jdwpError outStream_writeFrameID(PacketOutputStream *stream, FrameID val);
 jdwpError outStream_writeMethodID(PacketOutputStream *stream, jmethodID val);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/instances/instances002/instances002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/instances/instances002/instances002.java
@@ -189,7 +189,10 @@ public class instances002 extends HeapwalkingDebugger {
             for (Method method : methods) {
                 if (method.isConstructor()) {
                     for (int i = 0; i < createInstanceCount; i++) {
-                        objectReferences.add(classType.newInstance(breakpointEvent.thread(), method, new ArrayList<Value>(), 0));
+                        ObjectReference obj = classType.newInstance(breakpointEvent.thread(), method, new ArrayList<Value>(), 0);
+                        obj.disableCollection();
+                        objectReferences.add(obj);
+                        obj.enableCollection();
                     }
 
                     debuggee.resume();

--- a/test/jdk/com/sun/jdi/InvokeGcDisabledTest.java
+++ b/test/jdk/com/sun/jdi/InvokeGcDisabledTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8311176
+ * @summary Test that newly allocated object are initially collectable.
+ * @library /test/lib
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run compile -g InvokeGcDisabledTest.java
+ * @run driver InvokeGcDisabledTest
+ * @run driver InvokeGcDisabledTest stress
+ */
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import com.sun.jdi.request.*;
+
+import java.util.*;
+
+import jdk.test.whitebox.WhiteBox;
+
+    /********** target program **********/
+
+class InvokeGcDisabledTarg {
+    static boolean stressMode = false;
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static volatile boolean stop = false;
+
+    public static void main(String[] args){
+        System.out.println("Howdy!");
+        if (args.length == 1 && "stress".equals(args[0])) {
+            System.out.println("debuggee stress mode");
+            stressMode = true;
+        }
+        if (stressMode) {
+            Thread gcThread = new Thread(() -> {
+                    while (!stop) WB.fullGC();
+            });
+            gcThread.start();
+        }
+        (new InvokeGcDisabledTarg()).sayHi();
+        stop = true;
+    }
+
+    void sayHi() {
+    }
+
+    InvokeGcDisabledTarg() {
+        System.out.println("InvokeGcDisabledTarg::InvokeGcDisabledTarg called");
+    }
+
+    InvokeGcDisabledTarg(boolean ignore) {
+        System.out.println("InvokeGcDisabledTarg::InvokeGcDisabledTarg for exception called");
+        throw new RuntimeException("Exception from debuggee");
+    }
+
+    Object newObject() {
+        System.out.println("InvokeGcDisabledTarg::newObject called");
+        return new Object();
+    }
+
+    static Object staticNewObject() {
+        System.out.println("InvokeGcDisabledTarg::staticNewObject called");
+        return new Object();
+    }
+
+    void throwException() {
+        System.out.println("InvokeGcDisabledTarg::throwException called");
+        throw new RuntimeException("Exception from debuggee");
+    }
+
+    void throwStaticException() {
+        System.out.println("InvokeGcDisabledTarg::throwStaticException called");
+        throw new RuntimeException("Exception from debuggee");
+    }
+
+    Object[] newObjectArray() {
+        System.out.println("InvokeGcDisabledTarg::newObjectArray called");
+        return new Object[0];
+    }
+
+    int[] newIntArray() {
+        System.out.println("InvokeGcDisabledTarg::newIntArray called");
+        return new int[0];
+    }
+
+    void fullGC() {
+        WB.fullGC();
+    }
+
+}
+
+    /********** test program **********/
+
+public class InvokeGcDisabledTest extends TestScaffold {
+    static boolean stressMode = false;
+    ClassType targetClass;
+    ThreadReference mainThread;
+    ObjectReference thisObject;
+    List<Value> emptyArgs;
+    List<Value> booleanArg;
+
+    Method forceDebuggeeGCMethod = null;
+
+    InvokeGcDisabledTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            if ("stress".equals(args[0])) {
+                System.out.println("debugger stress mode");
+                stressMode = true;
+            } else {
+                throw new RuntimeException("bad argument: " + args[0]);
+            }
+        }
+        try {
+            new InvokeGcDisabledTest(args).startTests();
+        } catch (Throwable t) {
+            t.printStackTrace(System.out);
+            throw t;
+        }
+    }
+
+    /********** test assist **********/
+
+    void forceDebuggeeGC() throws Exception {
+        if (forceDebuggeeGCMethod == null) {
+            forceDebuggeeGCMethod = findMethod(targetClass, "fullGC", "()V");
+            if (forceDebuggeeGCMethod == null) {
+                failure("FAILED: Can't find method: \"fullGC\" for class = " + targetClass);
+                return;
+            }
+        }
+
+        println("Forcing debuggee full GC");
+        thisObject.invokeMethod(mainThread, forceDebuggeeGCMethod, emptyArgs, ObjectReference.INVOKE_SINGLE_THREADED);
+    }
+
+    ObjectReference invoke(Method method, InvokeType invokeType, int options, boolean throwsException)
+            throws Exception {
+        Value returnValue = null;
+        options = options | ObjectReference.INVOKE_SINGLE_THREADED;
+
+        try {
+            switch (invokeType) {
+            case VIRTUAL_INVOKE_METHOD:
+                returnValue = thisObject.invokeMethod(mainThread, method, emptyArgs, options);
+                break;
+            case STATIC_INVOKE_METHOD:
+                returnValue = targetClass.invokeMethod(mainThread, method, emptyArgs, options);
+                break;
+            case NEW_INSTANCE:
+                returnValue = targetClass.newInstance(mainThread, method,
+                                                      throwsException ? booleanArg : emptyArgs, options);
+                break;
+            }
+        } catch (InvocationException ie) {
+            if (!throwsException) {
+                ie.printStackTrace();
+                failure("Got Exception: " + ie);
+                throw ie;
+            } else {
+                println("Got expected InvocationException: " + ie.exception());
+                returnValue = ie.exception();
+            }
+        } catch (Exception ee) {
+            ee.printStackTrace();
+            failure("Got Exception: " + ee);
+            throw ee;
+        }
+        println("        return val = " + returnValue);
+        return (ObjectReference)returnValue;
+    }
+
+    void verifyCollected(ObjectReference obj) {
+        println("Verifying object is collected: " + obj);
+        if (!obj.isCollected()) {
+            failure("FAILED: object not collected: " + obj);
+        }
+    }
+
+    void verifyNotCollected(ObjectReference obj) {
+        println("Verifying object is not collected: " + obj);
+        if (obj.isCollected()) {
+            failure("FAILED: object collected: " + obj);
+        }
+    }
+
+    private enum InvokeType {
+        VIRTUAL_INVOKE_METHOD,
+        STATIC_INVOKE_METHOD,
+        NEW_INSTANCE
+    }
+
+    private void testInvoke(String invokeMethod, String methodName, String methodSig, InvokeType invokeType,
+                            boolean throwsException) throws Exception {
+        ObjectReference obj;
+        Method method = findMethod(targetClass, methodName, methodSig);
+        if (method == null) {
+            failure("FAILED: Can't find method: \"" + methodName + methodSig + "\" for class = " + targetClass);
+            return;
+        }
+
+        println("*************************************************************************");
+        println("* TESTING " + invokeMethod +" on " + targetClass.name() + "." + methodName + methodSig);
+        println("* throwsException=" + throwsException + " stressMode=" + stressMode);
+        println("*************************************************************************");
+
+        println("TEST: Verify invoke disables collection of allocated object");
+        obj = invoke(method, invokeType, 0, throwsException);
+        forceDebuggeeGC();
+        verifyNotCollected(obj);
+
+        println("TEST: Verify enableCollection allows allocated object to be collected");
+        obj.disableCollection();
+        obj.enableCollection();
+        forceDebuggeeGC();
+        verifyCollected(obj);
+    }
+
+    private enum AllocationType {
+        ALLOCATE_STRING,
+        ALLOCATE_OBJECT_ARRAY,
+        ALLOCATE_PRIMITIVE_ARRAY
+    }
+
+    private ObjectReference newArray(String methodName, String methodSig) throws Exception {
+        Method method = findMethod(targetClass, methodName, methodSig);
+        if (method == null) {
+            failure("FAILED: Can't find method: \"" + methodName + methodSig + "\" for class = " + targetClass);
+            return null;
+        }
+        ObjectReference invokeResult = (ObjectReference)thisObject.invokeMethod(mainThread, method, emptyArgs, ObjectReference.INVOKE_SINGLE_THREADED);
+        ArrayType type = (ArrayType)invokeResult.referenceType();
+        return type.newInstance(3);
+    }
+    
+    private void testAllocation(AllocationType allocType, String testDescription)
+            throws Exception {
+        ObjectReference obj = null;
+        println("*************************************************************************");
+        println("* TESTING " + testDescription);
+        println("*************************************************************************");
+        try {
+            switch (allocType) {
+            case ALLOCATE_STRING:
+                obj = vm().mirrorOf("Test String");
+                break;
+            case ALLOCATE_OBJECT_ARRAY:
+                obj = newArray("newObjectArray", "()[Ljava/lang/Object;");
+                break;
+            case ALLOCATE_PRIMITIVE_ARRAY:
+                obj = newArray("newIntArray", "()[I");
+                break;
+            }
+        } catch (Exception ee) {
+            ee.printStackTrace();
+            failure("Got Exception: " + ee);
+            throw ee;
+        }
+
+        println("allocated object: " + obj);
+        println("TEST: Verify allocated object has collection disabled by default");
+        forceDebuggeeGC();
+        verifyNotCollected(obj);
+        println("TEST: Verify enableCollection allows allocated object to be collected");
+        obj.disableCollection();
+        obj.enableCollection();
+        forceDebuggeeGC();
+        verifyCollected(obj);
+    }
+    
+    /********** test core **********/
+
+    protected void runTests() throws Exception {
+        ObjectReference obj;
+
+        enableWhiteBoxAPI(); // Allow debuggee to use WhiteBoxAPI
+
+        BreakpointEvent bpe = startTo("InvokeGcDisabledTarg", "sayHi", "()V");
+        targetClass = (ClassType)bpe.location().declaringType();
+        mainThread = bpe.thread();
+        StackFrame frame = mainThread.frame(0);
+        thisObject = frame.thisObject();
+
+        emptyArgs = new ArrayList(0);
+        booleanArg = Arrays.asList(new Value[]{vm().mirrorOf(true)});
+
+        // Resume all but the main thread. We don't want to be under a suspendAll.
+        mainThread.suspend();
+        vm().resume();
+
+        /*
+         * We test 3 invocation APIs to make sure the results have been pinned and
+         * can't initially be collected:
+         * -ObjectReference.invokeMethod(): We don't differentiate between virtual and
+         *  non-virtual because it uses the same code paths.
+         * -ClassType.invokeMethod(): Invocation of a static method.
+         * -ClassType.newInstance(): Invocation of a constructor. We don't test
+         *  InterfaceType.newInstance() because it uses the same code paths.
+         *
+         * Each of these APIs can throw an InvocationException, which contains
+         * the ObjectReference of the exception thrown by the debuggee, so we also
+         * need to test each of the above 3 APIs with an exception thrown to make
+         * the exception can't initially be collected.
+         */
+        testInvoke("ObjectReference.invokeMethod()",
+                   "newObject", "()Ljava/lang/Object;",
+                   InvokeType.VIRTUAL_INVOKE_METHOD, false);
+        testInvoke("ObjectReference.invokeMethod()",
+                   "newObject", "()Ljava/lang/Object;",
+                   InvokeType.VIRTUAL_INVOKE_METHOD, true);
+        testInvoke("ClassType.invokeMethod()",
+                   "staticNewObject", "()Ljava/lang/Object;",
+                   InvokeType.STATIC_INVOKE_METHOD,false);
+        testInvoke("ClassType.invokeMethod()",
+                   "staticNewObject", "()Ljava/lang/Object;",
+                   InvokeType.STATIC_INVOKE_METHOD, true);
+        testInvoke("ClassType.newInstance()",
+                   "<init>", "()V",
+                   InvokeType.NEW_INSTANCE, false);
+        testInvoke("ClassType.newInstance()",
+                   "<init>", "(Z)V",
+                   InvokeType.NEW_INSTANCE, true);
+
+        testAllocation(AllocationType.ALLOCATE_STRING,          "String allocation");
+        testAllocation(AllocationType.ALLOCATE_OBJECT_ARRAY,    "Object array allocation");
+        testAllocation(AllocationType.ALLOCATE_PRIMITIVE_ARRAY, "Primitive array allocation");
+       
+        /*
+         * resume the target so it can exit.
+         */
+        mainThread.resume();
+        listenUntilVMDisconnect();
+
+        /*
+         * Deal with results of test.
+         * Of anything has called failure("foo") testFailed will be true.
+         */
+        if (!testFailed) {
+            println("InvokeGcDisabledTest: passed");
+        } else {
+            throw new Exception("InvokeGcDisabledTest: failed");
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/OomDebugTest.java
+++ b/test/jdk/com/sun/jdi/OomDebugTest.java
@@ -136,6 +136,13 @@ public class OomDebugTest extends TestScaffold {
         this.testMethod = args[1];
     }
 
+    void forceCollection() {
+        // Need to force unreferenced ObjectReferences to be collected so the ObjectID
+        // can be released on the debuggee side, allowing any hard reference to be
+        // released and the object collected.
+        System.gc();
+    }
+
     @Override
     protected void runTests() throws Exception {
         try {
@@ -193,6 +200,7 @@ public class OomDebugTest extends TestScaffold {
             ClassType clsType = (ClassType)field.type();
             Method constructor = getConstructorForClass(clsType);
             for (int i = 0; i < 15; i++) {
+                forceCollection();
                 @SuppressWarnings({ "rawtypes", "unchecked" })
                 ObjectReference objRef = clsType.newInstance(mainThread,
                                                              constructor,
@@ -220,6 +228,7 @@ public class OomDebugTest extends TestScaffold {
             ArrayType arrType = (ArrayType)field.type();
 
             for (int i = 0; i < 15; i++) {
+                forceCollection();
                 ArrayReference byteArrayVal = arrType.newInstance(3000000);
                 if (byteArrayVal.isCollected()) {
                     System.out.println("DEBUG: Object got GC'ed before we can use it. NO-OP.");
@@ -240,6 +249,7 @@ public class OomDebugTest extends TestScaffold {
         System.out.println("DEBUG: ------------> Running test3");
         try {
             for (int i = 0; i < 15; i++) {
+                forceCollection();
                 invoke("testPrimitiveArrRetval",
                        "()[B",
                        Collections.EMPTY_LIST,
@@ -258,6 +268,7 @@ public class OomDebugTest extends TestScaffold {
         System.out.println("DEBUG: ------------> Running test4");
         try {
             for (int i = 0; i < 15; i++) {
+                forceCollection();
                 invoke("testFooClsRetval",
                        "()LOomDebugTestTarget$FooCls;",
                        Collections.EMPTY_LIST,
@@ -276,6 +287,7 @@ public class OomDebugTest extends TestScaffold {
         System.out.println("DEBUG: ------------> Running test5");
         try {
             ClassType type = (ClassType)thisObject.type();
+            forceCollection();
             for (int i = 0; i < 15; i++) {
                 type.newInstance(mainThread,
                                  findMethod(targetClass, "<init>", "()V"),

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,8 @@ abstract public class TestScaffold extends TargetAdapter {
 
     // Set true by tests that need the debug agent to be run with includevirtualthreads=y.
     private boolean includeVThreads = false;
+    // Set true by tests that need the debuggee to be run with WhiteBoxAPI enabled.
+    private boolean enableWhiteBoxAPI = false;
 
     ThreadReference mainThread;
     /**
@@ -89,6 +91,10 @@ abstract public class TestScaffold extends TargetAdapter {
 
     void enableIncludeVirtualthreads() {
         includeVThreads = true;
+    }
+
+    void enableWhiteBoxAPI() {
+        enableWhiteBoxAPI = true;
     }
 
     boolean getExceptionCaught() {
@@ -564,6 +570,10 @@ abstract public class TestScaffold extends TargetAdapter {
             // the test specified @enablePreview.
             argInfo.targetVMArgs += "--enable-preview ";
         }
+        if (enableWhiteBoxAPI) {
+            argInfo.targetVMArgs += "-XX:+UnlockDiagnosticVMOptions -Xbootclasspath/a:. -XX:+WhiteBoxAPI ";
+        }
+
         return argInfo;
     }
 
@@ -594,6 +604,7 @@ abstract public class TestScaffold extends TargetAdapter {
         ArgInfo argInfo = parseArgs(args);
 
         argInfo.targetVMArgs = VMConnection.getDebuggeeVMOptions() + " " + argInfo.targetVMArgs;
+        println("targetVMArgs: " + argInfo.targetVMArgs);
         connection = new VMConnection(argInfo.connectorSpec,
                                       argInfo.traceFlags,
                                       includeVThreads);


### PR DESCRIPTION
Add support in the debug agent for pinning all objects returned from invoker or allocation APIs. See first comment for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31586/head:pull/31586` \
`$ git checkout pull/31586`

Update a local copy of the PR: \
`$ git checkout pull/31586` \
`$ git pull https://git.openjdk.org/jdk.git pull/31586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31586`

View PR using the GUI difftool: \
`$ git pr show -t 31586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31586.diff">https://git.openjdk.org/jdk/pull/31586.diff</a>

</details>
