### PR TITLE
8387388: AArch64: Optimize reduceLanes MUL op with ext instruction

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -1809,19 +1809,19 @@ void C2_MacroAssembler::neon_reduce_mul_integral(Register dst, BasicType bt,
         if (isQ) {
           // Multiply the lower half and higher half of vector iteratively.
           // vtmp1 = vsrc[8:15]
-          ins(vtmp1, D, vsrc, 0, 1);
+          ext(vtmp1, T16B, vsrc, vsrc, 8);
           // vtmp1[n] = vsrc[n] * vsrc[n + 8], where n=[0, 7]
           mulv(vtmp1, T8B, vtmp1, vsrc);
           // vtmp2 = vtmp1[4:7]
-          ins(vtmp2, S, vtmp1, 0, 1);
+          ext(vtmp2, T8B, vtmp1, vtmp1, 4);
           // vtmp1[n] = vtmp1[n] * vtmp1[n + 4], where n=[0, 3]
           mulv(vtmp1, T8B, vtmp2, vtmp1);
         } else {
-          ins(vtmp1, S, vsrc, 0, 1);
+          ext(vtmp1, T8B, vsrc, vsrc, 4);
           mulv(vtmp1, T8B, vtmp1, vsrc);
         }
         // vtmp2 = vtmp1[2:3]
-        ins(vtmp2, H, vtmp1, 0, 1);
+        ext(vtmp2, T8B, vtmp1, vtmp1, 2);
         // vtmp2[n] = vtmp1[n] * vtmp1[n + 2], where n=[0, 1]
         mulv(vtmp2, T8B, vtmp2, vtmp1);
         // dst = vtmp2[0] * isrc * vtmp2[1]
@@ -1834,12 +1834,12 @@ void C2_MacroAssembler::neon_reduce_mul_integral(Register dst, BasicType bt,
         break;
       case T_SHORT:
         if (isQ) {
-          ins(vtmp2, D, vsrc, 0, 1);
+          ext(vtmp2, T16B, vsrc, vsrc, 8);
           mulv(vtmp2, T4H, vtmp2, vsrc);
-          ins(vtmp1, S, vtmp2, 0, 1);
+          ext(vtmp1, T8B, vtmp2, vtmp2, 4);
           mulv(vtmp1, T4H, vtmp1, vtmp2);
         } else {
-          ins(vtmp1, S, vsrc, 0, 1);
+          ext(vtmp1, T8B, vsrc, vsrc, 4);
           mulv(vtmp1, T4H, vtmp1, vsrc);
         }
         umov(rscratch1, vtmp1, H, 0);
@@ -1851,7 +1851,7 @@ void C2_MacroAssembler::neon_reduce_mul_integral(Register dst, BasicType bt,
         break;
       case T_INT:
         if (isQ) {
-          ins(vtmp1, D, vsrc, 0, 1);
+          ext(vtmp1, T16B, vsrc, vsrc, 8);
           mulv(vtmp1, T2S, vtmp1, vsrc);
         } else {
           vtmp1 = vsrc;
@@ -1907,19 +1907,19 @@ void C2_MacroAssembler::neon_reduce_mul_fp(FloatRegister dst, BasicType bt,
         break;
       case T_FLOAT:
         fmuls(dst, fsrc, vsrc);
-        ins(vtmp, S, vsrc, 0, 1);
+        ext(vtmp, T8B, vsrc, vsrc, 4);
         fmuls(dst, dst, vtmp);
         if (isQ) {
-          ins(vtmp, S, vsrc, 0, 2);
+          ext(vtmp, T16B, vsrc, vsrc, 8);
           fmuls(dst, dst, vtmp);
-          ins(vtmp, S, vsrc, 0, 3);
+          ext(vtmp, T16B, vsrc, vsrc, 12);
           fmuls(dst, dst, vtmp);
          }
         break;
       case T_DOUBLE:
         assert(isQ, "unsupported");
         fmuld(dst, fsrc, vsrc);
-        ins(vtmp, D, vsrc, 0, 1);
+        ext(vtmp, T16B, vsrc, vsrc, 8);
         fmuld(dst, dst, vtmp);
         break;
       default:


### PR DESCRIPTION
The ReduceLane MUL operation multiplies the values of all lanes in a vector and stores the result in a scalar register. AArch64 does not have native instructions to support this operation, so this API is implemented using the vector&scalar `mul` and `ins` instructions.

The `ins` instruction (used in `neon_reduce_mul_integral` and `neon_reduce_mul_fp`) is used to extract part of the vector elements. This instruction only writes a single lane of the destination register but reads the whole destination, keeping the remaining lanes unchanged. This creates an unexpected read-after-write dependency on the previous value of the destination register, which serializes adjacent loop iterations after unrolling when the destination registers happen to be the same.

For example:
```
// iteration 1
ins	v17.d[0], v18.d[1]
mul	v17.2s, v17.2s, v18.2s
...

// iteration 2
ins	v17.d[0], v18.d[1]    // has data dependence with previous "mul"
mul	v17.2s, v17.2s, v18.2s
...
```

Due to the register rename mechanism, we expect the first `mul` and the second `ins` instructions to have no dependency on the write to `v17`. However, there is actually a `read-after-write` dependency between them because the second `ins` instruction only writes to one lane of the `v17` register, but needs to ensure that the values of the other lanes of `v17` remain unchanged. Therefore, it needs to wait for the result of the first `mul` instruction's write to the v17 register. This dependency is not what we expect.

Replace `ins` with `ext`, which writes the entire destination register and therefore has no dependency on its previous contents. Then, different iterations can be executed in parallel. The extracted low order lanes are identical to those produced by the original `ins` sequence, so the reduction result is unchanged.

There are already correctness tests in files like `test/jdk/jdk/incubator/vector/IntVector128Tests.java`, so this PR doesn't add new tests. All existing tests (tier1, tier2, tier3) passed.

JMH benchmark test results on a Nvidia Grace (Neoverse-V2) machine with 128-bit SVE2 are as follow. The JMH benchmarks are in the panama-vector/ vectorIntrinsics branch [1].

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/erfang/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/erfang/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Fixed;}
.xl66
	{mso-number-format:"0\.0";}
-->
</head>

<body link="#467886" vlink="#96607D">


Benchmark | Unit | Before | Error | After | Error | Uplift
-- | -- | -- | -- | -- | -- | --
Byte128Vector.MULLanes | ops/ms | 7240.5 | 3.1 | 11401.6 | 3.9 | 1.57
Byte128Vector.MULMaskedLanes | ops/ms | 6719.1 | 2.7 | 10893.3 | 34.2 | 1.62
Double128Vector.MULLanes | ops/ms | 1930.3 | 0.5 | 2209.9 | 1.1 | 1.14
Double128Vector.MULMaskedLanes | ops/ms | 2163.1 | 1.5 | 2177.4 | 1.1 | 1.01
Float128Vector.MULLanes | ops/ms | 2129.3 | 0.7 | 4269.5 | 1.1 | 2.01
Float128Vector.MULMaskedLanes | ops/ms | 1668.1 | 2.9 | 3971.9 | 1.4 | 2.38
Int128Vector.MULLanes | ops/ms | 3475.5 | 0.6 | 3850.1 | 3.1 | 1.11
Int128Vector.MULMaskedLanes | ops/ms | 3581.7 | 0.9 | 3777.8 | 1.6 | 1.05
Long128Vector.MULLanes | ops/ms | 1994.3 | 0.8 | 1993.8 | 0.6 | 1.00
Long128Vector.MULMaskedLanes | ops/ms | 1985.5 | 0.8 | 1986.1 | 0.4 | 1.00
Short128Vector.MULLanes | ops/ms | 5032.6 | 0.8 | 6523.7 | 0.9 | 1.30
Short128Vector.MULMaskedLanes | ops/ms | 4819.9 | 1.2 | 6407.4 | 1.4 | 1.33
  |   |   |   |   |   |  
Byte64Vector.MULLanes | ops/ms | 4442.7 | 3.9 | 6699.8 | 35.8 | 1.51
Byte64Vector.MULMaskedLanes | ops/ms | 4941.4 | 3.1 | 6591.5 | 32.9 | 1.33
Double64Vector.MULLanes | ops/ms | 64.6 | 0.4 | 63.8 | 0.5 | 0.99
Double64Vector.MULMaskedLanes | ops/ms | 54.9 | 0.1 | 54.9 | 0.1 | 1.00
Float64Vector.MULLanes | ops/ms | 2151.9 | 1.8 | 2277.2 | 1.7 | 1.06
Float64Vector.MULMaskedLanes | ops/ms | 2221.3 | 0.5 | 2207.1 | 0.6 | 0.99
Int64Vector.MULLanes | ops/ms | 2027.2 | 0.7 | 2030.3 | 1.8 | 1.00
Int64Vector.MULMaskedLanes | ops/ms | 2005.5 | 0.8 | 2004.7 | 0.6 | 1.00
Long64Vector.MULLanes | ops/ms | 63.3 | 0.2 | 63.3 | 0.2 | 1.00
Long64Vector.MULMaskedLanes | ops/ms | 54.6 | 0.4 | 55.0 | 0.3 | 1.01
Short64Vector.MULLanes | ops/ms | 3511.7 | 3.4 | 3480.7 | 3.4 | 0.99
Short64Vector.MULMaskedLanes | ops/ms | 3426.6 | 0.6 | 3428.7 | 3.6 | 1.00



</body>

</html>


[1] https://github.com/openjdk/panama-vector/blob/vectorIntrinsics/test/micro/org/openjdk/bench/jdk/incubator/vector/operation/Int128Vector.java#L1518




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387388](https://bugs.openjdk.org/browse/JDK-8387388): AArch64: Optimize reduceLanes MUL op with ext instruction (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31735/head:pull/31735` \
`$ git checkout pull/31735`

Update a local copy of the PR: \
`$ git checkout pull/31735` \
`$ git pull https://git.openjdk.org/jdk.git pull/31735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31735`

View PR using the GUI difftool: \
`$ git pr show -t 31735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31735.diff">https://git.openjdk.org/jdk/pull/31735.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31735#issuecomment-4852676856)
</details>
