### PR TITLE
8386985: PacketSpaceManagerTest failed with AssertionError; A race condition may cause packetSent to mistakenly skip rescheduling of the transmitter task

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/quic/PacketSpaceManager.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/quic/PacketSpaceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -645,22 +645,15 @@ public sealed class PacketSpaceManager implements PacketSpace
             return false;
         }
 
-        boolean hasNoDeadline() {
-            return Deadline.MAX.equals(nextDeadline);
-        }
-
         // reschedule this task
         void reschedule() {
             Deadline deadline = computeNextDeadline();
-            Deadline nextDeadline = this.nextDeadline;
             if (Deadline.MAX.equals(deadline)) {
-                debug.log("no deadline, don't reschedule");
-            } else if (deadline.equals(nextDeadline)) {
-                debug.log("deadline unchanged, don't reschedule");
-            } else {
-                packetEmitter.reschedule(this, deadline);
-                debug.log("retransmission task: rescheduled");
+                if (debug.on()) debug.log("no deadline, don't reschedule");
+                return;
             }
+            if (debug.on()) debug.log("retransmission task: rescheduled");
+            packetEmitter.reschedule(this, deadline);
         }
 
         @Override
@@ -1304,7 +1297,7 @@ public sealed class PacketSpaceManager implements PacketSpace
             } finally {
                 transferLock.unlock();
             }
-            if (found && packetTransmissionTask.hasNoDeadline()) {
+            if (found) {
                 packetTransmissionTask.reschedule();
             }
             if (!found) {
@@ -1340,9 +1333,7 @@ public sealed class PacketSpaceManager implements PacketSpace
                         return;
                     }
                     addAcknowledgement(pending);
-                    if (packetTransmissionTask.hasNoDeadline()) {
-                        packetTransmissionTask.reschedule();
-                    }
+                    packetTransmissionTask.reschedule();
                 } finally {
                     transferLock.unlock();
                 }

--- a/test/jdk/java/net/httpclient/quic/PacketSpaceManagerTest.java
+++ b/test/jdk/java/net/httpclient/quic/PacketSpaceManagerTest.java
@@ -770,6 +770,9 @@ public class PacketSpaceManagerTest {
             }
         }
 
+        // Sends a trivial INITIAL packet, with a CRYPTO frame containing
+        // a payload of length 1 for the provided offset. If ackFrameToSend
+        // is not null it will be included in the packet.
         public List<QuicFrame> sendPacket(long offset, AckFrame ackFrameToSend, Packet packet, long largestReceivedAckedPN) {
             // add a crypto frame and build the packet
             CryptoFrame crypto = new CryptoFrame(offset, 1,
@@ -786,6 +789,7 @@ public class PacketSpaceManagerTest {
             manager.packetSent(newPacket, -1, packet.packetNumber);
             return frames;
         }
+
         /**
          * Drives the test by pretending to emit each packet in order,
          * then pretending to receive ack frames (as soon as possible
@@ -1177,7 +1181,8 @@ public class PacketSpaceManagerTest {
         for (Runnable task : tasks) {
             task.run();
         }
-        driver.manager.processAckFrame(new AckFrameBuilder().addAck(1).addAck(2).build());
+        driver.manager.processAckFrame(new AckFrameBuilder()
+                .addAck(1).addAck(2).build());
         driver.run();
         driver.check();
     }

--- a/test/jdk/java/net/httpclient/quic/PacketSpaceManagerTest.java
+++ b/test/jdk/java/net/httpclient/quic/PacketSpaceManagerTest.java
@@ -80,16 +80,19 @@ import javax.net.ssl.SSLSession;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
+ * @bug 8349910 8386985
  * @summary tests the logic to build an AckFrame
  * @library /test/lib
  * @library ../debug
@@ -102,6 +105,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @run junit/othervm -Dseed=-4159871071396382784 ${test.main.class}
  * @run junit/othervm -Dseed=2252276218459363615 ${test.main.class}
  * @run junit/othervm -Dseed=-5130588140709404919 ${test.main.class}
+ * @run junit/othervm -Dseed=4257295716830862528 ${test.main.class}
  */
 // -Djdk.internal.httpclient.debug=true
 public class PacketSpaceManagerTest {
@@ -766,6 +770,22 @@ public class PacketSpaceManagerTest {
             }
         }
 
+        public List<QuicFrame> sendPacket(long offset, AckFrame ackFrameToSend, Packet packet, long largestReceivedAckedPN) {
+            // add a crypto frame and build the packet
+            CryptoFrame crypto = new CryptoFrame(offset, 1,
+                    ByteBuffer.wrap(new byte[] {nextByte(offset)}));
+            List<QuicFrame> frames = ackFrameToSend == null ?
+                    List.of(crypto) : List.of(crypto, ackFrameToSend);
+            QuicPacket newPacket = codingContext.encoder
+                    .newInitialPacket(localId, peerId,
+                            null,
+                            packet.packetNumber,
+                            largestReceivedAckedPN,
+                            frames, codingContext);
+            // pretend that we sent a packet
+            manager.packetSent(newPacket, -1, packet.packetNumber);
+            return frames;
+        }
         /**
          * Drives the test by pretending to emit each packet in order,
          * then pretending to receive ack frames (as soon as possible
@@ -830,19 +850,8 @@ public class PacketSpaceManagerTest {
                     debug.log("largestAckSent is: " + largestAckAcked);
                 }
 
-                // add a crypto frame and build the packet
-                CryptoFrame crypto = new CryptoFrame(offset, 1,
-                        ByteBuffer.wrap(new byte[] {nextByte(offset)}));
-                List<QuicFrame> frames = ackFrameToSend == null ?
-                        List.of(crypto) : List.of(crypto, ackFrameToSend);
-                QuicPacket newPacket = codingContext.encoder
-                        .newInitialPacket(localId, peerId,
-                                null,
-                                packet.packetNumber,
-                                largestReceivedAckedPN,
-                                frames, codingContext);
-                // pretend that we sent a packet
-                manager.packetSent(newPacket, -1, packet.packetNumber);
+                // send a packet
+                List<QuicFrame> frames = sendPacket(offset, ackFrameToSend, packet, largestReceivedAckedPN);
 
                 // compute next deadline
                 var nextDeadline = timerQueue.nextDeadline();
@@ -1121,6 +1130,54 @@ public class PacketSpaceManagerTest {
     public void testPacketSpaceManager(TestCase testCase) throws Exception {
         System.out.printf("%n -------  testPacketSpaceManager ------- %n");
         SynchronousTestDriver driver = new SynchronousTestDriver(testCase);
+        driver.run();
+        driver.check();
+    }
+
+    @Test
+    public void testPacketSent() throws Exception {
+        // this test case is specifically for JDK-8386985
+        System.out.printf("%n -------  testPacketSent ------- %n");
+
+        // create a minimal SynchronousTestDriver
+        TestCase testCase = new TestCase(List.of(new Acknowledged(1, 3), new Acknowledged(4,4)),
+                List.of(new Packet(3, 0), new Packet(4, 0)));
+        SynchronousTestDriver driver = new SynchronousTestDriver(testCase);
+
+        // send a first ack-eliciting packet, and move the timeline past PTO
+        driver.sendPacket(0, null, new Packet(1, 0), -1);
+        Deadline pto = driver.manager.nextScheduledDeadline(); // should be PTO
+        driver.timeSource.advance(driver.timeSource.instant().until(pto, ChronoUnit.MILLIS) + 250, ChronoUnit.MILLIS);
+
+        // start processing events, but delay the task that will run the transmitter
+        ArrayList<Runnable> tasks = new ArrayList<>();
+        Executor executor = new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                tasks.add(command);
+            }
+        };
+        driver.timerQueue.processEventsAndReturnNextDeadline(driver.timeSource.instant(), executor);
+
+        // acknowledge the first packet so that it's no longer pending retransmission
+        driver.manager.processAckFrame(new AckFrameBuilder().addAck(1).build());
+
+        // send a second packet, and examine the timerQueue next deadline
+        // if sending the second packet didn't cause the task to be rescheduled, we
+        // will observe Deadline.MAX, or a deadline before now: that's the bug.
+        driver.sendPacket(1, null, new Packet(2, 0), -1);
+
+        Deadline next = driver.timerQueue.nextDeadline();
+        assertNotEquals(next, Deadline.MAX);
+        assertTrue(next.isAfter(driver.timeSource.instant()));
+
+        // now finish running the task and ack the second packet,
+        // so that we leave the packet space manager in a clean state
+        // for running the driver with the next two packets.
+        for (Runnable task : tasks) {
+            task.run();
+        }
+        driver.manager.processAckFrame(new AckFrameBuilder().addAck(1).addAck(2).build());
         driver.run();
         driver.check();
     }


### PR DESCRIPTION
The issue was observed on a local run in PacketSpaceManagerTest:

org.opentest4j.AssertionFailedError: nextDeadline should not be after 250ms from now! ==> expected: <false> but was: <true>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertFalse.failNotFalse(AssertFalse.java:63)
        at org.junit.jupiter.api.AssertFalse.assertFalse(AssertFalse.java:36)
        at org.junit.jupiter.api.Assertions.assertFalse(Assertions.java:239)
        at PacketSpaceManagerTest$SynchronousTestDriver.run(PacketSpaceManagerTest.java:856)

Investigation suggests that this is caused by a race condition where `packetSent` was invoked while the transmitter task was running: `packetSent` will only reschedule the transmitter if there is no deadline, that is, if it observes that `deadline == Deadline.MAX`; But if `deadline` is already in the past, which is typically the case when the transmitter task is running, then there's no guarantee that the transmitter task will actually end up rescheduling itself with a new deadline. It may not if it thinks there is nothing pending. The transmitter will then remain unscheduled until something else happens that causes it to be rescheduled.

In a typical HTTP/3 request/response exchange chances are high that "something else" will happen, which explains why even if `packetSent` fails to reschedule, there might not be any observable consequence (outside of PacketSpaceManagerTest). However, there is no guarantee.

The fix is to always call PacketSpaceManager::reschedule, which will compute a new prospective deadline which the timer queue can then reliably use to decide whether the selector should be woken up to take into account the new deadline.

A new testPacketSent() test that deterministically fails without the fix is added to  PacketSpaceManagerTest.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386985](https://bugs.openjdk.org/browse/JDK-8386985): PacketSpaceManagerTest failed with AssertionError; A race condition may cause packetSent to mistakenly skip rescheduling of the transmitter task (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31662/head:pull/31662` \
`$ git checkout pull/31662`

Update a local copy of the PR: \
`$ git checkout pull/31662` \
`$ git pull https://git.openjdk.org/jdk.git pull/31662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31662`

View PR using the GUI difftool: \
`$ git pr show -t 31662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31662.diff">https://git.openjdk.org/jdk/pull/31662.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31662#issuecomment-4798894056)
</details>
