### PR TITLE
8385833: C2 Vector API: assert(false) failed: infinite loop in PhaseIterGVN::transform_old

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1343,6 +1343,14 @@ Node* VectorNode::reassociate_vector_operation(PhaseGVN* phase) {
     return nullptr;
   }
 
+  // Reassociation is beneficial if transformed node with replicate inputs can
+  // subsequently be collapsed by push_through_replicate into Replicate(ScalarOp(..)).
+  // That folding needs a scalar opcode for this operation/element type.
+  // Safety check to ensure we skip useless/redundant reassociations.
+  if (scalar_opcode(Opcode(), vect_type()->element_basic_type()) == 0) {
+    return nullptr;
+  }
+
   Node* in1 = in(1);
   Node* in2 = in(2);
   if (in2->Opcode() == Op_Replicate && in1->Opcode() == Opcode()) {

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorReassociations.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorReassociations.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 8358521
+ * @bug 8358521 8385833
+ * @key randomness
  * @summary Test reassociation of broadcasted inputs across vector operations
  * @modules jdk.incubator.vector
  * @library /test/lib /
@@ -32,7 +33,10 @@
 
 package compiler.vectorapi;
 
+import compiler.lib.generators.Generator;
+import compiler.lib.generators.Generators;
 import compiler.lib.ir_framework.*;
+import compiler.lib.verify.*;
 import jdk.incubator.vector.*;
 import java.util.stream.IntStream;
 
@@ -601,5 +605,57 @@ public class TestVectorReassociations {
                   .lanewise(VectorOperators.MUL,
                             ByteVector.broadcast(BSP, bb))
                   .intoArray(byteOut, 0);
+    }
+
+    private static final Generators RD = Generators.G;
+
+    static int uA, uB, uC;
+
+    static {
+        Generator<Integer> ig = RD.ints();
+        uA = ig.next(); uB = ig.next(); uC = ig.next();
+    }
+
+    static int[] umaxIntOut = new int[ISP.length()];
+    static int[] uminIntOut = new int[ISP.length()];
+
+    // UMAX(UMAX(bcast(uA), bcast(uB)), bcast(uC)).
+    @Test
+    @IR(counts = { IRNode.UMAX_VI, " >0 " },
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
+    @Warmup(value = 10000)
+    static void test_int_umax_all_broadcast() {
+        IntVector.broadcast(ISP, uA)
+                 .lanewise(VectorOperators.UMAX, uB)
+                 .lanewise(VectorOperators.UMAX, uC)
+                 .intoArray(umaxIntOut, 0);
+    }
+
+    @Check(test = "test_int_umax_all_broadcast")
+    static void check_int_umax_all_broadcast() {
+        int e = VectorMath.maxUnsigned(VectorMath.maxUnsigned(uA, uB), uC);
+        for (int v : umaxIntOut) {
+            Verify.checkEQ(v, e);
+        }
+    }
+
+    // UMIN(UMIN(bcast(uA), bcast(uB)), bcast(uC)).
+    @Test
+    @IR(counts = { IRNode.UMIN_VI, " >0 " },
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
+    @Warmup(value = 10000)
+    static void test_int_umin_all_broadcast() {
+        IntVector.broadcast(ISP, uA)
+                 .lanewise(VectorOperators.UMIN, uB)
+                 .lanewise(VectorOperators.UMIN, uC)
+                 .intoArray(uminIntOut, 0);
+    }
+
+    @Check(test = "test_int_umin_all_broadcast")
+    static void check_int_umin_all_broadcast() {
+        int e = VectorMath.minUnsigned(VectorMath.minUnsigned(uA, uB), uC);
+        for (int v : uminIntOut) {
+            Verify.checkEQ(v, e);
+        }
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [915efc50](https://github.com/openjdk/jdk/commit/915efc50640b3635c021d2a41da7be29c543a1b8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jatin Bhateja on 18 Jun 2026 and was reviewed by Emanuel Peter, Manuel Hässig and Vladimir Ivanov.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385833](https://bugs.openjdk.org/browse/JDK-8385833): C2 Vector API: assert(false) failed: infinite loop in PhaseIterGVN::transform_old (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31672/head:pull/31672` \
`$ git checkout pull/31672`

Update a local copy of the PR: \
`$ git checkout pull/31672` \
`$ git pull https://git.openjdk.org/jdk.git pull/31672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31672`

View PR using the GUI difftool: \
`$ git pr show -t 31672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31672.diff">https://git.openjdk.org/jdk/pull/31672.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31672#issuecomment-4797954986)
</details>
