### PR TITLE
8387041: Add a URL link to BCP 47 in the Locale class

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -80,7 +80,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * user's native country, region, or culture.
  *
  * <p>The {@code Locale} class implements
- * <a href="https://www.rfc-editor.org/info/bcp47">IETF BCP 47</a> which is composed of
+ * <a href="https://www.rfc-editor.org/info/bcp47">IETF BCP 47</a> which contains
  * <a href="https://www.rfc-editor.org/info/rfc4647">RFC 4647 "Matching of Language
  * Tags"</a> and <a href="https://www.rfc-editor.org/info/rfc5646">RFC 5646 "Tags
  * for Identifying Languages"</a> with support for the LDML (UTS#35, "Unicode
@@ -223,8 +223,10 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  * <h3><a id="def_locale_extension">Unicode BCP 47 U Extension</a></h3>
  *
- * <p>UTS#35, "Unicode Locale Data Markup Language" defines optional
- * attributes and keywords to override or refine the default behavior
+ * <p>UTS#35, "Unicode Locale Data Markup Language" defines the
+ * <a href="https://www.unicode.org/reports/tr35/#u_Extension">Unicode BCP 47 U Extension</a>,
+ * an extension based on <a href="https://www.rfc-editor.org/info/rfc6067">RFC 6067</a>,
+ * which describes optional attributes and keywords to override or refine the default behavior
  * associated with a locale.  A keyword is represented by a pair of
  * key and type.  For example, "nu-thai" indicates that Thai local
  * digits (value:"thai") should be used for formatting numbers

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -79,9 +79,10 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * the number should be formatted according to the customs and conventions of the
  * user's native country, region, or culture.
  *
- * <p>The {@code Locale} class implements IETF BCP 47 which is composed of
- * <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 "Matching of Language
- * Tags"</a> and <a href="https://tools.ietf.org/html/rfc5646">RFC 5646 "Tags
+ * <p>The {@code Locale} class implements
+ * <a href="https://www.rfc-editor.org/info/bcp47">IETF BCP 47</a> which is composed of
+ * <a href="https://www.rfc-editor.org/info/rfc4647">RFC 4647 "Matching of Language
+ * Tags"</a> and <a href="https://www.rfc-editor.org/info/rfc5646">RFC 5646 "Tags
  * for Identifying Languages"</a> with support for the LDML (UTS#35, "Unicode
  * Locale Data Markup Language") BCP 47-compatible extensions for locale data
  * exchange. Each {@code Locale} is associated with locale data which is provided
@@ -101,7 +102,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * <p>
  * {@code Locale} implements IETF BCP 47 and any deviations should be observed
  * by the comments prefixed by <em>"BCP 47 deviation:"</em>.
- * <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>
+ * <a href="https://www.rfc-editor.org/info/rfc5646">RFC 5646</a>
  * combines subtags from various ISO (639, 3166, 15924) standards which are also
  * included in the composition of {@code Locale}.
  * Additionally, the full list of valid codes for each field can be found in the
@@ -120,7 +121,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  *   <dd> <em>Syntax:</em> Well-formed {@code language} values have the form {@code [a-zA-Z]{2,8}}.</dd>
  *   <dd> <em> BCP 47 deviation:</em> this is not the full BCP 47 language production, since it excludes
- *   <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.2">extlang</a>
+ *   <a href="https://www.rfc-editor.org/rfc/rfc5646#section-2.2.2">extlang</a>
  *   (as modern three-letter language codes are preferred).</dd>
  *
  *   <dd> <em>Example:</em> "en" (English), "ja" (Japanese), "kok" (Konkani)</dd>
@@ -208,7 +209,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * </dl>
  *
  * <b>BCP 47 deviation:</b> BCP47 defines the following two levels of
- * <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.9">conformance</a>,
+ * <a href="https://www.rfc-editor.org/rfc/rfc5646#section-2.2.9">conformance</a>,
  * "valid" and "well-formed". A valid tag requires that it is well-formed, its
  * subtag values are registered in the IANA Language Subtag Registry, and it does not
  * contain duplicate variant or extension singleton subtags. The {@code Locale}
@@ -410,7 +411,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * with "locale" in the following locale matching documentation.
  *
  * <p>In order to match a user's preferred locales to a set of language
- * tags, <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
+ * tags, <a href="https://www.rfc-editor.org/info/rfc4647">RFC 4647 Matching of
  * Language Tags</a> defines two mechanisms: filtering and lookup.
  * <em>Filtering</em> is used to get all matching locales, whereas
  * <em>lookup</em> is to select the best matching locale.
@@ -546,6 +547,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * this mapping, so that resources can be named using either convention,
  * see {@link ResourceBundle.Control}.
  *
+ * @spec https://www.rfc-editor.org/info/bcp47
+ *      IETF BCP 47
  * @spec https://www.rfc-editor.org/info/rfc4647
  *      RFC 4647: Matching of Language Tags
  * @spec https://www.rfc-editor.org/info/rfc5646
@@ -2985,7 +2988,7 @@ public final class Locale implements Cloneable, Serializable {
 
     /**
      * This enum provides constants to select a filtering mode for locale
-     * matching. Refer to <a href="https://tools.ietf.org/html/rfc4647">RFC 4647
+     * matching. Refer to <a href="https://www.rfc-editor.org/info/rfc4647">RFC 4647
      * Matching of Language Tags</a> for details.
      *
      * <p>As an example, think of two Language Priority Lists each of which
@@ -3122,7 +3125,7 @@ public final class Locale implements Cloneable, Serializable {
 
     /**
      * This class expresses a <em>Language Range</em> defined in
-     * <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
+     * <a href="https://www.rfc-editor.org/info/rfc4647">RFC 4647 Matching of
      * Language Tags</a>. A language range is an identifier which is used to
      * select language tag(s) meeting specific requirements by using the
      * mechanisms described in {@linkplain Locale##LocaleMatching Locale


### PR DESCRIPTION
Adds a URL link to the “BCP 47” reference in the Locale class description. Also normalizes the existing RFC 4647 and RFC 5646 links to use rfc-editor.org URLs

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387041](https://bugs.openjdk.org/browse/JDK-8387041): Add a URL link to BCP 47 in the Locale class (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) Review applies to [be1326c3](https://git.openjdk.org/jdk/pull/31621/files/be1326c3a14f2c15d3fbfea6f339d58f5ace396e)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31621/head:pull/31621` \
`$ git checkout pull/31621`

Update a local copy of the PR: \
`$ git checkout pull/31621` \
`$ git pull https://git.openjdk.org/jdk.git pull/31621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31621`

View PR using the GUI difftool: \
`$ git pr show -t 31621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31621.diff">https://git.openjdk.org/jdk/pull/31621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31621#issuecomment-4772775648)
</details>
