### PR TITLE
8387262: Enum constant frame::pc_return_offset is always zero

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -66,7 +66,6 @@
 
  public:
   enum {
-    pc_return_offset                                 =  0,
     // All frames
     link_offset                                      =  0,
     return_addr_offset                               =  1,

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
 
  public:
   enum {
-    pc_return_offset                                 =  0,
     // All frames
     link_offset                                      =  0,
     return_addr_offset                               =  1,

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -391,8 +391,6 @@
   }
 
   enum {
-    // normal return address is 1 bundle past PC
-    pc_return_offset                       = 0,
     // size, in words, of frame metadata (e.g. pc and link)
     metadata_words                         = sizeof(java_abi) >> LogBytesPerWord,
     // size, in words, of metadata at frame bottom, i.e. it is not part of the

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -103,8 +103,6 @@
 
  public:
   enum {
-    pc_return_offset                                 =  0,
-
     // All frames
     link_offset                                      = -2,
     return_addr_offset                               = -1,

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -542,14 +542,6 @@
                          unsigned long flags, int max_frames = 0);
 
   enum {
-    // This enum value specifies the offset from the pc remembered by
-    // call instructions to the location where control returns to
-    // after a normal return. Most architectures remember the return
-    // location directly, i.e. the offset is zero. This is the case
-    // for z/Architecture, too.
-    //
-    // Normal return address is the instruction following the branch.
-    pc_return_offset         = 0,
     metadata_words           = 0,
     metadata_words_at_bottom = 0,
     metadata_words_at_top    = 0,

--- a/src/hotspot/cpu/x86/frame_x86.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,6 @@
 
  public:
   enum {
-    pc_return_offset                                 =  0,
     // All frames
     link_offset                                      =  0,
     return_addr_offset                               =  1,

--- a/src/hotspot/cpu/zero/frame_zero.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -30,7 +30,6 @@
 
  public:
   enum {
-    pc_return_offset = 0,
     metadata_words   = 0,
     // size, in words, of metadata at frame bottom, i.e. it is not part of the
     // caller/callee overlap

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -2424,9 +2424,6 @@ int AOTCodeAddressTable::id_for_address(address addr, RelocIterator reloc, CodeB
     id = search_address(addr, _stubs_addr, _stubs_max);
     if (id == BAD_ADDRESS_ID) {
       StubCodeDesc* desc = StubCodeDesc::desc_for(addr);
-      if (desc == nullptr) {
-        desc = StubCodeDesc::desc_for(addr + frame::pc_return_offset);
-      }
       const char* sub_name = (desc != nullptr) ? desc->name() : "<unknown>";
       assert(false, "Address " INTPTR_FORMAT " for Stub:%s is missing in AOT Code Cache addresses table", p2i(addr), sub_name);
     } else {

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3783,9 +3783,6 @@ const char* nmethod::reloc_string_for(u_char* begin, u_char* end) {
           address dest = r->destination();
           if (StubRoutines::contains(dest)) {
             StubCodeDesc* desc = StubCodeDesc::desc_for(dest);
-            if (desc == nullptr) {
-              desc = StubCodeDesc::desc_for(dest + frame::pc_return_offset);
-            }
             if (desc != nullptr) {
               st.print(" Stub::%s", desc->name());
               return st.as_string();

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,9 +302,6 @@ void ExternalsRecorder::print_statistics() {
         if (addr != nullptr) {
           if (StubRoutines::contains(addr)) {
             StubCodeDesc* desc = StubCodeDesc::desc_for(addr);
-            if (desc == nullptr) {
-              desc = StubCodeDesc::desc_for(addr + frame::pc_return_offset);
-            }
             const char* stub_name = (desc != nullptr) ? desc->name() : "<unknown>";
             tty->print(" stub: %s", stub_name);
           } else {

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -922,9 +922,6 @@ void RelocIterator::print_current_on(outputStream* st) {
       st->print(" | [destination=" INTPTR_FORMAT "]", p2i(dest));
       if (StubRoutines::contains(dest)) {
         StubCodeDesc* desc = StubCodeDesc::desc_for(dest);
-        if (desc == nullptr) {
-          desc = StubCodeDesc::desc_for(dest + frame::pc_return_offset);
-        }
         if (desc != nullptr) {
           st->print(" Stub::%s", desc->name());
         }

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -591,9 +591,6 @@ void decode_env::print_address(address adr) {
   if (Universe::is_fully_initialized()) {
     if (StubRoutines::contains(adr)) {
       StubCodeDesc* desc = StubCodeDesc::desc_for(adr);
-      if (desc == nullptr) {
-        desc = StubCodeDesc::desc_for(adr + frame::pc_return_offset);
-      }
       if (desc != nullptr) {
         st->print("Stub::%s", desc->name());
         if (desc->begin() != adr) {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -673,7 +673,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
     // as interpreted so the skeleton frame will be walkable
     // The correct pc will be set when the skeleton frame is completely filled out
     // The final pc we store in the loop is wrong and will be overwritten below
-    frame_pcs[number_of_frames - 1 - index ] = Interpreter::deopt_entry(vtos, 0) - frame::pc_return_offset;
+    frame_pcs[number_of_frames - 1 - index ] = Interpreter::deopt_entry(vtos, 0);
 
     callee_parameters = array->element(index)->method()->size_of_parameters();
     callee_locals = array->element(index)->method()->max_locals();

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -206,9 +206,9 @@ address frame::raw_pc() const {
   if (is_deoptimized_frame()) {
     nmethod* nm = cb()->as_nmethod_or_null();
     assert(nm != nullptr, "only nmethod is expected here");
-    return nm->deopt_handler_entry() - pc_return_offset;
+    return nm->deopt_handler_entry();
   } else {
-    return (pc() - pc_return_offset);
+    return pc();
   }
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1810,7 +1810,7 @@ JRT_LEAF(void, SharedRuntime::fixup_callers_callsite(Method* method, address cal
   nmethod* caller = cb->as_nmethod();
 
   // Get the return PC for the passed caller PC.
-  address return_pc = caller_pc + frame::pc_return_offset;
+  address return_pc = caller_pc;
 
   if (!caller->is_in_use() || !NativeCall::is_call_before(return_pc)) {
     return;

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1709,8 +1709,6 @@
   /**********************/                                                \
   NOT_ZERO(PPC64_ONLY(declare_constant(frame::entry_frame_locals_size)))  \
                                                                           \
-  declare_constant(frame::pc_return_offset)                               \
-                                                                          \
   /*************/                                                         \
   /* vmSymbols */                                                         \
   /*************/                                                         \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Frame.java
@@ -75,12 +75,6 @@ public abstract class Frame implements Cloneable {
   /** Size of ConstMethod for computing BCI from BCP (FIXME: hack) */
   private static long    ConstMethodSize;
 
-  private static int pcReturnOffset;
-
-  public static int pcReturnOffset() {
-    return pcReturnOffset;
-  }
-
   protected void adjustForDeopt() {
     if (pc != null) {
       // Look for a deopt pc and if it is deopted convert to original pc
@@ -104,8 +98,6 @@ public abstract class Frame implements Cloneable {
     // FIXME: not sure whether alignment here is correct or how to
     // force it (round up to address size?)
     ConstMethodSize = ConstMethodType.getSize();
-
-    pcReturnOffset = db.lookupIntConstant("frame::pc_return_offset").intValue();
   }
 
   protected int bcpToBci(Address bcp, ConstMethod cm) {


### PR DESCRIPTION
Remove a constant that was zero on all platforms.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387262](https://bugs.openjdk.org/browse/JDK-8387262): Enum constant frame::pc_return_offset is always zero (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31666/head:pull/31666` \
`$ git checkout pull/31666`

Update a local copy of the PR: \
`$ git checkout pull/31666` \
`$ git pull https://git.openjdk.org/jdk.git pull/31666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31666`

View PR using the GUI difftool: \
`$ git pr show -t 31666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31666.diff">https://git.openjdk.org/jdk/pull/31666.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31666#issuecomment-4794274540)
</details>
