### PR TITLE
8380750: Test runtime/cds/appcds/TestSerialGCWithCDS.java#id1 failed: StringIndexOutOfBoundsException

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -62,7 +62,7 @@ public class TestCDSVMCrash {
             throw new Error("Expected VM to crash");
         } catch(RuntimeException e) {
             if (!e.getMessage().contains("A fatal error has been detected")) {
-                throw new Error("Expected message: A fatal error has been detected");
+                throw new Error("Expected message: A fatal error has been detected. Instead message is: " + e.getMessage());
             }
         }
         System.out.println("PASSED");

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -703,7 +703,7 @@ public class CDSTestUtils {
 
     static String getCrashMessage(String stdOut) {
         int start = stdOut.indexOf("# A fatal error has been detected by the Java Runtime Environment:");
-        int end = stdOut.indexOf(".log", start) + 4;
+        int end = stdOut.indexOf("# If you would like to submit a bug report, please visit", start);
         return stdOut.substring(start, end);
     }
 

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -703,7 +703,7 @@ public class CDSTestUtils {
 
     static String getCrashMessage(String stdOut) {
         int start = stdOut.indexOf("# A fatal error has been detected by the Java Runtime Environment:");
-        int end = stdOut.indexOf("# If you would like to submit a bug report, please visit", start);
+        int end = stdOut.indexOf("# JRE version", start);
         return stdOut.substring(start, end);
     }
 


### PR DESCRIPTION
This test was failing with this error:
` java.lang.StringIndexOutOfBoundsException: Range [3973, 3) out of bounds for length 4540`
due to an issue with getCrashMessage in CDSTestUtils. It is possible for the hserr log file to not be present with errors like OOME, so this had to be refactored to check for a more reliably present part of the error message. Verifed with tier 1-5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380750](https://bugs.openjdk.org/browse/JDK-8380750): Test runtime/cds/appcds/TestSerialGCWithCDS.java#id1 failed: StringIndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31698/head:pull/31698` \
`$ git checkout pull/31698`

Update a local copy of the PR: \
`$ git checkout pull/31698` \
`$ git pull https://git.openjdk.org/jdk.git pull/31698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31698`

View PR using the GUI difftool: \
`$ git pr show -t 31698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31698.diff">https://git.openjdk.org/jdk/pull/31698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31698#issuecomment-4834664139)
</details>
