### PR TITLE
8385903: G1: G1CollectionSet::_num_regions needs to be Atomic

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -33,7 +33,6 @@
 #include "gc/g1/g1ParScanThreadState.hpp"
 #include "gc/g1/g1Policy.hpp"
 #include "logging/logStream.hpp"
-#include "runtime/orderAccess.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -128,8 +127,11 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
   _g1h->register_old_collection_set_region_with_region_attr(hr);
 
-  assert(num_regions() < _max_num_regions, "Collection set now larger than maximum size.");
-  _regions[_num_regions++] = hr->hrm_index();
+  uint local_num_regions = num_regions();
+  assert(local_num_regions < _max_num_regions, "Collection set now larger than maximum size.");
+  _regions[local_num_regions] = hr->hrm_index();
+  _num_regions.store_relaxed(local_num_regions + 1);
+
   _num_initial_old_regions++;
 
   _g1h->old_set_remove(hr);
@@ -162,14 +164,13 @@ void G1CollectionSet::stop_incremental_building() {
 
 void G1CollectionSet::clear() {
   assert_at_safepoint_on_vm_thread();
-  _num_regions = 0;
+  _num_regions.store_relaxed(0);
   _groups.clear();
   assert(_optional_groups.length() == 0, "must be");
 }
 
 void G1CollectionSet::iterate(G1HeapRegionClosure* cl) const {
-  uint len = _num_regions;
-  OrderAccess::loadload();
+  uint len = _num_regions.load_acquire();
 
   for (uint i = 0; i < len; i++) {
     G1HeapRegion* r = _g1h->region_at(_regions[i]);
@@ -233,8 +234,7 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   _regions[index] = hr->hrm_index();
   // Concurrent readers must observe the store of the value in the array before an
   // update to the _num_regions field.
-  OrderAccess::storestore();
-  _num_regions++;
+  _num_regions.fetch_then_add(1u, memory_order_release);
 }
 
 void G1CollectionSet::add_survivor_regions(G1HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1COLLECTIONSET_HPP
 
 #include "gc/g1/g1CollectionSetCandidates.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -142,14 +143,14 @@ class G1CollectionSet {
   // All regions in _regions below _num_regions are assumed to be part of the
   // collection set.
   // We assume that at any time there is at most only one writer and (one or more)
-  // concurrent readers. This means synchronization using storestore and loadload
-  // barriers on the writer and reader respectively only are sufficient.
+  // concurrent readers. This means synchronization using release and acquire
+  // on the writer and reader respectively only are sufficient.
   //
   // This corresponds to the regions referenced by the candidate groups further below.
   uint* _regions;
   uint _max_num_regions;
 
-  volatile uint _num_regions;
+  Atomic<uint> _num_regions;
 
   // Old gen groups selected for evacuation.
   G1CSetCandidateGroupList _groups;
@@ -285,7 +286,7 @@ public:
   // Returns the number of regions in the current collection set increment.
   uint num_regions_in_increment() const { return num_regions() - _regions_inc_part_start; }
   // Returns the total number of regions in the current collection set.
-  uint num_regions() const { return _num_regions; }
+  uint num_regions() const { return _num_regions.load_relaxed(); }
 
   // Iterate over the entire collection set (all increments calculated so far), applying
   // the given G1HeapRegionClosure on all of the regions.


### PR DESCRIPTION
Hi all,

  please review this change to use `Atomic` class for `G1CollectionSet::_num_regions`. Fairly straightforward, also replaced the `loadload/storestore` combination with the equivalent and nicer reading `store_release/load_acquire` combination.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385903](https://bugs.openjdk.org/browse/JDK-8385903): G1: G1CollectionSet::_num_regions needs to be Atomic (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31658/head:pull/31658` \
`$ git checkout pull/31658`

Update a local copy of the PR: \
`$ git checkout pull/31658` \
`$ git pull https://git.openjdk.org/jdk.git pull/31658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31658`

View PR using the GUI difftool: \
`$ git pr show -t 31658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31658.diff">https://git.openjdk.org/jdk/pull/31658.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31658#issuecomment-4789383459)
</details>
