### PR TITLE
8327967: vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002/TestDescription.java fails intermittently

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -31,7 +31,6 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 
 
 vmTestbase/nsk/jvmti/unit/functions/Dispose/JvmtiTest/TestDescription.java 8387429 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/TestDescription.java 8299217 generic-all
-vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002/TestDescription.java 8327967 generic-all
 
 
 ####

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,6 +242,7 @@ public class JDIBase {
                 ThreadStartEvent tse = (ThreadStartEvent) event;
                 log2("ThreadStartEvent is received while waiting for a breakpoint" +
                      " event, thread: : " + tse.thread().name());
+                eventSet.resume();                
                 continue;
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -242,7 +242,7 @@ public class JDIBase {
                 ThreadStartEvent tse = (ThreadStartEvent) event;
                 log2("ThreadStartEvent is received while waiting for a breakpoint" +
                      " event, thread: : " + tse.thread().name());
-                eventSet.resume();                
+                eventSet.resume();
                 continue;
             }
 


### PR DESCRIPTION
The test creates and enables about 10 ThreadStartRequests. It does not expect there to be any threads created while these requests are active. It simply creates them to test out some ThreadStartRequest bookkeeping APIs. However, VirtualThreads introduces spurious creation of ForkJoinPool-1-worker threads. When the test eventually calls EventQueue.remove() to get the next event, it expects a BreakpointEvent. But now it sometimes gets a ThreadStartEvent. This was fixed in JDIBase.breakpointForCommunication() by filtering out ThreadStartRequests. However, that was done to fix other tests that create ThreadStartRequests, not this one. What is different about this test is that the ThreadStartRequests use SUSPEND_ALL rather then SUSPEND_NONE. So it is not enough to just skip the ThreadStartEvent. eventSet.resume() needs to be called to resume all the threads, including the one that the breakpoint is set on (which may or may not have triggered). The end result of this bug is that the thread the breakpoint happens on remains suspended, so the BreakpointEvent is never sent and the test times out. Calling eventSet.resume() seems to fix the issue. 

Tested by running the test with virtual threads at least 1000 times (it was reproducing much more often than this). Ran all nsk/jdk tests about 200 times. Ran all svc tier2 and tier5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8327967](https://bugs.openjdk.org/browse/JDK-8327967): vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002/TestDescription.java fails intermittently (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31746/head:pull/31746` \
`$ git checkout pull/31746`

Update a local copy of the PR: \
`$ git checkout pull/31746` \
`$ git pull https://git.openjdk.org/jdk.git pull/31746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31746`

View PR using the GUI difftool: \
`$ git pr show -t 31746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31746.diff">https://git.openjdk.org/jdk/pull/31746.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31746#issuecomment-4860833438)
</details>
