### PR TITLE
8387491: AArch64: implement _vectorizedMismatch intrinsic

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -172,6 +172,7 @@ source %{
       case Op_OrVMask:
       case Op_XorVMask:
       case Op_MaskAll:
+      case Op_VectorCmpMasked:
       case Op_VectorMaskGen:
       case Op_LoadVectorMasked:
       case Op_StoreVectorMasked:
@@ -6880,6 +6881,31 @@ instruct vmaskAllL_masked(pReg dst, iRegL src, pRegGov pg, vReg tmp, rFlagsReg c
     __ sve_dup($tmp$$FloatRegister, size, $src$$Register);
     __ sve_cmp(Assembler::NE, $dst$$PRegister, size,
                $pg$$PRegister, $tmp$$FloatRegister, 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// partial inlining for vectorizedMismatch
+
+instruct vmask_cmp_node(iRegINoSp dst, vReg src1, vReg src2, pRegGov pg, pReg ptmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (VectorCmpMasked src1 (Binary src2 pg)));
+  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
+  format %{ "vmask_cmp $dst, $src1, $src2, $pg\t# KILL $ptmp, cr" %}
+  ins_encode %{
+    assert(Matcher::vector_length_in_bytes(this, $src1) == Matcher::vector_length_in_bytes(this, $src2), "mismatch");
+    assert(Matcher::vector_element_basic_type(this, $src1) == Matcher::vector_element_basic_type(this, $src2), "mismatch");
+
+    Label DONE;
+    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+
+    __ mov($dst$$Register, -1);
+    __ sve_cmp(Assembler::NE, $ptmp$$PRegister, size, $pg$$PRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ br(Assembler::EQ, DONE);
+    __ sve_brkb($ptmp$$PRegister, $pg$$PRegister, $ptmp$$PRegister, false);
+    __ sve_cntp($dst$$Register, size, $pg$$PRegister, $ptmp$$PRegister);
+    __ bind(DONE);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -162,6 +162,7 @@ source %{
       case Op_OrVMask:
       case Op_XorVMask:
       case Op_MaskAll:
+      case Op_VectorCmpMasked:
       case Op_VectorMaskGen:
       case Op_LoadVectorMasked:
       case Op_StoreVectorMasked:
@@ -4606,6 +4607,31 @@ VMASKALL_PREDICATE(I, iRegIorL2I)
 VMASKALL_IMM(L, long)
 VMASKALL(L, iRegL)
 VMASKALL_PREDICATE(L, iRegL)
+
+// partial inlining for vectorizedMismatch
+
+instruct vmask_cmp_node(iRegINoSp dst, vReg src1, vReg src2, pRegGov pg, pReg ptmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (VectorCmpMasked src1 (Binary src2 pg)));
+  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
+  format %{ "vmask_cmp $dst, $src1, $src2, $pg\t# KILL $ptmp, cr" %}
+  ins_encode %{
+    assert(Matcher::vector_length_in_bytes(this, $src1) == Matcher::vector_length_in_bytes(this, $src2), "mismatch");
+    assert(Matcher::vector_element_basic_type(this, $src1) == Matcher::vector_element_basic_type(this, $src2), "mismatch");
+
+    Label DONE;
+    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+
+    __ mov($dst$$Register, -1);
+    __ sve_cmp(Assembler::NE, $ptmp$$PRegister, size, $pg$$PRegister, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ br(Assembler::EQ, DONE);
+    __ sve_brkb($ptmp$$PRegister, $pg$$PRegister, $ptmp$$PRegister, false);
+    __ sve_cntp($dst$$Register, size, $pg$$PRegister, $ptmp$$PRegister);
+    __ bind(DONE);
+  %}
+  ins_pipe(pipe_slow);
+%}
 
 // vetcor mask generation
 

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -1100,7 +1100,69 @@ void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {
 }
 
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {
-  fatal("vectorizedMismatch intrinsic is not implemented on this platform");
+  assert(UseVectorizedMismatchIntrinsic, "need SVE support");
+
+  LIR_Opr result = rlock_result(x);
+
+  LIRItem a(x->argument_at(0), this); // Object
+  LIRItem aOffset(x->argument_at(1), this); // long
+  LIRItem b(x->argument_at(2), this); // Object
+  LIRItem bOffset(x->argument_at(3), this); // long
+  LIRItem length(x->argument_at(4), this); // int
+  LIRItem log2ArrayIndexScale(x->argument_at(5), this); // int
+
+  a.load_item();
+  aOffset.load_nonconstant();
+  b.load_item();
+  bOffset.load_nonconstant();
+
+  long constant_aOffset = 0;
+  LIR_Opr result_aOffset = aOffset.result();
+  if (result_aOffset->is_constant()) {
+    constant_aOffset = result_aOffset->as_jlong();
+    result_aOffset = LIR_OprFact::illegalOpr;
+  }
+  LIR_Opr result_a = a.result();
+
+  long constant_bOffset = 0;
+  LIR_Opr result_bOffset = bOffset.result();
+  if (result_bOffset->is_constant()) {
+    constant_bOffset = result_bOffset->as_jlong();
+    result_bOffset = LIR_OprFact::illegalOpr;
+  }
+  LIR_Opr result_b = b.result();
+
+  LIR_Address* addr_a = new LIR_Address(result_a,
+                                        result_aOffset,
+                                        constant_aOffset,
+                                        T_BYTE);
+
+  LIR_Address* addr_b = new LIR_Address(result_b,
+                                        result_bOffset,
+                                        constant_bOffset,
+                                        T_BYTE);
+
+  BasicTypeList signature(4);
+  signature.append(T_ADDRESS);
+  signature.append(T_ADDRESS);
+  signature.append(T_INT);
+  signature.append(T_INT);
+  CallingConvention* cc = frame_map()->c_calling_convention(&signature);
+  const LIR_Opr result_reg = result_register_for(x->type());
+
+  LIR_Opr ptr_addr_a = new_register(T_ADDRESS);
+  __ leal(LIR_OprFact::address(addr_a), ptr_addr_a);
+
+  LIR_Opr ptr_addr_b = new_register(T_ADDRESS);
+  __ leal(LIR_OprFact::address(addr_b), ptr_addr_b);
+
+  __ move(ptr_addr_a, cc->at(0));
+  __ move(ptr_addr_b, cc->at(1));
+  length.load_item_force(cc->at(2));
+  log2ArrayIndexScale.load_item_force(cc->at(3));
+
+  __ call_runtime_leaf(StubRoutines::vectorizedMismatch(), getThreadTemp(), result_reg, cc->args());
+  __ move(result_reg, result);
 }
 
 // _i2l, _i2f, _i2d, _l2i, _l2f, _l2d, _f2i, _f2l, _f2d, _d2i, _d2l, _d2f

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2024, Red Hat Inc. All rights reserved.
+ * Copyright 2026 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -7301,4 +7302,67 @@ void MacroAssembler::try_to_replace_prev_vector_copy_with_movprfx(FloatRegister 
   uint32_t rn = Instruction_aarch64::extract(insn, 9, 5);
   Instruction_aarch64::patch(prev, 31, 0,
                              NativeInstruction::encode_sve_movprfx(rd, rn));
+}
+
+// Code for ArraysSupport::vectorizedMismatch() intrinsic
+// Clobbers: obja, length, tmp, rscratch1-2, vtmp1-2, pgtmp, ptmp
+void MacroAssembler::vectorized_mismatch(Register obja, Register objb, Register length,
+                                         Register log2_array_indxscale, Register result,
+                                         Register tmp, FloatRegister vtmp1, FloatRegister vtmp2,
+                                         PRegister pgtmp, PRegister ptmp) {
+  assert(UseVectorizedMismatchIntrinsic, "UseVectorizedMismatchIntrinsic must be enabled");
+  assert(UseSVE > 0, "SVE is required");
+
+  assert_different_registers(obja, objb, length, log2_array_indxscale, tmp, rscratch1, rscratch2);
+  assert_different_registers(vtmp1, vtmp2);
+  assert_different_registers(pgtmp, ptmp);
+
+  uint32_t vector_size = VM_Version::get_initial_sve_vector_length();
+
+  Label LOOP, TAIL, MISMATCH, DONE;
+
+#define LOAD_PAIR(ztmp1, ztmp2, pgtmp, src1, src2, offset)  \
+  sve_ld1b(ztmp1, B, pgtmp, Address(src1, offset)); \
+  sve_ld1b(ztmp2, B, pgtmp, Address(src2, offset));
+
+  assert(vector_size > 8, "unexpected SVE vector size");
+  sve_ptrue(pgtmp, B, 0b01000 | (exact_log2(vector_size) - 3));
+
+  Register limit = tmp;
+  Register off = rscratch1;
+  Register tmp_result = rscratch2;
+  mov(off, 0);
+  mov(tmp_result, -1);
+
+  lslv(length, length, log2_array_indxscale);
+  subs(limit, length, vector_size);
+  br(LT, TAIL);
+
+  // Process full-vector chunk with a ptrue predicated SVE loop
+  bind(LOOP);
+  LOAD_PAIR(vtmp1, vtmp2, pgtmp, obja, objb, off);
+  sve_cmp(Assembler::NE, ptmp, B, pgtmp, vtmp1, vtmp2);
+  br(NE, MISMATCH);
+  add(off, off, vector_size);
+  cmp(off, limit);
+  br(LE, LOOP);
+
+  // Process tail elements
+  bind(TAIL);
+  sve_whilelo(pgtmp, B, off, length);
+  br(EQ, DONE);
+  LOAD_PAIR(vtmp1, vtmp2, pgtmp, obja, objb, off);
+  sve_cmp(Assembler::NE, ptmp, B, pgtmp, vtmp1, vtmp2);
+  br(EQ, DONE);
+
+  bind(MISMATCH);
+  sve_brkb(ptmp, pgtmp, ptmp, false);
+  sve_cntp(tmp_result, B, pgtmp, ptmp);
+  add(tmp_result, tmp_result, off);
+  lsrv(tmp_result, tmp_result, log2_array_indxscale);
+
+  bind(DONE);
+  mov(result, tmp_result);
+
+#undef LOAD_PAIR
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1750,6 +1750,12 @@ public:
   void fast_lock(Register basic_lock, Register obj, Register t1, Register t2, Register t3, Label& slow);
   void fast_unlock(Register obj, Register t1, Register t2, Register t3, Label& slow);
 
+  // Code for ArraysSupport::vectorizedMismatch() intrinsic
+  void vectorized_mismatch(Register obja, Register objb, Register length,
+                           Register log2_array_indxscale, Register result, Register tmp,
+                           FloatRegister vtmp1, FloatRegister vtmp2, PRegister pgtmp,
+                           PRegister ptmp);
+
 private:
   // Check the current thread doesn't need a cross modify fence.
   void verify_cross_modify_fence_not_required() PRODUCT_RETURN;

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2025, Red Hat Inc. All rights reserved.
+ * Copyright 2026 Arm Limited and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -8410,6 +8411,53 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  /**
+   *  Arguments:
+   *
+   *  Input:
+   *    c_rarg0   - obja     address
+   *    c_rarg1   - objb     address
+   *    c_rarg2   - length   length
+   *    c_rarg3   - scale    log2_array_indxscale
+   *
+   *  Output:
+   *         r0   - int >= 0 mismatched index, < 0 bitwise complement of tail
+   */
+  address generate_vectorizedMismatch() {
+    StubId stub_id = StubId::stubgen_vectorizedMismatch_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, stub_id);
+    start = __ pc();
+
+    const Register obja = c_rarg0;
+    const Register objb = c_rarg1;
+    const Register length = c_rarg2;
+    const Register scale = c_rarg3;
+    const Register tmp = r4;
+    const FloatRegister ztmp1 = z0;
+    const FloatRegister ztmp2 = z1;
+    const PRegister pgtmp = p0;
+    const PRegister ptmp = p8;
+    const Register result = r0; // return value
+
+    BLOCK_COMMENT("Entry:");
+    __ enter();
+    __ vectorized_mismatch(obja, objb, length, scale, result, tmp, ztmp1, ztmp2, pgtmp, ptmp);
+    __ leave();
+    __ ret(lr);
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
+    return start;
+  }
+
   address generate_squareToLen() {
     // squareToLen algorithm for sizes 1..127 described in java code works
     // faster than multiply_to_len on some CPUs and slower on others, but
@@ -12627,6 +12675,10 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
 
     StubRoutines::aarch64::_spin_wait = generate_spin_wait();
+
+    if (UseVectorizedMismatchIntrinsic) {
+      StubRoutines::_vectorizedMismatch = generate_vectorizedMismatch();
+    }
 
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
     StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -326,11 +326,6 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseAdler32Intrinsics, true);
   }
 
-  if (UseVectorizedMismatchIntrinsic) {
-    warning("UseVectorizedMismatchIntrinsic specified, but not available on this CPU.");
-    FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
-  }
-
   if (supports_aes()) {
     if (FLAG_IS_DEFAULT(UseAESIntrinsics)) {
       FLAG_SET_DEFAULT(UseAESIntrinsics, true);
@@ -661,6 +656,17 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseVectorizedHashCodeIntrinsic, true);
   }
 #endif
+
+  if (UseSVE > 0) {
+    if (FLAG_IS_DEFAULT(UseVectorizedMismatchIntrinsic)) {
+      UseVectorizedMismatchIntrinsic = true;
+    }
+  } else if (UseVectorizedMismatchIntrinsic) {
+    if (!FLAG_IS_DEFAULT(UseVectorizedMismatchIntrinsic)) {
+      warning("UseVectorizedMismatchIntrinsic specified, but not supported on this CPU");
+    }
+    FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
+  }
 
   _spin_wait = get_spin_wait_desc();
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6645,7 +6645,7 @@ bool LibraryCallKit::inline_vectorizedMismatch() {
 
   if (elem_bt != T_ILLEGAL && ArrayOperationPartialInlineSize > 0) {
     inline_limit = ArrayOperationPartialInlineSize / type2aelembytes(elem_bt);
-    do_partial_inline = inline_limit >= 16;
+    do_partial_inline = inline_limit > 0 && Matcher::vector_size_supported(elem_bt, inline_limit);
   }
 
   if (do_partial_inline) {

--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -1066,7 +1066,7 @@
   do_stub(final, method_entry_barrier)                                  \
   do_entry(final, method_entry_barrier, method_entry_barrier,           \
            method_entry_barrier)                                        \
-  do_stub(final, vectorizedMismatch) /* only used by x86! */            \
+  do_stub(final, vectorizedMismatch)                                    \
   do_entry(final, vectorizedMismatch, vectorizedMismatch,               \
            vectorizedMismatch)                                          \
   do_stub(final, upcall_stub_exception_handler)                         \

--- a/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
@@ -25,166 +25,587 @@ package compiler.intrinsics;
 
 /*
  * @test
+ * @library /test/lib
  * @requires vm.opt.final.UseVectorizedMismatchIntrinsic == true
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.util
- *
- *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
- *                    -Xbatch -XX:-TieredCompilation
- *                    -XX:UseAVX=3
- *                     compiler.intrinsics.VectorizedMismatchTest
- *
- *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
- *                    -Xbatch -XX:-TieredCompilation
- *                    -XX:+UnlockDiagnosticVMOptions -XX:UseAVX=3 -XX:AVX3Threshold=0
- *                     compiler.intrinsics.VectorizedMismatchTest
+ * @run main compiler.intrinsics.VectorizedMismatchTest
  */
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class VectorizedMismatchTest {
-    private boolean[] boolean_a = new boolean[128];
-    private boolean[] boolean_b = new boolean[128];
 
-    int testBooleanConstantLength(int length) {
-        boolean[] obja = boolean_a;
-        boolean[] objb = boolean_b;
+    static abstract class Test {
+        static final int fill = -1;
+        static final int mismatch = 0;
+
+        static final Test tests[] = {
+            new BooleanTest(), new ByteTest(), new ShortTest(), new CharTest(), new IntTest(),
+            new FloatTest(), new LongTest(), new DoubleTest(), new LoopUnswitch(), new LoopHoist()
+        };
+
+        public static void main(String[] args) {
+            for (int i = 0; i < 20_000; i++) {
+                for (Test t : tests) {
+                    t.test();
+                }
+            }
+        }
+
+        abstract void test();
+    }
+
+    /* ==================================================================================== */
+
+    static class BooleanTest extends Test {
+        boolean[] array = new boolean[128];
         long offset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_BOOLEAN_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testBooleanConstantLength0()   { return testBooleanConstantLength(0);   }
-    int testBooleanConstantLength1()   { return testBooleanConstantLength(1);   }
-    int testBooleanConstantLength64()  { return testBooleanConstantLength(64);  }
-    int testBooleanConstantLength128() { return testBooleanConstantLength(128); }
+        {
+            Arrays.fill(array, fill != 0);
+        }
+
+        void testConstantLengthMatch(int length) {
+            boolean[] obja = array;
+            boolean[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected boolean arrays of length " + length
+                        + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            boolean[] obja = array;
+            boolean[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = mismatch != 0;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected boolean arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength64() {
+            testConstantLengthMatch(64);
+            testConstantLengthMismatch(64);
+        }
+
+        void testConstantLength128() {
+            testConstantLengthMatch(128);
+            testConstantLengthMismatch(128);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength64();
+            testConstantLength128();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private byte[] byte_a = new byte[128];
-    private byte[] byte_b = new byte[128];
-
-    int testByteConstantLength(int length) {
-        byte[] obja = byte_a;
-        byte[] objb = byte_b;
+    static class ByteTest extends Test {
+        byte[] array = new byte[128];
         long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testByteConstantLength0()   { return testByteConstantLength(0);   }
-    int testByteConstantLength1()   { return testByteConstantLength(1);   }
-    int testByteConstantLength64()  { return testByteConstantLength(64);  }
-    int testByteConstantLength128() { return testByteConstantLength(128); }
+        {
+            Arrays.fill(array, (byte) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            byte[] obja = array;
+            byte[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException(
+                        "Expected byte arrays of length " + length + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            byte[] obja = array;
+            byte[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (byte) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected byte arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength64() {
+            testConstantLengthMatch(64);
+            testConstantLengthMismatch(64);
+        }
+
+        void testConstantLength128() {
+            testConstantLengthMatch(128);
+            testConstantLengthMismatch(128);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength64();
+            testConstantLength128();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private short[] short_a = new short[64];
-    private short[] short_b = new short[64];
-
-    int testShortConstantLength(int length) {
-        short[] obja = short_a;
-        short[] objb = short_b;
+    static class ShortTest extends Test {
+        short[] array = new short[64];
         long offset = Unsafe.ARRAY_SHORT_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_SHORT_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testShortConstantLength0()  { return testShortConstantLength(0);  }
-    int testShortConstantLength1()  { return testShortConstantLength(1);  }
-    int testShortConstantLength32() { return testShortConstantLength(32); }
-    int testShortConstantLength64() { return testShortConstantLength(64); }
+        {
+            Arrays.fill(array, (short) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            short[] obja = array;
+            short[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected short arrays of length " + length
+                        + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            short[] obja = array;
+            short[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (short) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected short arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength32() {
+            testConstantLengthMatch(32);
+            testConstantLengthMismatch(32);
+        }
+
+        void testConstantLength64() {
+            testConstantLengthMatch(64);
+            testConstantLengthMismatch(64);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength32();
+            testConstantLength64();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private char[] char_a = new char[64];
-    private char[] char_b = new char[64];
-
-    int testCharConstantLength(int length) {
-        char[] obja = char_a;
-        char[] objb = char_b;
+    static class CharTest extends Test {
+        char[] array = new char[64];
         long offset = Unsafe.ARRAY_CHAR_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_CHAR_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testCharConstantLength0()  { return testCharConstantLength(0);  }
-    int testCharConstantLength1()  { return testCharConstantLength(1);  }
-    int testCharConstantLength32() { return testCharConstantLength(32); }
-    int testCharConstantLength64() { return testCharConstantLength(64); }
+        {
+            Arrays.fill(array, (char) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            char[] obja = array;
+            char[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException(
+                        "Expected char arrays of length " + length + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            char[] obja = array;
+            char[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (char) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected char arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength32() {
+            testConstantLengthMatch(32);
+            testConstantLengthMismatch(32);
+        }
+
+        void testConstantLength64() {
+            testConstantLengthMatch(64);
+            testConstantLengthMismatch(64);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength32();
+            testConstantLength64();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private int[] int_a = new int[32];
-    private int[] int_b = new int[32];
-
-    int testIntConstantLength(int length) {
-        int[] obja = int_a;
-        int[] objb = int_b;
+    static class IntTest extends Test {
+        int[] array = new int[32];
         long offset = Unsafe.ARRAY_INT_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_INT_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testIntConstantLength0()  { return testIntConstantLength(0);  }
-    int testIntConstantLength1()  { return testIntConstantLength(1);  }
-    int testIntConstantLength16() { return testIntConstantLength(16); }
-    int testIntConstantLength32() { return testIntConstantLength(32); }
+        {
+            Arrays.fill(array, (int) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            int[] obja = array;
+            int[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException(
+                        "Expected int arrays of length " + length + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            int[] obja = array;
+            int[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (int) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected int arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength16() {
+            testConstantLengthMatch(16);
+            testConstantLengthMismatch(16);
+        }
+
+        void testConstantLength32() {
+            testConstantLengthMatch(32);
+            testConstantLengthMismatch(32);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength16();
+            testConstantLength32();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private float[] float_a = new float[32];
-    private float[] float_b = new float[32];
-
-    int testFloatConstantLength(int length) {
-        float[] obja = float_a;
-        float[] objb = float_b;
+    static class FloatTest extends Test {
+        float[] array = new float[32];
         long offset = Unsafe.ARRAY_FLOAT_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_FLOAT_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testFloatConstantLength0()  { return testFloatConstantLength(0);  }
-    int testFloatConstantLength1()  { return testFloatConstantLength(1);  }
-    int testFloatConstantLength16() { return testFloatConstantLength(16); }
-    int testFloatConstantLength32() { return testFloatConstantLength(32); }
+        {
+            Arrays.fill(array, (float) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            float[] obja = array;
+            float[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected float arrays of length " + length
+                        + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            float[] obja = array;
+            float[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (float) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected float arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength16() {
+            testConstantLengthMatch(16);
+            testConstantLengthMismatch(16);
+        }
+
+        void testConstantLength32() {
+            testConstantLengthMatch(32);
+            testConstantLengthMismatch(32);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength16();
+            testConstantLength32();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private long[] long_a = new long[16];
-    private long[] long_b = new long[16];
-
-    int testLongConstantLength(int length) {
-        long[] obja = long_a;
-        long[] objb = long_b;
+    static class LongTest extends Test {
+        long[] array = new long[16];
         long offset = Unsafe.ARRAY_LONG_BASE_OFFSET;
         int scale = ArraysSupport.LOG2_ARRAY_LONG_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
-    }
 
-    int testLongConstantLength0()  { return testLongConstantLength(0);  }
-    int testLongConstantLength1()  { return testLongConstantLength(1);  }
-    int testLongConstantLength8()  { return testLongConstantLength(8);  }
-    int testLongConstantLength16() { return testLongConstantLength(16); }
+        {
+            Arrays.fill(array, (long) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            long[] obja = array;
+            long[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException(
+                        "Expected long arrays of length " + length + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            long[] obja = array;
+            long[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (long) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected long arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength8() {
+            testConstantLengthMatch(8);
+            testConstantLengthMismatch(8);
+        }
+
+        void testConstantLength16() {
+            testConstantLengthMatch(16);
+            testConstantLengthMismatch(16);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength8();
+            testConstantLength16();
+        }
+    }
 
     /* ==================================================================================== */
 
-    private double[] double_a = new double[16];
-    private double[] double_b = new double[16];
-
-    int testDoubleConstantLength(int length) {
-        double[] obja = double_a;
-        double[] objb = double_b;
+    static class DoubleTest extends Test {
+        double[] array = new double[16];
         long offset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET;
-        int  scale  = ArraysSupport.LOG2_ARRAY_DOUBLE_INDEX_SCALE;
-        return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length, scale);
+        int scale = ArraysSupport.LOG2_ARRAY_DOUBLE_INDEX_SCALE;
+
+        {
+            Arrays.fill(array, (double) fill);
+        }
+
+        void testConstantLengthMatch(int length) {
+            double[] obja = array;
+            double[] objb = array.clone();
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != -1 && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected double arrays of length " + length
+                        + " to match but got " + result);
+            }
+        }
+
+        void testConstantLengthMismatch(int length) {
+            double[] obja = array;
+            double[] objb = array.clone();
+            int mismatchPos = length - 1;
+            objb[mismatchPos] = (double) mismatch;
+            int result = ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, length,
+                    scale);
+            if (result != mismatchPos && result != -(1 + length % Long.BYTES)) {
+                throw new RuntimeException("Expected double arrays of length " + length
+                        + " to mismatch at " + mismatchPos + " but got " + result);
+            }
+        }
+
+        void testConstantLength0() {
+            testConstantLengthMatch(0);
+        }
+
+        void testConstantLength1() {
+            testConstantLengthMatch(1);
+            testConstantLengthMismatch(1);
+        }
+
+        void testConstantLength8() {
+            testConstantLengthMatch(8);
+            testConstantLengthMismatch(8);
+        }
+
+        void testConstantLength16() {
+            testConstantLengthMatch(16);
+            testConstantLengthMismatch(16);
+        }
+
+        void test() {
+            testConstantLength0();
+            testConstantLength1();
+            testConstantLength8();
+            testConstantLength16();
+        }
     }
 
-    int testDoubleConstantLength0()  { return testDoubleConstantLength(0);  }
-    int testDoubleConstantLength1()  { return testDoubleConstantLength(1);  }
-    int testDoubleConstantLength8()  { return testDoubleConstantLength(8);  }
-    int testDoubleConstantLength16() { return testDoubleConstantLength(16); }
+    /* ==================================================================================== */
+
+    static class LoopUnswitch extends Test {
+        byte[] byteA = new byte[32];
+        byte[] byteB = new byte[32];
+        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+
+        int testLoopUnswitch(int length) {
+
+            int acc = 0;
+            for (int i = 0; i < 32; i++) {
+                acc += ArraysSupport.vectorizedMismatch(byteA, offset, byteB, offset, length,
+                        scale);
+            }
+            return acc;
+        }
+
+        void test() {
+            testLoopUnswitch(32);
+        }
+    }
+
+    /* ==================================================================================== */
+
+    static class LoopHoist extends Test {
+        byte[] byteA = new byte[128];
+        byte[] byteB = new byte[128];
+        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+        int scale = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+
+        int testLoopHoist(int length, int stride) {
+
+            int acc = 0;
+
+            for (int i = 0; i < 32; i += stride) {
+                acc += ArraysSupport.vectorizedMismatch(byteA, offset, byteB, offset, length,
+                        scale);
+            }
+            return acc;
+        }
+
+        void test() {
+            testLoopHoist(128, 2);
+        }
+    }
 
     /* ==================================================================================== */
 
@@ -202,8 +623,9 @@ public class VectorizedMismatchTest {
 
         static int test(byte[] obja, byte[] objb) {
             long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
-            int  scale  = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
-            return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, LENGTH, scale); // LENGTH is not considered a constant
+            int scale = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+            // LENGTH is not considered a constant
+            return ArraysSupport.vectorizedMismatch(obja, offset, objb, offset, LENGTH, scale);
         }
     }
 
@@ -213,76 +635,84 @@ public class VectorizedMismatchTest {
 
     /* ==================================================================================== */
 
-    int testLoopUnswitch(int length) {
-        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
-        int  scale  = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+    // Default to 1/4 of the CPUs, and allow users to override.
+    static final int MAX_PARALLELISM = Integer.getInteger("maxParallelism",
+            Math.max(1, Runtime.getRuntime().availableProcessors() / 4));
 
-        int acc = 0;
-        for (int i = 0; i < 32; i++) {
-            acc += ArraysSupport.vectorizedMismatch(byte_a, offset, byte_b, offset, length, scale);
+    private static List<String> mix(List<String> o, String... mix) {
+        List<String> n = new ArrayList<>(o);
+        for (String m : mix) {
+            n.add(m);
         }
-        return acc;
+        return n;
     }
 
-    int testLoopHoist(int length, int stride) {
-        long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
-        int  scale  = ArraysSupport.LOG2_ARRAY_BYTE_INDEX_SCALE;
+    public static void main(String[] args) throws Exception {
+        List<String> baseConfig = List.of("-XX:CompileCommand=quiet",
+                "-XX:CompileCommand=compileonly,*::test*", "-Xbatch",
+                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                "--add-exports=java.base/jdk.internal.util=ALL-UNNAMED");
+        List<String> c1BaseConfig = Stream.concat(baseConfig.stream(),
+                Stream.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=3")).toList();
+        List<String> c2BaseConfig = Stream
+                .concat(baseConfig.stream(), Stream.of("-XX:-TieredCompilation")).toList();
 
-        int acc = 0;
+        List<List<String>> configs = new ArrayList<>();
+        configs.add(new ArrayList<>(c1BaseConfig));
+        configs.add(new ArrayList<>(c2BaseConfig));
 
-        for (int i = 0; i < 32; i += stride) {
-            acc += ArraysSupport.vectorizedMismatch(byte_a, offset, byte_b, offset, length, scale);
+        if (Platform.isX64()) {
+            for (List<String> config : configs) {
+                config.add("-XX:UseAVX=3");
+            }
+
+            List<String> zeroAVX3ThresholdConfig = new ArrayList<>(c2BaseConfig);
+            zeroAVX3ThresholdConfig.add("-XX:+UnlockDiagnosticVMOptions");
+            zeroAVX3ThresholdConfig.add("-XX:UseAVX=3");
+            zeroAVX3ThresholdConfig.add("-XX:AVX3Threshold=0");
+            configs.add(zeroAVX3ThresholdConfig);
         }
-        return acc;
+
+        ArrayList<Fork> forks = new ArrayList<>();
+        int jobs = 0;
+
+        for (List<String> c : configs) {
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                    mix(c, "compiler.intrinsics.VectorizedMismatchTest$Test"));
+            Process p = pb.start();
+            forks.add(new Fork(p, new OutputAnalyzer(p)));
+            jobs++;
+
+            // Wait for the completion of other jobs
+            while (jobs >= MAX_PARALLELISM) {
+                Fork f = findDone(forks);
+                if (f != null) {
+                    OutputAnalyzer oa = f.oa();
+                    oa.shouldHaveExitValue(0);
+                    forks.remove(f);
+                    jobs--;
+                } else {
+                    // Nothing is done, wait a little.
+                    Thread.sleep(200);
+                }
+            }
+        }
+
+        // Drain the rest
+        for (Fork f : forks) {
+            OutputAnalyzer oa = f.oa();
+            oa.shouldHaveExitValue(0);
+        }
     }
 
-    /* ==================================================================================== */
+    private static record Fork(Process p, OutputAnalyzer oa) { }
 
-    public static void main(String[] args) {
-        VectorizedMismatchTest t = new VectorizedMismatchTest();
-        for (int i = 0; i < 20_000; i++) {
-            t.testBooleanConstantLength0();
-            t.testBooleanConstantLength1();
-            t.testBooleanConstantLength64();
-            t.testBooleanConstantLength128();
-
-            t.testByteConstantLength0();
-            t.testByteConstantLength1();
-            t.testByteConstantLength64();
-            t.testByteConstantLength128();
-
-            t.testShortConstantLength0();
-            t.testShortConstantLength1();
-            t.testShortConstantLength32();
-            t.testShortConstantLength64();
-
-            t.testCharConstantLength0();
-            t.testCharConstantLength1();
-            t.testCharConstantLength32();
-            t.testCharConstantLength64();
-
-            t.testIntConstantLength0();
-            t.testIntConstantLength1();
-            t.testIntConstantLength16();
-            t.testIntConstantLength32();
-
-            t.testFloatConstantLength0();
-            t.testFloatConstantLength1();
-            t.testFloatConstantLength16();
-            t.testFloatConstantLength32();
-
-            t.testLongConstantLength0();
-            t.testLongConstantLength1();
-            t.testLongConstantLength8();
-            t.testLongConstantLength16();
-
-            t.testDoubleConstantLength0();
-            t.testDoubleConstantLength1();
-            t.testDoubleConstantLength8();
-            t.testDoubleConstantLength16();
-
-            t.testLoopUnswitch(32);
-            t.testLoopHoist(128, 2);
+    private static Fork findDone(List<Fork> forks) {
+        for (Fork f : forks) {
+            if (!f.p().isAlive()) {
+                return f;
+            }
         }
+        return null;
     }
 }


### PR DESCRIPTION
Improve the performance of `ArraysSupport.vectorizedMismatch()` on SVE/SVE2-capable targets by adding an AArch64 implementation of the `_vectorizedMismatch `intrinsic.

A partial inlining path in `LibraryCallKit::inline_vectorizedMismatch()` is no longer guarded by the `inline_limit >= 16` check. It's not clear to me why it was added in this form in the first place. Description for https://github.com/openjdk/jdk/pull/3999 that added this code reads:

> For small compare operation whose size fits in one vector register
> i.e. < 32 bytes or <= 64 bytes, this patch employ partial in-lining
> technique to emit the fast path code at the call site which does
> vector comparison under the influence of a predicate register/mask
> computed as a function of comparison length.

> If the length of comparison is greater than the vector register size
> then the slow path comprising of stub call is emitted.

> This prevents the call overhead associated with stub call which is
> significant compared to actual comparison operation for small sized
> comparisons.

None of the above suggests that the intention was to prevent partial inlining based on a specific number of array elements. I suggest to remove this hard-coded logic.

---

## Performance

Below are processed performance results observed on Arm® Neoverse® V2. All numbers below are achieved relative difference in ops/time scores. Higher is better.

### `org.openjdk.bench.java.util.ArraysMismatch`

#### size = 90

| Data type | matches | mismatchStart | mismatchMid | mismatchEnd | differentSubrangeMatches |
| :-------- | ------: | ------------: | ----------: | ----------: | -----------------------: |
| Byte      | +60.67% |       -45.60% |      -2.18% |      +1.74% |                  +52.74% |
| Char      | +18.42% |       -43.64% |      +4.18% |      +5.72% |                  +10.43% |
| Short     | +18.53% |       -42.34% |      +2.86% |     +10.85% |                   +8.97% |
| Int       | +16.79% |       -15.84% |      +9.21% |      -8.91% |                   +5.45% |
| Long      | +15.83% |       -28.38% |      +4.85% |      -8.18% |                  +17.87% |
| Float     | +19.55% |       -14.81% |      +9.75% |     +12.93% |                   +5.25% |
| Double    |  +1.33% |       -25.70% |      +6.10% |      +0.41% |                  +10.81% |
| Average   | +21.59% |       -30.90% |      +4.97% |      +2.08% |                  +15.93% |

#### size = 800

| Data type | matches | mismatchStart | mismatchMid | mismatchEnd | differentSubrangeMatches |
| :-------- | ------: | ------------: | ----------: | ----------: | -----------------------: |
| Byte      | +13.95% |       -43.47% |     +12.79% |      +4.70% |                   +7.77% |
| Char      |  +7.92% |       -43.25% |     +13.77% |     +23.26% |                  +18.94% |
| Short     | +14.57% |       -43.75% |      +1.14% |     +21.34% |                  +17.06% |
| Int       | +19.52% |       -18.24% |      +7.28% |     +12.18% |                  +15.28% |
| Long      | +22.97% |       -27.36% |     +11.29% |     +13.37% |                  +12.95% |
| Float     | +19.21% |       -16.61% |      -0.77% |     +22.13% |                  +20.21% |
| Double    | +23.51% |       -28.26% |      +5.78% |     +14.12% |                  +13.77% |
| Average   | +17.38% |       -31.56% |      +7.33% |     +15.87% |                  +15.14% |

### `org.openjdk.bench.java.util.ArraysMismatchPartialInlining`

| Data type |       3 |        7 |       15 |      31 |      63 |      95 |     800 |
| :-------- | ------: | -------: | -------: | ------: | ------: | ------: | ------: |
| Byte      |  +8.01% |   -6.36% | +164.98% | +48.35% | +58.76% | +56.72% |  -6.70% |
| Char      |  -2.09% | +101.96% |  +16.38% | +35.13% | +41.70% | +32.57% | +12.70% |
| Short     |  -1.31% |  +97.55% |  +15.08% | +36.61% | +41.53% | +28.93% |  +1.61% |
| Int       | +77.47% |   +8.58% |  +19.00% | +29.60% | +25.97% | +23.65% |  +9.74% |
| Long      | -37.65% |   -3.49% |   +4.40% | +11.40% | +14.29% | +14.42% | +18.54% |
| Float     | +53.26% |  +10.91% |  +25.05% | +27.19% | +22.03% | +20.83% | +10.41% |
| Double    | -31.41% |   -2.43% |   +3.46% |  +8.69% | +11.23% | +10.70% | +13.03% |
| Average   |  +9.47% |  +29.53% |  +35.48% | +28.14% | +30.79% | +26.83% |  +8.48% |

---

## Testing

The patch has passed the following test groups on AArch64 system implementing 128-bit and 256-bit SVE and an x86_64 machine with AVX-512 support:

- `hotspot:hotspot_all` (no vmTestbase stress)
- `jdk:tier1,:tier2,:tier3`
- `langtools:tier1`

In addition to that, this PR contributes an updated dedicated JTReg test for `ArraysSupport.vectorizedMismath()`.




---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387491](https://bugs.openjdk.org/browse/JDK-8387491): AArch64: implement _vectorizedMismatch intrinsic (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31738/head:pull/31738` \
`$ git checkout pull/31738`

Update a local copy of the PR: \
`$ git checkout pull/31738` \
`$ git pull https://git.openjdk.org/jdk.git pull/31738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31738`

View PR using the GUI difftool: \
`$ git pr show -t 31738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31738.diff">https://git.openjdk.org/jdk/pull/31738.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31738#issuecomment-4855329709)
</details>
