### PR TITLE
8387267: Editor for the last column in JTable is hard to activate after AUTO_RESIZE_LAST_COLUMN was configured

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1264,12 +1264,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             autoResizeMode = mode;
             resizeAndRepaint();
             if (tableHeader != null) {
-                if (mode == JTable.AUTO_RESIZE_LAST_COLUMN) {
-                    int colCnt = columnModel.getColumnCount();
-                    if (colCnt > 0) {
-                        tableHeader.setResizingColumn(columnModel.getColumn(colCnt - 1));
-                    }
-                }
                 tableHeader.resizeAndRepaint();
             }
             firePropertyChange("autoResizeMode", old, autoResizeMode);
@@ -3195,19 +3189,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
     public void doLayout() {
         boolean prefWidthSet = false;
         TableColumn resizingColumn = getResizingColumn();
-        // doLayout is called for both pack and show
-        // so if initial preferred width is set by user then
-        // it needs to be honoured even if resizingColumn
-        // is set to last column on account of
-        // AUTO_RESIZE_LAST_COLUMN autoResizeMode
-        for (int i = 0; i < columnModel.getColumnCount(); i++) {
-            if (columnModel.getColumn(i).getPreferredWidth() != 75
-                    && columnModel.getColumn(i).getWidth() == 75) {
-                prefWidthSet = true;
-                break;
-            }
-        }
-        if (resizingColumn == null || prefWidthSet) {
+        if (resizingColumn == null) {
             setWidthsFromPreferredWidths(false);
         }
         else {
@@ -3294,7 +3276,57 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         }
     }
 
+    private boolean isInitialPreferredWidthLayout() {
+        for (int i = 0; i < columnModel.getColumnCount(); i++) {
+            TableColumn column = columnModel.getColumn(i);
+            if (column.getPreferredWidth() != 75 && column.getWidth() == 75) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void accommodateLastColumnOnly() {
+        int columnCount = getColumnCount();
+        if (columnCount == 0) {
+            return;
+        }
+
+        int delta = getWidth() - getColumnModel().getTotalColumnWidth();
+        if (delta != 0) {
+            accommodateDelta(columnCount - 1, delta);
+        }
+    }
+
+    private void setWidthsFromPreferredWidthsLastColumnOnly() {
+        int columnCount = getColumnCount();
+        if (columnCount == 0) {
+            return;
+        }
+
+        int totalWidth = getWidth();
+        int total = 0;
+
+        for (int i = 0; i < columnCount - 1; i++) {
+            TableColumn column = columnModel.getColumn(i);
+            int width = column.getPreferredWidth();
+            column.setWidth(width);
+            total += width;
+        }
+
+        TableColumn lastColumn = columnModel.getColumn(columnCount - 1);
+        lastColumn.setWidth(totalWidth - total);
+    }
+
     private void setWidthsFromPreferredWidths(final boolean inverse) {
+        if (!inverse && autoResizeMode == AUTO_RESIZE_LAST_COLUMN) {
+            if (isInitialPreferredWidthLayout()) {
+                setWidthsFromPreferredWidthsLastColumnOnly();
+            } else {
+                accommodateLastColumnOnly();
+            }
+            return;
+        }
         int totalWidth     = getWidth();
         int totalPreferred = getPreferredSize().width;
         int target = !inverse ? totalWidth : totalPreferred;

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -3283,16 +3283,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         }
     }
 
-    private boolean isInitialPreferredWidthLayout() {
-        for (int i = 0; i < columnModel.getColumnCount(); i++) {
-            TableColumn column = columnModel.getColumn(i);
-            if (column.getPreferredWidth() != 75 && column.getWidth() == 75) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private void accommodateLastColumnOnly() {
         int columnCount = getColumnCount();
         if (columnCount == 0) {
@@ -4670,7 +4660,10 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * @see TableColumnModelListener
      */
     public void columnAdded(TableColumnModelEvent e) {
-        columnWidthsInitialized = false;
+        if (columnWidthsInitialized) {
+            TableColumn column = columnModel.getColumn(e.getToIndex());
+            column.setWidth(column.getPreferredWidth());
+        }
         // If I'm currently editing, then I should stop editing
         if (isEditing()) {
             removeEditor();
@@ -4687,7 +4680,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * @see TableColumnModelListener
      */
     public void columnRemoved(TableColumnModelEvent e) {
-        columnWidthsInitialized = false;
         // If I'm currently editing, then I should stop editing
         if (isEditing()) {
             removeEditor();

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -4684,10 +4684,10 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * Application code will not use these methods explicitly, they
      * are used internally by JTable.
      *
-        columnWidthsInitialized = false;
      * @see TableColumnModelListener
      */
     public void columnRemoved(TableColumnModelEvent e) {
+        columnWidthsInitialized = false;
         // If I'm currently editing, then I should stop editing
         if (isEditing()) {
             removeEditor();

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -453,6 +453,14 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * needed.
      */
     private boolean columnSelectionAdjusting;
+
+    /*
+     * True after column widths have been initialized/synchronized by layout.
+     * Used to distinguish the first preferred-width layout from later normal
+     * AUTO_RESIZE_LAST_COLUMN layouts.
+     */
+    private boolean columnWidthsInitialized;
+
     /**
      * The last value of getValueIsAdjusting from the row selection models
      * valueChanged notification. Used to test if a repaint is needed.
@@ -3187,7 +3195,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      */
 
     public void doLayout() {
-        boolean prefWidthSet = false;
         TableColumn resizingColumn = getResizingColumn();
         if (resizingColumn == null) {
             setWidthsFromPreferredWidths(false);
@@ -3304,27 +3311,22 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             return;
         }
 
-        int totalWidth = getWidth();
-        int total = 0;
-
         for (int i = 0; i < columnCount - 1; i++) {
             TableColumn column = columnModel.getColumn(i);
-            int width = column.getPreferredWidth();
-            column.setWidth(width);
-            total += width;
+            column.setWidth(column.getPreferredWidth());
         }
 
-        TableColumn lastColumn = columnModel.getColumn(columnCount - 1);
-        lastColumn.setWidth(totalWidth - total);
+        accommodateLastColumnOnly();
     }
 
     private void setWidthsFromPreferredWidths(final boolean inverse) {
         if (!inverse && autoResizeMode == AUTO_RESIZE_LAST_COLUMN) {
-            if (isInitialPreferredWidthLayout()) {
+            if (!columnWidthsInitialized) {
                 setWidthsFromPreferredWidthsLastColumnOnly();
             } else {
                 accommodateLastColumnOnly();
             }
+            columnWidthsInitialized = true;
             return;
         }
         int totalWidth     = getWidth();
@@ -3355,6 +3357,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         };
 
         adjustSizes(target, r, inverse);
+        columnWidthsInitialized = true;
     }
 
 
@@ -3853,6 +3856,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         if (columnModel == null) {
             throw new IllegalArgumentException("Cannot set a null ColumnModel");
         }
+        columnWidthsInitialized = false;
         TableColumnModel old = this.columnModel;
         if (columnModel != old) {
             if (old != null) {
@@ -4666,6 +4670,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * @see TableColumnModelListener
      */
     public void columnAdded(TableColumnModelEvent e) {
+        columnWidthsInitialized = false;
         // If I'm currently editing, then I should stop editing
         if (isEditing()) {
             removeEditor();
@@ -4679,6 +4684,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * Application code will not use these methods explicitly, they
      * are used internally by JTable.
      *
+        columnWidthsInitialized = false;
      * @see TableColumnModelListener
      */
     public void columnRemoved(TableColumnModelEvent e) {

--- a/test/jdk/javax/swing/JTable/TestAutoResizeLastColumn.java
+++ b/test/jdk/javax/swing/JTable/TestAutoResizeLastColumn.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8234071 8387267
+ * @summary AUTO_RESIZE_LAST_COLUMN should resize only the last column during table layout
+ * @run main TestAutoResizeLastColumn
+ */
+
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.TableColumnModel;
+
+public class TestAutoResizeLastColumn {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(TestAutoResizeLastColumn::testLastColumnOnly);
+    }
+
+    private static void testLastColumnOnly() {
+        JTable table = new JTable(3, 3);
+        table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
+
+        table.getTableHeader().setResizingColumn(null);
+
+        TableColumnModel cm = table.getColumnModel();
+        for (int i = 0; i < cm.getColumnCount(); i++) {
+            cm.getColumn(i).setMinWidth(10);
+            cm.getColumn(i).setPreferredWidth(100);
+            cm.getColumn(i).setWidth(100);
+        }
+
+        table.setSize(300, 100);
+        table.doLayout();
+
+        assertWidth(cm, 0, 100);
+        assertWidth(cm, 1, 100);
+        assertWidth(cm, 2, 100);
+
+        table.setSize(360, 100);
+        table.doLayout();
+
+        /*
+         * AUTO_RESIZE_LAST_COLUMN means the +60 delta is absorbed by
+         * the last column only.
+         * Without fix all columns width will change to 120.
+         */
+        assertWidth(cm, 0, 100);
+        assertWidth(cm, 1, 100);
+        assertWidth(cm, 2, 160);
+
+        table.setSize(330, 100);
+        table.doLayout();
+
+        assertWidth(cm, 0, 100);
+        assertWidth(cm, 1, 100);
+        assertWidth(cm, 2, 130);
+    }
+
+    private static void assertWidth(TableColumnModel cm, int column, int expected) {
+        int actual = cm.getColumn(column).getWidth();
+        if (actual != expected) {
+            throw new RuntimeException(
+                    "Unexpected width for column " + column
+                            + ": expected " + expected
+                            + ", actual " + actual);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTable/TestAutoResizeLastColumn.java
+++ b/test/jdk/javax/swing/JTable/TestAutoResizeLastColumn.java
@@ -41,7 +41,10 @@ public class TestAutoResizeLastColumn {
         JTable table = new JTable(3, 3);
         table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
 
-        table.getTableHeader().setResizingColumn(null);
+        if (table.getTableHeader().getResizingColumn() != null) {
+            throw new RuntimeException(
+                    "AUTO_RESIZE_LAST_COLUMN must not set resizingColumn");
+        }
 
         TableColumnModel cm = table.getColumnModel();
         for (int i = 0; i < cm.getColumnCount(); i++) {


### PR DESCRIPTION
When JTable.setAutoResizeMode is called with JTable.AUTO_RESIZE_LAST_COLUMN, 
 it is supposed to adjust the delta width to the last column only when table itself changes width
 but before JDK-8234071 fix, AUTO_RESIZE_LAST_COLUMN, was behaving exactly as if user specified AUTO_RESIZE_ALL_COLUMNS
 so width of all columns of table gets adjusted. 
 
 JDK-8234071 fixes this issue by setting "resizingColumn" to last column when AUTO_RESIZE_LAST_COLUMN is specified so that only last column gets resized
 but the fix was wrongly instructing the JTable that the user is currently resizing the last column with the mouse
 so JTable started believing a header resize was active even during normal layout, window resizing or cell editing
 thus it caused side-effects like initial preferred column widths was ignored as seen in JDK-8375573
 and real mouse resizing of another column was conflicting with the “last column is resizing” state as mousePressed/Released uses "resizingColumn" to ensure a certain column is getting resized
 and editing is disturbed because JTable thought column resizing/layout activity is happening as seen in this particular issue.

 The issue is that a left click on an editable cell starts editing and then selects the cell. 
 Selecting the cell scrolls it into view, which revalidates the table and runs doLayout(). 
 Because the header now permanently reports a resizing column, the layout pass adjusts a column's preferred width 
 and fires TableColumnModelListener.columnMarginChanged(). JTable.columnMarginChanged() stops the active cell editor.
 
 Also, after a user drags the first column header divider, resizingColumn is reset to null in `BasicTableHeaderUI.mouseReleased` and
 JTable then syncs preferred widths from actual widths using `setWidthsFromPreferredWidths(true)`. 
 Later, when the dialog is resized, `setWidthsFromPreferredWidths(false)` runs again and all columns are recalculated so AUTO_RESIZE_LAST_COLUMN was not honoured
 
 Fix is made to handle AUTO_RESIZE_LAST_COLUMN in the layout code
 so the width distribution logic ensures that
  During normal window/dialog resize: change is made only to the last column.
  During initial layout: honors the user’s preferred widths, then let the last column absorbs extra space.
  During real header drag: allows the dragged column to resize, and uses the last column to compensate.
  and it doesn't hamper editing of any cell in last column when double-clicked




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8387267](https://bugs.openjdk.org/browse/JDK-8387267): Editor for the last column in JTable is hard to activate after AUTO_RESIZE_LAST_COLUMN was configured (**Bug** - P3)
 * [JDK-8388467](https://bugs.openjdk.org/browse/JDK-8388467): Test "api/javax_swing/interactive/JTableTests.html" JTable freezes during rapid column resize (**Bug** - P5)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - no project role)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31704/head:pull/31704` \
`$ git checkout pull/31704`

Update a local copy of the PR: \
`$ git checkout pull/31704` \
`$ git pull https://git.openjdk.org/jdk.git pull/31704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31704`

View PR using the GUI difftool: \
`$ git pr show -t 31704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31704.diff">https://git.openjdk.org/jdk/pull/31704.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31704#issuecomment-4829173232)
</details>
