### PR TITLE
8377980: Add methods returning Instant instead of Date to X509CRL and X509CRLEntry

### DIFF
--- a/src/java.base/share/classes/java/security/cert/X509CRL.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRL.java
@@ -31,6 +31,7 @@ import sun.security.x509.X509CRLImpl;
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
 import java.security.*;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Set;
@@ -348,12 +349,49 @@ public abstract non-sealed class X509CRL extends CRL implements X509Extension, B
     public abstract Date getThisUpdate();
 
     /**
+     * Gets the {@code thisUpdate} instant from the CRL.
+     * See {@link #getThisUpdate() getThisUpdate} for relevant ASN.1
+     * definitions.
+     *
+     * @apiNote Subclasses should override this method to directly return an
+     * instant.
+     *
+     * @implSpec
+     * The default implementation calls {@code getThisUpdate()}
+     * and returns the output as an {@code Instant} value.
+     *
+     * @return the {@code thisUpdate} instant from the CRL.
+     */
+    public Instant getThisUpdateInstant() {
+        final Date date = getThisUpdate();
+        return date == null ? null : date.toInstant();
+    }
+
+    /**
      * Gets the {@code nextUpdate} date from the CRL.
      *
      * @return the {@code nextUpdate} date from the CRL, or null if
      * not present.
      */
     public abstract Date getNextUpdate();
+
+    /**
+     * Gets the {@code nextUpdate} instant from the CRL.
+     *
+     * @apiNote Subclasses should override this method to directly return an
+     * instant.
+     *
+     * @implSpec
+     * The default implementation calls {@code getNextUpdate()}
+     * and returns the output as an {@code Instant} value.
+     *
+     * @return the {@code nextUpdate} instant from the CRL, or null if
+     * not present.
+     */
+    public Instant getNextUpdateInstant() {
+        final Date date = getNextUpdate();
+        return date == null ? null : date.toInstant();
+    }
 
     /**
      * Gets the CRL entry, if any, with the given certificate serialNumber.

--- a/src/java.base/share/classes/java/security/cert/X509CRL.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRL.java
@@ -349,7 +349,7 @@ public abstract non-sealed class X509CRL extends CRL implements X509Extension, B
     public abstract Date getThisUpdate();
 
     /**
-     * Gets the {@code thisUpdate} instant from the CRL.
+     * Gets the {@code thisUpdate} date as an {@code Instant} from the CRL.
      * See {@link #getThisUpdate() getThisUpdate} for relevant ASN.1
      * definitions.
      *
@@ -358,13 +358,12 @@ public abstract non-sealed class X509CRL extends CRL implements X509Extension, B
      *
      * @implSpec
      * The default implementation calls {@code getThisUpdate()}
-     * and returns the output as an {@code Instant} value.
+     * and returns the date as an {@code Instant}.
      *
-     * @return the {@code thisUpdate} instant from the CRL.
+     * @return the {@code thisUpdate} date from the CRL.
      */
     public Instant getThisUpdateInstant() {
-        final Date date = getThisUpdate();
-        return date == null ? null : date.toInstant();
+        return getThisUpdate().toInstant();
     }
 
     /**
@@ -376,16 +375,16 @@ public abstract non-sealed class X509CRL extends CRL implements X509Extension, B
     public abstract Date getNextUpdate();
 
     /**
-     * Gets the {@code nextUpdate} instant from the CRL.
+     * Gets the {@code nextUpdate} date as an {@code Instant} from the CRL.
      *
      * @apiNote Subclasses should override this method to directly return an
      * instant.
      *
      * @implSpec
      * The default implementation calls {@code getNextUpdate()}
-     * and returns the output as an {@code Instant} value.
+     * and returns the date as an {@code Instant}.
      *
-     * @return the {@code nextUpdate} instant from the CRL, or null if
+     * @return the {@code nextUpdate} date from the CRL, or null if
      * not present.
      */
     public Instant getNextUpdateInstant() {

--- a/src/java.base/share/classes/java/security/cert/X509CRLEntry.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.security.cert;
 
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import javax.security.auth.x500.X500Principal;
@@ -155,6 +156,24 @@ public abstract class X509CRLEntry implements X509Extension {
      * @return the revocation date.
      */
     public abstract Date getRevocationDate();
+
+    /**
+     * Gets the revocation instant from this X509CRLEntry,
+     * the <em>revocationDate</em>.
+     *
+     * @apiNote Subclasses should override this method to directly return an
+     * instant.
+     *
+     * @implSpec
+     * The default implementation calls {@code getRevocationDate()}
+     * and returns the output as an {@code Instant} value.
+     *
+     * @return the revocation instant.
+     */
+    public Instant getRevocationInstant() {
+        final Date date = getRevocationDate();
+        return date == null ? null : date.toInstant();
+    }
 
     /**
      * Returns true if this CRL entry has extensions.

--- a/src/java.base/share/classes/java/security/cert/X509CRLEntry.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLEntry.java
@@ -158,17 +158,16 @@ public abstract class X509CRLEntry implements X509Extension {
     public abstract Date getRevocationDate();
 
     /**
-     * Gets the revocation instant from this X509CRLEntry,
-     * the <em>revocationDate</em>.
+     * Gets the revocation date as an {@code Instant} from this X509CRLEntry.
      *
      * @apiNote Subclasses should override this method to directly return an
      * instant.
      *
      * @implSpec
      * The default implementation calls {@code getRevocationDate()}
-     * and returns the output as an {@code Instant} value.
+     * and returns the date as an {@code Instant}.
      *
-     * @return the revocation instant.
+     * @return the revocation date.
      */
     public Instant getRevocationInstant() {
         final Date date = getRevocationDate();

--- a/test/jdk/java/security/cert/X509CRL/X509CRLTest.java
+++ b/test/jdk/java/security/cert/X509CRL/X509CRLTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8377980
+ * @library /test/lib
+ * @summary check that the default implementations of
+ *          X509CRL.getThisUpdateInstant()/getNextUpdateInstant() and
+ *          X509CRLEntry.getRevocationDateInstant() are consistent with
+ *          their Date-returning counterparts on custom subclasses.
+ * @run junit X509CRLTest
+ */
+
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.security.cert.CRLException;
+import java.security.cert.X509CRL;
+import java.security.cert.X509CRLEntry;
+import java.util.Date;
+import java.util.Set;
+
+import jdk.test.lib.security.CertUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class X509CRLTest {
+    private static final String TEST_CRL =
+            """
+            -----BEGIN X509 CRL-----
+            MIIBGzCBhQIBATANBgkqhkiG9w0BAQQFADAfMQswCQYDVQQGEwJVUzEQMA4GA1UE
+            ChMHRXhhbXBsZRcNMDkwNDI3MDIzODA0WhcNMjgwNjI2MDIzODA0WjAiMCACAQUX
+            DTA5MDQyNzAyMzgwMFowDDAKBgNVHRUEAwoBBKAOMAwwCgYDVR0UBAMCAQIwDQYJ
+            KoZIhvcNAQEEBQADgYEAoarfzXEtw3ZDi4f9U8eSvRIipHSyxOrJC7HR/hM5VhmY
+            CErChny6x9lBVg9s57tfD/P9PSzBLusCcHwHMAbMOEcTltVVKUWZnnbumpywlYyg
+            oKLrE9+yCOkYUOpiRlz43/3vkEL5hjIKMcDSZnPKBZi1h16Yj2hPe9GMibNip54=
+            -----END X509 CRL-----""";
+
+    private static class TestX509CRL extends X509CRL {
+        private final X509CRL crl;
+
+        TestX509CRL(X509CRL crl) {
+            this.crl = crl;
+        }
+
+        public Set<String> getCriticalExtensionOIDs() {
+            return crl.getCriticalExtensionOIDs();
+        }
+
+        public byte[] getExtensionValue(String oid) {
+            return crl.getExtensionValue(oid);
+        }
+
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return crl.getNonCriticalExtensionOIDs();
+        }
+
+        public boolean hasUnsupportedCriticalExtension() {
+            return crl.hasUnsupportedCriticalExtension();
+        }
+
+        public Set<? extends X509CRLEntry> getRevokedCertificates() {
+            return crl.getRevokedCertificates();
+        }
+
+        public X509CRLEntry getRevokedCertificate(BigInteger serialNumber) {
+            return crl.getRevokedCertificate(serialNumber);
+        }
+
+        public boolean isRevoked(Certificate cert) {
+            return crl.isRevoked(cert);
+        }
+
+        public Date getNextUpdate() {
+            return crl.getNextUpdate();
+        }
+
+        public Date getThisUpdate() {
+            return crl.getThisUpdate();
+        }
+
+        public int getVersion() {
+            return crl.getVersion();
+        }
+
+        public Principal getIssuerDN() {
+            return crl.getIssuerDN();
+        }
+
+        public byte[] getTBSCertList() throws CRLException {
+            return crl.getTBSCertList();
+        }
+
+        public byte[] getSignature() {
+            return crl.getSignature();
+        }
+
+        public String getSigAlgName() {
+            return crl.getSigAlgName();
+        }
+
+        public String getSigAlgOID() {
+            return crl.getSigAlgOID();
+        }
+
+        public byte[] getSigAlgParams() {
+            return crl.getSigAlgParams();
+        }
+
+        public byte[] getEncoded() throws CRLException {
+            return crl.getEncoded();
+        }
+
+        public void verify(PublicKey key) throws CRLException,
+                InvalidKeyException, NoSuchAlgorithmException,
+                NoSuchProviderException, SignatureException {
+            crl.verify(key);
+        }
+
+        public void verify(PublicKey key, String sigProvider) throws
+                CRLException, InvalidKeyException, NoSuchAlgorithmException,
+                NoSuchProviderException, SignatureException {
+            crl.verify(key, sigProvider);
+        }
+
+        public String toString() {
+            return crl.toString();
+        }
+    }
+
+    private static class TestX509CRLEntry extends X509CRLEntry {
+        private final X509CRLEntry entry;
+
+        TestX509CRLEntry(X509CRLEntry entry) {
+            this.entry = entry;
+        }
+
+        public byte[] getEncoded() throws CRLException {
+            return entry.getEncoded();
+        }
+
+        public BigInteger getSerialNumber() {
+            return entry.getSerialNumber();
+        }
+
+        public Date getRevocationDate() {
+            return entry.getRevocationDate();
+        }
+
+        public boolean hasExtensions() {
+            return entry.hasExtensions();
+        }
+
+        public String toString() {
+            return entry.toString();
+        }
+
+        public Set<String> getCriticalExtensionOIDs() {
+            return entry.getCriticalExtensionOIDs();
+        }
+
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return entry.getNonCriticalExtensionOIDs();
+        }
+
+        public byte[] getExtensionValue(String oid) {
+            return entry.getExtensionValue(oid);
+        }
+
+        public boolean hasUnsupportedCriticalExtension() {
+            return entry.hasUnsupportedCriticalExtension();
+        }
+    }
+
+    private static TestX509CRL getTestCrl() throws Exception {
+        return new TestX509CRL(CertUtils.getCRLFromString(TEST_CRL));
+    }
+
+    @Test
+    public void thisUpdateInstantMatchesThisUpdate() throws Exception {
+        final TestX509CRL crl = getTestCrl();
+        assertEquals(crl.getThisUpdate().toInstant(),
+                crl.getThisUpdateInstant());
+    }
+
+    @Test
+    public void nextUpdateInstantMatchesNextUpdate() throws Exception {
+        final TestX509CRL crl = getTestCrl();
+        assertEquals(crl.getNextUpdate().toInstant(),
+                crl.getNextUpdateInstant());
+    }
+
+    @Test
+    public void revocationInstantMatchesRevocationDate() throws Exception {
+        final X509CRL crl = CertUtils.getCRLFromString(TEST_CRL);
+        final Set<? extends X509CRLEntry> entries =
+                crl.getRevokedCertificates();
+        assertNotNull(entries);
+        assertFalse(entries.isEmpty());
+
+        final TestX509CRLEntry entry =
+                new TestX509CRLEntry(entries.iterator().next());
+        assertEquals(entry.getRevocationDate().toInstant(),
+                entry.getRevocationInstant());
+    }
+}


### PR DESCRIPTION
Introducing Instant returning methods in the public api to similar to X509Certificate:
* X509CRL: getThisUpdate, getNextUpdate
* X509CRLEntry: getRevocationDate

Please note, this pr only changes public api with internals changed as a separate pr due to overlap with other implementations in the queue for a `Date` to `Instant` change

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8387373](https://bugs.openjdk.org/browse/JDK-8387373) to be approved

### Issues
 * [JDK-8377980](https://bugs.openjdk.org/browse/JDK-8377980): Add methods returning Instant instead of Date to X509CRL and X509CRLEntry (**Enhancement** - P4)
 * [JDK-8387373](https://bugs.openjdk.org/browse/JDK-8387373): Add methods returning Instant instead of Date to X509CRL and X509CRLEntry (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31700/head:pull/31700` \
`$ git checkout pull/31700`

Update a local copy of the PR: \
`$ git checkout pull/31700` \
`$ git pull https://git.openjdk.org/jdk.git pull/31700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31700`

View PR using the GUI difftool: \
`$ git pr show -t 31700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31700.diff">https://git.openjdk.org/jdk/pull/31700.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31700#issuecomment-4816581992)
</details>
