### PR TITLE
8387025: Typo in java man page option --illegal-final-field-mutation=warn "performaed"

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -483,7 +483,7 @@ the JVM.
         without any warnings.
 
     -   `warn`: This mode is identical to `allow` except that a warning message is
-        issued for the first illegal final field mutation performaed in a module.
+        issued for the first illegal final field mutation performed in a module.
         This mode is the default for the current JDK but will change in a future
         release.
 

--- a/test/jdk/java/awt/event/helpers/lwcomponents/LWButton.java
+++ b/test/jdk/java/awt/event/helpers/lwcomponents/LWButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class LWButton extends LWComponent {
   private transient ActionListener actionListener;
 
   /*
-   * The action to be performaed once a button has been
+   * The action to be performed once a button has been
    * pressed.
    * actionCommand can be null.
    * @serial


### PR DESCRIPTION
Fixing some typos.
The change in `LWButton.java` is somewhat out of scope but it didn't seem worth a dedicated JBS issue.
I can split this change into two PRs if needed.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387025](https://bugs.openjdk.org/browse/JDK-8387025): Typo in java man page option --illegal-final-field-mutation=warn "performaed" (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31642/head:pull/31642` \
`$ git checkout pull/31642`

Update a local copy of the PR: \
`$ git checkout pull/31642` \
`$ git pull https://git.openjdk.org/jdk.git pull/31642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31642`

View PR using the GUI difftool: \
`$ git pr show -t 31642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31642.diff">https://git.openjdk.org/jdk/pull/31642.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31642#issuecomment-4789038324)
</details>
