### PR TITLE
8387298: IS_WIN2000 and IS_WINXP macros are obsolete

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -173,15 +173,13 @@ public final class WToolkit extends SunToolkit implements Runnable {
         }
     }
 
-    private static native String getWindowsVersion();
-
     static {
         loadLibraries();
         initIDs();
 
         // Print out which version of Windows is running
         if (log.isLoggable(PlatformLogger.Level.FINE)) {
-            log.fine("Win version: " + getWindowsVersion());
+            log.fine("Win version: " + System.getProperty("os.version"));
         }
     }
 

--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,32 +42,18 @@ void ComCtl32Util::InitLibraries() {
 }
 
 WNDPROC ComCtl32Util::SubclassHWND(HWND hwnd, WNDPROC _WindowProc) {
-    if (IS_WINXP) {
-        const SUBCLASSPROC p = SharedWindowProc; // let compiler check type of SharedWindowProc
-        ::SetWindowSubclass(hwnd, p, (UINT_PTR)_WindowProc, NULL); // _WindowProc is used as subclass ID
-        return NULL;
-    } else {
-        return (WNDPROC)::SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)_WindowProc);
-    }
+    const SUBCLASSPROC p = SharedWindowProc; // let compiler check type of SharedWindowProc
+    ::SetWindowSubclass(hwnd, p, (UINT_PTR)_WindowProc, NULL); // _WindowProc is used as subclass ID
+    return NULL;
 }
 
 void ComCtl32Util::UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc, WNDPROC _DefWindowProc) {
-    if (IS_WINXP) {
-        const SUBCLASSPROC p = SharedWindowProc; // let compiler check type of SharedWindowProc
-        ::RemoveWindowSubclass(hwnd, p, (UINT_PTR)_WindowProc); // _WindowProc is used as subclass ID
-    } else {
-        ::SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)_DefWindowProc);
-    }
+    const SUBCLASSPROC p = SharedWindowProc; // let compiler check type of SharedWindowProc
+    ::RemoveWindowSubclass(hwnd, p, (UINT_PTR)_WindowProc); // _WindowProc is used as subclass ID
 }
 
 LRESULT ComCtl32Util::DefWindowProc(WNDPROC _DefWindowProc, HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-    if (IS_WINXP) {
-        return ::DefSubclassProc(hwnd, msg, wParam, lParam);
-    } else if (_DefWindowProc != NULL) {
-        return ::CallWindowProc(_DefWindowProc, hwnd, msg, wParam, lParam);
-    } else {
-        return ::DefWindowProc(hwnd, msg, wParam, lParam);
-    }
+    return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
 LRESULT ComCtl32Util::SharedWindowProc(HWND hwnd, UINT msg,

--- a/src/java.desktop/windows/native/libawt/windows/awt.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,12 +155,10 @@ typedef AwtObject* PDATA;
 /*  /NEW JNI */
 
 /*
- * IS_WIN2000 returns TRUE on 2000, XP and Vista
  * IS_WINXP returns TRUE on XP and Vista
  * IS_WINVISTA returns TRUE on Vista
  */
-#define IS_WIN2000 (LOBYTE(LOWORD(::GetVersion())) >= 5)
-#define IS_WINXP ((IS_WIN2000 && HIBYTE(LOWORD(::GetVersion())) >= 1) || LOBYTE(LOWORD(::GetVersion())) > 5)
+#define IS_WINXP ((HIBYTE(LOWORD(::GetVersion())) >= 1) || LOBYTE(LOWORD(::GetVersion())) > 5)
 #define IS_WINVISTA (LOBYTE(LOWORD(::GetVersion())) >= 6)
 #define IS_WIN8 (                                                              \
     (IS_WINVISTA && (HIBYTE(LOWORD(::GetVersion())) >= 2)) ||                  \

--- a/src/java.desktop/windows/native/libawt/windows/awt.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt.h
@@ -155,10 +155,8 @@ typedef AwtObject* PDATA;
 /*  /NEW JNI */
 
 /*
- * IS_WINXP returns TRUE on XP and Vista
  * IS_WINVISTA returns TRUE on Vista
  */
-#define IS_WINXP ((HIBYTE(LOWORD(::GetVersion())) >= 1) || LOBYTE(LOWORD(::GetVersion())) > 5)
 #define IS_WINVISTA (LOBYTE(LOWORD(::GetVersion())) >= 6)
 #define IS_WIN8 (                                                              \
     (IS_WINVISTA && (HIBYTE(LOWORD(::GetVersion())) >= 2)) ||                  \

--- a/src/java.desktop/windows/native/libawt/windows/awt_Choice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Choice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,11 +179,7 @@ AwtChoice* AwtChoice::Create(jobject peer, jobject parent) {
             ::GetClientRect(c->GetHWnd(), &rc);
             env->SetIntField(target, AwtComponent::widthID, c->ScaleDownX(rc.right));
             env->SetIntField(target, AwtComponent::heightID, c->ScaleDownY(rc.bottom));
-
-            if (IS_WINXP) {
-                ::SendMessage(c->GetHWnd(), CB_SETMINVISIBLE, (WPARAM) MINIMUM_NUMBER_OF_VISIBLE_ITEMS, 0);
-            }
-
+            ::SendMessage(c->GetHWnd(), CB_SETMINVISIBLE, (WPARAM) MINIMUM_NUMBER_OF_VISIBLE_ITEMS, 0);
             env->DeleteLocalRef(dimension);
         }
     } catch (...) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -503,9 +503,6 @@ void AwtDesktopProperties::GetColorParameters() {
     SetColorProperty(TEXT("win.mdi.backgroundColor"), GetSysColor(COLOR_APPWORKSPACE));
     SetColorProperty(TEXT("win.menu.backgroundColor"), GetSysColor(COLOR_MENU));
     SetColorProperty(TEXT("win.menu.textColor"), GetSysColor(COLOR_MENUTEXT));
-#ifndef COLOR_MENUBAR
-#define COLOR_MENUBAR 30
-#endif
     SetColorProperty(TEXT("win.menubar.backgroundColor"), GetSysColor(COLOR_MENUBAR));
     SetColorProperty(TEXT("win.scrollbar.backgroundColor"), GetSysColor(COLOR_SCROLLBAR));
     SetColorProperty(TEXT("win.text.grayedTextColor"), GetSysColor(COLOR_GRAYTEXT));

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,9 +76,7 @@ void AwtDesktopProperties::GetWindowsParameters() {
     GetOtherParameters();
     GetSoundEvents();
     GetSystemProperties();
-    if (IS_WINXP) {
-        GetXPStyleProperties();
-    }
+    GetXPStyleProperties();
 }
 
 void getInvScale(float &invScaleX, float &invScaleY) {
@@ -423,12 +421,8 @@ void CheckFontSmoothingSettings(HWND hWnd) {
 
     if (firstTime) {
         SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, &fontSmoothing, 0);
-        if (IS_WINXP) {
-            SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0,
-                                 &fontSmoothingType, 0);
-            SystemParametersInfo(SPI_GETFONTSMOOTHINGCONTRAST, 0,
-                                 &fontSmoothingContrast, 0);
-        }
+        SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0, &fontSmoothingType, 0);
+        SystemParametersInfo(SPI_GETFONTSMOOTHINGCONTRAST, 0, &fontSmoothingContrast, 0);
         lastFontSmoothing = fontSmoothing;
         lastFontSmoothingType = fontSmoothingType;
         lastFontSmoothingContrast = fontSmoothingContrast;
@@ -441,28 +435,18 @@ void CheckFontSmoothingSettings(HWND hWnd) {
             /* no need to check the other settings in this case. */
             return;
         }
-        if (IS_WINXP) {
-            SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0,
-                                 &fontSmoothingType, 0);
-            settingsChanged |= fontSmoothingType != lastFontSmoothingType;
-            if (!settingsChanged &&
-                fontSmoothingType == FONTSMOOTHING_STANDARD) {
-                /* No need to check any LCD specific settings */
-                return;
-            } else {
-                SystemParametersInfo(SPI_GETFONTSMOOTHINGCONTRAST, 0,
-                                     &fontSmoothingContrast, 0);
-                settingsChanged |=
-                    fontSmoothingContrast != lastFontSmoothingContrast;
-                if (fontSmoothingType == FONTSMOOTHING_LCD) {
-                    // Order is a registry entry so more expensive to check.x
-                    subPixelOrder = GetLCDSubPixelOrder();
-                    settingsChanged |= subPixelOrder != lastSubpixelOrder;
-                }
-            }
+        SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0, &fontSmoothingType, 0);
+        settingsChanged |= fontSmoothingType != lastFontSmoothingType;
+        if (!settingsChanged && fontSmoothingType == FONTSMOOTHING_STANDARD) {
+            /* No need to check any LCD specific settings */
+            return;
         } else {
-            if (settingsChanged && fontSmoothing == FONTSMOOTHING_ON) {
-                fontSmoothingType = FONTSMOOTHING_STANDARD;
+            SystemParametersInfo(SPI_GETFONTSMOOTHINGCONTRAST, 0, &fontSmoothingContrast, 0);
+            settingsChanged |= fontSmoothingContrast != lastFontSmoothingContrast;
+            if (fontSmoothingType == FONTSMOOTHING_LCD) {
+                // Order is a registry entry so more expensive to check.x
+                subPixelOrder = GetLCDSubPixelOrder();
+                settingsChanged |= subPixelOrder != lastSubpixelOrder;
             }
         }
     }
@@ -519,13 +503,10 @@ void AwtDesktopProperties::GetColorParameters() {
     SetColorProperty(TEXT("win.mdi.backgroundColor"), GetSysColor(COLOR_APPWORKSPACE));
     SetColorProperty(TEXT("win.menu.backgroundColor"), GetSysColor(COLOR_MENU));
     SetColorProperty(TEXT("win.menu.textColor"), GetSysColor(COLOR_MENUTEXT));
-    // COLOR_MENUBAR is only defined on WindowsXP. Our binaries are
-    // built on NT, hence the below ifdef.
 #ifndef COLOR_MENUBAR
 #define COLOR_MENUBAR 30
 #endif
-    SetColorProperty(TEXT("win.menubar.backgroundColor"),
-                                GetSysColor(IS_WINXP ? COLOR_MENUBAR : COLOR_MENU));
+    SetColorProperty(TEXT("win.menubar.backgroundColor"), GetSysColor(COLOR_MENUBAR));
     SetColorProperty(TEXT("win.scrollbar.backgroundColor"), GetSysColor(COLOR_SCROLLBAR));
     SetColorProperty(TEXT("win.text.grayedTextColor"), GetSysColor(COLOR_GRAYTEXT));
     SetColorProperty(TEXT("win.tooltip.backgroundColor"), GetSysColor(COLOR_INFOBK));
@@ -540,14 +521,9 @@ void AwtDesktopProperties::GetOtherParameters() {
     SetBooleanProperty(TEXT("win.text.fontSmoothingOn"), GetBooleanParameter(SPI_GETFONTSMOOTHING));
     // TODO END
 
-    if (IS_WINXP) {
-        SetIntegerProperty(TEXT("win.text.fontSmoothingType"),
-                           GetIntegerParameter(SPI_GETFONTSMOOTHINGTYPE));
-        SetIntegerProperty(TEXT("win.text.fontSmoothingContrast"),
-                           GetIntegerParameter(SPI_GETFONTSMOOTHINGCONTRAST));
-        SetIntegerProperty(TEXT("win.text.fontSmoothingOrientation"),
-                           GetLCDSubPixelOrder());
-    }
+    SetIntegerProperty(TEXT("win.text.fontSmoothingType"), GetIntegerParameter(SPI_GETFONTSMOOTHINGTYPE));
+    SetIntegerProperty(TEXT("win.text.fontSmoothingContrast"), GetIntegerParameter(SPI_GETFONTSMOOTHINGCONTRAST));
+    SetIntegerProperty(TEXT("win.text.fontSmoothingOrientation"), GetLCDSubPixelOrder());
 
     int cxdrag = GetSystemMetrics(SM_CXDRAG);
     int cydrag = GetSystemMetrics(SM_CYDRAG);

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
@@ -369,12 +369,6 @@ AwtMenuItem::DrawSelf(DRAWITEMSTRUCT& drawInfo)
         // Disabled text must be drawn in gray.
         crText = ::GetSysColor(bEnabled? COLOR_HIGHLIGHTTEXT : COLOR_GRAYTEXT);
     } else {
-        // COLOR_MENUBAR is only defined on WindowsXP. Our binaries are
-        // built on NT, hence the below ifdef.
-
-#ifndef COLOR_MENUBAR
-#define COLOR_MENUBAR 30
-#endif
         // Set background and text colors for unselected item
         if (IsTopMenu() && AwtDesktopProperties::IsXPStyle()) {
             crBack = ::GetSysColor (COLOR_MENUBAR);

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -376,7 +376,7 @@ AwtMenuItem::DrawSelf(DRAWITEMSTRUCT& drawInfo)
 #define COLOR_MENUBAR 30
 #endif
         // Set background and text colors for unselected item
-        if (IS_WINXP && IsTopMenu() && AwtDesktopProperties::IsXPStyle()) {
+        if (IsTopMenu() && AwtDesktopProperties::IsXPStyle()) {
             crBack = ::GetSysColor (COLOR_MENUBAR);
         } else {
             crBack = ::GetSysColor (COLOR_MENU);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -2864,14 +2864,10 @@ Java_sun_awt_windows_WToolkit_getWindowsVersion(JNIEnv *env, jclass cls)
     swprintf(szVer, 128, L"0x%x = %ld", version, version);
     int l = lstrlen(szVer);
 
-    if (IS_WINXP) {
-        if (IS_WINVISTA) {
-            swprintf(szVer + l, 128, L" (Windows Vista)");
-        } else {
-            swprintf(szVer + l, 128, L" (Windows XP)");
-        }
+    if (IS_WINVISTA) {
+        swprintf(szVer + l, 128, L" (Windows Vista)");
     } else {
-        swprintf(szVer + l, 128, L" (Windows 2000)");
+        swprintf(szVer + l, 128, L" (Windows XP)");
     }
 
     return JNU_NewStringPlatform(env, szVer);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -2864,18 +2864,14 @@ Java_sun_awt_windows_WToolkit_getWindowsVersion(JNIEnv *env, jclass cls)
     swprintf(szVer, 128, L"0x%x = %ld", version, version);
     int l = lstrlen(szVer);
 
-    if (IS_WIN2000) {
-        if (IS_WINXP) {
-            if (IS_WINVISTA) {
-                swprintf(szVer + l, 128, L" (Windows Vista)");
-            } else {
-                swprintf(szVer + l, 128, L" (Windows XP)");
-            }
+    if (IS_WINXP) {
+        if (IS_WINVISTA) {
+            swprintf(szVer + l, 128, L" (Windows Vista)");
         } else {
-            swprintf(szVer + l, 128, L" (Windows 2000)");
+            swprintf(szVer + l, 128, L" (Windows XP)");
         }
     } else {
-        swprintf(szVer + l, 128, L" (Unknown)");
+        swprintf(szVer + l, 128, L" (Windows 2000)");
     }
 
     return JNU_NewStringPlatform(env, szVer);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -2848,33 +2848,6 @@ Java_sun_awt_windows_WToolkit_isDynamicLayoutSupportedNative(JNIEnv *env,
     CATCH_BAD_ALLOC_RET(FALSE);
 }
 
-/*
- * Class:     sun_awt_windows_WToolkit
- * Method:    printWindowsVersion
- * Signature: ()Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL
-Java_sun_awt_windows_WToolkit_getWindowsVersion(JNIEnv *env, jclass cls)
-{
-    TRY;
-
-    WCHAR szVer[128];
-
-    DWORD version = ::GetVersion();
-    swprintf(szVer, 128, L"0x%x = %ld", version, version);
-    int l = lstrlen(szVer);
-
-    if (IS_WINVISTA) {
-        swprintf(szVer + l, 128, L" (Windows Vista)");
-    } else {
-        swprintf(szVer + l, 128, L" (Windows XP)");
-    }
-
-    return JNU_NewStringPlatform(env, szVer);
-
-    CATCH_BAD_ALLOC_RET(NULL);
-}
-
 JNIEXPORT void JNICALL
 Java_sun_awt_windows_WToolkit_showTouchKeyboard(JNIEnv *env, jobject self,
     jboolean causedByTouchEvent)


### PR DESCRIPTION
The IS_WIN2000 macro checks for Windows major version number >= 5, see https://github.com/search?q=repo%3Aopenjdk%2Fjdk%20IS_WIN2000&type=code
but we run for a long time on much higher Windows versions as a minimum.
So the check is obsolete. Same is true for the IS_WINXP check.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387298](https://bugs.openjdk.org/browse/JDK-8387298): IS_WIN2000 and IS_WINXP macros are obsolete (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Daniel Gredler](https://openjdk.org/census#dgredler) (@gredler - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31676/head:pull/31676` \
`$ git checkout pull/31676`

Update a local copy of the PR: \
`$ git checkout pull/31676` \
`$ git pull https://git.openjdk.org/jdk.git pull/31676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31676`

View PR using the GUI difftool: \
`$ git pr show -t 31676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31676.diff">https://git.openjdk.org/jdk/pull/31676.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31676#issuecomment-4807329491)
</details>
