### PR TITLE
8386085: Livelock in AbstractQueuedSyncronizer.cleanQueue() when multiple threads do tryAcquire() with a short timeout and no permits available

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -452,7 +452,8 @@ public abstract class AbstractQueuedLongSynchronizer
                 if (q.status < 0) {              // cancelled
                     if ((s == null ? casTail(q, p) : s.casPrev(q, p)) &&
                         q.prev == p) {
-                        p.casNext(q, s);         // OK if fails
+                        if (s != null)
+                            p.casNext(q, s);     // OK if fails
                         if (p.prev == null)
                             signalNext(p);
                     }

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -832,7 +832,8 @@ public abstract class AbstractQueuedSynchronizer
                 if (q.status < 0) {              // cancelled
                     if ((s == null ? casTail(q, p) : s.casPrev(q, p)) &&
                         q.prev == p) {
-                        p.casNext(q, s);         // OK if fails
+                        if (s != null)
+                            p.casNext(q, s);     // OK if fails
                         if (p.prev == null)
                             signalNext(p);
                     }

--- a/src/java.base/share/classes/java/util/concurrent/locks/StampedLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/StampedLock.java
@@ -1450,7 +1450,8 @@ public class StampedLock implements java.io.Serializable {
                 if (q.status < 0) {              // cancelled
                     if ((s == null ? casTail(q, p) : s.casPrev(q, p)) &&
                         q.prev == p) {
-                        p.casNext(q, s);         // OK if fails
+                        if (s != null)
+                            p.casNext(q, s);     // OK if fails
                         if (p.prev == null)
                             signalNext(p);
                     }

--- a/test/jdk/java/util/concurrent/tck/SemaphoreTest.java
+++ b/test/jdk/java/util/concurrent/tck/SemaphoreTest.java
@@ -33,11 +33,15 @@
  * Pat Fisher, Mike Judd.
  */
 
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.util.Collection;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -670,6 +674,41 @@ public class SemaphoreTest extends JSR166TestCase {
         assertTrue(s.toString().contains("Permits = 3"));
         s.reducePermits(5);
         assertTrue(s.toString().contains("Permits = -2"));
+    }
+
+    /**
+     * Test scenario for JDK-8386085
+     * When investigating failures of this test, it is important to know that AbstractQueuedSynchronizer,
+     * AbstractQueuedLongSynchronizer, and StampedLock all share similar code which was fixed for JDK-8386085
+     */
+    public void testShortTimeoutAcquisition() throws InterruptedException {
+        final int width = Runtime.getRuntime().availableProcessors();
+        try (var pool = Executors.newFixedThreadPool(width)) {
+            // Setup
+            final AtomicBoolean done = new AtomicBoolean(false);
+            final CountDownLatch waitingToRun = new CountDownLatch(width);
+            final Semaphore s = new Semaphore(0);
+            final Callable<Void> c = () -> {
+                waitingToRun.countDown();
+                do {
+                    s.tryAcquire(1, MICROSECONDS); // acquisition storm
+                } while (!done.get());
+                return null;
+            };
+
+            // Task creation
+            for(int i = 0; i < width; ++i)
+                pool.submit(c);
+
+            waitingToRun.await();                 // Wait for all tasks to start
+            Thread.sleep(3000);             // Wait a while for acquisitions
+            s.release(width);                     // Hand out permits
+            Thread.sleep(1000);             // Wait a while for permit acquisitions
+
+            final int permitsAvailable = s.availablePermits();
+            done.set(true);                       // Ensure that tasks can exit
+            assertTrue(permitsAvailable < width); // Some permits should've been taken
+        }
     }
 
 }

--- a/test/jdk/java/util/concurrent/tck/StampedLockTest.java
+++ b/test/jdk/java/util/concurrent/tck/StampedLockTest.java
@@ -33,8 +33,8 @@
  */
 
 import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import static java.util.concurrent.locks.StampedLock.isLockStamp;
 import static java.util.concurrent.locks.StampedLock.isOptimisticReadStamp;
 import static java.util.concurrent.locks.StampedLock.isReadLockStamp;
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -1527,4 +1528,38 @@ public class StampedLockTest extends JSR166TestCase {
             checkTimedGet(future, null);
     }
 
+        /**
+     * test scenario for JDK-8386085
+     */
+    public void testShortTimeoutAcquisition() throws InterruptedException {
+        final int width = Runtime.getRuntime().availableProcessors();
+        final StampedLock s = new StampedLock();
+        try (var pool = Executors.newFixedThreadPool(width)) {
+            // Setup
+            final AtomicBoolean done = new AtomicBoolean(false);
+            final CountDownLatch waitingToRun = new CountDownLatch(width);
+            final long stamp = s.writeLock();
+            assertTrue(s.validate(stamp));
+            final Callable<Void> c = () -> {
+                waitingToRun.countDown();
+                do {
+                    long lock = s.tryWriteLock(1, MICROSECONDS); // acquisition storm
+                    if (s.validate(lock))
+                        s.unlockWrite(lock);
+                } while (!done.get());
+                return null;
+            };
+
+            // Task creation
+            for(int i = 0; i < width; ++i)
+                pool.submit(c);
+
+            waitingToRun.await();                 // Wait for all tasks to start
+            Thread.sleep(3000);             // Wait a while for acquisitions
+            s.unlockWrite(stamp);                 // Hand out permits
+            Thread.sleep(1000);             // Wait a while for permit acquisitions
+            done.set(true);                       // Ensure that tasks can exit
+        }
+        assertTrue(s.validate(s.writeLockInterruptibly())); // Should succeed
+    }
 }


### PR DESCRIPTION
Testing performed:
- [8386085-BugReproducer2-27b-linux-x64.log](https://github.com/user-attachments/files/29151852/8386085-BugReproducer2-27b-linux-x64.log)
- [juc-tests-27b-linux-x64.log](https://github.com/user-attachments/files/29151854/juc-tests-27b-linux-x64.log)
- [juc-tests-27b-macosx-aarch64.log](https://github.com/user-attachments/files/29151855/juc-tests-27b-macosx-aarch64.log)
- [juc-tests-27b-windows-x64.log](https://github.com/user-attachments/files/29151884/juc-tests-27b-windows-x64.log)

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386085](https://bugs.openjdk.org/browse/JDK-8386085): Livelock in AbstractQueuedSyncronizer.cleanQueue() when multiple threads do tryAcquire() with a short timeout and no permits available (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31595/head:pull/31595` \
`$ git checkout pull/31595`

Update a local copy of the PR: \
`$ git checkout pull/31595` \
`$ git pull https://git.openjdk.org/jdk.git pull/31595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31595`

View PR using the GUI difftool: \
`$ git pr show -t 31595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31595.diff">https://git.openjdk.org/jdk/pull/31595.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31595#issuecomment-4754748789)
</details>
