### PR TITLE
8387002: Test ManualTests/JPackage/JPKG001/JPKG001_004: CommonLicenseTest fails on Windows because the license agreement text is not displayed

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/RtfConverter.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/RtfConverter.java
@@ -58,7 +58,7 @@ sealed interface RtfConverter {
     }
 
     static Optional<RtfConverter> createSimple(Path path) throws IOException {
-        if (isRtfFile(path)) {
+        if (!Files.isDirectory(path) && !isRtfFile(path)) {
             return Optional.of(Details.Simple.VALUE);
         } else {
             return Optional.empty();

--- a/test/jdk/tools/jpackage/junit/windows/jdk.jpackage/jdk/jpackage/internal/RtfConverterTest.java
+++ b/test/jdk/tools/jpackage/junit/windows/jdk.jpackage/jdk/jpackage/internal/RtfConverterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jpackage.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+
+class RtfConverterTest {
+
+    @Test
+    void test_createSimple_dir(@TempDir Path workDir) throws IOException {
+
+        assertEquals(Optional.empty(), RtfConverter.createSimple(workDir));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Empty value to exercise the case when the file's content is shorter than the RTF's header
+            "",
+            // Value to exercise the case when the file's content is shorter than the RTF's header
+            "Hello",
+            "Hello Duke!",
+    })
+    void test_createSimple_text_file(String text, @TempDir Path workDir) throws IOException {
+
+        final var licenseFile = workDir.resolve("license");
+
+        Files.writeString(licenseFile, text);
+
+        final var conv = RtfConverter.createSimple(licenseFile);
+
+        assertTrue(conv.isPresent());
+
+        conv.orElseThrow().convert(licenseFile);
+
+        assertEquals(Optional.empty(), RtfConverter.createSimple(licenseFile));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 Arial;}}\\f0\\fs24 Hello, Duke!}",
+    })
+    void test_createSimple_rtf_file(String text, @TempDir Path workDir) throws IOException {
+
+        final var licenseFile = workDir.resolve("license");
+
+        Files.writeString(licenseFile, text);
+
+        assertEquals(Optional.empty(), RtfConverter.createSimple(workDir));
+    }
+}

--- a/test/jdk/tools/jpackage/junit/windows/junit.java
+++ b/test/jdk/tools/jpackage/junit/windows/junit.java
@@ -57,3 +57,11 @@
  *    jdk/jpackage/internal/WixToolTest.java
  * @run junit jdk.jpackage/jdk.jpackage.internal.WixToolTest
  */
+
+/* @test
+ * @summary RtfConverter unit tests
+ * @requires (os.family == "windows")
+ * @compile/module=jdk.jpackage -Xlint:all -Werror
+ *    jdk/jpackage/internal/RtfConverterTest.java
+ * @run junit jdk.jpackage/jdk.jpackage.internal.RtfConverterTest
+ */


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jdk/pull/31616 PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387002](https://bugs.openjdk.org/browse/JDK-8387002): Test ManualTests/JPackage/JPKG001/JPKG001_004: CommonLicenseTest fails on Windows because the license agreement text is not displayed (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31641/head:pull/31641` \
`$ git checkout pull/31641`

Update a local copy of the PR: \
`$ git checkout pull/31641` \
`$ git pull https://git.openjdk.org/jdk.git pull/31641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31641`

View PR using the GUI difftool: \
`$ git pr show -t 31641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31641.diff">https://git.openjdk.org/jdk/pull/31641.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31641#issuecomment-4781985289)
</details>
