### PR TITLE
8387490: G1: Dynamically creating worker threads exposes memory visibility race

### DIFF
--- a/src/hotspot/share/gc/shared/workerThread.cpp
+++ b/src/hotspot/share/gc/shared/workerThread.cpp
@@ -103,7 +103,7 @@ bool WorkerThreads::allow_inject_creation_failure() const {
     return false;
   }
 
-  if (_created_workers == 0) {
+  if (_created_workers.load_relaxed() == 0) {
     // Never allow creation failures of the first worker, it will cause the VM to exit
     return false;
   }
@@ -135,18 +135,20 @@ uint WorkerThreads::set_active_workers(uint num_workers) {
             "Invalid number of active workers %u (should be 1-%u)",
             num_workers, _max_workers);
 
-  while (_created_workers < num_workers) {
-    WorkerThread* const worker = create_worker(_created_workers);
+  uint local_created_workers = created_workers();
+  while (local_created_workers < num_workers) {
+    WorkerThread* const worker = create_worker(local_created_workers);
     if (worker == nullptr) {
       log_error(gc, task)("Failed to create worker thread");
       break;
     }
 
-    _workers[_created_workers] = worker;
-    _created_workers++;
+    _workers[local_created_workers] = worker;
+    local_created_workers++;
+    _created_workers.release_store(local_created_workers);
   }
 
-  _active_workers = MIN2(_created_workers, num_workers);
+  _active_workers = MIN2(local_created_workers, num_workers);
 
   log_trace(gc, task)("%s: using %d out of %d workers", _name, _active_workers, _max_workers);
 
@@ -154,14 +156,16 @@ uint WorkerThreads::set_active_workers(uint num_workers) {
 }
 
 void WorkerThreads::threads_do(ThreadClosure* tc) const {
-  for (uint i = 0; i < _created_workers; i++) {
+  uint local_created_workers = created_workers();
+  for (uint i = 0; i < local_created_workers; i++) {
     tc->do_thread(_workers[i]);
   }
 }
 
 template <typename Function>
 void WorkerThreads::threads_do_f(Function function) const {
-  for (uint i = 0; i < _created_workers; i++) {
+  uint local_created_workers = created_workers();
+  for (uint i = 0; i < local_created_workers; i++) {
     function(_workers[i]);
   }
 }

--- a/src/hotspot/share/gc/shared/workerThread.hpp
+++ b/src/hotspot/share/gc/shared/workerThread.hpp
@@ -88,7 +88,7 @@ private:
   const char* const    _name;
   WorkerThread**       _workers;
   const uint           _max_workers;
-  uint                 _created_workers;
+  Atomic<uint>         _created_workers;
   uint                 _active_workers;
   WorkerTaskDispatcher _dispatcher;
 
@@ -107,7 +107,7 @@ public:
   bool allow_inject_creation_failure() const;
 
   uint max_workers() const     { return _max_workers; }
-  uint created_workers() const { return _created_workers; }
+  uint created_workers() const { return _created_workers.load_acquire(); }
   uint active_workers() const  { return _active_workers; }
 
   uint set_active_workers(uint num_workers);

--- a/src/hotspot/share/gc/shared/workerThread.hpp
+++ b/src/hotspot/share/gc/shared/workerThread.hpp
@@ -88,6 +88,10 @@ private:
   const char* const    _name;
   WorkerThread**       _workers;
   const uint           _max_workers;
+  // _created_workers publishes the initialized prefix of _workers.
+  // Writers release-store to it after initializing an entry. Readers
+  // load-acquire before accessing _workers to not access uninitalized
+  // data.
   Atomic<uint>         _created_workers;
   uint                 _active_workers;
   WorkerTaskDispatcher _dispatcher;


### PR DESCRIPTION
Hi all,

  please review this change that fixes visibility issues with the (concurrent mark) worker threads - if g1 creates workers just before a garbage collection, the worker count but not the worker thread data structure itself would be updated, leading to crashes.

The fix is to make sure that users of created_workers() always see the complete associated `WorkerThread` data structure as well. using store_release/load_acquire memory barriers.

Testing: local compilation, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387490](https://bugs.openjdk.org/browse/JDK-8387490): G1: Dynamically creating worker threads exposes memory visibility race (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31739/head:pull/31739` \
`$ git checkout pull/31739`

Update a local copy of the PR: \
`$ git checkout pull/31739` \
`$ git pull https://git.openjdk.org/jdk.git pull/31739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31739`

View PR using the GUI difftool: \
`$ git pr show -t 31739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31739.diff">https://git.openjdk.org/jdk/pull/31739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31739#issuecomment-4855338177)
</details>
