### PR TITLE
8385661: jvmti/vthread/ThreadStateTest/ThreadStateTest.java triggers assert(f.pc() == _chunk->pc()) failed

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1371,16 +1371,10 @@ JvmtiEnvBase::set_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth
       return JVMTI_ERROR_OPAQUE_FRAME;
     }
 
-    if (state->is_virtual() && (thread == nullptr || !thread->is_vthread_mounted())) { // unmounted virtual thread
-      assert(fr.is_heap_frame(), "sanity check");
-      fr = jvf->stack_chunk()->derelativize(fr);
-      jvf->stack_chunk()->force_slow_path();
-      fr.deoptimize(nullptr);
-    } else { // platform thread or mounted virtual thread
-      if (fr.is_heap_frame()) {
-        fr = jvf->stack_chunk()->derelativize(fr);
-        jvf->stack_chunk()->force_slow_path();
-      }
+    if (fr.is_heap_frame()) {
+      assert(state->is_virtual(), "invariant");
+      fr.deoptimize(nullptr, jvf->stack_chunk());
+    } else {
       Deoptimization::deoptimize(thread, fr);
     }
   }

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -387,6 +387,22 @@ void frame::deoptimize(JavaThread* thread) {
 #endif // ASSERT
 }
 
+void frame::deoptimize(JavaThread* thread, stackChunkOop chunk) {
+  assert(is_heap_frame() && _frame_index >= 0, "wrong frame type");
+
+  // Fast path does not expect deopted frames
+  chunk->force_slow_path();
+
+  frame fr = chunk->derelativize(*this);
+  fr.deoptimize(nullptr);
+
+  // Fix chunk pc if deopted frame is the top one
+  bool is_top = fr.sp() == chunk->sp_address();
+  if (is_top) {
+    chunk->set_pc(fr.raw_pc());
+  }
+}
+
 frame frame::java_sender() const {
   RegisterMap map(JavaThread::current(),
                   RegisterMap::UpdateMap::skip,

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -282,6 +282,7 @@ class frame {
 
   // Support for deoptimization
   void deoptimize(JavaThread* thread);
+  void deoptimize(JavaThread* thread, stackChunkOop chunk);
 
   // The frame's original SP, before any extension by an interpreted callee;
   // used for packing debug info into vframeArray objects and vframeArray lookup.


### PR DESCRIPTION
This is the backport of commit [2456994e](https://github.com/openjdk/jdk/commit/2456994e8494831331f7d472a08e6333c0ebd730) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385661](https://bugs.openjdk.org/browse/JDK-8385661): jvmti/vthread/ThreadStateTest/ThreadStateTest.java triggers assert(f.pc() == _chunk-&gt;pc()) failed (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31612/head:pull/31612` \
`$ git checkout pull/31612`

Update a local copy of the PR: \
`$ git checkout pull/31612` \
`$ git pull https://git.openjdk.org/jdk.git pull/31612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31612`

View PR using the GUI difftool: \
`$ git pr show -t 31612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31612.diff">https://git.openjdk.org/jdk/pull/31612.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31612#issuecomment-4770140888)
</details>
