### PR TITLE
8386842: Preview files in root directory not recognized in system image

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -683,9 +683,9 @@ public final class ImageReader implements AutoCloseable {
                             } else {
                                 assert type == MODULES_DIR : "Invalid location type: " + childLoc;
                                 Node childNode = nodes.get(nonPreviewChildName);
-                                assert isPreviewOnly == (childNode != null) :
+                                assert !(isPreviewOnly && childNode == null) :
                                         "Inconsistent child node: " + nonPreviewChildName;
-                                return childNode;
+                                return isPreviewOnly ? childNode : null;
                             }
                         });
                     }

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -561,7 +561,19 @@ public final class ImageReader implements AutoCloseable {
             // Now try the non-prefixed resource name, but be careful to avoid false
             // positives for names like "/modules/modules/xxx" which could return a
             // location of a directory entry.
-            loc = findLocation(name.substring(MODULES_PREFIX.length()));
+            String resourceName = name.substring(MODULES_PREFIX.length());
+            if (isPreviewEnabled) {
+                // Root-level preview resources are not pre-cached when an image
+                // is opened, so check for them first.
+                int pathStart = resourceName.indexOf('/', 1);
+                if (pathStart > 1 && resourceName.indexOf('/', pathStart + 1) < 0) {
+                    loc = findLocation(resourceName.substring(0, pathStart)
+                            + PREVIEW_INFIX + "/" + resourceName.substring(pathStart + 1));
+                }
+            }
+            if (loc == null) {
+                loc = findLocation(resourceName);
+            }
             return loc != null && loc.getType() == RESOURCE
                     ? ensureCached(newResource(name, loc))
                     : null;
@@ -649,6 +661,36 @@ public final class ImageReader implements AutoCloseable {
         private Directory completeModuleDirectory(Directory dir, ImageLocation loc) {
             assert dir.getName().equals(loc.getFullName()) : "Mismatched location for directory: " + dir;
             List<Node> previewOnlyNodes = getPreviewNodesToMerge(dir);
+            if (isPreviewEnabled && previewOnlyNodes.isEmpty()) {
+                // When opening an image in preview mode, packages that have preview
+                // content are eagerly processed, caching preview resources and
+                // preview-only directories for direct lookup. Root-level preview
+                // resources are omitted during this process, since they have no
+                // package path and the empty package is not represented under
+                // "/packages", and must be processed separately.
+                int moduleStart = MODULES_PREFIX.length() + 1;
+                if (dir.getName().indexOf('/', moduleStart) < 0) {
+                    ImageLocation previewLoc = findLocation(dir.getName() + PREVIEW_INFIX);
+                    if (previewLoc != null) {
+                        previewOnlyNodes = createChildNodes(previewLoc, 0, childLoc -> {
+                            String baseName = getBaseName(childLoc);
+                            String nonPreviewChildName = dir.getName() + "/" + baseName;
+                            boolean isPreviewOnly = ImageLocation.isPreviewOnly(childLoc.getFlags());
+                            LocationType type = childLoc.getType();
+                            if (type == RESOURCE) {
+                                Node childNode = nodes.computeIfAbsent(nonPreviewChildName, n -> newResource(n, childLoc));
+                                return isPreviewOnly ? childNode : null;
+                            } else {
+                                assert type == MODULES_DIR : "Invalid location type: " + childLoc;
+                                Node childNode = nodes.get(nonPreviewChildName);
+                                assert isPreviewOnly == (childNode != null) :
+                                        "Inconsistent child node: " + nonPreviewChildName;
+                                return childNode;
+                            }
+                        });
+                    }
+                }
+            }
             // We hide preview names from direct lookup, but must also prevent
             // the preview directory from appearing in any META-INF directories.
             boolean parentIsMetaInfDir = isMetaInf(dir);

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -486,7 +486,7 @@ public final class ImageReader implements AutoCloseable {
                     ImageLocation loc = null;
                     if (isPreviewEnabled) {
                         // We must test preview location first (if in preview mode).
-                        loc = findLocation(moduleName, PREVIEW_RESOURCE_PREFIX + resourcePath);
+                        loc = findLocation(moduleName, PREVIEW_RESOURCE_PREFIX + "/" + resourcePath);
                     }
                     if (loc == null) {
                         loc = findLocation(moduleName, resourcePath);
@@ -531,7 +531,7 @@ public final class ImageReader implements AutoCloseable {
                         return node.isResource();
                     }
                 }
-                loc = findLocation(moduleName, PREVIEW_RESOURCE_PREFIX + resourcePath);
+                loc = findLocation(moduleName, PREVIEW_RESOURCE_PREFIX + "/" + resourcePath);
             }
             if (loc == null) {
                 loc = findLocation(moduleName, resourcePath);

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -88,8 +88,10 @@ public class ImageReaderTest {
                     "!META-INF/collision/child.properties",
                     "!META-INF/collision",
                     // Non-class resource in top level directory
-                    "!file.txt",
-                    "!META-INF/preview/file.txt",
+                    "!fileA.txt",
+                    "!fileB.txt",
+                    "!META-INF/preview/fileA.txt",
+                    "!META-INF/preview/fileB.txt",
                     // Replaces original class in preview mode.
                     "@com.foo.HasPreviewVersion",
                     // New class in existing package in preview mode.
@@ -100,6 +102,11 @@ public class ImageReaderTest {
                     // Two new packages in preview mode (new symbolic links).
                     "@com.bar.preview.stuff.Foo",
                     "@com.bar.preview.stuff.Bar"),
+            "modbaz", Arrays.asList(
+                    "!file.txt",
+                    "!normal.txt",
+                    "!META-INF/preview/file.txt",
+                    "!META-INF/preview/previewOnly.txt"),
             "modgus", Arrays.asList(
                     // A second module with a preview-only empty package (preview).
                     "@com.bar.preview.other.Gus"));
@@ -276,8 +283,16 @@ public class ImageReaderTest {
             assertDirContents(reader, "/modules/modfoo/com/foo/bar", "NormalBar.class");
 
             // Non-class resource in top level directory
-            assertResource(reader, "modfoo", "file.txt");
-            assertNonPreviewResourceVersion(reader, "modfoo", "file.txt");
+            assertResource(reader, "modfoo", "fileA.txt");
+            assertNonPreviewResourceVersion(reader, "modfoo", "fileA.txt");
+            assertNode(reader, "/modules/modfoo/fileB.txt");
+            assertNonPreviewResourceVersion(reader, "modfoo", "fileB.txt");
+            assertDirContents(reader, "/modules/modfoo", "META-INF", "module-info.class", "fileA.txt", "fileB.txt", "com");
+
+            assertAbsent(reader, "/modules/modbaz/previewOnly.txt");
+            assertDirContents(reader, "/modules/modbaz", "META-INF", "module-info.class", "file.txt", "normal.txt");
+            assertNonPreviewResourceVersion(reader, "modbaz", "file.txt");
+            assertNonPreviewResourceVersion(reader, "modbaz", "normal.txt");
         }
     }
 
@@ -299,8 +314,17 @@ public class ImageReaderTest {
             assertDirContents(reader, "/modules/modfoo/com/foo/bar", "NormalBar.class", "IsPreviewOnly.class");
 
             // Non-class resource in top level directory
-            assertResource(reader, "modfoo", "file.txt");
-            assertPreviewResourceVersion(reader, "modfoo", "file.txt");
+            assertResource(reader, "modfoo", "fileA.txt");
+            assertPreviewResourceVersion(reader, "modfoo", "fileA.txt");
+            assertNode(reader, "/modules/modfoo/fileB.txt");
+            assertPreviewResourceVersion(reader, "modfoo", "fileB.txt");
+            assertDirContents(reader, "/modules/modfoo", "META-INF", "module-info.class", "fileA.txt", "fileB.txt", "com");
+
+            assertNode(reader, "/modules/modbaz/previewOnly.txt");
+            assertDirContents(reader, "/modules/modbaz", "META-INF", "module-info.class", "file.txt", "normal.txt", "previewOnly.txt");
+            assertPreviewResourceVersion(reader, "modbaz", "file.txt");
+            assertNonPreviewResourceVersion(reader, "modbaz", "normal.txt");
+            assertPreviewResourceVersion(reader, "modbaz", "previewOnly.txt");
         }
     }
 

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,7 +60,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 /*
  * @test
- * @bug 8385355
+ * @bug 8385355 8386842
  * @summary Tests for ImageReader.
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
@@ -86,6 +87,9 @@ public class ImageReaderTest {
                     "!META-INF/z",
                     "!META-INF/collision/child.properties",
                     "!META-INF/collision",
+                    // Non-class resource in top level directory
+                    "!file.txt",
+                    "!META-INF/preview/file.txt",
                     // Replaces original class in preview mode.
                     "@com.foo.HasPreviewVersion",
                     // New class in existing package in preview mode.
@@ -270,6 +274,10 @@ public class ImageReaderTest {
             assertAbsent(reader, "/modules/modfoo/com/foo/bar/IsPreviewOnly.class");
             assertDirContents(reader, "/modules/modfoo/com/foo", "HasPreviewVersion.class", "NormalFoo.class", "bar");
             assertDirContents(reader, "/modules/modfoo/com/foo/bar", "NormalBar.class");
+
+            // Non-class resource in top level directory
+            assertResource(reader, "modfoo", "file.txt");
+            assertNonPreviewResourceVersion(reader, "modfoo", "file.txt");
         }
     }
 
@@ -289,6 +297,10 @@ public class ImageReaderTest {
             assertResource(reader, "modfoo", "com/foo/bar/IsPreviewOnly.class");
             assertDirContents(reader, "/modules/modfoo/com/foo", "HasPreviewVersion.class", "NormalFoo.class", "bar");
             assertDirContents(reader, "/modules/modfoo/com/foo/bar", "NormalBar.class", "IsPreviewOnly.class");
+
+            // Non-class resource in top level directory
+            assertResource(reader, "modfoo", "file.txt");
+            assertPreviewResourceVersion(reader, "modfoo", "file.txt");
         }
     }
 
@@ -405,6 +417,17 @@ public class ImageReaderTest {
         assertSame(resNode, reader.findNode(nodeName));
     }
 
+    private static void assertNonPreviewResourceVersion(ImageReader reader, String modName, String resPath) throws IOException {
+        Node resNode = reader.findResourceNode(modName, resPath);
+        assertArrayEquals(resPath.getBytes(StandardCharsets.UTF_8), reader.getResource(resNode));
+    }
+
+    private static void assertPreviewResourceVersion(ImageReader reader, String modName, String resPath) throws IOException {
+        Node resNode = reader.findResourceNode(modName, resPath);
+        String name = "META-INF/preview/" + resPath;
+        assertArrayEquals(name.getBytes(StandardCharsets.UTF_8), reader.getResource(resNode));
+    }
+
     private static void assertNonPreviewVersion(ImageClassLoader loader, String module, String fqn) throws IOException {
         assertEquals("Class: " + fqn, loader.loadAndGetToString(module, fqn));
     }
@@ -441,7 +464,7 @@ public class ImageReaderTest {
 
             classes.forEach(fqn -> {
                 if (fqn.startsWith("!")) {
-                    jar.addEntry(fqn.substring(1), "resource".getBytes(StandardCharsets.UTF_8));
+                    jar.addEntry(fqn.substring(1), fqn.substring(1).getBytes(StandardCharsets.UTF_8));
                     return;
                 }
                 boolean isPreviewEntry = fqn.startsWith("@");

--- a/test/jdk/jdk/internal/jimage/ImageReaderTest.java
+++ b/test/jdk/jdk/internal/jimage/ImageReaderTest.java
@@ -318,6 +318,7 @@ public class ImageReaderTest {
             assertPreviewResourceVersion(reader, "modfoo", "fileA.txt");
             assertNode(reader, "/modules/modfoo/fileB.txt");
             assertPreviewResourceVersion(reader, "modfoo", "fileB.txt");
+            assertDirContents(reader, "/modules/modfoo/com", "foo");
             assertDirContents(reader, "/modules/modfoo", "META-INF", "module-info.class", "fileA.txt", "fileB.txt", "com");
 
             assertNode(reader, "/modules/modbaz/previewOnly.txt");


### PR DESCRIPTION
`ImageReader` fails to locate preview resources in a module’s top-level directory. A resource stored as
`META-INF/preview/file.txt` should be exposed in preview mode as `file.txt` matching how nested preview resources such as `META-INF/preview/directory/file.txt` are exposed as `directory/file.txt`.

The first problem is that the preview resource lookup path is constructed by concatenating `META-INF/preview` and the requested resource path without an intervening `/`. As a result, looking up `file.txt` in preview mode searches for
`META-INF/previewfile.txt` instead of `META-INF/preview/file.txt`. This affected both `findResourceNode` and `containsResource`.

The second problem is that top-level preview resources are not covered by the package-driven preview pre-scan when the image is opened, since they have no package path and the empty package is intentionally not represented under `/packages`. At lookup time, all preview resources are taken from caches; therefore, top-level preview resources are never returned. This affected `findNode`.

The proposal here is to add the missing slash when forming preview resource names in `ImageReader` and to check for top-level preview resources at lookup time. This allows top-level preview resources to be found and to override their non-preview counterparts when preview mode is enabled.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386842](https://bugs.openjdk.org/browse/JDK-8386842): Preview files in root directory not recognized in system image (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [cb9d6ddc](https://git.openjdk.org/jdk/pull/31609/files/cb9d6ddc7240883bc126d3cac1954a7e157f0b3f)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Xueming Shen](https://openjdk.org/census#sherman) (@xuemingshen-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31609/head:pull/31609` \
`$ git checkout pull/31609`

Update a local copy of the PR: \
`$ git checkout pull/31609` \
`$ git pull https://git.openjdk.org/jdk.git pull/31609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31609`

View PR using the GUI difftool: \
`$ git pr show -t 31609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31609.diff">https://git.openjdk.org/jdk/pull/31609.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31609#issuecomment-4768385372)
</details>
