### PR TITLE
8387322: G1: G1CSetCandidateGroupList::_num_regions should be Atomic

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -134,7 +134,7 @@ void G1CSetCandidateGroupList::append(G1CSetCandidateGroup* group) {
   assert(group->length() > 0, "Do not add empty groups");
   assert(!_groups.contains(group), "Already added to list");
   _groups.append(group);
-  _num_regions += group->length();
+  _num_regions.store_relaxed(num_regions() + group->length());
 }
 
 G1CSetCandidateGroup* G1CSetCandidateGroupList::at(uint index) {
@@ -147,7 +147,7 @@ void G1CSetCandidateGroupList::clear(bool uninstall_group_cardset) {
     delete gr;
   }
   _groups.clear();
-  _num_regions = 0;
+  _num_regions.store_relaxed(0);
 }
 
 void G1CSetCandidateGroupList::prepare_for_scan() {
@@ -156,9 +156,9 @@ void G1CSetCandidateGroupList::prepare_for_scan() {
   }
 }
 
-void G1CSetCandidateGroupList::remove_selected(uint count, uint num_regions) {
+void G1CSetCandidateGroupList::remove_selected(uint count, uint num_regions_to_remove) {
   _groups.remove_till(count);
-  _num_regions -= num_regions;
+  _num_regions.store_relaxed(num_regions() - num_regions_to_remove);
 }
 
 void G1CSetCandidateGroupList::remove(G1CSetCandidateGroupList* other) {
@@ -172,7 +172,7 @@ void G1CSetCandidateGroupList::remove(G1CSetCandidateGroupList* other) {
   // Create a list from scratch, copying over the elements from the candidate
   // list not in the other list. Finally deallocate and overwrite the old list.
   int new_length = _groups.length() - other->length();
-  _num_regions = num_regions() - other->num_regions();
+  _num_regions.store_relaxed(num_regions() - other->num_regions());
   GrowableArray<G1CSetCandidateGroup*> new_list(new_length, mtGC);
 
   uint other_idx = 0;

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -29,6 +29,7 @@
 #include "gc/g1/g1CollectionSetCandidates.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/growableArray.hpp"
 
@@ -147,7 +148,7 @@ using G1CSetCandidateGroupListIterator = GrowableArrayIterator<G1CSetCandidateGr
 
 class G1CSetCandidateGroupList {
   GrowableArray<G1CSetCandidateGroup*> _groups;
-  volatile uint _num_regions;
+  Atomic<uint> _num_regions;
 
 public:
   G1CSetCandidateGroupList();
@@ -163,7 +164,7 @@ public:
 
   uint length() const { return (uint)_groups.length(); }
 
-  uint num_regions() const { return _num_regions; }
+  uint num_regions() const { return _num_regions.load_relaxed(); }
 
   void remove_selected(uint count, uint num_regions);
 


### PR DESCRIPTION
Hi all,

  please review this conversion of `G1CollectionSetCandidatGroups::_num_regions` to use the Atomic API.

Straightforward.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387322](https://bugs.openjdk.org/browse/JDK-8387322): G1: G1CSetCandidateGroupList::_num_regions should be Atomic (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31691/head:pull/31691` \
`$ git checkout pull/31691`

Update a local copy of the PR: \
`$ git checkout pull/31691` \
`$ git pull https://git.openjdk.org/jdk.git pull/31691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31691`

View PR using the GUI difftool: \
`$ git pr show -t 31691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31691.diff">https://git.openjdk.org/jdk/pull/31691.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31691#issuecomment-4807547726)
</details>
