### PR TITLE
8386960: BUILD_LIBVERIFY remove special warning settings

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -35,8 +35,6 @@ ifeq ($(INCLUDE), true)
 $(eval $(call SetupJdkLibrary, BUILD_LIBVERIFY, \
     NAME := verify, \
     OPTIMIZATION := HIGH, \
-    DISABLED_WARNINGS_gcc_check_code.c := unused-variable, \
-    DISABLED_WARNINGS_clang_check_code.c := unused-variable, \
     EXTRA_HEADER_DIRS := libjava, \
     JDK_LIBS := libjvm, \
 ))

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3705,7 +3705,7 @@ CCerror (context_type *context, char *format, ...)
 static void
 CCout_of_memory(context_type *context)
 {
-    int n = print_CCerror_info(context);
+    print_CCerror_info(context);
     context->err_code = CC_OutOfMemory;
     longjmp(context->jump_buffer, 1);
 }


### PR DESCRIPTION
BUILD_LIBVERIFY disables some warnings in the makefile, but this can be avoided.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386960](https://bugs.openjdk.org/browse/JDK-8386960): BUILD_LIBVERIFY remove special warning settings (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31590/head:pull/31590` \
`$ git checkout pull/31590`

Update a local copy of the PR: \
`$ git checkout pull/31590` \
`$ git pull https://git.openjdk.org/jdk.git pull/31590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31590`

View PR using the GUI difftool: \
`$ git pr show -t 31590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31590.diff">https://git.openjdk.org/jdk/pull/31590.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31590#issuecomment-4749443309)
</details>
