### PR TITLE
8386865: Fix links in JDK 27 JavaDoc API documentation

### DIFF
--- a/src/java.base/share/classes/java/util/spi/LocaleNameProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleNameProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public abstract class LocaleNameProvider extends LocaleServiceProvider {
     }
 
     /**
-     * Returns a localized name for the given <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+     * Returns a localized name for the given <a href="https://www.rfc-editor.org/info/bcp47/">
      * IETF BCP47</a> language code and the given locale that is appropriate for
      * display to the user.
      * For example, if {@code languageCode} is "fr" and {@code locale}
@@ -70,7 +70,7 @@ public abstract class LocaleNameProvider extends LocaleServiceProvider {
     public abstract String getDisplayLanguage(String languageCode, Locale locale);
 
     /**
-     * Returns a localized name for the given <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+     * Returns a localized name for the given <a href="https://www.rfc-editor.org/info/bcp47/">
      * IETF BCP47</a> script code and the given locale that is appropriate for
      * display to the user.
      * For example, if {@code scriptCode} is "Latn" and {@code locale}
@@ -100,7 +100,7 @@ public abstract class LocaleNameProvider extends LocaleServiceProvider {
     }
 
     /**
-     * Returns a localized name for the given <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+     * Returns a localized name for the given <a href="https://www.rfc-editor.org/info/bcp47/">
      * IETF BCP47</a> region code (either ISO 3166 country code or UN M.49 area
      * codes) and the given locale that is appropriate for display to the user.
      * For example, if {@code countryCode} is "FR" and {@code locale}

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ public class LocaleNameProviderImpl extends LocaleNameProvider implements Availa
     }
 
     /**
-     * Returns a localized name for the given <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+     * Returns a localized name for the given <a href="https://www.rfc-editor.org/info/bcp47/">
      * IETF BCP47</a> script code and the given locale that is appropriate for
      * display to the user.
      * For example, if <code>scriptCode</code> is "Latn" and <code>locale</code>


### PR DESCRIPTION
Please review this backport of a doc-only fix to JDK 27.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386865](https://bugs.openjdk.org/browse/JDK-8386865): Fix links in JDK 27 JavaDoc API documentation (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31624/head:pull/31624` \
`$ git checkout pull/31624`

Update a local copy of the PR: \
`$ git checkout pull/31624` \
`$ git pull https://git.openjdk.org/jdk.git pull/31624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31624`

View PR using the GUI difftool: \
`$ git pr show -t 31624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31624.diff">https://git.openjdk.org/jdk/pull/31624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31624#issuecomment-4776298739)
</details>
