### PR TITLE
8386573: Test "java/awt/PrintJob/PrintProgressBarTest.java" failed after clicking the Print button, and the test terminated with RuntimeException: Test FAILED: ClassCastException

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -187,50 +187,37 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
         return Double.isNaN(value) ? 0 : value;
     }
 
-    private void paintProgressBar(Graphics2D g2, Insets i, int width, int height) {
-        // this is questionable. We may want the insets to mean something different.
-
-        final AffineTransform savedAT = g2.getTransform();
-        try {
-            if (!progressBar.getComponentOrientation().isLeftToRight()) {
-                //Scale operation: Flips component about pivot
-                //Translate operation: Moves component back into original position
-                g2.scale(-1, 1);
-                g2.translate(-progressBar.getWidth(), 0);
-            }
-            painter.paint(g2, progressBar, i.left, i.top, width, height);
-        } finally {
-            g2.setTransform(savedAT);
-        }
-    }
-
     protected void paint(final Graphics g) {
         final Insets i = progressBar.getInsets();
         final int width = progressBar.getWidth() - (i.right + i.left);
         final int height = progressBar.getHeight() - (i.bottom + i.top);
 
-        Graphics2D g2d = null;
+        Graphics2D g2;
+        BufferedImage image = null;
         if (g instanceof Graphics2D) {
-            g2d = (Graphics2D)g;
-            paintProgressBar(g2d, i, width, height);
-            if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-                paintString(g2d, i.left, i.top, width, height);
-            }
+            g2 = (Graphics2D)g;
         } else {
-            BufferedImage image = new BufferedImage(width, height,
+            image = new BufferedImage(width, height,
                                                     BufferedImage.TYPE_INT_RGB);
-            g2d = image.createGraphics();
-            try {
-                g2d.setColor(progressBar.getBackground());
-                g2d.fillRect(0, 0, width, height);
-                paintProgressBar(g2d, i, width, height);
-                if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-                    paintString(g2d, i.left, i.top, width, height);
-                }
-            } finally {
-                g2d.dispose();
-            }
+            g2 = image.createGraphics();
+            g2.setColor(progressBar.getBackground());
+            g2.fillRect(0, 0, width, height);
+        }
+        final AffineTransform savedAT = g2.getTransform();
+        if (!progressBar.getComponentOrientation().isLeftToRight()) {
+            //Scale operation: Flips component about pivot
+            //Translate operation: Moves component back into original position
+            g2.scale(-1, 1);
+            g2.translate(-progressBar.getWidth(), 0);
+        }
+        painter.paint(g2, progressBar, i.left, i.top, width, height);
+        g2.setTransform(savedAT);
+        if (image != null) {
             g.drawImage(image, 0, 0, width, height, null);
+            g2.dispose();
+        }
+        if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+            paintString(g, i.left, i.top, width, height);
         }
     }
 
@@ -241,32 +228,39 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
     }
 
     protected void paintString(final Graphics g, final int x, final int y, final int width, final int height) {
-        if (!(g instanceof Graphics2D)) return;
 
-        final Graphics2D g2 = (Graphics2D)g;
         final String progressString = progressBar.getString();
-        g2.setFont(progressBar.getFont());
-        final Point renderLocation = getStringPlacement(g2, progressString, x, y, width, height);
-        final Rectangle oldClip = g2.getClipBounds();
+        g.setFont(progressBar.getFont());
+        final Point renderLocation = getStringPlacement(g, progressString, x, y, width, height);
+        final Rectangle oldClip = g.getClipBounds();
 
         if (isHorizontal()) {
-            g2.setColor(selectionForeground);
-            SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
+            g.setColor(selectionForeground);
+            SwingUtilities2.drawString(progressBar, g, progressString, renderLocation.x, renderLocation.y);
         } else { // VERTICAL
-            // We rotate it -90 degrees, then translate it down since we are going to be bottom up.
-            final AffineTransform savedAT = g2.getTransform();
-            g2.transform(AffineTransform.getRotateInstance(0.0f - (Math.PI / 2.0f), 0, 0));
-            g2.translate(-progressBar.getHeight(), 0);
+            Graphics2D g2 = null;
+            AffineTransform savedAT = null;
+            if (g instanceof Graphics2D) {
+                g2 = (Graphics2D)g;
+            }
+            if (g instanceof Graphics2D) {
+                // We rotate it -90 degrees, then translate it down since we are going to be bottom up.
+                savedAT = g2.getTransform();
+                g2.transform(AffineTransform.getRotateInstance(0.0f - (Math.PI / 2.0f), 0, 0));
+                g2.translate(-progressBar.getHeight(), 0);
+                // 0,0 is now the bottom left of the viewable area, so we just draw our image at
+                // the render location since that calculation knows about rotation.
+            }
 
-            // 0,0 is now the bottom left of the viewable area, so we just draw our image at
-            // the render location since that calculation knows about rotation.
-            g2.setColor(selectionForeground);
-            SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
+            g.setColor(selectionForeground);
+            SwingUtilities2.drawString(progressBar, g, progressString, renderLocation.x, renderLocation.y);
 
-            g2.setTransform(savedAT);
+            if (g instanceof Graphics2D) {
+                g2.setTransform(savedAT);
+            }
         }
 
-        g2.setClip(oldClip);
+        g.setClip(oldClip);
     }
 
     /**

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -26,6 +26,7 @@
 package com.apple.laf;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.awt.event.*;
 import java.awt.geom.AffineTransform;
 import java.beans.*;
@@ -186,25 +187,47 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
         return Double.isNaN(value) ? 0 : value;
     }
 
-    protected void paint(final Graphics g) {
+    private void paintProgressBar(Graphics2D g2) {
         // this is questionable. We may want the insets to mean something different.
         final Insets i = progressBar.getInsets();
         final int width = progressBar.getWidth() - (i.right + i.left);
         final int height = progressBar.getHeight() - (i.bottom + i.top);
 
-        Graphics2D g2 = (Graphics2D) g;
         final AffineTransform savedAT = g2.getTransform();
-        if (!progressBar.getComponentOrientation().isLeftToRight()) {
-            //Scale operation: Flips component about pivot
-            //Translate operation: Moves component back into original position
-            g2.scale(-1, 1);
-            g2.translate(-progressBar.getWidth(), 0);
+        try {
+            if (!progressBar.getComponentOrientation().isLeftToRight()) {
+                //Scale operation: Flips component about pivot
+                //Translate operation: Moves component back into original position
+                g2.scale(-1, 1);
+                g2.translate(-progressBar.getWidth(), 0);
+            }
+            painter.paint(g2, progressBar, i.left, i.top, width, height);
+            if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+                paintString(g2, i.left, i.top, width, height);
+            }
+        } finally {
+            g2.setTransform(savedAT);
         }
-        painter.paint(g, progressBar, i.left, i.top, width, height);
+    }
 
-        g2.setTransform(savedAT);
-        if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-                paintString(g, i.left, i.top, width, height);
+    protected void paint(final Graphics g) {
+
+        if (g instanceof Graphics2D g2d) {
+            paintProgressBar(g2d);
+        } else {
+            int w = progressBar.getWidth();
+            int h = progressBar.getHeight();
+            BufferedImage image = new BufferedImage(w, h,
+                                                    BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2 = image.createGraphics();
+            try {
+                g2.setColor(progressBar.getBackground());
+                g2.fillRect(0, 0, w, h);
+                paintProgressBar(g2);
+            } finally {
+                g2.dispose();
+            }
+            g.drawImage(image, 0, 0, w, h, null);
         }
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -187,11 +187,8 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
         return Double.isNaN(value) ? 0 : value;
     }
 
-    private void paintProgressBar(Graphics2D g2) {
+    private void paintProgressBar(Graphics2D g2, Insets i, int width, int height) {
         // this is questionable. We may want the insets to mean something different.
-        final Insets i = progressBar.getInsets();
-        final int width = progressBar.getWidth() - (i.right + i.left);
-        final int height = progressBar.getHeight() - (i.bottom + i.top);
 
         final AffineTransform savedAT = g2.getTransform();
         try {
@@ -202,32 +199,38 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
                 g2.translate(-progressBar.getWidth(), 0);
             }
             painter.paint(g2, progressBar, i.left, i.top, width, height);
-            if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-                paintString(g2, i.left, i.top, width, height);
-            }
         } finally {
             g2.setTransform(savedAT);
         }
     }
 
     protected void paint(final Graphics g) {
+        final Insets i = progressBar.getInsets();
+        final int width = progressBar.getWidth() - (i.right + i.left);
+        final int height = progressBar.getHeight() - (i.bottom + i.top);
 
-        if (g instanceof Graphics2D g2d) {
-            paintProgressBar(g2d);
-        } else {
-            int w = progressBar.getWidth();
-            int h = progressBar.getHeight();
-            BufferedImage image = new BufferedImage(w, h,
-                                                    BufferedImage.TYPE_INT_RGB);
-            Graphics2D g2 = image.createGraphics();
-            try {
-                g2.setColor(progressBar.getBackground());
-                g2.fillRect(0, 0, w, h);
-                paintProgressBar(g2);
-            } finally {
-                g2.dispose();
+        Graphics2D g2d = null;
+        if (g instanceof Graphics2D) {
+            g2d = (Graphics2D)g;
+            paintProgressBar(g2d, i, width, height);
+            if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+                paintString(g2d, i.left, i.top, width, height);
             }
-            g.drawImage(image, 0, 0, w, h, null);
+        } else {
+            BufferedImage image = new BufferedImage(width, height,
+                                                    BufferedImage.TYPE_INT_RGB);
+            g2d = image.createGraphics();
+            try {
+                g2d.setColor(progressBar.getBackground());
+                g2d.fillRect(0, 0, width, height);
+                paintProgressBar(g2d, i, width, height);
+                if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+                    paintString(g2d, i.left, i.top, width, height);
+                }
+            } finally {
+                g2d.dispose();
+            }
+            g.drawImage(image, 0, 0, width, height, null);
         }
     }
 
@@ -238,6 +241,7 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
     }
 
     protected void paintString(final Graphics g, final int x, final int y, final int width, final int height) {
+System.out.println(g instanceof Graphics2D);
         if (!(g instanceof Graphics2D)) return;
 
         final Graphics2D g2 = (Graphics2D)g;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -241,7 +241,6 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
     }
 
     protected void paintString(final Graphics g, final int x, final int y, final int width, final int height) {
-System.out.println(g instanceof Graphics2D);
         if (!(g instanceof Graphics2D)) return;
 
         final Graphics2D g2 = (Graphics2D)g;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -218,13 +218,25 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
         g2.setTransform(savedAT);
 
         if (image != null) {
-            if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-                paintString(g2, i.left, i.top, width, height);
+            if (!isHorizontal()) {
+                if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+                    paintString(g2, i.left, i.top, width, height);
+                }
+                g2.dispose();
+                g.drawImage(image, 0, 0, null);
+            } else {
+                g.drawImage(image, 0, 0, null);
+                g2.dispose();
+                if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+                    paintString(g, i.left, i.top, width, height);
+                }
             }
-            g2.dispose();
-            g.drawImage(image, 0, 0, null);
         } else if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-            paintString(g, i.left, i.top, width, height);
+            BufferedImage stringImage = new BufferedImage(componentWidth, componentHeight, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D stringGraphics = stringImage.createGraphics();
+            paintString(stringGraphics, i.left, i.top, width, height);
+            stringGraphics.dispose();
+            g.drawImage(stringImage, 0, 0, null);
         }
     }
 
@@ -235,18 +247,17 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
     }
 
     protected void paintString(final Graphics g, final int x, final int y, final int width, final int height) {
-        if (!(g instanceof Graphics2D)) return;
 
-        final Graphics2D g2 = (Graphics2D)g;
         final String progressString = progressBar.getString();
-        g2.setFont(progressBar.getFont());
-        final Point renderLocation = getStringPlacement(g2, progressString, x, y, width, height);
-        final Rectangle oldClip = g2.getClipBounds();
+        g.setFont(progressBar.getFont());
+        final Point renderLocation = getStringPlacement(g, progressString, x, y, width, height);
+        final Rectangle oldClip = g.getClipBounds();
 
         if (isHorizontal()) {
-            g2.setColor(selectionForeground);
-            SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
+            g.setColor(selectionForeground);
+            SwingUtilities2.drawString(progressBar, g, progressString, renderLocation.x, renderLocation.y);
         } else { // VERTICAL
+            Graphics2D g2 = (Graphics2D) g;
             // We rotate it -90 degrees, then translate it down since we are going to be bottom up.
             final AffineTransform savedAT = g2.getTransform();
             g2.transform(AffineTransform.getRotateInstance(0.0f - (Math.PI / 2.0f), 0, 0));
@@ -260,7 +271,7 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
             g2.setTransform(savedAT);
         }
 
-        g2.setClip(oldClip);
+        g.setClip(oldClip);
     }
 
     /**

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -240,13 +240,13 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
             g2.setColor(selectionForeground);
             SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
         } else { // VERTICAL
-                // We rotate it -90 degrees, then translate it down since we are going to be bottom up.
+            // We rotate it -90 degrees, then translate it down since we are going to be bottom up.
             final AffineTransform savedAT = g2.getTransform();
             g2.transform(AffineTransform.getRotateInstance(0.0f - (Math.PI / 2.0f), 0, 0));
             g2.translate(-progressBar.getHeight(), 0);
+
             // 0,0 is now the bottom left of the viewable area, so we just draw our image at
             // the render location since that calculation knows about rotation.
-
             g2.setColor(selectionForeground);
             SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -189,35 +189,42 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
 
     protected void paint(final Graphics g) {
         final Insets i = progressBar.getInsets();
-        final int width = progressBar.getWidth() - (i.right + i.left);
-        final int height = progressBar.getHeight() - (i.bottom + i.top);
+        final int componentWidth = progressBar.getWidth();
+        final int componentHeight = progressBar.getHeight();
+        final int width = componentWidth - (i.right + i.left);
+        final int height = componentHeight - (i.bottom + i.top);
 
         Graphics2D g2;
         BufferedImage image = null;
+
         if (g instanceof Graphics2D) {
-            g2 = (Graphics2D)g;
+            g2 = (Graphics2D) g;
         } else {
-            image = new BufferedImage(width, height,
-                                                    BufferedImage.TYPE_INT_RGB);
+            image = new BufferedImage(componentWidth, componentHeight,
+                                      BufferedImage.TYPE_INT_RGB);
             g2 = image.createGraphics();
             g2.setColor(progressBar.getBackground());
-            g2.fillRect(0, 0, width, height);
+            g2.fillRect(0, 0, componentWidth, componentHeight);
         }
+
         final AffineTransform savedAT = g2.getTransform();
         if (!progressBar.getComponentOrientation().isLeftToRight()) {
             //Scale operation: Flips component about pivot
             //Translate operation: Moves component back into original position
             g2.scale(-1, 1);
-            g2.translate(-progressBar.getWidth(), 0);
+            g2.translate(-componentWidth, 0);
         }
         painter.paint(g2, progressBar, i.left, i.top, width, height);
         g2.setTransform(savedAT);
-        if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-            paintString(g2, i.left, i.top, width, height);
-        }
+
         if (image != null) {
-            g.drawImage(image, 0, 0, width, height, null);
+            if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+                paintString(g2, i.left, i.top, width, height);
+            }
             g2.dispose();
+            g.drawImage(image, 0, 0, null);
+        } else if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+            paintString(g, i.left, i.top, width, height);
         }
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -212,12 +212,12 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
         }
         painter.paint(g2, progressBar, i.left, i.top, width, height);
         g2.setTransform(savedAT);
+        if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
+            paintString(g2, i.left, i.top, width, height);
+        }
         if (image != null) {
             g.drawImage(image, 0, 0, width, height, null);
             g2.dispose();
-        }
-        if (progressBar.isStringPainted() && !progressBar.isIndeterminate()) {
-            paintString(g, i.left, i.top, width, height);
         }
     }
 
@@ -228,39 +228,32 @@ public final class AquaProgressBarUI extends ProgressBarUI implements ChangeList
     }
 
     protected void paintString(final Graphics g, final int x, final int y, final int width, final int height) {
+        if (!(g instanceof Graphics2D)) return;
 
+        final Graphics2D g2 = (Graphics2D)g;
         final String progressString = progressBar.getString();
-        g.setFont(progressBar.getFont());
-        final Point renderLocation = getStringPlacement(g, progressString, x, y, width, height);
-        final Rectangle oldClip = g.getClipBounds();
+        g2.setFont(progressBar.getFont());
+        final Point renderLocation = getStringPlacement(g2, progressString, x, y, width, height);
+        final Rectangle oldClip = g2.getClipBounds();
 
         if (isHorizontal()) {
-            g.setColor(selectionForeground);
-            SwingUtilities2.drawString(progressBar, g, progressString, renderLocation.x, renderLocation.y);
+            g2.setColor(selectionForeground);
+            SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
         } else { // VERTICAL
-            Graphics2D g2 = null;
-            AffineTransform savedAT = null;
-            if (g instanceof Graphics2D) {
-                g2 = (Graphics2D)g;
-            }
-            if (g instanceof Graphics2D) {
                 // We rotate it -90 degrees, then translate it down since we are going to be bottom up.
-                savedAT = g2.getTransform();
-                g2.transform(AffineTransform.getRotateInstance(0.0f - (Math.PI / 2.0f), 0, 0));
-                g2.translate(-progressBar.getHeight(), 0);
-                // 0,0 is now the bottom left of the viewable area, so we just draw our image at
-                // the render location since that calculation knows about rotation.
-            }
+            final AffineTransform savedAT = g2.getTransform();
+            g2.transform(AffineTransform.getRotateInstance(0.0f - (Math.PI / 2.0f), 0, 0));
+            g2.translate(-progressBar.getHeight(), 0);
+            // 0,0 is now the bottom left of the viewable area, so we just draw our image at
+            // the render location since that calculation knows about rotation.
 
-            g.setColor(selectionForeground);
-            SwingUtilities2.drawString(progressBar, g, progressString, renderLocation.x, renderLocation.y);
+            g2.setColor(selectionForeground);
+            SwingUtilities2.drawString(progressBar, g2, progressString, renderLocation.x, renderLocation.y);
 
-            if (g instanceof Graphics2D) {
-                g2.setTransform(savedAT);
-            }
+            g2.setTransform(savedAT);
         }
 
-        g.setClip(oldClip);
+        g2.setClip(oldClip);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
@@ -773,7 +773,8 @@ public class BasicProgressBarUI extends ProgressBarUI {
                 } else {
                     g.drawRect(b.left, b.top, barRectWidth, barRectHeight);
                     if (cellSpacing == 0 && amountFull > 0) {
-                        g.fillRect(barRectWidth + b.left, b.top, amountFull, barRectHeight);
+                        g.fillRect(barRectWidth + b.left, b.top,
+                                   barRectWidth + b.left - amountFull, barRectHeight);
                     } else {
                         for (int i = 0; i < barRectWidth; i += cellLength + cellSpacing) {
                             g.fillRect( barRectWidth + b.left + i, b.top,

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsProgressBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsProgressBarUI.java
@@ -188,10 +188,10 @@ public class WindowsProgressBarUI extends BasicProgressBarUI
                                     2 + barRectWidth - (amountFull - 2),
                                     barRectHeight / 2 + 1);
                         } else {
-                            g.drawRect(2 + barRectWidth, barRectHeight + 1,
+                            g.drawRect(0, 0, barRectWidth, barRectHeight);,
                                        barRectWidth, barRectHeight + 1);
-                            g.fillRect(2 + barRectWidth, barRectHeight + 1,
-                                        amountFull, barRectHeight + 1);
+                            g.fillRect(barRectWidth - amountFill, 0,
+                                        amountFull, barRectHeight);
                         }
                     }
                     paintString(g, 0, 0, (int)(barRectWidth / scaleX),

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsProgressBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsProgressBarUI.java
@@ -183,30 +183,29 @@ public class WindowsProgressBarUI extends BasicProgressBarUI
                         }
                     } else {
                         if (g instanceof Graphics2D) {
-                            g2d.drawLine(2 + barRectWidth,
-                                    barRectHeight / 2 + 1,
-                                    2 + barRectWidth - (amountFull - 2),
-                                    barRectHeight / 2 + 1);
+                            g2d.drawLine(progressBar.getWidth(),
+                                    progressBar.getHeight() / 2,
+                                     progressBar.getWidth() - amountFull,
+                                    progressBar.getHeight() / 2);
                         } else {
-                            g.drawRect(0, 0, barRectWidth, barRectHeight);,
-                                       barRectWidth, barRectHeight + 1);
-                            g.fillRect(barRectWidth - amountFill, 0,
-                                        amountFull, barRectHeight);
+                            g.drawRect(0, 0, barRectWidth, barRectHeight);
+                            g.fillRect(barRectWidth - amountFull, 0, amountFull, barRectHeight);
                         }
                     }
                     paintString(g, 0, 0, (int)(barRectWidth / scaleX),
                                 (int)(barRectHeight / scaleY), amountFull, null);
                 } else {
                     if (g instanceof Graphics2D) {
-                        g2d.drawLine(barRectWidth / 2 + 1, barRectHeight + 1,
-                                barRectWidth / 2 + 1, barRectHeight + 1 - amountFull + 2);
+                        int drawWidth = progressBar.getWidth();
+                        int drawHeight = progressBar.getHeight();
+                        g2d.drawLine(drawWidth / 2, drawHeight - 1,
+                                     drawWidth / 2, drawHeight - amountFull);
+                        paintString(g, 0, 0, drawWidth, drawHeight, amountFull, null);
                     } else {
-                        g.drawRect(barRectWidth + 1, barRectHeight + 1,
-                                barRectWidth + 1, barRectHeight + 1);
-                        g.fillRect(barRectWidth + 1, barRectHeight + 1,
-                                    barRectWidth + 1, amountFull);
+                        g.drawRect(0, 0, barRectWidth, barRectHeight);
+                        g.fillRect(0, barRectHeight - amountFull, barRectWidth, amountFull);
+                        paintString(g, 2, 2, barRectWidth, barRectHeight, amountFull, null);
                     }
-                    paintString(g, 2, 2, barRectWidth, barRectHeight, amountFull, null);
                 }
 
             } else {

--- a/test/jdk/java/awt/PrintJob/PrintProgressBarTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintProgressBarTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6328248
+ * @bug 6328248 8386573
  * @summary JProgessBar should be printed on paper with PrintJob
  * @key printer
  * @library /java/awt/regtesthelpers

--- a/test/jdk/java/awt/PrintJob/PrintProgressBarTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintProgressBarTest.java
@@ -82,6 +82,7 @@ public class PrintProgressBarTest {
                 if (pj != null) {
                     try {
                         Graphics g = pj.getGraphics();
+                        g.translate(20, 20);
                         panel.printAll(g);
                         g.dispose();
                         pj.end();

--- a/test/jdk/java/awt/PrintJob/PrintProgressBarTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintProgressBarTest.java
@@ -38,6 +38,7 @@ import javax.swing.JProgressBar;
 import javax.swing.SwingConstants;
 import java.awt.Graphics;
 import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
 import java.awt.FlowLayout;
 import java.awt.PrintJob;
 import java.awt.Toolkit;
@@ -48,10 +49,11 @@ import java.util.Properties;
 public class PrintProgressBarTest {
 
     private static final String INSTRUCTIONS = """
-        This test shows a frame with a progressbar and a "Print" button.
+        This test shows a frame with 2 progressbars
+        with LTR and RTL orientation respectively  and a "Print" button.
             1. Click the 'Print' button on the frame
             2. Select a printer/pdf-printer in the print dialog and proceed
-               If the progressbar is printed along with progress string
+               If the progressbars are printed along with progress string
                test PASSED else FAILED.
         """;
 
@@ -66,14 +68,25 @@ public class PrintProgressBarTest {
 
     private static JFrame createTestUI() {
         JPanel panel = new JPanel(new FlowLayout());
-        JProgressBar bar = new JProgressBar();
-        bar.setOpaque(true);
-        bar.setStringPainted(true);
-        bar.setValue(50);
-        panel.add("Center", bar);
+        JProgressBar ltrBar = new JProgressBar();
+        ltrBar.setOpaque(true);
+        ltrBar.setStringPainted(true);
+        ltrBar.setValue(50);
+        ltrBar.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT);
+
+        JProgressBar rtlBar = new JProgressBar();
+        rtlBar.setOpaque(true);
+        rtlBar.setStringPainted(true);
+        rtlBar.setValue(50);
+        rtlBar.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+
+        panel.add(ltrBar);
+        panel.add(rtlBar);
 
         JFrame frame = new JFrame("Print Progressbar");
-        frame.setContentPane(panel);
+        frame.setLayout(new BorderLayout());
+        frame.add(panel, BorderLayout.CENTER);
+
         JButton b = new JButton("Print");
         b.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent ev) {
@@ -95,8 +108,8 @@ public class PrintProgressBarTest {
             }
         });
 
-        frame.setSize(200, 150);
-        frame.add(b);
+        frame.add(b, BorderLayout.SOUTH);
+        frame.setSize(240, 160);
         return frame;
     }
 


### PR DESCRIPTION
 [JDK-6328248](https://bugs.openjdk.org/browse/JDK-6328248) fixed PrintJob (1.1 Graphics API) based JProgressBar printing for most L&F however it seems to cause ClassCastException in AquaProgressBarUI.paint as non-Graphics2D path was not handled
`Caused by: java.lang.ClassCastException: class sun.print.ProxyPrintGraphics cannot be cast to class java.awt.Graphics2D (sun.print.ProxyPrintGraphics and java.awt.Graphics2D are in module java.desktop of loader 'bootstrap') `

FIx is made to render Aqua progress bar into BufferedImage, then drawImage for non-Graphics2D case where 1.1 PrintJob is used




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386573](https://bugs.openjdk.org/browse/JDK-8386573): Test "java/awt/PrintJob/PrintProgressBarTest.java" failed after clicking the Print button, and the test terminated with RuntimeException: Test FAILED: ClassCastException (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31749/head:pull/31749` \
`$ git checkout pull/31749`

Update a local copy of the PR: \
`$ git checkout pull/31749` \
`$ git pull https://git.openjdk.org/jdk.git pull/31749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31749`

View PR using the GUI difftool: \
`$ git pr show -t 31749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31749.diff">https://git.openjdk.org/jdk/pull/31749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31749#issuecomment-4862673290)
</details>
