### PR TITLE
8364404: PanelRepaint.java should not be resizable

### DIFF
--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -71,12 +71,15 @@ public class PanelRepaint extends Panel implements FocusListener {
         Frame f = new Frame("Panel Repaint Test");
         f.setLayout(new BorderLayout());
         PanelRepaint pr = new PanelRepaint();
-        pr.setLayout(new BorderLayout());
+        pr.setLayout(null);
 
         panel = new Panel();
         panel.setLayout(null);
         panel.setSize(500, 500);
         sPanel = new ScrollPanel(panel);
+        Dimension contentSize = panel.getSize();
+        Dimension scrollPanelSize = new Dimension(contentSize.width,
+                                                  contentSize.height / 2);
 
         Button btn = new Button("Open");
         pr.addComp(btn);
@@ -173,9 +176,11 @@ public class PanelRepaint extends Panel implements FocusListener {
         pr.addComp(t29);
         t29.setBounds(240, 330, 100, 20);
 
-        pr.add(sPanel, BorderLayout.CENTER);
+        sPanel.setBounds(0, 0, scrollPanelSize.width, scrollPanelSize.height);
+        pr.setPreferredSize(scrollPanelSize);
+        pr.add(sPanel);
         f.add(pr, BorderLayout.CENTER);
-        f.setSize(620, 288);
+        f.pack();
         return f;
     }
 

--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,18 @@
 
 /*
  * @test
- * @bug 4148078
+ * @bug 4148078 8364404
  * @summary Repainting problems in scrolled panel
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual PanelRepaint
  */
 
+import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.Panel;
 import java.awt.Point;
@@ -69,9 +69,9 @@ public class PanelRepaint extends Panel implements FocusListener {
 
     public static Frame createUI() {
         Frame f = new Frame("Panel Repaint Test");
-        f.setLayout(new FlowLayout());
-        f.setSize(620, 288);
+        f.setLayout(new BorderLayout());
         PanelRepaint pr = new PanelRepaint();
+        pr.setLayout(new BorderLayout());
 
         panel = new Panel();
         panel.setLayout(null);
@@ -173,10 +173,9 @@ public class PanelRepaint extends Panel implements FocusListener {
         pr.addComp(t29);
         t29.setBounds(240, 330, 100, 20);
 
-        pr.add(sPanel);
-        f.add(pr);
-        sPanel.setBounds(100, 100, 500, 250);
-        sPanel.doLayout();
+        pr.add(sPanel, BorderLayout.CENTER);
+        f.add(pr, BorderLayout.CENTER);
+        f.setSize(620, 288);
         return f;
     }
 

--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -30,11 +30,11 @@
  * @run main/manual PanelRepaint
  */
 
-import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.Panel;
 import java.awt.Point;
@@ -69,8 +69,9 @@ public class PanelRepaint extends Panel implements FocusListener {
 
     public static Frame createUI() {
         Frame f = new Frame("Panel Repaint Test");
+        f.setLayout(new FlowLayout());
+        f.setSize(620, 288);
         f.setResizable(false);
-        f.setLayout(new BorderLayout());
         PanelRepaint pr = new PanelRepaint();
         pr.setLayout(null);
 
@@ -78,9 +79,7 @@ public class PanelRepaint extends Panel implements FocusListener {
         panel.setLayout(null);
         panel.setSize(500, 500);
         sPanel = new ScrollPanel(panel);
-        Dimension contentSize = panel.getSize();
-        Dimension scrollPanelSize = new Dimension(contentSize.width,
-                                                  contentSize.height / 2);
+        Dimension size = panel.getSize();
 
         Button btn = new Button("Open");
         pr.addComp(btn);
@@ -177,11 +176,10 @@ public class PanelRepaint extends Panel implements FocusListener {
         pr.addComp(t29);
         t29.setBounds(240, 330, 100, 20);
 
-        sPanel.setBounds(0, 0, scrollPanelSize.width, scrollPanelSize.height);
-        pr.setPreferredSize(scrollPanelSize);
+        sPanel.setBounds(0, 0, size.width, size.height / 2);
+        pr.setPreferredSize(new Dimension(size.width, size.height / 2));
         pr.add(sPanel);
-        f.add(pr, BorderLayout.CENTER);
-        f.pack();
+        f.add(pr);
         return f;
     }
 

--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -73,13 +73,11 @@ public class PanelRepaint extends Panel implements FocusListener {
         f.setSize(620, 288);
         f.setResizable(false);
         PanelRepaint pr = new PanelRepaint();
-        pr.setLayout(null);
 
         panel = new Panel();
         panel.setLayout(null);
         panel.setSize(500, 500);
         sPanel = new ScrollPanel(panel);
-        Dimension size = panel.getSize();
 
         Button btn = new Button("Open");
         pr.addComp(btn);
@@ -176,10 +174,10 @@ public class PanelRepaint extends Panel implements FocusListener {
         pr.addComp(t29);
         t29.setBounds(240, 330, 100, 20);
 
-        sPanel.setBounds(0, 0, size.width, size.height / 2);
-        pr.setPreferredSize(new Dimension(size.width, size.height / 2));
         pr.add(sPanel);
         f.add(pr);
+        sPanel.setBounds(100, 100, 500, 250);
+        sPanel.doLayout();
         return f;
     }
 

--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4148078 8364404
+ * @bug 4148078
  * @summary Repainting problems in scrolled panel
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame

--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -69,6 +69,7 @@ public class PanelRepaint extends Panel implements FocusListener {
 
     public static Frame createUI() {
         Frame f = new Frame("Panel Repaint Test");
+        f.setResizable(false);
         f.setLayout(new BorderLayout());
         PanelRepaint pr = new PanelRepaint();
         pr.setLayout(null);

--- a/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
+++ b/test/jdk/java/awt/Panel/PanelRepaint/PanelRepaint.java
@@ -70,14 +70,15 @@ public class PanelRepaint extends Panel implements FocusListener {
     public static Frame createUI() {
         Frame f = new Frame("Panel Repaint Test");
         f.setLayout(new FlowLayout());
-        f.setSize(620, 288);
         f.setResizable(false);
         PanelRepaint pr = new PanelRepaint();
+        pr.setLayout(null);
 
         panel = new Panel();
         panel.setLayout(null);
         panel.setSize(500, 500);
         sPanel = new ScrollPanel(panel);
+        Dimension size = panel.getSize();
 
         Button btn = new Button("Open");
         pr.addComp(btn);
@@ -174,10 +175,11 @@ public class PanelRepaint extends Panel implements FocusListener {
         pr.addComp(t29);
         t29.setBounds(240, 330, 100, 20);
 
+        sPanel.setBounds(0, 0, size.width, size.height / 2);
+        pr.setPreferredSize(new Dimension(size.width, size.height / 2));
         pr.add(sPanel);
         f.add(pr);
-        sPanel.setBounds(100, 100, 500, 250);
-        sPanel.doLayout();
+        f.pack();
         return f;
     }
 


### PR DESCRIPTION
Please review this

Platforms tested:
Windows 11, macOS, Linux, Ubuntu

Summary:
Update PanelRepaint manual test to make the test frame non-resizable, keeping the UI layout fixed during verification.  While testing the non-resizable frame change, observed that tab focus traversal did not scroll lower rows into view.  Set a clear size for the custom ScrollPanel so when focus moves with the Tab key, the selected row can scroll into view properly.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8364404](https://bugs.openjdk.org/browse/JDK-8364404): PanelRepaint.java should not be resizable (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) Review applies to [510723a3](https://git.openjdk.org/jdk/pull/31687/files/510723a3bb35aa6fb7251b6ba0090781701971e5)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31687/head:pull/31687` \
`$ git checkout pull/31687`

Update a local copy of the PR: \
`$ git checkout pull/31687` \
`$ git pull https://git.openjdk.org/jdk.git pull/31687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31687`

View PR using the GUI difftool: \
`$ git pr show -t 31687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31687.diff">https://git.openjdk.org/jdk/pull/31687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31687#issuecomment-4861715492)
</details>
