### PR TITLE
8386802: ClassFile Util.entryList should consider non-RandomAccess lists

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,16 +189,19 @@ public final class Util {
 
     public static List<ClassEntry> entryList(List<? extends ClassDesc> list) {
         var result = new Object[list.size()]; // null check
-        for (int i = 0; i < result.length; i++) {
-            result[i] = TemporaryConstantPool.INSTANCE.classEntry(list.get(i));
+        int i = 0;
+        for (var entry : list) {
+            result[i++] = TemporaryConstantPool.INSTANCE.classEntry(entry);
         }
         return SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(result);
     }
 
     public static List<ModuleEntry> moduleEntryList(List<? extends ModuleDesc> list) {
         var result = new Object[list.size()]; // null check
-        for (int i = 0; i < result.length; i++) {
-            result[i] = TemporaryConstantPool.INSTANCE.moduleEntry(TemporaryConstantPool.INSTANCE.utf8Entry(list.get(i).name()));
+        int i = 0;
+        for (var entry : list) {
+            result[i++] = TemporaryConstantPool.INSTANCE.moduleEntry(
+                    TemporaryConstantPool.INSTANCE.utf8Entry(entry.name()));
         }
         return SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(result);
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -200,8 +200,7 @@ public final class Util {
         var result = new Object[list.size()]; // null check
         int i = 0;
         for (var entry : list) {
-            result[i++] = TemporaryConstantPool.INSTANCE.moduleEntry(
-                    TemporaryConstantPool.INSTANCE.utf8Entry(entry.name()));
+            result[i++] = TemporaryConstantPool.INSTANCE.moduleEntry(entry);
         }
         return SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(result);
     }


### PR DESCRIPTION
As noted in https://bugs.openjdk.org/browse/JDK-8386802, `Util.entryList` and `Util.moduleEntryList` copy their input lists using indexed access. This is fine for `RandomAccess` lists but can be inefficient for sequentially-accessed implementations.

This patch keeps the existing indexed path for `RandomAccess` lists and falls back to iteration otherwise. Regression coverage is added for non-`RandomAccess` inputs.

Testing:
- `make CONF_CHECK=ignore java.base-java images`
- `make CONF_CHECK=ignore test-only TEST="test/jdk/jdk/classfile/UtilTest.java"`
- `make CONF_CHECK=ignore test-only TEST="test/jdk/jdk/classfile"`
- `make CONF_CHECK=ignore test-only TEST="test/jdk:tier1" JTREG="VERBOSE=summary"`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386802](https://bugs.openjdk.org/browse/JDK-8386802): ClassFile Util.entryList should consider non-RandomAccess lists (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31719/head:pull/31719` \
`$ git checkout pull/31719`

Update a local copy of the PR: \
`$ git checkout pull/31719` \
`$ git pull https://git.openjdk.org/jdk.git pull/31719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31719`

View PR using the GUI difftool: \
`$ git pr show -t 31719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31719.diff">https://git.openjdk.org/jdk/pull/31719.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31719#issuecomment-4837806344)
</details>
