### PR TITLE
8386593: AArch64: serviceability/sa/TestJhsdbJstackMixedWithXComp.java fails on Ubuntu 26.04

### DIFF
--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -60,6 +60,9 @@ LIBSAPROC_EXCLUDE_FILES :=
 ifneq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, x86_64 aarch64)), true)
   LIBSAPROC_EXCLUDE_FILES := DwarfParser.cpp dwarf.cpp
 endif
+ifneq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), true)
+  LIBSAPROC_EXCLUDE_FILES += AARCH64DwarfParser.cpp aarch64Dwarf.cpp LinuxAARCH64DebuggerLocal.cpp
+endif
 
 $(eval $(call SetupJdkLibrary, BUILD_LIBSAPROC, \
     NAME := saproc, \

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -544,6 +544,13 @@ void VM_Version::initialize() {
     UsePopCountInstruction = true;
   }
 
+  if (supports_paca()) {
+    // Determine the mask of address bits used for PAC. Clear bit 55 of
+    // the input to make it look like a user address.
+    // This mask would be used in mixed jstack in SA.
+    _pac_mask = (uintptr_t)pauth_strip_pointer((address)~(UINT64_C(1) << 55));
+  }
+
   if (UseBranchProtection == nullptr || strcmp(UseBranchProtection, "none") == 0) {
     _rop_protection = false;
   } else if (strcmp(UseBranchProtection, "standard") == 0 ||
@@ -565,13 +572,6 @@ void VM_Version::initialize() {
   } else {
     vm_exit_during_initialization(err_msg("Unsupported UseBranchProtection: %s", UseBranchProtection));
   }
-
-  if (_rop_protection == true) {
-    // Determine the mask of address bits used for PAC. Clear bit 55 of
-    // the input to make it look like a user address.
-    _pac_mask = (uintptr_t)pauth_strip_pointer((address)~(UINT64_C(1) << 55));
-  }
-
 #ifdef COMPILER2
   if (FLAG_IS_DEFAULT(UseMultiplyToLenIntrinsic)) {
     UseMultiplyToLenIntrinsic = true;

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/AARCH64DwarfParser.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/AARCH64DwarfParser.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include <jni.h>
+
+#include "aarch64Dwarf.hpp"
+
+/*
+ * Class:     sun_jvm_hotspot_debugger_linux_aarch64_AARCH64DwarfParser
+ * Method:    createDwarfContext
+ * Signature: (J)J
+ */
+extern "C"
+JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_linux_aarch64_AARCH64DwarfParser_createDwarfContext
+  (JNIEnv *env, jclass this_cls, jlong lib) {
+  AARCH64DwarfParser *parser = new AARCH64DwarfParser(reinterpret_cast<lib_info *>(lib));
+  if (!parser->is_parseable()) {
+    jclass ex_cls = env->FindClass("sun/jvm/hotspot/debugger/DebuggerException");
+    if (!env->ExceptionCheck()) {
+        env->ThrowNew(ex_cls, "DWARF not found");
+    }
+    delete parser;
+    return 0L;
+  }
+
+  return reinterpret_cast<jlong>(parser);
+}
+
+/*
+ * Class:     sun_jvm_hotspot_debugger_linux_aarch64_AARCH64DwarfParser
+ * Method:    isRASigned0
+ * Signature: (J)Z
+ */
+extern "C"
+JNIEXPORT jboolean JNICALL Java_sun_jvm_hotspot_debugger_linux_aarch64_AARCH64DwarfParser_isRASigned0
+  (JNIEnv *env, jobject this_obj, jlong inst) {
+  AARCH64DwarfParser *parser = reinterpret_cast<AARCH64DwarfParser *>(inst);
+  return static_cast<jboolean>(parser->is_ra_signed());
+}

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxAARCH64DebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxAARCH64DebuggerLocal.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,34 +23,17 @@
  *
  */
 
-package sun.jvm.hotspot.debugger;
+#include <jni.h>
+#include "libproc.h"
 
-public class MachineDescriptionAArch64 extends MachineDescriptionTwosComplement implements MachineDescription {
 
-  private boolean pac;
-
-  public MachineDescriptionAArch64() {
-    pac = false;
-  }
-
-  public long getAddressSize() {
-    return 8;
-  }
-
-  public boolean isLP64() {
-    return true;
-  }
-
-  public boolean isBigEndian() {
-    return false;
-  }
-
-  public void enablePAC() {
-    pac = true;
-  }
-
-  public boolean isPACEnabled() {
-    return pac;
-  }
-
+/*
+ * Class:     sun_jvm_hotspot_debugger_linux_aarch64_LinuxAARCH64DebuggerLocal
+ * Method:    isPACEnabled0
+ * Signature: (J)Z
+ */
+extern "C"
+JNIEXPORT jboolean JNICALL Java_sun_jvm_hotspot_debugger_linux_aarch64_LinuxAARCH64DebuggerLocal_isPACEnabled0
+  (JNIEnv *env, jobject this_obj, jlong inst) {
+  return pac_enabled(reinterpret_cast<struct ps_prochandle*>(inst));
 }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -290,12 +290,6 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_at
     THROW_NEW_DEBUGGER_EXCEPTION(msg);
   }
 
-#ifdef __aarch64__
-  if (pac_enabled(ph)) {
-    printf("WARNING: PAC is enabled. Stack traces might be incomplete.\n");
-  }
-#endif
-
   env->SetLongField(this_obj, p_ps_prochandle_ID, (jlong)(intptr_t)ph);
   fillThreadsAndLoadObjects(env, this_obj, ph);
 }
@@ -320,12 +314,6 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_at
   if ( (ph = Pgrab_core(execName_cstr, coreName_cstr)) == NULL) {
     THROW_NEW_DEBUGGER_EXCEPTION("Can't attach to the core file. For more information, export LIBSAPROC_DEBUG=1 and try again.");
   }
-
-#ifdef __aarch64__
-  if (pac_enabled(ph)) {
-    printf("WARNING: PAC is enabled. Stack traces might be incomplete.\n");
-  }
-#endif
 
   env->SetLongField(this_obj, p_ps_prochandle_ID, (jlong)(intptr_t)ph);
   fillThreadsAndLoadObjects(env, this_obj, ph);

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/aarch64Dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/aarch64Dwarf.cpp
@@ -34,7 +34,7 @@ bool AARCH64DwarfParser::process_arch_specific_dwarf_instructions(const unsigned
       } else if (_sign_state == RA_SIGNED_SP) {
         _sign_state = RA_NOT_SIGNED;
       } else {
-        print_debug("DWARF: DW_CFA_AARCH64_negate_ra_state: illegal state (%d)\n", _sign_state);
+        print_error("DWARF: DW_CFA_AARCH64_negate_ra_state: illegal state (%d)\n", _sign_state);
         return false;
       }
       break;
@@ -44,7 +44,7 @@ bool AARCH64DwarfParser::process_arch_specific_dwarf_instructions(const unsigned
       } else if (_sign_state == RA_SIGNED_SP_PC) {
         _sign_state = RA_NOT_SIGNED;
       } else {
-        print_debug("DWARF: DW_CFA_AARCH64_negate_ra_state_with_pc: illegal state (%d\n)", _sign_state);
+        print_error("DWARF: DW_CFA_AARCH64_negate_ra_state_with_pc: illegal state (%d)\n", _sign_state);
         return false;
       }
       break;
@@ -64,7 +64,7 @@ void AARCH64DwarfParser::remember_arch_specific_state() {
 
 void AARCH64DwarfParser::restore_arch_specific_state() {
   if (remember_state.empty()) {
-    print_debug("DWARF Error: DW_CFA_restore_state for AArch64 is empty.\n");
+    print_error("DWARF Error: DW_CFA_restore_state for AArch64 is empty.\n");
     return;
   }
   _sign_state = remember_state.top();

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/aarch64Dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/aarch64Dwarf.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "aarch64Dwarf.hpp"
+
+
+bool AARCH64DwarfParser::process_arch_specific_dwarf_instructions(const unsigned char op) {
+  switch(op) {
+    case 0x2d: // DW_CFA_AARCH64_negate_ra_state
+      if (_sign_state == RA_NOT_SIGNED) {
+        _sign_state = RA_SIGNED_SP;
+      } else if (_sign_state == RA_SIGNED_SP) {
+        _sign_state = RA_NOT_SIGNED;
+      } else {
+        print_debug("DWARF: DW_CFA_AARCH64_negate_ra_state: illegal state (%d)\n", _sign_state);
+        return false;
+      }
+      break;
+    case 0x2c: // DW_CFA_AARCH64_negate_ra_state_with_pc
+      if (_sign_state == RA_NOT_SIGNED) {
+        _sign_state = RA_SIGNED_SP_PC;
+      } else if (_sign_state == RA_SIGNED_SP_PC) {
+        _sign_state = RA_NOT_SIGNED;
+      } else {
+        print_debug("DWARF: DW_CFA_AARCH64_negate_ra_state_with_pc: illegal state (%d\n)", _sign_state);
+        return false;
+      }
+      break;
+    case 0x2b: // DW_CFA_AARCH64_set_ra_state
+      _sign_state = static_cast<RASignState>(read_leb(false));
+      read_leb(false); // operand 2: dummy
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+void AARCH64DwarfParser::remember_arch_specific_state() {
+  remember_state.push(_sign_state);
+}
+
+void AARCH64DwarfParser::restore_arch_specific_state() {
+  if (remember_state.empty()) {
+    print_debug("DWARF Error: DW_CFA_restore_state for AArch64 is empty.\n");
+    return;
+  }
+  _sign_state = remember_state.top();
+  remember_state.pop();
+}

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/aarch64Dwarf.hpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/aarch64Dwarf.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,34 +23,35 @@
  *
  */
 
-package sun.jvm.hotspot.debugger;
+#ifndef AARCH64_DWARF_H
+#define AARCH64_DWARF_H
 
-public class MachineDescriptionAArch64 extends MachineDescriptionTwosComplement implements MachineDescription {
+#include <stack>
 
-  private boolean pac;
+#include "dwarf.hpp"
 
-  public MachineDescriptionAArch64() {
-    pac = false;
-  }
+enum RASignState {
+  RA_NOT_SIGNED = 0,
+  RA_SIGNED_SP,
+  RA_SIGNED_SP_PC
+};
 
-  public long getAddressSize() {
-    return 8;
-  }
+class AARCH64DwarfParser : public DwarfParser {
+  private:
+    RASignState _sign_state; // RA_SIGN_STATE pseudo DWARF register
+    std::stack<RASignState> remember_state;
 
-  public boolean isLP64() {
-    return true;
-  }
+  protected:
+    virtual bool process_arch_specific_dwarf_instructions(const unsigned char op);
+    virtual void remember_arch_specific_state();
+    virtual void restore_arch_specific_state();
 
-  public boolean isBigEndian() {
-    return false;
-  }
+  public:
+    // RA_SIGN_STATE should be initialized by DW_AARCH64_RA_NOT_SIGNED.
+    AARCH64DwarfParser(lib_info* lib) : DwarfParser(lib), _sign_state(RA_NOT_SIGNED), remember_state() {}
+    ~AARCH64DwarfParser() {}
 
-  public void enablePAC() {
-    pac = true;
-  }
+    bool is_ra_signed() { return _sign_state != RA_NOT_SIGNED; }
+};
 
-  public boolean isPACEnabled() {
-    return pac;
-  }
-
-}
+#endif

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
@@ -210,6 +210,7 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
         break;
       case 0x0a: // DW_CFA_remember_state
         remember_state.push(_state);
+        remember_arch_specific_state();
         break;
       case 0x0b: // DW_CFA_restore_state
         if (remember_state.empty()) {
@@ -218,29 +219,18 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
         }
         _state = remember_state.top();
         remember_state.pop();
+        restore_arch_specific_state();
         break;
       case 0xc0: {// DW_CFA_restore
         enum DWARF_Register reg = static_cast<enum DWARF_Register>(opa);
         _state.offset_from_cfa[reg] = _initial_state.offset_from_cfa[reg];
         break;
       }
-#ifdef __aarch64__
-      // SA hasn't yet supported Pointer Authetication Code (PAC), so following
-      // instructions would be ignored with warning message.
-      //   https://github.com/ARM-software/abi-aa/blob/2025Q4/aadwarf64/aadwarf64.rst
-      case 0x2d: // DW_CFA_AARCH64_negate_ra_state
-        print_debug("DWARF: DW_CFA_AARCH64_negate_ra_state is unimplemented.\n", op);
-        break;
-      case 0x2c: // DW_CFA_AARCH64_negate_ra_state_with_pc
-        print_debug("DWARF: DW_CFA_AARCH64_negate_ra_state_with_pc is unimplemented.\n", op);
-        break;
-      case 0x2b: // DW_CFA_AARCH64_set_ra_state
-        print_debug("DWARF: DW_CFA_AARCH64_set_ra_state is unimplemented.\n", op);
-        break;
-#endif
       default:
-        print_debug("DWARF: Unknown opcode: 0x%x\n", op);
-        return;
+        if (!process_arch_specific_dwarf_instructions(op)) {
+          print_debug("DWARF: Unknown opcode: 0x%x\n", op);
+          return;
+        }
     }
   }
 }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
@@ -228,7 +228,7 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
       }
       default:
         if (!process_arch_specific_dwarf_instructions(op)) {
-          print_error("DWARF: Unknown opcode: 0x%x\n", op);
+          print_debug("DWARF: Unknown opcode: 0x%x\n", op);
           return;
         }
     }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
@@ -228,7 +228,7 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
       }
       default:
         if (!process_arch_specific_dwarf_instructions(op)) {
-          print_debug("DWARF: Unknown opcode: 0x%x\n", op);
+          print_error("DWARF: Unknown opcode: 0x%x\n", op);
           return;
         }
     }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.hpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.hpp
@@ -73,16 +73,30 @@ class DwarfParser {
     struct DwarfState _state;
 
     void init_state(struct DwarfState& st);
-    uintptr_t read_leb(bool sign);
     uint64_t get_entry_length();
     bool process_cie(unsigned char *start_of_entry, uint32_t id);
     void parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const unsigned char *end);
     uint32_t get_decoded_value(unsigned char enc);
     unsigned int get_pc_range();
 
+  protected:
+    uintptr_t read_leb(bool sign);
+
+    virtual bool process_arch_specific_dwarf_instructions(const unsigned char op) {
+      return false; // Do nothing by default - it should be implemented by inherited classes.
+    };
+
+    virtual void remember_arch_specific_state() {
+      // Do nothing by default - it should be implemented by inherited classes.
+    };
+
+    virtual void restore_arch_specific_state() {
+      // Do nothing by default - it should be implemented by inherited classes.
+    };
+
   public:
     DwarfParser(lib_info *lib);
-    ~DwarfParser() {}
+    virtual ~DwarfParser() {}
     bool process_dwarf(const uintptr_t pc);
     enum DWARF_Register get_cfa_register() { return _state.cfa_reg; }
     int get_cfa_offset() { return _state.cfa_offset; }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,6 +40,7 @@ import sun.jvm.hotspot.debugger.MachineDescriptionRISCV64;
 import sun.jvm.hotspot.debugger.NoSuchSymbolException;
 import sun.jvm.hotspot.debugger.bsd.BsdDebuggerLocal;
 import sun.jvm.hotspot.debugger.linux.LinuxDebuggerLocal;
+import sun.jvm.hotspot.debugger.linux.aarch64.LinuxAARCH64DebuggerLocal;
 import sun.jvm.hotspot.debugger.remote.RemoteDebugger;
 import sun.jvm.hotspot.debugger.remote.RemoteDebuggerClient;
 import sun.jvm.hotspot.debugger.remote.RemoteDebuggerServer;
@@ -551,27 +552,29 @@ public class HotSpotAgent {
     private void setupDebuggerLinux() {
         setupJVMLibNamesLinux();
 
-        if (cpu.equals("amd64")) {
-            machDesc = new MachineDescriptionAMD64();
-        } else if (cpu.equals("ppc64")) {
-            machDesc = new MachineDescriptionPPC64();
-        } else if (cpu.equals("aarch64")) {
+        if (cpu.equals("aarch64")) {
             machDesc = new MachineDescriptionAArch64();
-        } else if (cpu.equals("riscv64")) {
-            machDesc = new MachineDescriptionRISCV64();
+            debugger = new LinuxAARCH64DebuggerLocal(machDesc, !isServer);
         } else {
-          try {
-            machDesc = (MachineDescription)
-              Class.forName("sun.jvm.hotspot.debugger.MachineDescription" +
-                            cpu.toUpperCase()).getDeclaredConstructor().newInstance();
-          } catch (Exception e) {
-            throw new DebuggerException("Linux not supported on machine type " + cpu);
-          }
+            if (cpu.equals("amd64")) {
+                machDesc = new MachineDescriptionAMD64();
+            } else if (cpu.equals("ppc64")) {
+                machDesc = new MachineDescriptionPPC64();
+            } else if (cpu.equals("aarch64")) {
+                machDesc = new MachineDescriptionAArch64();
+            } else if (cpu.equals("riscv64")) {
+                machDesc = new MachineDescriptionRISCV64();
+            } else {
+                try {
+                    machDesc = (MachineDescription)
+                        Class.forName("sun.jvm.hotspot.debugger.MachineDescription" +
+                                      cpu.toUpperCase()).getDeclaredConstructor().newInstance();
+                } catch (Exception _) {
+                    throw new DebuggerException("Linux not supported on machine type " + cpu);
+                }
+            }
+            debugger = new LinuxDebuggerLocal(machDesc, !isServer);
         }
-
-        LinuxDebuggerLocal dbg =
-        new LinuxDebuggerLocal(machDesc, !isServer);
-        debugger = dbg;
 
         attachDebugger();
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -560,8 +560,6 @@ public class HotSpotAgent {
                 machDesc = new MachineDescriptionAMD64();
             } else if (cpu.equals("ppc64")) {
                 machDesc = new MachineDescriptionPPC64();
-            } else if (cpu.equals("aarch64")) {
-                machDesc = new MachineDescriptionAArch64();
             } else if (cpu.equals("riscv64")) {
                 machDesc = new MachineDescriptionRISCV64();
             } else {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfCFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfCFrame.java
@@ -32,6 +32,7 @@ import sun.jvm.hotspot.debugger.UnmappedAddressException;
 import sun.jvm.hotspot.debugger.cdbg.CFrame;
 import sun.jvm.hotspot.debugger.cdbg.ClosestSymbol;
 import sun.jvm.hotspot.debugger.cdbg.basic.BasicCFrame;
+import sun.jvm.hotspot.debugger.linux.aarch64.AARCH64DwarfParser;
 import sun.jvm.hotspot.runtime.VM;
 
 public class DwarfCFrame extends BasicCFrame {
@@ -53,7 +54,8 @@ public class DwarfCFrame extends BasicCFrame {
     protected static DwarfParser createDwarfParser(LinuxDebugger linuxDbg, Address pc) {
         Address libptr = linuxDbg.findLibPtrByAddress(pc);
         if (libptr != null) {
-            DwarfParser dwarf = new DwarfParser(libptr);
+            DwarfParser dwarf = linuxDbg.getCPU().equals("aarch64") ? new AARCH64DwarfParser(libptr)
+                                                                    : new DwarfParser(libptr);
             dwarf.processDwarf(pc);
             return dwarf;
         }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfParser.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfParser.java
@@ -31,7 +31,7 @@ import sun.jvm.hotspot.debugger.DebuggerException;
 
 public class DwarfParser {
   private static final Cleaner CLEANER = Cleaner.create();
-  private final long p_dwarf_context; // native dwarf context handle
+  protected final long p_dwarf_context; // native dwarf context handle
 
   private static native void init0();
   private static native long createDwarfContext(long lib);
@@ -46,14 +46,20 @@ public class DwarfParser {
     return () -> DwarfParser.destroyDwarfContext(context);
   }
 
-  public DwarfParser(Address lib) {
-    p_dwarf_context = createDwarfContext(lib.asLongValue());
+  // Declare this constructor as protected because it is danger if 3rd party classes passes
+  // non-pointer value of DwarfParser class in JNI.
+  protected DwarfParser(long ptr) {
+    p_dwarf_context = ptr;
 
     if (p_dwarf_context == 0L) {
       throw new DebuggerException("Could not create DWARF context");
     }
 
     CLEANER.register(this, cleanerFor(p_dwarf_context));
+  }
+
+  public DwarfParser(Address lib) {
+    this(createDwarfContext(lib.asLongValue()));
   }
 
   public boolean isIn(Address pc) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
@@ -40,7 +40,6 @@ import sun.jvm.hotspot.debugger.DebuggerBase;
 import sun.jvm.hotspot.debugger.DebuggerException;
 import sun.jvm.hotspot.debugger.DebuggerUtilities;
 import sun.jvm.hotspot.debugger.MachineDescription;
-import sun.jvm.hotspot.debugger.MachineDescriptionAArch64;
 import sun.jvm.hotspot.debugger.NotInHeapException;
 import sun.jvm.hotspot.debugger.OopHandle;
 import sun.jvm.hotspot.debugger.ProcessInfo;
@@ -51,7 +50,6 @@ import sun.jvm.hotspot.debugger.UnmappedAddressException;
 import sun.jvm.hotspot.debugger.cdbg.CDebugger;
 import sun.jvm.hotspot.debugger.cdbg.ClosestSymbol;
 import sun.jvm.hotspot.debugger.cdbg.LoadObject;
-import sun.jvm.hotspot.debugger.linux.aarch64.LinuxAARCH64DebuggerLocal;
 import sun.jvm.hotspot.utilities.PlatformInfo;
 
 /** <P> An implementation of the JVMDebugger interface. The basic debug
@@ -300,6 +298,10 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
         }
     }
 
+    protected void onAttach() {
+       // Do nothing by default: it should be implemented by inherited classes.
+    }
+
     /** From the Debugger interface via JVMDebugger */
     public synchronized void attach(int processID) throws DebuggerException {
         checkAttached();
@@ -321,12 +323,11 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
            int pid;
            public void doit(LinuxDebuggerLocal debugger) {
               debugger.attach0(pid);
-              if ((debugger instanceof LinuxAARCH64DebuggerLocal d) && d.isPACEnabled()) {
-                 ((MachineDescriptionAArch64)d.getMachineDescription()).enablePAC();
-              }
               debugger.attached = true;
               debugger.isCore = false;
               findABIVersion();
+
+              onAttach();
            }
         }
 
@@ -341,12 +342,11 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
         threadList = new ArrayList<>();
         loadObjectList = new ArrayList<>();
         attach0(execName, coreName);
-        if ((this instanceof LinuxAARCH64DebuggerLocal d) && d.isPACEnabled()) {
-            ((MachineDescriptionAArch64)d.getMachineDescription()).enablePAC();
-        }
         attached = true;
         isCore = true;
         findABIVersion();
+
+        onAttach();
     }
 
     /** From the Debugger interface via JVMDebugger */

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
@@ -40,6 +40,7 @@ import sun.jvm.hotspot.debugger.DebuggerBase;
 import sun.jvm.hotspot.debugger.DebuggerException;
 import sun.jvm.hotspot.debugger.DebuggerUtilities;
 import sun.jvm.hotspot.debugger.MachineDescription;
+import sun.jvm.hotspot.debugger.MachineDescriptionAArch64;
 import sun.jvm.hotspot.debugger.NotInHeapException;
 import sun.jvm.hotspot.debugger.OopHandle;
 import sun.jvm.hotspot.debugger.ProcessInfo;
@@ -50,6 +51,7 @@ import sun.jvm.hotspot.debugger.UnmappedAddressException;
 import sun.jvm.hotspot.debugger.cdbg.CDebugger;
 import sun.jvm.hotspot.debugger.cdbg.ClosestSymbol;
 import sun.jvm.hotspot.debugger.cdbg.LoadObject;
+import sun.jvm.hotspot.debugger.linux.aarch64.LinuxAARCH64DebuggerLocal;
 import sun.jvm.hotspot.utilities.PlatformInfo;
 
 /** <P> An implementation of the JVMDebugger interface. The basic debug
@@ -71,7 +73,7 @@ import sun.jvm.hotspot.utilities.PlatformInfo;
 public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
     private boolean useGCC32ABI;
     private boolean attached;
-    private long    p_ps_prochandle; // native debugger handle
+    protected long  p_ps_prochandle; // native debugger handle
     private boolean isCore;
 
     // CDebugger support
@@ -319,6 +321,9 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
            int pid;
            public void doit(LinuxDebuggerLocal debugger) {
               debugger.attach0(pid);
+              if ((debugger instanceof LinuxAARCH64DebuggerLocal d) && d.isPACEnabled()) {
+                 ((MachineDescriptionAArch64)d.getMachineDescription()).enablePAC();
+              }
               debugger.attached = true;
               debugger.isCore = false;
               findABIVersion();
@@ -336,6 +341,9 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
         threadList = new ArrayList<>();
         loadObjectList = new ArrayList<>();
         attach0(execName, coreName);
+        if ((this instanceof LinuxAARCH64DebuggerLocal d) && d.isPACEnabled()) {
+            ((MachineDescriptionAArch64)d.getMachineDescription()).enablePAC();
+        }
         attached = true;
         isCore = true;
         findABIVersion();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/AARCH64DwarfParser.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/AARCH64DwarfParser.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,34 +23,27 @@
  *
  */
 
-package sun.jvm.hotspot.debugger;
+package sun.jvm.hotspot.debugger.linux.aarch64;
 
-public class MachineDescriptionAArch64 extends MachineDescriptionTwosComplement implements MachineDescription {
+import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.debugger.linux.DwarfParser;
 
-  private boolean pac;
 
-  public MachineDescriptionAArch64() {
-    pac = false;
-  }
+public class AARCH64DwarfParser extends DwarfParser {
 
-  public long getAddressSize() {
-    return 8;
-  }
+    private static native long createDwarfContext(long lib);
 
-  public boolean isLP64() {
-    return true;
-  }
+    public AARCH64DwarfParser(Address lib) {
+        super(createDwarfContext(lib.asLongValue()));
+    }
 
-  public boolean isBigEndian() {
-    return false;
-  }
+    /**
+     * @return true if return address (RA) is signed by PAC.
+     */
+    public boolean isRASigned() {
+        return isRASigned0(p_dwarf_context);
+    }
 
-  public void enablePAC() {
-    pac = true;
-  }
-
-  public boolean isPACEnabled() {
-    return pac;
-  }
+    public native boolean isRASigned0(long inst);
 
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64CFrame.java
@@ -120,6 +120,13 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
      throw new DebuggerException("JavaThread not found");
    }
 
+   // Most of code is copied from AARCH64Frame.java.
+   // CFrame need to consider PAC in native frame even if -XX:UseBranchProtection is disabled.
+   // (_rop_protection in HotSpot)
+   private Address stripPAC(Address addr) {
+      return addr.andWithMask(AARCH64Frame.pacMask());
+   }
+
    @Override
    public CFrame sender(ThreadProxy thread, Address senderSP, Address senderFP, Address senderPC) {
       if (linuxDbg().isSignalTrampoline(pc())) {
@@ -165,6 +172,13 @@ public final class LinuxAARCH64CFrame extends DwarfCFrame {
       }
       if (senderSP == null) {
         return null;
+      }
+
+      // Strip PAC
+      if (((MachineDescriptionAArch64)linuxDbg().getMachineDescription()).isPACEnabled() &&
+          ((dwarf() != null && ((AARCH64DwarfParser)dwarf()).isRASigned() /* for native */ ) ||
+           (AARCH64Frame.ropProtection() != 0 /* for Java */ ))) {
+        senderPC = stripPAC(senderPC);
       }
 
       DwarfParser senderDwarf = null;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64DebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64DebuggerLocal.java
@@ -28,12 +28,20 @@ package sun.jvm.hotspot.debugger.linux.aarch64;
 import sun.jvm.hotspot.debugger.linux.LinuxDebuggerLocal;
 import sun.jvm.hotspot.debugger.DebuggerException;
 import sun.jvm.hotspot.debugger.MachineDescription;
+import sun.jvm.hotspot.debugger.MachineDescriptionAArch64;
 
 
 public class LinuxAARCH64DebuggerLocal extends LinuxDebuggerLocal {
 
     public LinuxAARCH64DebuggerLocal(MachineDescription machDesc, boolean useCache) throws DebuggerException {
         super(machDesc, useCache);
+    }
+
+    @Override
+    protected void onAttach() {
+        if (isPACEnabled()) {
+            ((MachineDescriptionAArch64)getMachineDescription()).enablePAC();
+        }
     }
 
     public boolean isPACEnabled() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64DebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/aarch64/LinuxAARCH64DebuggerLocal.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,34 +23,23 @@
  *
  */
 
-package sun.jvm.hotspot.debugger;
+package sun.jvm.hotspot.debugger.linux.aarch64;
 
-public class MachineDescriptionAArch64 extends MachineDescriptionTwosComplement implements MachineDescription {
+import sun.jvm.hotspot.debugger.linux.LinuxDebuggerLocal;
+import sun.jvm.hotspot.debugger.DebuggerException;
+import sun.jvm.hotspot.debugger.MachineDescription;
 
-  private boolean pac;
 
-  public MachineDescriptionAArch64() {
-    pac = false;
-  }
+public class LinuxAARCH64DebuggerLocal extends LinuxDebuggerLocal {
 
-  public long getAddressSize() {
-    return 8;
-  }
+    public LinuxAARCH64DebuggerLocal(MachineDescription machDesc, boolean useCache) throws DebuggerException {
+        super(machDesc, useCache);
+    }
 
-  public boolean isLP64() {
-    return true;
-  }
+    public boolean isPACEnabled() {
+        return isPACEnabled0(p_ps_prochandle);
+    }
 
-  public boolean isBigEndian() {
-    return false;
-  }
-
-  public void enablePAC() {
-    pac = true;
-  }
-
-  public boolean isPACEnabled() {
-    return pac;
-  }
+    private native boolean isPACEnabled0(long inst);
 
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
@@ -83,6 +83,14 @@ public class AARCH64Frame extends Frame {
       });
   }
 
+  public static long ropProtection() {
+    return ropProtectionField.getValue();
+  }
+
+  public static long pacMask() {
+    return pacMaskField.getValue();
+  }
+
   private static synchronized void initialize(TypeDataBase db) {
     INTERPRETER_FRAME_MDX_OFFSET                  = INTERPRETER_FRAME_METHOD_OFFSET - 1;
     INTERPRETER_FRAME_PADDING_OFFSET              = INTERPRETER_FRAME_MDX_OFFSET - 1;


### PR DESCRIPTION
TestJhsdbJstackMixedWithXComp.java fails on Ubuntu 26.04 on Neoverse V1 and V2 processor.

I introduced DWARF support in mixed jstack in [JDK-8377946](https://bugs.openjdk.org/browse/JDK-8377946), however I mentioned it does not support PAC (Pointer Authentication Code) in PR #29731. It is the reason why TestJhsdbJstackMixedWithXComp.java failed on Neoverse V1 and V2. They support PAC, and it is enabled on the Kernel on Ubuntu 26.04 by default.

This PR adds to feature to treat PAC in Linux AArch64. It is Arm-specific feature, so I separated them in following new classes. It is one of the reason why this change is bigger.

- AARCH64DwarfParser.java
- LinuxAARCH64DebuggerLocal.java
- aarch64Dwarf.cpp/hpp (for `DwarfParser` in native)

serviceability/sa tests passed on Linux AMD64, Linux AArch64 (PAC disabled), and Linux AArch64 (PAC enabled).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386593](https://bugs.openjdk.org/browse/JDK-8386593): AArch64: serviceability/sa/TestJhsdbJstackMixedWithXComp.java fails on Ubuntu 26.04 (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31669/head:pull/31669` \
`$ git checkout pull/31669`

Update a local copy of the PR: \
`$ git checkout pull/31669` \
`$ git pull https://git.openjdk.org/jdk.git pull/31669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31669`

View PR using the GUI difftool: \
`$ git pr show -t 31669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31669.diff">https://git.openjdk.org/jdk/pull/31669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31669#issuecomment-4795126843)
</details>
