### PR TITLE
8387148: Linux perf map should record individual vtable trampolines

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -30,6 +30,7 @@
 #include "code/dependencyContext.hpp"
 #include "code/nmethod.hpp"
 #include "code/pcDesc.hpp"
+#include "code/vtableStubs.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
@@ -1971,8 +1972,8 @@ void CodeCache::write_perf_map(const char* filename, outputStream* st) {
   AllCodeBlobsIterator iter(AllCodeBlobsIterator::not_unloading);
   while (iter.next()) {
     CodeBlob *cb = iter.method();
-    if (is_stub_code_blob(cb)) {
-      // Individual stub routines are dumped after the main loop.
+    if (is_stub_code_blob(cb) || cb->is_vtable_blob()) {
+      // Individual stub routines and vtable stubs are dumped after the main loop.
       continue;
     }
     ResourceMark rm;
@@ -1991,6 +1992,13 @@ void CodeCache::write_perf_map(const char* filename, outputStream* st) {
                 (intptr_t)d->begin(), (intptr_t)d->size_in_bytes(),
                 d->group(), d->name());
   }
+  VtableStubs::vtable_stub_do([&](VtableStub* s) {
+    fs.print_cr(INTPTR_FORMAT " " INTPTR_FORMAT " %s [%d]",
+                (intptr_t)s->code_begin(),
+                (intptr_t)s->code_size(),
+                s->is_vtable_stub() ? "vtable stub" : "itable stub",
+                s->index());
+  });
 }
 #endif // LINUX
 

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,15 +318,6 @@ VtableStub* VtableStubs::stub_containing(address pc) {
 void vtableStubs_init() {
   VtableStubs::initialize();
 }
-
-void VtableStubs::vtable_stub_do(void f(VtableStub*)) {
-  for (int i = 0; i < N; i++) {
-    for (VtableStub* s = AtomicAccess::load_acquire(&_table[i]); s != nullptr; s = s->next()) {
-      f(s);
-    }
-  }
-}
-
 
 //-----------------------------------------------------------------------------------------------------
 // Non-product code

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "asm/macroAssembler.hpp"
 #include "code/vmreg.hpp"
 #include "memory/allStatic.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "utilities/checkedCast.hpp"
 
 // A VtableStub holds an individual code stub for a pair (vtable index, #args) for either itables or vtables
@@ -111,7 +112,9 @@ class VtableStubs : AllStatic {
   static bool        contains(address pc);                           // is pc within any stub?
   static VtableStub* stub_containing(address pc);                    // stub containing pc or nullptr
   static void        initialize();
-  static void        vtable_stub_do(void f(VtableStub*));            // iterates over all vtable stubs
+
+  template <typename F>
+  static void vtable_stub_do(F f);
 };
 
 
@@ -142,13 +145,14 @@ class VtableStub {
         : _next(nullptr), _index(index), _ame_offset(-1), _npe_offset(-1),
           _type(is_vtable_stub ? Type::vtable_stub : Type::itable_stub) {}
   VtableStub* next() const                       { return _next; }
-  int index() const                              { return _index; }
   static VMReg receiver_location()               { return _receiver_location; }
   void set_next(VtableStub* n)                   { _next = n; }
 
  public:
+  int index() const                              { return _index; }
+  int code_size() const                          { return VtableStubs::code_size_limit(is_vtable_stub()); }
   address code_begin() const                     { return (address)(this + 1); }
-  address code_end() const                       { return code_begin() + VtableStubs::code_size_limit(is_vtable_stub()); }
+  address code_end() const                       { return code_begin() + code_size(); }
   address entry_point() const                    { return code_begin(); }
   static int entry_offset()                      { return sizeof(class VtableStub); }
 
@@ -188,5 +192,14 @@ class VtableStub {
   void print() const;
 
 };
+
+template <typename F>
+void VtableStubs::vtable_stub_do(F f) {
+  for (int i = 0; i < N; i++) {
+    for (VtableStub* s = AtomicAccess::load_acquire(&_table[i]); s != nullptr; s = s->next()) {
+      f(s);
+    }
+  }
+}
 
 #endif // SHARE_CODE_VTABLESTUBS_HPP

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -83,7 +83,7 @@ public class PerfMapTest {
                 if (m.group(3).contains("StubRoutines call_stub")) {
                     sawCallStub = true;
                 }
-                if (m.group(3).contains("vtable stub [") {
+                if (m.group(3).contains("vtable stub [")) {
                     sawVtableStub = true;
                 }
             }

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -75,6 +75,7 @@ public class PerfMapTest {
 
         // Sanity check the file contents
         boolean sawCallStub = false;
+        boolean sawVtableStub = false;
         try {
             for (String entry : Files.readAllLines(path)) {
                 Matcher m = LINE_PATTERN.matcher(entry);
@@ -82,12 +83,17 @@ public class PerfMapTest {
                 if (m.group(3).contains("StubRoutines call_stub")) {
                     sawCallStub = true;
                 }
+                if (m.group(3).contains("vtable stub [") {
+                    sawVtableStub = true;
+                }
             }
         } catch (IOException e) {
             Assert.fail(e.toString());
         }
         Assert.assertTrue(sawCallStub,
                           "Expected StubRoutines call_stub entry in " + path);
+        Assert.assertTrue(sawVtableStub,
+                          "Expected vtable stub entry in " + path);
     }
 
     @Test


### PR DESCRIPTION
The Linux JIT perf map now lists ranges for individual vtable trampolines.

Example perf map output snippet before:
```
0x00007b6b8fc03ce0 0x0000000000000608 vtable chunks 
```

Example perf map output snippet after:
```
0x00007f6fa05726c0 0x000000000000001f vtable stub [39]
0x00007f6fa0572960 0x000000000000001f vtable stub [28]
0x00007f6fa0572990 0x000000000000001f vtable stub [30]
0x00007f6fa05729f0 0x000000000000001f vtable stub [14]
0x00007f6fa0572630 0x000000000000001f vtable stub [8]
0x00007f6fa0572690 0x000000000000001f vtable stub [9]
0x00007f6fa0572480 0x000000000000001f vtable stub [10]
0x00007f6fa05726f0 0x000000000000001f vtable stub [5]
0x00007f6fa0572660 0x000000000000001f vtable stub [6]
0x00007f6fa05729c0 0x000000000000001f vtable stub [7]
0x00007f6fa0572450 0x000000000000001f vtable stub [1]
0x00007f6fa0572170 0x000000000000001f vtable stub [3]
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387148](https://bugs.openjdk.org/browse/JDK-8387148): Linux perf map should record individual vtable trampolines (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.org/census#ysuenaga) (@YaSuenag - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31638/head:pull/31638` \
`$ git checkout pull/31638`

Update a local copy of the PR: \
`$ git checkout pull/31638` \
`$ git pull https://git.openjdk.org/jdk.git pull/31638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31638`

View PR using the GUI difftool: \
`$ git pr show -t 31638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31638.diff">https://git.openjdk.org/jdk/pull/31638.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31638#issuecomment-4781558679)
</details>
