### PR TITLE
8387044: test/jdk/javax/script/CommonSetup.sh incorrectly sets isCygwin=true for MSys/MinGW

### DIFF
--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CommonSetup.sh
@@ -52,7 +52,7 @@ case "$OS" in
     OS="Windows"
     FS="\\"
     ;;
-  CYGWIN* | MSYS* | MINGW*)
+  CYGWIN*)
     PS=";"
     OS="Windows"
     FS="\\"

--- a/test/jdk/javax/script/CommonSetup.sh
+++ b/test/jdk/javax/script/CommonSetup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/script/CommonSetup.sh
+++ b/test/jdk/javax/script/CommonSetup.sh
@@ -45,7 +45,7 @@ case "$OS" in
     OS="Windows"
     FS="\\"
     ;;
-  CYGWIN* | MSYS* | MINGW* )
+  CYGWIN* )
     PS=";"
     OS="Windows"
     FS="\\"


### PR DESCRIPTION
Removed duplicate case and incorrect setting of `isCygwin` for MSys/MinGW.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387044](https://bugs.openjdk.org/browse/JDK-8387044): test/jdk/javax/script/CommonSetup.sh incorrectly sets isCygwin=true for MSys/MinGW (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31618/head:pull/31618` \
`$ git checkout pull/31618`

Update a local copy of the PR: \
`$ git checkout pull/31618` \
`$ git pull https://git.openjdk.org/jdk.git pull/31618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31618`

View PR using the GUI difftool: \
`$ git pr show -t 31618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31618.diff">https://git.openjdk.org/jdk/pull/31618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31618#issuecomment-4771536820)
</details>
