### PR TITLE
8387596: DEVKIT_LIB_DIR is unused

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -326,14 +326,6 @@ AC_DEFUN_ONCE([BASIC_SETUP_DEVKIT],
       SYSROOT="$DEVKIT_ROOT/$host_alias/libc"
     elif test -d "$DEVKIT_ROOT/$host/sys-root"; then
       SYSROOT="$DEVKIT_ROOT/$host/sys-root"
-    fi
-
-    if test "x$DEVKIT_ROOT" != x; then
-      DEVKIT_LIB_DIR="$DEVKIT_ROOT/lib"
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
-        DEVKIT_LIB_DIR="$DEVKIT_ROOT/lib64"
-      fi
-      AC_SUBST(DEVKIT_LIB_DIR)
     fi
   fi
 


### PR DESCRIPTION
DEVKIT_LIB_DIR is defined in the autoconf m4 files, but it is not used outside of them. So we probably can remove it.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387596](https://bugs.openjdk.org/browse/JDK-8387596): DEVKIT_LIB_DIR is unused (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31737/head:pull/31737` \
`$ git checkout pull/31737`

Update a local copy of the PR: \
`$ git checkout pull/31737` \
`$ git pull https://git.openjdk.org/jdk.git pull/31737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31737`

View PR using the GUI difftool: \
`$ git pr show -t 31737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31737.diff">https://git.openjdk.org/jdk/pull/31737.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31737#issuecomment-4854819565)
</details>
