### PR TITLE
8387302: Disable reserved stack areas for critical sections on Windows AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -61,7 +61,9 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 // evidence that it's worth doing.
 #define DEOPTIMIZE_WHEN_PATCHING
 
+#if !defined(_WINDOWS)
 #define SUPPORT_RESERVED_STACK_AREA
+#endif
 
 #if defined(__APPLE__) || defined(_WIN64)
 #define R18_RESERVED

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -48,7 +48,7 @@ define_pd_global(intx, OptoLoopAlignment,        16);
 // stack if compiled for unix and LP64. To pass stack overflow tests we need
 // 20 shadow pages.
 #define DEFAULT_STACK_SHADOW_PAGES (20 DEBUG_ONLY(+5))
-#define DEFAULT_STACK_RESERVED_PAGES (1)
+#define DEFAULT_STACK_RESERVED_PAGES (NOT_WINDOWS(1) WINDOWS_ONLY(0))
 
 #define MIN_STACK_YELLOW_PAGES DEFAULT_STACK_YELLOW_PAGES
 #define MIN_STACK_RED_PAGES    DEFAULT_STACK_RED_PAGES


### PR DESCRIPTION
[JEP 270](https://openjdk.org/jeps/270) introduced reservation of extra space on thread stacks for use by critical sections, so that they can complete their execution where regular code would have been interrupted by a stack overflow. The ReservedStackTest uses the `-XX:StackReservedPages=1` flag to test this functionality. This flag can be used on platforms on which SUPPORT_RESERVED_STACK_AREA is defined. Otherwise, a warning is displayed by [Arguments::check_vm_args_consistency()](https://github.com/openjdk/jdk/blob/a37b02baa220b4434b1fb59f123fd3f5ce97aab0/src/hotspot/share/runtime/arguments.cpp#L1597-L1602)

SUPPORT_RESERVED_STACK_AREA is currently defined for all aarch64 platforms in [globalDefinitions_aarch64](https://github.com/openjdk/jdk/blob/a37b02baa220b4434b1fb59f123fd3f5ce97aab0/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp#L64). Therefore, the warning is not displayed on any of these platforms. However, ReservedStackTest fails on windows-aarch64 because it isn't a supported platform. This change prevents SUPPORT_RESERVED_STACK_AREA from being defined on windows-aarch64, which also enables the test to pass on this platform. Tier 1 tests pass with this change.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387302](https://bugs.openjdk.org/browse/JDK-8387302): Disable reserved stack areas for critical sections on Windows AArch64 (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31729/head:pull/31729` \
`$ git checkout pull/31729`

Update a local copy of the PR: \
`$ git checkout pull/31729` \
`$ git pull https://git.openjdk.org/jdk.git pull/31729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31729`

View PR using the GUI difftool: \
`$ git pr show -t 31729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31729.diff">https://git.openjdk.org/jdk/pull/31729.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31729#issuecomment-4846776204)
</details>
