### PR TITLE
8387381: RISC-V: assert failed with fastdebug build on systems with different core types

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -261,13 +261,16 @@ void RiscvHwprobe::add_features_from_query_result() {
 
   // ====== non-extensions ======
   //
-  if (is_valid(RISCV_HWPROBE_KEY_MARCHID)) {
+  // For value-type keys, the kernel returns (uint64_t)-1 when CPUs in the
+  // query set disagree (different core types). Skip these as the value is
+  // not meaningful for the system as a whole.
+  if (is_valid(RISCV_HWPROBE_KEY_MARCHID) && query[RISCV_HWPROBE_KEY_MARCHID].value != (uint64_t)-1) {
     VM_Version::marchid.enable_feature(query[RISCV_HWPROBE_KEY_MARCHID].value);
   }
-  if (is_valid(RISCV_HWPROBE_KEY_MIMPID)) {
+  if (is_valid(RISCV_HWPROBE_KEY_MIMPID) && query[RISCV_HWPROBE_KEY_MIMPID].value != (uint64_t)-1) {
     VM_Version::mimpid.enable_feature(query[RISCV_HWPROBE_KEY_MIMPID].value);
   }
-  if (is_valid(RISCV_HWPROBE_KEY_MVENDORID)) {
+  if (is_valid(RISCV_HWPROBE_KEY_MVENDORID) && query[RISCV_HWPROBE_KEY_MVENDORID].value != (uint64_t)-1) {
     VM_Version::mvendorid.enable_feature(query[RISCV_HWPROBE_KEY_MVENDORID].value);
   }
   // RISCV_HWPROBE_KEY_CPUPERF_0 is deprecated and returns similar values


### PR DESCRIPTION
HI, Can you help to review this patch? Thanks!
Here is a crash with a fastdebug build on SpacemiT Key Stone K3, which has different core types.
```
zifeihan@riscv-spacemitk3picoitx:~$ cat /proc/cpuinfo | grep -i march
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000058000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
marchid		: 0x8000000041000002
zifeihan@riscv-spacemitk3picoitx:~$ cat /home/zifeihan/jdk/make/hs_err_pid1348135.log | head -100
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/zifeihan/jdk/src/hotspot/cpu/riscv/vm_version_riscv.hpp:206), pid=1348135, tid=1348139
#  assert(value != DEFAULT_VALUE) failed: Sanity
#
# JRE version:  (28.0) (fastdebug build )
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 28-internal-adhoc.zifeihan.jdk, mixed mode, tiered, compressed oops, compact obj headers, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x14ce4cc]  RiscvHwprobe::add_features_from_query_result()+0x6fa
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
#

---------------  S U M M A R Y ------------

Command Line: -Denv.class.path= -Dapplication.home=/home/zifeihan/jdk/build/linux-riscv64-server-fastdebug/jdk --add-modules=ALL-DEFAULT -Xms8m -Djava.io.tmpdir=/home/zifeihan/jdk/build/linux-riscv64-server-fastdebug/support/javatmp -Djdk.module.main=jdk.compiler jdk.compiler/com.sun.tools.javac.Main -g -Xlint:all -source 28 -target 28 -implicit:none -Xprefer:source -XDignore.symbol.file=true --add-modules jdk.compiler,jdk.jdeps --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED -encoding utf-8 -Werror -Xlint:-options -XDmodifiedInputs=/home/zifeihan/jdk/build/linux-riscv64-server-fastdebug/buildtools/create_symbols_javac/_the.COMPILE_CREATE_SYMBOLS_batch.modfiles.fixed -d /home/zifeihan/jdk/build/linux-riscv64-server-fastdebug/buildtools/create_symbols_javac @/home/zifeihan/jdk/build/linux-riscv64-server-fastdebug/buildtools/create_symbols_javac/_the.COMPILE_CREATE_SYMBOLS_batch.filelist

Host: riscv-spacemitk3picoitx, RISCV64, 16 cores, 31G, Bianbu 4.0rc2
Time: Sun Jun 28 22:36:53 2026 CST elapsed time: 0.121988 seconds (0d 0h 0m 0s)

---------------  T H R E A D  ---------------

Current thread (0x0000003f9402df50):  JavaThread "Unknown thread" [_thread_in_vm, id=1348139, stack(0x0000003f9ac00000,0x0000003f9ae00000) (2048K)]

Stack: [0x0000003f9ac00000,0x0000003f9ae00000],  sp=0x0000003f9adfba70,  free space=2030k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x14ce4cc]  RiscvHwprobe::add_features_from_query_result()+0x6fa  (vm_version_riscv.hpp:206)
V  [libjvm.so+0x14ce53a]  RiscvHwprobe::probe_features()+0x64
V  [libjvm.so+0x194ad48]  VM_Version::setup_cpu_available_features()+0x48
V  [libjvm.so+0x194d572]  VM_Version::common_initialize()+0x56
V  [libjvm.so+0x194dabc]  VM_Version::initialize()+0xc
V  [libjvm.so+0x19495d8]  VM_Version_init()+0x28
V  [libjvm.so+0xd7c4c6]  init_globals()+0x62
V  [libjvm.so+0x184f11a]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x35a
V  [libjvm.so+0xf4a174]  JNI_CreateJavaVM+0x64
C  [libjli.so+0x3aaa]  JavaMain+0x7c  (java.c:1494)
C  [libjli.so+0x76ca]  ThreadJavaMain+0xc  (java_md.c:646)
C  [libc.so.6+0x7799e]
```
On systems with different core types, the kernel hwprobe syscall returns (uint64_t)-1 as value for MARCHID/MIMPID when CPUs disagree[1]. RVNonExtFeatureValue uses the same -1 as its internal sentinel (DEFAULT_VALUE), so enable_feature(-1) hits the assert.

SpacemiT Key Stone K3 has X100 (marchid=0x8000000058000002) and A100 (marchid=0x8000000041000002) cores, querying all CPUs gives marchid=-1 and mimpid=-1.
Fix: use a separate bool _enabled flag instead of the sentinel value.
[1] https://docs.kernel.org/arch/riscv/hwprobe.html

```
For value-like keys (eg. vendor, arch, impl), the returned value will only be valid if all CPUs in the given set have the same value. Otherwise -1 will be returned. 
```

### Testing
- [x]  fastdebug build on SpacemiT Key Stone K3


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387381](https://bugs.openjdk.org/browse/JDK-8387381): RISC-V: assert failed with fastdebug build on systems with different core types (**Bug** - P4)


### Reviewers
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31717/head:pull/31717` \
`$ git checkout pull/31717`

Update a local copy of the PR: \
`$ git checkout pull/31717` \
`$ git pull https://git.openjdk.org/jdk.git pull/31717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31717`

View PR using the GUI difftool: \
`$ git pr show -t 31717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31717.diff">https://git.openjdk.org/jdk/pull/31717.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31717#issuecomment-4835074957)
</details>
