### PR TITLE
8387261: Locale.LanguageRange weight validation issues

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3340,11 +3340,9 @@ public final class Locale implements Cloneable, Serializable {
          * matching locale (or language tag) even if the application or system
          * offers only {@code "he"} as a supported locale (or language tag).
          *
-         * @implNote This implementation interprets weights within the {@code ranges}
-         * string using {@link Double#parseDouble(String)}. As a result, some
-         * non-RFC 2616 forms of otherwise in-range values, such as leading
-         * signs, scientific notation, or more than three fractional digits, may be
-         * accepted.
+         * @implNote Since this implementation uses {@link Double#parseDouble(String)}
+         * for string to double conversion, a proper superset of the RFC 2616
+         * syntax is accepted for weights.
          * @param ranges a list of comma-separated language ranges or a list of
          *     language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
@@ -3353,8 +3351,9 @@ public final class Locale implements Cloneable, Serializable {
          *     included in the given {@code ranges} and their equivalent
          *     language ranges if available. The list is modifiable.
          * @throws NullPointerException if {@code ranges} is null
-         * @throws IllegalArgumentException if a language range or a weight
-         *     found in the given {@code ranges} is ill-formed
+         * @throws IllegalArgumentException if, in the given {@code ranges}, a
+         *     language range is ill-formed, or a weight is ill-formed after
+         *     string to double conversion by {@link Double#parseDouble(String)}
          * @spec https://www.rfc-editor.org/info/rfc2616 RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1
          */
         public static List<LanguageRange> parse(String ranges) {
@@ -3367,11 +3366,9 @@ public final class Locale implements Cloneable, Serializable {
          * This method is equivalent to
          * {@code mapEquivalents(parse(ranges), map)}.
          *
-         * @implNote This implementation interprets weights within the {@code ranges}
-         * string using {@link Double#parseDouble(String)}. As a result, some
-         * non-RFC 2616 forms of otherwise in-range values, such as leading
-         * signs, scientific notation, or more than three fractional digits, may be
-         * accepted.
+         * @implNote Since this implementation uses {@link Double#parseDouble(String)}
+         * for string to double conversion, a proper superset of the RFC 2616
+         * syntax is accepted for weights.
          * @param ranges a list of comma-separated language ranges or a list
          *     of language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
@@ -3380,8 +3377,9 @@ public final class Locale implements Cloneable, Serializable {
          * @return a Language Priority List with customization. The list is
          *     modifiable.
          * @throws NullPointerException if {@code ranges} is null
-         * @throws IllegalArgumentException if a language range or a weight
-         *     found in the given {@code ranges} is ill-formed
+         * @throws IllegalArgumentException if, in the given {@code ranges}, a
+         *     language range is ill-formed, or a weight is ill-formed after
+         *     string to double conversion by {@link Double#parseDouble(String)}
          * @spec https://www.rfc-editor.org/info/rfc2616 RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1
          * @see #parse(String)
          * @see #mapEquivalents(List, Map)

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3214,7 +3214,7 @@ public final class Locale implements Cloneable, Serializable {
          */
         public LanguageRange(String range, double weight) {
             Objects.requireNonNull(range);
-            if (weight < MIN_WEIGHT || weight > MAX_WEIGHT) {
+            if (weight < MIN_WEIGHT || weight > MAX_WEIGHT || Double.isNaN(weight)) {
                 throw new IllegalArgumentException("weight=" + weight);
             }
 

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3209,7 +3209,7 @@ public final class Locale implements Cloneable, Serializable {
          *     {@code null}
          * @throws IllegalArgumentException if the given {@code range} does not
          * comply with the syntax of the language range mentioned in RFC 4647
-         * or if the given {@code weight} is less than {@code MIN_WEIGHT}
+         * or if the given {@code weight} is {@code Double.NaN}, less than {@code MIN_WEIGHT}
          * or greater than {@code MAX_WEIGHT}
          */
         public LanguageRange(String range, double weight) {

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3208,7 +3208,7 @@ public final class Locale implements Cloneable, Serializable {
          * @throws NullPointerException if the given {@code range} is
          *     {@code null}
          * @throws IllegalArgumentException if the given {@code range} does not
-         * comply with the syntax of the language range mentioned in RFC 4647
+         * comply with the syntax of the language range mentioned in RFC 4647,
          * or if the given {@code weight} is {@code Double.NaN}, less than {@code MIN_WEIGHT}
          * or greater than {@code MAX_WEIGHT}
          */
@@ -3338,6 +3338,10 @@ public final class Locale implements Cloneable, Serializable {
          * matching locale (or language tag) even if the application or system
          * offers only {@code "he"} as a supported locale (or language tag).
          *
+         * @implNote This implementation interprets weights within the {@code ranges}
+         * string using {@link Double#parseDouble(String)}. As a result, some
+         * non-RFC 2616 forms of otherwise in range values, such as one with a leading
+         * sign, may be accepted.
          * @param ranges a list of comma-separated language ranges or a list of
          *     language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
@@ -3360,6 +3364,10 @@ public final class Locale implements Cloneable, Serializable {
          * This method is equivalent to
          * {@code mapEquivalents(parse(ranges), map)}.
          *
+         * @implNote This implementation interprets weights within the {@code ranges}
+         * string using {@link Double#parseDouble(String)}. As a result, some
+         * non-RFC 2616 forms of otherwise in range values, such as one with a leading
+         * sign, may be accepted.
          * @param ranges a list of comma-separated language ranges or a list
          *     of language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3204,7 +3204,7 @@ public final class Locale implements Cloneable, Serializable {
          *
          * @param range  a language range
          * @param weight a weight value between {@code MIN_WEIGHT} and
-         *     {@code MAX_WEIGHT}
+         *     {@code MAX_WEIGHT}, inclusive
          * @throws NullPointerException if the given {@code range} is
          *     {@code null}
          * @throws IllegalArgumentException if the given {@code range} does not

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3209,13 +3209,15 @@ public final class Locale implements Cloneable, Serializable {
          *     {@code null}
          * @throws IllegalArgumentException if the given {@code range} does not
          * comply with the syntax of the language range mentioned in RFC 4647,
-         * or if the given {@code weight} is {@code Double.NaN}, less than {@code MIN_WEIGHT}
-         * or greater than {@code MAX_WEIGHT}
+         * or if the given {@code weight} is {@code Double.NaN}, less than {@code
+         * MIN_WEIGHT} or greater than {@code MAX_WEIGHT}
          */
         public LanguageRange(String range, double weight) {
             Objects.requireNonNull(range);
             if (weight < MIN_WEIGHT || weight > MAX_WEIGHT || Double.isNaN(weight)) {
-                throw new IllegalArgumentException("weight=" + weight);
+                throw new IllegalArgumentException(
+                        "The weight " + weight + " must be between "
+                        + MIN_WEIGHT + " and " + MAX_WEIGHT + ", inclusive.");
             }
 
             range = range.toLowerCase(Locale.ROOT);
@@ -3340,8 +3342,9 @@ public final class Locale implements Cloneable, Serializable {
          *
          * @implNote This implementation interprets weights within the {@code ranges}
          * string using {@link Double#parseDouble(String)}. As a result, some
-         * non-RFC 2616 forms of otherwise in range values, such as one with a leading
-         * sign, may be accepted.
+         * non-RFC 2616 forms of otherwise in-range values, such as leading
+         * signs, scientific notation, or more than three fractional digits, may be
+         * accepted.
          * @param ranges a list of comma-separated language ranges or a list of
          *     language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
@@ -3366,8 +3369,9 @@ public final class Locale implements Cloneable, Serializable {
          *
          * @implNote This implementation interprets weights within the {@code ranges}
          * string using {@link Double#parseDouble(String)}. As a result, some
-         * non-RFC 2616 forms of otherwise in range values, such as one with a leading
-         * sign, may be accepted.
+         * non-RFC 2616 forms of otherwise in-range values, such as leading
+         * signs, scientific notation, or more than three fractional digits, may be
+         * accepted.
          * @param ranges a list of comma-separated language ranges or a list
          *     of language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -3303,9 +3303,9 @@ public final class Locale implements Cloneable, Serializable {
          * </pre>
          *
          * In a weighted list, each language range is given a weight value.
-         * The weight value is identical to the "quality value" in
+         * The weight value has the same numeric bounds as the "quality value"
          * <a href="https://tools.ietf.org/html/rfc2616">RFC 2616</a>, and it
-         * expresses how much the user prefers  the language. A weight value is
+         * expresses how much the user prefers the language. A weight value is
          * specified after a corresponding language range followed by
          * {@code ";q="}, and the default weight value is {@code MAX_WEIGHT}
          * when it is omitted.
@@ -3340,9 +3340,6 @@ public final class Locale implements Cloneable, Serializable {
          * matching locale (or language tag) even if the application or system
          * offers only {@code "he"} as a supported locale (or language tag).
          *
-         * @implNote Since this implementation uses {@link Double#parseDouble(String)}
-         * for string to double conversion, a proper superset of the RFC 2616
-         * syntax is accepted for weights.
          * @param ranges a list of comma-separated language ranges or a list of
          *     language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
@@ -3352,7 +3349,7 @@ public final class Locale implements Cloneable, Serializable {
          *     language ranges if available. The list is modifiable.
          * @throws NullPointerException if {@code ranges} is null
          * @throws IllegalArgumentException if, in the given {@code ranges}, a
-         *     language range is ill-formed, or a weight is ill-formed after
+         *     language range is ill-formed, or a weight is out of range after
          *     string to double conversion by {@link Double#parseDouble(String)}
          * @spec https://www.rfc-editor.org/info/rfc2616 RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1
          */
@@ -3366,9 +3363,6 @@ public final class Locale implements Cloneable, Serializable {
          * This method is equivalent to
          * {@code mapEquivalents(parse(ranges), map)}.
          *
-         * @implNote Since this implementation uses {@link Double#parseDouble(String)}
-         * for string to double conversion, a proper superset of the RFC 2616
-         * syntax is accepted for weights.
          * @param ranges a list of comma-separated language ranges or a list
          *     of language ranges in the form of the "Accept-Language" header
          *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
@@ -3378,7 +3372,7 @@ public final class Locale implements Cloneable, Serializable {
          *     modifiable.
          * @throws NullPointerException if {@code ranges} is null
          * @throws IllegalArgumentException if, in the given {@code ranges}, a
-         *     language range is ill-formed, or a weight is ill-formed after
+         *     language range is ill-formed, or a weight is out of range after
          *     string to double conversion by {@link Double#parseDouble(String)}
          * @spec https://www.rfc-editor.org/info/rfc2616 RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1
          * @see #parse(String)

--- a/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
@@ -467,17 +467,18 @@ public final class LocaleMatcher {
                 try {
                     w = Double.parseDouble(range.substring(index));
                 }
-                catch (Exception e) {
-                    throw new IllegalArgumentException("weight=\""
+                catch (NumberFormatException _) {
+                    throw new IllegalArgumentException("The weight \""
                                   + range.substring(index)
-                                  + "\" for language range \"" + r + "\"");
+                                  + "\" for language range \"" + r + "\""
+                                  + " must be between " + MIN_WEIGHT
+                                  + " and " + MAX_WEIGHT + ", inclusive.");
                 }
-
                 if (w < MIN_WEIGHT || w > MAX_WEIGHT) {
-                    throw new IllegalArgumentException("weight=" + w
-                                  + " for language range \"" + r
-                                  + "\". It must be between " + MIN_WEIGHT
-                                  + " and " + MAX_WEIGHT + ".");
+                    throw new IllegalArgumentException("The weight \"" + w
+                                  + "\" for language range \"" + r + "\""
+                                  + " must be between " + MIN_WEIGHT
+                                  + " and " + MAX_WEIGHT + ", inclusive.");
                 }
             }
 

--- a/test/jdk/java/util/Locale/LocaleMatchingTest.java
+++ b/test/jdk/java/util/Locale/LocaleMatchingTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7069824 8042360 8032842 8175539 8210443 8242010 8276302 8381644
+ * @bug 7069824 8042360 8032842 8175539 8210443 8242010 8276302 8381644 8387261
  * @summary Verify implementation for Locale matching.
  * @run junit/othervm LocaleMatchingTest
  */
@@ -93,6 +93,7 @@ public class LocaleMatchingTest {
                 {"1996-de-Latn", MAX_WEIGHT},
                 // Testcase for 8042360
                 {"en-Latn-1234567890", MAX_WEIGHT},
+                {"en", Double.NaN},
         };
     }
 
@@ -146,6 +147,7 @@ public class LocaleMatchingTest {
                 // Ranges
                 {""},
                 {"ja;q=3"},
+                {"en;q=NaN"}
         };
     }
 


### PR DESCRIPTION
This PR addresses an edge case where the `Locale.LanguageRange(String, double)` constructor accepts `Double.NaN` as a weight. A `LanguageRange` weight is specified by https://datatracker.ietf.org/doc/html/rfc2616#section-3.9 and must be between 0.0 and 1.0, inclusive. The existing bounds checks do not handle this case. This change adds an explicit `Double.isNaN(weight)` check.

The issue does not affect parsed range strings in the same way, since the input is normalized to lower case before parsing and `"nan"` is not accepted by `Double.parseDouble`. However, I added a test for that case as well, since one did not previously exist.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8387368](https://bugs.openjdk.org/browse/JDK-8387368) to be approved

### Issues
 * [JDK-8387261](https://bugs.openjdk.org/browse/JDK-8387261): Locale.LanguageRange weight validation issues (**Bug** - P4)
 * [JDK-8387368](https://bugs.openjdk.org/browse/JDK-8387368): Locale.LanguageRange weight validation issues (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31697/head:pull/31697` \
`$ git checkout pull/31697`

Update a local copy of the PR: \
`$ git checkout pull/31697` \
`$ git pull https://git.openjdk.org/jdk.git pull/31697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31697`

View PR using the GUI difftool: \
`$ git pr show -t 31697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31697.diff">https://git.openjdk.org/jdk/pull/31697.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31697#issuecomment-4812094340)
</details>
