### PR TITLE
8387660: Oop verification is sometimes wrong

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -389,8 +389,8 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
   __ cbnz(tmp1, error);
 
   // make sure klass is 'reasonable', which is not zero.
-  __ load_narrow_klass(obj, obj); // get klass
-  __ cbz(obj, error);      // if klass is null it is broken
+  __ load_narrow_klass(tmp1, obj); // get klass
+  __ cbz(tmp1, error);      // if klass is null it is broken
 }
 
 void BarrierSetAssembler::try_peek_weak_handle_in_nmethod(MacroAssembler* masm, Register weak_handle, Register obj, Register tmp, Label& slow_path) {

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -389,7 +389,7 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
   __ cbnz(tmp1, error);
 
   // make sure klass is 'reasonable', which is not zero.
-  __ load_klass(obj, obj); // get klass
+  __ load_narrow_klass(obj, obj); // get klass
   __ cbz(obj, error);      // if klass is null it is broken
 }
 

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -1385,9 +1385,8 @@ void ZBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Registe
   __ bind(check_oop);
 
   // make sure klass is 'reasonable', which is not zero.
-  __ load_klass(tmp1, obj);  // get klass
-  __ tst(tmp1, tmp1);
-  __ br(Assembler::EQ, error); // if klass is null it is broken
+  __ load_narrow_klass(tmp1, obj); // get narrow klass
+  __ cbz(tmp1, error);      // if klass is null it is broken
 
   __ bind(check_zaddress);
   // Check if the oop is in the right area of memory

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5108,12 +5108,16 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   lsr(dst, dst, markWord::klass_shift);
 }
 
-void MacroAssembler::load_klass(Register dst, Register src) {
+void MacroAssembler::load_narrow_klass(Register dst, Register obj) {
   if (UseCompactObjectHeaders) {
-    load_narrow_klass_compact(dst, src);
+    load_narrow_klass_compact(dst, obj);
   } else {
-    ldrw(dst, Address(src, oopDesc::klass_offset_in_bytes()));
+    ldrw(dst, Address(obj, oopDesc::klass_offset_in_bytes()));
   }
+}
+
+void MacroAssembler::load_klass(Register dst, Register src) {
+  load_narrow_klass(dst, src);
   decode_klass_not_null(dst);
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5097,7 +5097,7 @@ void MacroAssembler::load_method_holder(Register holder, Register method) {
   ldr(holder, Address(holder, ConstantPool::pool_holder_offset()));          // InstanceKlass*
 }
 
-// Loads the obj's Klass* into dst.
+// Loads the obj's narrow Klass from a compact object header (+COH) into dst.
 // Preserves all registers (incl src, rscratch1 and rscratch2).
 // Input:
 // src - the oop we want to load the klass from.
@@ -5108,6 +5108,7 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   lsr(dst, dst, markWord::klass_shift);
 }
 
+// Loads the obj's narrow Klass from any header (compact or not) into dst.
 void MacroAssembler::load_narrow_klass(Register dst, Register src) {
   if (UseCompactObjectHeaders) {
     load_narrow_klass_compact(dst, src);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5108,11 +5108,11 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   lsr(dst, dst, markWord::klass_shift);
 }
 
-void MacroAssembler::load_narrow_klass(Register dst, Register obj) {
+void MacroAssembler::load_narrow_klass(Register dst, Register src) {
   if (UseCompactObjectHeaders) {
-    load_narrow_klass_compact(dst, obj);
+    load_narrow_klass_compact(dst, src);
   } else {
-    ldrw(dst, Address(obj, oopDesc::klass_offset_in_bytes()));
+    ldrw(dst, Address(src, oopDesc::klass_offset_in_bytes()));
   }
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -924,6 +924,7 @@ public:
 
   // oop manipulations
   void load_narrow_klass_compact(Register dst, Register src);
+  void load_narrow_klass(Register dst, Register obj);
   void load_klass(Register dst, Register src);
   void store_klass(Register dst, Register src);
   void cmp_klass(Register obj, Register klass, Register tmp);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -924,7 +924,7 @@ public:
 
   // oop manipulations
   void load_narrow_klass_compact(Register dst, Register src);
-  void load_narrow_klass(Register dst, Register obj);
+  void load_narrow_klass(Register dst, Register src);
   void load_klass(Register dst, Register src);
   void store_klass(Register dst, Register src);
   void cmp_klass(Register obj, Register klass, Register tmp);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2578,7 +2578,7 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(L1);
       __ stop("broken null klass");
       __ bind(L2);
-      __ load_klass(rscratch1, dst);
+      __ load_narrow_klass(rscratch1, dst);
       __ cbz(rscratch1, L1);     // this would be broken also
       BLOCK_COMMENT("} assert klasses not null done");
     }

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -352,8 +352,8 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
   __ bne(tmp1, tmp2, error);
 
   // Make sure klass is 'reasonable', which is not zero.
-  __ load_narrow_klass(obj, obj); // get klass
-  __ beqz(obj, error);           // if klass is null it is broken
+  __ load_narrow_klass(tmp1, obj); // get klass
+  __ beqz(tmp1, error);           // if klass is null it is broken
 }
 
 void BarrierSetAssembler::try_peek_weak_handle_in_nmethod(MacroAssembler* masm, Register weak_handle, Register obj,

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -352,7 +352,7 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
   __ bne(tmp1, tmp2, error);
 
   // Make sure klass is 'reasonable', which is not zero.
-  __ load_klass(obj, obj, tmp1); // get klass
+  __ load_narrow_klass(obj, obj); // get klass
   __ beqz(obj, error);           // if klass is null it is broken
 }
 

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -1039,7 +1039,7 @@ void ZBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Registe
   __ bind(check_oop);
 
   // Make sure klass is 'reasonable', which is not zero
-  __ load_klass(tmp1, obj, tmp2);
+  __ load_narrow_klass(tmp1, obj);
   __ beqz(tmp1, error);
 
   __ bind(check_zaddress);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3767,16 +3767,19 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   srli(dst, dst, markWord::klass_shift);
 }
 
+void MacroAssembler::load_narrow_klass(Register dst, Register obj) {
+  if (UseCompactObjectHeaders) {
+    load_narrow_klass_compact(dst, obj);
+  } else {
+    lwu(dst, Address(obj, oopDesc::klass_offset_in_bytes()));
+  }
+}
+
 void MacroAssembler::load_klass(Register dst, Register src, Register tmp) {
   assert_different_registers(dst, tmp);
   assert_different_registers(src, tmp);
-  if (UseCompactObjectHeaders) {
-    load_narrow_klass_compact(dst, src);
-    decode_klass_not_null(dst, tmp);
-  } else {
-    lwu(dst, Address(src, oopDesc::klass_offset_in_bytes()));
-    decode_klass_not_null(dst, tmp);
-  }
+  load_narrow_klass(dst, src);
+  decode_klass_not_null(dst, tmp);
 }
 
 void MacroAssembler::store_klass(Register dst, Register src, Register tmp) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3767,11 +3767,11 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   srli(dst, dst, markWord::klass_shift);
 }
 
-void MacroAssembler::load_narrow_klass(Register dst, Register obj) {
+void MacroAssembler::load_narrow_klass(Register dst, Register src) {
   if (UseCompactObjectHeaders) {
-    load_narrow_klass_compact(dst, obj);
+    load_narrow_klass_compact(dst, src);
   } else {
-    lwu(dst, Address(obj, oopDesc::klass_offset_in_bytes()));
+    lwu(dst, Address(src, oopDesc::klass_offset_in_bytes()));
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -197,6 +197,7 @@ class MacroAssembler: public Assembler {
                        Register val, Register tmp1, Register tmp2, Register tmp3);
   void load_klass(Register dst, Register src, Register tmp = t0);
   void load_narrow_klass_compact(Register dst, Register src);
+  void load_narrow_klass(Register dst, Register obj);
   void store_klass(Register dst, Register src, Register tmp = t0);
   void cmp_klass_beq(Register obj, Register klass,
                      Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -197,7 +197,7 @@ class MacroAssembler: public Assembler {
                        Register val, Register tmp1, Register tmp2, Register tmp3);
   void load_klass(Register dst, Register src, Register tmp = t0);
   void load_narrow_klass_compact(Register dst, Register src);
-  void load_narrow_klass(Register dst, Register obj);
+  void load_narrow_klass(Register dst, Register src);
   void store_klass(Register dst, Register src, Register tmp = t0);
   void cmp_klass_beq(Register obj, Register klass,
                      Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1898,7 +1898,7 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(L1);
       __ stop("broken null klass");
       __ bind(L2);
-      __ load_klass(t0, dst, t1);
+      __ load_narrow_klass(t0, dst);
       __ beqz(t0, L1);     // this would be broken also
       BLOCK_COMMENT("} assert klasses not null done");
     }

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -357,8 +357,8 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
   __ jcc(Assembler::notZero, error);
 
   // make sure klass is 'reasonable', which is not zero.
-  __ load_narrow_klass(obj, obj); // get narrow Klass
-  __ testl(obj, obj);
+  __ load_narrow_klass(tmp1, obj); // get narrow Klass
+  __ testl(tmp1, tmp1);
   __ jcc(Assembler::zero, error); // if klass is null it is broken
 }
 

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -357,8 +357,8 @@ void BarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Register
   __ jcc(Assembler::notZero, error);
 
   // make sure klass is 'reasonable', which is not zero.
-  __ load_klass(obj, obj, tmp1);  // get klass
-  __ testptr(obj, obj);
+  __ load_narrow_klass(obj, obj); // get narrow Klass
+  __ testl(obj, obj);
   __ jcc(Assembler::zero, error); // if klass is null it is broken
 }
 

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -1551,8 +1551,8 @@ void ZBarrierSetAssembler::check_oop(MacroAssembler* masm, Register obj, Registe
   __ bind(check_oop);
 
   // make sure klass is 'reasonable', which is not zero.
-  __ load_klass(tmp1, obj, tmp2);  // get klass
-  __ testptr(tmp1, tmp1);
+  __ load_narrow_klass(tmp1, obj); // get narrow klass
+  __ testl(tmp1, tmp1);
   __ jcc(Assembler::zero, error); // if klass is null it is broken
 
   __ bind(check_zaddress);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5434,17 +5434,19 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   shrq(dst, markWord::klass_shift);
 }
 
+void MacroAssembler::load_narrow_klass(Register dst, Register obj) {
+  if (UseCompactObjectHeaders) {
+    load_narrow_klass_compact(dst, obj);
+  } else {
+    movl(dst, Address(obj, oopDesc::klass_offset_in_bytes()));
+  }
+}
+
 void MacroAssembler::load_klass(Register dst, Register src, Register tmp) {
   assert_different_registers(src, tmp);
   assert_different_registers(dst, tmp);
-
-  if (UseCompactObjectHeaders) {
-    load_narrow_klass_compact(dst, src);
-    decode_klass_not_null(dst, tmp);
-  } else {
-    movl(dst, Address(src, oopDesc::klass_offset_in_bytes()));
-    decode_klass_not_null(dst, tmp);
-  }
+  load_narrow_klass(dst, src);
+  decode_klass_not_null(dst, tmp);
 }
 
 void MacroAssembler::store_klass(Register dst, Register src, Register tmp) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5434,11 +5434,11 @@ void MacroAssembler::load_narrow_klass_compact(Register dst, Register src) {
   shrq(dst, markWord::klass_shift);
 }
 
-void MacroAssembler::load_narrow_klass(Register dst, Register obj) {
+void MacroAssembler::load_narrow_klass(Register dst, Register src) {
   if (UseCompactObjectHeaders) {
-    load_narrow_klass_compact(dst, obj);
+    load_narrow_klass_compact(dst, src);
   } else {
-    movl(dst, Address(obj, oopDesc::klass_offset_in_bytes()));
+    movl(dst, Address(src, oopDesc::klass_offset_in_bytes()));
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -350,6 +350,7 @@ class MacroAssembler: public Assembler {
 
   // oop manipulations
   void load_narrow_klass_compact(Register dst, Register src);
+  void load_narrow_klass(Register dst, Register obj);
   void load_klass(Register dst, Register src, Register tmp);
   void store_klass(Register dst, Register src, Register tmp);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -350,7 +350,7 @@ class MacroAssembler: public Assembler {
 
   // oop manipulations
   void load_narrow_klass_compact(Register dst, Register src);
-  void load_narrow_klass(Register dst, Register obj);
+  void load_narrow_klass(Register dst, Register src);
   void load_klass(Register dst, Register src, Register tmp);
   void store_klass(Register dst, Register src, Register tmp);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -3571,8 +3571,8 @@ address StubGenerator::generate_generic_copy(address byte_copy_entry, address sh
     __ bind(L1);
     __ stop("broken null klass");
     __ bind(L2);
-    __ load_klass(rax, dst, rklass_tmp);
-    __ cmpq(rax, 0);
+    __ load_narrow_klass(rax, dst);
+    __ testl(rax, rax);
     __ jcc(Assembler::equal, L1);     // this would be broken also
     BLOCK_COMMENT("} assert klasses not null done");
   }


### PR DESCRIPTION
There is a small bug I see at least on aarch64, riscv, and x86 where we do a basic "oop is ok" check by, among other things, checking the klass pointer against NULL.

We do this by loading Klass* with `load_klass(...)` and then comparing against NULL, for instance, in barrierSetAssembler here:

```
  // make sure klass is 'reasonable', which is not zero.
  __ load_klass(tmp1, obj); // get klass
  __ tst(tmp1, tmp1);
  __ br(Assembler::EQ, error); // if klass is null it is broken
```

This does not work as intended since load_klass does not handle narrowKlass=0. So, with a non-zero encoding base, we don't catch anything, and the assertion is dead.

Since with +COH (default now) we never run zero-based (and even if we would, CDS prevents us from doing it as well) this is usually always the case.

Fix is easy and less wasteful, too: Since we removed UseCompressedClassPointers with [JDK-8363996](https://bugs.openjdk.org/browse/JDK-8363996), there is no need to decode to Klass* at all. We can skip decoding and just compare the narrowKlass against zero.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387660](https://bugs.openjdk.org/browse/JDK-8387660): Oop verification is sometimes wrong (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31752/head:pull/31752` \
`$ git checkout pull/31752`

Update a local copy of the PR: \
`$ git checkout pull/31752` \
`$ git pull https://git.openjdk.org/jdk.git pull/31752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31752`

View PR using the GUI difftool: \
`$ git pr show -t 31752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31752.diff">https://git.openjdk.org/jdk/pull/31752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31752#issuecomment-4866591628)
</details>
