### PR TITLE
8387253: Locale incorrectly accepts extlangs after non 2*3ALPHA lang

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/LanguageTag.java
+++ b/src/java.base/share/classes/sun/util/locale/LanguageTag.java
@@ -120,7 +120,7 @@ public record LanguageTag(String language,
         List<String> extensions;
         // langtag must start with either language or privateuse
         if (!language.isEmpty()) {
-            extlangs = parseExtlangs(itr, pp);
+            extlangs = parseExtlangs(itr, pp, language);
             script = parseScript(itr, pp);
             region = parseRegion(itr, pp);
             variants = parseVariants(itr, pp);
@@ -170,8 +170,11 @@ public record LanguageTag(String language,
         return EMPTY_SUBTAG;
     }
 
-    private static List<String> parseExtlangs(StringTokenIterator itr, ParsePosition pp) {
-        if (itr.isDone() || pp.getErrorIndex() != -1) {
+    private static List<String> parseExtlangs(StringTokenIterator itr, ParsePosition pp, String lang) {
+        var langLen = lang.length();
+        if (itr.isDone() || pp.getErrorIndex() != -1
+                // Extlangs only accepted after 2*3ALPHA lang
+                || (langLen != 2 && langLen != 3)) {
             return EMPTY_SUBTAGS;
         }
         List<String> extlangs = null;

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -1397,8 +1397,8 @@ public class LocaleEnhanceTest {
         assertEquals(tag, locale.toLanguageTag());
     }
 
-    // Ensure that extlang is only accepted after a 2*3ALPHA lang
-    // That is, 4 ALPHA (future use) and 5*8 ALPHA langs should not accept extlangs
+    // Ensure that extlang is only accepted after a 2*3ALPHA language subtag
+    // That is, the 4 ALPHA and 5*8 ALPHA language subtags should not accept extlangs
     @ParameterizedTest
     @ValueSource(strings = {"quux", "foobar"})
     public void testExtlangAfterReservedLanguage(String lang) {

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @test
  * @bug 6875847 6992272 7002320 7015500 7023613 7032820 7033504 7004603
  *      7044019 8008577 8176853 8255086 8263202 8287868 8174269 8369452
- *      8369590 8387185
+ *      8369590 8387185 8387253
  * @summary test API changes to Locale
  * @modules jdk.localedata
  * @run junit/othervm -esa LocaleEnhanceTest
@@ -1394,6 +1395,19 @@ public class LocaleEnhanceTest {
                 .build();
         assertEquals(value, locale.getExtension(singleton));
         assertEquals(tag, locale.toLanguageTag());
+    }
+
+    // Ensure that extlang is only accepted after a 2*3ALPHA lang
+    // That is, 4 ALPHA (future use) and 5*8 ALPHA langs should not accept extlangs
+    @ParameterizedTest
+    @ValueSource(strings = {"quux", "foobar"})
+    public void testExtlangAfterReservedLanguage(String lang) {
+        String tag = lang + "-baz";
+        // Locale.forLanguageTag is lenient and truncates the extlang
+        assertEquals(lang, Locale.forLanguageTag(tag).toLanguageTag());
+        // Locale.Builder is strict and should throw
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLanguageTag(tag));
     }
 
     private void checkCalendar(Locale loc, String expected) {


### PR DESCRIPTION
This PR corrects Locale parsing logic for extra languages. The BCP syntax enforces that extlangs may only follow `2*3 ALPHA` langs. This is also reinforced by the syntax comment described in `LanguageTag.parse` (which is based off the BNF). However, the current implementation does not respect this, and allows extlangs to follow `4ALPHA` (future use) as well as `5*8ALPHA` langs.

For example, `Locale.forLanguageTag("quux-bar").toLanguageTag()` returns the extlang "bar" when it should return the lang "quux" and discard the extlang "bar".

This is likely an oversight and should be fixed rather than kept and specified as a BCP deviation, since it is non standard for extlangs to follow those previously mentioned longer tags.

I can file a release note if deemed warranted since the acceptable inputs shrink as a result (even if the correct behavior). Personally, I would lean towards not filing one since such occurrences would be non-standard as there are no extlangs that follow a non 2-3 length language prefix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387253](https://bugs.openjdk.org/browse/JDK-8387253): Locale incorrectly accepts extlangs after non 2*3ALPHA lang (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31663/head:pull/31663` \
`$ git checkout pull/31663`

Update a local copy of the PR: \
`$ git checkout pull/31663` \
`$ git pull https://git.openjdk.org/jdk.git pull/31663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31663`

View PR using the GUI difftool: \
`$ git pr show -t 31663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31663.diff">https://git.openjdk.org/jdk/pull/31663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31663#issuecomment-4792624809)
</details>
