### PR TITLE
8387315: Add macosx-aarch64 bootcycle build profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -644,7 +644,7 @@ var getJibProfilesProfiles = function (input, common, data) {
     // Bootcycle profiles runs the build with itself as the boot jdk. This can
     // be done in two ways. Either using the builtin bootcycle target in the
     // build system. Or by supplying the main jdk build as bootjdk to configure.
-    [ "linux-x64", "macosx-x64", "windows-x64", "linux-aarch64" ]
+    [ "linux-x64", "macosx-aarch64", "macosx-x64", "windows-x64", "linux-aarch64" ]
         .forEach(function (name) {
             var bootcycleName = name + "-bootcycle";
             var bootcyclePrebuiltName = name + "-bootcycle-prebuilt";


### PR DESCRIPTION
Please review this small change, adding a missing build profile. 
We have noticed that "bootcycle" build profile is missing for macosx-aarch64 in make/conf/jib-profiles.js
This change is to add the missing profile.

------------------ Testing:
Ran configure and build with bootcycle-images target - PASS
(See comments in RFE for more details)


- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387315](https://bugs.openjdk.org/browse/JDK-8387315): Add macosx-aarch64 bootcycle build profiles (**Enhancement** - P3)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31685/head:pull/31685` \
`$ git checkout pull/31685`

Update a local copy of the PR: \
`$ git checkout pull/31685` \
`$ git pull https://git.openjdk.org/jdk.git pull/31685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31685`

View PR using the GUI difftool: \
`$ git pr show -t 31685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31685.diff">https://git.openjdk.org/jdk/pull/31685.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31685#issuecomment-4805432962)
</details>
