### PR TITLE
8387258: Test jdk/jfr/event/runtime/TestResidentSetSizeEvent.java failed on Windows: The size should be less than or equal to peak

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -6387,7 +6387,7 @@ void os::jfr_report_memory_info() {
     // Send the RSS JFR event
     EventResidentSetSize event;
     event.set_size(pmex.WorkingSetSize);
-    event.set_peak(pmex.PeakWorkingSetSize);
+    event.set_peak(MAX2(pmex.PeakWorkingSetSize, pmex.WorkingSetSize));
     event.commit();
   } else {
     // Log a warning


### PR DESCRIPTION
Hi all,

  please review this small fix to avoid inconsistencies with Windows' RSS current/peak usage.

The documentation for this function does not mention any kind of consistency guarantee, so apply the same fix as for all other OSes in that area.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387258](https://bugs.openjdk.org/browse/JDK-8387258): Test jdk/jfr/event/runtime/TestResidentSetSizeEvent.java failed on Windows: The size should be less than or equal to peak (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31708/head:pull/31708` \
`$ git checkout pull/31708`

Update a local copy of the PR: \
`$ git checkout pull/31708` \
`$ git pull https://git.openjdk.org/jdk.git pull/31708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31708`

View PR using the GUI difftool: \
`$ git pr show -t 31708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31708.diff">https://git.openjdk.org/jdk/pull/31708.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31708#issuecomment-4833128817)
</details>
