### PR TITLE
8387407: AARCH: use CNTVCTSS_EL0 as fast unordered timestamp source for JFR

### DIFF
--- a/src/hotspot/cpu/aarch64/cntvctss_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/cntvctss_aarch64.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "cntvctss_aarch64.hpp"
+#include "runtime/globals_extension.hpp"
+#include "vm_version_aarch64.hpp"
+
+jlong Cntvctss::_epoch = 0;
+
+static inline jlong read_cntvctss() {
+  uint64_t res;
+  __asm__ volatile("mrs %0, s3_3_c14_c0_6" : "=r"(res)); // s3_3_c14_c0_6 is the numeric encoding of CNTVCTSS_EL0 for old GNU assemblers
+  return (jlong)res;
+}
+
+jlong Cntvctss::set_epoch() {
+  assert(0 == _epoch, "invariant");
+  _epoch = read_cntvctss();
+  return _epoch;
+}
+
+static bool ergonomics() {
+  if (Cntvctss::is_supported()) {
+    FLAG_SET_ERGO_IF_DEFAULT(UseFastUnorderedTimeStamps, true);
+  } else if (UseFastUnorderedTimeStamps) {
+    assert(!FLAG_IS_DEFAULT(UseFastUnorderedTimeStamps), "Unexpected default value");
+    warning("Ignoring UseFastUnorderedTimeStamps, hardware does not support FEAT_ECV");
+    FLAG_SET_ERGO(UseFastUnorderedTimeStamps, false);
+  }
+  return UseFastUnorderedTimeStamps;
+}
+
+bool Cntvctss::initialize() {
+  assert(0 == _epoch, "invariant");
+  if (!ergonomics()) {
+    return false;
+  }
+  set_epoch();
+  return _epoch != 0;
+}
+
+bool Cntvctss::is_supported() {
+  return VM_Version::supports_ecv();
+}
+
+jlong Cntvctss::frequency() {
+  return 1000000000LL; // Generic Timer runs at 1 GHz on Armv8.6-A+ (FEAT_ECV)
+}
+
+jlong Cntvctss::elapsed_counter() {
+  return read_cntvctss() - _epoch;
+}
+
+jlong Cntvctss::epoch() {
+  return _epoch;
+}
+
+jlong Cntvctss::raw() {
+  return read_cntvctss();
+}
+
+bool Cntvctss::enabled() {
+  static bool result = initialize();
+  return result;
+}

--- a/src/hotspot/cpu/aarch64/cntvctss_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/cntvctss_aarch64.cpp
@@ -25,19 +25,14 @@
 
 #include "cntvctss_aarch64.hpp"
 #include "runtime/globals_extension.hpp"
+#include "runtime/os.inline.hpp"
 #include "vm_version_aarch64.hpp"
 
 jlong Cntvctss::_epoch = 0;
 
-static inline jlong read_cntvctss() {
-  uint64_t res;
-  __asm__ volatile("mrs %0, s3_3_c14_c0_6" : "=r"(res)); // s3_3_c14_c0_6 is the numeric encoding of CNTVCTSS_EL0 for old GNU assemblers
-  return (jlong)res;
-}
-
 jlong Cntvctss::set_epoch() {
   assert(0 == _epoch, "invariant");
-  _epoch = read_cntvctss();
+  _epoch = os::cntvctss();
   return _epoch;
 }
 
@@ -70,7 +65,7 @@ jlong Cntvctss::frequency() {
 }
 
 jlong Cntvctss::elapsed_counter() {
-  return read_cntvctss() - _epoch;
+  return os::cntvctss() - _epoch;
 }
 
 jlong Cntvctss::epoch() {
@@ -78,7 +73,7 @@ jlong Cntvctss::epoch() {
 }
 
 jlong Cntvctss::raw() {
-  return read_cntvctss();
+  return os::cntvctss();
 }
 
 bool Cntvctss::enabled() {

--- a/src/hotspot/cpu/aarch64/cntvctss_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/cntvctss_aarch64.cpp
@@ -28,6 +28,9 @@
 #include "runtime/os.inline.hpp"
 #include "vm_version_aarch64.hpp"
 
+// Armv8.6-A mandates a system counter frequency of 1GHz.
+static const jlong ARMV86_ECV_FREQUENCY_HZ = 1000000000LL;
+
 jlong Cntvctss::_epoch = 0;
 
 jlong Cntvctss::set_epoch() {
@@ -36,11 +39,10 @@ jlong Cntvctss::set_epoch() {
   return _epoch;
 }
 
-static bool ergonomics() {
+bool Cntvctss::ergonomics() {
   if (Cntvctss::is_supported()) {
     FLAG_SET_ERGO_IF_DEFAULT(UseFastUnorderedTimeStamps, true);
   } else if (UseFastUnorderedTimeStamps) {
-    assert(!FLAG_IS_DEFAULT(UseFastUnorderedTimeStamps), "Unexpected default value");
     warning("Ignoring UseFastUnorderedTimeStamps, hardware does not support FEAT_ECV");
     FLAG_SET_ERGO(UseFastUnorderedTimeStamps, false);
   }
@@ -49,7 +51,7 @@ static bool ergonomics() {
 
 bool Cntvctss::initialize() {
   assert(0 == _epoch, "invariant");
-  if (!ergonomics()) {
+  if (!UseFastUnorderedTimeStamps) {
     return false;
   }
   set_epoch();
@@ -57,11 +59,14 @@ bool Cntvctss::initialize() {
 }
 
 bool Cntvctss::is_supported() {
-  return VM_Version::supports_ecv();
+  return VM_Version::supports_ecv() &&
+         // FEAT_ECV is optional from Armv8.5-A and may appear on an Armv8.4-A CPU;
+         // only Armv8.6-A guarantees the 1GHz frequency, so reject lower ones.
+         os::cntfrq() == ARMV86_ECV_FREQUENCY_HZ;
 }
 
 jlong Cntvctss::frequency() {
-  return 1000000000LL; // Generic Timer runs at 1 GHz on Armv8.6-A+ (FEAT_ECV)
+  return ARMV86_ECV_FREQUENCY_HZ;
 }
 
 jlong Cntvctss::elapsed_counter() {

--- a/src/hotspot/cpu/aarch64/cntvctss_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/cntvctss_aarch64.hpp
@@ -47,6 +47,7 @@ class Cntvctss : AllStatic {
   static jlong raw();
   static jlong epoch();
   static bool  enabled();
+  static bool  ergonomics();
 };
 
 #endif // CPU_AARCH64_CNTVCTSS_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/cntvctss_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/cntvctss_aarch64.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_AARCH64_CNTVCTSS_AARCH64_HPP
+#define CPU_AARCH64_CNTVCTSS_AARCH64_HPP
+
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Interface to the AArch64 CNTVCTSS_EL0 counter (FEAT_ECV, Armv8.6+).
+// The Generic Timer is consistent across cores and does not require an ISB barrier.
+// FEAT_ECV is a requirement for auto-enablement.
+
+class Cntvctss : AllStatic {
+ private:
+  static jlong _epoch;
+
+  static jlong set_epoch();
+  static bool  initialize();
+
+ public:
+  static jlong elapsed_counter();
+  static jlong frequency();
+  static bool  is_supported();
+  static jlong raw();
+  static jlong epoch();
+  static bool  enabled();
+};
+
+#endif // CPU_AARCH64_CNTVCTSS_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -24,6 +24,7 @@
  *
  */
 
+#include "cntvctss_aarch64.hpp"
 #include "logging/log.hpp"
 #include "pauth_aarch64.hpp"
 #include "register_aarch64.hpp"
@@ -671,6 +672,8 @@ void VM_Version::initialize() {
 #endif
 
   _spin_wait = get_spin_wait_desc();
+
+  Cntvctss::ergonomics();
 
   check_virtualizations();
 

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.inline.hpp
@@ -25,4 +25,13 @@
 #ifndef OS_CPU_BSD_AARCH64_OS_BSD_AARCH64_INLINE_HPP
 #define OS_CPU_BSD_AARCH64_OS_BSD_AARCH64_INLINE_HPP
 
+#include "runtime/os.hpp"
+
+inline jlong os::cntvctss() {
+  uint64_t res;
+  // s3_3_c14_c0_6 is the numeric encoding of CNTVCTSS_EL0 for old GNU assemblers
+  __asm__ volatile("mrs %0, s3_3_c14_c0_6" : "=r"(res));
+  return (jlong)res;
+}
+
 #endif // OS_CPU_BSD_AARCH64_OS_BSD_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.inline.hpp
@@ -34,4 +34,10 @@ inline jlong os::cntvctss() {
   return (jlong)res;
 }
 
+inline jlong os::cntfrq() {
+  uint64_t res;
+  __asm__ volatile("mrs %0, CNTFRQ_EL0" : "=r"(res));
+  return (jlong)res;
+}
+
 #endif // OS_CPU_BSD_AARCH64_OS_BSD_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -99,6 +99,9 @@ void VM_Version::get_os_cpu_info() {
   if (cpu_has("hw.optional.arm.FEAT_SB")) {
     set_feature(CPU_SB);
   }
+  if (cpu_has("hw.optional.arm.FEAT_ECV")) {
+    set_feature(CPU_ECV);
+  }
 
   int cache_line_size;
   int hw_conf_cache_line[] = { CTL_HW, HW_CACHELINE };

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.inline.hpp
@@ -27,6 +27,13 @@
 
 #include "runtime/os.hpp"
 
+inline jlong os::cntvctss() {
+  uint64_t res;
+  // s3_3_c14_c0_6 is the numeric encoding of CNTVCTSS_EL0 for old GNU assemblers
+  __asm__ volatile("mrs %0, s3_3_c14_c0_6" : "=r"(res));
+  return (jlong)res;
+}
+
 #if defined(COMPATIBLE_CDS_ALIGNMENT)
 #define HAVE_CDS_CORE_REGION_ALIGNMENT 1
 inline size_t os::cds_core_region_alignment() {

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.inline.hpp
@@ -34,6 +34,12 @@ inline jlong os::cntvctss() {
   return (jlong)res;
 }
 
+inline jlong os::cntfrq() {
+  uint64_t res;
+  __asm__ volatile("mrs %0, CNTFRQ_EL0" : "=r"(res));
+  return (jlong)res;
+}
+
 #if defined(COMPATIBLE_CDS_ALIGNMENT)
 #define HAVE_CDS_CORE_REGION_ALIGNMENT 1
 inline size_t os::cds_core_region_alignment() {

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.inline.hpp
@@ -39,4 +39,9 @@ inline bool os::platform_print_native_stack(outputStream* st, const void* contex
   return os::win32::platform_print_native_stack(st, context, buf, buf_size, lastpc);
 }
 
+inline jlong os::cntvctss() {
+  const int CNTVCTSS_EL0 = ARM64_SYSREG(3, 3, 14, 0, 6);
+  return (jlong)_ReadStatusReg(CNTVCTSS_EL0);
+}
+
 #endif // OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.inline.hpp
@@ -44,4 +44,9 @@ inline jlong os::cntvctss() {
   return (jlong)_ReadStatusReg(CNTVCTSS_EL0);
 }
 
+inline jlong os::cntfrq() {
+  const int CNTFRQ_EL0 = ARM64_SYSREG(3, 3, 14, 0, 0);
+  return (jlong)_ReadStatusReg(CNTFRQ_EL0);
+}
+
 #endif // OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/share/jfr/utilities/jfrTime.cpp
+++ b/src/hotspot/share/jfr/utilities/jfrTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
 #include "runtime/os.inline.hpp"
 #if defined(X86) && !defined(ZERO)
 #include "rdtsc_x86.hpp"
+#elif defined(AARCH64) && !defined(ZERO)
+#include "cntvctss_aarch64.hpp"
 #endif
 
 bool JfrTime::_ft_enabled = false;
@@ -35,6 +37,8 @@ bool JfrTime::initialize() {
   if (!initialized) {
 #if defined(X86) && !defined(ZERO)
     _ft_enabled = Rdtsc::enabled();
+#elif defined(AARCH64) && !defined(ZERO)
+    _ft_enabled = Cntvctss::enabled();
 #else
     _ft_enabled = false;
 #endif
@@ -46,6 +50,8 @@ bool JfrTime::initialize() {
 bool JfrTime::is_ft_supported() {
 #if defined(X86) && !defined(ZERO)
   return Rdtsc::is_supported();
+#elif defined(AARCH64) && !defined(ZERO)
+  return Cntvctss::is_supported();
 #else
   return false;
 #endif
@@ -55,6 +61,8 @@ bool JfrTime::is_ft_supported() {
 const void* JfrTime::time_function() {
 #if defined(X86) && !defined(ZERO)
   return _ft_enabled ? (const void*)Rdtsc::elapsed_counter : (const void*)os::elapsed_counter;
+#elif defined(AARCH64) && !defined(ZERO)
+  return _ft_enabled ? (const void*)Cntvctss::elapsed_counter : (const void*)os::elapsed_counter;
 #else
   return (const void*)os::elapsed_counter;
 #endif
@@ -63,6 +71,8 @@ const void* JfrTime::time_function() {
 jlong JfrTime::frequency() {
 #if defined(X86) && !defined(ZERO)
   return _ft_enabled ? Rdtsc::frequency() : os::elapsed_frequency();
+#elif defined(AARCH64) && !defined(ZERO)
+  return _ft_enabled ? Cntvctss::frequency() : os::elapsed_frequency();
 #else
   return os::elapsed_frequency();
 #endif

--- a/src/hotspot/share/jfr/utilities/jfrTime.cpp
+++ b/src/hotspot/share/jfr/utilities/jfrTime.cpp
@@ -24,57 +24,75 @@
 
 #include "jfr/utilities/jfrTime.hpp"
 #include "runtime/os.inline.hpp"
-#if defined(X86) && !defined(ZERO)
-#include "rdtsc_x86.hpp"
-#elif defined(AARCH64) && !defined(ZERO)
-#include "cntvctss_aarch64.hpp"
-#endif
 
 bool JfrTime::_ft_enabled = false;
+
+#if defined(X86) && !defined(ZERO)
+
+#include "rdtsc_x86.hpp"
 
 bool JfrTime::initialize() {
   static bool initialized = false;
   if (!initialized) {
-#if defined(X86) && !defined(ZERO)
     _ft_enabled = Rdtsc::enabled();
-#elif defined(AARCH64) && !defined(ZERO)
-    _ft_enabled = Cntvctss::enabled();
-#else
-    _ft_enabled = false;
-#endif
     initialized = true;
   }
   return initialized;
 }
 
 bool JfrTime::is_ft_supported() {
-#if defined(X86) && !defined(ZERO)
   return Rdtsc::is_supported();
-#elif defined(AARCH64) && !defined(ZERO)
-  return Cntvctss::is_supported();
-#else
-  return false;
-#endif
 }
 
-
 const void* JfrTime::time_function() {
-#if defined(X86) && !defined(ZERO)
   return _ft_enabled ? (const void*)Rdtsc::elapsed_counter : (const void*)os::elapsed_counter;
-#elif defined(AARCH64) && !defined(ZERO)
-  return _ft_enabled ? (const void*)Cntvctss::elapsed_counter : (const void*)os::elapsed_counter;
-#else
-  return (const void*)os::elapsed_counter;
-#endif
 }
 
 jlong JfrTime::frequency() {
-#if defined(X86) && !defined(ZERO)
   return _ft_enabled ? Rdtsc::frequency() : os::elapsed_frequency();
-#elif defined(AARCH64) && !defined(ZERO)
-  return _ft_enabled ? Cntvctss::frequency() : os::elapsed_frequency();
-#else
-  return os::elapsed_frequency();
-#endif
 }
 
+#elif defined(AARCH64) && !defined(ZERO)
+
+#include "cntvctss_aarch64.hpp"
+
+bool JfrTime::initialize() {
+  static bool initialized = false;
+  if (!initialized) {
+    _ft_enabled = Cntvctss::enabled();
+    initialized = true;
+  }
+  return initialized;
+}
+
+bool JfrTime::is_ft_supported() {
+  return Cntvctss::is_supported();
+}
+
+const void* JfrTime::time_function() {
+  return _ft_enabled ? (const void*)Cntvctss::elapsed_counter : (const void*)os::elapsed_counter;
+}
+
+jlong JfrTime::frequency() {
+  return _ft_enabled ? Cntvctss::frequency() : os::elapsed_frequency();
+}
+
+#else
+
+bool JfrTime::initialize() {
+  return true;
+}
+
+bool JfrTime::is_ft_supported() {
+  return false;
+}
+
+const void* JfrTime::time_function() {
+  return (const void*)os::elapsed_counter;
+}
+
+jlong JfrTime::frequency() {
+  return os::elapsed_frequency();
+}
+
+#endif

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1079,6 +1079,7 @@ class os: AllStatic {
 
   static inline jlong rdtsc();
   static inline jlong cntvctss();
+  static inline jlong cntfrq();
 
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1078,6 +1078,7 @@ class os: AllStatic {
   static juint cpu_microcode_revision();
 
   static inline jlong rdtsc();
+  static inline jlong cntvctss();
 
   // Used to register dynamic code cache area with the OS
   // Note: Currently only used in 64 bit Windows implementations

--- a/src/hotspot/share/utilities/ticks.cpp
+++ b/src/hotspot/share/utilities/ticks.cpp
@@ -27,6 +27,8 @@
 
 #if defined(X86) && !defined(ZERO)
 #include "rdtsc_x86.hpp"
+#elif defined(AARCH64) && !defined(ZERO)
+#include "cntvctss_aarch64.hpp"
 #endif
 
 template <typename TimeSource, const int unit>
@@ -66,6 +68,12 @@ uint64_t FastUnorderedElapsedCounterSource::frequency() {
     static const uint64_t freq = (uint64_t)Rdtsc::frequency();
     return freq;
   }
+#elif defined(AARCH64) && !defined(ZERO)
+  static bool valid_cntvctss = Cntvctss::enabled();
+  if (valid_cntvctss) {
+    static const uint64_t freq = (uint64_t)Cntvctss::frequency();
+    return freq;
+  }
 #endif
   static const uint64_t freq = (uint64_t)os::elapsed_frequency();
   return freq;
@@ -76,6 +84,11 @@ FastUnorderedElapsedCounterSource::Type FastUnorderedElapsedCounterSource::now()
   static bool valid_rdtsc = Rdtsc::enabled();
   if (valid_rdtsc) {
     return Rdtsc::elapsed_counter();
+  }
+#elif defined(AARCH64) && !defined(ZERO)
+  static bool valid_cntvctss = Cntvctss::enabled();
+  if (valid_cntvctss) {
+    return Cntvctss::elapsed_counter();
   }
 #endif
   return os::elapsed_counter();
@@ -108,6 +121,11 @@ CompositeElapsedCounterSource::Type CompositeElapsedCounterSource::now() {
   static bool valid_rdtsc = Rdtsc::enabled();
   if (valid_rdtsc) {
     ct.val2 = Rdtsc::elapsed_counter();
+  }
+#elif defined(AARCH64) && !defined(ZERO)
+  static bool valid_cntvctss = Cntvctss::enabled();
+  if (valid_cntvctss) {
+    ct.val2 = Cntvctss::elapsed_counter();
   }
 #endif
   return ct;


### PR DESCRIPTION
AArch64 processors with FEAT_ECV (Armv8.6+) expose a self-synchronized counter via the CNTVCTSS_EL0 register, which can serve as a low-overhead timestamp source for JFR. Added cntvctss_aarch64.cpp/hpp that reads CNTVCTSS_EL0 and mirrors the x86 Rdtsc interface. Reduces JFR event commit latency on AArch64 with FEAT_ECV, replacing clock_gettime with a direct register read.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387407](https://bugs.openjdk.org/browse/JDK-8387407): AARCH: use CNTVCTSS_EL0 as fast unordered timestamp source for JFR (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31720/head:pull/31720` \
`$ git checkout pull/31720`

Update a local copy of the PR: \
`$ git checkout pull/31720` \
`$ git pull https://git.openjdk.org/jdk.git pull/31720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31720`

View PR using the GUI difftool: \
`$ git pr show -t 31720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31720.diff">https://git.openjdk.org/jdk/pull/31720.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31720#issuecomment-4838490501)
</details>
