### PR TITLE
8387074: Remove duplicate handling of sparc in platform.m4

### DIFF
--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -174,18 +174,6 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_CPU],
       VAR_CPU_BITS=64
       VAR_CPU_ENDIAN=big
       ;;
-    sparc)
-      VAR_CPU=sparc
-      VAR_CPU_ARCH=sparc
-      VAR_CPU_BITS=32
-      VAR_CPU_ENDIAN=big
-      ;;
-    sparcv9|sparc64)
-      VAR_CPU=sparcv9
-      VAR_CPU_ARCH=sparc
-      VAR_CPU_BITS=64
-      VAR_CPU_ENDIAN=big
-      ;;
     *)
       AC_MSG_ERROR([unsupported cpu $1])
       ;;


### PR DESCRIPTION
In platform.m4 we have duplicate handing of sparc CPUs, this can be removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387074](https://bugs.openjdk.org/browse/JDK-8387074): Remove duplicate handling of sparc in platform.m4 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31630/head:pull/31630` \
`$ git checkout pull/31630`

Update a local copy of the PR: \
`$ git checkout pull/31630` \
`$ git pull https://git.openjdk.org/jdk.git pull/31630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31630`

View PR using the GUI difftool: \
`$ git pr show -t 31630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31630.diff">https://git.openjdk.org/jdk/pull/31630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31630#issuecomment-4778925729)
</details>
