### PR TITLE
8387260: Shenandoah: ShenandoahOldGeneration::_promoted_reserve should be atomic

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -132,16 +132,18 @@ ShenandoahOldGeneration::ShenandoahOldGeneration(uint max_queues)
 
 void ShenandoahOldGeneration::set_promoted_reserve(size_t new_val) {
   shenandoah_assert_heaplocked_or_safepoint();
-  _promoted_reserve = new_val;
+  _promoted_reserve.store_relaxed(new_val);
 }
 
 size_t ShenandoahOldGeneration::get_promoted_reserve() const {
-  return _promoted_reserve;
+  return _promoted_reserve.load_relaxed();
 }
 
 void ShenandoahOldGeneration::augment_promoted_reserve(size_t increment) {
   shenandoah_assert_heaplocked_or_safepoint();
-  _promoted_reserve += increment;
+  // Written under the heap lock, so a plain load/store of the current value is sufficient; the
+  // atomic store only guards the concurrent lock-free reader.
+  _promoted_reserve.store_relaxed(_promoted_reserve.load_relaxed() + increment);
 }
 
 void ShenandoahOldGeneration::reset_promoted_expended() {
@@ -194,9 +196,11 @@ void ShenandoahOldGeneration::maybe_log_promotion_failure_stats(bool concurrent)
 }
 
 bool ShenandoahOldGeneration::try_expend_promoted(size_t increment) {
-  const size_t reserve = get_promoted_reserve();
   size_t cur = _promoted_expended.load_relaxed();
-  while (cur + increment <= reserve) {
+  // Reload the reserve on every iteration: it may be augmented concurrently (e.g. promote-in-place
+  // adding to the reserve under the heap lock), so a stale snapshot could reject a promotion the
+  // freshly-grown reserve would allow.
+  while (cur + increment <= get_promoted_reserve()) {
     size_t prev = _promoted_expended.compare_exchange(cur, cur + increment);
     if (prev == cur) {
       return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -196,8 +196,8 @@ void ShenandoahOldGeneration::maybe_log_promotion_failure_stats(bool concurrent)
 }
 
 bool ShenandoahOldGeneration::try_expend_promoted(size_t increment) {
-  // The reserve does not change during evacuation, so snapshot it once; only _promoted_expended is
-  // contended and re-read on CAS failure.
+  // The promote reserve rarely changes during evacuation(only when there is PIP region), so snapshot it once;
+  // only _promoted_expended is contended and re-read on CAS failure.
   const size_t reserve = get_promoted_reserve();
   size_t cur = _promoted_expended.load_relaxed();
   while (cur + increment <= reserve) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -141,9 +141,9 @@ size_t ShenandoahOldGeneration::get_promoted_reserve() const {
 
 void ShenandoahOldGeneration::augment_promoted_reserve(size_t increment) {
   shenandoah_assert_heaplocked_or_safepoint();
-  // Written under the heap lock, so a plain load/store of the current value is sufficient; the
-  // atomic store only guards the concurrent lock-free reader.
-  _promoted_reserve.store_relaxed(_promoted_reserve.load_relaxed() + increment);
+  // Writers are serialized by the heap lock, so relaxed ordering is sufficient; the atomic RMW
+  // only guards against tearing the concurrent lock-free reader (get_promoted_reserve).
+  _promoted_reserve.fetch_then_add(increment, memory_order_relaxed);
 }
 
 void ShenandoahOldGeneration::reset_promoted_expended() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -196,11 +196,11 @@ void ShenandoahOldGeneration::maybe_log_promotion_failure_stats(bool concurrent)
 }
 
 bool ShenandoahOldGeneration::try_expend_promoted(size_t increment) {
+  // The reserve does not change during evacuation, so snapshot it once; only _promoted_expended is
+  // contended and re-read on CAS failure.
+  const size_t reserve = get_promoted_reserve();
   size_t cur = _promoted_expended.load_relaxed();
-  // Reload the reserve on every iteration: it may be augmented concurrently (e.g. promote-in-place
-  // adding to the reserve under the heap lock), so a stale snapshot could reject a promotion the
-  // freshly-grown reserve would allow.
-  while (cur + increment <= get_promoted_reserve()) {
+  while (cur + increment <= reserve) {
     size_t prev = _promoted_expended.compare_exchange(cur, cur + increment);
     if (prev == cur) {
       return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -58,9 +58,6 @@ private:
   // and in addition to the evacuation reserve for intra-generation evacuations (ShenandoahGeneration::_evacuation_reserve).
   // If there is more data ready to be promoted than can fit within this reserve, the promotion of some objects will be
   // deferred until a subsequent evacuation pass.
-  // Written only under the heap lock or at a safepoint, but read lock-free on the promotion gating
-  // path (try_expend_promoted/can_promote during evacuation), so it is accessed atomically to avoid
-  // a data race on the concurrent read.
   Atomic<size_t> _promoted_reserve;
 
   // Bytes of old-gen memory expended on promotions. This may be modified concurrently

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -58,7 +58,10 @@ private:
   // and in addition to the evacuation reserve for intra-generation evacuations (ShenandoahGeneration::_evacuation_reserve).
   // If there is more data ready to be promoted than can fit within this reserve, the promotion of some objects will be
   // deferred until a subsequent evacuation pass.
-  size_t _promoted_reserve;
+  // Written only under the heap lock or at a safepoint, but read lock-free on the promotion gating
+  // path (try_expend_promoted/can_promote during evacuation), so it is accessed atomically to avoid
+  // a data race on the concurrent read.
+  Atomic<size_t> _promoted_reserve;
 
   // Bytes of old-gen memory expended on promotions. This may be modified concurrently
   // by mutators and gc workers when promotion LABs are retired during evacuation. It


### PR DESCRIPTION
  ShenandoahOldGeneration::_promoted_reserve is a plain size_t. It is written only under the heap lock or at a safepoint (set_promoted_reserve, augment_promoted_reserve, both of which assert shenandoah_assert_heaplocked_or_safepoint()), but it is read lock-free on the promotion gating path during evacuation:
  - ShenandoahOldGeneration::try_expend_promoted() → get_promoted_reserve()
  - ShenandoahOldGeneration::can_promote() / can_allocate() → get_promoted_reserve()

  These reads run on GC worker and mutator threads without the heap lock (the same reason the sibling field _promoted_expended is already Atomic<size_t> and try_expend_promoted uses a CAS loop). augment_promoted_reserve() is called during promote-in-place (ShenandoahFreeSet::find_regions_with_alloc_capacity) while those lock-free reads may be in flight, so a concurrent write to _promoted_reserve races with the read. Reading a plain size_t that is concurrently written is a data race / undefined behavior and can yield a torn or stale value.

   It used be safe because all the read/write operations were done under heap lock, but after JDK-8385592, the read on allocation path is done w/o holding heap lock. 

Test
- [x] MacOS aarch64 - hotspot_gc_shenandoah test suite

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387260](https://bugs.openjdk.org/browse/JDK-8387260): Shenandoah: ShenandoahOldGeneration::_promoted_reserve should be atomic (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**) Review applies to [779e96c6](https://git.openjdk.org/jdk/pull/31665/files/779e96c65477493a853b4acc573d0e152bab033b)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31665/head:pull/31665` \
`$ git checkout pull/31665`

Update a local copy of the PR: \
`$ git checkout pull/31665` \
`$ git pull https://git.openjdk.org/jdk.git pull/31665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31665`

View PR using the GUI difftool: \
`$ git pr show -t 31665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31665.diff">https://git.openjdk.org/jdk/pull/31665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31665#issuecomment-4793922850)
</details>
