### PR TITLE
8387375: Update package sun.font to use instanceof pattern variable

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CFont.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,8 +306,8 @@ public final class CFont extends PhysicalFont implements FontSubstitution {
          if (!super.equals(o)) {
              return false;
          }
-
-         return ((Font2D)o).getStyle() == this.getStyle();
+         return o instanceof Font2D other &&
+             other.getStyle() == this.getStyle();
     }
 
     @Override

--- a/src/java.desktop/macosx/classes/sun/font/CFontManager.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFontManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,8 +288,8 @@ public final class CFontManager extends SunFontManager {
     public String getFontPath(boolean noType1Fonts) {
         // In the case of the Cocoa toolkit, since we go through NSFont, we don't need to register /Library/Fonts
         Toolkit tk = Toolkit.getDefaultToolkit();
-        if (tk instanceof HeadlessToolkit) {
-            tk = ((HeadlessToolkit)tk).getUnderlyingToolkit();
+        if (tk instanceof HeadlessToolkit htk) {
+            tk = htk.getUnderlyingToolkit();
         }
         if (tk instanceof LWCToolkit) {
             return "";

--- a/src/java.desktop/macosx/classes/sun/font/CStrike.java
+++ b/src/java.desktop/macosx/classes/sun/font/CStrike.java
@@ -194,8 +194,8 @@ public final class CStrike extends PhysicalStrike {
         GeneralPath gp = getGlyphOutline(glyphCode, 0f, 0f);
         Rectangle2D r2d = gp.getBounds2D();
         Rectangle2D.Float r2df;
-        if (r2d instanceof Rectangle2D.Float) {
-            r2df = (Rectangle2D.Float)r2d;
+        if (r2d instanceof Rectangle2D.Float rf) {
+            r2df = rf;
         } else {
             float x = (float)r2d.getX();
             float y = (float)r2d.getY();

--- a/src/java.desktop/share/classes/sun/font/AttributeValues.java
+++ b/src/java.desktop/share/classes/sun/font/AttributeValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ import java.text.AttributedCharacterIterator.Attribute;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Objects;
 
 public final class AttributeValues implements Cloneable {
     private int defined;
@@ -309,11 +310,9 @@ public final class AttributeValues implements Cloneable {
         return merge(map, MASK_ALL);
     }
 
-    public AttributeValues merge(Map<? extends Attribute, ?>map,
-                                 int mask) {
-        if (map instanceof AttributeMap &&
-            ((AttributeMap) map).getValues() != null) {
-            merge(((AttributeMap)map).getValues(), mask);
+    public AttributeValues merge(Map<? extends Attribute, ?> map, int mask) {
+        if (map instanceof AttributeMap am && am.getValues() != null) {
+            merge(am.getValues(), mask);
         } else if (map != null && !map.isEmpty()) {
             for (Map.Entry<? extends Attribute, ?> e: map.entrySet()) {
                 try {
@@ -393,15 +392,10 @@ public final class AttributeValues implements Cloneable {
                 Object val = e.getValue();
                 if (key.equals(DEFINED_KEY)) {
                     result.defineAll(((Integer)val).intValue());
-                } else {
-                    try {
-                        EAttribute ea =
-                            EAttribute.forAttribute((Attribute)key);
-                        if (ea != null) {
-                            result.set(ea, val);
-                        }
-                    }
-                    catch (ClassCastException ex) {
+                } else if (key instanceof Attribute attr) {
+                    EAttribute ea = EAttribute.forAttribute(attr);
+                    if (ea != null) {
+                        result.set(ea, val);
                     }
                 }
             }
@@ -436,24 +430,15 @@ public final class AttributeValues implements Cloneable {
         return defined << 8 ^ nondefault;
     }
 
-    public boolean equals(Object rhs) {
-        try {
-            return equals((AttributeValues)rhs);
-        }
-        catch (ClassCastException e) {
-        }
-        return false;
-    }
-
-    public boolean equals(AttributeValues rhs) {
+    public boolean equals(Object o) {
         // test in order of most likely to differ and easiest to compare
         // also assumes we're generally calling this only if family,
         // size, weight, posture are the same
-
-        if (rhs == null) return false;
-        if (rhs == this) return true;
-
-        return defined == rhs.defined
+        if (o == this) {
+            return true;
+        }
+        return o instanceof AttributeValues rhs
+            && defined == rhs.defined
             && nondefault == rhs.nondefault
             && underline == rhs.underline
             && strikethrough == rhs.strikethrough
@@ -465,19 +450,19 @@ public final class AttributeValues implements Cloneable {
             && runDirection == rhs.runDirection
             && bidiEmbedding == rhs.bidiEmbedding
             && swapColors == rhs.swapColors
-            && equals(transform, rhs.transform)
-            && equals(foreground, rhs.foreground)
-            && equals(background, rhs.background)
-            && equals(numericShaping, rhs.numericShaping)
-            && equals(justification, rhs.justification)
-            && equals(charReplacement, rhs.charReplacement)
+            && Objects.equals(transform, rhs.transform)
+            && Objects.equals(foreground, rhs.foreground)
+            && Objects.equals(background, rhs.background)
+            && Objects.equals(numericShaping, rhs.numericShaping)
+            && Objects.equals(justification, rhs.justification)
+            && Objects.equals(charReplacement, rhs.charReplacement)
             && size == rhs.size
             && weight == rhs.weight
             && posture == rhs.posture
-            && equals(family, rhs.family)
-            && equals(font, rhs.font)
+            && Objects.equals(family, rhs.family)
+            && Objects.equals(font, rhs.font)
             && imUnderline == rhs.imUnderline
-            && equals(imHighlight, rhs.imHighlight);
+            && Objects.equals(imHighlight, rhs.imHighlight);
     }
 
     public AttributeValues clone() {
@@ -549,10 +534,6 @@ public final class AttributeValues implements Cloneable {
 
     // internal utilities
 
-    private static boolean equals(Object lhs, Object rhs) {
-        return lhs == null ? rhs == null : lhs.equals(rhs);
-    }
-
     private void update(EAttribute a) {
         defined |= a.mask;
         if (i_validate(a)) {
@@ -599,26 +580,26 @@ public final class AttributeValues implements Cloneable {
 
     private boolean i_equals(EAttribute a, AttributeValues src) {
         switch (a) {
-        case EFAMILY: return equals(family, src.family);
+        case EFAMILY: return Objects.equals(family, src.family);
         case EWEIGHT: return weight == src.weight;
         case EWIDTH: return width == src.width;
         case EPOSTURE: return posture == src.posture;
         case ESIZE: return size == src.size;
-        case ETRANSFORM: return equals(transform, src.transform);
+        case ETRANSFORM: return Objects.equals(transform, src.transform);
         case ESUPERSCRIPT: return superscript == src.superscript;
-        case EFONT: return equals(font, src.font);
-        case ECHAR_REPLACEMENT: return equals(charReplacement, src.charReplacement);
-        case EFOREGROUND: return equals(foreground, src.foreground);
-        case EBACKGROUND: return equals(background, src.background);
+        case EFONT: return Objects.equals(font, src.font);
+        case ECHAR_REPLACEMENT: return Objects.equals(charReplacement, src.charReplacement);
+        case EFOREGROUND: return Objects.equals(foreground, src.foreground);
+        case EBACKGROUND: return Objects.equals(background, src.background);
         case EUNDERLINE: return underline == src.underline;
         case ESTRIKETHROUGH: return strikethrough == src.strikethrough;
         case ERUN_DIRECTION: return runDirection == src.runDirection;
         case EBIDI_EMBEDDING: return bidiEmbedding == src.bidiEmbedding;
         case EJUSTIFICATION: return justification == src.justification;
-        case EINPUT_METHOD_HIGHLIGHT: return equals(imHighlight, src.imHighlight);
+        case EINPUT_METHOD_HIGHLIGHT: return Objects.equals(imHighlight, src.imHighlight);
         case EINPUT_METHOD_UNDERLINE: return imUnderline == src.imUnderline;
         case ESWAP_COLORS: return swapColors == src.swapColors;
-        case ENUMERIC_SHAPING: return equals(numericShaping, src.numericShaping);
+        case ENUMERIC_SHAPING: return Objects.equals(numericShaping, src.numericShaping);
         case EKERNING: return kerning == src.kerning;
         case ELIGATURES: return ligatures == src.ligatures;
         case ETRACKING: return tracking == src.tracking;
@@ -634,8 +615,7 @@ public final class AttributeValues implements Cloneable {
         case EPOSTURE: posture = ((Number)o).floatValue(); break;
         case ESIZE: size = ((Number)o).floatValue(); break;
         case ETRANSFORM: {
-            if (o instanceof TransformAttribute) {
-                TransformAttribute ta = (TransformAttribute)o;
+            if (o instanceof TransformAttribute ta) {
                 if (ta.isIdentity()) {
                     transform = null;
                 } else {
@@ -663,8 +643,7 @@ public final class AttributeValues implements Cloneable {
         case EBIDI_EMBEDDING: bidiEmbedding = (byte)((Integer)o).intValue(); break;
         case EJUSTIFICATION: justification = ((Number)o).floatValue(); break;
         case EINPUT_METHOD_HIGHLIGHT: {
-            if (o instanceof Annotation) {
-                Annotation at = (Annotation)o;
+            if (o instanceof Annotation at) {
                 imHighlight = (InputMethodHighlight)at.getValue();
             } else {
                 imHighlight = (InputMethodHighlight)o;
@@ -759,9 +738,8 @@ public final class AttributeValues implements Cloneable {
     // Plan to remove these.
     public static float getJustification(Map<?, ?> map) {
         if (map != null) {
-            if (map instanceof AttributeMap &&
-                ((AttributeMap) map).getValues() != null) {
-                return ((AttributeMap)map).getValues().justification;
+            if (map instanceof AttributeMap am && am.getValues() != null) {
+                return am.getValues().justification;
             }
             Object obj = map.get(TextAttribute.JUSTIFICATION);
             if (obj instanceof Number number) {
@@ -773,9 +751,8 @@ public final class AttributeValues implements Cloneable {
 
     public static NumericShaper getNumericShaping(Map<?, ?> map) {
         if (map != null) {
-            if (map instanceof AttributeMap &&
-                ((AttributeMap) map).getValues() != null) {
-                return ((AttributeMap)map).getValues().numericShaping;
+            if (map instanceof AttributeMap am && am.getValues() != null) {
+                return am.getValues().numericShaping;
             }
             Object obj = map.get(TextAttribute.NUMERIC_SHAPING);
             if (obj instanceof NumericShaper shaper) {
@@ -792,8 +769,8 @@ public final class AttributeValues implements Cloneable {
     public AttributeValues applyIMHighlight() {
         if (imHighlight != null) {
             InputMethodHighlight hl = null;
-            if (imHighlight instanceof InputMethodHighlight) {
-                hl = (InputMethodHighlight)imHighlight;
+            if (imHighlight instanceof InputMethodHighlight imh) {
+                hl = imh;
             } else {
                 hl = (InputMethodHighlight)((Annotation)imHighlight).getValue();
             }
@@ -816,9 +793,8 @@ public final class AttributeValues implements Cloneable {
     public static AffineTransform getBaselineTransform(Map<?, ?> map) {
         if (map != null) {
             AttributeValues av = null;
-            if (map instanceof AttributeMap &&
-                ((AttributeMap) map).getValues() != null) {
-                av = ((AttributeMap)map).getValues();
+            if (map instanceof AttributeMap am && am.getValues() != null) {
+                av = am.getValues();
             } else if (map.get(TextAttribute.TRANSFORM) != null) {
                 av = AttributeValues.fromMap((Map<Attribute, ?>)map); // yuck
             }
@@ -833,9 +809,8 @@ public final class AttributeValues implements Cloneable {
     public static AffineTransform getCharTransform(Map<?, ?> map) {
         if (map != null) {
             AttributeValues av = null;
-            if (map instanceof AttributeMap &&
-                ((AttributeMap) map).getValues() != null) {
-                av = ((AttributeMap)map).getValues();
+            if (map instanceof AttributeMap am && am.getValues() != null) {
+                av = am.getValues();
             } else if (map.get(TextAttribute.TRANSFORM) != null) {
                 av = AttributeValues.fromMap((Map<Attribute, ?>)map); // yuck
             }
@@ -850,9 +825,8 @@ public final class AttributeValues implements Cloneable {
     public static float getTracking(Map<?, ?> map) {
         if (map != null) {
             AttributeValues av = null;
-            if (map instanceof AttributeMap &&
-                    ((AttributeMap) map).getValues() != null) {
-                av = ((AttributeMap)map).getValues();
+            if (map instanceof AttributeMap am && am.getValues() != null) {
+                av = am.getValues();
             } else if (map.get(TextAttribute.TRACKING) != null) {
                 av = AttributeValues.fromMap((Map<Attribute, ?>)map);
             }

--- a/src/java.desktop/share/classes/sun/font/CompositeFont.java
+++ b/src/java.desktop/share/classes/sun/font/CompositeFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -297,15 +297,15 @@ public final class CompositeFont extends Font2D {
                     /* If a component specifies the file with a bad font,
                      * the corresponding slot will be initialized by
                      * default physical font. In such case findFont2D may
-                     * return composite font which cannot be casted to
+                     * return composite font which cannot be cast to
                      * physical font.
                      */
-                    try {
-                        components[slot] =
-                            (PhysicalFont) fm.findFont2D(componentNames[slot],
-                                                         style,
-                                                FontManager.PHYSICAL_FALLBACK);
-                    } catch (ClassCastException cce) {
+                    Font2D f2d = fm.findFont2D(componentNames[slot],
+                                               style,
+                                               FontManager.PHYSICAL_FALLBACK);
+                    if (f2d instanceof PhysicalFont pf) {
+                        components[slot] = pf;
+                    } else {
                         /* Assign default physical font to the slot */
                         components[slot] = fm.getDefaultPhysicalFont();
                     }
@@ -379,12 +379,13 @@ public final class CompositeFont extends Font2D {
         try {
             PhysicalFont font = components[slot];
             if (font == null) {
-                try {
-                    font = (PhysicalFont) fm.
-                        findFont2D(componentNames[slot], style,
-                                   FontManager.PHYSICAL_FALLBACK);
+                Font2D f2d = fm.findFont2D(componentNames[slot],
+                                           style,
+                                           FontManager.PHYSICAL_FALLBACK);
+                if (f2d instanceof PhysicalFont pf) {
+                    font = pf;
                     components[slot] = font;
-                } catch (ClassCastException cce) {
+                } else {
                     font = fm.getDefaultPhysicalFont();
                 }
             }

--- a/src/java.desktop/share/classes/sun/font/CoreMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/CoreMetrics.java
@@ -70,36 +70,24 @@ public final class CoreMetrics {
         return Float.floatToIntBits(ascent + ssOffset);
     }
 
-    public boolean equals(Object rhs) {
-        try {
-            return equals((CoreMetrics)rhs);
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
         }
-        catch(ClassCastException e) {
-            return false;
-        }
-    }
-
-    public boolean equals(CoreMetrics rhs) {
-        if (rhs != null) {
-            if (this == rhs) {
-                return true;
-            }
-
-            return ascent == rhs.ascent
-                && descent == rhs.descent
-                && leading == rhs.leading
-                && baselineIndex == rhs.baselineIndex
-                && baselineOffsets[0] == rhs.baselineOffsets[0]
-                && baselineOffsets[1] == rhs.baselineOffsets[1]
-                && baselineOffsets[2] == rhs.baselineOffsets[2]
-                && strikethroughOffset == rhs.strikethroughOffset
-                && strikethroughThickness == rhs.strikethroughThickness
-                && underlineOffset == rhs.underlineOffset
-                && underlineThickness == rhs.underlineThickness
-                && ssOffset == rhs.ssOffset
-                && italicAngle == rhs.italicAngle;
-        }
-        return false;
+        return o instanceof CoreMetrics rhs
+            && ascent == rhs.ascent
+            && descent == rhs.descent
+            && leading == rhs.leading
+            && baselineIndex == rhs.baselineIndex
+            && baselineOffsets[0] == rhs.baselineOffsets[0]
+            && baselineOffsets[1] == rhs.baselineOffsets[1]
+            && baselineOffsets[2] == rhs.baselineOffsets[2]
+            && strikethroughOffset == rhs.strikethroughOffset
+            && strikethroughThickness == rhs.strikethroughThickness
+            && underlineOffset == rhs.underlineOffset
+            && underlineThickness == rhs.underlineThickness
+            && ssOffset == rhs.ssOffset
+            && italicAngle == rhs.italicAngle;
     }
 
     // fullOffsets is an array of 5 baseline offsets,

--- a/src/java.desktop/share/classes/sun/font/Decoration.java
+++ b/src/java.desktop/share/classes/sun/font/Decoration.java
@@ -47,6 +47,7 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.GeneralPath;
 import java.text.AttributedCharacterIterator.Attribute;
+import java.util.Objects;
 
 import static sun.font.AttributeValues.*;
 import static sun.font.EAttribute.*;
@@ -169,48 +170,17 @@ public class Decoration {
             this.imUnderline = imUnderline;
         }
 
-        private static boolean areEqual(Object lhs, Object rhs) {
-
-            if (lhs == null) {
-                return rhs == null;
-            }
-            else {
-                return lhs.equals(rhs);
-            }
-        }
-
-        public boolean equals(Object rhs) {
-
-            if (rhs == this) {
+        public boolean equals(Object o) {
+            if (o == this) {
                 return true;
             }
-            if (rhs == null) {
-                return false;
-            }
-
-            DecorationImpl other = null;
-            try {
-                other = (DecorationImpl) rhs;
-            }
-            catch(ClassCastException e) {
-                return false;
-            }
-
-            if (!(swapColors == other.swapColors &&
-                        strikethrough == other.strikethrough)) {
-                return false;
-            }
-
-            if (!areEqual(stdUnderline, other.stdUnderline)) {
-                return false;
-            }
-            if (!areEqual(fgPaint, other.fgPaint)) {
-                return false;
-            }
-            if (!areEqual(bgPaint, other.bgPaint)) {
-                return false;
-            }
-            return areEqual(imUnderline, other.imUnderline);
+            return o instanceof DecorationImpl other &&
+                swapColors == other.swapColors &&
+                strikethrough == other.strikethrough &&
+                Objects.equals(stdUnderline, other.stdUnderline) &&
+                Objects.equals(fgPaint, other.fgPaint) &&
+                Objects.equals(bgPaint, other.bgPaint) &&
+                Objects.equals(imUnderline, other.imUnderline);
         }
 
         public int hashCode() {
@@ -304,8 +274,7 @@ public class Decoration {
                 if (swapColors) {
                     background = fgPaint==null? savedPaint : fgPaint;
                     if (bgPaint == null) {
-                        if (background instanceof Color) {
-                            Color bg = (Color)background;
+                        if (background instanceof Color bg) {
                             // 30/59/11 is standard weights, tweaked a bit
                             int brightness = 33 * bg.getRed()
                                 + 53 * bg.getGreen()

--- a/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,12 +214,12 @@ public final class FontDesignMetrics extends FontMetrics {
         }
 
         public boolean equals(Object key) {
-            if (!(key instanceof MetricsKey)) {
-                return false;
+            if (key == this) {
+                return true;
             }
-            return
-                font.equals(((MetricsKey)key).font) &&
-                frc.equals(((MetricsKey)key).frc);
+            return key instanceof MetricsKey other &&
+                font.equals(other.font) &&
+                frc.equals(other.frc);
         }
 
         public int hashCode() {

--- a/src/java.desktop/share/classes/sun/font/FontFamily.java
+++ b/src/java.desktop/share/classes/sun/font/FontFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,14 +114,14 @@ public class FontFamily {
         }
 
         FileFont existingFont = null;
-        if (plain instanceof FileFont) {
-            existingFont = (FileFont)plain;
-        } else if (bold instanceof FileFont) {
-            existingFont = (FileFont)bold;
-        } else if (italic instanceof FileFont) {
-             existingFont = (FileFont)italic;
-        } else if (bolditalic instanceof FileFont) {
-             existingFont = (FileFont)bolditalic;
+        if (plain instanceof FileFont plainFF) {
+            existingFont = plainFF;
+        } else if (bold instanceof FileFont boldFF) {
+            existingFont = boldFF;
+        } else if (italic instanceof FileFont italicFF) {
+             existingFont = italicFF;
+        } else if (bolditalic instanceof FileFont boldItalicFF) {
+             existingFont = boldItalicFF;
         }
         // A family isn't created until there's a font.
         // So if we didn't find a file font it means this

--- a/src/java.desktop/share/classes/sun/font/FontLineMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontLineMetrics.java
@@ -99,12 +99,10 @@ public final class FontLineMetrics extends LineMetrics implements Cloneable {
     }
 
     public boolean equals(Object rhs) {
-        try {
-            return cm.equals(((FontLineMetrics)rhs).cm);
+        if (rhs == this) {
+            return true;
         }
-        catch (ClassCastException e) {
-            return false;
-        }
+        return rhs instanceof FontLineMetrics other && cm.equals(other.cm);
     }
 
     public Object clone() {

--- a/src/java.desktop/share/classes/sun/font/FontStrikeDesc.java
+++ b/src/java.desktop/share/classes/sun/font/FontStrikeDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,23 +85,18 @@ public class FontStrikeDesc {
     }
 
     public boolean equals(Object obj) {
-        try {
-            FontStrikeDesc desc = (FontStrikeDesc)obj;
-            return (desc.valuemask == this.valuemask &&
-                    desc.glyphTx.equals(this.glyphTx) &&
-                    desc.devTx.equals(this.devTx));
-        } catch (Exception e) {
-            /* class cast or NP exceptions should not happen often, if ever,
-             * and I am hoping that this is faster than an instanceof check.
-             */
-            return false;
+        if (obj == this) {
+            return true;
         }
+        return obj instanceof FontStrikeDesc desc &&
+            desc.valuemask == this.valuemask &&
+            desc.glyphTx.equals(this.glyphTx) &&
+            desc.devTx.equals(this.devTx);
     }
 
     FontStrikeDesc() {
         // used with init
     }
-
 
     /* This maps a public text AA hint value into one of the subset of values
      * used to index strikes. For the purpose of the strike cache there are

--- a/src/java.desktop/share/classes/sun/font/FontUtilities.java
+++ b/src/java.desktop/share/classes/sun/font/FontUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -481,7 +481,7 @@ public final class FontUtilities {
         FontUIResource fuir = new FontUIResource(font);
         Font2D font2D = FontUtilities.getFont2D(font);
 
-        if (!(font2D instanceof PhysicalFont)) {
+        if (!(font2D instanceof PhysicalFont physicalFont)) {
             /* Swing should only be calling this when a font is obtained
              * from desktop properties, so should generally be a physical font,
              * an exception might be for names like "MS Serif" which are
@@ -499,7 +499,6 @@ public final class FontUtilities {
         if (!(dialog instanceof CompositeFont dialog2D)) {
             return fuir;
         }
-        PhysicalFont physicalFont = (PhysicalFont)font2D;
         ConcurrentHashMap<PhysicalFont, CompositeFont> compMap = compMapRef.get();
         if (compMap == null) { // Its been collected.
             compMap = new ConcurrentHashMap<PhysicalFont, CompositeFont>();
@@ -565,15 +564,13 @@ public final class FontUtilities {
 
         FontUIResource fuir;
         FontManager fm = FontManagerFactory.getInstance();
-        if (fm instanceof SunFontManager) {
-            SunFontManager sfm = (SunFontManager) fm;
+        if (fm instanceof SunFontManager sfm) {
             fuir = sfm.getFontConfigFUIR(mapped, style, size);
         } else {
             fuir = new FontUIResource(mapped, style, size);
         }
         return fuir;
     }
-
 
     /**
      * Used by windows printing to assess if a font is likely to
@@ -583,10 +580,8 @@ public final class FontUtilities {
      * fonts GDI handles differently.
      */
     public static boolean textLayoutIsCompatible(Font font) {
-
         Font2D font2D = getFont2D(font);
-        if (font2D instanceof TrueTypeFont) {
-            TrueTypeFont ttf = (TrueTypeFont) font2D;
+        if (font2D instanceof TrueTypeFont ttf) {
             return
                 ttf.getDirectoryEntry(TrueTypeFont.GSUBTag) == null ||
                 ttf.getDirectoryEntry(TrueTypeFont.GPOSTag) != null;

--- a/src/java.desktop/share/classes/sun/font/FreetypeFontScaler.java
+++ b/src/java.desktop/share/classes/sun/font/FreetypeFontScaler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,12 +60,9 @@ class FreetypeFontScaler extends FontScaler {
 
     public FreetypeFontScaler(Font2D font, int indexInCollection,
                      boolean supportsCJK, int filesize) {
-        int fonttype = TRUETYPE_FONT;
-        if (font instanceof Type1Font) {
-            fonttype = TYPE1_FONT;
-        }
+        int type = font instanceof Type1Font ? TYPE1_FONT : TRUETYPE_FONT;
         nativeScaler = initNativeScaler(font,
-                                        fonttype,
+                                        type,
                                         indexInCollection,
                                         supportsCJK,
                                         filesize);

--- a/src/java.desktop/share/classes/sun/font/GlyphLayout.java
+++ b/src/java.desktop/share/classes/sun/font/GlyphLayout.java
@@ -178,16 +178,13 @@ public final class GlyphLayout {
             }
 
             public boolean equals(Object o) {
-                try {
-                    SDKey rhs = (SDKey)o;
-                    return
-                        hash == rhs.hash &&
-                        font.equals(rhs.font) &&
-                        frc.equals(rhs.frc);
+                if (o == this) {
+                    return true;
                 }
-                catch (ClassCastException e) {
-                }
-                return false;
+                return o instanceof SDKey rhs &&
+                    hash == rhs.hash &&
+                    font.equals(rhs.font) &&
+                    frc.equals(rhs.frc);
             }
         }
 
@@ -302,15 +299,15 @@ public final class GlyphLayout {
         }
 
         Font2D font2D = FontUtilities.getFont2D(font);
-        if (font2D instanceof FontSubstitution) {
-            font2D = ((FontSubstitution)font2D).getCompositeFont2D();
+        if (font2D instanceof FontSubstitution sub) {
+            font2D = sub.getCompositeFont2D();
         }
 
         _textRecord.init(text, offset, lim, min, max);
         int start = offset;
-        if (font2D instanceof CompositeFont) {
+        if (font2D instanceof CompositeFont composite) {
             _scriptRuns.init(text, offset, count); // ??? how to handle 'common' chars
-            _fontRuns.init((CompositeFont)font2D, text, offset, lim);
+            _fontRuns.init(composite, text, offset, lim);
             while (_scriptRuns.next()) {
                 int limit = _scriptRuns.getScriptLimit();
                 int script = _scriptRuns.getScriptCode();
@@ -322,8 +319,8 @@ public final class GlyphLayout {
                      * its consistent with the way NativeFonts delegate
                      * in other cases too.
                      */
-                    if (pfont instanceof NativeFont) {
-                        pfont = ((NativeFont)pfont).getDelegateFont();
+                    if (pfont instanceof NativeFont nf) {
+                        pfont = nf.getDelegateFont();
                     }
                     int gmask = _fontRuns.getGlyphMask();
                     int pos = _fontRuns.getPos();

--- a/src/java.desktop/share/classes/sun/font/PhysicalFont.java
+++ b/src/java.desktop/share/classes/sun/font/PhysicalFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/font/PhysicalFont.java
+++ b/src/java.desktop/share/classes/sun/font/PhysicalFont.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.util.Objects;
 
 public abstract class PhysicalFont extends Font2D {
 
@@ -41,14 +42,13 @@ public abstract class PhysicalFont extends Font2D {
     protected Object nativeNames;
 
     public boolean equals(Object o) {
-        if (o == null || o.getClass() != this.getClass()) {
-            return false;
+        if (o == this) {
+            return true;
         }
-        PhysicalFont other = (PhysicalFont)o;
-        return
-           (this.fullName.equals(other.fullName)) &&
-            ((this.platName == null && other.platName == null) ||
-             (this.platName != null && this.platName.equals(other.platName)));
+        return o.getClass() == this.getClass() &&
+            o instanceof PhysicalFont other &&
+            fullName.equals(other.fullName) &&
+            Objects.equals(platName, other.platName);
     }
 
     public int hashCode() {

--- a/src/java.desktop/share/classes/sun/font/PhysicalFont.java
+++ b/src/java.desktop/share/classes/sun/font/PhysicalFont.java
@@ -45,8 +45,8 @@ public abstract class PhysicalFont extends Font2D {
         if (o == this) {
             return true;
         }
-        return o.getClass() == this.getClass() &&
-            o instanceof PhysicalFont other &&
+        return o instanceof PhysicalFont other &&
+            other.getClass() == this.getClass() &&
             fullName.equals(other.fullName) &&
             Objects.equals(platName, other.platName);
     }

--- a/src/java.desktop/share/classes/sun/font/StandardGlyphVector.java
+++ b/src/java.desktop/share/classes/sun/font/StandardGlyphVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,8 +278,8 @@ public class StandardGlyphVector extends GlyphVector {
                 return new StandardGlyphVector(gv, frc);
             }
         }
-        if (gv instanceof StandardGlyphVector) {
-            return (StandardGlyphVector)gv;
+        if (gv instanceof StandardGlyphVector sgv) {
+            return sgv;
         }
         return new StandardGlyphVector(gv, gv.getFontRenderContext());
     }
@@ -636,61 +636,54 @@ public class StandardGlyphVector extends GlyphVector {
         return null;
     }
 
-    public boolean equals(GlyphVector rhs) {
-        if (this == rhs) {
+    public boolean equals(GlyphVector gv) {
+
+        if (gv == this) {
             return true;
         }
-        if (rhs == null) {
+
+        if (!(gv instanceof StandardGlyphVector other)) {
             return false;
         }
 
-        try {
-            StandardGlyphVector other = (StandardGlyphVector)rhs;
+        if (glyphs.length != other.glyphs.length) {
+            return false;
+        }
 
-            if (glyphs.length != other.glyphs.length) {
+        for (int i = 0; i < glyphs.length; ++i) {
+            if (glyphs[i] != other.glyphs[i]) {
                 return false;
             }
+        }
 
-            for (int i = 0; i < glyphs.length; ++i) {
-                if (glyphs[i] != other.glyphs[i]) {
+        if (!font.equals(other.font)) {
+            return false;
+        }
+
+        if (!frc.equals(other.frc)) {
+            return false;
+        }
+
+        if ((other.positions == null) != (positions == null)) {
+            if (positions == null) {
+                initPositions();
+            } else {
+                other.initPositions();
+            }
+        }
+
+        if (positions != null) {
+            for (int i = 0; i < positions.length; ++i) {
+                if (positions[i] != other.positions[i]) {
                     return false;
                 }
             }
-
-            if (!font.equals(other.font)) {
-                return false;
-            }
-
-            if (!frc.equals(other.frc)) {
-                return false;
-            }
-
-            if ((other.positions == null) != (positions == null)) {
-                if (positions == null) {
-                    initPositions();
-                } else {
-                    other.initPositions();
-                }
-            }
-
-            if (positions != null) {
-                for (int i = 0; i < positions.length; ++i) {
-                    if (positions[i] != other.positions[i]) {
-                        return false;
-                    }
-                }
-            }
-
-            if (gti == null) {
-                return other.gti == null;
-            } else {
-                return gti.equals(other.gti);
-            }
         }
-        catch (ClassCastException e) {
-            // assume they are different simply by virtue of the class difference
 
-            return false;
+        if (gti == null) {
+            return other.gti == null;
+        } else {
+            return gti.equals(other.gti);
         }
     }
 
@@ -707,13 +700,11 @@ public class StandardGlyphVector extends GlyphVector {
      * the inherited Object.equals(Object) as well.  GlyphVector should do
      * this, and define two glyphvectors as not equal if the classes differ.
      */
-    public boolean equals(Object rhs) {
-        try {
-            return equals((GlyphVector)rhs);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
         }
-        catch (ClassCastException e) {
-            return false;
-        }
+        return o instanceof GlyphVector other && this.equals(other);
     }
 
     /**
@@ -1110,8 +1101,8 @@ public class StandardGlyphVector extends GlyphVector {
 
     private void initFontData() {
         font2D = FontUtilities.getFont2D(font);
-        if (font2D instanceof FontSubstitution) {
-           font2D = ((FontSubstitution)font2D).getCompositeFont2D();
+        if (font2D instanceof FontSubstitution sub) {
+           font2D = sub.getCompositeFont2D();
         }
         float s = font.getSize2D();
         if (font.isTransformed()) {
@@ -1731,11 +1722,11 @@ public class StandardGlyphVector extends GlyphVector {
                                                      aa, fm);
             // Get the strike via the handle. Shouldn't matter
             // if we've invalidated the font but its an extra precaution.
-        // do we want the CompFont from CFont here ?
-        Font2D f2d = sgv.font2D;
-        if (f2d instanceof FontSubstitution) {
-           f2d = ((FontSubstitution)f2d).getCompositeFont2D();
-        }
+            // do we want the CompFont from CFont here ?
+            Font2D f2d = sgv.font2D;
+            if (f2d instanceof FontSubstitution sub) {
+               f2d = sub.getCompositeFont2D();
+            }
             FontStrike strike = f2d.handle.font2D.getStrike(desc);  // !!! getStrike(desc, false)
 
             return new GlyphStrike(sgv, strike, dx, dy);

--- a/src/java.desktop/share/classes/sun/font/StrikeCache.java
+++ b/src/java.desktop/share/classes/sun/font/StrikeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -386,8 +386,7 @@ public final class StrikeCache {
         if (!GraphicsEnvironment.isHeadless()) {
             GraphicsConfiguration gc =
                 ge.getDefaultScreenDevice().getDefaultConfiguration();
-            if (gc instanceof AccelGraphicsConfig) {
-                AccelGraphicsConfig agc = (AccelGraphicsConfig)gc;
+            if (gc instanceof AccelGraphicsConfig agc) {
                 BufferedContext bc = agc.getContext();
                 if (bc != null) {
                     rq = bc.getRenderQueue();

--- a/src/java.desktop/share/classes/sun/font/SunFontManager.java
+++ b/src/java.desktop/share/classes/sun/font/SunFontManager.java
@@ -437,11 +437,10 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
     public Font2DHandle getNewComposite(String family, int style,
                                         Font2DHandle handle) {
 
-        if (!(handle.font2D instanceof CompositeFont)) {
+        if (!(handle.font2D instanceof CompositeFont oldComp)) {
             return handle;
         }
 
-        CompositeFont oldComp = (CompositeFont)handle.font2D;
         PhysicalFont oldFont = oldComp.getSlotFont(0);
 
         if (family == null) {
@@ -643,10 +642,8 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
                  * more complete (larger) one.
                  */
                 if (oldFont.getRank() == rank) {
-                    if (oldFont instanceof TrueTypeFont &&
-                        newFont instanceof TrueTypeFont) {
-                        TrueTypeFont oldTTFont = (TrueTypeFont)oldFont;
-                        TrueTypeFont newTTFont = (TrueTypeFont)newFont;
+                    if (oldFont instanceof TrueTypeFont oldTTFont &&
+                        newFont instanceof TrueTypeFont newTTFont) {
                         if (oldTTFont.fileSize >= newTTFont.fileSize) {
                             return oldFont;
                         }
@@ -998,8 +995,8 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
             // findFont2D will load all fonts
             Font2D font2d = findFont2D(defaultFontName, Font.PLAIN, NO_FALLBACK);
             if (font2d != null) {
-                if (font2d instanceof PhysicalFont) {
-                    defaultPhysicalFont = (PhysicalFont)font2d;
+                if (font2d instanceof PhysicalFont pf) {
+                    defaultPhysicalFont = pf;
                 } else {
                     if (FontUtilities.isLogging()) {
                         FontUtilities.logWarning("Font returned by findFont2D for default font name " +
@@ -2264,14 +2261,12 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
      * make sense for a Composite to be "bad".
      */
     public synchronized void deRegisterBadFont(Font2D font2D) {
-        if (!(font2D instanceof PhysicalFont)) {
-            /* We should never reach here, but just in case */
-            return;
-        } else {
+        // this should always be a physical font, but check just in case
+        if (font2D instanceof PhysicalFont pf) {
             if (FontUtilities.isLogging()) {
                 FontUtilities.logSevere("Deregister bad font: " + font2D);
             }
-            replaceFont((PhysicalFont)font2D, getDefaultPhysicalFont());
+            replaceFont(pf, getDefaultPhysicalFont());
         }
     }
 
@@ -2382,8 +2377,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
         localeFullNamesToFont = new HashMap<>();
         Font2D[] fonts = getRegisteredFonts();
         for (int i=0; i<fonts.length; i++) {
-            if (fonts[i] instanceof TrueTypeFont) {
-                TrueTypeFont ttf = (TrueTypeFont)fonts[i];
+            if (fonts[i] instanceof TrueTypeFont ttf) {
                 String[] fullNames = ttf.getAllFullNames();
                 for (int n=0; n<fullNames.length; n++) {
                     localeFullNamesToFont.put(fullNames[n], ttf);

--- a/src/java.desktop/share/classes/sun/font/TrueTypeFont.java
+++ b/src/java.desktop/share/classes/sun/font/TrueTypeFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.font;
 import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.geom.Point2D;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
@@ -215,8 +214,8 @@ public class TrueTypeFont extends FileFont {
             }
         } catch (Throwable t) {
             close();
-            if (t instanceof FontFormatException) {
-                throw (FontFormatException)t;
+            if (t instanceof FontFormatException ffe) {
+                throw ffe;
             } else {
                 throw new FontFormatException("Unexpected runtime exception.");
             }
@@ -247,8 +246,8 @@ public class TrueTypeFont extends FileFont {
                 fileSize = (int)disposerRecord.channel.size();
                 if (usePool) {
                     FontManager fm = FontManagerFactory.getInstance();
-                    if (fm instanceof SunFontManager) {
-                        ((SunFontManager) fm).addToPool(this);
+                    if (fm instanceof SunFontManager sfm) {
+                        sfm.addToPool(this);
                     }
                 }
             } catch (ClosedChannelException e) {
@@ -509,8 +508,8 @@ public class TrueTypeFont extends FileFont {
             if (FontUtilities.isLogging()) {
                 FontUtilities.logSevere(e.toString());
             }
-            if (e instanceof FontFormatException) {
-                throw (FontFormatException)e;
+            if (e instanceof FontFormatException ffe) {
+                throw ffe;
             } else {
                 throw new FontFormatException(e.toString());
             }

--- a/src/java.desktop/share/classes/sun/font/Type1Font.java
+++ b/src/java.desktop/share/classes/sun/font/Type1Font.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,8 +168,8 @@ public class Type1Font extends FileFont {
                 Disposer.addObjectRecord(bufferRef, ref);
                 bufferRef = null;
             }
-            if (t instanceof FontFormatException) {
-                throw (FontFormatException)t;
+            if (t instanceof FontFormatException ffe) {
+                throw ffe;
             } else {
                 throw new FontFormatException("Unexpected runtime exception.");
             }

--- a/src/java.desktop/unix/classes/sun/font/FontConfigManager.java
+++ b/src/java.desktop/unix/classes/sun/font/FontConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,8 +267,8 @@ public final class FontConfigManager {
                 Font2D f2d = fm.findFont2D(fcInfo.firstFont.familyName,
                                            fcInfo.style,
                                            FontManager.NO_FALLBACK);
-                if (f2d instanceof PhysicalFont) { /* paranoia */
-                    return (PhysicalFont)f2d;
+                if (f2d instanceof PhysicalFont pf) { /* paranoia */
+                    return pf;
                 } else {
                     return null;
                 }
@@ -295,8 +295,8 @@ public final class FontConfigManager {
                     Font2D f2d = fm.findFont2D(fcInfo.firstFont.familyName,
                                                fcInfo.style,
                                                FontManager.NO_FALLBACK);
-                    if (f2d instanceof PhysicalFont) { /* paranoia */
-                        return (PhysicalFont)f2d;
+                    if (f2d instanceof PhysicalFont pf) { /* paranoia */
+                        return pf;
                     } else {
                         return null;
                     }
@@ -387,8 +387,8 @@ public final class FontConfigManager {
         PhysicalFont physFont = null;
         if (family != null) {
             Font2D f2D = family.getFontWithExactStyleMatch(fcInfo.style);
-            if (f2D instanceof PhysicalFont) {
-                physFont = (PhysicalFont)f2D;
+            if (f2D instanceof PhysicalFont pf) {
+                physFont = pf;
             }
         }
 

--- a/src/java.desktop/unix/classes/sun/font/NativeFont.java
+++ b/src/java.desktop/unix/classes/sun/font/NativeFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,8 +251,8 @@ public final class NativeFont extends PhysicalFont {
             /* If no FileFont's are found, delegate font may be
              * a NativeFont, so we need to avoid recursing here.
              */
-            if (delegateFont instanceof NativeFont) {
-                return new NativeStrike((NativeFont)delegateFont, desc);
+            if (delegateFont instanceof NativeFont nf) {
+                return new NativeStrike(nf, desc);
             }
             FontStrike delegate = delegateFont.createStrike(desc);
             return new DelegateStrike(this, desc, delegate);


### PR DESCRIPTION
Update code in the package `sun.font` to make use of the `instanceof` pattern variable. Includes `equals` methods and a few methods using `ClassCastException` for flow control.

While looking through this code, I've noticed a few pre-existing suspicious differences between `equals` and `hashCode` implementations, but have not made any functional changes to fix this (best to address separately, if needed).

Tests checked locally on Linux, Windows and macOS:
- make test TEST="jtreg:test/jdk/java/awt/font"
- make test TEST="jtreg:test/jdk/java/awt/Graphics2D/DrawString"

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387375](https://bugs.openjdk.org/browse/JDK-8387375): Update package sun.font to use instanceof pattern variable (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31702/head:pull/31702` \
`$ git checkout pull/31702`

Update a local copy of the PR: \
`$ git checkout pull/31702` \
`$ git pull https://git.openjdk.org/jdk.git pull/31702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31702`

View PR using the GUI difftool: \
`$ git pr show -t 31702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31702.diff">https://git.openjdk.org/jdk/pull/31702.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31702#issuecomment-4827155174)
</details>
