### PR TITLE
8387197: C2: Improve klass_ptr_type in GraphKit::gen_instanceof() similarly to GraphKit::gen_checkcast()

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3242,7 +3242,8 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
   assert( !stopped(), "dead parse path should be checked in callers" );
   assert(!TypePtr::NULL_PTR->higher_equal(_gvn.type(superklass)->is_klassptr()),
          "must check for not-null not-dead klass in callers");
-
+  const TypeKlassPtr* klass_ptr_type = _gvn.type(superklass)->is_klassptr();
+  const TypeKlassPtr* improved_klass_ptr_type = klass_ptr_type->try_improve();
   // Make the merge point
   enum { _obj_path = 1, _fail_path, _null_path, PATH_LIMIT };
   RegionNode* region = new RegionNode(PATH_LIMIT);
@@ -3278,11 +3279,10 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
 
   // Do we know the type check always succeed?
   bool known_statically = false;
-  if (_gvn.type(superklass)->singleton()) {
-    const TypeKlassPtr* superk = _gvn.type(superklass)->is_klassptr();
+  if (improved_klass_ptr_type->singleton()) {
     const TypeKlassPtr* subk = _gvn.type(obj)->is_oopptr()->as_klass_type();
     if (subk->is_loaded()) {
-      int static_res = C->static_subtype_check(superk, subk);
+      int static_res = C->static_subtype_check(improved_klass_ptr_type, subk);
       known_statically = (static_res == Compile::SSC_always_true || static_res == Compile::SSC_always_false);
     }
   }
@@ -3305,7 +3305,11 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
   }
 
   // Generate the subtype check
-  Node* not_subtype_ctrl = gen_subtype_check(not_null_obj, superklass);
+  Node* improved_superklass = superklass;
+  if (improved_klass_ptr_type != klass_ptr_type && improved_klass_ptr_type->singleton()) {
+    improved_superklass = makecon(improved_klass_ptr_type);
+  }
+  Node* not_subtype_ctrl = gen_subtype_check(not_null_obj, improved_superklass);
 
   // Plug in the success path to the general merge in slot 1.
   region->init_req(_obj_path, control());

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3240,10 +3240,10 @@ Node* GraphKit::maybe_cast_profiled_obj(Node* obj,
 Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replace) {
   kill_dead_locals();           // Benefit all the uncommon traps
   assert( !stopped(), "dead parse path should be checked in callers" );
-  assert(!TypePtr::NULL_PTR->higher_equal(_gvn.type(superklass)->is_klassptr()),
+  const TypeKlassPtr* klass_ptr_type = _gvn.type(superklass)->isa_klassptr();
+  assert(klass_ptr_type != nullptr && !TypePtr::NULL_PTR->higher_equal(klass_ptr_type),
          "must check for not-null not-dead klass in callers");
-  const TypeKlassPtr* klass_ptr_type = _gvn.type(superklass)->is_klassptr();
-  const TypeKlassPtr* improved_klass_ptr_type = klass_ptr_type->try_improve();
+  klass_ptr_type = klass_ptr_type->try_improve();
   // Make the merge point
   enum { _obj_path = 1, _fail_path, _null_path, PATH_LIMIT };
   RegionNode* region = new RegionNode(PATH_LIMIT);
@@ -3279,10 +3279,10 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
 
   // Do we know the type check always succeed?
   bool known_statically = false;
-  if (improved_klass_ptr_type->singleton()) {
+  if (klass_ptr_type->singleton()) {
     const TypeKlassPtr* subk = _gvn.type(obj)->is_oopptr()->as_klass_type();
     if (subk->is_loaded()) {
-      int static_res = C->static_subtype_check(improved_klass_ptr_type, subk);
+      int static_res = C->static_subtype_check(klass_ptr_type, subk);
       known_statically = (static_res == Compile::SSC_always_true || static_res == Compile::SSC_always_false);
     }
   }
@@ -3305,10 +3305,7 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
   }
 
   // Generate the subtype check
-  Node* improved_superklass = superklass;
-  if (improved_klass_ptr_type != klass_ptr_type && improved_klass_ptr_type->singleton()) {
-    improved_superklass = makecon(improved_klass_ptr_type);
-  }
+  Node* improved_superklass = klass_ptr_type->singleton() ? makecon(klass_ptr_type) : superklass;
   Node* not_subtype_ctrl = gen_subtype_check(not_null_obj, improved_superklass);
 
   // Plug in the success path to the general merge in slot 1.

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3243,7 +3243,7 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
   const TypeKlassPtr* klass_ptr_type = _gvn.type(superklass)->isa_klassptr();
   assert(klass_ptr_type != nullptr && !TypePtr::NULL_PTR->higher_equal(klass_ptr_type),
          "must check for not-null not-dead klass in callers");
-  klass_ptr_type = klass_ptr_type->try_improve();
+  const TypeKlassPtr* improved_klass_ptr_type = klass_ptr_type->try_improve();
   // Make the merge point
   enum { _obj_path = 1, _fail_path, _null_path, PATH_LIMIT };
   RegionNode* region = new RegionNode(PATH_LIMIT);
@@ -3279,10 +3279,10 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
 
   // Do we know the type check always succeed?
   bool known_statically = false;
-  if (klass_ptr_type->singleton()) {
+  if (improved_klass_ptr_type->singleton()) {
     const TypeKlassPtr* subk = _gvn.type(obj)->is_oopptr()->as_klass_type();
     if (subk->is_loaded()) {
-      int static_res = C->static_subtype_check(klass_ptr_type, subk);
+      int static_res = C->static_subtype_check(improved_klass_ptr_type, subk);
       known_statically = (static_res == Compile::SSC_always_true || static_res == Compile::SSC_always_false);
     }
   }
@@ -3305,7 +3305,10 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
   }
 
   // Generate the subtype check
-  Node* improved_superklass = klass_ptr_type->singleton() ? makecon(klass_ptr_type) : superklass;
+  Node* improved_superklass = superklass;
+  if (improved_klass_ptr_type != klass_ptr_type && improved_klass_ptr_type->singleton()) {
+    improved_superklass = makecon(improved_klass_ptr_type);
+  }
   Node* not_subtype_ctrl = gen_subtype_check(not_null_obj, improved_superklass);
 
   // Plug in the success path to the general merge in slot 1.

--- a/test/hotspot/jtreg/compiler/parsing/TestInstanceOfImprovedKlassPtrType.java
+++ b/test/hotspot/jtreg/compiler/parsing/TestInstanceOfImprovedKlassPtrType.java
@@ -48,6 +48,7 @@ public class TestInstanceOfImprovedKlassPtrType {
         TestFramework.run();
     }
 
+    @DontInline
     int testHelper2(Object o) {
         return 1;
     }
@@ -65,6 +66,7 @@ public class TestInstanceOfImprovedKlassPtrType {
     }
 
     @Run(test = "test1")
+    @Warmup(0)
     void runTest() {
         int sum = 0;
         Object[] arr = new Object[] {new C(), new D(), new E()};

--- a/test/hotspot/jtreg/compiler/parsing/TestInstanceOfImprovedKlassPtrType.java
+++ b/test/hotspot/jtreg/compiler/parsing/TestInstanceOfImprovedKlassPtrType.java
@@ -31,12 +31,12 @@
  * @run driver ${test.main.class}
  */
 
-package compiler.types;
+package compiler.parsing;
 
 import compiler.lib.ir_framework.*;
 import jdk.test.lib.Asserts;
 
-public class TestSubTypeCheckInterfaceCheck {
+public class TestInstanceOfImprovedKlassPtrType {
     static abstract class B {}
     static final class C extends B {}
 
@@ -45,7 +45,7 @@ public class TestSubTypeCheckInterfaceCheck {
     static class E implements I {}
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckInterfaceCheck::*");
+        TestFramework.run();
     }
 
     int testHelper2(Object o) {

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckInterfaceCheck.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckInterfaceCheck.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387197
+ * @summary Verify that improving klass_ptr_type in GraphKit::gen_instanceof() allows
+ *          eliminating SubTypeCheckNode when the receiver implements an interface
+ *          unrelated to the checked class.
+ * @library /test/lib /
+ * @run driver ${test.main.class}
+ */
+
+package compiler.types;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+public class TestSubTypeCheckInterfaceCheck {
+    static abstract class B {}
+    static final class C extends B {}
+
+    interface I {}
+    static class D implements I {}
+    static class E implements I {}
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckInterfaceCheck::*");
+    }
+
+    int testHelper2(Object o) {
+        return 1;
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUBTYPE_CHECK, "1"},
+        phase = CompilePhase.AFTER_PARSING)
+    int test1(Object o) {
+        Object o1 = (I) o;
+        if (o1 instanceof B) {
+            return testHelper2(o1);
+        } else {
+            return 2;
+        }
+    }
+
+    @Run(test = "test1")
+    void runTest() {
+        int sum = 0;
+        Object[] arr = new Object[] {new C(), new D(), new E()};
+        for (int i = 0; i < 3; i++){
+            Object o = arr[i];
+            if (o instanceof I) {
+                sum += test1(o);
+            } else {
+                sum += 3;
+            }
+        }
+        Asserts.assertEquals(sum, 7);
+        return;
+    }
+}


### PR DESCRIPTION
**Description:**

GraphKit::gen_instanceof() does not try to improve the klass pointer type in the same way as GraphKit::gen_checkcast(), which may prevent some later optimizations from eliminating redundant subtype checks.

**Solution:**

Improve klass_ptr_type in GraphKit::gen_instanceof() similarly to GraphKit::gen_checkcast().

**Test:**

GHA

Please review this change. Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387197](https://bugs.openjdk.org/browse/JDK-8387197): C2: Improve klass_ptr_type in GraphKit::gen_instanceof() similarly to GraphKit::gen_checkcast() (**Enhancement** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31649/head:pull/31649` \
`$ git checkout pull/31649`

Update a local copy of the PR: \
`$ git checkout pull/31649` \
`$ git pull https://git.openjdk.org/jdk.git pull/31649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31649`

View PR using the GUI difftool: \
`$ git pr show -t 31649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31649.diff">https://git.openjdk.org/jdk/pull/31649.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31649#issuecomment-4788057078)
</details>
