### PR TITLE
8383823: C2: Meet not symmetric for TypeAryKlassPtr types

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6182,6 +6182,16 @@ const TypeOopPtr* TypeAryKlassPtr::as_instance_type(bool klass_change) const {
   return TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(el, TypeInt::POS), k, xk, 0);
 }
 
+static const Type* lower_klassptr(const Type* t) {
+  const TypeKlassPtr* kptr = t->isa_klassptr();
+  if (kptr == nullptr) {
+    return nullptr;
+  }
+  if (kptr->ptr() == TypePtr::AnyNull) {
+    return kptr->cast_to_ptr_type(TypePtr::NotNull);
+  }
+  return t;
+}
 
 //------------------------------xmeet------------------------------------------
 // Compute the MEET of two types, return a new Type object.
@@ -6261,9 +6271,22 @@ const Type    *TypeAryKlassPtr::xmeet( const Type *t ) const {
     const Type* elem = _elem->meet(tap->_elem);
 
     PTR ptr = meet_ptr(tap->ptr());
+    PTR old_ptr = ptr;
     ciKlass* res_klass = nullptr;
     bool res_xk = false;
-    meet_aryptr(ptr, elem, this, tap, res_klass, res_xk);
+    TypePtr::MeetResult result = meet_aryptr(ptr, elem, this, tap, res_klass, res_xk);
+    // If the outer AryKlassPtr was widened from Constant to NotNull, re-meet
+    // the lowered element KlassPtrs so the element follows the outer widening.
+    if (result == TypePtr::NOT_SUBTYPE &&
+        old_ptr == TypePtr::Constant &&
+        ptr == TypePtr::NotNull) {
+      const Type* e1 = lower_klassptr(_elem);
+      const Type* e2 = lower_klassptr(tap->_elem);
+      if (e1 != nullptr && e2 != nullptr &&
+          (e1 != _elem || e2 != tap->_elem)) {
+        elem = e1->meet(e2);
+      }
+    }
     assert(res_xk == (ptr == Constant), "");
     return make(ptr, elem, res_klass, off);
   } // End of case KlassPtr


### PR DESCRIPTION
**Description:**

While working on another C2 type-analysis PR (https://github.com/openjdk/jdk/pull/30690), I used `TypeKlassPtr::filter()`. This exposed a `Meet Not Symmetric` assert in some GHA test jobs involving `TypeAryKlassPtr`.

The issue is in `TypeAryKlassPtr::xmeet()`.  `meet_aryptr()` may widen the outer array klass pointer from Constant to NotNull, but the element klass pointer may still keep the more precise type computed before that widening.The resulting `TypeAryKlassPtr` can then fail the meet/dual symmetry check and trigger the `Meet Not Symmetric` assert.

**Solution:**

When `meet_aryptr()` returns `NOT_SUBTYPE` and widens the outer array klass pointer from Constant to NotNull, recompute the element klass pointer meet after lowering AnyNull element klass pointers to NotNull.

**Test:**

GHA

No standalone regression test has been added yet.  I have not yet been able to reduce the failure to a small standalone test case.

The issue is reproducible through the other in-progress C2 type-analysis PR (https://github.com/openjdk/jdk/pull/30690) which uses `TypeKlassPtr::filter()`. With this fix applied, the `Meet Not Symmetric` assert no longer reproduces in those GHA test jobs.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-BoldItalic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Italic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif.woff)

### Issue
 * [JDK-8383823](https://bugs.openjdk.org/browse/JDK-8383823): C2: Meet not symmetric for TypeAryKlassPtr types (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31714/head:pull/31714` \
`$ git checkout pull/31714`

Update a local copy of the PR: \
`$ git checkout pull/31714` \
`$ git pull https://git.openjdk.org/jdk.git pull/31714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31714`

View PR using the GUI difftool: \
`$ git pr show -t 31714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31714.diff">https://git.openjdk.org/jdk/pull/31714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31714#issuecomment-4833849085)
</details>
