### PR TITLE
8387129: Parallel: Wrong TaskTerminator in ParallelScavengeRefProcProxyTask

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -60,7 +60,6 @@ public:
 class ParCompactionManager : public CHeapObj<mtGC> {
   friend class MarkFromRootsTask;
   friend class ParallelCompactRefProcProxyTask;
-  friend class ParallelScavengeRefProcProxyTask;
   friend class ParMarkBitMap;
   friend class PSParallelCompact;
   friend class FillDensePrefixAndCompactionTask;

--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -55,6 +55,7 @@ class ParCompactionManager;
 
 class PSPromotionManager {
   friend class PSScavenge;
+  friend class ParallelScavengeRefProcProxyTask;
   friend class ScavengeRootsTask;
 
  private:

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -193,7 +193,7 @@ class ParallelScavengeRefProcProxyTask : public RefProcProxyTask {
 public:
   ParallelScavengeRefProcProxyTask(uint max_workers)
     : RefProcProxyTask("ParallelScavengeRefProcProxyTask", max_workers),
-      _terminator(max_workers, ParCompactionManager::marking_stacks()) {}
+      _terminator(max_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {}
 
   void work(uint worker_id) override {
     assert(worker_id < _max_workers, "sanity");


### PR DESCRIPTION
A trivial essentinally-oneline fix of using young-gc stack during scavenging (young-gc), instead of full-gc marking stack.

No correctness issue has been identified -- using the wrong stack here seems to cause only poor work-stealing during young-gc ref-processing.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387129](https://bugs.openjdk.org/browse/JDK-8387129): Parallel: Wrong TaskTerminator in ParallelScavengeRefProcProxyTask (**Bug** - P4)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31732/head:pull/31732` \
`$ git checkout pull/31732`

Update a local copy of the PR: \
`$ git checkout pull/31732` \
`$ git pull https://git.openjdk.org/jdk.git pull/31732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31732`

View PR using the GUI difftool: \
`$ git pr show -t 31732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31732.diff">https://git.openjdk.org/jdk/pull/31732.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31732#issuecomment-4851103517)
</details>
