### PR TITLE
8370131: C2: Improve ReachabilityFence test coverage

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2540,6 +2540,7 @@ void Compile::Optimize() {
 
   // Once loop optimizations are over, it is safe to get rid of all reachability fence nodes and
   // migrate reachability edges to safepoints.
+  DEBUG_ONLY(if (_reachability_fences.length() > 0) { verify_reachability_fences(); })
   if (OptimizeReachabilityFences && _reachability_fences.length() > 0) {
     TracePhase tp1(_t_idealLoop);
     TracePhase tp2(_t_reachability);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -755,6 +755,8 @@ public:
     _reachability_fences.remove_if_existing(n);
   }
 
+  DEBUG_ONLY(void verify_reachability_fences() const;)
+
   void add_parse_predicate(ParsePredicateNode* n) {
     assert(!_parse_predicates.contains(n), "duplicate entry in Parse Predicate list");
     _parse_predicates.append(n);

--- a/src/hotspot/share/opto/reachability.cpp
+++ b/src/hotspot/share/opto/reachability.cpp
@@ -510,3 +510,31 @@ void Compile::expand_reachability_edges(Unique_Node_List& safepoints) {
     }
   }
 }
+
+#ifdef ASSERT
+void Compile::verify_reachability_fences() const {
+  for (int i = 0; i < reachability_fences_count(); i++) {
+    ReachabilityFenceNode* rf = reachability_fence(i);
+
+    // RF node must have a control input.
+    Node* ctrl = rf->in(TypeFunc::Control);
+    assert(ctrl != nullptr, "ReachabilityFence N%d has null control", rf->_idx);
+    assert(ctrl->is_CFG(), "ReachabilityFence N%d control N%d is not CFG", rf->_idx, ctrl->_idx);
+
+    // RF node must have a referent.
+    Node* referent = rf->referent();
+    assert(referent != nullptr, "ReachabilityFence N%d has null referent", rf->_idx);
+
+    // Referent must be an oop type.
+    const Type* referent_t = referent->bottom_type();
+    assert(referent_t->isa_oopptr() != nullptr ||
+           referent_t->isa_narrowoop() != nullptr ||
+           referent_t == TypePtr::NULL_PTR,
+           "ReachabilityFence N%d referent N%d has non-oop type: %s",
+           rf->_idx, referent->_idx, Type::str(referent_t));
+
+    // RF node must have at least one use (its control output) to be live.
+    assert(rf->outcnt() > 0, "ReachabilityFence N%d is dead (no uses)", rf->_idx);
+  }
+}
+#endif


### PR DESCRIPTION
Add a debug-only verification pass for ReachabilityFence (RF) nodes that runs before RF expansion. The pass iterates over all RF nodes in the compiler's list and checks that each node is well-formed:

  - Has a valid CFG control input
  - Has a non-null referent of oop type (`oopptr`, `narrowoop`, or `NULL_PTR`)
  - Is still live in the graph (has at least one use)

The verification is invoked in `Compile::Optimize()` right before the RF expansion phase (Phase 2) and is guarded by `#ifdef ASSERT`, so it only runs in debug/fastdebug builds.

This helps catch RF invariant violations early, especially when `-XX:+StressReachabilityFences` is enabled and RF nodes are aggressively inserted for all oop method arguments during parsing.

### Files changed
  - `reachability.cpp`: added `Compile::verify_reachability_fences()`
  - `compile.hpp`: added declaration under `DEBUG_ONLY`
  - `compile.cpp`: added verification call before RF expansion

### Testing
  Built hotspot (`linux-x86_64-server-release` and `linux-x86_64-server-fastdebug`) successfully. No compilation errors.

https://bugs.openjdk.org/browse/JDK-8370131





---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8370131](https://bugs.openjdk.org/browse/JDK-8370131): C2: Improve ReachabilityFence test coverage (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31596/head:pull/31596` \
`$ git checkout pull/31596`

Update a local copy of the PR: \
`$ git checkout pull/31596` \
`$ git pull https://git.openjdk.org/jdk.git pull/31596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31596`

View PR using the GUI difftool: \
`$ git pr show -t 31596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31596.diff">https://git.openjdk.org/jdk/pull/31596.diff</a>

</details>
