### PR TITLE
8387017: java/lang/instrument/GetObjectSizeIntrinsicsTest.java fails with Error evaluating expression: invalid boolean value: `null' for expression `vm.opt.VerifyOops'

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -26,7 +26,7 @@
  * @bug 8253525
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -55,7 +55,7 @@
  * @summary Test for fInst.getObjectSize with zero-based compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -84,7 +84,7 @@
  * @summary Test for fInst.getObjectSize without compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -113,7 +113,7 @@
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -146,7 +146,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -179,7 +179,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -212,7 +212,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -245,7 +245,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -279,7 +279,7 @@
  * @requires vm.bits == 64
  * @requires vm.debug
  * @requires os.maxMemory >= 10G
- * @requires !vm.opt.VerifyOops
+ * @requires (vm.opt.VerifyOops == "null" | !vm.opt.VerifyOops)
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest

--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -26,6 +26,7 @@
  * @bug 8253525
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -54,6 +55,7 @@
  * @summary Test for fInst.getObjectSize with zero-based compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -82,6 +84,7 @@
  * @summary Test for fInst.getObjectSize without compressed oops
  * @library /test/lib
  * @requires vm.bits == 64
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -110,6 +113,7 @@
  * @summary Test for fInst.getObjectSize with 32-bit compressed oops
  * @library /test/lib
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -142,6 +146,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -174,6 +179,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -206,6 +212,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -238,6 +245,7 @@
  * @library /test/lib
  * @requires vm.bits == 64
  * @requires vm.debug
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest
@@ -271,6 +279,7 @@
  * @requires vm.bits == 64
  * @requires vm.debug
  * @requires os.maxMemory >= 10G
+ * @requires !vm.opt.VerifyOops
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run build GetObjectSizeIntrinsicsTest


### PR DESCRIPTION
This is a clean backport of JDK-8384251 (#31567) and JDK-8387017 (#31608). Both test fixes need to be backported together, because JDK-8384251 was incomplete.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8387017](https://bugs.openjdk.org/browse/JDK-8387017): java/lang/instrument/GetObjectSizeIntrinsicsTest.java fails with Error evaluating expression: invalid boolean value: `null' for expression `vm.opt.VerifyOops' (**Bug** - P4)
 * [JDK-8384251](https://bugs.openjdk.org/browse/JDK-8384251): Test java/lang/instrument/GetObjectSizeIntrinsicsTest.java crashed: fatal error: Not compilable at tier 1: CodeBuffer overflow (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31611/head:pull/31611` \
`$ git checkout pull/31611`

Update a local copy of the PR: \
`$ git checkout pull/31611` \
`$ git pull https://git.openjdk.org/jdk.git pull/31611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31611`

View PR using the GUI difftool: \
`$ git pr show -t 31611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31611.diff">https://git.openjdk.org/jdk/pull/31611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31611#issuecomment-4776471441)
</details>
