### PR TITLE
8387259: Clarify extlang in Locale composition description

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -120,9 +120,13 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   {@code Locale} always canonicalizes to lower case.</dd>
  *
  *   <dd> <em>Syntax:</em> Well-formed {@code language} values have the form {@code [a-zA-Z]{2,8}}.</dd>
- *   <dd> <em> BCP 47 deviation:</em> this is not the full BCP 47 language production, since it excludes
+ *   <dd> <em> BCP 47 deviation:</em> {@code Locale} does not retain the
  *   <a href="https://www.rfc-editor.org/rfc/rfc5646#section-2.2.2">extlang</a>
- *   (as modern three-letter language codes are preferred).</dd>
+ *   subtag. This is because three-letter language codes are preferred over extlang
+ *   subtags. When a {@code Locale} is created from a language tag containing an
+ *   extlang subtag, the first extlang subtag is interpreted as the <i>language</i>
+ *   field. The primary language subtag and any subsequent extlang subtags
+ *   are ignored.</dd>
  *
  *   <dd> <em>Example:</em> "en" (English), "ja" (Japanese), "kok" (Konkani)</dd>
  *


### PR DESCRIPTION
This pull request contains a backport of commit [db24b35a](https://github.com/openjdk/jdk/commit/db24b35a30cd28fda1f37d5e5e4a7241bdeeff3c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. It is a doc-only change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8387316](https://bugs.openjdk.org/browse/JDK-8387316) to be approved

### Issues
 * [JDK-8387259](https://bugs.openjdk.org/browse/JDK-8387259): Clarify extlang in Locale composition description (**Bug** - P4)
 * [JDK-8387316](https://bugs.openjdk.org/browse/JDK-8387316): Clarify extlang in Locale composition description (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31716/head:pull/31716` \
`$ git checkout pull/31716`

Update a local copy of the PR: \
`$ git checkout pull/31716` \
`$ git pull https://git.openjdk.org/jdk.git pull/31716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31716`

View PR using the GUI difftool: \
`$ git pr show -t 31716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31716.diff">https://git.openjdk.org/jdk/pull/31716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31716#issuecomment-4834962749)
</details>
