### PR TITLE
8387185: Locale does not respect numeric singletons

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/LanguageTag.java
+++ b/src/java.base/share/classes/sun/util/locale/LanguageTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -601,7 +601,7 @@ public record LanguageTag(String language,
         //               / %x79-7A             ; y - z
 
         return (s.length() == 1)
-                && LocaleUtils.isAlphaString(s)
+                && LocaleUtils.isAlphaNumericString(s)
                 && !LocaleUtils.caseIgnoreMatch(PRIVATEUSE, s);
     }
 

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @test
  * @bug 6875847 6992272 7002320 7015500 7023613 7032820 7033504 7004603
  *      7044019 8008577 8176853 8255086 8263202 8287868 8174269 8369452
- *      8369590
+ *      8369590 8387185
  * @summary test API changes to Locale
  * @modules jdk.localedata
  * @run junit/othervm -esa LocaleEnhanceTest
@@ -351,6 +351,11 @@ public class LocaleEnhanceTest {
         // regular extension
         locale = new Builder().setExtension('a', "some-ex-tension").build();
         assertEquals("some-ex-tension", locale.getExtension('a'), "builder");
+
+        // regular numeric singleton extension
+        locale = Locale.forLanguageTag("en-0-foo");
+        assertEquals("foo", locale.getExtension('0'),
+                "numeric singleton extension key should be supported");
 
         // returns null if extension is not present
         assertNull(locale.getExtension('b'), "empty b");
@@ -1057,6 +1062,16 @@ public class LocaleEnhanceTest {
                 .build()
                 .toLanguageTag();
         assertEquals("und-u-posix", result, "duplicate attributes");
+
+        // regular numeric singleton extension
+        result = builder
+                .clear()
+                .setLanguage("en")
+                .setExtension('0', "foo")
+                .build()
+                .toLanguageTag();
+        assertEquals("en-0-foo", result,
+                "numeric singleton extension key should be supported");
     }
 
     @Test

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -352,11 +352,6 @@ public class LocaleEnhanceTest {
         locale = new Builder().setExtension('a', "some-ex-tension").build();
         assertEquals("some-ex-tension", locale.getExtension('a'), "builder");
 
-        // regular numeric singleton extension
-        locale = Locale.forLanguageTag("en-0-foo");
-        assertEquals("foo", locale.getExtension('0'),
-                "numeric singleton extension key should be supported");
-
         // returns null if extension is not present
         assertNull(locale.getExtension('b'), "empty b");
 
@@ -1062,16 +1057,6 @@ public class LocaleEnhanceTest {
                 .build()
                 .toLanguageTag();
         assertEquals("und-u-posix", result, "duplicate attributes");
-
-        // regular numeric singleton extension
-        result = builder
-                .clear()
-                .setLanguage("en")
-                .setExtension('0', "foo")
-                .build()
-                .toLanguageTag();
-        assertEquals("en-0-foo", result,
-                "numeric singleton extension key should be supported");
     }
 
     @Test
@@ -1390,6 +1375,25 @@ public class LocaleEnhanceTest {
         checkDigit(Locale.of("th", "TH", "TH"), '\u0e50');
         checkDigit(Locale.of("th", "TH", "TH"), '\u0e50');
         checkDigit(Locale.forLanguageTag("en-u-nu-thai"), '\u0e50');
+    }
+
+    // Test that numeric singletons are supported
+    @Test
+    public void numericSingletonRoundTripTest() {
+        var tag = "en-0-foo";
+        var value = "foo";
+        var singleton = '0';
+        // test `forLanguageTag`
+        var locale = Locale.forLanguageTag(tag);
+        assertEquals(value, locale.getExtension(singleton));
+        assertEquals(tag, locale.toLanguageTag());
+        // test `Locale.Builder`
+        locale = new Builder()
+                .setLanguage("en")
+                .setExtension(singleton, value)
+                .build();
+        assertEquals(value, locale.getExtension(singleton));
+        assertEquals(tag, locale.toLanguageTag());
     }
 
     private void checkCalendar(Locale loc, String expected) {


### PR DESCRIPTION
Locale does not respect numeric singleton extensions. Currently `LanguageTag` which handles singleton extension parsing only allows `alpha` characters when it should allow `alphaNumeric`.

This PR corrects this and adds tests for `forLanguageTag` as well as the builder.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387185](https://bugs.openjdk.org/browse/JDK-8387185): Locale does not respect numeric singletons (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31644/head:pull/31644` \
`$ git checkout pull/31644`

Update a local copy of the PR: \
`$ git checkout pull/31644` \
`$ git pull https://git.openjdk.org/jdk.git pull/31644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31644`

View PR using the GUI difftool: \
`$ git pr show -t 31644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31644.diff">https://git.openjdk.org/jdk/pull/31644.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31644#issuecomment-4784016404)
</details>
