### PR TITLE
8387369: Extend ReduceAllocationMerges to CheckCastPP and SubTypeCheck nodes

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -42,6 +42,7 @@
 #include "opto/narrowptrnode.hpp"
 #include "opto/phaseX.hpp"
 #include "opto/rootnode.hpp"
+#include "opto/subtypenode.hpp"
 #include "utilities/macros.hpp"
 
 ConnectionGraph::ConnectionGraph(Compile * C, PhaseIterGVN *igvn, int invocation) :
@@ -506,7 +507,17 @@ bool ConnectionGraph::can_reduce_phi_check_inputs(PhiNode* ophi) const {
 // I require the 'other' input to be a constant so that I can move the Cmp
 // around safely.
 bool ConnectionGraph::can_reduce_cmp(PhiNode* phi, Node* cmp) const {
-  assert(cmp->Opcode() == Op_CmpP || cmp->Opcode() == Op_CmpN, "not expected node: %s", cmp->Name());
+  assert(cmp->Opcode() == Op_CmpP ||
+         cmp->Opcode() == Op_CmpN ||
+         cmp->Opcode() == Op_SubTypeCheck,
+         "not expected node: %s", cmp->Name());
+
+  if (cmp->Opcode() == Op_SubTypeCheck) {
+    return cmp->in(SubTypeCheckNode::ObjOrSubKlass) == phi &&
+           cmp->in(SubTypeCheckNode::SuperKlass)->is_Con() &&
+           cmp->outcnt() == 1;
+  }
+
   Node* left = cmp->in(1);
   Node* right = cmp->in(2);
 
@@ -537,12 +548,12 @@ bool ConnectionGraph::has_been_reduced(PhiNode* phi, SafePointNode* sfpt) const 
 // Check if we are able to untangle the merge. The following patterns are
 // supported:
 //  - Phi -> SafePoints
-//  - Phi -> CmpP/N
+//  - Phi -> CmpP/CmpN/SubTypeCheck
 //  - Phi -> AddP -> Load
-//  - Phi -> CastPP -> SafePoints
-//  - Phi -> CastPP -> AddP -> Load
+//  - Phi -> CastPP/CheckCastPP -> SafePoints
+//  - Phi -> CastPP/CheckCastPP -> AddP -> Load
 bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
-  assert((n->is_Phi() && nesting == 0) || (n->is_CastPP() && nesting > 0),
+  assert((n->is_Phi() && nesting == 0) || ((n->is_CastPP() || n->is_CheckCastPP()) && nesting > 0),
          "invalid node class %s and nesting %d combination", n->Name(), nesting);
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* use = n->fast_out(i);
@@ -551,7 +562,7 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
       if (use->is_Call() && use->as_Call()->has_non_debug_use(n)) {
         NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Call has non_debug_use().", n->_idx, _invocation);)
         return false;
-      } else if (has_been_reduced(n->is_Phi() ? n->as_Phi() : n->as_CastPP()->in(1)->as_Phi(), use->as_SafePoint())) {
+      } else if (has_been_reduced(n->is_Phi() ? n->as_Phi() : n->as_ConstraintCast()->in(1)->as_Phi(), use->as_SafePoint())) {
         NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. It has already been reduced.", n->_idx, _invocation);)
         return false;
       }
@@ -572,22 +583,22 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
     } else if (nesting > 0) {
       NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Unsupported user %s at nesting level %d.", n->_idx, _invocation, use->Name(), nesting);)
       return false;
-    } else if (use->is_CastPP()) {
+    } else if (use->is_CastPP() || use->is_CheckCastPP()) {
       const Type* cast_t = _igvn->type(use);
       if (cast_t == nullptr || cast_t->make_ptr()->isa_instptr() == nullptr) {
 #ifndef PRODUCT
         if (TraceReduceAllocationMerges) {
-          tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP is not to an instance.", n->_idx, _invocation);
+          tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP/CheckCastPP is not to an instance.", n->_idx, _invocation);
           use->dump();
         }
 #endif
         return false;
       }
 
-      if (!can_reduce_phi_at_castpp(n->as_Phi(), use->as_CastPP())) {
+      if (!can_reduce_phi_at_castpp(n->as_Phi(), use->as_ConstraintCast())) {
 #ifdef ASSERT
         if (TraceReduceAllocationMerges) {
-          tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
+          tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP/CheckCastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
           n->dump(5);
         }
 #endif
@@ -597,9 +608,9 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
       if (!can_reduce_check_users(use, nesting+1)) {
         return false;
       }
-    } else if (use->Opcode() == Op_CmpP || use->Opcode() == Op_CmpN) {
+    } else if (use->Opcode() == Op_CmpP || use->Opcode() == Op_CmpN || use->Opcode() == Op_SubTypeCheck) {
       if (!can_reduce_cmp(n->as_Phi(), use)) {
-        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CmpP/N %d isn't reducible.", n->_idx, _invocation, use->_idx);)
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CmpP/N/SubTypeCheck %d isn't reducible.", n->_idx, _invocation, use->_idx);)
         return false;
       }
     } else {
@@ -611,16 +622,16 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
   return true;
 }
 
-// Returns true if the CastPP's control is simple enough to reduce the Phi:
+// Returns true if the CastPP/CheckCastPP's control is simple enough to reduce the Phi:
 //  1) no control,
 //  2) control is the same Region as the Phi, or
-//  3) an IfTrue/IfFalse coming from an CmpP/N between the phi and a constant.
-bool ConnectionGraph::can_reduce_phi_at_castpp(PhiNode* phi, CastPPNode* castpp) const {
+//  3) an IfTrue/IfFalse coming from an CmpP/CmpN/SubTypeCheck between the phi and a constant.
+bool ConnectionGraph::can_reduce_phi_at_castpp(PhiNode* phi, ConstraintCastNode* castpp) const {
   if (castpp->in(0) == nullptr || castpp->in(0) == phi->in(0)) {
     return true;
   }
   // If it's not a trivial control then we check if we can reduce the
-  // CmpP/N used by the If controlling the cast.
+  // CmpP/CmpN/SubTypeCheck used by the If controlling the cast.
   if (!(castpp->in(0)->is_IfTrue() || castpp->in(0)->is_IfFalse())) {
     return false; // Only If control is considered
   } else {
@@ -630,7 +641,7 @@ bool ConnectionGraph::can_reduce_phi_at_castpp(PhiNode* phi, CastPPNode* castpp)
     if (iff->Opcode() == Op_If && iff->in(1)->is_Bool() && iff->in(1)->in(1)->is_Cmp()) {
       Node* iff_cmp  = iff->in(1)->in(1);
       int opc = iff_cmp->Opcode();
-      if ((opc == Op_CmpP || opc == Op_CmpN) && can_reduce_cmp(phi, iff_cmp)) {
+      if ((opc == Op_CmpP || opc == Op_CmpN || opc == Op_SubTypeCheck) && can_reduce_cmp(phi, iff_cmp)) {
         return true;
       }
     }
@@ -666,15 +677,16 @@ bool ConnectionGraph::can_reduce_phi(PhiNode* ophi) const {
 }
 
 // This method will return a CmpP/N that we need to use on the If controlling a
-// CastPP after it was split. This method is only called on bases that are
-// nullable therefore we always need a controlling if for the splitted CastPP.
+// CastPP/CheckCastPP after it was split. This method is only called on bases
+// that are nullable therefore we always need a controlling if for the splitted
+// CastPP/CheckCastPP.
 //
-// 'curr_ctrl' is the control of the CastPP that we want to split through phi.
-// If the CastPP currently doesn't have a control then the CmpP/N will be
-// against the null constant, otherwise it will be against the constant input of
-// the existing CmpP/N. It's guaranteed that there will be a CmpP/N in the later
-// case because we have constraints on it and because the CastPP has a control
-// input.
+// 'curr_ctrl' is the control of the CastPP/CheckCastPP that we want to split
+// through phi. If the cast currently doesn't have a control then the CmpP/N
+// will be against the null constant, otherwise it will be against the constant
+// input of the existing CmpP/N/SubTypeCheck. It's guaranteed that there will be
+// a CmpP/N/SubTypeCheck in the later case because we have constraints on it and
+// because the cast has a control input.
 Node* ConnectionGraph::specialize_cmp(Node* base, Node* curr_ctrl) {
   const Type* t = base->bottom_type();
   Node* con = nullptr;
@@ -687,6 +699,14 @@ Node* ConnectionGraph::specialize_cmp(Node* base, Node* curr_ctrl) {
     Node* bol = curr_ctrl->in(0)->in(1);
     assert(bol->is_Bool(), "unexpected node %s", bol->Name());
     Node* curr_cmp = bol->in(1);
+    // Copy elements of the original SubTypeCheck node into a new
+    // SubTypeCheck node that is specialized to `base`.
+    if (curr_cmp->Opcode() == Op_SubTypeCheck) {
+      int bci = curr_cmp->as_SubTypeCheck()->bci();
+      ciMethod* method = curr_cmp->as_SubTypeCheck()->method();
+      Node* superklass = curr_cmp->in(SubTypeCheckNode::SuperKlass);
+      return new SubTypeCheckNode(_compile, base, superklass, method, bci);
+    }
     assert(curr_cmp->Opcode() == Op_CmpP || curr_cmp->Opcode() == Op_CmpN, "unexpected node %s", curr_cmp->Name());
     con = curr_cmp->in(1)->is_Con() ? curr_cmp->in(1) : curr_cmp->in(2);
   }
@@ -891,9 +911,10 @@ Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr
 //                      \|/
 //                      Phi        # "Field" Phi
 //
-void ConnectionGraph::reduce_phi_on_castpp_field_load(CastPPNode* curr_castpp, GrowableArray<Node*> &alloc_worklist) {
+void ConnectionGraph::reduce_phi_on_castpp_field_load(Node* curr_castpp, GrowableArray<Node*> &alloc_worklist) {
+  assert(curr_castpp->is_CastPP() || curr_castpp->is_CheckCastPP(), "must be a CastPP/CheckCastPP");
   PhiNode* ophi = curr_castpp->in(1)->as_Phi();
-  precond(can_reduce_phi_at_castpp(ophi, curr_castpp));
+  precond(can_reduce_phi_at_castpp(ophi, curr_castpp->as_ConstraintCast()));
 
   // Identify which base should be used for AddP->Load later when spliting the
   // CastPP->Loads through ophi. Three kind of values may be stored in this
@@ -1019,7 +1040,11 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
     Node* ophi_input = ophi->in(i);
     Node* res_phi_input = nullptr;
 
-    const TypeInt* tcmp = optimize_ptr_compare(ophi_input, other);
+    // Pointer comparisons are valid only for CmpP and CmpN nodes, not for
+    // SubTypeCheck nodes, so don't perform any constant folding and instead
+    // leave the comparison result as unknown.
+    const TypeInt* tcmp = cmp->Opcode() == Op_SubTypeCheck ?
+        TypeInt::CC : optimize_ptr_compare(ophi_input, other);
     if (tcmp->singleton()) {
       if ((mask == BoolTest::mask::eq && tcmp == TypeInt::CC_EQ) ||
           (mask == BoolTest::mask::ne && tcmp == TypeInt::CC_GT)) {
@@ -1234,10 +1259,10 @@ bool ConnectionGraph::reduce_phi_on_safepoints(PhiNode* ophi) {
     Node* use = ophi->raw_out(i);
     if (use->is_SafePoint()) {
       safepoints.push(use);
-    } else if (use->is_CastPP()) {
+    } else if (use->is_CastPP() || use->is_CheckCastPP()) {
       casts.push(use);
     } else {
-      assert(use->outcnt() == 0, "Only CastPP & SafePoint users should be left.");
+      assert(use->outcnt() == 0, "Only CastPP/CheckCastPP & SafePoint users should be left.");
     }
   }
 
@@ -1365,13 +1390,13 @@ void ConnectionGraph::reduce_phi(PhiNode* ophi, GrowableArray<Node*> &alloc_work
 
   // Copying all users first because some will be removed and others won't.
   // Ophi also may acquire some new users as part of Cast reduction.
-  // CastPPs also need to be processed before CmpPs.
+  // CastPP/CheckCastPP nodes also need to be processed before CmpP/SubTypeCheck.
   Unique_Node_List castpps;
   Unique_Node_List others;
   for (DUIterator_Fast imax, i = ophi->fast_outs(imax); i < imax; i++) {
     Node* use = ophi->fast_out(i);
 
-    if (use->is_CastPP()) {
+    if (use->is_CastPP() || use->is_CheckCastPP()) {
       castpps.push(use);
     } else if (use->is_AddP() || use->is_Cmp()) {
       others.push(use);
@@ -1383,11 +1408,11 @@ void ConnectionGraph::reduce_phi(PhiNode* ophi, GrowableArray<Node*> &alloc_work
 
   _compile->print_method(PHASE_EA_BEFORE_PHI_REDUCTION, 5, ophi);
 
-  // CastPPs need to be processed before Cmps because during the process of
-  // splitting CastPPs we make reference to the inputs of the Cmp that is used
-  // by the If controlling the CastPP.
+  // CastPP/CheckCastPP nodes need to be processed before Cmps because during
+  // the process of splitting casts we make reference to the inputs of the Cmp
+  // that is used by the If controlling the CastPP/CheckCastPP.
   for (uint i = 0; i < castpps.size(); i++) {
-    reduce_phi_on_castpp_field_load(castpps.at(i)->as_CastPP(), alloc_worklist);
+    reduce_phi_on_castpp_field_load(castpps.at(i), alloc_worklist);
     _compile->print_method(PHASE_EA_AFTER_PHI_CASTPP_REDUCTION, 6, castpps.at(i));
   }
 
@@ -4773,7 +4798,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       // At this point reducible Phis shouldn't have AddP users anymore; only SafePoints or Casts.
       for (DUIterator_Fast jmax, j = phi->fast_outs(jmax); j < jmax; j++) {
         Node* use = phi->fast_out(j);
-        if (!use->is_SafePoint() && !use->is_CastPP()) {
+        if (!use->is_SafePoint() && !use->is_CastPP() && !use->is_CheckCastPP()) {
           phi->dump(2);
           phi->dump(-2);
           assert(false, "Unexpected user of reducible Phi -> %d:%s:%d", use->_idx, use->Name(), use->outcnt());

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -614,10 +614,10 @@ private:
   bool can_reduce_phi(PhiNode* ophi) const;
   bool can_reduce_check_users(Node* n, uint nesting) const;
   bool can_reduce_phi_check_inputs(PhiNode* ophi) const;
-  bool can_reduce_phi_at_castpp(PhiNode* phi, CastPPNode* castpp) const;
+  bool can_reduce_phi_at_castpp(PhiNode* phi, ConstraintCastNode* castpp) const;
 
   void reduce_phi_on_field_access(Node* previous_addp, GrowableArray<Node *>  &alloc_worklist);
-  void reduce_phi_on_castpp_field_load(CastPPNode* castpp, GrowableArray<Node*> &alloc_worklist);
+  void reduce_phi_on_castpp_field_load(Node* castpp, GrowableArray<Node*> &alloc_worklist);
   void reduce_phi_on_cmp(Node* cmp);
   bool reduce_phi_on_safepoints(PhiNode* ophi);
   bool reduce_phi_on_safepoints_helper(Node* ophi, Node* cast, Node* selector, Unique_Node_List& safepoints);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1685,7 +1685,7 @@ static bool stable_phi(PhiNode* phi, PhaseGVN *phase) {
 // by 'split_through_phi'. The first use of this method was in EA code as part
 // of simplification of allocation merges.
 // Some differences from original method (split_through_phi):
-//  - If base->is_CastPP(): base = base->in(1)
+//  - If base->is_CastPP() or base->is_CheckCastPP(): base = base->in(1)
 bool LoadNode::can_split_through_phi_base(PhaseGVN* phase) {
   Node* mem        = in(Memory);
   Node* address    = in(Address);
@@ -1696,7 +1696,7 @@ bool LoadNode::can_split_through_phi_base(PhaseGVN* phase) {
     return false;
   }
 
-  if (base->is_CastPP()) {
+  if (base->is_CastPP() || base->is_CheckCastPP()) {
     base = base->in(1);
   }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -125,7 +125,10 @@ public class AllocationMergesTests {
                  "testString_two_C2",
                  "testLoadKlassFromCast_C2",
                  "testLoadKlassFromPhi_C2",
-                 "testReReduce_C2"
+                 "testReReduce_C2",
+                 "testInstanceOfNullMerge_C2",
+                 "testInstanceOfWithBinding_C2",
+                 "testInstanceOfWithoutBinding_C2"
                 })
     public void runner(RunInfo info) {
         invocations++;
@@ -183,6 +186,9 @@ public class AllocationMergesTests {
         Asserts.assertEQ(testLoadKlassFromCast_Interp(cond1),                       testLoadKlassFromCast_C2(cond1));
         Asserts.assertEQ(testLoadKlassFromPhi_Interp(cond1),                        testLoadKlassFromPhi_C2(cond1));
         Asserts.assertEQ(testReReduce_Interp(cond1, x, y),                          testReReduce_C2(cond1, x, y));
+        Asserts.assertEQ(testInstanceOfNullMerge_Interp(cond1, x),                  testInstanceOfNullMerge_C2(cond1, x));
+        Asserts.assertEQ(testInstanceOfWithBinding_Interp(cond1, x, y),             testInstanceOfWithBinding_C2(cond1, x, y));
+        Asserts.assertEQ(testInstanceOfWithoutBinding_Interp(cond1, x, y),          testInstanceOfWithoutBinding_C2(cond1, x, y));
 
         Asserts.assertEQ(testSRAndNSR_Trap_Interp(false, cond1, cond2, x, y),
                          testSRAndNSR_Trap_C2(info.isTestC2Compiled("testSRAndNSR_Trap_C2"), cond1, cond2, x, y));
@@ -1366,6 +1372,63 @@ public class AllocationMergesTests {
     @DontCompile
     int testReReduce_Interp(boolean cond1, int x, int y) { return testReReduce(cond1, x, y); }
 
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testInstanceOfNullMerge(boolean cond, int x) {
+        ArrayShape s = null;
+        if (cond) {
+            s = new ArraySquare(x);
+        }
+        if (s instanceof ArraySquare sq) {
+            return sq.l;
+        }
+        return 0;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    int testInstanceOfNullMerge_C2(boolean cond, int x) { return testInstanceOfNullMerge(cond, x); }
+
+    @DontCompile
+    int testInstanceOfNullMerge_Interp(boolean cond, int x) { return testInstanceOfNullMerge(cond, x); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testInstanceOfWithBinding(boolean cond, int x, int y) {
+        ArrayShape s = cond ? new ArraySquare(x) : new ArrayCircle(y);
+        if (s instanceof ArraySquare sq) {
+            return sq.l;
+        }
+        return s.l;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    int testInstanceOfWithBinding_C2(boolean cond, int x, int y) { return testInstanceOfWithBinding(cond, x, y); }
+
+    @DontCompile
+    int testInstanceOfWithBinding_Interp(boolean cond, int x, int y) { return testInstanceOfWithBinding(cond, x, y); }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testInstanceOfWithoutBinding(boolean cond, int x, int y) {
+        ArrayShape s = cond ? new ArraySquare(x) : new ArrayCircle(y);
+        if (s instanceof ArraySquare) {
+            return s.x;
+        }
+        return s.l;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.ALLOC })
+    int testInstanceOfWithoutBinding_C2(boolean cond, int x, int y) { return testInstanceOfWithoutBinding(cond, x, y); }
+
+    @DontCompile
+    int testInstanceOfWithoutBinding_Interp(boolean cond, int x, int y) { return testInstanceOfWithoutBinding(cond, x, y); }
+
     // ------------------ Utility for Testing ------------------- //
 
     @DontCompile
@@ -1440,6 +1503,30 @@ public class AllocationMergesTests {
 
     class Circle extends Shape {
         Circle(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ArrayShape {
+        int x, y, l;
+        int[] dummy = new int[32];
+
+        ArrayShape(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static class ArraySquare extends ArrayShape {
+        ArraySquare(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ArrayCircle extends ArrayShape {
+        ArrayCircle(int l) {
             super(0, 0);
             this.l = l;
         }

--- a/test/micro/org/openjdk/bench/vm/compiler/AllocationMerges.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AllocationMerges.java
@@ -1192,6 +1192,70 @@ public abstract class AllocationMerges {
         bh.consume(result);
     }
 
+    // -------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testInstanceOfNullMerge(boolean cond, int x) {
+        ArrayShape s = null;
+        if (cond) {
+            s = new ArraySquare(x);
+        }
+        if (s instanceof ArraySquare sq) {
+            return sq.l;
+        }
+        return 0;
+    }
+
+    @Benchmark
+    public void testInstanceOfNullMerge_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testInstanceOfNullMerge(cond1[i], xs[i]);
+        }
+        bh.consume(result);
+    }
+
+    // -------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testInstanceOfWithBinding(boolean cond, int x, int y) {
+        ArrayShape s = cond ? new ArraySquare(x) : new ArrayCircle(y);
+        if (s instanceof ArraySquare sq) {
+            return sq.l;
+        }
+        return s.l;
+    }
+
+    @Benchmark
+    public void testInstanceOfWithBinding_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testInstanceOfWithBinding(cond1[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    // -------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testInstanceOfWithoutBinding(boolean cond, int x, int y) {
+        ArrayShape s = cond ? new ArraySquare(x) : new ArrayCircle(y);
+        if (s instanceof ArraySquare) {
+            return s.x;
+        }
+        return s.l;
+    }
+
+    @Benchmark
+    public void testInstanceOfWithoutBinding_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testInstanceOfWithoutBinding(cond1[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+
     // ------------------ Utility for Benchmarking ------------------- //
 
     @Fork(value = 3, jvmArgs = {
@@ -1281,6 +1345,30 @@ public abstract class AllocationMerges {
 
     class Circle extends Shape {
         Circle(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ArrayShape {
+        int x, y, l;
+        int[] dummy = new int[32];
+
+        ArrayShape(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static class ArraySquare extends ArrayShape {
+        ArraySquare(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ArrayCircle extends ArrayShape {
+        ArrayCircle(int l) {
             super(0, 0);
             this.l = l;
         }


### PR DESCRIPTION
This patch strengthens the escape analysis in ReduceAllocationMerges to
now recognize merges whose users are either `CheckCastPP` and
`SubTypeCheck` nodes, which in turn enables optimizations over
conditional statements that merge values from two or more  allocations
(see the JBS issue for code snippet).  The key idea is to hoist the
`CheckCastPP` and `SubTypeCheck` nodes before the Phi node, thus
isolating the allocation.

Prior to this patch, neither `CheckCastPP` nodes nor `SubTypeCheck`
nodes were recognized as reducible, so merge nodes were left in place
and allocation nodes could not be replaced with scalars.  With this
patch, each allocation node is isolated and non-escaping, so ordinary
scalar replacment is able to remove the node.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387369](https://bugs.openjdk.org/browse/JDK-8387369): Extend ReduceAllocationMerges to CheckCastPP and SubTypeCheck nodes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31699/head:pull/31699` \
`$ git checkout pull/31699`

Update a local copy of the PR: \
`$ git checkout pull/31699` \
`$ git pull https://git.openjdk.org/jdk.git pull/31699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31699`

View PR using the GUI difftool: \
`$ git pr show -t 31699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31699.diff">https://git.openjdk.org/jdk/pull/31699.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31699#issuecomment-4814050247)
</details>
