### PR TITLE
8387265: G1: Shutdown during concurrent cycle leaves SATB queues in inconsistent state

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1654,6 +1654,9 @@ void G1CollectedHeap::stop() {
   // that are destroyed during shutdown.
   _cr->stop();
   _service_thread->stop();
+  VM_G1StopMarking op;
+  VMThread::execute(&op);
+
   _cm->stop();
 }
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2036,6 +2036,20 @@ void G1ConcurrentMark::print_stats() {
   }
 }
 
+void G1ConcurrentMark::shutdown_concurrent_cycle() {
+  assert_at_safepoint_on_vm_thread();
+
+  abort_root_region_scan_at_safepoint();
+  abort_marking_threads();
+
+  SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
+  satb_mq_set.abandon_partial_marking();
+  // This can be called either during or outside marking, we'll read
+  // the expected_active value from the SATB queue set.
+  satb_mq_set.set_active_all_threads(false, /* new active value */
+                                     satb_mq_set.is_active() /* expected_active */);
+}
+
 bool G1ConcurrentMark::concurrent_cycle_abort() {
   assert_at_safepoint_on_vm_thread();
   assert(_g1h->collector_state()->is_in_full_gc(), "must be");

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2036,6 +2036,12 @@ void G1ConcurrentMark::print_stats() {
   }
 }
 
+bool G1ConcurrentMark::shutdown_cleanup_needed() const {
+  // Cleanup (aborting threads, setting abort flags) is needed throughout the whole cycle before
+  // stopping the CM thread.
+  return is_fully_initialized() && is_in_concurrent_cycle();
+}
+
 void G1ConcurrentMark::shutdown_concurrent_cycle() {
   assert_at_safepoint_on_vm_thread();
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -603,6 +603,7 @@ public:
   bool mark_stack_empty() const                 { return _global_mark_stack.is_empty(); }
 
   void concurrent_cycle_start();
+  void shutdown_concurrent_cycle();
   // Abandon current marking iteration due to a Full GC.
   bool concurrent_cycle_abort();
   void concurrent_cycle_end(bool mark_cycle_completed);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -603,6 +603,7 @@ public:
   bool mark_stack_empty() const                 { return _global_mark_stack.is_empty(); }
 
   void concurrent_cycle_start();
+  bool shutdown_cleanup_needed() const;
   void shutdown_concurrent_cycle();
   // Abandon current marking iteration due to a Full GC.
   bool concurrent_cycle_abort();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
@@ -50,7 +50,8 @@ class G1ConcurrentMarkThread: public ConcurrentGCThread {
 
   Atomic<ServiceState> _state;
 
-  ServiceState state() const { return _state.load_relaxed(); }
+  ServiceState state() const { return _state.load_acquire(); }
+  void set_state(ServiceState new_state) { _state.release_store(new_state); }
 
   // Returns whether we are in a "Full" cycle.
   bool is_in_full_concurrent_cycle() const;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
@@ -48,31 +48,31 @@ inline bool G1ConcurrentMarkThread::is_in_full_concurrent_cycle() const {
 inline void G1ConcurrentMarkThread::set_idle() {
   // Concurrent cycle may be aborted any time.
   assert(!is_idle(), "must not be idle");
-  _state.store_relaxed(Idle);
+  set_state(Idle);
 }
 
 inline void G1ConcurrentMarkThread::start_full_cycle() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
   assert(is_idle(), "cycle in progress");
-  _state.store_relaxed(FullCycleMarking);
+  set_state(FullCycleMarking);
 }
 
 inline void G1ConcurrentMarkThread::start_undo_cycle() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
   assert(is_idle(), "cycle in progress");
-  _state.store_relaxed(UndoCycleResetForNextCycle);
+  set_state(UndoCycleResetForNextCycle);
 }
 
 inline void G1ConcurrentMarkThread::set_full_cycle_rebuild_and_scrub() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
   assert(state() == FullCycleMarking, "must be");
-  _state.store_relaxed(FullCycleRebuildOrScrub);
+  set_state(FullCycleRebuildOrScrub);
 }
 
 inline void G1ConcurrentMarkThread::set_full_cycle_reset_for_next_cycle() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
   assert(state() == FullCycleRebuildOrScrub, "must be");
-  _state.store_relaxed(FullCycleResetForNextCycle);
+  set_state(FullCycleResetForNextCycle);
 }
 
 inline bool G1ConcurrentMarkThread::is_in_marking() const {

--- a/src/hotspot/share/gc/g1/g1SATBMarkQueueSet.cpp
+++ b/src/hotspot/share/gc/g1/g1SATBMarkQueueSet.cpp
@@ -114,12 +114,5 @@ public:
 };
 
 void G1SATBMarkQueueSet::filter(SATBMarkQueue& queue) {
-  G1CollectedHeap* g1h = G1CollectedHeap::heap();
-  if (g1h->collector_state()->is_in_marking()) {
-    apply_filter(G1SATBMarkQueueFilterFn(), queue);
-  } else {
-    // is_in_marking() covers both the concurrent marking and the Remark pause. Outside
-    // of that, there can be no entry that requires SATB marking.
-    queue.set_empty();
-  }
+  apply_filter(G1SATBMarkQueueFilterFn(), queue);
 }

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -156,9 +156,7 @@ bool VM_G1PauseConcurrent::doit_prologue() {
   Heap_lock->lock();
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   _is_shutting_down = g1h->is_shutting_down();
-  // If we are shutting down and concurrent mark is cleaned up, ignore this VM operation.
-  // Otherwise help with concurrent marking cleanup in the pause.
-  if (_is_shutting_down && !G1BarrierSet::satb_mark_queue_set().is_active()) {
+  if (_is_shutting_down && !g1h->concurrent_mark()->shutdown_cleanup_needed()) {
     Heap_lock->unlock();
     return false;
   }
@@ -183,13 +181,14 @@ void VM_G1PauseCleanup::work() {
 }
 
 bool VM_G1StopMarking::doit_prologue() {
+  G1CollectedHeap* g1h = G1CollectedHeap::heap();
 #ifdef ASSERT
   {
     MutexLocker ml(Heap_lock);
-    assert(G1CollectedHeap::heap()->is_shutting_down(), "must be");
+    assert(g1h->is_shutting_down(), "must be");
   }
 #endif
-  return G1BarrierSet::satb_mark_queue_set().is_active();
+  return g1h->concurrent_mark()->shutdown_cleanup_needed();
 }
 
 void VM_G1StopMarking::doit() {

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -130,8 +130,13 @@ void VM_G1CollectForAllocation::doit() {
 }
 
 void VM_G1PauseConcurrent::doit() {
-  GCIdMark gc_id_mark(_gc_id);
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
+  if (_is_shutting_down) {
+    g1h->concurrent_mark()->shutdown_concurrent_cycle();
+    return;
+  }
+
+  GCIdMark gc_id_mark(_gc_id);
   GCTraceCPUTime tcpu(g1h->concurrent_mark()->gc_tracer_cm());
 
   // GCTraceTime(...) only supports sub-phases, so a more verbose version
@@ -150,12 +155,11 @@ void VM_G1PauseConcurrent::doit() {
 bool VM_G1PauseConcurrent::doit_prologue() {
   Heap_lock->lock();
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
-  if (g1h->is_shutting_down()) {
+  _is_shutting_down = g1h->is_shutting_down();
+  // If we are shutting down and concurrent mark is cleaned up, ignore this VM operation.
+  // Otherwise help with concurrent marking cleanup in the pause.
+  if (_is_shutting_down && !G1BarrierSet::satb_mark_queue_set().is_active()) {
     Heap_lock->unlock();
-    // JVM shutdown has started. Abort concurrent marking to ensure that any further
-    // concurrent VM operations will not try to start and interfere with the shutdown
-    // process.
-    g1h->concurrent_mark()->abort_marking_threads();
     return false;
   }
   return true;
@@ -176,4 +180,19 @@ void VM_G1PauseRemark::work() {
 void VM_G1PauseCleanup::work() {
   G1ConcurrentMark* cm = G1CollectedHeap::heap()->concurrent_mark();
   cm->cleanup();
+}
+
+bool VM_G1StopMarking::doit_prologue() {
+#ifdef ASSERT
+  {
+    MutexLocker ml(Heap_lock);
+    assert(G1CollectedHeap::heap()->is_shutting_down(), "must be");
+  }
+#endif
+  return G1BarrierSet::satb_mark_queue_set().is_active();
+}
+
+void VM_G1StopMarking::doit() {
+  G1ConcurrentMark* cm = G1CollectedHeap::heap()->concurrent_mark();
+  cm->shutdown_concurrent_cycle();
 }

--- a/src/hotspot/share/gc/g1/g1VMOperations.hpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.hpp
@@ -80,11 +80,12 @@ public:
 // Concurrent G1 stop-the-world operations such as remark and cleanup.
 class VM_G1PauseConcurrent : public VM_Operation {
   uint         _gc_id;
+  bool         _is_shutting_down;
   const char*  _message;
 
 protected:
   VM_G1PauseConcurrent(const char* message) :
-    _gc_id(GCId::current()), _message(message) { }
+    _gc_id(GCId::current()), _is_shutting_down(false), _message(message) { }
   virtual void work() = 0;
 
   // Does this concurrent pause affect the memory pools? If so, update the collectionUsage()
@@ -114,6 +115,17 @@ public:
   VM_G1PauseCleanup() : VM_G1PauseConcurrent("Pause Cleanup") { }
   VMOp_Type type() const override { return VMOp_G1PauseCleanup; }
   void work() override;
+};
+
+class VM_G1StopMarking : public VM_Operation {
+public:
+  VM_G1StopMarking() : VM_Operation() { }
+  VMOp_Type type() const override { return VMOp_G1StopMarking; }
+
+  bool doit_prologue() override;
+  void doit() override;
+
+  bool is_gc_operation() const override { return true; }
 };
 
 #endif // SHARE_GC_G1_G1VMOPERATIONS_HPP

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -59,6 +59,7 @@
   template(G1PauseCleanup)                        \
   template(G1TryInitiateConcMark)                 \
   template(G1RendezvousGCThreads)                 \
+  template(G1StopMarking)                         \
   template(ZMarkEndOld)                           \
   template(ZMarkEndYoung)                         \
   template(ZMarkFlushOperation)                   \


### PR DESCRIPTION
Hi all,

  please review this change that fixes the inconsistency between SATB active enabled flags in the SATB queues and concurrent marking being uncleanly shut down during VM shutdown.

During concurrent mark, SATB queues are marked as "active" indicating that they (and the upper layers) can accept new objects to be looked for new references to establish the SATB snapshot.

When the VM shuts down, G1 uncleanly stops and aborts the VM thread, which means that new items are added to the SATB buffers; at some point they are full and are passed on to be processed. One step of that is filtering out unnecessarily added SATB buffer entries. In this step there is a race:

Thread 1: checks if marking is active (it is)
Thread 2: shutdown proceeds and we abort marking, making the concurrent cycle state Idle
Thread 1: the failing assert re-checks that we are still marking fails

This is basically a day-one bug, just that JDK-8381128 added the assert where we are failing now. The assert is good, verifying that we are not accessing marking data structures outside of marking. The values this assert is guarding would be reasonable too, but conceptually it is bad.

However the actual problem is that during shutdown, we never clean up the SATB buffers when aborting the concurrent cycle threads during shutdown. They still contain entries, and still get items added to.

So before shutting down marking (in `G1CollectedHeap::stop()`) we need to do that, and we need a safepoint for that.

This change guarantees the execution of a safepoint that cleans up in two ways:
* Cleanup and Remark pause during VM shutdown will only skip if outside a concurrent cycle but enter the safe point, and do the cleanup
* if, during VM shutdown no other "Cleanup" pause occurred yet (or we are beyond the "Cleanup" pause), `G1CollectedHeap::stop()` will trigger a dedicated `G1StopMarking` VM operation that performs that cleanup

only after either of that (or due to races more than one) of these VM operations occurred, we can let the concurrent cycle (concurrent mark thread) go quiescent/idle.

With that, SATB buffers are always inactive outside of actual marking, and no elements will be added to them, and that code path will not be executed. And there are no other things left that need clean up.

Testing: gha, running the failing test often, tier1-5

Thanks,
  Thomas

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387265](https://bugs.openjdk.org/browse/JDK-8387265): G1: Shutdown during concurrent cycle leaves SATB queues in inconsistent state (**Bug** - P2)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31678/head:pull/31678` \
`$ git checkout pull/31678`

Update a local copy of the PR: \
`$ git checkout pull/31678` \
`$ git pull https://git.openjdk.org/jdk.git pull/31678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31678`

View PR using the GUI difftool: \
`$ git pr show -t 31678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31678.diff">https://git.openjdk.org/jdk/pull/31678.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31678#issuecomment-4830052750)
</details>
