### PR TITLE
8387455: Restrict legacy Locale compatibility handling to exact matches

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2689,6 +2689,12 @@ public final class Locale implements Cloneable, Serializable {
          * <li>Locale("th", "TH", "TH") is treated as "th-TH-u-nu-thai"
          * <li>Locale("no", "NO", "NY") is treated as "nn-NO"</ul>
          *
+         * <p>For the Japanese and Thai cases, compatibility handling only applies
+         * when the script is non-empty and the Unicode locale keyword {@code
+         * ca=japanese} or {@code nu=thai}, respectively, is present. Otherwise,
+         * the two-letter variant is treated as ill-formed, and an
+         * {@code IllformedLocaleException} is thrown.
+         *
          * @param locale the locale
          * @return This builder.
          * @throws IllformedLocaleException if {@code locale} has

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2689,11 +2689,12 @@ public final class Locale implements Cloneable, Serializable {
          * <li>Locale("th", "TH", "TH") is treated as "th-TH-u-nu-thai"
          * <li>Locale("no", "NO", "NY") is treated as "nn-NO"</ul>
          *
-         * <p>For the Japanese and Thai cases, compatibility handling only applies
-         * when the script is non-empty and the Unicode locale keyword {@code
-         * ca=japanese} or {@code nu=thai}, respectively, is present. Otherwise,
-         * the two-letter variant is treated as ill-formed, and an
-         * {@code IllformedLocaleException} is thrown.
+         * <p>For all three cases, compatibility handling only applies when the script
+         * is empty. Additionally, the Japanese case requires the Unicode
+         * locale keyword {@code ca=japanese}, and the Thai case requires
+         * {@code nu=thai}. If these conditions are not met, the two-letter
+         * variant is treated as ill-formed, and an {@code IllformedLocaleException}
+         * is thrown.
          *
          * @param locale the locale
          * @return This builder.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -519,25 +519,24 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * <p>For compatibility reasons, two
  * non-conforming locales are treated as special cases.  These are
  * <b>{@code ja_JP_JP}</b> and <b>{@code th_TH_TH}</b>. These are ill-formed
- * in BCP 47 since the {@linkplain ##def_variant variants} are too short. To ease migration to BCP 47,
- * these are treated specially during construction.  These two cases (and only
- * these) cause a constructor to generate an extension, all other values behave
- * exactly as they did prior to Java 7.
+ * in BCP 47 since the {@linkplain ##def_variant variants} are too short. To ease
+ * migration to BCP 47, these are treated specially during construction. Creation
+ * of these two cases generates a compatibility extension.
  *
  * <p>Java has used {@code ja_JP_JP} to represent Japanese as used in
  * Japan together with the Japanese Imperial calendar. This is now
  * representable using a Unicode locale extension, by specifying the
  * Unicode locale key {@code ca} (for "calendar") and type
- * {@code japanese}. When the Locale constructor is called with the
- * arguments "ja", "JP", "JP", the extension "u-ca-japanese" is
- * automatically added.
+ * {@code japanese}. When a {@code Locale} is created with language "ja", an
+ * empty script, region "JP", variant "JP", and no extensions, the extension
+ * "u-ca-japanese" is automatically added.
  *
  * <p>Java has used {@code th_TH_TH} to represent Thai as used in
  * Thailand together with Thai digits. This is also now representable using
  * a Unicode locale extension, by specifying the Unicode locale key
- * {@code nu} (for "number") and value {@code thai}. When the Locale
- * constructor is called with the arguments "th", "TH", "TH", the
- * extension "u-nu-thai" is automatically added.
+ * {@code nu} (for "number") and value {@code thai}. When a {@code Locale} is
+ * created with language "th", an empty script, region "TH", variant "TH", and
+ * no extensions, the extension "u-nu-thai" is automatically added.
  *
  * <h3><a id="legacy_language_codes">Legacy language codes</a></h3>
  *
@@ -1608,9 +1607,9 @@ public final class Locale implements Cloneable, Serializable {
      * <li>Deprecated ISO language codes "iw", "ji", and "in" are
      * converted to "he", "yi", and "id", respectively.
      *
-     * <li>A locale with language "no", country "NO", and variant
-     * "NY", representing Norwegian Nynorsk (Norway), is converted
-     * to a language tag "nn-NO".</li></ul>
+     * <li>A locale with language "no", an empty script, country "NO", variant
+     * "NY", and no extensions, representing Norwegian Nynorsk (Norway), is
+     * converted to a language tag "nn-NO".</li></ul>
      *
      * <p><b>Note:</b> Although the language tag obtained by this
      * method is well-formed (satisfies the syntax requirements
@@ -2690,11 +2689,11 @@ public final class Locale implements Cloneable, Serializable {
          * <li>Locale("no", "NO", "NY") is treated as "nn-NO"</ul>
          *
          * <p>For all three cases, compatibility handling only applies when the script
-         * is empty. Additionally, the Japanese case requires the Unicode
-         * locale keyword {@code ca=japanese}, and the Thai case requires
-         * {@code nu=thai}. If these conditions are not met, the two-letter
-         * variant is treated as ill-formed, and an {@code IllformedLocaleException}
-         * is thrown.
+         * is empty. Additionally, the Japanese case requires exactly the
+         * {@code u-ca-japanese} extension, the Thai case requires
+         * exactly the {@code u-nu-thai} extension, and the Norwegian case
+         * requires no extensions. If these conditions are not met, the two-letter
+         * variant is treated as ill-formed, and an {@code IllformedLocaleException} is thrown.
          *
          * @param locale the locale
          * @return This builder.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -520,7 +520,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * non-conforming locales are treated as special cases.  These are
  * <b>{@code ja_JP_JP}</b> and <b>{@code th_TH_TH}</b>. These are ill-formed
  * in BCP 47 since the {@linkplain ##def_variant variants} are too short. To ease
- * migration to BCP 47, these are treated specially during construction. Creation
+ * migration to BCP 47, these are treated specially during creation. Creation
  * of these two cases generates a compatibility extension.
  *
  * <p>Java has used {@code ja_JP_JP} to represent Japanese as used in
@@ -528,14 +528,14 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * representable using a Unicode locale extension, by specifying the
  * Unicode locale key {@code ca} (for "calendar") and type
  * {@code japanese}. When a {@code Locale} is created with language "ja", an
- * empty script, region "JP", variant "JP", and no extensions, the extension
+ * empty script, country "JP", variant "JP", and no extensions, the extension
  * "u-ca-japanese" is automatically added.
  *
  * <p>Java has used {@code th_TH_TH} to represent Thai as used in
  * Thailand together with Thai digits. This is also now representable using
  * a Unicode locale extension, by specifying the Unicode locale key
  * {@code nu} (for "number") and value {@code thai}. When a {@code Locale} is
- * created with language "th", an empty script, region "TH", variant "TH", and
+ * created with language "th", an empty script, country "TH", variant "TH", and
  * no extensions, the extension "u-nu-thai" is automatically added.
  *
  * <h3><a id="legacy_language_codes">Legacy language codes</a></h3>

--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -2842,7 +2842,7 @@ public abstract class ResourceBundle {
             boolean isNorwegianBokmal = false;
             boolean isNorwegianNynorsk = false;
             if (language.equals("no")) {
-                if (region.equals("NO") && variant.equals("NY")) {
+                if (region.equals("NO") && variant.equals("NY") && script.isEmpty()) {
                     variant = "";
                     isNorwegianNynorsk = true;
                 } else {

--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -402,7 +402,7 @@ public final class InternalLocaleBuilder {
             // Exception 3 - no_NO_NY
             else if (language.equals("no") && region.equals("NO") && variant.equals("NY")) {
                 // no_NO_NY is a valid locale and used by Java 6 or older versions.
-                // The build ignores the variant "NY" and change the language to "nn".
+                // The builder ignores the variant "NY" and changes the language to "nn".
                 language = "nn";
                 variant = "";
             }

--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -380,33 +380,32 @@ public final class InternalLocaleBuilder {
         String variant = base.getVariant();
 
         // Special backward compatibility support
-
-        // Exception 1 - ja_JP_JP
-        if (language.equals("ja") && region.equals("JP") && variant.equals("JP")
-                && script.isEmpty()
-                && localeExtensions != null
-                && "japanese".equals(localeExtensions.getUnicodeLocaleType("ca"))) {
-            // When locale ja_JP_JP is created, ca-japanese is always added.
-            // If the extension exists, the builder ignores the variant "JP"
-            // otherwise "JP" is merely an ill-formed variant
-            variant = "";
-        }
-        // Exception 2 - th_TH_TH
-        else if (language.equals("th") && region.equals("TH") && variant.equals("TH")
-                && script.isEmpty()
-                && localeExtensions != null
-                && "thai".equals(localeExtensions.getUnicodeLocaleType("nu"))) {
-            // When locale th_TH_TH is created, nu-thai is always added.
-            // If the extension exists, the builder ignores the variant "TH"
-            // otherwise "TH" is merely an ill-formed variant
-            variant = "";
-        }
-        // Exception 3 - no_NO_NY
-        else if (language.equals("no") && region.equals("NO") && variant.equals("NY")) {
-            // no_NO_NY is a valid locale and used by Java 6 or older versions.
-            // The build ignores the variant "NY" and change the language to "nn".
-            language = "nn";
-            variant = "";
+        if (script.isEmpty()) {
+            // Exception 1 - ja_JP_JP
+            if (language.equals("ja") && region.equals("JP") && variant.equals("JP")
+                    && localeExtensions != null
+                    && "japanese".equals(localeExtensions.getUnicodeLocaleType("ca"))) {
+                // When locale ja_JP_JP is created, ca-japanese is always added.
+                // If the extension exists, the builder ignores the variant "JP"
+                // otherwise "JP" is merely an ill-formed variant
+                variant = "";
+            }
+            // Exception 2 - th_TH_TH
+            else if (language.equals("th") && region.equals("TH") && variant.equals("TH")
+                    && localeExtensions != null
+                    && "thai".equals(localeExtensions.getUnicodeLocaleType("nu"))) {
+                // When locale th_TH_TH is created, nu-thai is always added.
+                // If the extension exists, the builder ignores the variant "TH"
+                // otherwise "TH" is merely an ill-formed variant
+                variant = "";
+            }
+            // Exception 3 - no_NO_NY
+            else if (language.equals("no") && region.equals("NO") && variant.equals("NY")) {
+                // no_NO_NY is a valid locale and used by Java 6 or older versions.
+                // The build ignores the variant "NY" and change the language to "nn".
+                language = "nn";
+                variant = "";
+            }
         }
 
         // Validate base locale fields before updating internal state.

--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -382,17 +382,21 @@ public final class InternalLocaleBuilder {
         // Special backward compatibility support
 
         // Exception 1 - ja_JP_JP
-        if (language.equals("ja") && region.equals("JP") && variant.equals("JP")) {
-            // When locale ja_JP_JP is created, ca-japanese is always there.
-            // The builder ignores the variant "JP"
-            assert("japanese".equals(localeExtensions.getUnicodeLocaleType("ca")));
+        if (language.equals("ja") && region.equals("JP") && variant.equals("JP")
+                && localeExtensions != null
+                && "japanese".equals(localeExtensions.getUnicodeLocaleType("ca"))) {
+            // When locale ja_JP_JP is created, ca-japanese is always added.
+            // If the extension exists, the builder ignores the variant "JP"
+            // otherwise "JP" is merely an ill-formed variant
             variant = "";
         }
         // Exception 2 - th_TH_TH
-        else if (language.equals("th") && region.equals("TH") && variant.equals("TH")) {
-            // When locale th_TH_TH is created, nu-thai is always there.
-            // The builder ignores the variant "TH"
-            assert("thai".equals(localeExtensions.getUnicodeLocaleType("nu")));
+        else if (language.equals("th") && region.equals("TH") && variant.equals("TH") &&
+                localeExtensions != null
+                && "thai".equals(localeExtensions.getUnicodeLocaleType("nu"))) {
+            // When locale th_TH_TH is created, nu-thai is always added.
+            // If the extension exists, the builder ignores the variant "TH"
+            // otherwise "TH" is merely an ill-formed variant
             variant = "";
         }
         // Exception 3 - no_NO_NY

--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -383,6 +383,7 @@ public final class InternalLocaleBuilder {
 
         // Exception 1 - ja_JP_JP
         if (language.equals("ja") && region.equals("JP") && variant.equals("JP")
+                && script.isEmpty()
                 && localeExtensions != null
                 && "japanese".equals(localeExtensions.getUnicodeLocaleType("ca"))) {
             // When locale ja_JP_JP is created, ca-japanese is always added.
@@ -391,8 +392,9 @@ public final class InternalLocaleBuilder {
             variant = "";
         }
         // Exception 2 - th_TH_TH
-        else if (language.equals("th") && region.equals("TH") && variant.equals("TH") &&
-                localeExtensions != null
+        else if (language.equals("th") && region.equals("TH") && variant.equals("TH")
+                && script.isEmpty()
+                && localeExtensions != null
                 && "thai".equals(localeExtensions.getUnicodeLocaleType("nu"))) {
             // When locale th_TH_TH is created, nu-thai is always added.
             // If the extension exists, the builder ignores the variant "TH"

--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -383,8 +383,7 @@ public final class InternalLocaleBuilder {
         if (script.isEmpty()) {
             // Exception 1 - ja_JP_JP
             if (language.equals("ja") && region.equals("JP") && variant.equals("JP")
-                    && localeExtensions != null
-                    && "japanese".equals(localeExtensions.getUnicodeLocaleType("ca"))) {
+                    && LocaleExtensions.CALENDAR_JAPANESE.equals(localeExtensions)) {
                 // When locale ja_JP_JP is created, ca-japanese is always added.
                 // If the extension exists, the builder ignores the variant "JP"
                 // otherwise "JP" is merely an ill-formed variant
@@ -392,15 +391,15 @@ public final class InternalLocaleBuilder {
             }
             // Exception 2 - th_TH_TH
             else if (language.equals("th") && region.equals("TH") && variant.equals("TH")
-                    && localeExtensions != null
-                    && "thai".equals(localeExtensions.getUnicodeLocaleType("nu"))) {
+                    && LocaleExtensions.NUMBER_THAI.equals(localeExtensions)){
                 // When locale th_TH_TH is created, nu-thai is always added.
                 // If the extension exists, the builder ignores the variant "TH"
                 // otherwise "TH" is merely an ill-formed variant
                 variant = "";
             }
             // Exception 3 - no_NO_NY
-            else if (language.equals("no") && region.equals("NO") && variant.equals("NY")) {
+            else if (language.equals("no") && region.equals("NO") && variant.equals("NY")
+                    && localeExtensions == null) {
                 // no_NO_NY is a valid locale and used by Java 6 or older versions.
                 // The builder ignores the variant "NY" and changes the language to "nn".
                 language = "nn";

--- a/src/java.base/share/classes/sun/util/locale/LanguageTag.java
+++ b/src/java.base/share/classes/sun/util/locale/LanguageTag.java
@@ -418,7 +418,8 @@ public record LanguageTag(String language,
         }
 
         // Special handling for no_NO_NY - use nn_NO for language tag
-        if (language.equals("no") && region.equals("NO") && baseVariant.equals("NY")) {
+        if (language.equals("no") && region.equals("NO") && baseVariant.equals("NY")
+                && script.isEmpty() && localeExtensions == null) {
             language = "nn";
             baseVariant = EMPTY_SUBTAG;
         }

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleServiceProviderPool.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleServiceProviderPool.java
@@ -370,16 +370,10 @@ public final class LocaleServiceProviderPool {
                 locbld.clearExtensions();
                 lookupLocale = locbld.build();
             } catch (IllformedLocaleException e) {
-                // A Locale with non-empty extensions
-                // should have well-formed fields except
-                // for ja_JP_JP and th_TH_TH. Therefore,
-                // it should never enter in this catch clause.
-                System.getLogger(LocaleServiceProviderPool.class.getCanonicalName())
-                    .log(System.Logger.Level.INFO,
-                        "A locale(" + locale + ") has non-empty extensions, but has illformed fields.");
-
-                // Fallback - script field will be lost.
-                lookupLocale = Locale.of(locale.getLanguage(), locale.getCountry(), locale.getVariant());
+                // E.g. "en-Latn-US-a-foo-x-lvariant-xy"
+                // Extensions can exist while variant is ill-formed
+                // Simply strip the extensions so that all fields are preserved
+                lookupLocale = lookupLocale.stripExtensions();
             }
         }
         return lookupLocale;

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -741,11 +741,13 @@ public class LocaleEnhanceTest {
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.forLanguageTag("th-TH-u-nu-foobar-x-lvariant-TH")));
 
-        // Legacy locales with correct compatibility extensions but non-empty script are invalid
+        // Legacy locales with non-empty script are invalid
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.forLanguageTag("ja-Jpan-JP-u-ca-japanese-x-lvariant-JP")));
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.forLanguageTag("th-Thai-TH-u-nu-thai-x-lvariant-TH")));
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("no-Latn-NO-x-lvariant-NY")));
 
         // non-canonical, non-legacy locales are invalid
         assertThrows(IllformedLocaleException.class,

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -735,6 +735,12 @@ public class LocaleEnhanceTest {
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.of("th", "TH", "TH").stripExtensions()));
 
+        // Legacy locales without the correct compatibility extensions are invalid
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("ja-JP-u-ca-foobar-x-lvariant-JP")));
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("th-TH-u-nu-foobar-x-lvariant-TH")));
+
         // non-canonical, non-legacy locales are invalid
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.of("123", "4567", "89")), "123_4567_89");

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @test
  * @bug 6875847 6992272 7002320 7015500 7023613 7032820 7033504 7004603
  *      7044019 8008577 8176853 8255086 8263202 8287868 8174269 8369452
- *      8369590 8387185 8387253
+ *      8369590 8387185 8387253 8387455
  * @summary test API changes to Locale
  * @modules jdk.localedata
  * @run junit/othervm -esa LocaleEnhanceTest
@@ -728,6 +728,12 @@ public class LocaleEnhanceTest {
         assertEquals("nn-NO", locale.toLanguageTag(), "no_NO_NY languagetag");
         assertEquals("nn", locale.getLanguage(), "no_NO_NY language");
         assertEquals("", locale.getVariant(), "no_NO_NY variant");
+
+        // Legacy locales that stripped their compatibility extensions are invalid
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.of("ja", "JP", "JP").stripExtensions()));
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.of("th", "TH", "TH").stripExtensions()));
 
         // non-canonical, non-legacy locales are invalid
         assertThrows(IllformedLocaleException.class,

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -741,6 +741,12 @@ public class LocaleEnhanceTest {
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.forLanguageTag("th-TH-u-nu-foobar-x-lvariant-TH")));
 
+        // Legacy locales with correct compatibility extensions but non-empty script are invalid
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("ja-Jpan-JP-u-ca-japanese-x-lvariant-JP")));
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("th-Thai-TH-u-nu-thai-x-lvariant-TH")));
+
         // non-canonical, non-legacy locales are invalid
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.of("123", "4567", "89")), "123_4567_89");

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -498,6 +498,23 @@ public class LocaleEnhanceTest {
                 // private use only language tag is preserved (no extra "und")
                 {"x-elmer", "x-elmer"},
                 {"x-lvariant-JP", "x-lvariant-JP"},
+                // Legacy locale cases
+                // no/NO/NY case is normalized during `toLanguageTag`
+                // ja/JP/JP & th/TH/TH case is normalized during `forLanguageTag`
+                    // Script prevents the legacy conversions
+                {"no-Latn-NO-x-lvariant-NY",
+                        "no-Latn-NO-x-lvariant-NY"},
+                {"ja-Jpan-JP-x-lvariant-JP",
+                        "ja-Jpan-JP-x-lvariant-JP"},
+                {"th-Thai-TH-x-lvariant-TH",
+                        "th-Thai-TH-x-lvariant-TH"},
+                    // Unexpected extensions prevent the legacy conversions
+                {"no-NO-a-foo-x-lvariant-NY",
+                        "no-NO-a-foo-x-lvariant-NY"},
+                {"ja-JP-a-foo-x-lvariant-JP",
+                        "ja-JP-a-foo-x-lvariant-JP"},
+                {"th-TH-a-foo-x-lvariant-TH",
+                        "th-TH-a-foo-x-lvariant-TH"},
         };
         for (String[] test : tests1) {
             Locale locale = Locale.forLanguageTag(test[0]);
@@ -735,11 +752,19 @@ public class LocaleEnhanceTest {
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.of("th", "TH", "TH").stripExtensions()));
 
-        // Legacy locales without the correct compatibility extensions are invalid
+        // Legacy locales without the correct Unicode locale extension value are invalid
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.forLanguageTag("ja-JP-u-ca-foobar-x-lvariant-JP")));
         assertThrows(IllformedLocaleException.class,
                 () -> new Builder().setLocale(Locale.forLanguageTag("th-TH-u-nu-foobar-x-lvariant-TH")));
+
+        // Legacy locales with additional extensions are invalid
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("no-NO-a-foo-x-lvariant-NY")));
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("ja-JP-a-foo-x-lvariant-JP")));
+        assertThrows(IllformedLocaleException.class,
+                () -> new Builder().setLocale(Locale.forLanguageTag("th-TH-a-foo-x-lvariant-TH")));
 
         // Legacy locales with non-empty script are invalid
         assertThrows(IllformedLocaleException.class,

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -501,14 +501,14 @@ public class LocaleEnhanceTest {
                 // Legacy locale cases
                 // no/NO/NY case is normalized during `toLanguageTag`
                 // ja/JP/JP & th/TH/TH case is normalized during `forLanguageTag`
-                    // Script prevents the legacy conversions
+                // Script prevents the legacy conversions
                 {"no-Latn-NO-x-lvariant-NY",
                         "no-Latn-NO-x-lvariant-NY"},
                 {"ja-Jpan-JP-x-lvariant-JP",
                         "ja-Jpan-JP-x-lvariant-JP"},
                 {"th-Thai-TH-x-lvariant-TH",
                         "th-Thai-TH-x-lvariant-TH"},
-                    // Unexpected extensions prevent the legacy conversions
+                // Unexpected extensions prevent the legacy conversions
                 {"no-NO-a-foo-x-lvariant-NY",
                         "no-NO-a-foo-x-lvariant-NY"},
                 {"ja-JP-a-foo-x-lvariant-JP",

--- a/test/jdk/java/util/ResourceBundle/Control/DefaultControlTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/DefaultControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 5102289 6278334 8261179
+ * @bug 5102289 6278334 8261179 8387455
  * @summary Test the default Control implementation. The expiration
  * functionality of newBundle, getTimeToLive, and needsReload is
  * tested by ExpirationTest.sh. The factory methods are tested
@@ -171,6 +171,15 @@ public class DefaultControlTest {
         candidateData.put(Locale.ROOT, new Locale[] {
                               Locale.ROOT });
 
+        // Norwegian Nynorsk
+        candidateData.put(Locale.of("no", "NO", "NY"), new Locale[] {
+                Locale.of("nn", "NO"),
+                Locale.of("nn"),
+                Locale.of("no", "NO", "NY"),
+                Locale.of("no", "NO"),
+                Locale.of("no"),
+                Locale.ROOT});
+
         // Norwegian Bokmal
         candidateData.put(Locale.forLanguageTag("nb-NO-POSIX"), new Locale[] {
                 Locale.forLanguageTag("nb-NO-POSIX"),
@@ -188,7 +197,21 @@ public class DefaultControlTest {
                 Locale.forLanguageTag("no"),
                 Locale.forLanguageTag("nb"),
                 Locale.ROOT});
-
+        // Appears as no-NO-NY legacy locale (but contains script) so treat as Norwegian Bokmal
+        candidateData.put(Locale.forLanguageTag("no-Latn-NO-x-lvariant-NY"), new Locale[] {
+                Locale.forLanguageTag("no-Latn-NO-x-lvariant-NY"),
+                Locale.forLanguageTag("nb-Latn-NO-x-lvariant-NY"),
+                Locale.forLanguageTag("no-Latn-NO"),
+                Locale.forLanguageTag("nb-Latn-NO"),
+                Locale.forLanguageTag("no-Latn"),
+                Locale.forLanguageTag("nb-Latn"),
+                Locale.forLanguageTag("no-NO-x-lvariant-NY"),
+                Locale.forLanguageTag("nb-NO-x-lvariant-NY"),
+                Locale.forLanguageTag("no-NO"),
+                Locale.forLanguageTag("nb-NO"),
+                Locale.forLanguageTag("no"),
+                Locale.forLanguageTag("nb"),
+                Locale.ROOT});
 
         for (Locale locale : candidateData.keySet()) {
             List<Locale> candidates = CONTROL.getCandidateLocales("any", locale);


### PR DESCRIPTION
This PR corrects the special case handling in `Locale.Builder.setLocale`. The current handling always assumes a `Locale` matching the `ja/JP/JP` and `th/TH/TH` special cases will contain the correct compatibility extensions. A user can remove the extension or create a Locale in the form of the special case without the correct compatibility extension.

For example, the current implementation does the following,

> jshell> loc = new Builder().setLocale(Locale.of("ja", "JP", "JP").stripExtensions()).build()
> loc ==> ja_JP
> 
> jshell> loc = new Builder().setLocale(Locale.forLanguageTag("ja-JP-u-ca-foobar-x-lvariant-JP")).build()
> loc ==> ja_JP_#u-ca-foobar

That is, it silently discards the ill-formed JP variant.

With assertions on, this instead becomes a `NullPointerException` when the extensions are not present, or an `AssertionError` when the extension has the wrong value.

For the example above, one would expect an `IllFormedLocaleException` to be thrown, since without a correct compatibility extension, JP is merely an invalid variant and `setLocale(Locale)` throws on ill-formed fields.

The changes in this PR ensure that these cases throw as expected.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change requires CSR request [JDK-8387555](https://bugs.openjdk.org/browse/JDK-8387555) to be approved
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8387455](https://bugs.openjdk.org/browse/JDK-8387455): Restrict legacy Locale compatibility handling to exact matches (**Bug** - P4)
 * [JDK-8387555](https://bugs.openjdk.org/browse/JDK-8387555): Restrict legacy Locale compatibility handling to exact matches (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31728/head:pull/31728` \
`$ git checkout pull/31728`

Update a local copy of the PR: \
`$ git checkout pull/31728` \
`$ git pull https://git.openjdk.org/jdk.git pull/31728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31728`

View PR using the GUI difftool: \
`$ git pr show -t 31728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31728.diff">https://git.openjdk.org/jdk/pull/31728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31728#issuecomment-4846237689)
</details>
