### PR TITLE
8381880: Test compiler/c1/TestTooManyVirtualRegistersMain.java uses wrong class in CompileCommand

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestTooManyVirtualRegistersMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestTooManyVirtualRegistersMain.java
@@ -29,7 +29,7 @@
  *          The test should bail out in C1.
  *
  * @compile TestTooManyVirtualRegisters.jasm
- * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,${test.main.class}::*
+ * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,compiler.c1.TestTooManyVirtualRegisters::*
  *                   ${test.main.class}
  */
 

--- a/test/hotspot/jtreg/compiler/c1/TestTooManyVirtualRegistersMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestTooManyVirtualRegistersMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,8 @@
  *          The test should bail out in C1.
  *
  * @compile TestTooManyVirtualRegisters.jasm
- * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,compiler.c1.TestExceptionBlockWithPredecessors::*
- *                   compiler.c1.TestTooManyVirtualRegistersMain
+ * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,${test.main.class}::*
+ *                   ${test.main.class}
  */
 
 package compiler.c1;


### PR DESCRIPTION
This PR fixes a trivial typo in `compiler/c1/TestTooManyVirtualRegistersMain.java` that made the compile-command a no-op.

Testing:
 - [x] Github Actions
 - [x] `compiler/c1/TestTooManyVirtualRegistersMain.java` with all configuration from tier1,tier2,tier3 and additional stress testing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381880](https://bugs.openjdk.org/browse/JDK-8381880): Test compiler/c1/TestTooManyVirtualRegistersMain.java uses wrong class in CompileCommand (**Bug** - P5)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31751/head:pull/31751` \
`$ git checkout pull/31751`

Update a local copy of the PR: \
`$ git checkout pull/31751` \
`$ git pull https://git.openjdk.org/jdk.git pull/31751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31751`

View PR using the GUI difftool: \
`$ git pr show -t 31751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31751.diff">https://git.openjdk.org/jdk/pull/31751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31751#issuecomment-4865881818)
</details>
