### PR TITLE
8370870: IGV: add simple regression tests for graph dumping

### DIFF
--- a/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
+++ b/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
@@ -38,79 +38,214 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class TestIdealGraphDump {
 
+    private static final String TEST_CLASS = TestMethods.class.getName();
+    private static final String METHOD_COMPUTE = TEST_CLASS + "::compute";
+    private static final String METHOD_BRANCH = TEST_CLASS + "::branchyMethod";
+
     public static void main(String[] args) throws Exception {
+        testDisabled();
+        testLevel0();
         testLevel1();
         testLevel2();
-        testHigherLevelHasMorePhases();
-        testXmlStructure();
+        testLevel3();
+        testLevel4();
+        testLevel5();
+        testLevel6();
+        testLevelSpecificPhases();
+        testMonotonicallyIncreasingGraphCounts();
+        testXmlWellFormedness();
+        testMethodNameInGraph();
+        testMultipleMethods();
+        testIGVPrintLevelDirective();
+    }
+
+    private static void testDisabled() throws Exception {
+        Path xmlFile = dumpAtLevel(-1);
+        Asserts.assertTrue(Files.size(xmlFile) == 0,
+            "Level -1 (disabled) must produce an empty file");
+        System.out.println("testDisabled PASSED");
+    }
+
+    private static void testLevel0() throws Exception {
+        Path xmlFile = dumpAtLevel(0);
+        Asserts.assertTrue(Files.size(xmlFile) == 0,
+            "Level 0 must produce an empty file (no system-wide dumps)");
+        System.out.println("testLevel0 PASSED");
     }
 
     private static void testLevel1() throws Exception {
         Path xmlFile = dumpAtLevel(1);
         String content = Files.readString(xmlFile);
-
-        Asserts.assertTrue(content.contains("<graphDocument>"), "Must contain <graphDocument> root element");
-        Asserts.assertTrue(content.contains("</graphDocument>"), "Must contain closing </graphDocument>");
-        Asserts.assertTrue(content.contains("<group>"), "Must contain <group> element");
-        Asserts.assertTrue(content.contains("<graph name="), "Must contain at least one <graph> element");
-
-        int graphCount = countOccurrences(content, "<graph name=");
-        Asserts.assertTrue(graphCount >= 1, "Level 1 must produce at least 1 graph dump, got " + graphCount);
-
-        System.out.println("testLevel1 PASSED: " + graphCount + " graph(s) at level 1");
+        assertContainsPhase(content, "After Parsing", 1);
+        assertContainsPhase(content, "Final Code", 1);
+        System.out.println("testLevel1 PASSED: " + countGraphs(content) + " graph(s)");
     }
 
     private static void testLevel2() throws Exception {
         Path xmlFile = dumpAtLevel(2);
         String content = Files.readString(xmlFile);
-
-        Asserts.assertTrue(content.contains("<graphDocument>"), "Must contain <graphDocument>");
-        Asserts.assertTrue(content.contains("<graph name="), "Must contain at least one <graph>");
-
-        int graphCount = countOccurrences(content, "<graph name=");
-        Asserts.assertTrue(graphCount >= 1, "Level 2 must produce at least 1 graph dump, got " + graphCount);
-
-        System.out.println("testLevel2 PASSED: " + graphCount + " graph(s) at level 2");
+        assertContainsPhase(content, "After Parsing", 2);
+        assertContainsPhase(content, "Final Code", 2);
+        assertContainsPhase(content, "After Iter GVN 1", 2);
+        assertContainsPhase(content, "PhaseCCP 1", 2);
+        System.out.println("testLevel2 PASSED: " + countGraphs(content) + " graph(s)");
     }
 
-    private static void testHigherLevelHasMorePhases() throws Exception {
+    private static void testLevel3() throws Exception {
+        Path xmlFile = dumpAtLevel(3);
+        String content = Files.readString(xmlFile);
+        assertContainsPhase(content, "Before Macro Expansion", 3);
+        System.out.println("testLevel3 PASSED: " + countGraphs(content) + " graph(s)");
+    }
+
+    private static void testLevel4() throws Exception {
+        Path xmlFile = dumpAtLevel(4);
+        String content = Files.readString(xmlFile);
+        int count = countGraphs(content);
+        Asserts.assertTrue(count > 0, "Level 4 must produce graphs");
+        System.out.println("testLevel4 PASSED: " + count + " graph(s)");
+    }
+
+    private static void testLevel5() throws Exception {
+        Path xmlFile = dumpAtLevel(5);
+        String content = Files.readString(xmlFile);
+        assertContainsPhase(content, "After Iter GVN Step", 5);
+        System.out.println("testLevel5 PASSED: " + countGraphs(content) + " graph(s)");
+    }
+
+    private static void testLevel6() throws Exception {
+        Path xmlFile = dumpAtLevel(6);
+        String content = Files.readString(xmlFile);
+        int count = countGraphs(content);
+        Asserts.assertTrue(count > 0, "Level 6 must produce graphs");
+        System.out.println("testLevel6 PASSED: " + count + " graph(s)");
+    }
+
+    private static void testLevelSpecificPhases() throws Exception {
         Path xmlLevel1 = dumpAtLevel(1);
-        Path xmlLevel4 = dumpAtLevel(4);
+        Path xmlLevel2 = dumpAtLevel(2);
+        Path xmlLevel5 = dumpAtLevel(5);
 
         String content1 = Files.readString(xmlLevel1);
-        String content4 = Files.readString(xmlLevel4);
+        String content2 = Files.readString(xmlLevel2);
+        String content5 = Files.readString(xmlLevel5);
 
-        int count1 = countOccurrences(content1, "<graph name=");
-        int count4 = countOccurrences(content4, "<graph name=");
+        Asserts.assertTrue(containsPhase(content1, "Final Code"),
+            "Level 1 must contain 'Final Code' phase");
+        Asserts.assertFalse(containsPhase(content1, "PhaseCCP 1"),
+            "Level 1 must NOT contain 'PhaseCCP 1' (requires level 2+)");
+        Asserts.assertFalse(containsPhase(content1, "After Iter GVN Step"),
+            "Level 1 must NOT contain 'After Iter GVN Step' (requires level 5+)");
 
-        Asserts.assertTrue(count4 >= count1,
-            "Higher print level must produce at least as many graphs: level 1 had " + count1 +
-            ", level 4 had " + count4);
+        Asserts.assertTrue(containsPhase(content2, "PhaseCCP 1"),
+            "Level 2 must contain 'PhaseCCP 1'");
+        Asserts.assertFalse(containsPhase(content2, "After Iter GVN Step"),
+            "Level 2 must NOT contain 'After Iter GVN Step' (requires level 5+)");
 
-        System.out.println("testHigherLevelHasMorePhases PASSED: level 1=" + count1 + ", level 4=" + count4);
+        Asserts.assertTrue(containsPhase(content5, "After Iter GVN Step"),
+            "Level 5 must contain 'After Iter GVN Step'");
+
+        System.out.println("testLevelSpecificPhases PASSED");
     }
 
-    private static void testXmlStructure() throws Exception {
+    private static void testMonotonicallyIncreasingGraphCounts() throws Exception {
+        int prevCount = 0;
+        for (int level = 1; level <= 6; level++) {
+            Path xmlFile = dumpAtLevel(level);
+            String content = Files.readString(xmlFile);
+            int count = countGraphs(content);
+            Asserts.assertTrue(count >= prevCount,
+                "Level " + level + " (" + count + " graphs) must have at least as many as level " +
+                (level - 1) + " (" + prevCount + " graphs)");
+            prevCount = count;
+        }
+        System.out.println("testMonotonicallyIncreasingGraphCounts PASSED");
+    }
+
+    private static void testXmlWellFormedness() throws Exception {
         Path xmlFile = dumpAtLevel(2);
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        try {
+            builder.parse(xmlFile.toFile());
+        } catch (Exception e) {
+            Asserts.fail("IGV XML at level 2 is not well-formed: " + e.getMessage());
+        }
+
+        String content = Files.readString(xmlFile);
+        Asserts.assertTrue(content.contains("<graphDocument>"), "Must contain <graphDocument>");
+        Asserts.assertTrue(content.contains("</graphDocument>"), "Must contain closing </graphDocument>");
+        Asserts.assertTrue(content.contains("<properties>"), "Must contain <properties>");
+        Asserts.assertTrue(content.contains("<nodes>"), "Must contain <nodes>");
+        Asserts.assertTrue(content.contains("<edges>"), "Must contain <edges>");
+        Asserts.assertTrue(content.contains("<node id="), "Must contain <node> elements");
+        Asserts.assertTrue(content.contains("<method name="), "Must contain <method>");
+        Asserts.assertTrue(content.contains("<bytecodes>"), "Must contain <bytecodes>");
+        Asserts.assertTrue(content.contains("<controlFlow>"), "Must contain <controlFlow>");
+
+        System.out.println("testXmlWellFormedness PASSED");
+    }
+
+    private static void testMethodNameInGraph() throws Exception {
+        Path xmlFile = dumpAtLevel(1);
         String content = Files.readString(xmlFile);
 
-        Asserts.assertTrue(content.contains("<properties>"), "Must contain <properties> element");
-        Asserts.assertTrue(content.contains("<nodes>"), "Must contain <nodes> element");
-        Asserts.assertTrue(content.contains("<edges>"), "Must contain <edges> element");
-        Asserts.assertTrue(content.contains("<node id="), "Must contain at least one <node>");
-        Asserts.assertTrue(content.contains("<method name="), "Must contain <method> element with name");
-        Asserts.assertTrue(content.contains("<bytecodes>"), "Must contain <bytecodes> element");
+        Asserts.assertTrue(content.contains("TestMethods.compute"),
+            "Graph output must contain the compiled method name 'TestMethods.compute'");
 
-        Asserts.assertTrue(content.contains("controlFlow") || content.contains("<controlFlow>"),
-            "Must contain control flow information");
+        System.out.println("testMethodNameInGraph PASSED");
+    }
 
-        System.out.println("testXmlStructure PASSED");
+    private static void testMultipleMethods() throws Exception {
+        Path xmlFile = dumpMultipleMethods(2);
+        String content = Files.readString(xmlFile);
+
+        Asserts.assertTrue(content.contains("TestMethods.compute"),
+            "Must contain graphs for 'compute' method");
+        Asserts.assertTrue(content.contains("TestMethods.branchyMethod"),
+            "Must contain graphs for 'branchyMethod' method");
+
+        int groupCount = countOccurrences(content, "<group>");
+        Asserts.assertTrue(groupCount >= 2,
+            "Must have at least 2 method groups in output, got " + groupCount);
+
+        System.out.println("testMultipleMethods PASSED: " + groupCount + " method group(s)");
+    }
+
+    private static void testIGVPrintLevelDirective() throws Exception {
+        Path xmlFile = Files.createTempFile("igv_directive_", ".xml");
+        xmlFile.toFile().deleteOnExit();
+
+        List<String> options = new ArrayList<>();
+        options.add("-Xbatch");
+        options.add("-XX:PrintIdealGraphLevel=0");
+        options.add("-XX:PrintIdealGraphFile=" + xmlFile.toAbsolutePath());
+        options.add("-XX:CompileCommand=option," + METHOD_COMPUTE + ",IGVPrintLevel,2");
+        options.add("-XX:CompileCommand=compileonly," + METHOD_COMPUTE);
+        options.add(TEST_CLASS);
+
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
+        oa.shouldHaveExitValue(0);
+        oa.shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
+
+        String content = Files.readString(xmlFile);
+        Asserts.assertTrue(Files.size(xmlFile) > 0,
+            "Per-method IGVPrintLevel directive must produce output even with system level 0");
+        Asserts.assertTrue(content.contains("TestMethods.compute"),
+            "Directive-based dump must contain the target method");
+        assertContainsPhase(content, "After Parsing", 2);
+
+        System.out.println("testIGVPrintLevelDirective PASSED");
     }
 
     private static Path dumpAtLevel(int level) throws Exception {
@@ -121,17 +256,48 @@ public class TestIdealGraphDump {
         options.add("-Xbatch");
         options.add("-XX:PrintIdealGraphLevel=" + level);
         options.add("-XX:PrintIdealGraphFile=" + xmlFile.toAbsolutePath());
-        options.add("-XX:CompileCommand=compileonly,compiler.igv.TestIdealGraphDump$TestMethod::compute");
-        options.add(TestMethod.class.getName());
+        options.add("-XX:CompileCommand=compileonly," + METHOD_COMPUTE);
+        options.add(TEST_CLASS);
 
         OutputAnalyzer oa = ProcessTools.executeTestJava(options);
         oa.shouldHaveExitValue(0);
         oa.shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        Asserts.assertTrue(Files.exists(xmlFile), "IGV XML file must exist: " + xmlFile);
-        Asserts.assertTrue(Files.size(xmlFile) > 0, "IGV XML file must not be empty: " + xmlFile);
+        return xmlFile;
+    }
+
+    private static Path dumpMultipleMethods(int level) throws Exception {
+        Path xmlFile = Files.createTempFile("igv_multi_", ".xml");
+        xmlFile.toFile().deleteOnExit();
+
+        List<String> options = new ArrayList<>();
+        options.add("-Xbatch");
+        options.add("-XX:PrintIdealGraphLevel=" + level);
+        options.add("-XX:PrintIdealGraphFile=" + xmlFile.toAbsolutePath());
+        options.add("-XX:CompileCommand=compileonly," + METHOD_COMPUTE);
+        options.add("-XX:CompileCommand=compileonly," + METHOD_BRANCH);
+        options.add(TEST_CLASS);
+
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
+        oa.shouldHaveExitValue(0);
+        oa.shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
         return xmlFile;
+    }
+
+    private static int countGraphs(String content) {
+        return countOccurrences(content, "<graph name=");
+    }
+
+    private static boolean containsPhase(String content, String phaseName) {
+        return content.contains("'" + phaseName + "'") ||
+               content.contains("\"" + phaseName + "\"") ||
+               content.contains(">" + phaseName + "<");
+    }
+
+    private static void assertContainsPhase(String content, String phaseName, int level) {
+        Asserts.assertTrue(containsPhase(content, phaseName),
+            "Level " + level + " must contain phase '" + phaseName + "'");
     }
 
     private static int countOccurrences(String str, String sub) {
@@ -144,11 +310,12 @@ public class TestIdealGraphDump {
         return count;
     }
 
-    public static class TestMethod {
+    public static class TestMethods {
         public static void main(String[] args) {
             int sum = 0;
             for (int i = 0; i < 20_000; i++) {
                 sum += compute(i, i + 1);
+                sum += branchyMethod(i, i % 7);
             }
             System.out.println(sum);
         }
@@ -159,6 +326,16 @@ public class TestIdealGraphDump {
                 result += b * i;
             }
             return result;
+        }
+
+        static int branchyMethod(int x, int y) {
+            if (x > y) {
+                return x * y + 1;
+            } else if (x == y) {
+                return x + y;
+            } else {
+                return y - x;
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
+++ b/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestIdealGraphDump
+ * @bug 8370870
+ * @summary Verify that IGV graph dumping produces well-structured XML at different print levels
+ * @library /test/lib
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @run driver compiler.igv.TestIdealGraphDump
+ */
+
+package compiler.igv;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestIdealGraphDump {
+
+    public static void main(String[] args) throws Exception {
+        testLevel1();
+        testLevel2();
+        testHigherLevelHasMorePhases();
+        testXmlStructure();
+    }
+
+    private static void testLevel1() throws Exception {
+        Path xmlFile = dumpAtLevel(1);
+        String content = Files.readString(xmlFile);
+
+        Asserts.assertTrue(content.contains("<graphDocument>"), "Must contain <graphDocument> root element");
+        Asserts.assertTrue(content.contains("</graphDocument>"), "Must contain closing </graphDocument>");
+        Asserts.assertTrue(content.contains("<group>"), "Must contain <group> element");
+        Asserts.assertTrue(content.contains("<graph name="), "Must contain at least one <graph> element");
+
+        int graphCount = countOccurrences(content, "<graph name=");
+        Asserts.assertTrue(graphCount >= 1, "Level 1 must produce at least 1 graph dump, got " + graphCount);
+
+        System.out.println("testLevel1 PASSED: " + graphCount + " graph(s) at level 1");
+    }
+
+    private static void testLevel2() throws Exception {
+        Path xmlFile = dumpAtLevel(2);
+        String content = Files.readString(xmlFile);
+
+        Asserts.assertTrue(content.contains("<graphDocument>"), "Must contain <graphDocument>");
+        Asserts.assertTrue(content.contains("<graph name="), "Must contain at least one <graph>");
+
+        int graphCount = countOccurrences(content, "<graph name=");
+        Asserts.assertTrue(graphCount >= 1, "Level 2 must produce at least 1 graph dump, got " + graphCount);
+
+        System.out.println("testLevel2 PASSED: " + graphCount + " graph(s) at level 2");
+    }
+
+    private static void testHigherLevelHasMorePhases() throws Exception {
+        Path xmlLevel1 = dumpAtLevel(1);
+        Path xmlLevel4 = dumpAtLevel(4);
+
+        String content1 = Files.readString(xmlLevel1);
+        String content4 = Files.readString(xmlLevel4);
+
+        int count1 = countOccurrences(content1, "<graph name=");
+        int count4 = countOccurrences(content4, "<graph name=");
+
+        Asserts.assertTrue(count4 >= count1,
+            "Higher print level must produce at least as many graphs: level 1 had " + count1 +
+            ", level 4 had " + count4);
+
+        System.out.println("testHigherLevelHasMorePhases PASSED: level 1=" + count1 + ", level 4=" + count4);
+    }
+
+    private static void testXmlStructure() throws Exception {
+        Path xmlFile = dumpAtLevel(2);
+        String content = Files.readString(xmlFile);
+
+        Asserts.assertTrue(content.contains("<properties>"), "Must contain <properties> element");
+        Asserts.assertTrue(content.contains("<nodes>"), "Must contain <nodes> element");
+        Asserts.assertTrue(content.contains("<edges>"), "Must contain <edges> element");
+        Asserts.assertTrue(content.contains("<node id="), "Must contain at least one <node>");
+        Asserts.assertTrue(content.contains("<method name="), "Must contain <method> element with name");
+        Asserts.assertTrue(content.contains("<bytecodes>"), "Must contain <bytecodes> element");
+
+        Asserts.assertTrue(content.contains("controlFlow") || content.contains("<controlFlow>"),
+            "Must contain control flow information");
+
+        System.out.println("testXmlStructure PASSED");
+    }
+
+    private static Path dumpAtLevel(int level) throws Exception {
+        Path xmlFile = Files.createTempFile("igv_level" + level + "_", ".xml");
+        xmlFile.toFile().deleteOnExit();
+
+        List<String> options = new ArrayList<>();
+        options.add("-Xbatch");
+        options.add("-XX:PrintIdealGraphLevel=" + level);
+        options.add("-XX:PrintIdealGraphFile=" + xmlFile.toAbsolutePath());
+        options.add("-XX:CompileCommand=compileonly,compiler.igv.TestIdealGraphDump$TestMethod::compute");
+        options.add(TestMethod.class.getName());
+
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
+        oa.shouldHaveExitValue(0);
+        oa.shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
+
+        Asserts.assertTrue(Files.exists(xmlFile), "IGV XML file must exist: " + xmlFile);
+        Asserts.assertTrue(Files.size(xmlFile) > 0, "IGV XML file must not be empty: " + xmlFile);
+
+        return xmlFile;
+    }
+
+    private static int countOccurrences(String str, String sub) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = str.indexOf(sub, idx)) != -1) {
+            count++;
+            idx += sub.length();
+        }
+        return count;
+    }
+
+    public static class TestMethod {
+        public static void main(String[] args) {
+            int sum = 0;
+            for (int i = 0; i < 20_000; i++) {
+                sum += compute(i, i + 1);
+            }
+            System.out.println(sum);
+        }
+
+        static int compute(int a, int b) {
+            int result = 0;
+            for (int i = 0; i < a % 10; i++) {
+                result += b * i;
+            }
+            return result;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
+++ b/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
@@ -36,7 +36,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -51,6 +53,8 @@ public class TestIdealGraphDump {
     private static final String METHOD_COMPUTE = TEST_CLASS + "::compute";
     private static final String METHOD_BRANCH = TEST_CLASS + "::branchyMethod";
 
+    private static final Map<Integer, Path> dumpCache = new HashMap<>();
+
     public static void main(String[] args) throws Exception {
         testDisabled();
         testLevel0();
@@ -60,7 +64,6 @@ public class TestIdealGraphDump {
         testLevel4();
         testLevel5();
         testLevel6();
-        testLevelSpecificPhases();
         testMonotonicallyIncreasingGraphCounts();
         testXmlWellFormedness();
         testMethodNameInGraph();
@@ -69,110 +72,71 @@ public class TestIdealGraphDump {
     }
 
     private static void testDisabled() throws Exception {
-        Path xmlFile = dumpAtLevel(-1);
+        Path xmlFile = getCachedDump(-1);
         Asserts.assertTrue(Files.size(xmlFile) == 0,
             "Level -1 (disabled) must produce an empty file");
-        System.out.println("testDisabled PASSED");
     }
 
     private static void testLevel0() throws Exception {
-        Path xmlFile = dumpAtLevel(0);
+        Path xmlFile = getCachedDump(0);
         Asserts.assertTrue(Files.size(xmlFile) == 0,
             "Level 0 must produce an empty file (no system-wide dumps)");
-        System.out.println("testLevel0 PASSED");
     }
 
     private static void testLevel1() throws Exception {
-        Path xmlFile = dumpAtLevel(1);
-        String content = Files.readString(xmlFile);
+        String content = getCachedContent(1);
         assertContainsPhase(content, "After Parsing", 1);
+        assertContainsPhase(content, "Before Matching", 1);
         assertContainsPhase(content, "Final Code", 1);
-        System.out.println("testLevel1 PASSED: " + countGraphs(content) + " graph(s)");
+        assertNotContainsPhase(content, "PhaseCCP 1", 1);
     }
 
     private static void testLevel2() throws Exception {
-        Path xmlFile = dumpAtLevel(2);
-        String content = Files.readString(xmlFile);
+        String content = getCachedContent(2);
         assertContainsPhase(content, "After Parsing", 2);
         assertContainsPhase(content, "Final Code", 2);
         assertContainsPhase(content, "After Iter GVN 1", 2);
         assertContainsPhase(content, "PhaseCCP 1", 2);
-        System.out.println("testLevel2 PASSED: " + countGraphs(content) + " graph(s)");
+        assertNotContainsPhase(content, "Before Macro Expansion", 2);
     }
 
     private static void testLevel3() throws Exception {
-        Path xmlFile = dumpAtLevel(3);
-        String content = Files.readString(xmlFile);
+        String content = getCachedContent(3);
         assertContainsPhase(content, "Before Macro Expansion", 3);
-        System.out.println("testLevel3 PASSED: " + countGraphs(content) + " graph(s)");
+        assertNotContainsPhase(content, "Initial Liveness", 3);
     }
 
     private static void testLevel4() throws Exception {
-        Path xmlFile = dumpAtLevel(4);
-        String content = Files.readString(xmlFile);
-        int count = countGraphs(content);
-        Asserts.assertTrue(count > 0, "Level 4 must produce graphs");
-        System.out.println("testLevel4 PASSED: " + count + " graph(s)");
+        String content = getCachedContent(4);
+        assertContainsPhase(content, "Initial Liveness", 4);
+        assertNotContainsPhase(content, "After Iter GVN Step", 4);
     }
 
     private static void testLevel5() throws Exception {
-        Path xmlFile = dumpAtLevel(5);
-        String content = Files.readString(xmlFile);
+        String content = getCachedContent(5);
         assertContainsPhase(content, "After Iter GVN Step", 5);
-        System.out.println("testLevel5 PASSED: " + countGraphs(content) + " graph(s)");
     }
 
     private static void testLevel6() throws Exception {
-        Path xmlFile = dumpAtLevel(6);
-        String content = Files.readString(xmlFile);
-        int count = countGraphs(content);
-        Asserts.assertTrue(count > 0, "Level 6 must produce graphs");
-        System.out.println("testLevel6 PASSED: " + count + " graph(s)");
-    }
-
-    private static void testLevelSpecificPhases() throws Exception {
-        Path xmlLevel1 = dumpAtLevel(1);
-        Path xmlLevel2 = dumpAtLevel(2);
-        Path xmlLevel5 = dumpAtLevel(5);
-
-        String content1 = Files.readString(xmlLevel1);
-        String content2 = Files.readString(xmlLevel2);
-        String content5 = Files.readString(xmlLevel5);
-
-        Asserts.assertTrue(containsPhase(content1, "Final Code"),
-            "Level 1 must contain 'Final Code' phase");
-        Asserts.assertFalse(containsPhase(content1, "PhaseCCP 1"),
-            "Level 1 must NOT contain 'PhaseCCP 1' (requires level 2+)");
-        Asserts.assertFalse(containsPhase(content1, "After Iter GVN Step"),
-            "Level 1 must NOT contain 'After Iter GVN Step' (requires level 5+)");
-
-        Asserts.assertTrue(containsPhase(content2, "PhaseCCP 1"),
-            "Level 2 must contain 'PhaseCCP 1'");
-        Asserts.assertFalse(containsPhase(content2, "After Iter GVN Step"),
-            "Level 2 must NOT contain 'After Iter GVN Step' (requires level 5+)");
-
-        Asserts.assertTrue(containsPhase(content5, "After Iter GVN Step"),
-            "Level 5 must contain 'After Iter GVN Step'");
-
-        System.out.println("testLevelSpecificPhases PASSED");
+        String content = getCachedContent(6);
+        Asserts.assertTrue(containsPhase(content, "Bytecode"),
+            "Level 6 must contain per-bytecode graphs (e.g., 'Bytecode 0: ...')");
     }
 
     private static void testMonotonicallyIncreasingGraphCounts() throws Exception {
         int prevCount = 0;
         for (int level = 1; level <= 6; level++) {
-            Path xmlFile = dumpAtLevel(level);
-            String content = Files.readString(xmlFile);
+            String content = getCachedContent(level);
             int count = countGraphs(content);
             Asserts.assertTrue(count >= prevCount,
                 "Level " + level + " (" + count + " graphs) must have at least as many as level " +
                 (level - 1) + " (" + prevCount + " graphs)");
             prevCount = count;
         }
-        System.out.println("testMonotonicallyIncreasingGraphCounts PASSED");
     }
 
     private static void testXmlWellFormedness() throws Exception {
-        Path xmlFile = dumpAtLevel(2);
+        Path xmlFile = getCachedDump(2);
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
@@ -182,7 +146,7 @@ public class TestIdealGraphDump {
             Asserts.fail("IGV XML at level 2 is not well-formed: " + e.getMessage());
         }
 
-        String content = Files.readString(xmlFile);
+        String content = getCachedContent(2);
         Asserts.assertTrue(content.contains("<graphDocument>"), "Must contain <graphDocument>");
         Asserts.assertTrue(content.contains("</graphDocument>"), "Must contain closing </graphDocument>");
         Asserts.assertTrue(content.contains("<properties>"), "Must contain <properties>");
@@ -192,22 +156,16 @@ public class TestIdealGraphDump {
         Asserts.assertTrue(content.contains("<method name="), "Must contain <method>");
         Asserts.assertTrue(content.contains("<bytecodes>"), "Must contain <bytecodes>");
         Asserts.assertTrue(content.contains("<controlFlow>"), "Must contain <controlFlow>");
-
-        System.out.println("testXmlWellFormedness PASSED");
     }
 
     private static void testMethodNameInGraph() throws Exception {
-        Path xmlFile = dumpAtLevel(1);
-        String content = Files.readString(xmlFile);
-
+        String content = getCachedContent(1);
         Asserts.assertTrue(content.contains("TestMethods.compute"),
             "Graph output must contain the compiled method name 'TestMethods.compute'");
-
-        System.out.println("testMethodNameInGraph PASSED");
     }
 
     private static void testMultipleMethods() throws Exception {
-        Path xmlFile = dumpMultipleMethods(2);
+        Path xmlFile = dumpMultipleMethods(1);
         String content = Files.readString(xmlFile);
 
         Asserts.assertTrue(content.contains("TestMethods.compute"),
@@ -215,11 +173,12 @@ public class TestIdealGraphDump {
         Asserts.assertTrue(content.contains("TestMethods.branchyMethod"),
             "Must contain graphs for 'branchyMethod' method");
 
-        int groupCount = countOccurrences(content, "<group>");
-        Asserts.assertTrue(groupCount >= 2,
-            "Must have at least 2 method groups in output, got " + groupCount);
-
-        System.out.println("testMultipleMethods PASSED: " + groupCount + " method group(s)");
+        int computeFinalCode = countMethodPhase(content, "TestMethods.compute", "Final Code");
+        int branchFinalCode = countMethodPhase(content, "TestMethods.branchyMethod", "Final Code");
+        Asserts.assertTrue(computeFinalCode >= 1,
+            "compute must emit at least one 'Final Code' graph, got " + computeFinalCode);
+        Asserts.assertTrue(branchFinalCode >= 1,
+            "branchyMethod must emit at least one 'Final Code' graph, got " + branchFinalCode);
     }
 
     private static void testIGVPrintLevelDirective() throws Exception {
@@ -230,8 +189,7 @@ public class TestIdealGraphDump {
         options.add("-Xbatch");
         options.add("-XX:PrintIdealGraphLevel=0");
         options.add("-XX:PrintIdealGraphFile=" + xmlFile.toAbsolutePath());
-        options.add("-XX:CompileCommand=option," + METHOD_COMPUTE + ",IGVPrintLevel,2");
-        options.add("-XX:CompileCommand=compileonly," + METHOD_COMPUTE);
+        options.add("-XX:CompileCommand=IGVPrintLevel," + METHOD_COMPUTE + ",2");
         options.add(TEST_CLASS);
 
         OutputAnalyzer oa = ProcessTools.executeTestJava(options);
@@ -244,8 +202,17 @@ public class TestIdealGraphDump {
         Asserts.assertTrue(content.contains("TestMethods.compute"),
             "Directive-based dump must contain the target method");
         assertContainsPhase(content, "After Parsing", 2);
+    }
 
-        System.out.println("testIGVPrintLevelDirective PASSED");
+    private static Path getCachedDump(int level) throws Exception {
+        if (!dumpCache.containsKey(level)) {
+            dumpCache.put(level, dumpAtLevel(level));
+        }
+        return dumpCache.get(level);
+    }
+
+    private static String getCachedContent(int level) throws Exception {
+        return Files.readString(getCachedDump(level));
     }
 
     private static Path dumpAtLevel(int level) throws Exception {
@@ -292,12 +259,33 @@ public class TestIdealGraphDump {
     private static boolean containsPhase(String content, String phaseName) {
         return content.contains("'" + phaseName + "'") ||
                content.contains("\"" + phaseName + "\"") ||
-               content.contains(">" + phaseName + "<");
+               content.contains(">" + phaseName + "<") ||
+               content.contains("'" + phaseName);
     }
 
     private static void assertContainsPhase(String content, String phaseName, int level) {
         Asserts.assertTrue(containsPhase(content, phaseName),
             "Level " + level + " must contain phase '" + phaseName + "'");
+    }
+
+    private static void assertNotContainsPhase(String content, String phaseName, int level) {
+        Asserts.assertFalse(containsPhase(content, phaseName),
+            "Level " + level + " must NOT contain phase '" + phaseName + "'");
+    }
+
+    private static int countMethodPhase(String content, String methodName, String phaseName) {
+        int count = 0;
+        int groupStart = 0;
+        while ((groupStart = content.indexOf("<group>", groupStart)) != -1) {
+            int groupEnd = content.indexOf("</group>", groupStart);
+            if (groupEnd == -1) break;
+            String group = content.substring(groupStart, groupEnd);
+            if (group.contains(methodName) && containsPhase(group, phaseName)) {
+                count++;
+            }
+            groupStart = groupEnd;
+        }
+        return count;
     }
 
     private static int countOccurrences(String str, String sub) {

--- a/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
+++ b/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
@@ -285,8 +285,8 @@ public class TestIdealGraphDump {
                 break;
             }
             String group = content.substring(groupStart, groupEnd);
-            if (group.contains(methodName) && containsPhase(group, phaseName)) {
-                count++;
+            if (group.contains(methodName)) {
+                count += countOccurrences(group, "<graph name='" + phaseName + "'>");
             }
             groupStart = groupEnd;
         }

--- a/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
+++ b/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
@@ -26,8 +26,8 @@
  * @bug 8370870
  * @summary Verify that IGV graph dumping produces well-structured XML at different print levels
  * @library /test/lib
- * @requires vm.debug == true & vm.compiler2.enabled
- * @run driver compiler.igv.TestIdealGraphDump
+ * @requires vm.debug == true & vm.compiler2.enabled & vm.flagless
+ * @run driver ${test.main.class}
  */
 
 package compiler.igv;
@@ -95,7 +95,7 @@ public class TestIdealGraphDump {
         String content = getCachedContent(2);
         assertContainsPhase(content, "After Parsing", 2);
         assertContainsPhase(content, "Final Code", 2);
-        assertContainsPhase(content, "After Iter GVN 1", 2);
+        assertContainsPhase(content, "Iter GVN 1", 2);
         assertContainsPhase(content, "PhaseCCP 1", 2);
         assertNotContainsPhase(content, "Before Macro Expansion", 2);
     }

--- a/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
+++ b/test/hotspot/jtreg/compiler/igv/TestIdealGraphDump.java
@@ -115,6 +115,7 @@ public class TestIdealGraphDump {
     private static void testLevel5() throws Exception {
         String content = getCachedContent(5);
         assertContainsPhase(content, "After Iter GVN Step", 5);
+        assertNotContainsPhase(content, "Bytecode", 5);
     }
 
     private static void testLevel6() throws Exception {
@@ -175,10 +176,10 @@ public class TestIdealGraphDump {
 
         int computeFinalCode = countMethodPhase(content, "TestMethods.compute", "Final Code");
         int branchFinalCode = countMethodPhase(content, "TestMethods.branchyMethod", "Final Code");
-        Asserts.assertTrue(computeFinalCode >= 1,
-            "compute must emit at least one 'Final Code' graph, got " + computeFinalCode);
-        Asserts.assertTrue(branchFinalCode >= 1,
-            "branchyMethod must emit at least one 'Final Code' graph, got " + branchFinalCode);
+        Asserts.assertEquals(computeFinalCode, 1,
+            "compute must emit exactly one 'Final Code' graph, got " + computeFinalCode);
+        Asserts.assertEquals(branchFinalCode, 1,
+            "branchyMethod must emit exactly one 'Final Code' graph, got " + branchFinalCode);
     }
 
     private static void testIGVPrintLevelDirective() throws Exception {
@@ -201,6 +202,8 @@ public class TestIdealGraphDump {
             "Per-method IGVPrintLevel directive must produce output even with system level 0");
         Asserts.assertTrue(content.contains("TestMethods.compute"),
             "Directive-based dump must contain the target method");
+        Asserts.assertFalse(content.contains("TestMethods.branchyMethod"),
+            "Directive-based dump must NOT contain non-targeted method");
         assertContainsPhase(content, "After Parsing", 2);
     }
 
@@ -278,7 +281,9 @@ public class TestIdealGraphDump {
         int groupStart = 0;
         while ((groupStart = content.indexOf("<group>", groupStart)) != -1) {
             int groupEnd = content.indexOf("</group>", groupStart);
-            if (groupEnd == -1) break;
+            if (groupEnd == -1) {
+                break;
+            }
             String group = content.substring(groupStart, groupEnd);
             if (group.contains(methodName) && containsPhase(group, phaseName)) {
                 count++;


### PR DESCRIPTION
Add a JTReg regression test that exercises IGV graph dumping over different `PrintIdealGraphLevel` values (1, 2, 4) and verifies the basic structure of the generated XML output.

The test spawns child JVMs with `-XX:PrintIdealGraphFile` and compiles a method with a loop to trigger C2. It checks:

  - Required XML elements are present: graphDocument, group, graph, nodes, edges, controlFlow, method, bytecodes, properties
  - Higher print levels produce at least as many phase dumps as lower levels
  - Output files are non-empty and well-formed

### Testing
Ran with jtreg on linux-x86_64 fastdebug build. All 4 subtests pass. Level 1 produces 3 graphs, level 2 produces 21, level 4 produces 65.

https://bugs.openjdk.org/browse/JDK-8370870

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8370870](https://bugs.openjdk.org/browse/JDK-8370870): IGV: add simple regression tests for graph dumping (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31594/head:pull/31594` \
`$ git checkout pull/31594`

Update a local copy of the PR: \
`$ git checkout pull/31594` \
`$ git pull https://git.openjdk.org/jdk.git pull/31594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31594`

View PR using the GUI difftool: \
`$ git pr show -t 31594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31594.diff">https://git.openjdk.org/jdk/pull/31594.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31594#issuecomment-4759872879)
</details>
