### PR TITLE
8382063: Jtreg test javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java fails

### DIFF
--- a/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
+++ b/test/jdk/javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 8081474
+ * @library /test/lib
  * @summary  Verifies if SwingWorker calls 'done'
  *           before the 'doInBackground' is finished
  * @run main TestDoneBeforeDoInBackground
@@ -34,22 +35,25 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jdk.test.lib.Utils;
+
 public class TestDoneBeforeDoInBackground {
 
-    private static final int WAIT_TIME = 200;
+    private static final long WAIT_TIME = Utils.adjustTimeout(200);
     private static final long CLEANUP_TIME = 1000;
 
     private static final AtomicBoolean doInBackgroundStarted = new AtomicBoolean(false);
     private static final AtomicBoolean doInBackgroundFinished = new AtomicBoolean(false);
     private static final AtomicBoolean doneFinished = new AtomicBoolean(false);
     private static final CountDownLatch doneLatch = new CountDownLatch(1);
+    private static final CountDownLatch workerStarted = new CountDownLatch(1);
 
     public static void main(String[] args) throws InterruptedException {
         SwingWorker<String, String> worker = new SwingWorker<>() {
             @Override
             protected String doInBackground() throws Exception {
                 try {
-                    while (!Thread.currentThread().isInterrupted()) {
+                    while (true) {
                         System.out.println("Working...");
                         Thread.sleep(WAIT_TIME);
                     }
@@ -85,6 +89,12 @@ public class TestDoneBeforeDoInBackground {
         worker.addPropertyChangeListener(
             new PropertyChangeListener() {
                 public void propertyChange(PropertyChangeEvent evt) {
+                    if (worker.getState() == SwingWorker.StateValue.STARTED) {
+                        // Now the worker has started and we got a STARTED
+                        // notification. It should be save to cancel now.
+                        workerStarted.countDown();
+                    }
+
                     System.out.println("doInBackgroundStarted: " +
                                         doInBackgroundStarted.get() +
                                         " doInBackgroundFinished: " +
@@ -121,7 +131,9 @@ public class TestDoneBeforeDoInBackground {
                 }
             });
         worker.execute();
-        Thread.sleep(WAIT_TIME * 3);
+        if (!workerStarted.await(5 * WAIT_TIME, TimeUnit.MILLISECONDS)) {
+            throw new RuntimeException("worker didn't start in time");
+        }
 
         final long start = System.currentTimeMillis();
         worker.cancel(true);


### PR DESCRIPTION
I would like to have this small test improvement in jdk27. It is a test-only change - applies clean and has no risk.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8382063](https://bugs.openjdk.org/browse/JDK-8382063): Jtreg test javax/swing/SwingWorker/TestDoneBeforeDoInBackground.java fails (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31734/head:pull/31734` \
`$ git checkout pull/31734`

Update a local copy of the PR: \
`$ git checkout pull/31734` \
`$ git pull https://git.openjdk.org/jdk.git pull/31734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31734`

View PR using the GUI difftool: \
`$ git pr show -t 31734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31734.diff">https://git.openjdk.org/jdk/pull/31734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31734#issuecomment-4851749036)
</details>
