### PR TITLE
8387554: ProblemList vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java in virtual thread configs

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -31,6 +31,7 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 
 
 vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java 8387429 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/TestDescription.java 8299217 generic-all
+vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002/TestDescription.java 8327967 generic-all
 
 
 ####

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -30,6 +30,7 @@ serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 gene
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all
 
 vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java 8387429 generic-all
+vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/TestDescription.java 8299217 generic-all
 
 
 ####

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -29,6 +29,9 @@ serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-al
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all
 
+vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java 8387429 generic-all
+
+
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -162,6 +162,7 @@ vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
 vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t006/TestDescription.java 8372206 generic-all
 vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-all
+vmTestbase/nsk/jvmti/unit/timers/JvmtiTest/TestDescription.java 8235348 windows-x64
 
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening002.java 8208259 generic-all


### PR DESCRIPTION
Trivial ProblemListing fixes:
- [JDK-8387554](https://bugs.openjdk.org/browse/JDK-8387554) ProblemList vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java in virtual thread configs
- [JDK-8387557](https://bugs.openjdk.org/browse/JDK-8387557) ProblemList vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/TestDescription.java in virtual thread configs
- [JDK-8387558](https://bugs.openjdk.org/browse/JDK-8387558) ProblemList vmTestbase/nsk/jvmti/unit/timers/JvmtiTest/TestDescription.java on windows
- [JDK-8387560](https://bugs.openjdk.org/browse/JDK-8387560) ProblemList vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002/TestDescription.java in virtual thread configs


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8387554](https://bugs.openjdk.org/browse/JDK-8387554): ProblemList vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java in virtual thread configs (**Sub-task** - P4)
 * [JDK-8387557](https://bugs.openjdk.org/browse/JDK-8387557): ProblemList vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/TestDescription.java in virtual thread configs (**Sub-task** - P4)
 * [JDK-8387558](https://bugs.openjdk.org/browse/JDK-8387558): ProblemList vmTestbase/nsk/jvmti/unit/timers/JvmtiTest/TestDescription.java on windows (**Sub-task** - P4)
 * [JDK-8387560](https://bugs.openjdk.org/browse/JDK-8387560): ProblemList vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002/TestDescription.java in virtual thread configs (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31730/head:pull/31730` \
`$ git checkout pull/31730`

Update a local copy of the PR: \
`$ git checkout pull/31730` \
`$ git pull https://git.openjdk.org/jdk.git pull/31730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31730`

View PR using the GUI difftool: \
`$ git pr show -t 31730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31730.diff">https://git.openjdk.org/jdk/pull/31730.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31730#issuecomment-4848412753)
</details>
