### PR TITLE
8387387: Parallel: Clean up startup allocation locking

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -315,17 +315,16 @@ HeapWord* ParallelScavengeHeap::mem_allocate_work(size_t size, bool is_tlab) {
         return result;
       }
 
+      // Ensure that is_init_completed() does not transition while expanding the heap.
+      ConditionalMutexLocker ml_init(InitCompleted_lock, !is_init_completed(), Mutex::_no_safepoint_check_flag);
       if (!is_init_completed()) {
-        // Double checked locking, this ensure that is_init_completed() does not
-        // transition while expanding the heap.
-        MonitorLocker ml(InitCompleted_lock, Monitor::_no_safepoint_check_flag);
-        if (!is_init_completed()) {
-          result = expand_heap_and_allocate(size, is_tlab);
-          // Return the result if it's tlab-allocation. If the result is null, callers will retry
-          // non-tlab allocation.
-          if (result != nullptr || is_tlab) {
-            return result;
-          }
+        // Rechecked !is_init_completed() implies we have mutual exclusion via
+        // `Heap_lock` and `InitCompleted_lock`
+        result = expand_heap_and_allocate(size, is_tlab);
+        // Return the result if it's tlab-allocation. If the result is null,
+        // callers will retry non-tlab allocation.
+        if (result != nullptr || is_tlab) {
+          return result;
         }
       }
     }


### PR DESCRIPTION
Simple cleanup in `ParallelScavengeHeap::mem_allocate_work`, which restructures the pre-initialization heap expansion check to use `ConditionalMutexLocker` for `InitCompleted_lock`, matching the nearby `Heap_lock` pattern, and polishes the comments around the locking invariant. There is no intended behavior change.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387387](https://bugs.openjdk.org/browse/JDK-8387387): Parallel: Clean up startup allocation locking (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31705/head:pull/31705` \
`$ git checkout pull/31705`

Update a local copy of the PR: \
`$ git checkout pull/31705` \
`$ git pull https://git.openjdk.org/jdk.git pull/31705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31705`

View PR using the GUI difftool: \
`$ git pr show -t 31705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31705.diff">https://git.openjdk.org/jdk/pull/31705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31705#issuecomment-4829761728)
</details>
