### PR TITLE
8387083: G1: Remove redundant NMT tagging from G1RegionToSpaceMapper

### DIFF
--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -28,7 +28,6 @@
 #include "gc/shared/gc_globals.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/reservedSpace.hpp"
-#include "nmt/memTracker.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
@@ -46,8 +45,6 @@ G1RegionToSpaceMapper::G1RegionToSpaceMapper(ReservedSpace rs,
   _memory_tag(mem_tag) {
   guarantee(is_power_of_2(page_size), "must be");
   guarantee(is_power_of_2(region_granularity), "must be");
-
-  MemTracker::record_virtual_memory_tag(rs, mem_tag);
 }
 
 // Used to manually signal a mapper to handle a set of regions as committed.


### PR DESCRIPTION
This removes the explicit `MemTracker::record_virtual_memory_tag(rs, mem_tag)` call from `G1RegionToSpaceMapper`.

The `ReservedSpace` objects passed to the mapper already come from reservation paths that record the reservation with the requested `MemTag`, so the extra tag update is redundant.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387083](https://bugs.openjdk.org/browse/JDK-8387083): G1: Remove redundant NMT tagging from G1RegionToSpaceMapper (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31628/head:pull/31628` \
`$ git checkout pull/31628`

Update a local copy of the PR: \
`$ git checkout pull/31628` \
`$ git pull https://git.openjdk.org/jdk.git pull/31628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31628`

View PR using the GUI difftool: \
`$ git pr show -t 31628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31628.diff">https://git.openjdk.org/jdk/pull/31628.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31628#issuecomment-4777855056)
</details>
