### PR TITLE
8386992: Shenandoah: Pad hot atomic counters to avoid false sharing on the allocation path

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAllocRate.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAllocRate.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHALLOCRATE_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHALLOCRATE_HPP
 
+#include "gc/shenandoah/shenandoahPadding.hpp"
 #include "gc/shenandoah/shenandoahWeightedSeq.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/mutex.hpp"
@@ -110,7 +111,9 @@ class ShenandoahAllocRate {
   static constexpr size_t ALLOC_SAMPLE_MAX = G;
 
   PaddedMonitor _sample_lock;
+  shenandoah_padding(0);
   Atomic<size_t> _allocated_bytes_since_last_sample;
+  shenandoah_padding(1);
   Atomic<size_t> _minimum_sample_size; // bytes, read by mutator, updated by gc
   jlong _last_sample_time;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -60,12 +60,12 @@ private:
   // deferred until a subsequent evacuation pass.
   size_t _promoted_reserve;
 
-  shenandoah_padding(0);
   // Bytes of old-gen memory expended on promotions. This may be modified concurrently
   // by mutators and gc workers when promotion LABs are retired during evacuation. It
   // is therefore always accessed through atomic operations. This is increased when a
   // PLAB is allocated for promotions. The value is decreased by the amount of memory
   // remaining in a PLAB when it is retired.
+  shenandoah_padding(0);
   Atomic<size_t> _promoted_expended;
   shenandoah_padding(1);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -29,6 +29,7 @@
 #include "gc/shenandoah/shenandoahAllocRequest.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
+#include "gc/shenandoah/shenandoahPadding.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 
@@ -59,12 +60,14 @@ private:
   // deferred until a subsequent evacuation pass.
   size_t _promoted_reserve;
 
+  shenandoah_padding(0);
   // Bytes of old-gen memory expended on promotions. This may be modified concurrently
   // by mutators and gc workers when promotion LABs are retired during evacuation. It
   // is therefore always accessed through atomic operations. This is increased when a
   // PLAB is allocated for promotions. The value is decreased by the amount of memory
   // remaining in a PLAB when it is retired.
   Atomic<size_t> _promoted_expended;
+  shenandoah_padding(1);
 
   // Represents the quantity of live bytes we expect to promote during the next GC cycle, either by
   // evacuation or by promote-in-place.  This value is used by the young heuristic to trigger mixed collections.


### PR DESCRIPTION
Two atomic counters that are updated on hot, multi-threaded allocation paths in Shenandoah share cache lines with neighboring fields, causing false sharing under allocation-heavy, multi-threaded workloads.

Overall the change should should be neutral for most of application because: 1.  TLAB mitigates most of the contention; 2. the actual allocation is always done with under heap lock, which also reduce the chance to have cache miss when update alloc rate sample. 

The [CAS allocator](https://bugs.openjdk.org/browse/JDK-8361099) will make the false sharing worse, with the CAS allocator and TLAB disabled(to simulate high chance of cache-line miss), running DaCapa h2 benchmark 31G heap, this change almost doubles the throughputs. 

Command line to run the DaCapa h2 benchmark:
```
java -XX:-TieredCompilation -XX:+AlwaysPreTouch -Xms31G -Xmx31G -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions  -XX:-ShenandoahUncommit -XX:ShenandoahGCMode=generational -XX:-UseTLAB -jar ~/tools/dacapo/dacapo-23.11-MR2-chopin.jar -n 5 h2
```

With paddings:
```
===== DaCapo 23.11-MR2-chopin h2 PASSED in 25315 msec =====
===== DaCapo processed 100000 requests in 25312 msec, 3950 requests per second =====
===== DaCapo tail latency, simple: 50% 5384 usec, 90% 74755 usec, 99% 207569 usec, 99.9% 350242 usec, 99.99% 510361 usec, max 622639 usec, measured over 100000 events =====
===== DaCapo tail latency, metered 100ms smoothing: 50% 6408 usec, 90% 75601 usec, 99% 208249 usec, 99.9% 351084 usec, 99.99% 510361 usec, max 622639 usec, measured over 100000 events =====
===== DaCapo tail latency, metered full smoothing: 50% 83861 usec, 90% 165779 usec, 99% 293390 usec, 99.9% 431767 usec, 99.99% 595638 usec, max 701331 usec, measured over 100000 events =====

```

W/o paddings:
```
===== DaCapo 23.11-MR2-chopin h2 PASSED in 48745 msec =====
===== DaCapo processed 100000 requests in 48742 msec, 2051 requests per second =====
===== DaCapo tail latency, simple: 50% 10286 usec, 90% 147511 usec, 99% 397584 usec, 99.9% 641465 usec, 99.99% 882889 usec, max 1549832 usec, measured over 100000 events =====
===== DaCapo tail latency, metered 100ms smoothing: 50% 11677 usec, 90% 148826 usec, 99% 399024 usec, 99.9% 642368 usec, 99.99% 885108 usec, max 1549832 usec, measured over 100000 events =====
===== DaCapo tail latency, metered full smoothing: 50% 139182 usec, 90% 279666 usec, 99% 523489 usec, 99.9% 766609 usec, 99.99% 1042862 usec, max 1695510 usec, measured over 100000 events =====

```


Test:
- [x] MacOs fastdebug TEST=hotspot_gc_shenandoah
- [x] Internal CI pipeline: jtreg + stress + perf


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386992](https://bugs.openjdk.org/browse/JDK-8386992): Shenandoah: Pad hot atomic counters to avoid false sharing on the allocation path (**Sub-task** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31600/head:pull/31600` \
`$ git checkout pull/31600`

Update a local copy of the PR: \
`$ git checkout pull/31600` \
`$ git pull https://git.openjdk.org/jdk.git pull/31600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31600`

View PR using the GUI difftool: \
`$ git pr show -t 31600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31600.diff">https://git.openjdk.org/jdk/pull/31600.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31600#issuecomment-4772996564)
</details>
