### PR TITLE
8377977: Crashes in CompileBroker::init_compiler_threads with -XX:+StressBailout and tracing enabled

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -906,7 +906,7 @@ void CompileBroker::init_compiler_threads() {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
+        if (!tlh.includes(ct)) continue;
         stringStream msg;
         msg.print("Added initial compiler thread %s", ct->name());
         print_compiler_threads(msg);
@@ -927,7 +927,7 @@ void CompileBroker::init_compiler_threads() {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
+        if (!tlh.includes(ct)) continue;
         stringStream msg;
         msg.print("Added initial compiler thread %s", ct->name());
         print_compiler_threads(msg);
@@ -1005,7 +1005,7 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
+        if (!tlh.includes(ct)) continue;
         stringStream msg;
         msg.print("Added compiler thread %s (free memory: %dMB, available non-profiled code cache: %dMB)",
                   ct->name(), (int)(free_memory/M), (int)(available_cc_np/M));
@@ -1028,7 +1028,7 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        assert(tlh.includes(ct), "ct=" INTPTR_FORMAT " exited unexpectedly.", p2i(ct));
+        if (!tlh.includes(ct)) continue;
         stringStream msg;
         msg.print("Added compiler thread %s (free memory: %dMB, available profiled code cache: %dMB)",
                   ct->name(), (int)(free_memory/M), (int)(available_cc_p/M));

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -874,15 +874,15 @@ static void print_compiler_threads(stringStream& msg) {
   }
 }
 
-static bool trace_compiler_thread_added(JavaThread* ct, const char* fmt, ...) {
-  if (!trace_compiler_threads()) return false;
+static void trace_compiler_thread_added(JavaThread* ct, const char* fmt, ...) {
+  if (!trace_compiler_threads()) return;
   ResourceMark rm;
   ThreadsListHandle tlh;
   if (!tlh.includes(ct)) {
     stringStream msg;
     msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
     print_compiler_threads(msg);
-    return true;
+    return;
   }
   stringStream msg;
   va_list ap;
@@ -890,7 +890,6 @@ static bool trace_compiler_thread_added(JavaThread* ct, const char* fmt, ...) {
   msg.vprint(fmt, ap);
   va_end(ap);
   print_compiler_threads(msg);
-  return false;
 }
 
 void CompileBroker::init_compiler_threads() {
@@ -922,7 +921,7 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c2_compile_queue, _compilers[1], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_thread_added(ct, "Added initial compiler thread %s", ct->name())) continue;
+      trace_compiler_thread_added(ct, "Added initial compiler thread %s", ct->name());
     }
   }
 
@@ -936,7 +935,7 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c1_compile_queue, _compilers[0], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_thread_added(ct, "Added initial compiler thread %s", ct->name())) continue;
+      trace_compiler_thread_added(ct, "Added initial compiler thread %s", ct->name());
     }
   }
 
@@ -1007,8 +1006,8 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       JavaThread *ct = make_thread(compiler_t, compiler2_object(i), _c2_compile_queue, _compilers[1], THREAD);
       if (ct == nullptr) break;
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_thread_added(ct, "Added compiler thread %s (free memory: %dMB, available non-profiled code cache: %dMB)",
-                  ct->name(), (int)(free_memory/M), (int)(available_cc_np/M))) continue;
+      trace_compiler_thread_added(ct, "Added compiler thread %s (free memory: %dMB, available non-profiled code cache: %dMB)",
+                  ct->name(), (int)(free_memory/M), (int)(available_cc_np/M));
     }
   }
 
@@ -1023,8 +1022,8 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       JavaThread *ct = make_thread(compiler_t, compiler1_object(i), _c1_compile_queue, _compilers[0], THREAD);
       if (ct == nullptr) break;
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_thread_added(ct, "Added compiler thread %s (free memory: %dMB, available profiled code cache: %dMB)",
-                  ct->name(), (int)(free_memory/M), (int)(available_cc_p/M))) continue;
+      trace_compiler_thread_added(ct, "Added compiler thread %s (free memory: %dMB, available profiled code cache: %dMB)",
+                  ct->name(), (int)(free_memory/M), (int)(available_cc_p/M));
     }
   }
 

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -906,7 +906,12 @@ void CompileBroker::init_compiler_threads() {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) continue;
+        if (!tlh.includes(ct)) {
+          stringStream msg;
+          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
+          print_compiler_threads(msg);
+          continue;
+        }
         stringStream msg;
         msg.print("Added initial compiler thread %s", ct->name());
         print_compiler_threads(msg);
@@ -927,7 +932,12 @@ void CompileBroker::init_compiler_threads() {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) continue;
+        if (!tlh.includes(ct)) {
+          stringStream msg;
+          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
+          print_compiler_threads(msg);
+          continue;
+        }
         stringStream msg;
         msg.print("Added initial compiler thread %s", ct->name());
         print_compiler_threads(msg);
@@ -1005,7 +1015,12 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) continue;
+        if (!tlh.includes(ct)) {
+          stringStream msg;
+          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
+          print_compiler_threads(msg);
+          continue;
+        }
         stringStream msg;
         msg.print("Added compiler thread %s (free memory: %dMB, available non-profiled code cache: %dMB)",
                   ct->name(), (int)(free_memory/M), (int)(available_cc_np/M));
@@ -1028,7 +1043,12 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       if (trace_compiler_threads()) {
         ResourceMark rm;
         ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) continue;
+        if (!tlh.includes(ct)) {
+          stringStream msg;
+          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
+          print_compiler_threads(msg);
+          continue;
+        }
         stringStream msg;
         msg.print("Added compiler thread %s (free memory: %dMB, available profiled code cache: %dMB)",
                   ct->name(), (int)(free_memory/M), (int)(available_cc_p/M));

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -874,6 +874,25 @@ static void print_compiler_threads(stringStream& msg) {
   }
 }
 
+static bool trace_compiler_thread_added(JavaThread* ct, const char* fmt, ...) {
+  if (!trace_compiler_threads()) return false;
+  ResourceMark rm;
+  ThreadsListHandle tlh;
+  if (!tlh.includes(ct)) {
+    stringStream msg;
+    msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
+    print_compiler_threads(msg);
+    return true;
+  }
+  stringStream msg;
+  va_list ap;
+  va_start(ap, fmt);
+  msg.vprint(fmt, ap);
+  va_end(ap);
+  print_compiler_threads(msg);
+  return false;
+}
+
 void CompileBroker::init_compiler_threads() {
   // Ensure any exceptions lead to vm_exit_during_initialization.
   EXCEPTION_MARK;
@@ -903,19 +922,7 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c2_compile_queue, _compilers[1], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_threads()) {
-        ResourceMark rm;
-        ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) {
-          stringStream msg;
-          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
-          print_compiler_threads(msg);
-          continue;
-        }
-        stringStream msg;
-        msg.print("Added initial compiler thread %s", ct->name());
-        print_compiler_threads(msg);
-      }
+      if (trace_compiler_thread_added(ct, "Added initial compiler thread %s", ct->name())) continue;
     }
   }
 
@@ -929,19 +936,7 @@ void CompileBroker::init_compiler_threads() {
       JavaThread *ct = make_thread(compiler_t, thread_handle, _c1_compile_queue, _compilers[0], THREAD);
       assert(ct != nullptr, "should have been handled for initial thread");
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_threads()) {
-        ResourceMark rm;
-        ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) {
-          stringStream msg;
-          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
-          print_compiler_threads(msg);
-          continue;
-        }
-        stringStream msg;
-        msg.print("Added initial compiler thread %s", ct->name());
-        print_compiler_threads(msg);
-      }
+      if (trace_compiler_thread_added(ct, "Added initial compiler thread %s", ct->name())) continue;
     }
   }
 
@@ -1012,20 +1007,8 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       JavaThread *ct = make_thread(compiler_t, compiler2_object(i), _c2_compile_queue, _compilers[1], THREAD);
       if (ct == nullptr) break;
       _compilers[1]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_threads()) {
-        ResourceMark rm;
-        ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) {
-          stringStream msg;
-          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
-          print_compiler_threads(msg);
-          continue;
-        }
-        stringStream msg;
-        msg.print("Added compiler thread %s (free memory: %dMB, available non-profiled code cache: %dMB)",
-                  ct->name(), (int)(free_memory/M), (int)(available_cc_np/M));
-        print_compiler_threads(msg);
-      }
+      if (trace_compiler_thread_added(ct, "Added compiler thread %s (free memory: %dMB, available non-profiled code cache: %dMB)",
+                  ct->name(), (int)(free_memory/M), (int)(available_cc_np/M))) continue;
     }
   }
 
@@ -1040,20 +1023,8 @@ void CompileBroker::possibly_add_compiler_threads(JavaThread* THREAD) {
       JavaThread *ct = make_thread(compiler_t, compiler1_object(i), _c1_compile_queue, _compilers[0], THREAD);
       if (ct == nullptr) break;
       _compilers[0]->set_num_compiler_threads(i + 1);
-      if (trace_compiler_threads()) {
-        ResourceMark rm;
-        ThreadsListHandle tlh;  // name() depends on the TLH.
-        if (!tlh.includes(ct)) {
-          stringStream msg;
-          msg.print("Compiler thread " INTPTR_FORMAT " exited before it could be tracked", p2i(ct));
-          print_compiler_threads(msg);
-          continue;
-        }
-        stringStream msg;
-        msg.print("Added compiler thread %s (free memory: %dMB, available profiled code cache: %dMB)",
-                  ct->name(), (int)(free_memory/M), (int)(available_cc_p/M));
-        print_compiler_threads(msg);
-      }
+      if (trace_compiler_thread_added(ct, "Added compiler thread %s (free memory: %dMB, available profiled code cache: %dMB)",
+                  ct->name(), (int)(free_memory/M), (int)(available_cc_p/M))) continue;
     }
   }
 

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -874,6 +874,7 @@ static void print_compiler_threads(stringStream& msg) {
   }
 }
 
+ATTRIBUTE_PRINTF(2, 3)
 static void trace_compiler_thread_added(JavaThread* ct, const char* fmt, ...) {
   if (!trace_compiler_threads()) return;
   ResourceMark rm;

--- a/test/hotspot/jtreg/compiler/debug/TestStressBailoutWithTracing.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressBailoutWithTracing.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8377977
+ * @summary Verify no crash when StressBailout is combined with compiler thread tracing
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @library /test/lib
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressBailout
+ *                   -XX:+TraceCompilerThreads -Xbatch
+ *                   compiler.debug.TestStressBailoutWithTracing
+ */
+
+package compiler.debug;
+
+public class TestStressBailoutWithTracing {
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            compute(i);
+        }
+    }
+
+    static int compute(int x) {
+        return x * x + 1;
+    }
+}


### PR DESCRIPTION
With `-XX:+StressBailout` and compiler thread tracing enabled (`-XX:+TraceCompilerThreads` or `-Xlog:jit+thread`), a newly created compiler thread can bail out and exit immediately before the creating thread takes a `ThreadsListHandle` to log the creation. This causes an assertion failure: "ct=0x... exited unexpectedly."

The race window: `make_thread()` starts the thread, the thread fails its first compilation due to `StressBailout`, exits, and is removed from the threads list, all before the `ThreadsListHandle` is constructed on the next line.

Replace the assert with a graceful check: if the thread already exited, skip the trace logging and continue.

### Files changed
  - `compileBroker.cpp`: replaced 4 assert(tlh.includes(ct)) with if (!tlh.includes(ct)) continue

### Testing
  - Built hotspot (`linux-x86_64-server-release`) successfully. No compilation errors.

https://bugs.openjdk.org/browse/JDK-8377977

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8377977](https://bugs.openjdk.org/browse/JDK-8377977): Crashes in CompileBroker::init_compiler_threads with -XX:+StressBailout and tracing enabled (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31604/head:pull/31604` \
`$ git checkout pull/31604`

Update a local copy of the PR: \
`$ git checkout pull/31604` \
`$ git pull https://git.openjdk.org/jdk.git pull/31604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31604`

View PR using the GUI difftool: \
`$ git pr show -t 31604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31604.diff">https://git.openjdk.org/jdk/pull/31604.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31604#issuecomment-4768637542)
</details>
