### PR TITLE
8387067: C2: "assert(C->live_nodes() <= C->max_node_limit()) failed: Live Node limit exceeded limit" for large string concats

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -727,10 +727,11 @@ PhaseStringOpts::PhaseStringOpts(PhaseGVN* gvn):
 
   for (int c = 0; c < concats.length(); c++) {
     StringConcat* sc = concats.at(c);
-    // before calling replace_string_concat(), check if the concat is
-    // too large and skip it
-    uint estimated_nodes = sc->num_arguments() * 150;
-    if (C->check_node_count(estimated_nodes, "string concat too large")) {
+    // Skip string concat optimization if the estimated node expansion
+    // would exceed the node budget. Each argument can generate up to
+    // ~330 nodes in the worst case (int_getChars with full digit extraction).
+    uint estimated_nodes = (uint)sc->num_arguments() * 330;
+    if (C->live_nodes() + estimated_nodes > C->max_node_limit()) {
       continue;
     }
     replace_string_concat(sc);

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -727,6 +727,12 @@ PhaseStringOpts::PhaseStringOpts(PhaseGVN* gvn):
 
   for (int c = 0; c < concats.length(); c++) {
     StringConcat* sc = concats.at(c);
+    // before calling replace_string_concat(), check if the concat is 
+    // too large and skip it 
+    uint estimated_nodes = sc->num_arguments() * 150;
+    if (C->check_node_count(estimated_nodes, "string concat too large")) {
+      continue;
+    }
     replace_string_concat(sc);
   }
 

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -727,8 +727,8 @@ PhaseStringOpts::PhaseStringOpts(PhaseGVN* gvn):
 
   for (int c = 0; c < concats.length(); c++) {
     StringConcat* sc = concats.at(c);
-    // before calling replace_string_concat(), check if the concat is 
-    // too large and skip it 
+    // before calling replace_string_concat(), check if the concat is
+    // too large and skip it
     uint estimated_nodes = sc->num_arguments() * 150;
     if (C->check_node_count(estimated_nodes, "string concat too large")) {
       continue;

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -730,14 +730,18 @@ PhaseStringOpts::PhaseStringOpts(PhaseGVN* gvn):
 
     // Skip string concat optimization if the estimated node expansion
     // would exceed the node budget. Each argument can generate up to
-    // estimated_nodes_per_concat_arg
-    uint estimated_nodes = (uint)sc->num_arguments() * estimated_nodes_per_concat_arg;
+    // estimated_nodes_per_concat_arg nodes; the extra "+ 1" reserves one
+    // argument's worth of headroom for the fixed per-concat overhead (the
+    // StringBuilder allocation elision, array setup and toString replacement)
+    // that is not attributable to any single argument. Without it a concat
+    // with zero arguments would get a budget of 0 yet still create nodes.
+    uint estimated_nodes = ((uint)sc->num_arguments() + 1) * estimated_nodes_per_concat_arg;
     if (C->live_nodes() + estimated_nodes > C->max_node_limit() - NodeLimitFudgeFactor) {
       continue;
     }
 
     // Assert to verify that a replacement did not create
-    // more than n * 330 nodes.
+    // more than the estimated number of nodes.
 #ifdef ASSERT
     uint nodes_before = C->live_nodes();
 #endif

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -727,14 +727,29 @@ PhaseStringOpts::PhaseStringOpts(PhaseGVN* gvn):
 
   for (int c = 0; c < concats.length(); c++) {
     StringConcat* sc = concats.at(c);
+
     // Skip string concat optimization if the estimated node expansion
     // would exceed the node budget. Each argument can generate up to
-    // ~330 nodes in the worst case (int_getChars with full digit extraction).
-    uint estimated_nodes = (uint)sc->num_arguments() * 330;
-    if (C->live_nodes() + estimated_nodes > C->max_node_limit()) {
+    // estimated_nodes_per_concat_arg
+    uint estimated_nodes = (uint)sc->num_arguments() * estimated_nodes_per_concat_arg;
+    if (C->live_nodes() + estimated_nodes > C->max_node_limit() - NodeLimitFudgeFactor) {
       continue;
     }
+
+    // Assert to verify that a replacement did not create
+    // more than n * 330 nodes.
+#ifdef ASSERT
+    uint nodes_before = C->live_nodes();
+#endif
+
     replace_string_concat(sc);
+
+#ifdef ASSERT
+    uint nodes_created = C->live_nodes() - nodes_before;
+    assert(nodes_created <= estimated_nodes,
+          "StringConcat node expansion estimate exceeded: estimated max %u, created %u",
+          estimated_nodes, nodes_created);
+#endif
   }
 
   remove_dead_nodes();

--- a/src/hotspot/share/opto/stringopts.hpp
+++ b/src/hotspot/share/opto/stringopts.hpp
@@ -102,7 +102,10 @@ class PhaseStringOpts : public Phase {
 
   enum {
     // max length of constant string copy unrolling in copy_string
-    unroll_string_copy_length = 6
+    unroll_string_copy_length = 6,
+    // Estimated worst-case number of IR nodes a single concat argument can expand to.
+    // Used to estimate whether expanding a concat would exceed the node limit.
+    estimated_nodes_per_concat_arg = 330
   };
 
  public:

--- a/test/hotspot/jtreg/compiler/stringopts/TestLargeIntConcat.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestLargeIntConcat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/compiler/stringopts/TestLargeIntConcat.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestLargeIntConcat.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387067
+ * @summary C2 should not crash with node limit exceeded for large int string concatenations
+ * @run main/othervm -Xbatch compiler.stringopts.TestLargeIntConcat
+ */
+
+package compiler.stringopts;
+
+public class TestLargeIntConcat {
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(i);
+        }
+    }
+
+    public static String test(int i) {
+        return new StringBuilder()
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .toString();
+    }
+}

--- a/test/hotspot/jtreg/compiler/stringopts/TestWorstCaseIntConcat.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestWorstCaseIntConcat.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387067
+ * @summary Exercise the worst-case per-argument node expansion of the C2 string
+ *          concat optimization: a non-constant String prefix keeps the destination
+ *          coder unknown, so int_getChars emits BOTH the Latin1 and UTF16 digit
+ *          loops for every int argument. On a fastdebug build this validates the
+ *          `nodes_created <= num_arguments * estimated_nodes_per_concat_arg` assert
+ *          in PhaseStringOpts. The argument count is kept moderate so the concat
+ *          stays under the node-budget guard and actually reaches
+ *          replace_string_concat (otherwise the guard skips it and the assert
+ *          never runs).
+ * @run main/othervm -Xbatch compiler.stringopts.TestWorstCaseIntConcat
+ * @run main/othervm -Xcomp
+ *      -XX:CompileCommand=compileonly,compiler.stringopts.TestWorstCaseIntConcat::test
+ *      compiler.stringopts.TestWorstCaseIntConcat
+ */
+
+package compiler.stringopts;
+
+public class TestWorstCaseIntConcat {
+
+    public static void main(String[] args) {
+        // Non-constant prefix -> destination coder is unknown at compile time,
+        // forcing both the Latin1 and UTF16 code paths in int_getChars.
+        String prefix = args.length > 0 ? args[0] : "éprefix"; // Latin1-ish default
+        String out = null;
+        for (int i = 0; i < 20_000; i++) {
+            out = test(prefix, i);
+        }
+        // Consume the result so nothing can be dead-code eliminated.
+        if (out == null || out.isEmpty()) {
+            throw new AssertionError("unexpected empty result");
+        }
+    }
+
+    // One unknown-coder String argument + many int arguments. Integer.MIN_VALUE is
+    // mixed in so the MIN_VALUE special-case branch is exercised too. Each int
+    // argument therefore hits the most expensive path in int_getChars.
+    public static String test(String prefix, int i) {
+        return new StringBuilder()
+            .append(prefix)
+            .append(Integer.MIN_VALUE)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .append(i).append(i).append(i).append(i).append(i).append(i).append(i).append(i)
+            .toString();
+    }
+}


### PR DESCRIPTION
When a method has a very large number of `StringBuilder.append(int)` calls (e.g., 500+), C2's `PhaseStringOpts::replace_string_concat()` can exceed the live node limit because each int append expands into ~150 IR nodes (division, modulo, character extraction).

Add a node budget check before expanding each concat: if the estimated cost `(num_arguments * 150)` would exceed the remaining node limit, skip the optimization. The method still compiles correctly via the unoptimized StringBuilder path.

### Testing
Added `test/hotspot/jtreg/compiler/stringopts/TestLargeIntConcat.java` which exercises a 500-append int concat chain, which verifies no crash on compilation.

Built hotspot (`linux-x86_64-server-release`) successfully.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387067](https://bugs.openjdk.org/browse/JDK-8387067): C2: "assert(C-&gt;live_nodes() &lt;= C-&gt;max_node_limit()) failed: Live Node limit exceeded limit" for large string concats (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31668/head:pull/31668` \
`$ git checkout pull/31668`

Update a local copy of the PR: \
`$ git checkout pull/31668` \
`$ git pull https://git.openjdk.org/jdk.git pull/31668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31668`

View PR using the GUI difftool: \
`$ git pr show -t 31668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31668.diff">https://git.openjdk.org/jdk/pull/31668.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31668#issuecomment-4865019219)
</details>
