### PR TITLE
8386989: QuicEndpoint.ClosedConnection should not use QuicTimerQueue::offer

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/quic/QuicEndpoint.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/quic/QuicEndpoint.java
@@ -1788,9 +1788,10 @@ public abstract sealed class QuicEndpoint implements AutoCloseable
                 if (more > 16) {
                     // the server doesn't seem to take into account our
                     // connection close frame. Just stop responding
-                    updatedDeadline = Deadline.MIN;
+                    updated = updatedDeadline = Deadline.MIN;
                 } else {
-                    updatedDeadline = updated.plusMillis(maxIdleTimeMs);
+                    updated = updatedDeadline = timeSource().instant()
+                            .plusMillis(maxIdleTimeMs);
                 }
                 handleIncoming(source, destConnId, headersType, buffer);
             } else {
@@ -1798,7 +1799,7 @@ public abstract sealed class QuicEndpoint implements AutoCloseable
                 dropIncoming(source, destConnId, headersType, buffer);
             }
 
-            timer().reschedule(this, updatedDeadline);
+            timer().reschedule(this, updated);
         }
 
         protected void handleIncoming(SocketAddress source, ByteBuffer idbytes,
@@ -1821,8 +1822,8 @@ public abstract sealed class QuicEndpoint implements AutoCloseable
         }
 
         public final void startTimer() {
-            deadline = updatedDeadline = timeSource().instant().plusMillis(maxIdleTimeMs);
-            timer().offer(this);
+            Deadline deadline = updatedDeadline = timeSource().instant().plusMillis(maxIdleTimeMs);
+            timer().reschedule(this, deadline);
         }
 
         @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/quic/QuicTimerQueue.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/quic/QuicTimerQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,9 @@ public final class QuicTimerQueue {
     private volatile Deadline scheduledDeadline = Deadline.MAX;
     private volatile Deadline returnedDeadline = Deadline.MAX;
 
+    // Not volatile: never accessed without holding monitor
+    private Deadline notifiedDeadline = Deadline.MAX;
+
     /**
      * Creates a new timer queue with the given notifier.
      * A notifier is used to notify the timer thread that
@@ -118,7 +121,7 @@ public final class QuicTimerQueue {
         assert QuicTimedEvent.COMPARATOR.compare(event, FLOOR) > 0;
         assert QuicTimedEvent.COMPARATOR.compare(event, CEILING) < 0;
         Deadline deadline = event.deadline();
-        scheduled.add(event);
+        rescheduled.add(event);
         scheduled(deadline);
         if (debug.on()) debug.log("QuicTimerQueue: event %s offered", event);
         if (notify(deadline)) {
@@ -181,7 +184,7 @@ public final class QuicTimerQueue {
         int drained = 0;
         int dues;
         synchronized (this) {
-            scheduledDeadline = Deadline.MAX;
+            scheduledDeadline = returnedDeadline = notifiedDeadline = Deadline.MAX;
         }
         // moved scheduled / rescheduled tasks to due, until
         // nothing else is due. Then process dues.
@@ -347,7 +350,16 @@ public final class QuicTimerQueue {
         synchronized (this) {
             if (deadline.isBefore(nextDeadline())
                 || deadline.isBefore(returnedDeadline)) {
-                return true;
+                // notifiedDeadline will be reset to MAX first thing in
+                // processEventAndReturnNextDeadline; We do not want
+                // to call the notifier (wake the selector) again if it's
+                // been already called for a notifiedDeadline <= to deadline;
+                // On the other hand, if deadline < notifiedDeadline, we
+                // need to call the notifier to force an additional wakeup
+                if (deadline.isBefore(notifiedDeadline)) {
+                    notifiedDeadline = deadline;
+                    return true;
+                }
             }
         }
         return false;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/quic/QuicTimerQueue.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/quic/QuicTimerQueue.java
@@ -116,33 +116,8 @@ public final class QuicTimerQueue {
      * @param event an event to be scheduled
      */
     public void offer(QuicTimedEvent event) {
-        if (event instanceof Marker marker)
-            throw new IllegalArgumentException(marker.name());
-        assert QuicTimedEvent.COMPARATOR.compare(event, FLOOR) > 0;
-        assert QuicTimedEvent.COMPARATOR.compare(event, CEILING) < 0;
-        Deadline deadline = event.deadline();
-        rescheduled.add(event);
-        scheduled(deadline);
         if (debug.on()) debug.log("QuicTimerQueue: event %s offered", event);
-        if (notify(deadline)) {
-            if (debug.on()) debug.log("QuicTimerQueue: event %s will be rescheduled", event);
-            if (Log.quicTimer()) {
-                var now = debugNow();
-                Log.logQuic(String.format("%s: QuicTimerQueue: event %s will be scheduled" +
-                                " at %s (returned deadline: %s, nextDeadline: %s)",
-                        Thread.currentThread().getName(), event, d(now, deadline),
-                        d(now, returnedDeadline), d(now, nextDeadline())));
-            }
-            notifier.run();
-        } else {
-            if (Log.quicTimer()) {
-                var now = debugNow();
-                Log.logQuic(String.format("%s: QuicTimerQueue: event %s will not be scheduled" +
-                                " at %s (returned deadline: %s, nextDeadline: %s)",
-                        Thread.currentThread().getName(), event, d(now, deadline),
-                        d(now, returnedDeadline), d(now, nextDeadline())));
-            }
-        }
+        reschedule(event, event.deadline());
     }
 
     /**

--- a/test/jdk/java/net/httpclient/http3/H3MultipleConnectionsToSameHost.java
+++ b/test/jdk/java/net/httpclient/http3/H3MultipleConnectionsToSameHost.java
@@ -77,7 +77,7 @@
  */
 /*
  * @test id=useNioSelector
- * @bug 8087112 8372409
+ * @bug 8087112 8372409 8386989
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext
  *        jdk.httpclient.test.lib.http2.Http2TestServer


### PR DESCRIPTION
This issue was noticed because `H3MultipleConnectionsToSameHost.java#useNioSelector` once threw an `AssertionError` in our CI:
```
16 failed: java.util.concurrent.CompletionException: java.io.IOException: java.lang.AssertionError: Invalid deadline for PacketTransmissionTask(QuicConnection(HttpClientImpl(1), QuicClientConnection(37))[HANDSHAKE])
```

This assertion is thrown if a task is found in the `QuicTimerQueue` with a deadline equals to `Deadline.MAX`, which should never happen. Code reading suggested a potential suspect in `QuicTimerQueue::offer`, but `PacketTransmissionTask` does not use that. Further instrumentation of the `QuicTimerQueue` (too intrusive, so not part of this fix) and repeated testing eventually reproduced the issue once and revealed that the issue originated from a race condition between `ClosedConnection::startTimer` and  `ClosedConnection::processIncoming` when switching to a `DrainingConnection`. Since the draining connection is added to the connections map before `startTimer` is called, then `processIncoming` can end up running concurrently, or before, `startTimer` is called. If that happens, then when `startTimer` is called the timer event can already be in the `QuicTimerQueue.rescheduled` set. `startTimer` assumes that the event has never been added to the list and calls `offer`, at a time when `QuicTimerQueue::processRescheduled` might be running, which could end up with `offer` re-adding the event to the `scheduled` skiplist at a time where `processRescheduled` has taken it out of the skiplist in order to call its `refreshDeadline`. 

This patch fixes the issue in two ways:

1. it modifies `ClosedConnection::startTimer` to call `QuicTimerQueue::reschedule` instead of `QuicTimerQueue::offer`; This fixes the issue and has the advantage of being able to pass a prospective deadline. Passing a prospective deadline can avoid re-awakening the selector if it is not needed.
2.  it also modifies `QuicTimerQueue::offer` to add the offered event to the `rescheduled` set, instead of adding it to the `scheduled` skiplist. This also would solve the issue on its own. It makes `QuicTimerQueue` more resilient to the use of `offer` which can be called concurrently with `reschedule` or `processRescheduled`. 

In addition I have revisited the policy with which the selector is awaken again. I noticed that multiple additions of events at the same deadline could cause repeated calls to notifier.run; This is now fixed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386989](https://bugs.openjdk.org/browse/JDK-8386989): QuicEndpoint.ClosedConnection should not use QuicTimerQueue::offer (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31693/head:pull/31693` \
`$ git checkout pull/31693`

Update a local copy of the PR: \
`$ git checkout pull/31693` \
`$ git pull https://git.openjdk.org/jdk.git pull/31693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31693`

View PR using the GUI difftool: \
`$ git pr show -t 31693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31693.diff">https://git.openjdk.org/jdk/pull/31693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31693#issuecomment-4809375199)
</details>
