### PR TITLE
8387214: TraceJavaAssertions is unused

### DIFF
--- a/src/hotspot/share/classfile/javaAssertions.cpp
+++ b/src/hotspot/share/classfile/javaAssertions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,13 +81,6 @@ void JavaAssertions::addOption(const char* name, bool enable) {
   // JavaAssertion::enabled(), but that is done once per loaded class.
   for (int i = 0; i < len; ++i) {
     if (name_copy[i] == JVM_SIGNATURE_DOT) name_copy[i] = JVM_SIGNATURE_SLASH;
-  }
-
-  if (TraceJavaAssertions) {
-    tty->print_cr("JavaAssertions: adding %s %s=%d",
-      head == &_classes ? "class" : "package",
-      name_copy[0] != '\0' ? name_copy : "'default'",
-      enable);
   }
 
   // Prepend a new item to the list.  Items added later take precedence, so
@@ -183,14 +176,6 @@ JavaAssertions::match_package(const char* classname) {
   return nullptr;
 }
 
-inline void JavaAssertions::trace(const char* name,
-const char* typefound, const char* namefound, bool enabled) {
-  if (TraceJavaAssertions) {
-    tty->print_cr("JavaAssertions:  search for %s found %s %s=%d",
-      name, typefound, namefound[0] != '\0' ? namefound : "'default'", enabled);
-  }
-}
-
 bool JavaAssertions::enabled(const char* classname, bool systemClass) {
   assert(classname != nullptr, "must have a classname");
 
@@ -201,18 +186,15 @@ bool JavaAssertions::enabled(const char* classname, bool systemClass) {
   // First check options that apply to classes.  If we find a match we're done.
   OptionList* p;
   if ((p = match_class(classname))) {
-    trace(classname, "class", p->name(), p->enabled());
     return p->enabled();
   }
 
   // Now check packages, from most specific to least.
   if ((p = match_package(classname))) {
-    trace(classname, "package", p->name(), p->enabled());
     return p->enabled();
   }
 
   // No match.  Return the default status.
   bool result = systemClass ? systemClassDefault() : userClassDefault();
-  trace(classname, systemClass ? "system" : "user", "default", result);
   return result;
 }

--- a/src/hotspot/share/classfile/javaAssertions.hpp
+++ b/src/hotspot/share/classfile/javaAssertions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,9 +57,6 @@ private:
   static void fillJavaArrays(const OptionList* p, int len, objArrayHandle names,
     typeArrayHandle status, TRAPS);
 
-  static inline void trace(const char* name, const char* typefound,
-    const char* namefound, bool enabled);
-
   static inline OptionList*     match_class(const char* classname);
   static OptionList*            match_package(const char* classname);
 
@@ -90,8 +87,6 @@ inline bool JavaAssertions::userClassDefault() {
 }
 
 inline void JavaAssertions::setUserClassDefault(bool enabled) {
-  if (TraceJavaAssertions)
-    tty->print_cr("JavaAssertions::setUserClassDefault(%d)", enabled);
   _userDefault = enabled;
 }
 
@@ -100,8 +95,6 @@ inline bool JavaAssertions::systemClassDefault() {
 }
 
 inline void JavaAssertions::setSystemClassDefault(bool enabled) {
-  if (TraceJavaAssertions)
-    tty->print_cr("JavaAssertions::setSystemClassDefault(%d)", enabled);
   _sysDefault = enabled;
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -465,9 +465,6 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, VerifyStackAtCalls, false,                                  \
           "Verify that the stack pointer is unchanged after calls")         \
                                                                             \
-  develop(bool, TraceJavaAssertions, false,                                 \
-          "Trace java language assertions")                                 \
-                                                                            \
   develop(bool, VerifyCodeCache, false,                                     \
           "Verify code cache on memory allocation/deallocation")            \
                                                                             \


### PR DESCRIPTION
Please remove this trivial change to remove a develop tracing option that is unused, in preference to converting it to Unified Logging.

Tested with tier1 sanity and javac tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387214](https://bugs.openjdk.org/browse/JDK-8387214): TraceJavaAssertions is unused (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31659/head:pull/31659` \
`$ git checkout pull/31659`

Update a local copy of the PR: \
`$ git checkout pull/31659` \
`$ git pull https://git.openjdk.org/jdk.git pull/31659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31659`

View PR using the GUI difftool: \
`$ git pr show -t 31659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31659.diff">https://git.openjdk.org/jdk/pull/31659.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31659#issuecomment-4789485656)
</details>
