### PR TITLE
8386846: G1: Crash in ~ThreadTotalCPUTimeClosure inside G1ServiceThread during CDS abort

### DIFF
--- a/src/hotspot/share/runtime/cpuTimeCounters.cpp
+++ b/src/hotspot/share/runtime/cpuTimeCounters.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023 Google LLC. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,6 +25,7 @@
 
 #include "runtime/atomicAccess.hpp"
 #include "runtime/cpuTimeCounters.hpp"
+#include "utilities/globalCounter.inline.hpp"
 
 const char* CPUTimeGroups::to_string(CPUTimeType val) {
   switch (val) {
@@ -77,6 +78,10 @@ void CPUTimeCounters::inc_gc_total_cpu_time(jlong diff) {
 }
 
 void CPUTimeCounters::publish_gc_total_cpu_time() {
+  GlobalCounter::CriticalSection cs(Thread::current());
+  if (!UsePerfData || !PerfDataManager::has_PerfData()) {
+    return;
+  }
   CPUTimeCounters* instance = CPUTimeCounters::get_instance();
   // Atomically fetch the current _gc_total_cpu_time_diff and reset it to zero.
   jlong new_value = 0;
@@ -103,6 +108,10 @@ PerfCounter* CPUTimeCounters::get_counter(CPUTimeGroups::CPUTimeType name) {
 }
 
 void CPUTimeCounters::update_counter(CPUTimeGroups::CPUTimeType name, jlong total) {
+  GlobalCounter::CriticalSection cs(Thread::current());
+  if (!UsePerfData || !PerfDataManager::has_PerfData()) {
+    return;
+  }
   CPUTimeCounters* instance = CPUTimeCounters::get_instance();
   PerfCounter* counter = instance->get_counter(name);
   jlong prev_value = counter->get_value();

--- a/src/hotspot/share/runtime/cpuTimeCounters.hpp
+++ b/src/hotspot/share/runtime/cpuTimeCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023 Google LLC. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -79,6 +79,8 @@ private:
 
   static void inc_gc_total_cpu_time(jlong diff);
 
+  static PerfCounter* get_counter(CPUTimeGroups::CPUTimeType name);
+
 public:
   static void initialize() {
     assert(_instance == nullptr, "we can only allocate one CPUTimeCounters object");
@@ -91,7 +93,6 @@ public:
   }
 
   static void create_counter(CPUTimeGroups::CPUTimeType name);
-  static PerfCounter* get_counter(CPUTimeGroups::CPUTimeType name);
   static void update_counter(CPUTimeGroups::CPUTimeType name, jlong total);
 
   static void publish_gc_total_cpu_time();


### PR DESCRIPTION
Hi all,

  please review this change that fixes a race between updating the performance counters and (premature) VM exit.

If the VM exits between executing a g1 service task and updating the performance counters (`g1ServiceThread.cpp:132`), the VM exit will deallocate the perf counters, and updating the performance counter will access deallocated memory and crash.

The solution is to guard the cpu counter updates properly with critical sections and checks whether performance counters are still active.

Testing: I could only reproduce with VM modifications (artificial delay between these two calls) and a delay in VM exit, but then with like 40% accuracy. With these fix, there are no crashes. Also reproduced only on Linux, on other OSes accessing the deallocated performance counter did not crash (but was wrong anyway).

Hth,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386846](https://bugs.openjdk.org/browse/JDK-8386846): G1: Crash in ~ThreadTotalCPUTimeClosure inside G1ServiceThread during CDS abort (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31721/head:pull/31721` \
`$ git checkout pull/31721`

Update a local copy of the PR: \
`$ git checkout pull/31721` \
`$ git pull https://git.openjdk.org/jdk.git pull/31721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31721`

View PR using the GUI difftool: \
`$ git pr show -t 31721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31721.diff">https://git.openjdk.org/jdk/pull/31721.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31721#issuecomment-4840815687)
</details>
