### PR TITLE
8385978: Test javax/net/ssl/SSLSession/TestEnabledProtocols.java failed: java.security.cert.CertificateException: Unable to initialize, java.io.IOException: Too short

### DIFF
--- a/src/java.base/share/classes/java/security/PEM.java
+++ b/src/java.base/share/classes/java/security/PEM.java
@@ -32,6 +32,7 @@ import sun.security.util.KeyUtil;
 import sun.security.util.Pem;
 
 import java.io.InputStream;
+import java.lang.ref.Reference;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Objects;
@@ -201,7 +202,11 @@ public final class PEM implements BinaryEncodable {
      * @since 27
      */
     public byte[] content() {
-        return content.clone();
+        try {
+            return content.clone();
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     /**
@@ -212,7 +217,11 @@ public final class PEM implements BinaryEncodable {
      * @throws IllegalArgumentException if decoding fails
      */
     public byte[] decode() {
-        return Base64.getMimeDecoder().decode(content);
+        try {
+            return Base64.getMimeDecoder().decode(content);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     /**
@@ -223,15 +232,23 @@ public final class PEM implements BinaryEncodable {
      */
     @Override
     public String toString() {
-        return new String(Pem.pemEncoded(type, content),
-            StandardCharsets.ISO_8859_1);
+        try {
+            return new String(Pem.pemEncoded(type, content),
+                StandardCharsets.ISO_8859_1);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     /*
      * Returns the PEM string representation as a byte array.
      */
     byte[] toTextualByteArray() {
-        return Pem.pemEncoded(type, content);
+        try {
+            return Pem.pemEncoded(type, content);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     // Clear internal content


### PR DESCRIPTION
I need a review for the backport of this intermittent test failures ([31564](https://github.com/openjdk/jdk/pull/31564)). There is a reachability fence issue with PEM.java when accessing the content.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385978](https://bugs.openjdk.org/browse/JDK-8385978): Test javax/net/ssl/SSLSession/TestEnabledProtocols.java failed: java.security.cert.CertificateException: Unable to initialize, java.io.IOException: Too short (**Bug** - P3)


### Reviewers
 * [Artur Barashev](https://openjdk.org/census#abarashev) (@artur-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31619/head:pull/31619` \
`$ git checkout pull/31619`

Update a local copy of the PR: \
`$ git checkout pull/31619` \
`$ git pull https://git.openjdk.org/jdk.git pull/31619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31619`

View PR using the GUI difftool: \
`$ git pr show -t 31619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31619.diff">https://git.openjdk.org/jdk/pull/31619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31619#issuecomment-4771624091)
</details>
