### PR TITLE
8364322: (fs) fchmodat support for AT_SYMLINK_NOFOLLOW flag too pessimistic on Linux

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -555,9 +555,10 @@ class UnixNativeDispatcher {
     /**
      * Capabilities
      */
-    private static final int SUPPORTS_OPENAT        = 1 << 1;  // syscalls
-    private static final int SUPPORTS_XATTR         = 1 << 3;
-    private static final int SUPPORTS_BIRTHTIME     = 1 << 16; // other features
+    private static final int SUPPORTS_OPENAT            = 1 << 1;  // syscalls
+    private static final int SUPPORTS_FCHMODAT_NOFOLLOW = 1 << 2;
+    private static final int SUPPORTS_XATTR             = 1 << 3;
+    private static final int SUPPORTS_BIRTHTIME         = 1 << 16; // other features
     private static final int capabilities;
 
     /**
@@ -585,9 +586,8 @@ class UnixNativeDispatcher {
      * Supports fchmodat with AT_SYMLINK_NOFOLLOW flag
      */
     static boolean fchmodatNoFollowSupported() {
-        return fchmodatNoFollowSupported0();
+        return (capabilities & SUPPORTS_FCHMODAT_NOFOLLOW) != 0;
     }
-    private static native boolean fchmodatNoFollowSupported0();
 
     private static native int init();
     static {

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -388,17 +388,16 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
     capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_XATTR;
 #endif
 
-    return capabilities;
-}
-
-JNIEXPORT jboolean JNICALL
-Java_sun_nio_fs_UnixNativeDispatcher_fchmodatNoFollowSupported0(JNIEnv* env, jclass this) {
 #if defined(__linux__)
-    // Linux recognizes but does not support the AT_SYMLINK_NOFOLLOW flag
-    return JNI_FALSE;
+    // Linux 6.6+ supports AT_SYMLINK_NOFOLLOW. glibc 2.32+ also provides emulation for older kernels.
+    if (fchmodat(AT_FDCWD, "", 0, AT_SYMLINK_NOFOLLOW) == 0 || errno != ENOTSUP) {
+        capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_FCHMODAT_NOFOLLOW;
+    }
 #else
-    return JNI_TRUE;
+    capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_FCHMODAT_NOFOLLOW;
 #endif
+
+    return capabilities;
 }
 
 JNIEXPORT jbyteArray JNICALL

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -212,6 +212,13 @@ public class SecureDS {
                 Path link = createSymbolicLink(aDir.resolve(linkEntry), fileEntry);
                 Set<PosixFilePermission> permsLink = getPosixFilePermissions(link, NOFOLLOW_LINKS);
 
+                // Test setting permissions on a regular file through the no-follow view
+                view = stream.getFileAttributeView(fileEntry, PosixFileAttributeView.class, NOFOLLOW_LINKS);
+                view.setPermissions(noperms);
+                assertEquals(noperms, getPosixFilePermissions(file));
+                view.setPermissions(permsFile);
+                assertEquals(permsFile, getPosixFilePermissions(file));
+
                 // Test following link to file
                 view = stream.getFileAttributeView(link, PosixFileAttributeView.class);
                 view.setPermissions(noperms);
@@ -220,14 +227,19 @@ public class SecureDS {
                 view.setPermissions(permsFile);
                 assertEquals(permsFile, getPosixFilePermissions(file));
                 assertEquals(permsLink, getPosixFilePermissions(link, NOFOLLOW_LINKS));
-                // Symbolic link permissions do not apply on Linux
-                if (!Platform.isLinux()) {
-                    // Test not following link to file
-                    view = stream.getFileAttributeView(link, PosixFileAttributeView.class, NOFOLLOW_LINKS);
-                    view.setPermissions(noperms);
+
+                // Test not following link to file
+                var linkView = stream.getFileAttributeView(link, PosixFileAttributeView.class, NOFOLLOW_LINKS);
+                if (Platform.isLinux()) {
+                    // Symbolic link permissions do not apply on Linux
+                    assertThrows(IOException.class, () -> linkView.setPermissions(noperms));
+                    assertEquals(permsFile, getPosixFilePermissions(file));
+                    assertThrows(IOException.class, () -> linkView.setPermissions(permsLink));
+                } else {
+                    linkView.setPermissions(noperms);
                     assertEquals(permsFile, getPosixFilePermissions(file));
                     assertEquals(noperms, getPosixFilePermissions(link, NOFOLLOW_LINKS));
-                    view.setPermissions(permsLink);
+                    linkView.setPermissions(permsLink);
                     assertEquals(permsFile, getPosixFilePermissions(file));
                     assertEquals(permsLink, getPosixFilePermissions(link, NOFOLLOW_LINKS));
                 }


### PR DESCRIPTION
Historically, Linux's `fchmodat` hasn't supported `AT_SYMLINK_NOFOLLOW`. However, glibc 2.32 gained support for emulating it, and Linux 6.6 natively supports the flag (via a `fchmodat2` syscall).

Modify `UnixNativeDispatcher` to probe for `AT_SYMLINK_NOFOLLOW` support on Linux.

Modify the `SecureDS` test to exercise the no-symlink-follow path on Linux.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8364322](https://bugs.openjdk.org/browse/JDK-8364322): (fs) fchmodat support for AT_SYMLINK_NOFOLLOW flag too pessimistic on Linux (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31645/head:pull/31645` \
`$ git checkout pull/31645`

Update a local copy of the PR: \
`$ git checkout pull/31645` \
`$ git pull https://git.openjdk.org/jdk.git pull/31645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31645`

View PR using the GUI difftool: \
`$ git pr show -t 31645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31645.diff">https://git.openjdk.org/jdk/pull/31645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31645#issuecomment-4784141493)
</details>
