### PR TITLE
8387391: hotspot_gc_shenandoah should include gtests

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -314,7 +314,8 @@ tier1_gc_shenandoah = \
   gc/shenandoah/compiler/ \
   gc/shenandoah/mxbeans/ \
   gc/shenandoah/TestSmallHeap.java \
-  gc/shenandoah/oom/
+  gc/shenandoah/oom/ \
+  gtest/ShenandoahGtests.java
 
 tier2_gc_shenandoah = \
   runtime/MemberName/MemberNameLeak.java \

--- a/test/hotspot/jtreg/gtest/ShenandoahGtests.java
+++ b/test/hotspot/jtreg/gtest/ShenandoahGtests.java
@@ -25,8 +25,6 @@
 /* @test
  * @summary Run Shenandoah gtests
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.xml
  * @requires vm.gc.Shenandoah
  * @requires vm.debug
  * @run main/native GTestWrapper --gtest_filter=Shenandoah*

--- a/test/hotspot/jtreg/gtest/ShenandoahGtests.java
+++ b/test/hotspot/jtreg/gtest/ShenandoahGtests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/* @test
+ * @summary Run Shenandoah gtests
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @requires vm.gc.Shenandoah
+ * @requires vm.debug
+ * @run main/native GTestWrapper --gtest_filter=Shenandoah*
+ */


### PR DESCRIPTION
There are some Shenandoah gtests, but they are not included in our standard hotspot_gc_shenandoah that we use for sanity checks. We need to add Shenandoah gtests to hotspot_gc_shenandoah. 

Additional testing:
 - [x] Sanity-checking the test reports with `hotspot_gc_shenandoah`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387391](https://bugs.openjdk.org/browse/JDK-8387391): hotspot_gc_shenandoah should include gtests (**Enhancement** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31706/head:pull/31706` \
`$ git checkout pull/31706`

Update a local copy of the PR: \
`$ git checkout pull/31706` \
`$ git pull https://git.openjdk.org/jdk.git pull/31706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31706`

View PR using the GUI difftool: \
`$ git pr show -t 31706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31706.diff">https://git.openjdk.org/jdk/pull/31706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31706#issuecomment-4830647747)
</details>
