### PR TITLE
8387393: Problemlist compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java on Windows AArch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -70,6 +70,8 @@ compiler/c2/aarch64/TestStaticCallStub.java 8359963 generic-aarch64
 
 compiler/unsafe/AlignmentGapAccess.java 8373487 generic-all
 
+compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java 8387392 windows-aarch64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Seeing this test consistently failing in current GHA testing, problemlisting to reduce noise.

Additional testing:
 - [x] GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387393](https://bugs.openjdk.org/browse/JDK-8387393): Problemlist compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java on Windows AArch64 (**Sub-task** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31707/head:pull/31707` \
`$ git checkout pull/31707`

Update a local copy of the PR: \
`$ git checkout pull/31707` \
`$ git pull https://git.openjdk.org/jdk.git pull/31707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31707`

View PR using the GUI difftool: \
`$ git pr show -t 31707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31707.diff">https://git.openjdk.org/jdk/pull/31707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31707#issuecomment-4830714360)
</details>
