### PR TITLE
8387188: JImageExtractTest.java test should deny APPEND_DATA ACL in `testExtractToReadOnlyDir`

### DIFF
--- a/test/jdk/tools/jimage/JImageExtractTest.java
+++ b/test/jdk/tools/jimage/JImageExtractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,8 @@ public class JImageExtractTest extends JImageCliTest {
             AclEntry entry = AclEntry.newBuilder()
                                      .setType(AclEntryType.DENY)
                                      .setPrincipal(fileOwner)
-                                     .setPermissions(AclEntryPermission.WRITE_DATA)
+                                     .setPermissions(AclEntryPermission.WRITE_DATA,
+                                                     AclEntryPermission.APPEND_DATA)
                                      .setFlags(AclEntryFlag.FILE_INHERIT, AclEntryFlag.DIRECTORY_INHERIT)
                                      .build();
             List<AclEntry> acl = view.getAcl();


### PR DESCRIPTION
Before this patch, the test in `testExtractToReadOnlyDir()`, which
validates whether making jimage extract to a read-only directory results
in a failure, denied creating files but it did not deny creating
subdirectories.  Although this does make jimage fail (and consequently,
make the test pass), this isn't completely correct for two reasons.

First, the test invocation ends up writing a series of empty
subdirectories, when in reality we don't want the destination directory
to be modified at all.  Second, and more importantly, this leaves these
directories in a state where Cygwin cannot remove them (see JBS issue
for more details).

This patch fixes the problem by adding `APPEND_DATA` to the deny list,
thus prohibiting the principal running the test from creating both files
as well as directories.  This effectively sidesteps the issue of leaving
broken directories on disk.

See
https://learn.microsoft.com/en-us/windows/win32/fileio/file-access-rights-constants
for details about the file permissions, reproduced in part below:

> FILE_WRITE_DATA: For a directory object, the right to create a file in
the directory.
>
> FILE_APPEND_DATA: For a directory object, the right to create a
subdirectory.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387188](https://bugs.openjdk.org/browse/JDK-8387188): JImageExtractTest.java test should deny APPEND_DATA ACL in `testExtractToReadOnlyDir` (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Dušan Bálek](https://openjdk.org/census#dbalek) (@dbalek - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31646/head:pull/31646` \
`$ git checkout pull/31646`

Update a local copy of the PR: \
`$ git checkout pull/31646` \
`$ git pull https://git.openjdk.org/jdk.git pull/31646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31646`

View PR using the GUI difftool: \
`$ git pr show -t 31646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31646.diff">https://git.openjdk.org/jdk/pull/31646.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31646#issuecomment-4784353478)
</details>
