### PR TITLE
8387257: (coll) add fast path for PriorityQueue.addAll(Collection)

### DIFF
--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -306,6 +306,9 @@ public class PriorityQueue<E> extends AbstractQueue<E>
         int len = es.length;
         if (cClass != ArrayList.class)
             es = Arrays.copyOf(es, len, Object[].class);
+        // heapify() will not examine a single element.
+        // If a comparator is used, null must be rejected before it is
+        // passed to the comparator.
         if (len == 1 || cmp != null)
             for (Object e : es)
                 if (e == null)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -372,10 +372,20 @@ public class PriorityQueue<E> extends AbstractQueue<E>
                 throw new NullPointerException();
             if (c == this)
                 throw new IllegalArgumentException();
-            if (c.isEmpty())
-                return false;
 
-            Object[] es = prepareElements(c, comparator);
+            // If c is an exact PriorityQueue, its elements are known to be non-null
+            // and its backing array can be copied directly.
+            Object[] es;
+            if (c.getClass() == PriorityQueue.class) {
+                if (c.isEmpty())
+                    return false;
+                es = c.toArray();
+            } else {
+                es = prepareElements(c, comparator);
+                if (es.length == 0)
+                    return false;
+            }
+
             heapify(es, es.length, comparator);
             modCount++;
             queue = ensureNonEmpty(es);

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -388,7 +388,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
             heapify(es, es.length, comparator);
             modCount++;
-            queue = ensureNonEmpty(es);
+            queue = es;
             size = es.length;
 
             return true;

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -85,7 +85,7 @@ import jdk.internal.util.ArraysSupport;
  */
 @SuppressWarnings("unchecked")
 public class PriorityQueue<E> extends AbstractQueue<E>
-    implements java.io.Serializable {
+        implements java.io.Serializable {
 
     @java.io.Serial
     private static final long serialVersionUID = -7720805057305804111L;
@@ -289,12 +289,12 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     private void initElementsFromCollection(Collection<? extends E> c) {
         Object[] es = c.toArray();
         es = prepareElements(es, c.getClass());
-        initElementsFromArray(es, es.length);
+        initElementsFromArray(es);
     }
 
-    private void initElementsFromArray(Object[] es, int size) {
+    private void initElementsFromArray(Object[] es) {
         this.queue = ensureNonEmpty(es);
-        this.size = size;
+        this.size = es.length;
     }
 
     private Object[] prepareElements(Object[] es, Class<?> cClass) {
@@ -374,8 +374,8 @@ public class PriorityQueue<E> extends AbstractQueue<E>
                 return false;
 
             es = prepareElements(es, c.getClass());
-            initElementsFromArray(es, len);
-            heapify();
+            heapify(es, len);
+            initElementsFromArray(es);
 
             this.modCount++;
             return true;
@@ -796,8 +796,11 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      * This classic algorithm due to Floyd (1964) is known to be O(size).
      */
     private void heapify() {
-        final Object[] es = queue;
-        int n = size, i = (n >>> 1) - 1;
+        heapify(queue, size);
+    }
+
+    private void heapify(Object[] es, int n) {
+        int i = (n >>> 1) - 1;
         final Comparator<? super E> cmp;
         if ((cmp = comparator) == null)
             for (; i >= 0; i--)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -373,13 +373,14 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             if (c == this)
                 throw new IllegalArgumentException();
 
-            // If c is an exact PriorityQueue, its elements are known to be non-null
-            // and its backing array can be copied directly.
+            // For an exact PriorityQueue source, the array is trusted to contain
+            // no null elements, so it can be copied directly without additional checks.
             Object[] es;
             if (c.getClass() == PriorityQueue.class) {
-                if (c.isEmpty())
+                PriorityQueue<?> pq = (PriorityQueue<?>) c;
+                if (pq.size == 0)
                     return false;
-                es = c.toArray();
+                es = Arrays.copyOf(pq.queue, pq.size);
             } else {
                 es = prepareElements(c, comparator);
                 if (es.length == 0)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -373,24 +373,36 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             if (c == this)
                 throw new IllegalArgumentException();
 
-            // For an exact PriorityQueue source, the array is trusted to contain
-            // no null elements, so it can be copied directly without additional checks.
             Object[] es;
-            if (c.getClass() == PriorityQueue.class) {
+            int len;
+
+            Class<?> cClass = c.getClass();
+            if (cClass == PriorityQueue.class) {
                 PriorityQueue<?> pq = (PriorityQueue<?>) c;
-                if (pq.size == 0)
+                if ((len = pq.size) == 0)
                     return false;
-                es = Arrays.copyOf(pq.queue, pq.size);
+                es = Arrays.copyOf(pq.queue, len);
+                if (pq.comparator != comparator)
+                    heapify(es, len, comparator);
             } else {
-                es = prepareElements(c, comparator);
-                if (es.length == 0)
+                es = c.toArray();
+                if ((len = es.length) == 0)
                     return false;
+                if (cClass != ArrayList.class)
+                    es = Arrays.copyOf(es, len, Object[].class);
+                // A single element is not examined by heapify(), and a comparator
+                // may permit nulls, so explicitly reject null before committing the
+                // new array.
+                if (len == 1 || comparator != null)
+                    for (Object e : es)
+                        if (e == null)
+                            throw new NullPointerException();
+                heapify(es, len, comparator);
             }
 
-            heapify(es, es.length, comparator);
             modCount++;
             queue = es;
-            size = es.length;
+            size = len;
 
             return true;
         }

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -797,8 +797,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      */
     private void heapify() {
         final Object[] es = queue;
-        int n = size;
-        int i = (n >>> 1) - 1;
+        int n = size, i = (n >>> 1) - 1;
         final Comparator<? super E> cmp;
         if ((cmp = comparator) == null)
             for (; i >= 0; i--)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -372,12 +372,11 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             throw new IllegalArgumentException();
 
         if (size == 0 && getClass() == PriorityQueue.class) {
-            Object[] es = prepareElements(c);
-            int len = es.length;
-            if (len == 0)
+            if (c.isEmpty())
                 return false;
 
-            heapify(es, len);
+            Object[] es = prepareElements(c);
+            heapify(es, es.length);
             initElementsFromArray(es);
 
             this.modCount++;

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -85,7 +85,7 @@ import jdk.internal.util.ArraysSupport;
  */
 @SuppressWarnings("unchecked")
 public class PriorityQueue<E> extends AbstractQueue<E>
-        implements java.io.Serializable {
+    implements java.io.Serializable {
 
     @java.io.Serial
     private static final long serialVersionUID = -7720805057305804111L;

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -306,9 +306,9 @@ public class PriorityQueue<E> extends AbstractQueue<E>
         int len = es.length;
         if (cClass != ArrayList.class)
             es = Arrays.copyOf(es, len, Object[].class);
-        // heapify() will not examine a single element.
-        // If a comparator is used, null must be rejected before it is
-        // passed to the comparator.
+        // A single element is not examined by heapify(), and a comparator
+        // may permit nulls, so explicitly reject null before committing the
+        // new array.
         if (len == 1 || cmp != null)
             for (Object e : es)
                 if (e == null)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -287,9 +287,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     }
 
     private void initElementsFromCollection(Collection<? extends E> c) {
-        Object[] es = c.toArray();
-        es = prepareElements(es, c.getClass());
-        initElementsFromArray(es);
+        initElementsFromArray(prepareElements(c));
     }
 
     private void initElementsFromArray(Object[] es) {
@@ -297,8 +295,10 @@ public class PriorityQueue<E> extends AbstractQueue<E>
         this.size = es.length;
     }
 
-    private Object[] prepareElements(Object[] es, Class<?> cClass) {
-        // If the collection is a PriorityQueue, we can skip the null check
+    private Object[] prepareElements(Collection<? extends E> c) {
+        Object[] es = c.toArray();
+        Class<?> cClass = c.getClass();
+        // If the collection is a PriorityQueue, we can skip the null check.
         if (cClass == PriorityQueue.class)
             return es;
 
@@ -372,12 +372,11 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             throw new IllegalArgumentException();
 
         if (size == 0 && getClass() == PriorityQueue.class) {
-            Object[] es = c.toArray();
+            Object[] es = prepareElements(c);
             int len = es.length;
             if (len == 0)
                 return false;
 
-            es = prepareElements(es, c.getClass());
             heapify(es, len);
             initElementsFromArray(es);
 

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -288,15 +288,24 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
     private void initElementsFromCollection(Collection<? extends E> c) {
         Object[] es = c.toArray();
+        es = prepareElements(es, c.getClass());
+        initElementsFromArray(es, es.length);
+    }
+
+    private void initElementsFromArray(Object[] es, int size) {
+        this.queue = ensureNonEmpty(es);
+        this.size = size;
+    }
+
+    private Object[] prepareElements(Object[] es, Class<?> cClass) {
         int len = es.length;
-        if (c.getClass() != ArrayList.class)
+        if (cClass != ArrayList.class)
             es = Arrays.copyOf(es, len, Object[].class);
         if (len == 1 || this.comparator != null)
             for (Object e : es)
                 if (e == null)
                     throw new NullPointerException();
-        this.queue = ensureNonEmpty(es);
-        this.size = len;
+        return es;
     }
 
     /**
@@ -335,6 +344,45 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      */
     public boolean add(E e) {
         return offer(e);
+    }
+
+    /**
+     * Adds all of the elements in the specified collection to this
+     * priority queue.
+     *
+     * @param c collection containing elements to be added to this queue
+     * @return {@code true} if this queue changed as a result of the call
+     * @throws ClassCastException if elements of the specified collection
+     *         cannot be compared with elements currently in this queue
+     *         according to the priority queue's ordering
+     * @throws NullPointerException if the specified collection contains a
+     *         null element, or if the specified collection is null
+     * @throws IllegalArgumentException if the specified collection is this
+     *         queue
+     */
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        if (c == null)
+            throw new NullPointerException();
+        if (c == this)
+            throw new IllegalArgumentException();
+
+        if (size == 0 && getClass() == PriorityQueue.class) {
+            Object[] es = c.toArray();
+            int len = es.length;
+            if (len == 0)
+                return false;
+
+            // Leave this queue unchanged if validation or heap construction fails.
+            es = prepareElements(es, c.getClass());
+            heapify(es, len);
+            initElementsFromArray(es, len);
+
+            this.modCount++;
+            return true;
+        }
+
+        return super.addAll(c);
     }
 
     /**
@@ -749,8 +797,11 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      * This classic algorithm due to Floyd (1964) is known to be O(size).
      */
     private void heapify() {
-        final Object[] es = queue;
-        int n = size, i = (n >>> 1) - 1;
+        heapify(queue, size);
+    }
+
+    private void heapify(Object[] es, int n) {
+        int i = (n >>> 1) - 1;
         final Comparator<? super E> cmp;
         if ((cmp = comparator) == null)
             for (; i >= 0; i--)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -298,6 +298,10 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     }
 
     private Object[] prepareElements(Object[] es, Class<?> cClass) {
+        // If the collection is a PriorityQueue, we can skip the null check
+        if (cClass == PriorityQueue.class)
+            return es;
+
         int len = es.length;
         if (cClass != ArrayList.class)
             es = Arrays.copyOf(es, len, Object[].class);

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -373,10 +373,9 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             if (len == 0)
                 return false;
 
-            // Leave this queue unchanged if validation or heap construction fails.
             es = prepareElements(es, c.getClass());
-            heapify(es, len);
             initElementsFromArray(es, len);
+            heapify();
 
             this.modCount++;
             return true;
@@ -797,10 +796,8 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      * This classic algorithm due to Floyd (1964) is known to be O(size).
      */
     private void heapify() {
-        heapify(queue, size);
-    }
-
-    private void heapify(Object[] es, int n) {
+        final Object[] es = queue;
+        int n = size;
         int i = (n >>> 1) - 1;
         final Comparator<? super E> cmp;
         if ((cmp = comparator) == null)

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -381,9 +381,9 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
             Object[] es = prepareElements(c, comparator);
             heapify(es, es.length, comparator);
+            modCount++;
             initElementsFromArray(es);
 
-            this.modCount++;
             return true;
         }
 

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -287,30 +287,16 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     }
 
     private void initElementsFromCollection(Collection<? extends E> c) {
-        Object[] es = prepareElements(c, comparator);
-        this.queue = ensureNonEmpty(es);
-        this.size = es.length;
-    }
-
-    private static <E> Object[] prepareElements(Collection<? extends E> c,
-                                                Comparator<? super E> cmp) {
         Object[] es = c.toArray();
-        Class<?> cClass = c.getClass();
-        // If the collection is a PriorityQueue, we can skip the null check.
-        if (cClass == PriorityQueue.class)
-            return es;
-
         int len = es.length;
-        if (cClass != ArrayList.class)
+        if (c.getClass() != ArrayList.class)
             es = Arrays.copyOf(es, len, Object[].class);
-        // A single element is not examined by heapify(), and a comparator
-        // may permit nulls, so explicitly reject null before committing the
-        // new array.
-        if (len == 1 || cmp != null)
+        if (len == 1 || this.comparator != null)
             for (Object e : es)
                 if (e == null)
                     throw new NullPointerException();
-        return es;
+        this.queue = ensureNonEmpty(es);
+        this.size = len;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -380,7 +380,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
                 return false;
 
             Object[] es = prepareElements(c, comparator);
-            heapify(es, es.length);
+            heapify(es, es.length, comparator);
             initElementsFromArray(es);
 
             this.modCount++;
@@ -802,18 +802,17 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      * This classic algorithm due to Floyd (1964) is known to be O(size).
      */
     private void heapify() {
-        heapify(queue, size);
+        heapify(queue, size, comparator);
     }
 
-    private void heapify(Object[] es, int n) {
+    private static <T> void heapify(Object[] es, int n, Comparator<? super T> cmp) {
         int i = (n >>> 1) - 1;
-        final Comparator<? super E> cmp;
-        if ((cmp = comparator) == null)
+        if (cmp == null)
             for (; i >= 0; i--)
-                siftDownComparable(i, (E) es[i], es, n);
+                siftDownComparable(i, (T) es[i], es, n);
         else
             for (; i >= 0; i--)
-                siftDownUsingComparator(i, (E) es[i], es, n, cmp);
+                siftDownUsingComparator(i, (T) es[i], es, n, cmp);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -370,12 +370,11 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      */
     @Override
     public boolean addAll(Collection<? extends E> c) {
-        if (c == null)
-            throw new NullPointerException();
-        if (c == this)
-            throw new IllegalArgumentException();
-
         if (size == 0 && getClass() == PriorityQueue.class) {
+            if (c == null)
+                throw new NullPointerException();
+            if (c == this)
+                throw new IllegalArgumentException();
             if (c.isEmpty())
                 return false;
 

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -287,10 +287,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     }
 
     private void initElementsFromCollection(Collection<? extends E> c) {
-        initElementsFromArray(prepareElements(c, comparator));
-    }
-
-    private void initElementsFromArray(Object[] es) {
+        Object[] es = prepareElements(c, comparator);
         this.queue = ensureNonEmpty(es);
         this.size = es.length;
     }
@@ -381,7 +378,8 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             Object[] es = prepareElements(c, comparator);
             heapify(es, es.length, comparator);
             modCount++;
-            initElementsFromArray(es);
+            queue = ensureNonEmpty(es);
+            size = es.length;
 
             return true;
         }

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -287,7 +287,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     }
 
     private void initElementsFromCollection(Collection<? extends E> c) {
-        initElementsFromArray(prepareElements(c));
+        initElementsFromArray(prepareElements(c, comparator));
     }
 
     private void initElementsFromArray(Object[] es) {
@@ -295,7 +295,8 @@ public class PriorityQueue<E> extends AbstractQueue<E>
         this.size = es.length;
     }
 
-    private Object[] prepareElements(Collection<? extends E> c) {
+    private static <E> Object[] prepareElements(Collection<? extends E> c,
+                                                Comparator<? super E> cmp) {
         Object[] es = c.toArray();
         Class<?> cClass = c.getClass();
         // If the collection is a PriorityQueue, we can skip the null check.
@@ -305,7 +306,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
         int len = es.length;
         if (cClass != ArrayList.class)
             es = Arrays.copyOf(es, len, Object[].class);
-        if (len == 1 || this.comparator != null)
+        if (len == 1 || cmp != null)
             for (Object e : es)
                 if (e == null)
                     throw new NullPointerException();
@@ -375,7 +376,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
             if (c.isEmpty())
                 return false;
 
-            Object[] es = prepareElements(c);
+            Object[] es = prepareElements(c, comparator);
             heapify(es, es.length);
             initElementsFromArray(es);
 

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -361,6 +361,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
             Object[] es;
             int len;
+            boolean needsHeapify;
 
             Class<?> cClass = c.getClass();
             if (cClass == PriorityQueue.class) {
@@ -368,23 +369,27 @@ public class PriorityQueue<E> extends AbstractQueue<E>
                 if ((len = pq.size) == 0)
                     return false;
                 es = Arrays.copyOf(pq.queue, len);
-                if (pq.comparator != comparator)
-                    heapify(es, len, comparator);
+
+                needsHeapify = pq.comparator != comparator;
             } else {
                 es = c.toArray();
                 if ((len = es.length) == 0)
                     return false;
                 if (cClass != ArrayList.class)
                     es = Arrays.copyOf(es, len, Object[].class);
-                // A single element is not examined by heapify(), and a comparator
-                // may permit nulls, so explicitly reject null before committing the
-                // new array.
-                if (len == 1 || comparator != null)
-                    for (Object e : es)
-                        if (e == null)
-                            throw new NullPointerException();
-                heapify(es, len, comparator);
+
+                needsHeapify = true;
             }
+
+            for (Object e : es) {
+                if (e == null)
+                    throw new NullPointerException();
+                if (comparator == null)
+                    Comparable.class.cast(e);
+            }
+
+            if (needsHeapify)
+                heapify(es, len, comparator);
 
             modCount++;
             queue = es;

--- a/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
@@ -79,6 +79,24 @@ public class PriorityQueueTest extends JSR166TestCase {
         }
     }
 
+    static class CountedComparator implements Comparator<Item> {
+        int comparisons;
+
+        public int compare(Item x, Item y) {
+            comparisons++;
+            return x.compareTo(y);
+        }
+    }
+
+    static class CountedAddPriorityQueue<E> extends PriorityQueue<E> {
+        int adds;
+
+        public boolean add(E e) {
+            adds++;
+            return super.add(e);
+        }
+    }
+
     /**
      * Returns a new queue of given size containing consecutive
      * Items 0 ... n - 1.
@@ -399,6 +417,49 @@ public class PriorityQueueTest extends JSR166TestCase {
         assertTrue(q.addAll(Arrays.asList(items)));
         for (int i = 0; i < SIZE; ++i)
             mustEqual(i, q.poll());
+    }
+
+    /**
+     * addAll into an empty queue heapifies the added elements
+     */
+    public void testAddAllEmptyQueueHeapifies() {
+        final int size = 10_000;
+        Item[] items = new Item[size];
+        for (int i = 0; i < size; ++i)
+            items[i] = itemFor(size - 1 - i);
+
+        CountedComparator cmp = new CountedComparator();
+        PriorityQueue<Item> q = new PriorityQueue<>(cmp);
+        assertTrue("addAll should return true for non-empty input",
+                   q.addAll(Arrays.asList(items)));
+        assertEquals("addAll should add all elements",
+                     size, q.size());
+        assertTrue("addAll should heapify instead of adding elements one at a time",
+                   cmp.comparisons < size * 4);
+        for (int i = 0; i < size; ++i)
+            mustEqual(i, q.poll());
+    }
+
+    /**
+     * addAll into a subclass adds elements one at a time
+     */
+    public void testAddAllSubclassAddsEachElement() {
+        CountedAddPriorityQueue<Item> q = new CountedAddPriorityQueue<>();
+        assertTrue("addAll should return true for non-empty input",
+                   q.addAll(Arrays.asList(three, two, one)));
+        assertEquals("empty subclass should add elements one at a time",
+                     3, q.adds);
+        assertEquals("empty subclass should contain all added elements",
+                     3, q.size());
+
+        q = new CountedAddPriorityQueue<>();
+        mustAdd(q, zero);
+        assertTrue("addAll should return true for non-empty input",
+                   q.addAll(Arrays.asList(three, two, one)));
+        assertEquals("non-empty subclass should add elements one at a time",
+                     4, q.adds);
+        assertEquals("non-empty subclass should contain all added elements",
+                     4, q.size());
     }
 
     /**

--- a/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
@@ -430,12 +430,9 @@ public class PriorityQueueTest extends JSR166TestCase {
 
         CountedComparator cmp = new CountedComparator();
         PriorityQueue<Item> q = new PriorityQueue<>(cmp);
-        assertTrue("addAll should return true for non-empty input",
-                   q.addAll(Arrays.asList(items)));
-        assertEquals("addAll should add all elements",
-                     size, q.size());
-        assertTrue("addAll should heapify instead of adding elements one at a time",
-                   cmp.comparisons < size * 4);
+        assertTrue(q.addAll(Arrays.asList(items)));
+        assertEquals(size, q.size());
+        assertTrue(cmp.comparisons < size * 4);
         for (int i = 0; i < size; ++i)
             mustEqual(i, q.poll());
     }
@@ -445,21 +442,15 @@ public class PriorityQueueTest extends JSR166TestCase {
      */
     public void testAddAllSubclassAddsEachElement() {
         CountedAddPriorityQueue<Item> q = new CountedAddPriorityQueue<>();
-        assertTrue("addAll should return true for non-empty input",
-                   q.addAll(Arrays.asList(three, two, one)));
-        assertEquals("empty subclass should add elements one at a time",
-                     3, q.adds);
-        assertEquals("empty subclass should contain all added elements",
-                     3, q.size());
+        assertTrue(q.addAll(Arrays.asList(three, two, one)));
+        assertEquals(3, q.adds);
+        assertEquals(3, q.size());
 
         q = new CountedAddPriorityQueue<>();
         mustAdd(q, zero);
-        assertTrue("addAll should return true for non-empty input",
-                   q.addAll(Arrays.asList(three, two, one)));
-        assertEquals("non-empty subclass should add elements one at a time",
-                     4, q.adds);
-        assertEquals("non-empty subclass should contain all added elements",
-                     4, q.size());
+        assertTrue(q.addAll(Arrays.asList(three, two, one)));
+        assertEquals(4, q.adds);
+        assertEquals(4, q.size());
     }
 
     /**

--- a/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
@@ -454,6 +454,32 @@ public class PriorityQueueTest extends JSR166TestCase {
     }
 
     /**
+     * addAll of a collection with non-Comparable elements throws CCE
+     */
+    public void testAddAllNonComparableSingleton() {
+        PriorityQueue<Object> q = new PriorityQueue<>();
+        assertThrows(ClassCastException.class,
+                () -> q.addAll(Arrays.asList(new Object())));
+        assertTrue(q.isEmpty());
+    }
+
+    /**
+     * addAll from a queue with a comparator to one using natural ordering
+     * rejects non-Comparable elements
+     */
+    public void testAddAllFromComparatorQueueToNaturalOrder() {
+        Comparator<Object> cmp = (a, b) -> 0;
+
+        PriorityQueue<Object> src = new PriorityQueue<>(cmp);
+        src.add(new Object());
+
+        PriorityQueue<Object> dst = new PriorityQueue<>();
+        assertThrows(ClassCastException.class,
+                () -> dst.addAll(src));
+        assertTrue(dst.isEmpty());
+    }
+
+    /**
      * poll succeeds unless empty
      */
     public void testPoll() {


### PR DESCRIPTION
Added a fast path for `PriorityQueue#addAll` when adding elements to an empty, exact `PriorityQueue` instance.

Instead of inserting each element one by one through `AbstractQueue#addAll`,
the implementation now copies the source collection into the backing array and calls `heapify()`.
This reduces the construction cost for bulk insertion into an empty queue from repeated per-element sift-up work to linear-time heap construction.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387257](https://bugs.openjdk.org/browse/JDK-8387257): (coll) add fast path for PriorityQueue.addAll(Collection) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31701/head:pull/31701` \
`$ git checkout pull/31701`

Update a local copy of the PR: \
`$ git checkout pull/31701` \
`$ git pull https://git.openjdk.org/jdk.git pull/31701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31701`

View PR using the GUI difftool: \
`$ git pr show -t 31701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31701.diff">https://git.openjdk.org/jdk/pull/31701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31701#issuecomment-4821839649)
</details>
