### PR TITLE
8379983: G1: Fix up friend class declarations

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -185,13 +185,11 @@ public:
 // it.
 // See its description below for more information.
 class G1CardSet : public CHeapObj<mtGCCardSet> {
-  friend class G1CardSetTest;
   friend class G1CardSetMtTestTask;
+  friend class G1CardSetTest;
   friend class G1CheckCardClosure;
-
-  friend class G1TransferCard;
-
   friend class G1ReleaseCardsets;
+  friend class G1TransferCard;
 
   // When splitting addresses into region and card within that region, the logical
   // shift value to get the region.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -146,27 +146,20 @@ public:
 };
 
 class G1CollectedHeap : public CollectedHeap {
+  friend class G1CheckRegionAttrTableClosure;
+  friend class G1EvacuateRegionsTask;
+  friend class G1FullCollector;
+  friend class G1GCAllocRegion;
+  friend class G1HeapPrinterMark;
+  friend class G1HeapRegionClaimer;
+  friend class G1HeapVerifier;
+  friend class G1PLABAllocator;
+  friend class G1YoungGCVerifierMark;
+  friend class MutatorAllocRegion;
   friend class VM_G1CollectForAllocation;
   friend class VM_G1CollectFull;
   friend class VM_G1TryInitiateConcMark;
   friend class VMStructs;
-  friend class MutatorAllocRegion;
-  friend class G1FullCollector;
-  friend class G1GCAllocRegion;
-  friend class G1HeapVerifier;
-
-  friend class G1YoungGCVerifierMark;
-
-  // Closures used in implementation.
-  friend class G1EvacuateRegionsTask;
-  friend class G1PLABAllocator;
-
-  // Other related classes.
-  friend class G1HeapPrinterMark;
-  friend class G1HeapRegionClaimer;
-
-  // Testing classes.
-  friend class G1CheckRegionAttrTableClosure;
 
 private:
   // GC Overhead Limit functionality related members.

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -323,6 +323,7 @@ public:
 // This class manages data structures and methods for doing liveness analysis in
 // G1's concurrent cycle.
 class G1ConcurrentMark : public CHeapObj<mtGC> {
+  friend class G1ClearBitMapTask;
   friend class G1CMBitMapClosure;
   friend class G1CMConcurrentMarkingTask;
   friend class G1CMDrainMarkingStackClosure;
@@ -331,7 +332,6 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
   friend class G1CMRemarkTask;
   friend class G1CMRootRegionScanTask;
   friend class G1CMTask;
-  friend class G1ClearBitMapTask;
   friend class G1CollectorState;
   friend class G1ConcurrentMarkThread;
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -71,8 +71,8 @@ class G1HeapRegionTable : public G1BiasedMappedArray<G1HeapRegion*> {
 //
 
 class G1HeapRegionManager: public CHeapObj<mtGC> {
-  friend class VMStructs;
   friend class G1HeapRegionClaimer;
+  friend class VMStructs;
 
   G1RegionToSpaceMapper* _bot_mapper;
   G1RegionToSpaceMapper* _card_table_mapper;

--- a/src/hotspot/share/gc/g1/g1HeapRegionType.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionType.hpp
@@ -32,7 +32,7 @@
   assert(is_valid((tag)), "invalid HR type: %u", (uint) (tag))
 
 class G1HeapRegionType {
-friend class VMStructs;
+  friend class VMStructs;
 
 private:
   // We encode the value of the heap region type so the generation can be

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -122,10 +122,10 @@ class MemoryPool;
 // path as low-overhead as possible.
 
 class G1MonitoringSupport : public CHeapObj<mtGC> {
-  friend class VMStructs;
-  friend class G1YoungGCMonitoringScope;
-  friend class G1FullGCMonitoringScope;
   friend class G1ConcGCMonitoringScope;
+  friend class G1FullGCMonitoringScope;
+  friend class G1YoungGCMonitoringScope;
+  friend class VMStructs;
 
   G1CollectedHeap* _g1h;
 

--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -32,8 +32,8 @@ class G1ServiceTaskQueue;
 class G1ServiceThread;
 
 class G1ServiceTask : public CHeapObj<mtGC> {
-  friend class G1ServiceTaskQueue;
   friend class G1ServiceThread;
+  friend class G1ServiceTaskQueue;
 
   // The next absolute time this task should be executed.
   jlong _time;


### PR DESCRIPTION
Sort friend class declarations alphabetically and group them consistently at the top of each class body. Remove interleaved comments and blank lines that previously separated friend declarations into ad-hoc groups, making them harder to maintain.

### Files changed
  - `g1CollectedHeap.hpp`: sorted 14 friend declarations, removed grouping comments
  - `g1CardSet.hpp`: sorted and removed blank lines between 5 friends
  - `g1ConcurrentMark.hpp`: sorted (moved G1ClearBitMapTask to correct position)
  - `g1HeapRegionManager.hpp`: sorted (swapped VMStructs/G1HeapRegionClaimer)
  - `g1HeapRegionType.hpp`: fixed missing indentation
  - `g1MonitoringSupport.hpp`: sorted 4 friends
  - `g1ServiceThread.hpp`: sorted within G1ServiceTask class

### Testing
  - Built hotspot (linux-x86_64-server-release) successfully. No compilation errors.
  - No behavioral change; purely cosmetic cleanup.

Fixes: https://bugs.openjdk.org/browse/JDK-8379983


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379983](https://bugs.openjdk.org/browse/JDK-8379983): G1: Fix up friend class declarations (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31593/head:pull/31593` \
`$ git checkout pull/31593`

Update a local copy of the PR: \
`$ git checkout pull/31593` \
`$ git pull https://git.openjdk.org/jdk.git pull/31593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31593`

View PR using the GUI difftool: \
`$ git pr show -t 31593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31593.diff">https://git.openjdk.org/jdk/pull/31593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31593#issuecomment-4759872442)
</details>
