### PR TITLE
8387206: G1: Code root verification crashes because of stale table scanner

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -415,6 +415,8 @@ bool G1HeapRegion::verify_code_roots(VerifyOption vo) const {
     return has_code_roots;
   }
 
+  rem_set()->reset_code_root_table_scanner();
+
   VerifyCodeRootNMethodClosure nm_cl(this);
   code_roots_do(&nm_cl);
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
@@ -87,8 +87,12 @@ void G1HeapRegionRemSet::clear(bool only_cardset, bool keep_tracked) {
   }
 }
 
-void G1HeapRegionRemSet::reset_table_scanner() {
+void G1HeapRegionRemSet::reset_code_root_table_scanner() {
   _code_roots.reset_table_scanner();
+}
+
+void G1HeapRegionRemSet::reset_table_scanner() {
+  reset_code_root_table_scanner();
   if (has_cset_group()) {
     card_set()->reset_table_scanner();
   }

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
@@ -154,6 +154,7 @@ public:
   // entries for this region in other remsets.
   void clear(bool only_cardset = false, bool keep_tracked = false);
 
+  void reset_code_root_table_scanner();
   void reset_table_scanner();
 
   G1MonotonicArenaMemoryStats card_set_memory_stats() const;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [22313f85](https://github.com/openjdk/jdk/commit/22313f85bac81e68e318976ff69439658d0a602f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 29 Jun 2026 and was reviewed by Ivan Walulya.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387206](https://bugs.openjdk.org/browse/JDK-8387206): G1: Code root verification crashes because of stale table scanner (**Bug** - P3)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31711/head:pull/31711` \
`$ git checkout pull/31711`

Update a local copy of the PR: \
`$ git checkout pull/31711` \
`$ git pull https://git.openjdk.org/jdk.git pull/31711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31711`

View PR using the GUI difftool: \
`$ git pr show -t 31711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31711.diff">https://git.openjdk.org/jdk/pull/31711.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31711#issuecomment-4832616891)
</details>
