### PR TITLE
8387581: Serial: Clean up startup allocation locking

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -306,10 +306,24 @@ HeapWord* SerialHeap::mem_allocate_work(size_t size, bool is_tlab) {
 
   for (uint try_count = 1; /* break */; try_count++) {
     {
+      // This lock is needed to sync with the VM-init expansion below.
       ConditionalMutexLocker locker(Heap_lock, !is_init_completed());
       result = mem_allocate_cas_noexpand(size, is_tlab);
       if (result != nullptr) {
         break;
+      }
+
+      // Ensure that is_init_completed() does not transition while expanding the heap.
+      ConditionalMutexLocker ml_init(InitCompleted_lock, !is_init_completed(), Mutex::_no_safepoint_check_flag);
+      if (!is_init_completed()) {
+        // Rechecked !is_init_completed() implies we have mutual exclusion via
+        // `Heap_lock` and `InitCompleted_lock`
+        result = expand_heap_and_allocate(size, is_tlab);
+        // Return the result if it's tlab-allocation. If the result is null,
+        // callers will retry non-tlab allocation.
+        if (result != nullptr || is_tlab) {
+          return result;
+        }
       }
     }
     uint gc_count_before;  // Read inside the Heap_lock locked region.
@@ -321,19 +335,6 @@ HeapWord* SerialHeap::mem_allocate_work(size_t size, bool is_tlab) {
       result = mem_allocate_cas_noexpand(size, is_tlab);
       if (result != nullptr) {
         break;
-      }
-
-      if (!is_init_completed()) {
-        // Double checked locking, this ensure that is_init_completed() does not
-        // transition while expanding the heap.
-        MonitorLocker ml(InitCompleted_lock, Monitor::_no_safepoint_check_flag);
-        if (!is_init_completed()) {
-          // Can't do GC; try heap expansion to satisfy the request.
-          result = expand_heap_and_allocate(size, is_tlab);
-          if (result != nullptr) {
-            return result;
-          }
-        }
       }
 
       gc_count_before = total_collections();


### PR DESCRIPTION
Align Serial's startup allocation path with Parallel's implementation structure. The pre-init heap expansion attempt now uses the same conditional Heap_lock/InitCompleted_lock pattern before entering the normal GC allocation-failure path.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387581](https://bugs.openjdk.org/browse/JDK-8387581): Serial: Clean up startup allocation locking (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31733/head:pull/31733` \
`$ git checkout pull/31733`

Update a local copy of the PR: \
`$ git checkout pull/31733` \
`$ git pull https://git.openjdk.org/jdk.git pull/31733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31733`

View PR using the GUI difftool: \
`$ git pr show -t 31733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31733.diff">https://git.openjdk.org/jdk/pull/31733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31733#issuecomment-4851225452)
</details>
