### PR TITLE
8387465: Remove isXP() function from WPathGraphics.java

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -312,16 +312,6 @@ final class WPathGraphics extends PathGraphics {
         }
     }
 
-    private static boolean isXP() {
-        String osVersion = System.getProperty("os.version");
-        if (osVersion != null) {
-            float version = Float.parseFloat(osVersion);
-            return version >= 5.1f;
-        } else {
-            return false;
-        }
-    }
-
     /* In case GDI doesn't handle shaping or BIDI consistently with
      * 2D's TextLayout, we can detect these cases and redelegate up to
      * be drawn via TextLayout, which in is rendered as runs of
@@ -335,8 +325,7 @@ final class WPathGraphics extends PathGraphics {
         } else if (!useGDITextLayout) {
             return true;
         } else {
-            if (preferGDITextLayout ||
-                (isXP() && FontUtilities.textLayoutIsCompatible(font))) {
+            if (preferGDITextLayout || FontUtilities.textLayoutIsCompatible(font)) {
                 return false;
             } else {
                 return true;

--- a/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
+++ b/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,23 +52,6 @@ static LPCTSTR STR_ACCESSBRIDGE =
 
 FILE* origFile;
 FILE* tempFile;
-
-bool isXP()
-{
-    static bool isXPFlag = false;
-    OSVERSIONINFO  osvi;
-
-    // Initialize the OSVERSIONINFO structure.
-    ZeroMemory( &osvi, sizeof( osvi ) );
-    osvi.dwOSVersionInfoSize = sizeof( osvi );
-
-    GetVersionEx( &osvi );
-
-    if ( osvi.dwMajorVersion == 5 ) // For Windows XP and Windows 2000
-        isXPFlag = true;
-
-    return isXPFlag ;
-}
 
 void enableJAB() {
     // Copy lines from orig to temp modifying the line containing
@@ -458,16 +441,14 @@ int main(int argc, char* argv[]) {
                 enableWasRequested = true;
                 error = modify(true);
                 if (error == 0) {
-                   if( !isXP() )
-                      regEnable();
+                    regEnable();
                 }
             } else if (_stricmp(argv[1], "-disable") == 0 || _stricmp(argv[1], "/disable") == 0) {
                 badParams = false;
                 disableWasRequested = true;
                 error = modify(false);
                 if (error == 0) {
-                   if( !isXP() )
-                      regDisable();
+                    regDisable();
                 }
             }
         }

--- a/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
+++ b/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,23 @@ static LPCTSTR STR_ACCESSBRIDGE =
 
 FILE* origFile;
 FILE* tempFile;
+
+bool isXP()
+{
+    static bool isXPFlag = false;
+    OSVERSIONINFO  osvi;
+
+    // Initialize the OSVERSIONINFO structure.
+    ZeroMemory( &osvi, sizeof( osvi ) );
+    osvi.dwOSVersionInfoSize = sizeof( osvi );
+
+    GetVersionEx( &osvi );
+
+    if ( osvi.dwMajorVersion == 5 ) // For Windows XP and Windows 2000
+        isXPFlag = true;
+
+    return isXPFlag ;
+}
 
 void enableJAB() {
     // Copy lines from orig to temp modifying the line containing
@@ -441,14 +458,16 @@ int main(int argc, char* argv[]) {
                 enableWasRequested = true;
                 error = modify(true);
                 if (error == 0) {
-                    regEnable();
+                   if( !isXP() )
+                      regEnable();
                 }
             } else if (_stricmp(argv[1], "-disable") == 0 || _stricmp(argv[1], "/disable") == 0) {
                 badParams = false;
                 disableWasRequested = true;
                 error = modify(false);
                 if (error == 0) {
-                    regDisable();
+                   if( !isXP() )
+                      regDisable();
                 }
             }
         }


### PR DESCRIPTION
We have at least 2 isXP() functions in the coding checking for very old Windows versions. These can be removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387465](https://bugs.openjdk.org/browse/JDK-8387465): Remove isXP() function from WPathGraphics.java (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31725/head:pull/31725` \
`$ git checkout pull/31725`

Update a local copy of the PR: \
`$ git checkout pull/31725` \
`$ git pull https://git.openjdk.org/jdk.git pull/31725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31725`

View PR using the GUI difftool: \
`$ git pr show -t 31725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31725.diff">https://git.openjdk.org/jdk/pull/31725.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31725#issuecomment-4844038658)
</details>
