### PR TITLE
8371720: G1: Move concurrent mark initialization to first concurrent start pause

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2723,13 +2723,14 @@ void G1CollectedHeap::do_collection_pause_at_safepoint(size_t allocation_word_si
 
   _bytes_used_during_gc = 0;
 
-  _cm->fully_initialize();
-
   policy()->decide_on_concurrent_start_pause();
   // Record whether this pause may need to trigger a concurrent operation. Later,
   // when we signal the G1ConcurrentMarkThread, the collector state has already
   // been reset for the next pause.
   bool should_start_concurrent_mark_operation = collector_state()->is_in_concurrent_start_gc();
+  if (should_start_concurrent_mark_operation) {
+    _cm->fully_initialize();
+  }
 
   // Perform the collection.
   G1YoungCollector collector(gc_cause(), allocation_word_size);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -569,6 +569,11 @@ public:
 
   uint worker_id_offset() const { return _worker_id_offset; }
 
+  // Fully allocates and initializes data structures for the concurrent cycle.
+  // Methods that use concurrent cycle state such as the concurrent mark threads,
+  // tasks, marking stack, statistics, TAMS or TARS require this initialization.
+  // Callers that run before the first concurrent start pause, which calls this,
+  // should guard calls with is_fully_initialized().
   void fully_initialize();
   bool is_fully_initialized() const { return _cm_thread != nullptr; }
 


### PR DESCRIPTION
Hi all,

  please review this change the moves `G1ConcurrentMark` initialization to be conditional on doing a concurrent mark.

This is trivial after JDK-8381128 which was about preparing this change.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8371720](https://bugs.openjdk.org/browse/JDK-8371720): G1: Move concurrent mark initialization to first concurrent start pause (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31656/head:pull/31656` \
`$ git checkout pull/31656`

Update a local copy of the PR: \
`$ git checkout pull/31656` \
`$ git pull https://git.openjdk.org/jdk.git pull/31656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31656`

View PR using the GUI difftool: \
`$ git pr show -t 31656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31656.diff">https://git.openjdk.org/jdk/pull/31656.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31656#issuecomment-4789065194)
</details>
