### PR TITLE
8387303: G1: Convert G1ConcurrentRefine::_num_threads_wanted to use the Atomic API

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
@@ -575,7 +575,7 @@ bool G1ConcurrentRefine::adjust_num_threads_periodically() {
   if (!_needs_adjust) {
     Tickspan since_adjust = Ticks::now() - _last_adjust;
     if (since_adjust.milliseconds() < adjust_threads_period_ms()) {
-      _num_threads_wanted = 0;
+      _num_threads_wanted.store_relaxed(0);
       return false;
     }
   }
@@ -592,7 +592,7 @@ bool G1ConcurrentRefine::adjust_num_threads_periodically() {
     _needs_adjust = true;
   }
 
-  return (_num_threads_wanted > 0) && !heap_was_locked();
+  return (num_threads_wanted() > 0) && !heap_was_locked();
 }
 
 void G1ConcurrentRefine::adjust_threads_wanted(size_t available_bytes) {
@@ -603,7 +603,7 @@ void G1ConcurrentRefine::adjust_threads_wanted(size_t available_bytes) {
 
   size_t num_cards = policy->current_pending_cards();
 
-  _threads_needed.update(_num_threads_wanted,
+  _threads_needed.update(num_threads_wanted(),
                          available_bytes,
                          num_cards,
                          _pending_cards_target);
@@ -613,7 +613,7 @@ void G1ConcurrentRefine::adjust_threads_wanted(size_t available_bytes) {
     new_wanted = _thread_control.max_num_threads();
   }
 
-  _num_threads_wanted = new_wanted;
+  _num_threads_wanted.store_relaxed(new_wanted);
 
   log_debug(gc, refine)("Concurrent refinement: wanted %u, pending cards: %zu (pending-from-gc %zu), "
                         "predicted: %zu, goal %zu, time-until-next-gc: %1.2fms pred-refine-rate %1.2fc/ms log-rate %1.2fc/ms",

--- a/src/hotspot/share/gc/g1/g1ConcurrentRefine.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefine.hpp
@@ -28,6 +28,7 @@
 #include "gc/g1/g1ConcurrentRefineStats.hpp"
 #include "gc/g1/g1ConcurrentRefineThreadsNeeded.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
@@ -212,7 +213,7 @@ public:
 //
 class G1ConcurrentRefine : public CHeapObj<mtGC> {
   G1Policy* _policy;
-  volatile uint _num_threads_wanted;
+  Atomic<uint> _num_threads_wanted;
   size_t _pending_cards_target;
   Ticks _last_adjust;
   Ticks _last_deactivate;
@@ -306,7 +307,7 @@ public:
   // obtaining the heap lock.
   bool heap_was_locked() const { return _heap_was_locked; }
 
-  uint num_threads_wanted() const { return _num_threads_wanted; }
+  uint num_threads_wanted() const { return _num_threads_wanted.load_relaxed(); }
   uint max_num_threads() const { return _thread_control.max_num_threads(); }
 
   // Iterate over all concurrent refinement threads applying the given closure.


### PR DESCRIPTION
Hi all,

  please review this fairly straightforward change to have `G1ConcurrentRefine::_num_threads_wanted` use the Atomic API.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387303](https://bugs.openjdk.org/browse/JDK-8387303): G1: Convert G1ConcurrentRefine::_num_threads_wanted to use the Atomic API (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31679/head:pull/31679` \
`$ git checkout pull/31679`

Update a local copy of the PR: \
`$ git checkout pull/31679` \
`$ git pull https://git.openjdk.org/jdk.git pull/31679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31679`

View PR using the GUI difftool: \
`$ git pr show -t 31679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31679.diff">https://git.openjdk.org/jdk/pull/31679.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31679#issuecomment-4801666383)
</details>
