### PR TITLE
8365887: Outdated comments in String::decode

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -671,14 +671,9 @@ public final class String
     }
 
     private static String decode(Charset charset, byte[] bytes, int offset, int length) {
-        // (1)We never cache the "external" cs, the only benefit of creating
-        // an additional StringDe/Encoder object to wrap it is to share the
-        // de/encode() method. These SD/E objects are short-lived, the young-gen
-        // gc should be able to take care of them well. But the best approach
-        // is still not to generate them if not really necessary.
-        // (2)The defensive copy of the input byte/char[] has a big performance
-        // impact, as well as the outgoing result byte/char[]. Need to do the
-        // optimization check of (sm==null && classLoader0==null) for both.
+        // Do not cache the CharsetDecoder created here. It is short-lived,
+        // so young-generation GC should handle it well. The ArrayDecoder
+        // fast paths below decode directly from arrays where possible.
         CharsetDecoder cd = charset.newDecoder();
         // ArrayDecoder fastpaths
         if (cd instanceof ArrayDecoder ad) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -671,9 +671,6 @@ public final class String
     }
 
     private static String decode(Charset charset, byte[] bytes, int offset, int length) {
-        // Do not cache the CharsetDecoder created here. It is short-lived,
-        // so young-generation GC should handle it well. The ArrayDecoder
-        // fast paths below decode directly from arrays where possible.
         CharsetDecoder cd = charset.newDecoder();
         // ArrayDecoder fastpaths
         if (cd instanceof ArrayDecoder ad) {


### PR DESCRIPTION
As noted in https://bugs.openjdk.org/browse/JDK-8365887, the comment in `String::decode` still referred to the old defensive copy / security manager optimization even though that path has been removed.

This updates the comment to describe the current shape of the method: a short-lived `CharsetDecoder` is created for this decode path, while the `ArrayDecoder` fast paths decode directly from arrays where possible.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8365887](https://bugs.openjdk.org/browse/JDK-8365887): Outdated comments in String::decode (**Enhancement** - P5)


### Reviewers
 * [Xueming Shen](https://openjdk.org/census#sherman) (@xuemingshen-oracle - **Reviewer**) Review applies to [7c64b0d9](https://git.openjdk.org/jdk/pull/31661/files/7c64b0d94fd18365e56c832f5e44428927438138)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31661/head:pull/31661` \
`$ git checkout pull/31661`

Update a local copy of the PR: \
`$ git checkout pull/31661` \
`$ git pull https://git.openjdk.org/jdk.git pull/31661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31661`

View PR using the GUI difftool: \
`$ git pr show -t 31661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31661.diff">https://git.openjdk.org/jdk/pull/31661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31661#issuecomment-4791490909)
</details>
