### PR TITLE
8387645: Replace obsolete sun.java2d.noddraw property with sun.java2d.d3d

### DIFF
--- a/src/java.desktop/windows/classes/sun/java2d/windows/WindowsFlags.java
+++ b/src/java.desktop/windows/classes/sun/java2d/windows/WindowsFlags.java
@@ -39,9 +39,9 @@ public final class WindowsFlags {
      * has forced it on with d3d=true.  These associated variables have
      * the same base (eg, d3d) but end in "Set" (eg, d3dEnabled and
      * d3dSet).
-     *      ddEnabled: usage: "-Dsun.java2d.d3d[=true|false]"
+     *      ddEnabled: usage: "-Dsun.java2d.noddraw[=false|true]"
      *               turns on/off all usage of Direct3D
-     *      ddOffscreenEnabled: equivalent of sun.java2d.d3d
+     *      ddOffscreenEnabled: equivalent of sun.java2d.noddraw
      *      gdiBlitEnabled: usage: "-Dsun.java2d.gdiblit=false"
      *               turns off Blit loops that use GDI for copying to
      *               the screen from certain image types.  Copies will,
@@ -169,7 +169,7 @@ public final class WindowsFlags {
         magPresent = getBooleanProp(
                 "javax.accessibility.screen_magnifier_present", false);
         boolean ddEnabled =
-                getBooleanProp("sun.java2d.d3d", magPresent);
+                !getBooleanProp("sun.java2d.noddraw", magPresent);
         boolean ddOffscreenEnabled =
                 getBooleanProp("sun.java2d.ddoffscreen", ddEnabled);
         d3dEnabled = getBooleanProp("sun.java2d.d3d",

--- a/src/java.desktop/windows/classes/sun/java2d/windows/WindowsFlags.java
+++ b/src/java.desktop/windows/classes/sun/java2d/windows/WindowsFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/classes/sun/java2d/windows/WindowsFlags.java
+++ b/src/java.desktop/windows/classes/sun/java2d/windows/WindowsFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,9 +39,9 @@ public final class WindowsFlags {
      * has forced it on with d3d=true.  These associated variables have
      * the same base (eg, d3d) but end in "Set" (eg, d3dEnabled and
      * d3dSet).
-     *      ddEnabled: usage: "-Dsun.java2d.noddraw[=false|true]"
+     *      ddEnabled: usage: "-Dsun.java2d.d3d[=true|false]"
      *               turns on/off all usage of Direct3D
-     *      ddOffscreenEnabled: equivalent of sun.java2d.noddraw
+     *      ddOffscreenEnabled: equivalent of sun.java2d.d3d
      *      gdiBlitEnabled: usage: "-Dsun.java2d.gdiblit=false"
      *               turns off Blit loops that use GDI for copying to
      *               the screen from certain image types.  Copies will,
@@ -169,7 +169,7 @@ public final class WindowsFlags {
         magPresent = getBooleanProp(
                 "javax.accessibility.screen_magnifier_present", false);
         boolean ddEnabled =
-                !getBooleanProp("sun.java2d.noddraw", magPresent);
+                getBooleanProp("sun.java2d.d3d", magPresent);
         boolean ddOffscreenEnabled =
                 getBooleanProp("sun.java2d.ddoffscreen", ddEnabled);
         d3dEnabled = getBooleanProp("sun.java2d.d3d",

--- a/test/jdk/java/awt/FullScreen/DisplayModeNoRefreshTest.java
+++ b/test/jdk/java/awt/FullScreen/DisplayModeNoRefreshTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public class DisplayModeNoRefreshTest extends Frame {
     public static void main(String[] args) throws Exception {
         try {
             EventQueue.invokeAndWait(() -> {
-                System.setProperty("sun.java2d.noddraw", "true");
+                System.setProperty("sun.java2d.d3d", "false");
                 fs = new DisplayModeNoRefreshTest();
             });
         } finally {

--- a/test/jdk/java/awt/FullScreen/MultimonFullscreenTest/MultimonFullscreenTest.java
+++ b/test/jdk/java/awt/FullScreen/MultimonFullscreenTest/MultimonFullscreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,18 +32,18 @@
  *    You could, however, alt+tab out of a fullscreen window, or at least
  *    minimize it (if you've entered the fs mode with a Window, you'll need
  *    to minimize the owner frame).
- *    Note that there may be issues with FS exclusive mode with ddraw and
+ *    Note that there may be issues with FS exclusive mode with d3d draw and
  *    multiple fullscreen windows (one per device).
  *  - if display mode is supported that it did change
  *  - that the original display mode is restored once
  *    the ws window is disposed
  *  All of the above should work with and w/o DirectDraw
- *  (-Dsun.java2d.noddraw=true) on windows, and w/ and w/o opengl on X11
+ *  (-Dsun.java2d.d3d=false) on windows, and w/ and w/o opengl on X11
  *  (-Dsun.java2d.opengl=True).
  * @run main/manual/othervm -Dsun.java2d.pmoffscreen=true MultimonFullscreenTest
  * @run main/manual/othervm -Dsun.java2d.pmoffscreen=false MultimonFullscreenTest
  * @run main/manual/othervm -Dsun.java2d.d3d=True MultimonFullscreenTest
- * @run main/manual/othervm -Dsun.java2d.noddraw=true MultimonFullscreenTest
+ * @run main/manual/othervm -Dsun.java2d.d3d=false MultimonFullscreenTest
  * @run main/manual/othervm MultimonFullscreenTest
  */
 

--- a/test/jdk/java/awt/FullScreen/NonExistentDisplayModeTest/NonExistentDisplayModeTest.java
+++ b/test/jdk/java/awt/FullScreen/NonExistentDisplayModeTest/NonExistentDisplayModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import static java.awt.DisplayMode.REFRESH_RATE_UNKNOWN;
  * @summary Test that we throw an exception for incorrect display modes
  * @author Dmitri.Trembovetski@Sun.COM area=FullScreen
  * @run main/othervm NonExistentDisplayModeTest
- * @run main/othervm -Dsun.java2d.noddraw=true NonExistentDisplayModeTest
+ * @run main/othervm -Dsun.java2d.d3d=false NonExistentDisplayModeTest
  */
 public class NonExistentDisplayModeTest {
 

--- a/test/jdk/java/awt/FullScreen/SetFSWindow/FSFrame.java
+++ b/test/jdk/java/awt/FullScreen/SetFSWindow/FSFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @summary verify that isFullScreenSupported and getFullScreenWindow work
  * correctly. Note that the test may fail on older Gnome versions (see bug 6500686).
  * @run main FSFrame
- * @run main/othervm -Dsun.java2d.noddraw=true FSFrame
+ * @run main/othervm -Dsun.java2d.d3d=false FSFrame
  */
 
 import java.awt.Color;

--- a/test/jdk/java/awt/GraphicsDevice/CloneConfigsTest.java
+++ b/test/jdk/java/awt/GraphicsDevice/CloneConfigsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *
  * @run     main CloneConfigsTest
  * @run     main/othervm -Dsun.java2d.d3d=true CloneConfigsTest
- * @run     main/othervm -Dsun.java2d.noddraw=true CloneConfigsTest
+ * @run     main/othervm -Dsun.java2d.d3d=false CloneConfigsTest
  */
 
 import java.awt.GraphicsConfiguration;

--- a/test/jdk/java/awt/Multiscreen/DeviceIdentificationTest/DeviceIdentificationTest.java
+++ b/test/jdk/java/awt/Multiscreen/DeviceIdentificationTest/DeviceIdentificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@
  * fs mode on the right device.
  *
  * @run main/manual/othervm DeviceIdentificationTest
- * @run main/manual/othervm -Dsun.java2d.noddraw=true DeviceIdentificationTest
+ * @run main/manual/othervm -Dsun.java2d.d3d=false DeviceIdentificationTest
  */
 
 import java.awt.Button;

--- a/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java
+++ b/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @compile -XDignore.symbol.file=true TranslucentShapedFrameTest.java
  * @compile -XDignore.symbol.file=true TSFrame.java
  * @run main/manual/othervm TranslucentShapedFrameTest
- * @run main/manual/othervm -Dsun.java2d.noddraw=true TranslucentShapedFrameTest
+ * @run main/manual/othervm -Dsun.java2d.d3d=false TranslucentShapedFrameTest
  */
 
 import java.awt.Color;

--- a/test/jdk/sun/java2d/DirectX/OpaqueImageToSurfaceBlitTest/OpaqueImageToSurfaceBlitTest.java
+++ b/test/jdk/sun/java2d/DirectX/OpaqueImageToSurfaceBlitTest/OpaqueImageToSurfaceBlitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * compositing
  * @author Dmitri.Trembovetski@sun.com: area=Graphics
  * @run main/othervm OpaqueImageToSurfaceBlitTest
- * @run main/othervm -Dsun.java2d.noddraw=true OpaqueImageToSurfaceBlitTest
+ * @run main/othervm -Dsun.java2d.d3d=false OpaqueImageToSurfaceBlitTest
  */
 
 import java.awt.AlphaComposite;

--- a/test/jdk/sun/java2d/DirectX/StrikeDisposalCrashTest/StrikeDisposalCrashTest.java
+++ b/test/jdk/sun/java2d/DirectX/StrikeDisposalCrashTest/StrikeDisposalCrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * during the lifetime of the application
  *
  * @run main/othervm -Dsun.java2d.font.reftype=weak StrikeDisposalCrashTest
- * @run main/othervm -Dsun.java2d.font.reftype=weak -Dsun.java2d.noddraw=true StrikeDisposalCrashTest
+ * @run main/othervm -Dsun.java2d.font.reftype=weak -Dsun.java2d.d3d=false StrikeDisposalCrashTest
  */
 
 import java.awt.Font;

--- a/test/jdk/sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ import sun.awt.ConstrainableGraphics;
  * @author Dmitri.Trembovetski@Sun.COM: area=Graphics
  * @modules java.desktop/sun.awt
  * @run main EmptyClipRenderingTest
- * @run main/othervm -Dsun.java2d.noddraw=true EmptyClipRenderingTest
+ * @run main/othervm -Dsun.java2d.d3d=false EmptyClipRenderingTest
  * @run main/othervm -Dsun.java2d.pmoffscreen=true EmptyClipRenderingTest
  */
 public class EmptyClipRenderingTest {

--- a/test/jdk/sun/java2d/pipe/MutableColorTest/MutableColorTest.java
+++ b/test/jdk/sun/java2d/pipe/MutableColorTest/MutableColorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * manner) mutable Colors
  *
  * @run main/othervm MutableColorTest
- * @run main/othervm -Dsun.java2d.noddraw=true MutableColorTest
+ * @run main/othervm -Dsun.java2d.d3d=false MutableColorTest
  */
 
 import java.awt.Color;

--- a/test/jdk/sun/java2d/pipe/hw/RSLAPITest/RSLAPITest.java
+++ b/test/jdk/sun/java2d/pipe/hw/RSLAPITest/RSLAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          java.desktop/sun.java2d.pipe.hw
  * @compile -XDignore.symbol.file=true RSLAPITest.java
  * @run main/othervm RSLAPITest
- * @run main/othervm -Dsun.java2d.noddraw=true RSLAPITest
+ * @run main/othervm -Dsun.java2d.d3d=false RSLAPITest
  */
 
 import java.awt.Graphics;


### PR DESCRIPTION
sun.java2d.noddraw property was used to render without d3d pipeline. However subsequent creation and use of sun.java2d.d3d property rendered it useless and obsolete.
We should consider removing it and replacing with sun.java2d.d3d property. We already have a start with JDK-8373493

CI testing is ok

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387645](https://bugs.openjdk.org/browse/JDK-8387645): Replace obsolete sun.java2d.noddraw property with sun.java2d.d3d (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31750/head:pull/31750` \
`$ git checkout pull/31750`

Update a local copy of the PR: \
`$ git checkout pull/31750` \
`$ git pull https://git.openjdk.org/jdk.git pull/31750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31750`

View PR using the GUI difftool: \
`$ git pr show -t 31750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31750.diff">https://git.openjdk.org/jdk/pull/31750.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31750#issuecomment-4862727791)
</details>
