### PR TITLE
8386163: C2 Vector API: assert(collect_unique_inputs(n, inputs) == 1) failed: not unary

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2721,13 +2721,10 @@ static uint collect_unique_inputs(Node* n, Unique_Node_List& inputs) {
   if (is_vector_bitwise_op(n)) {
     uint inp_cnt = n->is_predicated_vector() ? n->req()-1 : n->req();
     if (VectorNode::is_vector_bitwise_not_pattern(n)) {
-      for (uint i = 1; i < inp_cnt; i++) {
-        Node* in = n->in(i);
-        bool skip = VectorNode::is_all_ones_vector(in);
-        if (!skip && !inputs.member(in)) {
-          inputs.push(in);
-          cnt++;
-        }
+      Node* opnd = VectorNode::is_all_ones_vector(n->in(1)) ? n->in(2) : n->in(1);
+      if (!inputs.member(opnd)) {
+        inputs.push(opnd);
+        cnt++;
       }
       assert(cnt <= 1, "not unary");
     } else {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2721,6 +2721,7 @@ static uint collect_unique_inputs(Node* n, Unique_Node_List& inputs) {
   if (is_vector_bitwise_op(n)) {
     uint inp_cnt = n->is_predicated_vector() ? n->req()-1 : n->req();
     if (VectorNode::is_vector_bitwise_not_pattern(n)) {
+      assert(n->req() == (n->is_predicated_vector() ? 4 : 3), "must have 2 data inputs");
       Node* opnd = VectorNode::is_all_ones_vector(n->in(1)) ? n->in(2) : n->in(1);
       if (!inputs.member(opnd)) {
         inputs.push(opnd);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedNotAllOnes.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedNotAllOnes.java
@@ -36,6 +36,7 @@ import compiler.lib.ir_framework.*;
 import compiler.lib.verify.Verify;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
 public class TestMaskedNotAllOnes {
@@ -57,10 +58,27 @@ public class TestMaskedNotAllOnes {
         return out;
     }
 
-    static final int[] GOLD = testMaskedDivNegOne();
+    static final int[] GOLD_DIV = testMaskedDivNegOne();
 
     @Check(test = "testMaskedDivNegOne")
     static void checkMaskedDivNegOne(int[] out) {
-        Verify.checkEQ(GOLD, out);
+        Verify.checkEQ(GOLD_DIV, out);
+    }
+
+    @Test
+    @Warmup(10000)
+    static int[] testMaskedNotAllOnesVector() {
+        IntVector allOnes = IntVector.broadcast(ISP, -1);
+        VectorMask<Integer> mask = VectorMask.fromLong(ISP, -1L);
+        int[] out = new int[ISP.length()];
+        allOnes.lanewise(VectorOperators.NOT, mask).intoArray(out, 0);
+        return out;
+    }
+
+    static final int[] GOLD_NOT = testMaskedNotAllOnesVector();
+
+    @Check(test = "testMaskedNotAllOnesVector")
+    static void checkMaskedNotAllOnesVector(int[] out) {
+        Verify.checkEQ(GOLD_NOT, out);
     }
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedNotAllOnes.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedNotAllOnes.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8386163
+ * @summary Checks there is no assertion failure with macro logic optimization when both inputs of not patterns are all one vectors
+ * @modules jdk.incubator.vector
+ * @library /test/lib /
+ * @run driver compiler.vectorapi.TestMaskedNotAllOnes
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.verify.Verify;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+public class TestMaskedNotAllOnes {
+
+    private static final VectorSpecies<Integer> ISP = IntVector.SPECIES_PREFERRED;
+    private static final int VALUE = 1234567;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    @Test
+    @Warmup(10000)
+    static int[] testMaskedDivNegOne() {
+        IntVector v = IntVector.broadcast(ISP, VALUE);
+        VectorMask<Integer> mask = VectorMask.fromLong(ISP, -1L);
+        int[] out = new int[ISP.length()];
+        v.div(-1, mask).intoArray(out, 0);
+        return out;
+    }
+
+    static final Object GOLD = testMaskedDivNegOne();
+
+    @Check(test = "testMaskedDivNegOne")
+    static void checkMaskedDivNegOne(int[] out) {
+        Verify.checkEQ(GOLD, out);
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedNotAllOnes.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedNotAllOnes.java
@@ -27,7 +27,7 @@
  * @summary Checks there is no assertion failure with macro logic optimization when both inputs of not patterns are all one vectors
  * @modules jdk.incubator.vector
  * @library /test/lib /
- * @run driver compiler.vectorapi.TestMaskedNotAllOnes
+ * @run driver ${test.main.class}
  */
 
 package compiler.vectorapi;
@@ -57,7 +57,7 @@ public class TestMaskedNotAllOnes {
         return out;
     }
 
-    static final Object GOLD = testMaskedDivNegOne();
+    static final int[] GOLD = testMaskedDivNegOne();
 
     @Check(test = "testMaskedDivNegOne")
     static void checkMaskedDivNegOne(int[] out) {


### PR DESCRIPTION
This patch fixes an assertion failure seen in macro logic optimization caused by `collect_unique_inputs` mishandling of the bitwise-not pattern `XorV(operand, -1)` when the negated operand was itself an all-ones vector, i.e. `XorV(-1, -1)`. It skipped all all-ones operands, collecting zero inputs instead of one, which tripped an assertion failure. The fix makes input collection select the single negated operand, so exactly one input is collected.

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386163](https://bugs.openjdk.org/browse/JDK-8386163): C2 Vector API: assert(collect_unique_inputs(n, inputs) == 1) failed: not unary (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31626/head:pull/31626` \
`$ git checkout pull/31626`

Update a local copy of the PR: \
`$ git checkout pull/31626` \
`$ git pull https://git.openjdk.org/jdk.git pull/31626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31626`

View PR using the GUI difftool: \
`$ git pr show -t 31626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31626.diff">https://git.openjdk.org/jdk/pull/31626.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31626#issuecomment-4777179804)
</details>
