### PR TITLE
8387142: BUILD_LIBMANAGEMENT_EXT remove special warning settings

### DIFF
--- a/make/modules/jdk.management/Lib.gmk
+++ b/make/modules/jdk.management/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,6 @@ endif
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT_EXT, \
     NAME := management_ext, \
     OPTIMIZATION := HIGH, \
-    DISABLED_WARNINGS_gcc_DiagnosticCommandImpl.c := unused-variable, \
-    DISABLED_WARNINGS_clang_DiagnosticCommandImpl.c := unused-variable, \
     DISABLED_WARNINGS_clang_UnixOperatingSystem.c := format-nonliteral, \
     CFLAGS := $(LIBMANAGEMENT_EXT_CFLAGS), \
     JDK_LIBS := java.base:libjava java.base:libjvm, \

--- a/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +151,7 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
   jobjectArray args;
   jobject obj;
   jmmOptionalSupport mos;
-  jint ret = jmm_interface_management_ext->GetOptionalSupport(env, &mos);
+  jmm_interface_management_ext->GetOptionalSupport(env, &mos);
   jsize num_commands;
   dcmdInfo* dcmd_info_array;
   jstring jname, jdesc, jimpact, cmd;


### PR DESCRIPTION
BUILD_LIBMANAGEMENT_EXT disables some warnings; this should be removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387142](https://bugs.openjdk.org/browse/JDK-8387142): BUILD_LIBMANAGEMENT_EXT remove special warning settings (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31636/head:pull/31636` \
`$ git checkout pull/31636`

Update a local copy of the PR: \
`$ git checkout pull/31636` \
`$ git pull https://git.openjdk.org/jdk.git pull/31636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31636`

View PR using the GUI difftool: \
`$ git pr show -t 31636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31636.diff">https://git.openjdk.org/jdk/pull/31636.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31636#issuecomment-4786716510)
</details>
