### PR TITLE
8387293: Shenandoah: Improve gc+stats logging for generational mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
@@ -62,10 +62,12 @@ ShenandoahGenerationalEvacuationTask::ShenandoahGenerationalEvacuationTask(Shena
 
 void ShenandoahGenerationalEvacuationTask::work(uint worker_id) {
   if (_concurrent) {
+    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_evac, ShenandoahPhaseTimings::Work, worker_id, true);
     ShenandoahConcurrentWorkerSession worker_session(worker_id);
     SuspendibleThreadSetJoiner stsj;
     do_work();
   } else {
+    ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::degen_gc_evac, ShenandoahPhaseTimings::Work, worker_id, true);
     ShenandoahParallelWorkerSession worker_session(worker_id);
     do_work();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -722,10 +722,12 @@ public:
 
   void work(uint worker_id) override {
     if (CONCURRENT) {
+      ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::conc_update_refs, ShenandoahPhaseTimings::Work, worker_id, true);
       ShenandoahConcurrentWorkerSession worker_session(worker_id);
       SuspendibleThreadSetJoiner stsj;
       do_work<ShenandoahConcUpdateRefsClosure>(worker_id);
     } else {
+      ShenandoahWorkerTimingsTracker timer(ShenandoahPhaseTimings::degen_gc_update_refs, ShenandoahPhaseTimings::Work, worker_id, true);
       ShenandoahParallelWorkerSession worker_session(worker_id);
       do_work<ShenandoahNonConcUpdateRefsClosure>(worker_id);
     }


### PR DESCRIPTION
Apparently I have missed a few cases in GenShen in [JDK-8385334](https://bugs.openjdk.org/browse/JDK-8385334).

```
[4.982s][info][gc,stats] Concurrent Evacuation 63463 us // <--- no worker details
[4.982s][info][gc,stats] Concurrent Update Cards 238 us
[4.982s][info][gc,stats] Concurrent Update Refs Prepare 244 us
[4.982s][info][gc,stats] Concurrent Update Refs 84525 us // <--- no worker details
```

Now:

```
[3.661s][info][gc,stats] Concurrent Evacuation             36906 us with 7.58x parallelism
[3.661s][info][gc,stats]   CE: Work                       279695 us total, per worker: 36155, 36104, 36078, 35945, 35507, 33010, 32910, 33985, ---, ---, ---, ---, ---, ---, ---, ---, 
[3.661s][info][gc,stats] Concurrent Update Cards             947 us
[3.661s][info][gc,stats] Concurrent Update Refs Prepare      228 us
[3.661s][info][gc,stats] Concurrent Update Refs            63106 us with 7.86x parallelism
[3.661s][info][gc,stats]   CUR: Work                      495879 us total, per worker: 61832, 62810, 63015, 61841, 61820, 61795, 61717, 61051, ---, ---, ---, ---, ---, ---, ---, ---, 
```

Additional testing:
 - [x] Eyeballing the logs
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387293](https://bugs.openjdk.org/browse/JDK-8387293): Shenandoah: Improve gc+stats logging for generational mode (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31675/head:pull/31675` \
`$ git checkout pull/31675`

Update a local copy of the PR: \
`$ git checkout pull/31675` \
`$ git pull https://git.openjdk.org/jdk.git pull/31675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31675`

View PR using the GUI difftool: \
`$ git pr show -t 31675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31675.diff">https://git.openjdk.org/jdk/pull/31675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31675#issuecomment-4799929057)
</details>
