### PR TITLE
8387324: jlink --strip-debug should filter external debug symbols

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
@@ -224,7 +224,6 @@ public final class TaskHelper {
 
         // Duplicated here so as to avoid a direct dependency on platform specific plugin
         private static final String STRIP_NATIVE_DEBUG_SYMBOLS_NAME = "strip-native-debug-symbols";
-        private static final String EXCLUDE_FILES_NAME = "exclude-files";
         private ModuleLayer pluginsLayer = ModuleLayer.boot();
         private final List<Plugin> plugins;
         private String lastSorter;
@@ -236,8 +235,6 @@ public final class TaskHelper {
         private final Map<Plugin, List<Map<String, String>>> pluginToMaps = new HashMap<>();
         private final List<PluginOption> pluginsOptions = new ArrayList<>();
         private final List<PluginOption> mainOptions = new ArrayList<>();
-        // plugin names disabled via --disable-plugin
-        private final Set<String> disabledPlugins = new HashSet<>();
 
         private PluginsHelper() throws BadArgs {
 
@@ -252,7 +249,6 @@ public final class TaskHelper {
             mainOptions.add(new PluginOption(true, (task, opt, arg) -> {
                     for (Plugin plugin : plugins) {
                         if (plugin.getName().equals(arg)) {
-                            disabledPlugins.add(arg);
                             pluginToMaps.remove(plugin);
                             return;
                         }
@@ -470,12 +466,6 @@ public final class TaskHelper {
             // disable StripJavaDebugAttributesPlugin within DefaultStripDebug plugin if both enabled
             if (seenPlugins.contains(StripJavaDebugAttributesPlugin.NAME) && defaultStripDebugPlugin != null) {
                 defaultStripDebugPlugin.enableJavaStripPlugin(false);
-            }
-
-            // disable the internal ExcludeFilesPlugin within DefaultStripDebug plugin if
-            // the exclude-files plugin was explicitly disabled via --disable-plugin
-            if (defaultStripDebugPlugin != null && disabledPlugins.contains(EXCLUDE_FILES_NAME)) {
-                defaultStripDebugPlugin.enableExcludeFilesPlugin(false);
             }
 
             // recreate or postprocessing don't require an output directory.

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
@@ -224,6 +224,7 @@ public final class TaskHelper {
 
         // Duplicated here so as to avoid a direct dependency on platform specific plugin
         private static final String STRIP_NATIVE_DEBUG_SYMBOLS_NAME = "strip-native-debug-symbols";
+        private static final String EXCLUDE_FILES_NAME = "exclude-files";
         private ModuleLayer pluginsLayer = ModuleLayer.boot();
         private final List<Plugin> plugins;
         private String lastSorter;
@@ -235,6 +236,8 @@ public final class TaskHelper {
         private final Map<Plugin, List<Map<String, String>>> pluginToMaps = new HashMap<>();
         private final List<PluginOption> pluginsOptions = new ArrayList<>();
         private final List<PluginOption> mainOptions = new ArrayList<>();
+        // plugin names disabled via --disable-plugin
+        private final Set<String> disabledPlugins = new HashSet<>();
 
         private PluginsHelper() throws BadArgs {
 
@@ -249,6 +252,7 @@ public final class TaskHelper {
             mainOptions.add(new PluginOption(true, (task, opt, arg) -> {
                     for (Plugin plugin : plugins) {
                         if (plugin.getName().equals(arg)) {
+                            disabledPlugins.add(arg);
                             pluginToMaps.remove(plugin);
                             return;
                         }
@@ -466,6 +470,12 @@ public final class TaskHelper {
             // disable StripJavaDebugAttributesPlugin within DefaultStripDebug plugin if both enabled
             if (seenPlugins.contains(StripJavaDebugAttributesPlugin.NAME) && defaultStripDebugPlugin != null) {
                 defaultStripDebugPlugin.enableJavaStripPlugin(false);
+            }
+
+            // disable the internal ExcludeFilesPlugin within DefaultStripDebug plugin if
+            // the exclude-files plugin was explicitly disabled via --disable-plugin
+            if (defaultStripDebugPlugin != null && disabledPlugins.contains(EXCLUDE_FILES_NAME)) {
+                defaultStripDebugPlugin.enableExcludeFilesPlugin(false);
             }
 
             // recreate or postprocessing don't require an output directory.

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -27,6 +27,7 @@
 package jdk.tools.jlink.internal.plugins;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import jdk.tools.jlink.internal.Platform;
 import jdk.tools.jlink.internal.PluginRepository;
@@ -118,11 +119,6 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
         ResourcePoolManager mgr = new ResourcePoolManager(
                 pool.byteOrder(), ((ResourcePoolManager.ResourcePoolImpl)pool).getStringTable());
         return plugin.transform(pool, mgr.resourcePoolBuilder());
-    }
-
-    private static ResourcePool copyTo(ResourcePool pool, ResourcePoolBuilder out) {
-        pool.transformAndCopy(e -> e, out);
-        return out.build();
     }
 
     public interface NativePluginFactory {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 import jdk.tools.jlink.internal.PluginRepository;
 import jdk.tools.jlink.internal.ResourcePoolManager;
-import jdk.tools.jlink.internal.ResourcePoolManager.ResourcePoolImpl;
 import jdk.tools.jlink.plugin.Plugin;
 import jdk.tools.jlink.plugin.ResourcePool;
 import jdk.tools.jlink.plugin.ResourcePoolBuilder;
@@ -43,6 +42,8 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
 
     private static final String STRIP_NATIVE_DEBUG_PLUGIN = "strip-native-debug-symbols";
     private static final String EXCLUDE_DEBUGINFO = "exclude-debuginfo-files";
+    private static final String EXCLUDE_FILES_PLUGIN = "exclude-files";
+    private static final String EXCLUDE_DEBUG_FILES_PATTERN = "**.debuginfo,**.diz";
 
     private final Plugin javaStripPlugin;
     private final NativePluginFactory stripNativePluginFactory;
@@ -68,26 +69,25 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
     @Override
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         Plugin stripNativePlugin = stripNativePluginFactory.create();
-        if (stripNativePlugin != null) {
-            Map<String, String> stripNativeConfig = Map.of(
-                                     STRIP_NATIVE_DEBUG_PLUGIN, EXCLUDE_DEBUGINFO);
-            stripNativePlugin.configure(stripNativeConfig);
 
-            if (!isJavaStripPluginEnabled) {
-                return stripNativePlugin.transform(in, out);
-            }
+        ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
+        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, EXCLUDE_DEBUG_FILES_PATTERN));
 
-            ResourcePoolManager outRes =
-                                 new ResourcePoolManager(in.byteOrder(),
-                                                        ((ResourcePoolImpl)in).getStringTable());
-            ResourcePool strippedJava = javaStripPlugin.transform(in,
-                                                                  outRes.resourcePoolBuilder());
-            return stripNativePlugin.transform(strippedJava, out);
-        } else if (isJavaStripPluginEnabled) {
-            return javaStripPlugin.transform(in, out);
-        } else {
-            return in;
+        ResourcePool result = in;
+        if (isJavaStripPluginEnabled) {
+            result = pipe(result, javaStripPlugin);
         }
+        if (stripNativePlugin != null) {
+            stripNativePlugin.configure(Map.of(STRIP_NATIVE_DEBUG_PLUGIN, EXCLUDE_DEBUGINFO));
+            result = pipe(result, stripNativePlugin);
+        }
+        return excludeFilesPlugin.transform(result, out);
+    }
+
+    private ResourcePool pipe(ResourcePool pool, Plugin plugin) {
+        ResourcePoolManager mgr = new ResourcePoolManager(
+                pool.byteOrder(), ((ResourcePoolManager.ResourcePoolImpl)pool).getStringTable());
+        return plugin.transform(pool, mgr.resourcePoolBuilder());
     }
 
     public interface NativePluginFactory {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -27,7 +27,6 @@
 package jdk.tools.jlink.internal.plugins;
 
 import java.util.Map;
-import java.util.function.Function;
 
 import jdk.tools.jlink.internal.Platform;
 import jdk.tools.jlink.internal.PluginRepository;
@@ -52,7 +51,6 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
     private final NativePluginFactory stripNativePluginFactory;
 
     private boolean isJavaStripPluginEnabled = true;
-    private boolean isExcludeFilesPluginEnabled = true;
 
     public DefaultStripDebugPlugin() {
         this(new StripJavaDebugAttributesPlugin(),
@@ -70,13 +68,13 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
         isJavaStripPluginEnabled = enableJavaStripPlugin;
     }
 
-    public void enableExcludeFilesPlugin(boolean enableExcludeFilesPlugin) {
-        isExcludeFilesPluginEnabled = enableExcludeFilesPlugin;
-    }
-
     @Override
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         Plugin stripNativePlugin = stripNativePluginFactory.create();
+
+        String pattern = debugFilePattern(in);
+        ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
+        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, pattern));
 
         ResourcePool result = in;
         if (isJavaStripPluginEnabled) {
@@ -86,12 +84,6 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
             stripNativePlugin.configure(Map.of(STRIP_NATIVE_DEBUG_PLUGIN, EXCLUDE_DEBUGINFO));
             result = pipe(result, stripNativePlugin);
         }
-        if (!isExcludeFilesPluginEnabled) {
-            result.transformAndCopy(Function.identity(), out);
-            return out.build();
-        }
-        ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
-        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, debugFilePattern(in)));
         return excludeFilesPlugin.transform(result, out);
     }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -51,6 +51,7 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
     private final NativePluginFactory stripNativePluginFactory;
 
     private boolean isJavaStripPluginEnabled = true;
+    private boolean isExcludeFilesPluginEnabled = true;
 
     public DefaultStripDebugPlugin() {
         this(new StripJavaDebugAttributesPlugin(),
@@ -68,13 +69,13 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
         isJavaStripPluginEnabled = enableJavaStripPlugin;
     }
 
+    public void enableExcludeFilesPlugin(boolean enableExcludeFilesPlugin) {
+        isExcludeFilesPluginEnabled = enableExcludeFilesPlugin;
+    }
+
     @Override
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         Plugin stripNativePlugin = stripNativePluginFactory.create();
-
-        String pattern = debugFilePattern(in);
-        ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
-        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, pattern));
 
         ResourcePool result = in;
         if (isJavaStripPluginEnabled) {
@@ -84,6 +85,11 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
             stripNativePlugin.configure(Map.of(STRIP_NATIVE_DEBUG_PLUGIN, EXCLUDE_DEBUGINFO));
             result = pipe(result, stripNativePlugin);
         }
+        if (!isExcludeFilesPluginEnabled) {
+            return copyTo(result, out);
+        }
+        ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
+        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, debugFilePattern(in)));
         return excludeFilesPlugin.transform(result, out);
     }
 
@@ -111,6 +117,11 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
         ResourcePoolManager mgr = new ResourcePoolManager(
                 pool.byteOrder(), ((ResourcePoolManager.ResourcePoolImpl)pool).getStringTable());
         return plugin.transform(pool, mgr.resourcePoolBuilder());
+    }
+
+    private static ResourcePool copyTo(ResourcePool pool, ResourcePoolBuilder out) {
+        pool.transformAndCopy(e -> e, out);
+        return out.build();
     }
 
     public interface NativePluginFactory {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -27,11 +27,13 @@ package jdk.tools.jlink.internal.plugins;
 
 import java.util.Map;
 
+import jdk.tools.jlink.internal.Platform;
 import jdk.tools.jlink.internal.PluginRepository;
 import jdk.tools.jlink.internal.ResourcePoolManager;
 import jdk.tools.jlink.plugin.Plugin;
 import jdk.tools.jlink.plugin.ResourcePool;
 import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolModule;
 
 /**
  * Combined debug stripping plugin: Java debug attributes and native debug
@@ -43,7 +45,6 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
     private static final String STRIP_NATIVE_DEBUG_PLUGIN = "strip-native-debug-symbols";
     private static final String EXCLUDE_DEBUGINFO = "exclude-debuginfo-files";
     private static final String EXCLUDE_FILES_PLUGIN = "exclude-files";
-    private static final String EXCLUDE_DEBUG_FILES_PATTERN = "**.debuginfo,**.diz";
 
     private final Plugin javaStripPlugin;
     private final NativePluginFactory stripNativePluginFactory;
@@ -70,8 +71,9 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         Plugin stripNativePlugin = stripNativePluginFactory.create();
 
+        String pattern = debugFilePattern(in);
         ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
-        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, EXCLUDE_DEBUG_FILES_PATTERN));
+        excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, pattern));
 
         ResourcePool result = in;
         if (isJavaStripPluginEnabled) {
@@ -82,6 +84,26 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
             result = pipe(result, stripNativePlugin);
         }
         return excludeFilesPlugin.transform(result, out);
+    }
+
+    // Returns the glob pattern for debug files matching the target platform.
+    // Mirrors the per-OS exclusion logic in make/CreateJmods.gmk.
+    private static String debugFilePattern(ResourcePool in) {
+        Platform platform;
+        try {
+            String tp = in.moduleView()
+                    .findModule("java.base")
+                    .map(ResourcePoolModule::targetPlatform)
+                    .orElse(null);
+            platform = tp != null ? Platform.parsePlatform(tp) : Platform.runtime();
+        } catch (IllegalArgumentException e) {
+            platform = Platform.runtime();
+        }
+        return switch (platform.os()) {
+            case WINDOWS -> "**.pdb,**.map,**.diz";
+            case MACOS   -> "**.dSYM/**,**.diz";
+            default      -> "**.debuginfo,**.diz"; // Linux, AIX
+        };
     }
 
     private ResourcePool pipe(ResourcePool pool, Plugin plugin) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/DefaultStripDebugPlugin.java
@@ -86,7 +86,8 @@ public final class DefaultStripDebugPlugin extends AbstractPlugin {
             result = pipe(result, stripNativePlugin);
         }
         if (!isExcludeFilesPluginEnabled) {
-            return copyTo(result, out);
+            result.transformAndCopy(Function.identity(), out);
+            return out.build();
         }
         ExcludeFilesPlugin excludeFilesPlugin = new ExcludeFilesPlugin();
         excludeFilesPlugin.configure(Map.of(EXCLUDE_FILES_PLUGIN, debugFilePattern(in)));

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -155,43 +155,12 @@ public class DefaultStripDebugPluginTest {
         }
     }
 
-    // Disable the internal exclude-files stage: debug files must be retained.
-    public void testExcludeFilesDisabled() {
-        MockStripPlugin javaPlugin = new MockStripPlugin(false);
-        MockStripPlugin nativePlugin = new MockStripPlugin(true);
-        TestNativeStripPluginFactory nativeFactory =
-                                 new TestNativeStripPluginFactory(nativePlugin);
-        DefaultStripDebugPlugin plugin = new DefaultStripDebugPlugin(javaPlugin,
-                                                                     nativeFactory);
-        plugin.enableExcludeFilesPlugin(false);
-
-        ResourcePoolManager inManager = new ResourcePoolManager();
-        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
-                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
-        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
-                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
-        ResourcePoolManager outManager = new ResourcePoolManager();
-        ResourcePool pool = plugin.transform(inManager.resourcePool(),
-                                             outManager.resourcePoolBuilder());
-        if (!pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
-            !pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
-            throw new AssertionError("Expected both native and java to get called");
-        }
-        if (!pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
-            throw new AssertionError(".debuginfo file should have been retained");
-        }
-        if (!pool.findEntry(MockStripPlugin.DIZ_PATH).isPresent()) {
-            throw new AssertionError(".diz file should have been retained");
-        }
-    }
-
     public static void main(String[] args) {
         DefaultStripDebugPluginTest test = new DefaultStripDebugPluginTest();
         test.testNoNativeStripPluginPresent();
         test.testWithNativeStripPresent();
         test.testOnlyNativePlugin();
         test.testNoOperation();
-        test.testExcludeFilesDisabled();
     }
 
     public static class MockStripPlugin implements Plugin {

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -155,12 +155,43 @@ public class DefaultStripDebugPluginTest {
         }
     }
 
+    // Disable the internal exclude-files stage: debug files must be retained.
+    public void testExcludeFilesDisabled() {
+        MockStripPlugin javaPlugin = new MockStripPlugin(false);
+        MockStripPlugin nativePlugin = new MockStripPlugin(true);
+        TestNativeStripPluginFactory nativeFactory =
+                                 new TestNativeStripPluginFactory(nativePlugin);
+        DefaultStripDebugPlugin plugin = new DefaultStripDebugPlugin(javaPlugin,
+                                                                     nativeFactory);
+        plugin.enableExcludeFilesPlugin(false);
+
+        ResourcePoolManager inManager = new ResourcePoolManager();
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        ResourcePoolManager outManager = new ResourcePoolManager();
+        ResourcePool pool = plugin.transform(inManager.resourcePool(),
+                                             outManager.resourcePoolBuilder());
+        if (!pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
+            !pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
+            throw new AssertionError("Expected both native and java to get called");
+        }
+        if (!pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
+            throw new AssertionError(".debuginfo file should have been retained");
+        }
+        if (!pool.findEntry(MockStripPlugin.DIZ_PATH).isPresent()) {
+            throw new AssertionError(".diz file should have been retained");
+        }
+    }
+
     public static void main(String[] args) {
         DefaultStripDebugPluginTest test = new DefaultStripDebugPluginTest();
         test.testNoNativeStripPluginPresent();
         test.testWithNativeStripPresent();
         test.testOnlyNativePlugin();
         test.testNoOperation();
+        test.testExcludeFilesDisabled();
     }
 
     public static class MockStripPlugin implements Plugin {

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -51,14 +51,23 @@ public class DefaultStripDebugPluginTest {
         DefaultStripDebugPlugin plugin = new DefaultStripDebugPlugin(javaPlugin,
                                                                      nativeFactory);
         ResourcePoolManager inManager = new ResourcePoolManager();
-        addDebugEntries(inManager);
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        ResourcePoolManager outManager = new ResourcePoolManager();
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
-                                             inManager.resourcePoolBuilder());
+                                             outManager.resourcePoolBuilder());
         if (!pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
             !pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
             throw new AssertionError("Expected both native and java to get called");
         }
-        assertDebugEntriesExcluded(pool);
+        if (pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
+            throw new AssertionError(".debuginfo file should have been excluded");
+        }
+        if (pool.findEntry(MockStripPlugin.DIZ_PATH).isPresent()) {
+            throw new AssertionError(".diz file should have been excluded");
+        }
     }
 
     public void testNoNativeStripPluginPresent() {
@@ -68,13 +77,22 @@ public class DefaultStripDebugPluginTest {
         DefaultStripDebugPlugin plugin = new DefaultStripDebugPlugin(javaPlugin,
                                                                      nativeFactory);
         ResourcePoolManager inManager = new ResourcePoolManager();
-        addDebugEntries(inManager);
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        ResourcePoolManager outManager = new ResourcePoolManager();
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
-                                             inManager.resourcePoolBuilder());
+                                             outManager.resourcePoolBuilder());
         if (!pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent()) {
             throw new AssertionError("Expected java strip plugin to get called");
         }
-        assertDebugEntriesExcluded(pool);
+        if (pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
+            throw new AssertionError(".debuginfo file should have been excluded");
+        }
+        if (pool.findEntry(MockStripPlugin.DIZ_PATH).isPresent()) {
+            throw new AssertionError(".diz file should have been excluded");
+        }
     }
 
     // Disable embedded strip Java plugin, with native plugin present.
@@ -88,14 +106,23 @@ public class DefaultStripDebugPluginTest {
         plugin.enableJavaStripPlugin(false);
 
         ResourcePoolManager inManager = new ResourcePoolManager();
-        addDebugEntries(inManager);
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        ResourcePoolManager outManager = new ResourcePoolManager();
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
-                                             inManager.resourcePoolBuilder());
+                                             outManager.resourcePoolBuilder());
         if (pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
             !pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
             throw new AssertionError("Expected only native to get called");
         }
-        assertDebugEntriesExcluded(pool);
+        if (pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
+            throw new AssertionError(".debuginfo file should have been excluded");
+        }
+        if (pool.findEntry(MockStripPlugin.DIZ_PATH).isPresent()) {
+            throw new AssertionError(".diz file should have been excluded");
+        }
     }
 
     // Disable embedded strip Java plugin, and without native plugin present.
@@ -107,26 +134,17 @@ public class DefaultStripDebugPluginTest {
                                                                      nativeFactory);
         plugin.enableJavaStripPlugin(false);
         ResourcePoolManager inManager = new ResourcePoolManager();
-        addDebugEntries(inManager);
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        inManager.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
+                ResourcePoolEntry.Type.NATIVE_LIB, new byte[]{0, 1, 2, 3}));
+        ResourcePoolManager outManager = new ResourcePoolManager();
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
-                                             inManager.resourcePoolBuilder());
+                                             outManager.resourcePoolBuilder());
         if (pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
             pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
             throw new AssertionError("Expected both native and java not called");
         }
-        assertDebugEntriesExcluded(pool);
-    }
-
-    private void addDebugEntries(ResourcePoolManager mgr) {
-        mgr.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
-                                         ResourcePoolEntry.Type.NATIVE_LIB,
-                                         new byte[] { 0, 1, 2, 3 }));
-        mgr.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
-                                         ResourcePoolEntry.Type.NATIVE_LIB,
-                                         new byte[] { 0, 1, 2, 3 }));
-    }
-
-    private void assertDebugEntriesExcluded(ResourcePool pool) {
         if (pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
             throw new AssertionError(".debuginfo file should have been excluded");
         }

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -175,11 +175,14 @@ public class DefaultStripDebugPluginTest {
         private final boolean isNative;
 
         private static String platformDebugPath() {
-            return switch (Platform.runtime().os()) {
-                case WINDOWS -> "/foo/bin/libfoo.pdb";
-                case MACOS   -> "/foo/lib/libfoo.dylib.dSYM/Contents/Resources/DWARF/libfoo.dylib";
-                default      -> "/foo/lib/libfoo.so.debuginfo";
-            };
+            String platform = Platform.runtime().toString();
+            if (platform.startsWith("windows")) {
+                return "/foo/bin/libfoo.pdb";
+            } else if (platform.startsWith("macos")) {
+                return "/foo/lib/libfoo.dylib.dSYM/Contents/Resources/DWARF/libfoo.dylib";
+            } else {
+                return "/foo/lib/libfoo.so.debuginfo";
+            }
         }
 
         MockStripPlugin(boolean isNative) {

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -23,6 +23,7 @@
 
 import java.util.Map;
 
+import jdk.tools.jlink.internal.Platform;
 import jdk.tools.jlink.internal.ResourcePoolManager;
 import jdk.tools.jlink.internal.plugins.DefaultStripDebugPlugin;
 import jdk.tools.jlink.internal.plugins.DefaultStripDebugPlugin.NativePluginFactory;
@@ -165,11 +166,21 @@ public class DefaultStripDebugPluginTest {
 
         private static final String NATIVE_PATH = "/foo/lib/test.so.debug";
         private static final String JAVA_PATH = "/foo/TestClass.class";
-        static final String DEBUGINFO_PATH = "/foo/lib/libfoo.so.debuginfo";
+        // Platform-appropriate debug file paths, matching the patterns chosen by
+        // DefaultStripDebugPlugin.debugFilePattern() for the runtime platform.
+        static final String DEBUGINFO_PATH = platformDebugPath();
         static final String DIZ_PATH = "/foo/lib/libfoo.diz";
         private static final String STRIP_NATIVE_NAME = "strip-native-debug-symbols";
         private static final String OMIT_ARG = "exclude-debuginfo-files";
         private final boolean isNative;
+
+        private static String platformDebugPath() {
+            return switch (Platform.runtime().os()) {
+                case WINDOWS -> "/foo/bin/libfoo.pdb";
+                case MACOS   -> "/foo/lib/libfoo.dylib.dSYM/Contents/Resources/DWARF/libfoo.dylib";
+                default      -> "/foo/lib/libfoo.so.debuginfo";
+            };
+        }
 
         MockStripPlugin(boolean isNative) {
             this.isNative = isNative;

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/DefaultStripDebugPluginTest.java
@@ -51,12 +51,14 @@ public class DefaultStripDebugPluginTest {
         DefaultStripDebugPlugin plugin = new DefaultStripDebugPlugin(javaPlugin,
                                                                      nativeFactory);
         ResourcePoolManager inManager = new ResourcePoolManager();
+        addDebugEntries(inManager);
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
                                              inManager.resourcePoolBuilder());
         if (!pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
             !pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
             throw new AssertionError("Expected both native and java to get called");
         }
+        assertDebugEntriesExcluded(pool);
     }
 
     public void testNoNativeStripPluginPresent() {
@@ -66,11 +68,13 @@ public class DefaultStripDebugPluginTest {
         DefaultStripDebugPlugin plugin = new DefaultStripDebugPlugin(javaPlugin,
                                                                      nativeFactory);
         ResourcePoolManager inManager = new ResourcePoolManager();
+        addDebugEntries(inManager);
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
                                              inManager.resourcePoolBuilder());
         if (!pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent()) {
             throw new AssertionError("Expected java strip plugin to get called");
         }
+        assertDebugEntriesExcluded(pool);
     }
 
     // Disable embedded strip Java plugin, with native plugin present.
@@ -84,12 +88,14 @@ public class DefaultStripDebugPluginTest {
         plugin.enableJavaStripPlugin(false);
 
         ResourcePoolManager inManager = new ResourcePoolManager();
+        addDebugEntries(inManager);
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
                                              inManager.resourcePoolBuilder());
         if (pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
             !pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
             throw new AssertionError("Expected only native to get called");
         }
+        assertDebugEntriesExcluded(pool);
     }
 
     // Disable embedded strip Java plugin, and without native plugin present.
@@ -101,11 +107,31 @@ public class DefaultStripDebugPluginTest {
                                                                      nativeFactory);
         plugin.enableJavaStripPlugin(false);
         ResourcePoolManager inManager = new ResourcePoolManager();
+        addDebugEntries(inManager);
         ResourcePool pool = plugin.transform(inManager.resourcePool(),
                                              inManager.resourcePoolBuilder());
         if (pool.findEntry(MockStripPlugin.JAVA_PATH).isPresent() ||
             pool.findEntry(MockStripPlugin.NATIVE_PATH).isPresent()) {
             throw new AssertionError("Expected both native and java not called");
+        }
+        assertDebugEntriesExcluded(pool);
+    }
+
+    private void addDebugEntries(ResourcePoolManager mgr) {
+        mgr.add(ResourcePoolEntry.create(MockStripPlugin.DEBUGINFO_PATH,
+                                         ResourcePoolEntry.Type.NATIVE_LIB,
+                                         new byte[] { 0, 1, 2, 3 }));
+        mgr.add(ResourcePoolEntry.create(MockStripPlugin.DIZ_PATH,
+                                         ResourcePoolEntry.Type.NATIVE_LIB,
+                                         new byte[] { 0, 1, 2, 3 }));
+    }
+
+    private void assertDebugEntriesExcluded(ResourcePool pool) {
+        if (pool.findEntry(MockStripPlugin.DEBUGINFO_PATH).isPresent()) {
+            throw new AssertionError(".debuginfo file should have been excluded");
+        }
+        if (pool.findEntry(MockStripPlugin.DIZ_PATH).isPresent()) {
+            throw new AssertionError(".diz file should have been excluded");
         }
     }
 
@@ -121,6 +147,8 @@ public class DefaultStripDebugPluginTest {
 
         private static final String NATIVE_PATH = "/foo/lib/test.so.debug";
         private static final String JAVA_PATH = "/foo/TestClass.class";
+        static final String DEBUGINFO_PATH = "/foo/lib/libfoo.so.debuginfo";
+        static final String DIZ_PATH = "/foo/lib/libfoo.diz";
         private static final String STRIP_NATIVE_NAME = "strip-native-debug-symbols";
         private static final String OMIT_ARG = "exclude-debuginfo-files";
         private final boolean isNative;
@@ -153,8 +181,7 @@ public class DefaultStripDebugPluginTest {
                 resPath = NATIVE_PATH;
                 type = Type.NATIVE_LIB;
             }
-            ResourcePoolEntry entry = createMockEntry(resPath, type);
-            out.add(entry);
+            out.add(createMockEntry(resPath, type));
             return out.build();
         }
 


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change requires CSR request [JDK-8388393](https://bugs.openjdk.org/browse/JDK-8388393) to be approved
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8387324: jlink --strip-debug should filter external debug symbols`

### Issues
 * [JDK-8387324](https://bugs.openjdk.org/browse/JDK-8387324): jlink --strip-debug should filter external debug symbols (**Enhancement** - P4)
 * [JDK-8388393](https://bugs.openjdk.org/browse/JDK-8388393): jlink --strip-debug should filter external debug symbols (**CSR**)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Dušan Bálek](https://openjdk.org/census#dbalek) (@dbalek - Committer)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31690/head:pull/31690` \
`$ git checkout pull/31690`

Update a local copy of the PR: \
`$ git checkout pull/31690` \
`$ git pull https://git.openjdk.org/jdk.git pull/31690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31690`

View PR using the GUI difftool: \
`$ git pr show -t 31690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31690.diff">https://git.openjdk.org/jdk/pull/31690.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31690#issuecomment-4958098447)
</details>
