### PR TITLE
8387003: Stale doc comment in TrustFinalFields.java after JDK-8376777

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/annotation/TrustFinalFields.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/TrustFinalFields.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
 ///
 /// The compiler already treats static final fields and instance final fields in
 /// record classes and hidden classes as constant.  All classes in select
-/// packages (Defined in `trust_final_non_static_fields` in `ciField.cpp`) in
+/// packages (Defined in `trust_final_nonstatic_fields` in `ciField.cpp`) in
 /// the boot class loader also have their instance final fields trusted.  This
 /// annotation is not necessary in these cases.
 ///


### PR DESCRIPTION
Hello,

This is a trivial cleanup after [JDK-8376777](https://bugs.openjdk.org/browse/JDK-8376777), which missed a reference to a renamed method in the doc comment in TrustFinalFields.java.

Testing:
* GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387003](https://bugs.openjdk.org/browse/JDK-8387003): Stale doc comment in TrustFinalFields.java after JDK-8376777 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31601/head:pull/31601` \
`$ git checkout pull/31601`

Update a local copy of the PR: \
`$ git checkout pull/31601` \
`$ git pull https://git.openjdk.org/jdk.git pull/31601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31601`

View PR using the GUI difftool: \
`$ git pr show -t 31601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31601.diff">https://git.openjdk.org/jdk/pull/31601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31601#issuecomment-4765767513)
</details>
