### PR TITLE
8387306: Replace InputStream#read(byte[]) with InputStream#readNBytes(int) in RtfConverter.isRtfFile()

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/RtfConverter.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/RtfConverter.java
@@ -46,11 +46,11 @@ sealed interface RtfConverter {
         }
 
         try (InputStream fin = Files.newInputStream(path)) {
-            byte[] firstBits = new byte[7];
+            byte[] firstBits = fin.readNBytes(Details.RTF_HEADER.length());
 
-            if (fin.read(firstBits) == firstBits.length) {
+            if (Details.RTF_HEADER.length() == firstBits.length) {
                 String header = new String(firstBits);
-                return "{\\rtf1\\".equals(header);
+                return Details.RTF_HEADER.equals(header);
             }
         }
 
@@ -136,5 +136,6 @@ sealed interface RtfConverter {
             }
         }
 
+        private static final String RTF_HEADER = "{\\rtf1\\";
     }
 }


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jdk/pull/31681 PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387306](https://bugs.openjdk.org/browse/JDK-8387306): Replace InputStream#read(byte[]) with InputStream#readNBytes(int) in RtfConverter.isRtfFile() (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31712/head:pull/31712` \
`$ git checkout pull/31712`

Update a local copy of the PR: \
`$ git checkout pull/31712` \
`$ git pull https://git.openjdk.org/jdk.git pull/31712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31712`

View PR using the GUI difftool: \
`$ git pr show -t 31712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31712.diff">https://git.openjdk.org/jdk/pull/31712.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31712#issuecomment-4832799598)
</details>
