### PR TITLE
8387017: java/lang/instrument/GetObjectSizeIntrinsicsTest.java fails with Error evaluating expression: invalid boolean value: `null' for expression `vm.opt.VerifyOops'

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -26,7 +26,7 @@
  * @bug 8253525
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -55,7 +55,7 @@
  * @summary Test for fInst.getObjectSize with zero-based compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -84,7 +84,7 @@
  * @summary Test for fInst.getObjectSize without compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -113,7 +113,7 @@
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -146,7 +146,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -179,7 +179,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -212,7 +212,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -245,7 +245,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -279,7 +279,7 @@
  * @requires vm.bits == 64
  * @requires vm.debug
  * @requires os.maxMemory >= 10G
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest


### PR DESCRIPTION
The testing for my fix in #31567 did not hit the failure that the jtreg property `vm.opt.VerifyOops` can be null. This PR fixes this oversight.

Testing:
 - [x] Github Actions
 - [x] tier1,tier2,tier3 plus additional stress testing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387017](https://bugs.openjdk.org/browse/JDK-8387017): java/lang/instrument/GetObjectSizeIntrinsicsTest.java fails with Error evaluating expression: invalid boolean value: `null' for expression `vm.opt.VerifyOops' (**Bug** - P4)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Contributors
 * Joel Sikström `<jsikstro@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31608/head:pull/31608` \
`$ git checkout pull/31608`

Update a local copy of the PR: \
`$ git checkout pull/31608` \
`$ git pull https://git.openjdk.org/jdk.git pull/31608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31608`

View PR using the GUI difftool: \
`$ git pr show -t 31608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31608.diff">https://git.openjdk.org/jdk/pull/31608.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31608#issuecomment-4768694077)
</details>
