### PR TITLE
8386986: Problemlist gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -86,6 +86,10 @@ gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
 gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
+gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#generational 8386964 generic-all
+gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#default 8386964 generic-all
+gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#generational 8386964 generic-all
+gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#default 8386964 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
The previous fix didn't work: https://bugs.openjdk.org/browse/JDK-8386964

Problem list these two tests again.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386986](https://bugs.openjdk.org/browse/JDK-8386986): Problemlist gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java (**Sub-task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31592/head:pull/31592` \
`$ git checkout pull/31592`

Update a local copy of the PR: \
`$ git checkout pull/31592` \
`$ git pull https://git.openjdk.org/jdk.git pull/31592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31592`

View PR using the GUI difftool: \
`$ git pr show -t 31592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31592.diff">https://git.openjdk.org/jdk/pull/31592.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31592#issuecomment-4753656015)
</details>
