### PR TITLE
8387016: PPC64: Remove postalloc_expand from float/double compare nodes

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3556,9 +3556,6 @@ ins_attrib ins_alignment(1);
 ins_attrib ins_cannot_rematerialize(false);
 ins_attrib ins_should_rematerialize(false);
 
-// Instruction has variable size depending on alignment.
-ins_attrib ins_variable_size_depending_on_alignment(false);
-
 // Instruction is a nop.
 ins_attrib ins_is_nop(false);
 
@@ -7015,8 +7012,6 @@ instruct cmovF_reg(cmpOp cmp, flagsRegSrc crx, regF dst, regF src) %{
   match(Set dst (CMoveF (Binary cmp crx) (Binary dst src)));
   ins_cost(DEFAULT_COST+BRANCH_COST);
 
-  ins_variable_size_depending_on_alignment(true);
-
   format %{ "CMOVEF  $cmp, $crx, $dst, $src\n\t" %}
   size(8);
   ins_encode %{
@@ -7033,8 +7028,6 @@ instruct cmovF_reg(cmpOp cmp, flagsRegSrc crx, regF dst, regF src) %{
 instruct cmovD_reg(cmpOp cmp, flagsRegSrc crx, regD dst, regD src) %{
   match(Set dst (CMoveD (Binary cmp crx) (Binary dst src)));
   ins_cost(DEFAULT_COST+BRANCH_COST);
-
-  ins_variable_size_depending_on_alignment(true);
 
   format %{ "CMOVEF  $cmp, $crx, $dst, $src\n\t" %}
   size(8);
@@ -8276,8 +8269,6 @@ instruct cmovI_bne_negI_reg(iRegIdst dst, flagsRegSrc crx, iRegIsrc src1) %{
   effect(USE_DEF dst, USE src1, USE crx);
   predicate(false);
 
-  ins_variable_size_depending_on_alignment(true);
-
   format %{ "CMOVE   $dst, neg($src1), $crx" %}
   size(8);
   ins_encode %{
@@ -8333,8 +8324,6 @@ instruct divL_reg_regnotMinus1(iRegLdst dst, iRegLsrc src1, iRegLsrc src2) %{
 instruct cmovL_bne_negL_reg(iRegLdst dst, flagsRegSrc crx, iRegLsrc src1) %{
   effect(USE_DEF dst, USE src1, USE crx);
   predicate(false);
-
-  ins_variable_size_depending_on_alignment(true);
 
   format %{ "CMOVE   $dst, neg($src1), $crx" %}
   size(8);
@@ -10044,8 +10033,6 @@ instruct cmovI_bso_stackSlotL(iRegIdst dst, flagsRegSrc crx, stackSlotL src) %{
   effect(DEF dst, USE crx, USE src);
   predicate(false);
 
-  ins_variable_size_depending_on_alignment(true);
-
   format %{ "CMOVI   $crx, $dst, $src" %}
   size(8);
   ins_encode( enc_cmove_bso_stackSlotL(dst, crx, src) );
@@ -10056,8 +10043,6 @@ instruct cmovI_bso_reg(iRegIdst dst, flagsRegSrc crx, regD src) %{
   // no match-rule, false predicate
   effect(DEF dst, USE crx, USE src);
   predicate(false);
-
-  ins_variable_size_depending_on_alignment(true);
 
   format %{ "CMOVI   $crx, $dst, $src" %}
   size(8);
@@ -10219,8 +10204,6 @@ instruct cmovL_bso_stackSlotL(iRegLdst dst, flagsRegSrc crx, stackSlotL src) %{
   effect(DEF dst, USE crx, USE src);
   predicate(false);
 
-  ins_variable_size_depending_on_alignment(true);
-
   format %{ "CMOVL   $crx, $dst, $src" %}
   size(8);
   ins_encode( enc_cmove_bso_stackSlotL(dst, crx, src) );
@@ -10231,8 +10214,6 @@ instruct cmovL_bso_reg(iRegLdst dst, flagsRegSrc crx, regD src) %{
   // no match-rule, false predicate
   effect(DEF dst, USE crx, USE src);
   predicate(false);
-
-  ins_variable_size_depending_on_alignment(true);
 
   format %{ "CMOVL   $crx, $dst, $src" %}
   size(8);
@@ -10853,84 +10834,22 @@ instruct cmpFUnordered_reg_reg(flagsReg crx, regF src1, regF src2) %{
   ins_pipe(pipe_class_default);
 %}
 
-instruct cmov_bns_less(flagsReg crx) %{
-  // no match-rule, false predicate
-  effect(DEF crx);
-  predicate(false);
-
-  ins_variable_size_depending_on_alignment(true);
-
-  format %{ "CMOV    $crx" %}
-  size(12);
-  ins_encode %{
-    Label done;
-    __ bns($crx$$CondRegister, done);        // not unordered -> keep crx
-    __ li(R0, 0);
-    __ cmpwi($crx$$CondRegister, R0, 1);     // unordered -> set crx to 'less'
-    __ bind(done);
-  %}
-  ins_pipe(pipe_class_default);
-%}
-
 // Compare floating, generate condition code.
-instruct cmpF_reg_reg_Ex(flagsReg crx, regF src1, regF src2) %{
-  // FIXME: should we match 'If cmp (CmpF src1 src2))' ??
-  //
-  // The following code sequence occurs a lot in mpegaudio:
-  //
-  // block BXX:
-  // 0: instruct cmpFUnordered_reg_reg (cmpF_reg_reg-0):
-  //    cmpFUrd CR6, F11, F9
-  // 4: instruct cmov_bns_less (cmpF_reg_reg-1):
-  //    cmov CR6
-  // 8: instruct branchConSched:
-  //    B_FARle CR6, B56  P=0.500000 C=-1.000000
+instruct cmpF_reg_reg(flagsReg crx, regF src1, regF src2) %{
   match(Set crx (CmpF src1 src2));
   ins_cost(DEFAULT_COST+BRANCH_COST);
 
-  format %{ "CMPF    $crx, $src1, $src2 \t// postalloc expanded" %}
-  postalloc_expand %{
-    //
-    // replaces
-    //
-    //   region  src1  src2
-    //    \       |     |
-    //     crx=cmpF_reg_reg
-    //
-    // with
-    //
-    //   region  src1  src2
-    //    \       |     |
-    //     crx=cmpFUnordered_reg_reg
-    //      |
-    //      ^  region
-    //      |   \
-    //      crx=cmov_bns_less
-    //
-
-    // Create new nodes.
-    MachNode *m1 = new cmpFUnordered_reg_regNode();
-    MachNode *m2 = new cmov_bns_lessNode();
-
-    // inputs for new nodes
-    m1->add_req(n_region, n_src1, n_src2);
-    m2->add_req(n_region);
-    m2->add_prec(m1);
-
-    // operands for new nodes
-    m1->_opnds[0] = op_crx;
-    m1->_opnds[1] = op_src1;
-    m1->_opnds[2] = op_src2;
-    m2->_opnds[0] = op_crx;
-
-    // registers for new nodes
-    ra_->set_pair(m1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this)); // crx
-    ra_->set_pair(m2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this)); // crx
-
-    // Insert new nodes.
-    nodes->push(m1);
-    nodes->push(m2);
+  format %{ "CMPF    $crx, $src1, $src2" %}
+  size(16);
+  ins_encode %{
+    Label done;
+    __ fcmpu($crx$$CondRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ bns($crx$$CondRegister, done);
+    __ li(R0, 0);
+    __ cmpwi($crx$$CondRegister, R0, 1);
+    __ bind(done);
   %}
+  ins_pipe(pipe_class_default);
 %}
 
 // Compare float, generate -1,0,1
@@ -10968,53 +10887,21 @@ instruct cmpDUnordered_reg_reg(flagsReg crx, regD src1, regD src2) %{
   ins_pipe(pipe_class_default);
 %}
 
-instruct cmpD_reg_reg_Ex(flagsReg crx, regD src1, regD src2) %{
+instruct cmpD_reg_reg(flagsReg crx, regD src1, regD src2) %{
   match(Set crx (CmpD src1 src2));
   ins_cost(DEFAULT_COST+BRANCH_COST);
 
-  format %{ "CmpD    $crx, $src1, $src2 \t// postalloc expanded" %}
-  postalloc_expand %{
-    //
-    // replaces
-    //
-    //   region  src1  src2
-    //    \       |     |
-    //     crx=cmpD_reg_reg
-    //
-    // with
-    //
-    //   region  src1  src2
-    //    \       |     |
-    //     crx=cmpDUnordered_reg_reg
-    //      |
-    //      ^  region
-    //      |   \
-    //      crx=cmov_bns_less
-    //
-
-    // create new nodes
-    MachNode *m1 = new cmpDUnordered_reg_regNode();
-    MachNode *m2 = new cmov_bns_lessNode();
-
-    // inputs for new nodes
-    m1->add_req(n_region, n_src1, n_src2);
-    m2->add_req(n_region);
-    m2->add_prec(m1);
-
-    // operands for new nodes
-    m1->_opnds[0] = op_crx;
-    m1->_opnds[1] = op_src1;
-    m1->_opnds[2] = op_src2;
-    m2->_opnds[0] = op_crx;
-
-    // registers for new nodes
-    ra_->set_pair(m1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this)); // crx
-    ra_->set_pair(m2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this)); // crx
-
-    // Insert new nodes.
-    nodes->push(m1);
-    nodes->push(m2);
+  format %{ "CmpD    $crx, $src1, $src2" %}
+  size(16);
+  ins_encode %{
+    Label done;
+    __ fcmpu($crx$$CondRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ bns($crx$$CondRegister, done);
+    __ li(R0, 0);
+    __ cmpwi($crx$$CondRegister, R0, 1);
+    __ bind(done);
   %}
+  ins_pipe(pipe_class_default);
 %}
 
 // Compare double, generate -1,0,1

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -10891,7 +10891,7 @@ instruct cmpD_reg_reg(flagsReg crx, regD src1, regD src2) %{
   match(Set crx (CmpD src1 src2));
   ins_cost(DEFAULT_COST+BRANCH_COST);
 
-  format %{ "CmpD    $crx, $src1, $src2" %}
+  format %{ "CMPD    $crx, $src1, $src2" %}
   size(16);
   ins_encode %{
     Label done;


### PR DESCRIPTION
Rewrite cmpF_reg_reg_Ex and cmpD_reg_reg_Ex to not use postalloc expand and emit directly.

Tier 1 - Tier 4 tests were successful.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387016](https://bugs.openjdk.org/browse/JDK-8387016): PPC64: Remove postalloc_expand from float/double compare nodes (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31605/head:pull/31605` \
`$ git checkout pull/31605`

Update a local copy of the PR: \
`$ git checkout pull/31605` \
`$ git pull https://git.openjdk.org/jdk.git pull/31605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31605`

View PR using the GUI difftool: \
`$ git pr show -t 31605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31605.diff">https://git.openjdk.org/jdk/pull/31605.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31605#issuecomment-4767466746)
</details>
