### PR TITLE
8386958: Build failure due to incorrect copyright text in src/hotspot/share/gc/shenandoah/ files

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAllocator.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * DO NOT ALTER OR REMOVE THIS COPYRIGHT NOTICE OR THIS FILE HEADER.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as

--- a/src/hotspot/share/gc/shenandoah/shenandoahAllocator.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAllocator.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * DO NOT ALTER OR REMOVE THIS COPYRIGHT NOTICE OR THIS FILE HEADER.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as

--- a/src/hotspot/share/gc/shenandoah/shenandoahPartitionAllocator.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPartitionAllocator.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * DO NOT ALTER OR REMOVE THIS COPYRIGHT NOTICE OR THIS FILE HEADER.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as

--- a/src/hotspot/share/gc/shenandoah/shenandoahPartitionAllocator.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPartitionAllocator.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * DO NOT ALTER OR REMOVE THIS COPYRIGHT NOTICE OR THIS FILE HEADER.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as


### PR DESCRIPTION
Can I please get a review of this change which fixes the copyright header text in a few files to address a build failure?

I have build running with this change and once that completes successfully, I'll integrate this.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386958](https://bugs.openjdk.org/browse/JDK-8386958): Build failure due to incorrect copyright text in src/hotspot/share/gc/shenandoah/ files (**Bug** - P2)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31589/head:pull/31589` \
`$ git checkout pull/31589`

Update a local copy of the PR: \
`$ git checkout pull/31589` \
`$ git pull https://git.openjdk.org/jdk.git pull/31589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31589`

View PR using the GUI difftool: \
`$ git pr show -t 31589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31589.diff">https://git.openjdk.org/jdk/pull/31589.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31589#issuecomment-4749178694)
</details>
