### PR TITLE
8386945: RISC-V: Auto-enable Zvbb extension features

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -117,7 +117,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZihintpause, false, EXPERIMENTAL,                             \
           "Use Zihintpause instructions")                                        \
   product(bool, UseZtso, false, EXPERIMENTAL, "Assume Ztso memory model")        \
-  product(bool, UseZvbb, false, EXPERIMENTAL, "Use Zvbb instructions")           \
+  product(bool, UseZvbb, false, DIAGNOSTIC, "Use Zvbb instructions")             \
   product(bool, UseZvbc, false, EXPERIMENTAL, "Use Zvbc instructions")           \
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
   product(bool, UseZvkg, false, DIAGNOSTIC, "Use Zvkg instructions")             \

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -239,13 +239,13 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZTSO)) {
     VM_Version::ext_Ztso.enable_feature();
   }
-  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBB)) {
-    VM_Version::ext_Zvbb.enable_feature();
-  }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBC)) {
     VM_Version::ext_Zvbc.enable_feature();
   }
 #endif
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBB)) {
+    VM_Version::ext_Zvbb.enable_feature();
+  }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVFH)) {
     VM_Version::ext_Zvfh.enable_feature();
   }


### PR DESCRIPTION
Hi, 
Can you help to review this patch?
I ran some tests on the SpacemiT Key Stone K3 (which features physical zvbb hardware extensions). After enabling Zvbb, the relevant JMH performance metrics improved significantly. So I propose to auto-enable this feature through hwprobe.

auto-enable this feature through hwprobe:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk/build/linux-riscv64-server-release/jdk/bin$ ./java -XX:+PrintFlagsFinal -version | grep UseZv
     bool UseZvbb                                  = true                              {ARCH diagnostic} {default}
     bool UseZvbc                                  = false                           {ARCH experimental} {default}
     bool UseZvfh                                  = true                              {ARCH diagnostic} {default}
     bool UseZvkg                                  = true                              {ARCH diagnostic} {default}
     bool UseZvkn                                  = true                              {ARCH diagnostic} {default}
openjdk version "28-internal" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zifeihan.jdk, mixed mode)
```

cpuinfo like this:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk$ cat /proc/cpuinfo
processor	: 0
hart		: 0
model name	: Spacemit(R) X100
isa		: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
mmu		: sv39
mvendorid	: 0x710
marchid		: 0x8000000058000002
mimpid		: 0x33d8a600
hart isa	: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
```

kernel version like this:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk$ uname -r
6.18.3-generic
zifeihan@riscv-spacemitk3picoitx:~/jdk$ uname -a
Linux riscv-spacemitk3picoitx 6.18.3-generic #1.0.0~rc2.4 SMP PREEMPT_DYNAMIC Thu Apr 16 11:50:58 CST 2026 riscv64 GNU/Linux
zifeihan@riscv-spacemitk3picoitx:~/jdk$ cat /etc/issue
Bianbu 4.0rc2 \n \l
zifeihan@riscv-spacemitk3picoitx:~/jdk$
```


### Testing (SpacemiT Key Stone K3)

- [x] tier1-3 tests (release)
- [x] test/hotspot/jtreg/compiler/codegen/aes/  (release)
- [x] test/jdk/com/sun/crypto/  (release)

jmh testing:
without this patch (SpacemiT Key Stone K3):
```
Benchmark                         (bits)  (shift)  (size)   Mode  Cnt     Score     Error   Units
RotateBenchmark.testRotateLeftB      128        7     256  thrpt    3   989.101 ±   3.536  ops/ms
RotateBenchmark.testRotateLeftB      128        7     512  thrpt    3   496.456 ±   3.939  ops/ms
RotateBenchmark.testRotateLeftB      128       15     256  thrpt    3   988.007 ±  20.427  ops/ms
RotateBenchmark.testRotateLeftB      128       15     512  thrpt    3   499.270 ±   3.125  ops/ms
RotateBenchmark.testRotateLeftB      128       31     256  thrpt    3   984.238 ±  33.929  ops/ms
RotateBenchmark.testRotateLeftB      128       31     512  thrpt    3   499.212 ±  11.509  ops/ms
RotateBenchmark.testRotateLeftB      256        7     256  thrpt    3  1938.827 ± 111.819  ops/ms
RotateBenchmark.testRotateLeftB      256        7     512  thrpt    3   987.096 ±  40.595  ops/ms
RotateBenchmark.testRotateLeftB      256       15     256  thrpt    3  1943.601 ±   0.739  ops/ms
RotateBenchmark.testRotateLeftB      256       15     512  thrpt    3   988.832 ±   3.365  ops/ms
RotateBenchmark.testRotateLeftB      256       31     256  thrpt    3  1874.758 ± 104.235  ops/ms
RotateBenchmark.testRotateLeftB      256       31     512  thrpt    3   988.553 ±  10.018  ops/ms
RotateBenchmark.testRotateLeftB      512        7     256  thrpt    3   151.287 ±   9.622  ops/ms
RotateBenchmark.testRotateLeftB      512        7     512  thrpt    3    75.812 ±   0.526  ops/ms
RotateBenchmark.testRotateLeftB      512       15     256  thrpt    3   150.556 ±   2.749  ops/ms
RotateBenchmark.testRotateLeftB      512       15     512  thrpt    3    75.393 ±   3.038  ops/ms
RotateBenchmark.testRotateLeftB      512       31     256  thrpt    3   150.400 ±   4.706  ops/ms
RotateBenchmark.testRotateLeftB      512       31     512  thrpt    3    75.098 ±   3.213  ops/ms
RotateBenchmark.testRotateLeftI      128        7     256  thrpt    3   614.066 ±   0.714  ops/ms
RotateBenchmark.testRotateLeftI      128        7     512  thrpt    3   309.311 ±   3.541  ops/ms
RotateBenchmark.testRotateLeftI      128       15     256  thrpt    3   613.435 ±   9.473  ops/ms
RotateBenchmark.testRotateLeftI      128       15     512  thrpt    3   307.301 ±   7.366  ops/ms
RotateBenchmark.testRotateLeftI      128       31     256  thrpt    3   609.435 ±   6.421  ops/ms
RotateBenchmark.testRotateLeftI      128       31     512  thrpt    3   307.298 ±   2.116  ops/ms
RotateBenchmark.testRotateLeftI      256        7     256  thrpt    3  1209.773 ±  89.279  ops/ms
RotateBenchmark.testRotateLeftI      256        7     512  thrpt    3   612.072 ±  11.948  ops/ms
RotateBenchmark.testRotateLeftI      256       15     256  thrpt    3  1212.690 ±  31.529  ops/ms
RotateBenchmark.testRotateLeftI      256       15     512  thrpt    3   609.154 ±  19.398  ops/ms
RotateBenchmark.testRotateLeftI      256       31     256  thrpt    3  1216.714 ±   6.368  ops/ms
RotateBenchmark.testRotateLeftI      256       31     512  thrpt    3   608.428 ±  57.289  ops/ms
RotateBenchmark.testRotateLeftI      512        7     256  thrpt    3   109.876 ±   4.289  ops/ms
RotateBenchmark.testRotateLeftI      512        7     512  thrpt    3    53.114 ±   1.616  ops/ms
RotateBenchmark.testRotateLeftI      512       15     256  thrpt    3   110.865 ±   4.896  ops/ms
RotateBenchmark.testRotateLeftI      512       15     512  thrpt    3    54.903 ±   1.717  ops/ms
RotateBenchmark.testRotateLeftI      512       31     256  thrpt    3   112.125 ±   2.016  ops/ms
RotateBenchmark.testRotateLeftI      512       31     512  thrpt    3    56.398 ±   4.700  ops/ms
RotateBenchmark.testRotateLeftL      128        7     256  thrpt    3   309.174 ±   4.856  ops/ms
RotateBenchmark.testRotateLeftL      128        7     512  thrpt    3   155.291 ±   1.604  ops/ms
RotateBenchmark.testRotateLeftL      128       15     256  thrpt    3   307.601 ±   6.509  ops/ms
RotateBenchmark.testRotateLeftL      128       15     512  thrpt    3   154.768 ±  13.894  ops/ms
RotateBenchmark.testRotateLeftL      128       31     256  thrpt    3   307.177 ±  11.999  ops/ms
RotateBenchmark.testRotateLeftL      128       31     512  thrpt    3   155.188 ±   2.963  ops/ms
RotateBenchmark.testRotateLeftL      256        7     256  thrpt    3   605.672 ±  73.366  ops/ms
RotateBenchmark.testRotateLeftL      256        7     512  thrpt    3   308.662 ±   8.296  ops/ms
RotateBenchmark.testRotateLeftL      256       15     256  thrpt    3   613.039 ±  16.840  ops/ms
RotateBenchmark.testRotateLeftL      256       15     512  thrpt    3   308.810 ±   9.442  ops/ms
RotateBenchmark.testRotateLeftL      256       31     256  thrpt    3   611.160 ±  19.211  ops/ms
RotateBenchmark.testRotateLeftL      256       31     512  thrpt    3   307.068 ±   2.979  ops/ms
RotateBenchmark.testRotateLeftL      512        7     256  thrpt    3    59.331 ±   1.905  ops/ms
RotateBenchmark.testRotateLeftL      512        7     512  thrpt    3    29.648 ±   0.903  ops/ms
RotateBenchmark.testRotateLeftL      512       15     256  thrpt    3    57.777 ±   1.091  ops/ms
RotateBenchmark.testRotateLeftL      512       15     512  thrpt    3    27.409 ±   0.510  ops/ms
RotateBenchmark.testRotateLeftL      512       31     256  thrpt    3    59.861 ±   3.081  ops/ms
RotateBenchmark.testRotateLeftL      512       31     512  thrpt    3    28.829 ±   1.236  ops/ms
RotateBenchmark.testRotateLeftS      128        7     256  thrpt    3   497.066 ±   3.276  ops/ms
RotateBenchmark.testRotateLeftS      128        7     512  thrpt    3   250.521 ±   0.995  ops/ms
RotateBenchmark.testRotateLeftS      128       15     256  thrpt    3   498.582 ±  19.073  ops/ms
RotateBenchmark.testRotateLeftS      128       15     512  thrpt    3   250.702 ±   0.117  ops/ms
RotateBenchmark.testRotateLeftS      128       31     256  thrpt    3   499.783 ±   0.253  ops/ms
RotateBenchmark.testRotateLeftS      128       31     512  thrpt    3   250.563 ±   3.648  ops/ms
RotateBenchmark.testRotateLeftS      256        7     256  thrpt    3   988.543 ±  54.548  ops/ms
RotateBenchmark.testRotateLeftS      256        7     512  thrpt    3   498.083 ±  55.725  ops/ms
RotateBenchmark.testRotateLeftS      256       15     256  thrpt    3   990.013 ±  37.589  ops/ms
RotateBenchmark.testRotateLeftS      256       15     512  thrpt    3   498.807 ±  20.005  ops/ms
RotateBenchmark.testRotateLeftS      256       31     256  thrpt    3   969.103 ±  65.525  ops/ms
RotateBenchmark.testRotateLeftS      256       31     512  thrpt    3   498.919 ±  17.114  ops/ms
RotateBenchmark.testRotateLeftS      512        7     256  thrpt    3   124.307 ±   7.082  ops/ms
RotateBenchmark.testRotateLeftS      512        7     512  thrpt    3    61.331 ±   2.451  ops/ms
RotateBenchmark.testRotateLeftS      512       15     256  thrpt    3   124.095 ±  11.756  ops/ms
RotateBenchmark.testRotateLeftS      512       15     512  thrpt    3    62.070 ±   5.004  ops/ms
RotateBenchmark.testRotateLeftS      512       31     256  thrpt    3   124.489 ±   8.583  ops/ms
RotateBenchmark.testRotateLeftS      512       31     512  thrpt    3    62.074 ±   1.131  ops/ms
RotateBenchmark.testRotateRightB     128        7     256  thrpt    3   989.028 ±  17.444  ops/ms
RotateBenchmark.testRotateRightB     128        7     512  thrpt    3   499.316 ±   9.538  ops/ms
RotateBenchmark.testRotateRightB     128       15     256  thrpt    3   989.162 ±   0.355  ops/ms
RotateBenchmark.testRotateRightB     128       15     512  thrpt    3   494.831 ±   5.163  ops/ms
RotateBenchmark.testRotateRightB     128       31     256  thrpt    3   985.297 ±  12.890  ops/ms
RotateBenchmark.testRotateRightB     128       31     512  thrpt    3   499.668 ±   0.822  ops/ms
RotateBenchmark.testRotateRightB     256        7     256  thrpt    3  1932.286 ± 202.496  ops/ms
RotateBenchmark.testRotateRightB     256        7     512  thrpt    3   988.588 ±  12.139  ops/ms
RotateBenchmark.testRotateRightB     256       15     256  thrpt    3  1917.106 ± 117.802  ops/ms
RotateBenchmark.testRotateRightB     256       15     512  thrpt    3   983.798 ±  78.429  ops/ms
RotateBenchmark.testRotateRightB     256       31     256  thrpt    3  1912.023 ±  47.303  ops/ms
RotateBenchmark.testRotateRightB     256       31     512  thrpt    3   986.627 ±  25.987  ops/ms
RotateBenchmark.testRotateRightB     512        7     256  thrpt    3   151.672 ±   0.701  ops/ms
RotateBenchmark.testRotateRightB     512        7     512  thrpt    3    75.697 ±   1.519  ops/ms
RotateBenchmark.testRotateRightB     512       15     256  thrpt    3   151.298 ±   6.940  ops/ms
RotateBenchmark.testRotateRightB     512       15     512  thrpt    3    75.718 ±   0.571  ops/ms
RotateBenchmark.testRotateRightB     512       31     256  thrpt    3   151.568 ±   0.959  ops/ms
RotateBenchmark.testRotateRightB     512       31     512  thrpt    3    75.693 ±   1.341  ops/ms
RotateBenchmark.testRotateRightI     128        7     256  thrpt    3   613.593 ±  13.033  ops/ms
RotateBenchmark.testRotateRightI     128        7     512  thrpt    3   308.934 ±   5.884  ops/ms
RotateBenchmark.testRotateRightI     128       15     256  thrpt    3   613.624 ±   4.022  ops/ms
RotateBenchmark.testRotateRightI     128       15     512  thrpt    3   308.362 ±  22.278  ops/ms
RotateBenchmark.testRotateRightI     128       31     256  thrpt    3   612.428 ±  35.211  ops/ms
RotateBenchmark.testRotateRightI     128       31     512  thrpt    3   309.467 ±   0.314  ops/ms
RotateBenchmark.testRotateRightI     256        7     256  thrpt    3  1192.376 ±  91.730  ops/ms
RotateBenchmark.testRotateRightI     256        7     512  thrpt    3   606.632 ± 119.566  ops/ms
RotateBenchmark.testRotateRightI     256       15     256  thrpt    3  1207.767 ± 128.903  ops/ms
RotateBenchmark.testRotateRightI     256       15     512  thrpt    3   612.570 ±  20.673  ops/ms
RotateBenchmark.testRotateRightI     256       31     256  thrpt    3  1175.006 ±  19.634  ops/ms
RotateBenchmark.testRotateRightI     256       31     512  thrpt    3   611.919 ±  38.045  ops/ms
RotateBenchmark.testRotateRightI     512        7     256  thrpt    3   112.441 ±   2.705  ops/ms
RotateBenchmark.testRotateRightI     512        7     512  thrpt    3    54.740 ±   1.105  ops/ms
RotateBenchmark.testRotateRightI     512       15     256  thrpt    3   112.426 ±   5.922  ops/ms
RotateBenchmark.testRotateRightI     512       15     512  thrpt    3    55.569 ±   5.368  ops/ms
RotateBenchmark.testRotateRightI     512       31     256  thrpt    3   109.856 ±   4.047  ops/ms
RotateBenchmark.testRotateRightI     512       31     512  thrpt    3    55.304 ±   3.680  ops/ms
RotateBenchmark.testRotateRightL     128        7     256  thrpt    3   307.210 ±  10.018  ops/ms
RotateBenchmark.testRotateRightL     128        7     512  thrpt    3   154.739 ±   2.472  ops/ms
RotateBenchmark.testRotateRightL     128       15     256  thrpt    3   306.556 ±   6.301  ops/ms
RotateBenchmark.testRotateRightL     128       15     512  thrpt    3   155.270 ±   1.091  ops/ms
RotateBenchmark.testRotateRightL     128       31     256  thrpt    3   308.109 ±  19.207  ops/ms
RotateBenchmark.testRotateRightL     128       31     512  thrpt    3   155.063 ±   0.420  ops/ms
RotateBenchmark.testRotateRightL     256        7     256  thrpt    3   612.973 ±   8.768  ops/ms
RotateBenchmark.testRotateRightL     256        7     512  thrpt    3   308.696 ±   4.950  ops/ms
RotateBenchmark.testRotateRightL     256       15     256  thrpt    3   610.930 ±  13.674  ops/ms
RotateBenchmark.testRotateRightL     256       15     512  thrpt    3   308.757 ±   3.841  ops/ms
RotateBenchmark.testRotateRightL     256       31     256  thrpt    3   610.787 ±  21.009  ops/ms
RotateBenchmark.testRotateRightL     256       31     512  thrpt    3   308.520 ±   2.334  ops/ms
RotateBenchmark.testRotateRightL     512        7     256  thrpt    3    58.574 ±   9.699  ops/ms
RotateBenchmark.testRotateRightL     512        7     512  thrpt    3    28.631 ±   0.930  ops/ms
RotateBenchmark.testRotateRightL     512       15     256  thrpt    3    58.660 ±   6.023  ops/ms
RotateBenchmark.testRotateRightL     512       15     512  thrpt    3    30.035 ±   3.005  ops/ms
RotateBenchmark.testRotateRightL     512       31     256  thrpt    3    58.531 ±   3.006  ops/ms
RotateBenchmark.testRotateRightL     512       31     512  thrpt    3    28.440 ±   0.589  ops/ms
RotateBenchmark.testRotateRightS     128        7     256  thrpt    3   497.799 ±   4.641  ops/ms
RotateBenchmark.testRotateRightS     128        7     512  thrpt    3   250.711 ±   0.028  ops/ms
RotateBenchmark.testRotateRightS     128       15     256  thrpt    3   499.403 ±   5.123  ops/ms
RotateBenchmark.testRotateRightS     128       15     512  thrpt    3   249.973 ±   3.938  ops/ms
RotateBenchmark.testRotateRightS     128       31     256  thrpt    3   499.025 ±  14.428  ops/ms
RotateBenchmark.testRotateRightS     128       31     512  thrpt    3   249.424 ±   8.243  ops/ms
RotateBenchmark.testRotateRightS     256        7     256  thrpt    3   990.250 ±   3.908  ops/ms
RotateBenchmark.testRotateRightS     256        7     512  thrpt    3   499.060 ±   5.518  ops/ms
RotateBenchmark.testRotateRightS     256       15     256  thrpt    3   987.435 ±  20.067  ops/ms
RotateBenchmark.testRotateRightS     256       15     512  thrpt    3   497.432 ±   2.082  ops/ms
RotateBenchmark.testRotateRightS     256       31     256  thrpt    3   986.950 ±  66.237  ops/ms
RotateBenchmark.testRotateRightS     256       31     512  thrpt    3   497.139 ±   2.503  ops/ms
RotateBenchmark.testRotateRightS     512        7     256  thrpt    3   124.382 ±   9.130  ops/ms
RotateBenchmark.testRotateRightS     512        7     512  thrpt    3    61.648 ±   4.863  ops/ms
RotateBenchmark.testRotateRightS     512       15     256  thrpt    3   124.432 ±   6.950  ops/ms
RotateBenchmark.testRotateRightS     512       15     512  thrpt    3    61.902 ±   3.990  ops/ms
RotateBenchmark.testRotateRightS     512       31     256  thrpt    3   124.226 ±   5.952  ops/ms
RotateBenchmark.testRotateRightS     512       31     512  thrpt    3    62.262 ±   5.352  ops/ms
Finished running test 'micro:jdk.incubator.vector.RotateBenchmark'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_jdk_incubator_vector_RotateBenchmark

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:jdk.incubator.vector.RotateBenchmark            1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'
```

with this patch (SpacemiT Key Stone K3)::
```
Benchmark                         (bits)  (shift)  (size)   Mode  Cnt     Score     Error   Units
RotateBenchmark.testRotateLeftB      128        7     256  thrpt    3   989.966 ±   1.249  ops/ms
RotateBenchmark.testRotateLeftB      128        7     512  thrpt    3   499.480 ±   1.181  ops/ms
RotateBenchmark.testRotateLeftB      128       15     256  thrpt    3   987.942 ±  24.810  ops/ms
RotateBenchmark.testRotateLeftB      128       15     512  thrpt    3   499.531 ±   3.146  ops/ms
RotateBenchmark.testRotateLeftB      128       31     256  thrpt    3   989.196 ±   2.353  ops/ms
RotateBenchmark.testRotateLeftB      128       31     512  thrpt    3   499.526 ±   1.078  ops/ms
RotateBenchmark.testRotateLeftB      256        7     256  thrpt    3  1938.849 ±  50.190  ops/ms
RotateBenchmark.testRotateLeftB      256        7     512  thrpt    3   986.147 ±  27.117  ops/ms
RotateBenchmark.testRotateLeftB      256       15     256  thrpt    3  1901.011 ± 132.473  ops/ms
RotateBenchmark.testRotateLeftB      256       15     512  thrpt    3   988.537 ±  25.203  ops/ms
RotateBenchmark.testRotateLeftB      256       31     256  thrpt    3  1927.903 ±  64.853  ops/ms
RotateBenchmark.testRotateLeftB      256       31     512  thrpt    3   984.208 ±  58.648  ops/ms
RotateBenchmark.testRotateLeftB      512        7     256  thrpt    3   150.846 ±   5.180  ops/ms
RotateBenchmark.testRotateLeftB      512        7     512  thrpt    3    75.538 ±   2.371  ops/ms
RotateBenchmark.testRotateLeftB      512       15     256  thrpt    3   150.335 ±   8.202  ops/ms
RotateBenchmark.testRotateLeftB      512       15     512  thrpt    3    75.808 ±   0.222  ops/ms
RotateBenchmark.testRotateLeftB      512       31     256  thrpt    3   150.975 ±   1.535  ops/ms
RotateBenchmark.testRotateLeftB      512       31     512  thrpt    3    75.461 ±   2.740  ops/ms
RotateBenchmark.testRotateLeftI      128        7     256  thrpt    3  1182.800 ±  70.958  ops/ms
RotateBenchmark.testRotateLeftI      128        7     512  thrpt    3   602.749 ±  15.520  ops/ms
RotateBenchmark.testRotateLeftI      128       15     256  thrpt    3  1184.748 ±  82.258  ops/ms
RotateBenchmark.testRotateLeftI      128       15     512  thrpt    3   601.392 ±  35.915  ops/ms
RotateBenchmark.testRotateLeftI      128       31     256  thrpt    3  1180.393 ± 125.430  ops/ms
RotateBenchmark.testRotateLeftI      128       31     512  thrpt    3   600.041 ±   7.092  ops/ms
RotateBenchmark.testRotateLeftI      256        7     256  thrpt    3  2194.025 ± 212.230  ops/ms
RotateBenchmark.testRotateLeftI      256        7     512  thrpt    3  1170.992 ±  98.445  ops/ms
RotateBenchmark.testRotateLeftI      256       15     256  thrpt    3  2314.483 ± 127.387  ops/ms
RotateBenchmark.testRotateLeftI      256       15     512  thrpt    3  1184.226 ±  70.714  ops/ms
RotateBenchmark.testRotateLeftI      256       31     256  thrpt    3  2338.656 ± 107.874  ops/ms
RotateBenchmark.testRotateLeftI      256       31     512  thrpt    3  1180.635 ±  21.505  ops/ms
RotateBenchmark.testRotateLeftI      512        7     256  thrpt    3   113.355 ±   4.460  ops/ms
RotateBenchmark.testRotateLeftI      512        7     512  thrpt    3    53.538 ±   1.842  ops/ms
RotateBenchmark.testRotateLeftI      512       15     256  thrpt    3   111.503 ±  11.027  ops/ms
RotateBenchmark.testRotateLeftI      512       15     512  thrpt    3    53.822 ±   2.149  ops/ms
RotateBenchmark.testRotateLeftI      512       31     256  thrpt    3   110.030 ±   2.940  ops/ms
RotateBenchmark.testRotateLeftI      512       31     512  thrpt    3    53.590 ±   1.345  ops/ms
RotateBenchmark.testRotateLeftL      128        7     256  thrpt    3   602.599 ±   3.862  ops/ms
RotateBenchmark.testRotateLeftL      128        7     512  thrpt    3   303.417 ±   0.996  ops/ms
RotateBenchmark.testRotateLeftL      128       15     256  thrpt    3   602.231 ±  27.822  ops/ms
RotateBenchmark.testRotateLeftL      128       15     512  thrpt    3   304.039 ±   1.018  ops/ms
RotateBenchmark.testRotateLeftL      128       31     256  thrpt    3   596.160 ±  74.320  ops/ms
RotateBenchmark.testRotateLeftL      128       31     512  thrpt    3   303.190 ±  10.859  ops/ms
RotateBenchmark.testRotateLeftL      256        7     256  thrpt    3  1182.663 ±  91.192  ops/ms
RotateBenchmark.testRotateLeftL      256        7     512  thrpt    3   602.608 ±  11.551  ops/ms
RotateBenchmark.testRotateLeftL      256       15     256  thrpt    3  1179.830 ±  49.593  ops/ms
RotateBenchmark.testRotateLeftL      256       15     512  thrpt    3   601.321 ±  27.465  ops/ms
RotateBenchmark.testRotateLeftL      256       31     256  thrpt    3  1183.441 ±  35.673  ops/ms
RotateBenchmark.testRotateLeftL      256       31     512  thrpt    3   602.680 ±   6.021  ops/ms
RotateBenchmark.testRotateLeftL      512        7     256  thrpt    3    58.573 ±   2.072  ops/ms
RotateBenchmark.testRotateLeftL      512        7     512  thrpt    3    28.151 ±   1.275  ops/ms
RotateBenchmark.testRotateLeftL      512       15     256  thrpt    3    61.105 ±   0.181  ops/ms
RotateBenchmark.testRotateLeftL      512       15     512  thrpt    3    28.437 ±   0.065  ops/ms
RotateBenchmark.testRotateLeftL      512       31     256  thrpt    3    56.914 ±   3.848  ops/ms
RotateBenchmark.testRotateLeftL      512       31     512  thrpt    3    29.327 ±   0.729  ops/ms
RotateBenchmark.testRotateLeftS      128        7     256  thrpt    3   494.289 ±   8.837  ops/ms
RotateBenchmark.testRotateLeftS      128        7     512  thrpt    3   250.646 ±   0.352  ops/ms
RotateBenchmark.testRotateLeftS      128       15     256  thrpt    3   499.636 ±   5.070  ops/ms
RotateBenchmark.testRotateLeftS      128       15     512  thrpt    3   250.617 ±   1.742  ops/ms
RotateBenchmark.testRotateLeftS      128       31     256  thrpt    3   497.781 ±   6.735  ops/ms
RotateBenchmark.testRotateLeftS      128       31     512  thrpt    3   250.093 ±   9.345  ops/ms
RotateBenchmark.testRotateLeftS      256        7     256  thrpt    3   989.727 ±  31.839  ops/ms
RotateBenchmark.testRotateLeftS      256        7     512  thrpt    3   499.458 ±   9.080  ops/ms
RotateBenchmark.testRotateLeftS      256       15     256  thrpt    3   980.453 ±  19.520  ops/ms
RotateBenchmark.testRotateLeftS      256       15     512  thrpt    3   499.844 ±   3.886  ops/ms
RotateBenchmark.testRotateLeftS      256       31     256  thrpt    3   990.284 ±   1.974  ops/ms
RotateBenchmark.testRotateLeftS      256       31     512  thrpt    3   498.113 ±  18.473  ops/ms
RotateBenchmark.testRotateLeftS      512        7     256  thrpt    3   124.927 ±  10.917  ops/ms
RotateBenchmark.testRotateLeftS      512        7     512  thrpt    3    61.884 ±   2.341  ops/ms
RotateBenchmark.testRotateLeftS      512       15     256  thrpt    3   123.958 ±   8.896  ops/ms
RotateBenchmark.testRotateLeftS      512       15     512  thrpt    3    61.970 ±   1.521  ops/ms
RotateBenchmark.testRotateLeftS      512       31     256  thrpt    3   124.194 ±   8.054  ops/ms
RotateBenchmark.testRotateLeftS      512       31     512  thrpt    3    62.001 ±   1.041  ops/ms
RotateBenchmark.testRotateRightB     128        7     256  thrpt    3   989.574 ±  13.066  ops/ms
RotateBenchmark.testRotateRightB     128        7     512  thrpt    3   497.602 ±  31.121  ops/ms
RotateBenchmark.testRotateRightB     128       15     256  thrpt    3   983.032 ±  23.270  ops/ms
RotateBenchmark.testRotateRightB     128       15     512  thrpt    3   499.783 ±   0.672  ops/ms
RotateBenchmark.testRotateRightB     128       31     256  thrpt    3   988.036 ±  26.303  ops/ms
RotateBenchmark.testRotateRightB     128       31     512  thrpt    3   499.454 ±  10.916  ops/ms
RotateBenchmark.testRotateRightB     256        7     256  thrpt    3  1941.097 ±  84.019  ops/ms
RotateBenchmark.testRotateRightB     256        7     512  thrpt    3   987.587 ±  61.982  ops/ms
RotateBenchmark.testRotateRightB     256       15     256  thrpt    3  1943.424 ±  55.456  ops/ms
RotateBenchmark.testRotateRightB     256       15     512  thrpt    3   989.088 ±  32.950  ops/ms
RotateBenchmark.testRotateRightB     256       31     256  thrpt    3  1943.932 ±   4.466  ops/ms
RotateBenchmark.testRotateRightB     256       31     512  thrpt    3   980.171 ±  44.734  ops/ms
RotateBenchmark.testRotateRightB     512        7     256  thrpt    3   152.105 ±   9.590  ops/ms
RotateBenchmark.testRotateRightB     512        7     512  thrpt    3    75.739 ±   0.372  ops/ms
RotateBenchmark.testRotateRightB     512       15     256  thrpt    3   148.890 ±   6.389  ops/ms
RotateBenchmark.testRotateRightB     512       15     512  thrpt    3    73.677 ±   3.620  ops/ms
RotateBenchmark.testRotateRightB     512       31     256  thrpt    3   151.615 ±   4.762  ops/ms
RotateBenchmark.testRotateRightB     512       31     512  thrpt    3    75.598 ±   3.378  ops/ms
RotateBenchmark.testRotateRightI     128        7     256  thrpt    3  1183.723 ±  66.786  ops/ms
RotateBenchmark.testRotateRightI     128        7     512  thrpt    3   603.457 ±   1.639  ops/ms
RotateBenchmark.testRotateRightI     128       15     256  thrpt    3  1185.607 ±  43.887  ops/ms
RotateBenchmark.testRotateRightI     128       15     512  thrpt    3   602.464 ±  12.578  ops/ms
RotateBenchmark.testRotateRightI     128       31     256  thrpt    3  1187.466 ±   2.442  ops/ms
RotateBenchmark.testRotateRightI     128       31     512  thrpt    3   601.743 ±  25.264  ops/ms
RotateBenchmark.testRotateRightI     256        7     256  thrpt    3  2326.658 ± 228.748  ops/ms
RotateBenchmark.testRotateRightI     256        7     512  thrpt    3  1149.213 ±  50.509  ops/ms
RotateBenchmark.testRotateRightI     256       15     256  thrpt    3  2314.661 ± 244.182  ops/ms
RotateBenchmark.testRotateRightI     256       15     512  thrpt    3  1180.007 ± 195.847  ops/ms
RotateBenchmark.testRotateRightI     256       31     256  thrpt    3  2331.193 ±  68.762  ops/ms
RotateBenchmark.testRotateRightI     256       31     512  thrpt    3  1182.842 ±  72.794  ops/ms
RotateBenchmark.testRotateRightI     512        7     256  thrpt    3   113.097 ±   7.016  ops/ms
RotateBenchmark.testRotateRightI     512        7     512  thrpt    3    55.116 ±   3.697  ops/ms
RotateBenchmark.testRotateRightI     512       15     256  thrpt    3   111.236 ±   1.533  ops/ms
RotateBenchmark.testRotateRightI     512       15     512  thrpt    3    53.253 ±   2.204  ops/ms
RotateBenchmark.testRotateRightI     512       31     256  thrpt    3   113.375 ±   6.763  ops/ms
RotateBenchmark.testRotateRightI     512       31     512  thrpt    3    54.216 ±   2.611  ops/ms
RotateBenchmark.testRotateRightL     128        7     256  thrpt    3   599.989 ±  27.730  ops/ms
RotateBenchmark.testRotateRightL     128        7     512  thrpt    3   302.033 ±  10.980  ops/ms
RotateBenchmark.testRotateRightL     128       15     256  thrpt    3   602.615 ±   5.452  ops/ms
RotateBenchmark.testRotateRightL     128       15     512  thrpt    3   303.152 ±   1.893  ops/ms
RotateBenchmark.testRotateRightL     128       31     256  thrpt    3   598.226 ±  63.313  ops/ms
RotateBenchmark.testRotateRightL     128       31     512  thrpt    3   304.001 ±   1.356  ops/ms
RotateBenchmark.testRotateRightL     256        7     256  thrpt    3  1183.558 ±  17.108  ops/ms
RotateBenchmark.testRotateRightL     256        7     512  thrpt    3   599.101 ±  91.984  ops/ms
RotateBenchmark.testRotateRightL     256       15     256  thrpt    3  1188.067 ±  14.622  ops/ms
RotateBenchmark.testRotateRightL     256       15     512  thrpt    3   603.002 ±   2.727  ops/ms
RotateBenchmark.testRotateRightL     256       31     256  thrpt    3  1180.387 ±  53.311  ops/ms
RotateBenchmark.testRotateRightL     256       31     512  thrpt    3   601.587 ±  25.007  ops/ms
RotateBenchmark.testRotateRightL     512        7     256  thrpt    3    60.322 ±   6.231  ops/ms
RotateBenchmark.testRotateRightL     512        7     512  thrpt    3    27.612 ±   1.168  ops/ms
RotateBenchmark.testRotateRightL     512       15     256  thrpt    3    60.067 ±   4.349  ops/ms
RotateBenchmark.testRotateRightL     512       15     512  thrpt    3    27.182 ±   1.825  ops/ms
RotateBenchmark.testRotateRightL     512       31     256  thrpt    3    58.275 ±   0.697  ops/ms
RotateBenchmark.testRotateRightL     512       31     512  thrpt    3    28.948 ±   1.194  ops/ms
RotateBenchmark.testRotateRightS     128        7     256  thrpt    3   499.751 ±   6.047  ops/ms
RotateBenchmark.testRotateRightS     128        7     512  thrpt    3   250.661 ±   0.787  ops/ms
RotateBenchmark.testRotateRightS     128       15     256  thrpt    3   499.575 ±   3.741  ops/ms
RotateBenchmark.testRotateRightS     128       15     512  thrpt    3   250.678 ±   0.155  ops/ms
RotateBenchmark.testRotateRightS     128       31     256  thrpt    3   499.970 ±   1.864  ops/ms
RotateBenchmark.testRotateRightS     128       31     512  thrpt    3   250.694 ±   0.266  ops/ms
RotateBenchmark.testRotateRightS     256        7     256  thrpt    3   987.605 ±  19.488  ops/ms
RotateBenchmark.testRotateRightS     256        7     512  thrpt    3   496.841 ±   3.175  ops/ms
RotateBenchmark.testRotateRightS     256       15     256  thrpt    3   990.205 ±   7.173  ops/ms
RotateBenchmark.testRotateRightS     256       15     512  thrpt    3   497.045 ±  23.404  ops/ms
RotateBenchmark.testRotateRightS     256       31     256  thrpt    3   988.918 ±   9.494  ops/ms
RotateBenchmark.testRotateRightS     256       31     512  thrpt    3   498.733 ±  11.099  ops/ms
RotateBenchmark.testRotateRightS     512        7     256  thrpt    3   124.711 ±   5.016  ops/ms
RotateBenchmark.testRotateRightS     512        7     512  thrpt    3    62.297 ±   4.134  ops/ms
RotateBenchmark.testRotateRightS     512       15     256  thrpt    3   124.170 ±   3.362  ops/ms
RotateBenchmark.testRotateRightS     512       15     512  thrpt    3    61.669 ±   3.471  ops/ms
RotateBenchmark.testRotateRightS     512       31     256  thrpt    3   124.667 ±   8.234  ops/ms
RotateBenchmark.testRotateRightS     512       31     512  thrpt    3    61.406 ±   0.755  ops/ms
Finished running test 'micro:jdk.incubator.vector.RotateBenchmark'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_jdk_incubator_vector_RotateBenchmark

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:jdk.incubator.vector.RotateBenchmark            1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'
```

We can see that there is a significant improvement in the following scenario: Int/Long + bits ≤ 256. 

| case | bits | shift | size | without this patch (ops/ms) | with this patch (ops/ms) | Increase Ratio |
|------|------|-------|------|--------------------|-------------------|------|
| RotateBenchmark.testRotateLeftI | 128 | 7 | 256 | 614.066 | 1182.800 | **+92.6%** |
| RotateBenchmark.testRotateLeftI | 128 | 7 | 512 | 309.311 | 602.749 | **+94.8%** |


Scenario 1 where no improvement is observed: Byte/Short types; 
 `src/hotspot/cpu/riscv/riscv_v.ad:84-89` ：

```cpp
      case Op_RotateLeftV:
      case Op_RotateRightV:
        if (bt != T_INT && bt != T_LONG) {
          return false;
        }
        return UseZvbb;
```


Scenario 2 where no improvement is observed: bits = 512 (exceeding the hardware VLEN, SpacemiT Key Stone K3 X100 vlen is 256bit(32byte)).
```
zifeihan@riscv-spacemitk3picoitx:~/jdk/build/linux-riscv64-server-release/jdk/bin$ ./java -XX:+PrintFlagsFinal -version | grep MaxVector
     intx MaxVectorSize                            = 32                                     {C2 product} {default}
     bool UseSubwordForMaxVector                   = true                                   {C2 product} {default}
openjdk version "28-internal" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zifeihan.jdk, mixed mode)
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386945](https://bugs.openjdk.org/browse/JDK-8386945): RISC-V: Auto-enable Zvbb extension features (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31588/head:pull/31588` \
`$ git checkout pull/31588`

Update a local copy of the PR: \
`$ git checkout pull/31588` \
`$ git pull https://git.openjdk.org/jdk.git pull/31588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31588`

View PR using the GUI difftool: \
`$ git pr show -t 31588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31588.diff">https://git.openjdk.org/jdk/pull/31588.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31588#issuecomment-4749740463)
</details>
