### PR TITLE
8386891: AArch64: Implement getAndAddB*, getAndAddS*, getAndSetB*, getAndSetS*

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2014, 2024, Red Hat, Inc. All rights reserved.
-// Copyright 2025 Arm Limited and/or its affiliates.
+// Copyright 2025, 2026 Arm Limited and/or its affiliates.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -1510,10 +1510,14 @@ source %{
     case Op_CompareAndSwapN:
     case Op_CompareAndSwapB:
     case Op_CompareAndSwapS:
+    case Op_GetAndSetB:
+    case Op_GetAndSetS:
     case Op_GetAndSetI:
     case Op_GetAndSetL:
     case Op_GetAndSetP:
     case Op_GetAndSetN:
+    case Op_GetAndAddB:
+    case Op_GetAndAddS:
     case Op_GetAndAddI:
     case Op_GetAndAddL:
       return true;
@@ -4368,6 +4372,17 @@ operand immHDupV()
 operand immBAddSubV()
 %{
   predicate(n->get_int() <= 255 && n->get_int() >= -255);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+// 16 bit integer valid for add sub immediate
+operand immSAddSub()
+%{
+  predicate(n->get_int() <= 4095 && n->get_int() >= -4095);
   match(ConI);
 
   op_cost(0);

--- a/src/hotspot/cpu/aarch64/aarch64_atomic.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic.ad
@@ -1,5 +1,6 @@
 // Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2016, 2021, Red Hat Inc. All rights reserved.
+// Copyright 2026 Arm Limited and/or its affiliates.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -650,6 +651,28 @@ instruct weakCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP
   ins_pipe(pipe_slow);
 %}
 
+instruct getAndSetB(indirect mem, iRegI newval, iRegINoSp oldval) %{
+  match(Set oldval (GetAndSetB mem newval));
+  ins_cost(2*VOLATILE_REF_COST);
+  format %{ "atomic_xchgb  $oldval, $newval, [$mem]" %}
+  ins_encode %{
+    __ atomic_xchgb($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+    __ sxtbw($oldval$$Register, $oldval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndSetS(indirect mem, iRegI newval, iRegINoSp oldval) %{
+  match(Set oldval (GetAndSetS mem newval));
+  ins_cost(2*VOLATILE_REF_COST);
+  format %{ "atomic_xchgh  $oldval, $newval, [$mem]" %}
+  ins_encode %{
+    __ atomic_xchgh($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+    __ sxthw($oldval$$Register, $oldval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
 instruct getAndSetI(indirect mem, iRegI newval, iRegINoSp oldval) %{
   match(Set oldval (GetAndSetI mem newval));
   ins_cost(2*VOLATILE_REF_COST);
@@ -688,6 +711,30 @@ instruct getAndSetP(indirect mem, iRegP newval, iRegPNoSp oldval) %{
   format %{ "atomic_xchg  $oldval, $newval, [$mem]" %}
   ins_encode %{
     __ atomic_xchg($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndSetBAcq(indirect mem, iRegI newval, iRegINoSp oldval) %{
+  predicate(needs_acquiring_load_exclusive(n));
+  match(Set oldval (GetAndSetB mem newval));
+  ins_cost(VOLATILE_REF_COST);
+  format %{ "atomic_xchgb_acq  $oldval, $newval, [$mem]" %}
+  ins_encode %{
+    __ atomic_xchgalb($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+    __ sxtbw($oldval$$Register, $oldval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndSetSAcq(indirect mem, iRegI newval, iRegINoSp oldval) %{
+  predicate(needs_acquiring_load_exclusive(n));
+  match(Set oldval (GetAndSetS mem newval));
+  ins_cost(VOLATILE_REF_COST);
+  format %{ "atomic_xchgh_acq  $oldval, $newval, [$mem]" %}
+  ins_encode %{
+    __ atomic_xchgalh($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+    __ sxthw($oldval$$Register, $oldval$$Register);
   %}
   ins_pipe(pipe_serial);
 %}
@@ -732,6 +779,186 @@ instruct getAndSetPAcq(indirect mem, iRegP newval, iRegPNoSp oldval) %{
   format %{ "atomic_xchg_acq  $oldval, $newval, [$mem]" %}
   ins_encode %{
     __ atomic_xchgal($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddB(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
+  match(Set newval (GetAndAddB mem incr));
+  ins_cost(2*VOLATILE_REF_COST+1);
+  format %{ "get_and_addB $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addb($newval$$Register, $incr$$Register, as_Register($mem$$base));
+    __ sxtbw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBAcq(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
+  predicate(needs_acquiring_load_exclusive(n));
+  match(Set newval (GetAndAddB mem incr));
+  ins_cost(VOLATILE_REF_COST+1);
+  format %{ "get_and_addB_acq $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalb($newval$$Register, $incr$$Register, as_Register($mem$$base));
+    __ sxtbw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBNoRes(indirect mem, Universe dummy, iRegIorL2I incr) %{
+  predicate(n->as_LoadStore()->result_not_used());
+  match(Set dummy (GetAndAddB mem incr));
+  ins_cost(2*VOLATILE_REF_COST);
+  format %{ "get_and_addB noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addb(noreg, $incr$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBAcqNoRes(indirect mem, Universe dummy, iRegIorL2I incr) %{
+  predicate(n->as_LoadStore()->result_not_used() && needs_acquiring_load_exclusive(n));
+  match(Set dummy (GetAndAddB mem incr));
+  ins_cost(VOLATILE_REF_COST);
+  format %{ "get_and_addB_acq noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalb(noreg, $incr$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBConst(indirect mem, iRegINoSp newval, immI8 incr) %{
+  match(Set newval (GetAndAddB mem incr));
+  ins_cost(2*VOLATILE_REF_COST+1);
+  format %{ "get_and_addB $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addb($newval$$Register, $incr$$constant, as_Register($mem$$base));
+    __ sxtbw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBAcqConst(indirect mem, iRegINoSp newval, immI8 incr) %{
+  predicate(needs_acquiring_load_exclusive(n));
+  match(Set newval (GetAndAddB mem incr));
+  ins_cost(VOLATILE_REF_COST+1);
+  format %{ "get_and_addB_acq $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalb($newval$$Register, $incr$$constant, as_Register($mem$$base));
+    __ sxtbw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBNoResConst(indirect mem, Universe dummy, immI8 incr) %{
+  predicate(n->as_LoadStore()->result_not_used());
+  match(Set dummy (GetAndAddB mem incr));
+  ins_cost(2*VOLATILE_REF_COST);
+  format %{ "get_and_addB noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addb(noreg, $incr$$constant, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddBAcqNoResConst(indirect mem, Universe dummy, immI8 incr) %{
+  predicate(n->as_LoadStore()->result_not_used() && needs_acquiring_load_exclusive(n));
+  match(Set dummy (GetAndAddB mem incr));
+  ins_cost(VOLATILE_REF_COST);
+  format %{ "get_and_addB_acq noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalb(noreg, $incr$$constant, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddS(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
+  match(Set newval (GetAndAddS mem incr));
+  ins_cost(2*VOLATILE_REF_COST+1);
+  format %{ "get_and_addS $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addh($newval$$Register, $incr$$Register, as_Register($mem$$base));
+    __ sxthw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSAcq(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
+  predicate(needs_acquiring_load_exclusive(n));
+  match(Set newval (GetAndAddS mem incr));
+  ins_cost(VOLATILE_REF_COST+1);
+  format %{ "get_and_addS_acq $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalh($newval$$Register, $incr$$Register, as_Register($mem$$base));
+    __ sxthw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSNoRes(indirect mem, Universe dummy, iRegIorL2I incr) %{
+  predicate(n->as_LoadStore()->result_not_used());
+  match(Set dummy (GetAndAddS mem incr));
+  ins_cost(2*VOLATILE_REF_COST);
+  format %{ "get_and_addS noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addh(noreg, $incr$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSAcqNoRes(indirect mem, Universe dummy, iRegIorL2I incr) %{
+  predicate(n->as_LoadStore()->result_not_used() && needs_acquiring_load_exclusive(n));
+  match(Set dummy (GetAndAddS mem incr));
+  ins_cost(VOLATILE_REF_COST);
+  format %{ "get_and_addS_acq noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalh(noreg, $incr$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSConst(indirect mem, iRegINoSp newval, immSAddSub incr) %{
+  match(Set newval (GetAndAddS mem incr));
+  ins_cost(2*VOLATILE_REF_COST+1);
+  format %{ "get_and_addS $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addh($newval$$Register, $incr$$constant, as_Register($mem$$base));
+    __ sxthw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSAcqConst(indirect mem, iRegINoSp newval, immSAddSub incr) %{
+  predicate(needs_acquiring_load_exclusive(n));
+  match(Set newval (GetAndAddS mem incr));
+  ins_cost(VOLATILE_REF_COST+1);
+  format %{ "get_and_addS_acq $newval, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalh($newval$$Register, $incr$$constant, as_Register($mem$$base));
+    __ sxthw($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSNoResConst(indirect mem, Universe dummy, immSAddSub incr) %{
+  predicate(n->as_LoadStore()->result_not_used());
+  match(Set dummy (GetAndAddS mem incr));
+  ins_cost(2*VOLATILE_REF_COST);
+  format %{ "get_and_addS noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addh(noreg, $incr$$constant, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}
+
+instruct getAndAddSAcqNoResConst(indirect mem, Universe dummy, immSAddSub incr) %{
+  predicate(n->as_LoadStore()->result_not_used() && needs_acquiring_load_exclusive(n));
+  match(Set dummy (GetAndAddS mem incr));
+  ins_cost(VOLATILE_REF_COST);
+  format %{ "get_and_addS_acq noreg, [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_addalh(noreg, $incr$$constant, as_Register($mem$$base));
   %}
   ins_pipe(pipe_serial);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
@@ -1,5 +1,6 @@
 // Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2016, 2021, Red Hat Inc. All rights reserved.
+// Copyright 2026 Arm Limited and/or its affiliates.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -179,31 +180,54 @@ dnl ====================== GetAndSet*
 dnl
 define(`GAS_INSN1',
 `
-instruct getAndSet$1$3(indirect mem, iReg$1 newval, iReg$1NoSp oldval) %{
-ifelse($1$3,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
-       $1$3,NAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
+instruct getAndSet$1$4(indirect mem, iReg$2 newval, iReg$2NoSp oldval) %{
+ifelse($1$4,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
+       $1$4,NAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
        $1,P,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
        $1,N,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
-       $3,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
+       $4,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
        `dnl')
   match(Set oldval (GetAndSet$1 mem newval));
-  ins_cost(`'ifelse($3,Acq,,2*)VOLATILE_REF_COST);
-  format %{ "atomic_xchg$2`'ifelse($3,Acq,_acq)  $oldval, $newval, [$mem]" %}
+  ins_cost(`'ifelse($4,Acq,,2*)VOLATILE_REF_COST);
+  format %{ "atomic_xchg$3`'ifelse($4,Acq,_acq)  $oldval, $newval, [$mem]" %}
   ins_encode %{
-    __ atomic_xchg`'ifelse($3,Acq,al)$2($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+    __ atomic_xchg`'ifelse($4,Acq,al)$3($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+    __ $5($oldval$$Register, $oldval$$Register);
   %}
   ins_pipe(pipe_serial);
 %}')dnl
 dnl
-GAS_INSN1(I,    w,  )
-GAS_INSN1(L,    ,   )
-GAS_INSN1(N,    w,  )
-GAS_INSN1(P,    ,   )
+define(`GAS_INSN2',
+`
+instruct getAndSet$1$4(indirect mem, iReg$2 newval, iReg$2NoSp oldval) %{
+ifelse($1$4,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
+       $1$4,NAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
+       $1,P,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
+       $1,N,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
+       $4,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
+       `dnl')
+  match(Set oldval (GetAndSet$1 mem newval));
+  ins_cost(`'ifelse($4,Acq,,2*)VOLATILE_REF_COST);
+  format %{ "atomic_xchg$3`'ifelse($4,Acq,_acq)  $oldval, $newval, [$mem]" %}
+  ins_encode %{
+    __ atomic_xchg`'ifelse($4,Acq,al)$3($oldval$$Register, $newval$$Register, as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_serial);
+%}')dnl
 dnl
-GAS_INSN1(I,    w,  Acq)
-GAS_INSN1(L,    ,   Acq)
-GAS_INSN1(N,    w,  Acq)
-GAS_INSN1(P,    ,   Acq)
+GAS_INSN1(B, I, b,    , sxtbw)
+GAS_INSN1(S, I, h,    , sxthw)
+GAS_INSN2(I, I, w,    )
+GAS_INSN2(L, L,  ,    )
+GAS_INSN2(N, N, w,    )
+GAS_INSN2(P, P,  ,    )
+dnl
+GAS_INSN1(B, I, b, Acq, sxtbw)
+GAS_INSN1(S, I, h, Acq, sxthw)
+GAS_INSN2(I, I, w, Acq)
+GAS_INSN2(L, L,  , Acq)
+GAS_INSN2(N, N, w, Acq)
+GAS_INSN2(P, P,  , Acq)
 dnl
 dnl
 dnl
@@ -211,36 +235,69 @@ dnl ====================== GetAndAdd*
 dnl
 define(`GAA_INSN1',
 `
-instruct getAndAdd$1$4$5$6(indirect mem, `'ifelse($5,NoRes,Universe dummy,iReg$1NoSp newval), `'ifelse($6,Const,imm$1AddSub incr,iReg$2 incr)) %{
-ifelse($4$5,AcqNoRes,INDENT(predicate(n->as_LoadStore()->result_not_used() && needs_acquiring_load_exclusive(n));),
-       $5,NoRes,INDENT(predicate(n->as_LoadStore()->result_not_used());),
-       $4,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
+instruct getAndAdd$1$5$7(indirect mem, iReg$2NoSp newval, `'ifelse($7,Const,imm$3 incr,iReg$3 incr)) %{
+ifelse($5,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
        `dnl')
-  match(Set ifelse($5,NoRes,dummy,newval) (GetAndAdd$1 mem incr));
-  ins_cost(`'ifelse($4,Acq,,2*)VOLATILE_REF_COST`'ifelse($5,NoRes,,+1));
-  format %{ "get_and_add$1`'ifelse($4,Acq,_acq) `'ifelse($5,NoRes,noreg,$newval), [$mem], $incr" %}
+  match(Set newval (GetAndAdd$1 mem incr));
+  ins_cost(`'ifelse($5,Acq,,2*)VOLATILE_REF_COST+1);
+  format %{ "get_and_add$1`'ifelse($5,Acq,_acq) $newval, [$mem], $incr" %}
   ins_encode %{
-    __ atomic_add`'ifelse($4,Acq,al)$3(`'ifelse($5,NoRes,noreg,$newval$$Register), `'ifelse($6,Const,$incr$$constant,$incr$$Register), as_Register($mem$$base));
+    __ atomic_add`'ifelse($5,Acq,al)$4($newval$$Register, `'ifelse($7,Const,$incr$$constant,$incr$$Register), as_Register($mem$$base));
+    __ $6($newval$$Register, $newval$$Register);
+  %}
+  ins_pipe(pipe_serial);
+%}')dnl
+dnl
+define(`GAA_INSN2',
+`
+instruct getAndAdd$1$5$6$7(indirect mem, `'ifelse($6,NoRes,Universe dummy,iReg$2NoSp newval), `'ifelse($7,Const,imm$3 incr,iReg$3 incr)) %{
+ifelse($5$6,AcqNoRes,INDENT(predicate(n->as_LoadStore()->result_not_used() && needs_acquiring_load_exclusive(n));),
+       $6,NoRes,INDENT(predicate(n->as_LoadStore()->result_not_used());),
+       $5,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
+       `dnl')
+  match(Set ifelse($6,NoRes,dummy,newval) (GetAndAdd$1 mem incr));
+  ins_cost(`'ifelse($5,Acq,,2*)VOLATILE_REF_COST`'ifelse($6,NoRes,,+1));
+  format %{ "get_and_add$1`'ifelse($5,Acq,_acq) `'ifelse($6,NoRes,noreg,$newval), [$mem], $incr" %}
+  ins_encode %{
+    __ atomic_add`'ifelse($5,Acq,al)$4(`'ifelse($6,NoRes,noreg,$newval$$Register), `'ifelse($7,Const,$incr$$constant,$incr$$Register), as_Register($mem$$base));
   %}
   ins_pipe(pipe_serial);
 %}')dnl
 dnl
 dnl
-GAA_INSN1(I,    IorL2I,     w,  ,       ,           )
-GAA_INSN1(I,    IorL2I,     w,  Acq,    ,           )
-GAA_INSN1(I,    IorL2I,     w,  ,       NoRes,      )
-GAA_INSN1(I,    IorL2I,     w,  Acq,    NoRes,      )
-GAA_INSN1(I,    I,          w,  ,       ,       Const)
-GAA_INSN1(I,    I,          w,  Acq,    ,       Const)
-GAA_INSN1(I,    I,          w,  ,       NoRes,  Const)
-GAA_INSN1(I,    I,          w,  Acq,    NoRes,  Const)
+GAA_INSN1(B, I, IorL2I,  b,    , sxtbw,      )
+GAA_INSN1(B, I, IorL2I,  b, Acq, sxtbw,      )
+GAA_INSN2(B, I, IorL2I,  b, ,    NoRes,      )
+GAA_INSN2(B, I, IorL2I,  b, Acq, NoRes,      )
+GAA_INSN1(B, I, I8,      b,    , sxtbw, Const)
+GAA_INSN1(B, I, I8,      b, Acq, sxtbw, Const)
+GAA_INSN2(B, I, I8,      b, ,    NoRes, Const)
+GAA_INSN2(B, I, I8,      b, Acq, NoRes, Const)
 dnl
-GAA_INSN1(L,    L,          ,   ,       ,           )
-GAA_INSN1(L,    L,          ,   Acq,    ,           )
-GAA_INSN1(L,    L,          ,   ,       NoRes,      )
-GAA_INSN1(L,    L,          ,   Acq,    NoRes,      )
-GAA_INSN1(L,    L,          ,   ,       ,       Const)
-GAA_INSN1(L,    L,          ,   Acq,    ,       Const)
-GAA_INSN1(L,    L,          ,   ,       NoRes,  Const)
-GAA_INSN1(L,    L,          ,   Acq,    NoRes,  Const)
+GAA_INSN1(S, I, IorL2I,  h,    , sxthw,      )
+GAA_INSN1(S, I, IorL2I,  h, Acq, sxthw,      )
+GAA_INSN2(S, I, IorL2I,  h,    , NoRes,      )
+GAA_INSN2(S, I, IorL2I,  h, Acq, NoRes,      )
+GAA_INSN1(S, I, SAddSub, h,    , sxthw, Const)
+GAA_INSN1(S, I, SAddSub, h, Acq, sxthw, Const)
+GAA_INSN2(S, I, SAddSub, h,    , NoRes, Const)
+GAA_INSN2(S, I, SAddSub, h, Acq, NoRes, Const)
+dnl
+GAA_INSN2(I, I, IorL2I,  w,    ,      ,      )
+GAA_INSN2(I, I, IorL2I,  w, Acq,      ,      )
+GAA_INSN2(I, I, IorL2I,  w,    , NoRes,      )
+GAA_INSN2(I, I, IorL2I,  w, Acq, NoRes,      )
+GAA_INSN2(I, I, IAddSub, w,    ,      , Const)
+GAA_INSN2(I, I, IAddSub, w, Acq,      , Const)
+GAA_INSN2(I, I, IAddSub, w,    , NoRes, Const)
+GAA_INSN2(I, I, IAddSub, w, Acq, NoRes, Const)
+dnl
+GAA_INSN2(L, L, L,        ,    ,      ,      )
+GAA_INSN2(L, L, L,        , Acq,      ,      )
+GAA_INSN2(L, L, L,        ,    , NoRes,      )
+GAA_INSN2(L, L, L,        , Acq, NoRes,      )
+GAA_INSN2(L, L, LAddSub,  ,    ,      , Const)
+GAA_INSN2(L, L, LAddSub,  , Acq,      , Const)
+GAA_INSN2(L, L, LAddSub,  ,    , NoRes, Const)
+GAA_INSN2(L, L, LAddSub,  , Acq, NoRes, Const)
 dnl

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3580,8 +3580,12 @@ void MacroAssembler::atomic_##NAME(Register prev, RegisterOrConstant incr, Regis
 
 ATOMIC_OP(add, ldxr, add, sub, ldadd, stxr, Assembler::xword)
 ATOMIC_OP(addw, ldxrw, addw, subw, ldadd, stxrw, Assembler::word)
+ATOMIC_OP(addh, ldxrh, addw, subw, ldadd, stxrh, Assembler::halfword)
+ATOMIC_OP(addb, ldxrb, addw, subw, ldadd, stxrb, Assembler::byte)
 ATOMIC_OP(addal, ldaxr, add, sub, ldaddal, stlxr, Assembler::xword)
 ATOMIC_OP(addalw, ldaxrw, addw, subw, ldaddal, stlxrw, Assembler::word)
+ATOMIC_OP(addalh, ldaxrh, addw, subw, ldaddal, stlxrh, Assembler::halfword)
+ATOMIC_OP(addalb, ldaxrb, addw, subw, ldaddal, stlxrb, Assembler::byte)
 
 #undef ATOMIC_OP
 
@@ -3608,10 +3612,16 @@ void MacroAssembler::atomic_##OP(Register prev, Register newv, Register addr) { 
 
 ATOMIC_XCHG(xchg, swp, ldxr, stxr, Assembler::xword)
 ATOMIC_XCHG(xchgw, swp, ldxrw, stxrw, Assembler::word)
+ATOMIC_XCHG(xchgh, swp, ldxrh, stxrh, Assembler::halfword)
+ATOMIC_XCHG(xchgb, swp, ldxrb, stxrb, Assembler::byte)
 ATOMIC_XCHG(xchgl, swpl, ldxr, stlxr, Assembler::xword)
 ATOMIC_XCHG(xchglw, swpl, ldxrw, stlxrw, Assembler::word)
+ATOMIC_XCHG(xchglh, swpl, ldxrh, stlxrh, Assembler::halfword)
+ATOMIC_XCHG(xchglb, swpl, ldxrb, stlxrb, Assembler::byte)
 ATOMIC_XCHG(xchgal, swpal, ldaxr, stlxr, Assembler::xword)
 ATOMIC_XCHG(xchgalw, swpal, ldaxrw, stlxrw, Assembler::word)
+ATOMIC_XCHG(xchgalh, swpal, ldaxrh, stlxrh, Assembler::halfword)
+ATOMIC_XCHG(xchgalb, swpal, ldaxrb, stlxrb, Assembler::byte)
 
 #undef ATOMIC_XCHG
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1220,15 +1220,25 @@ public:
 
   void atomic_add(Register prev, RegisterOrConstant incr, Register addr);
   void atomic_addw(Register prev, RegisterOrConstant incr, Register addr);
+  void atomic_addh(Register prev, RegisterOrConstant incr, Register addr);
+  void atomic_addb(Register prev, RegisterOrConstant incr, Register addr);
   void atomic_addal(Register prev, RegisterOrConstant incr, Register addr);
   void atomic_addalw(Register prev, RegisterOrConstant incr, Register addr);
+  void atomic_addalh(Register prev, RegisterOrConstant incr, Register addr);
+  void atomic_addalb(Register prev, RegisterOrConstant incr, Register addr);
 
   void atomic_xchg(Register prev, Register newv, Register addr);
   void atomic_xchgw(Register prev, Register newv, Register addr);
+  void atomic_xchgh(Register prev, Register newv, Register addr);
+  void atomic_xchgb(Register prev, Register newv, Register addr);
   void atomic_xchgl(Register prev, Register newv, Register addr);
   void atomic_xchglw(Register prev, Register newv, Register addr);
+  void atomic_xchglh(Register prev, Register newv, Register addr);
+  void atomic_xchglb(Register prev, Register newv, Register addr);
   void atomic_xchgal(Register prev, Register newv, Register addr);
   void atomic_xchgalw(Register prev, Register newv, Register addr);
+  void atomic_xchgalh(Register prev, Register newv, Register addr);
+  void atomic_xchgalb(Register prev, Register newv, Register addr);
 
   void orptr(Address adr, RegisterOrConstant src) {
     ldr(rscratch1, adr);


### PR DESCRIPTION
AArch64 C2 is missing match rules for byte- and half-word sized variants of `GetAndAdd` and `GetAndSet` atomic operations.

Add AArch64 match rules for:

```
getAndAddB[Acq][NoRes][Const]
getAndAddS[Acq][NoRes][Const]
getAndSetB[Acq]
getAndSetS[Acq]
```

These should lower to the corresponding AArch64 LSE byte/half-word atomic instructions:

```
GetAndAddB* -> LDADDB / LDADDALB
GetAndAddS* -> LDADDH / LDADDALH
GetAndSetB* -> SWPB / SWPALB
GetAndSetS* -> SWPH / SWPALH
```

The patch has passed the following test groups on AArch64:

- hotspot:hotspot_all(no vmTestbase stress)
- jdk:tier1,:tier2,:tier3
- langtools:tier1
- jcstress with -tb 1d




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386891](https://bugs.openjdk.org/browse/JDK-8386891): AArch64: Implement getAndAddB*, getAndAddS*, getAndSetB*, getAndSetS* (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31640/head:pull/31640` \
`$ git checkout pull/31640`

Update a local copy of the PR: \
`$ git checkout pull/31640` \
`$ git pull https://git.openjdk.org/jdk.git pull/31640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31640`

View PR using the GUI difftool: \
`$ git pr show -t 31640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31640.diff">https://git.openjdk.org/jdk/pull/31640.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31640#issuecomment-4781944850)
</details>
