### PR TITLE
8387633: Remove UnlockExperimentalVMOptions for COH in CDS build

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -142,8 +142,7 @@ define CreateCDSArchive
   $1_$2_COOPS_OPTION := $(if $(findstring _nocoops, $2),-XX:-UseCompressedOops)
   # enable and also explicitly disable coh as needed.
   ifeq ($(call isTargetCpuBits, 64), true)
-    $1_$2_NOCOH_OPTION := -XX:+UnlockExperimentalVMOptions \
-                        $(if $(findstring _nocoh, $2),-XX:-UseCompactObjectHeaders,-XX:+UseCompactObjectHeaders)
+    $1_$2_NOCOH_OPTION := $(if $(findstring _nocoh, $2),-XX:-UseCompactObjectHeaders,-XX:+UseCompactObjectHeaders)
   endif
   $1_$2_DUMP_EXTRA_ARG := $$($1_$2_COOPS_OPTION) $$($1_$2_NOCOH_OPTION)
   $1_$2_DUMP_TYPE      := $(if $(findstring _nocoops, $2),-NOCOOPS,)$(if $(findstring _nocoh, $2),-NOCOH,)


### PR DESCRIPTION
Please review this trivial change to fix the build to not pass UnlockExperimentalVMOptions for UseCompactObjectHeaders since it hasn't been experimental in a few releases now.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387633](https://bugs.openjdk.org/browse/JDK-8387633): Remove UnlockExperimentalVMOptions for COH in CDS build (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31745/head:pull/31745` \
`$ git checkout pull/31745`

Update a local copy of the PR: \
`$ git checkout pull/31745` \
`$ git pull https://git.openjdk.org/jdk.git pull/31745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31745`

View PR using the GUI difftool: \
`$ git pr show -t 31745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31745.diff">https://git.openjdk.org/jdk/pull/31745.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31745#issuecomment-4860493029)
</details>
