### PR TITLE
8386466: DESedeKeySpec.isParityAdjusted spec permits 8-byte key but RI throws InvalidKeyException

### DIFF
--- a/src/java.base/share/classes/javax/crypto/spec/DESedeKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/DESedeKeySpec.java
@@ -117,7 +117,7 @@ public class DESedeKeySpec implements java.security.spec.KeySpec {
      *
      * @exception InvalidKeyException if the given key material is
      * <code>null</code>, or starting at <code>offset</code> inclusive, is
-     * shorter than 8 bytes.
+     * shorter than 24 bytes.
      * @exception ArrayIndexOutOfBoundsException if <code>offset</code> is
      * negative.
      */


### PR DESCRIPTION
Backport to JDK 27.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8386788](https://bugs.openjdk.org/browse/JDK-8386788) to be approved

### Issues
 * [JDK-8386466](https://bugs.openjdk.org/browse/JDK-8386466): DESedeKeySpec.isParityAdjusted spec permits 8-byte key but RI throws InvalidKeyException (**Bug** - P2) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).
 * [JDK-8386788](https://bugs.openjdk.org/browse/JDK-8386788): DESedeKeySpec.isParityAdjusted spec permits 8-byte key but RI throws InvalidKeyException (**CSR**)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31598/head:pull/31598` \
`$ git checkout pull/31598`

Update a local copy of the PR: \
`$ git checkout pull/31598` \
`$ git pull https://git.openjdk.org/jdk.git pull/31598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31598`

View PR using the GUI difftool: \
`$ git pr show -t 31598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31598.diff">https://git.openjdk.org/jdk/pull/31598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31598#issuecomment-4755212518)
</details>
