### PR TITLE
8387215: On-demand attribution of a record constructor body causes javac to emit an invalid diagnostic

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -1547,7 +1547,8 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
             }
             public void visitMethodDef(JCMethodDecl node) {
                 // remove super constructor call that may have been added during attribution:
-                if (TreeInfo.isConstructor(node) && node.sym != null && node.sym.owner.isEnum() &&
+                if (TreeInfo.isConstructor(node) && node.sym != null &&
+                    (node.sym.owner.isEnum() || TreeInfo.isCanonicalConstructor(node)) &&
                     node.body != null && node.body.stats.nonEmpty() && TreeInfo.isSuperCall(node.body.stats.head) &&
                     node.body.stats.head.pos == node.body.pos) {
                     node.body.stats = node.body.stats.tail;

--- a/test/langtools/tools/javac/processing/model/trees/OnDemandAttributionRecordConstructor.java
+++ b/test/langtools/tools/javac/processing/model/trees/OnDemandAttributionRecordConstructor.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387215
+ * @summary Check that javac does not report invalid errors when compiling a valid
+ *          compact record constructor when an on-demand attribution is triggered
+ *          by an annotation processor calling Trees.getElement(...) for identifiers
+ *          inside the constructor.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.Task;
+
+public class OnDemandAttributionRecordConstructor {
+
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testCompactRecordConstructorWithGetElementCall() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         record Repro(String name) {
+                             Repro {
+                                 name = name.trim();
+                             }
+                         }
+                         """)
+                .processors(new ProcessorImpl())
+                .run()
+                .writeAll();
+    }
+
+    @Test
+    void testCompactRecordConstructorWithoutGetElementCall() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString(), "-AskipGetElement=true")
+                .sources("""
+                         record Repro(String name) {
+                             Repro {
+                                 name = name.trim();
+                             }
+                         }
+                         """)
+                .processors(new ProcessorImpl())
+                .run()
+                .writeAll();
+    }
+
+    @Test
+    void testCanonicalRecordConstructorWithGetElementCall() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         record Repro(String name) {
+                             Repro(String name) {
+                                 this.name = name.trim();
+                             }
+                         }
+                         """)
+                .processors(new ProcessorImpl())
+                .run()
+                .writeAll();
+    }
+
+    @Test
+    void testBrokenRecordConstructorWithGetElementCall() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics", "-nowarn")
+                .sources("""
+                         record Repro(String name) {
+                             Repro(String name) {
+                                 super(); //illegal
+                                 this.name = name.trim();
+                             }
+                         }
+                         """)
+                .processors(new ProcessorImpl())
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Repro.java:2:5: compiler.err.invalid.canonical.constructor.in.record: (compiler.misc.canonical), Repro, (compiler.misc.canonical.must.not.contain.explicit.constructor.invocation)",
+                "1 error"));
+    }
+
+    @SupportedAnnotationTypes("*")
+    @SupportedOptions(ProcessorImpl.SKIP_GET_ELEMENT)
+    private static class ProcessorImpl extends AbstractProcessor {
+
+        private static final String SKIP_GET_ELEMENT = "skipGetElement";
+        private Trees trees;
+
+        @Override
+        public synchronized void init(ProcessingEnvironment processingEnv) {
+            super.init(processingEnv);
+            trees = Trees.instance(processingEnv);
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            if (roundEnv.processingOver()) {
+                return false;
+            }
+            for (Element rootElement : roundEnv.getRootElements()) {
+                TreePath rootPath = trees.getPath(rootElement);
+                if (rootPath == null) {
+                    continue;
+                }
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitIdentifier(IdentifierTree node, Void unused) {
+                        TreePath currentPath = getCurrentPath();
+                        if (!skipGetElement() && insideRecordConstructor(currentPath)) {
+                            processingEnv.getMessager()
+                                    .printMessage(Diagnostic.Kind.NOTE,
+                                                  "Calling Trees.getElement for identifier '" + node.getName()
+                                                          + "' inside a record constructor");
+                            trees.getElement(currentPath);
+                        }
+                        return super.visitIdentifier(node, unused);
+                    }
+                }.scan(rootPath, null);
+            }
+            return false;
+        }
+
+        private boolean skipGetElement() {
+            return Boolean.parseBoolean(processingEnv.getOptions().get(SKIP_GET_ELEMENT));
+        }
+
+        private static boolean insideRecordConstructor(TreePath path) {
+            TreePath current = path;
+            while (current != null) {
+                if (current.getLeaf() instanceof MethodTree method
+                        && method.getReturnType() == null
+                        && current.getParentPath() != null
+                        && current.getParentPath().getLeaf().getKind() == Tree.Kind.RECORD) {
+                    return true;
+                }
+                current = current.getParentPath();
+            }
+            return false;
+        }
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fea0c229](https://github.com/openjdk/jdk/commit/fea0c229130770230f97a7665dadefe42ef1f9fd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dusan Balek on 26 Jun 2026 and was reviewed by Jan Lahoda.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387215](https://bugs.openjdk.org/browse/JDK-8387215): On-demand attribution of a record constructor body causes javac to emit an invalid diagnostic (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31692/head:pull/31692` \
`$ git checkout pull/31692`

Update a local copy of the PR: \
`$ git checkout pull/31692` \
`$ git pull https://git.openjdk.org/jdk.git pull/31692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31692`

View PR using the GUI difftool: \
`$ git pr show -t 31692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31692.diff">https://git.openjdk.org/jdk/pull/31692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31692#issuecomment-4809023683)
</details>
