### PR TITLE
8387403: BUILD_LIBJAVA remove special warning settings

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -57,8 +57,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     ProcessImpl_md.c_CFLAGS := $(VERSION_CFLAGS), \
     java_props_md.c_CFLAGS := \
         -DARCHPROPNAME='"$(OPENJDK_TARGET_CPU_OSARCH)"', \
-    DISABLED_WARNINGS_gcc_ProcessImpl_md.c := unused-result, \
-    DISABLED_WARNINGS_clang_TimeZone_md.c := unused-variable, \
     JDK_LIBS := libjvm, \
     LIBS_linux := $(LIBDL), \
     LIBS_aix := $(LIBDL) $(LIBM), \

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -41,17 +41,11 @@
 #include "TimeZone_md.h"
 #include "path_util.h"
 
-#define fileopen        fopen
-#define filegets        fgets
-#define fileclose       fclose
-
-#if defined(__linux__) || defined(_ALLBSD_SOURCE)
+#if defined(__linux__) || defined(MACOSX)
 static const char *ZONEINFO_DIR = "/usr/share/zoneinfo";
 static const char *DEFAULT_ZONEINFO_FILE = "/etc/localtime";
 static const char popularZones[][4] = {"UTC", "GMT"};
-#endif /* defined(__linux__) || defined(_ALLBSD_SOURCE) */
 
-#if defined(__linux__) || defined(MACOSX)
 static char *isFileIdentical(char* buf, size_t size, char *pathname);
 
 /*
@@ -116,7 +110,7 @@ getPathName(const char *dir, const char *name) {
 /*
  * Scans the specified directory and its subdirectories to find a
  * zoneinfo file which has the same content as /etc/localtime on Linux
- * or /usr/share/lib/zoneinfo/localtime on Solaris given in 'buf'.
+ * given in 'buf'.
  * If file is symbolic link, then the contents it points to are in buf.
  * Returns a zone ID if found, otherwise, NULL is returned.
  */

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -48,13 +48,8 @@
 #if defined(__linux__) || defined(_ALLBSD_SOURCE)
 static const char *ZONEINFO_DIR = "/usr/share/zoneinfo";
 static const char *DEFAULT_ZONEINFO_FILE = "/etc/localtime";
-#else
-static const char *SYS_INIT_FILE = "/etc/default/init";
-static const char *ZONEINFO_DIR = "/usr/share/lib/zoneinfo";
-static const char *DEFAULT_ZONEINFO_FILE = "/usr/share/lib/zoneinfo/localtime";
-#endif /* defined(__linux__) || defined(_ALLBSD_SOURCE) */
-
 static const char popularZones[][4] = {"UTC", "GMT"};
+#endif /* defined(__linux__) || defined(_ALLBSD_SOURCE) */
 
 #if defined(__linux__) || defined(MACOSX)
 static char *isFileIdentical(char* buf, size_t size, char *pathname);
@@ -542,7 +537,6 @@ char *
 getGMTOffsetID()
 {
     char buf[32];
-    char offset[6];
     struct tm localtm;
     time_t clock = time(NULL);
     if (localtime_r(&clock, &localtm) == NULL) {
@@ -576,6 +570,7 @@ getGMTOffsetID()
     snprintf(buf, sizeof(buf), (const char *)"GMT%c%02.2d:%02.2d",
             gmt_off < 0 ? '-' : '+' , abs(gmt_off / 60), gmt_off % 60);
 #else
+    char offset[6];
     if (strftime(offset, 6, "%z", &localtm) != 5) {
         return strdup("GMT");
     }

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -464,7 +464,7 @@ tzerr:
     return javatz;
 }
 
-#endif /* defined(_AIX) */
+#endif /* defined(__linux__) || defined(MACOSX) || defined(_AIX) */
 
 /*
  * findJavaTZ_md() maps platform time zone ID to Java time zone ID


### PR DESCRIPTION
BUILD_LIBJAVA has some warnings disabled, this can be adjusted.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387403](https://bugs.openjdk.org/browse/JDK-8387403): BUILD_LIBJAVA remove special warning settings (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [617d5d88](https://git.openjdk.org/jdk/pull/31709/files/617d5d888531201088057631ad78ef4edf805ce5)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31709/head:pull/31709` \
`$ git checkout pull/31709`

Update a local copy of the PR: \
`$ git checkout pull/31709` \
`$ git pull https://git.openjdk.org/jdk.git pull/31709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31709`

View PR using the GUI difftool: \
`$ git pr show -t 31709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31709.diff">https://git.openjdk.org/jdk/pull/31709.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31709#issuecomment-4831968995)
</details>
