### PR TITLE
8387042: Shenandoah: Build time regression with LBE

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.hpp
@@ -134,8 +134,8 @@ private:
   template <class T>
   inline void arraycopy_update(T* src, size_t count);
 
-  inline void clone_evacuation(oop src);
-  inline void clone_update(oop src);
+  template <bool EVAC>
+  inline void clone_work(oop src);
 
   template <class T, bool HAS_FWD, bool EVAC, bool ENQUEUE>
   inline void arraycopy_work(T* src, size_t count);

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -469,18 +469,10 @@ public:
   virtual void do_oop(narrowOop* p) { do_oop_work(p); }
 };
 
-void ShenandoahBarrierSet::clone_evacuation(oop obj) {
-  assert(_heap->is_evacuation_in_progress(), "only during evacuation");
+template <bool EVAC>
+void ShenandoahBarrierSet::clone_work(oop obj) {
   if (need_bulk_update(cast_from_oop<HeapWord*>(obj))) {
-    ShenandoahUpdateEvacForCloneOopClosure<true> cl;
-    obj->oop_iterate(&cl);
-  }
-}
-
-void ShenandoahBarrierSet::clone_update(oop obj) {
-  assert(_heap->is_update_refs_in_progress(), "only during update-refs");
-  if (need_bulk_update(cast_from_oop<HeapWord*>(obj))) {
-    ShenandoahUpdateEvacForCloneOopClosure<false> cl;
+    ShenandoahUpdateEvacForCloneOopClosure<EVAC> cl;
     obj->oop_iterate(&cl);
   }
 }
@@ -494,9 +486,9 @@ void ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap
   if (gc_state != 0 && ShenandoahCloneBarrier) {
     ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
     if ((gc_state & ShenandoahHeap::EVACUATION) != 0) {
-      bs->clone_evacuation(src);
+      bs->clone_work<true>(src);
     } else if ((gc_state & ShenandoahHeap::UPDATE_REFS) != 0) {
-      bs->clone_update(src);
+      bs->clone_work<false>(src);
     }
   }
 


### PR DESCRIPTION
When working on [JDK-8387026](https://bugs.openjdk.org/browse/JDK-8387026), I realized there is a dis-proportionally large problem that was introduced by LBE. Particularly in this method:

shenandoahBarrierSet.inline.hpp:

```
void ShenandoahBarrierSet::clone_evacuation(oop obj) {
  assert(_heap->is_evacuation_in_progress(), "only during vacuation");
  if (need_bulk_update(cast_from_oop<HeapWord*>(obj))) {
    ShenandoahUpdateEvacForCloneOopClosure<true> cl;
    obj->oop_iterate(&cl);
  }
}
```

Since this is `.inline.hpp`, it is always parsed when included into outside TU. Since `ShenandoahUpdateEvacForCloneOopClosure<true>` is the explicit template instantiation, that instantiation always happens. So every time `access.hpp` is included, we end up template-instantiating this one, over and over again.

All other places in barrier set are templated enough to only be expanded *in the context* of the particular method in translation unit. So the fix is to lean into the same structure. This new `clone*` thing is really a mirror of `arraycopy_work` thing, so I just matched that.

This patch gets the build times back to normal:

```
$ time CONF=linux-x86_64-server-release make clean hotspot

# Current baseline
real	2m26.215s
user	59m24.533s
sys	6m41.064s

# --with-jvm-features=-shenandoahgc
real	1m23.825s
user	30m22.753s
sys	4m38.092s

# This patch
real	1m32.963s
user	34m22.689s
sys	5m16.068s
```

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387042](https://bugs.openjdk.org/browse/JDK-8387042): Shenandoah: Build time regression with LBE (**Enhancement** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31617/head:pull/31617` \
`$ git checkout pull/31617`

Update a local copy of the PR: \
`$ git checkout pull/31617` \
`$ git pull https://git.openjdk.org/jdk.git pull/31617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31617`

View PR using the GUI difftool: \
`$ git pr show -t 31617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31617.diff">https://git.openjdk.org/jdk/pull/31617.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31617#issuecomment-4771332891)
</details>
