### PR TITLE
8387015: C2: crash with "named projection 2 not found" from ArrayCopyNode::finish_transform() for clone

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -180,6 +180,12 @@ Node* ArrayCopyNode::try_clone_instance(PhaseGVN *phase, bool can_reshape, int c
     return nullptr;
   }
 
+  Node* out_mem = proj_out_or_null(TypeFunc::Memory);
+  if (can_reshape && out_mem == nullptr) { // dead node?
+    return NodeSentinel;
+  }
+
+
   Node* base_src = in(ArrayCopyNode::Src);
   Node* base_dest = in(ArrayCopyNode::Dest);
   Node* ctl = in(TypeFunc::Control);

--- a/test/hotspot/jtreg/compiler/arraycopy/TestDeadCloneMem.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestDeadCloneMem.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug JDK-8387015
+ * @summary C2: crash with "named projection 2 not found" from ArrayCopyNode::finish_transform() for clone
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:CompileOnly=${test.main.class}::test1
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::notInlined -XX:+StressIGVN
+ *                   -XX:StressSeed=1324432947 ${test.main.class}
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:CompileOnly=${test.main.class}::test1
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::notInlined -XX:+StressIGVN
+ *                   ${test.main.class}
+ */
+
+package compiler.arraycopy;
+
+public class TestDeadCloneMem {
+    private static int field;
+
+    public static void main(String[] args) {
+        int[] array = new int[10];
+        array.clone();
+        Object o = new Object();
+        test1(42, false);
+    }
+
+    private static int test1(int flag, boolean flag2) {
+        int len;
+        if (flag != 42) {
+            if (flag2) {
+                field = 42;
+            }
+            int[] array2;
+            if (flag != 42) {
+                len = -1;
+                array2 = new int[4];
+            } else {
+                len = 42;
+                array2 = new int[100];
+            }
+            int[] array = new int[len];
+            int length = array.length;
+            int i = 0;
+            do {
+                synchronized (new Object()) {}
+                notInlined();
+                array2.clone();
+                i++;
+            } while (i < 10);
+            return length;
+        }
+        return 0;
+    }
+
+    private static void notInlined() {
+
+    }
+}


### PR DESCRIPTION
This issue was hit by one of our customers with 25. I'd like to backport it to 27 first. The fix is simple and low risk.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387015](https://bugs.openjdk.org/browse/JDK-8387015): C2: crash with "named projection 2 not found" from ArrayCopyNode::finish_transform() for clone (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31726/head:pull/31726` \
`$ git checkout pull/31726`

Update a local copy of the PR: \
`$ git checkout pull/31726` \
`$ git pull https://git.openjdk.org/jdk.git pull/31726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31726`

View PR using the GUI difftool: \
`$ git pr show -t 31726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31726.diff">https://git.openjdk.org/jdk/pull/31726.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31726#issuecomment-4845339736)
</details>
