### PR TITLE
8387377: Compilation is very slow when --module-path contains many Automatic Modules and ALL-MODULE-PATH is used

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -717,19 +717,11 @@ public class Modules extends JCTree.Visitor {
 
         ListBuffer<RequiresDirective> requires = new ListBuffer<>();
 
-        //performance: pre-populate the requiresTransitiveCache:
-        Set<ModuleSymbol> requiresTransitive = new HashSet<>();
-
         for (ModuleSymbol ms : allModules()) {
             if (ms == syms.unnamedModule || ms == msym)
                 continue;
-            Set<RequiresFlag> flags;
-            if ((ms.flags_field & Flags.AUTOMATIC_MODULE) != 0) {
-                flags = EnumSet.of(RequiresFlag.TRANSITIVE);
-                requiresTransitive.add(ms);
-            } else {
-                flags = EnumSet.noneOf(RequiresFlag.class);
-            }
+            Set<RequiresFlag> flags = (ms.flags_field & Flags.AUTOMATIC_MODULE) != 0 ?
+                    EnumSet.of(RequiresFlag.TRANSITIVE) : EnumSet.noneOf(RequiresFlag.class);
             RequiresDirective d = new RequiresDirective(ms, flags);
             directives.add(d);
             requires.add(d);
@@ -741,8 +733,6 @@ public class Modules extends JCTree.Visitor {
 
         msym.requires = requires.toList();
         msym.directives = directives.toList();
-
-        requiresTransitiveCache.put(msym, requiresTransitive);
     }
 
     private Completer getSourceCompleter(JCCompilationUnit tree) {
@@ -1531,10 +1521,16 @@ public class Modules extends JCTree.Visitor {
 
         Set<ModuleSymbol> readable = new LinkedHashSet<>();
 
-        for (RequiresDirective d : msym.requires) {
-            d.module.complete();
-            readable.add(d.module);
-            readable.addAll(retrieveRequiresTransitive(d.module));
+        if ((msym.flags() & Flags.AUTOMATIC_MODULE) != 0) {
+            readable.addAll(allModules());
+            readable.remove(msym);
+            readable.forEach(Symbol::complete);
+        } else {
+            for (RequiresDirective d : msym.requires) {
+                d.module.complete();
+                readable.add(d.module);
+                readable.addAll(retrieveRequiresTransitive(d.module));
+            }
         }
 
         initVisiblePackages(msym, readable);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -717,11 +717,19 @@ public class Modules extends JCTree.Visitor {
 
         ListBuffer<RequiresDirective> requires = new ListBuffer<>();
 
+        //performance: pre-populate the requiresTransitiveCache:
+        Set<ModuleSymbol> requiresTransitive = new HashSet<>();
+
         for (ModuleSymbol ms : allModules()) {
             if (ms == syms.unnamedModule || ms == msym)
                 continue;
-            Set<RequiresFlag> flags = (ms.flags_field & Flags.AUTOMATIC_MODULE) != 0 ?
-                    EnumSet.of(RequiresFlag.TRANSITIVE) : EnumSet.noneOf(RequiresFlag.class);
+            Set<RequiresFlag> flags;
+            if ((ms.flags_field & Flags.AUTOMATIC_MODULE) != 0) {
+                flags = EnumSet.of(RequiresFlag.TRANSITIVE);
+                requiresTransitive.add(ms);
+            } else {
+                flags = EnumSet.noneOf(RequiresFlag.class);
+            }
             RequiresDirective d = new RequiresDirective(ms, flags);
             directives.add(d);
             requires.add(d);
@@ -733,6 +741,8 @@ public class Modules extends JCTree.Visitor {
 
         msym.requires = requires.toList();
         msym.directives = directives.toList();
+
+        requiresTransitiveCache.put(msym, requiresTransitive);
     }
 
     private Completer getSourceCompleter(JCCompilationUnit tree) {
@@ -1520,21 +1530,13 @@ public class Modules extends JCTree.Visitor {
         }
 
         Set<ModuleSymbol> readable = new LinkedHashSet<>();
-        Set<ModuleSymbol> requiresTransitive = new HashSet<>();
 
         for (RequiresDirective d : msym.requires) {
             d.module.complete();
             readable.add(d.module);
-            Set<ModuleSymbol> s = retrieveRequiresTransitive(d.module);
-            Assert.checkNonNull(s, () -> "no entry in cache for " + d.module);
-            readable.addAll(s);
-            if (d.flags.contains(RequiresFlag.TRANSITIVE)) {
-                requiresTransitive.add(d.module);
-                requiresTransitive.addAll(s);
-            }
+            readable.addAll(retrieveRequiresTransitive(d.module));
         }
 
-        requiresTransitiveCache.put(msym, requiresTransitive);
         initVisiblePackages(msym, readable);
         for (ExportsDirective d: msym.exports) {
             if (d.packge != null) {
@@ -1576,6 +1578,7 @@ public class Modules extends JCTree.Visitor {
             }
 
             requiresTransitive.remove(msym);
+            requiresTransitiveCache.putIfAbsent(msym, requiresTransitive);
         }
 
         return requiresTransitive;

--- a/test/langtools/tools/javac/modules/EdgeCases.java
+++ b/test/langtools/tools/javac/modules/EdgeCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8154283 8167320 8171098 8172809 8173068 8173117 8176045 8177311 8241519 8297988
+ * @bug 8154283 8167320 8171098 8172809 8173068 8173117 8176045 8177311 8241519 8297988 8387377
  * @summary tests for multi-module mode compilation
  * @library /tools/lib
  * @modules
@@ -37,7 +37,9 @@
  */
 
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.Writer;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -60,9 +62,14 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
 import com.sun.source.tree.CompilationUnitTree;
@@ -1243,4 +1250,62 @@ public class EdgeCases extends ModuleTestBase {
                     });
                 };
         }
+
+    @Test //JDK-8387377
+    public void testLargeNumberOfAutomaticModules(Path base) throws Exception {
+        final int moduleCount = 1_000;
+        Path lib = base.resolve("lib");
+
+        tb.createDirectories(lib);
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+            JavaFileManager generateAutomaticModules = new ForwardingJavaFileManager<JavaFileManager>(fm) {
+                @Override
+                public Iterable<Set<Location>> listLocationsForModules(Location location) throws IOException {
+                    if (location == StandardLocation.MODULE_PATH) {
+                        Set<Location> modules = new HashSet<>();
+                        for (int i = 0; i < moduleCount; i++) {
+                            modules.add(new AutomaticModuleLocation("m" + i));
+                        }
+                        return List.of(modules);
+                    }
+                    return super.listLocationsForModules(location);
+                }
+                @Override
+                public String inferModuleName(Location location) throws IOException {
+                    return location instanceof AutomaticModuleLocation aut
+                            ? aut.name
+                            : super.inferModuleName(location);
+                }
+                private class AutomaticModuleLocation implements Location {
+                    private final String name;
+                    public AutomaticModuleLocation(String name) {
+                        this.name = name;
+                    }
+                    @Override
+                    public String getName() {
+                        return name;
+                    }
+                    @Override
+                    public boolean isModuleOrientedLocation() {
+                        return false;
+                    }
+                    @Override
+                    public boolean isOutputLocation() {
+                        return false;
+                    }
+                }
+            };
+            CompilationTask task =
+                    compiler.getTask(null,
+                                     generateAutomaticModules,
+                                     null,
+                                     List.of("--add-modules", "ALL-MODULE-PATH"),
+                                     null,
+                                     List.of(SimpleJavaFileObject.forSource(URI.create("mem://Test.java"),
+                                                                            "")));
+            task.call();
+        }
+    }
 }


### PR DESCRIPTION
Automatic modules have `requires transitive` directives to all other automatic modules. When computing the transitive readability set, javac follows all these directives, for all the modules. When there's a high number of automatic modules, this can take a long time, as for each automatic module, javac does the full loop through all the other automatic modules.

This PR is attempting to improve the situation in two ways:
- the transitive readability computation is computed directly for automatic modules, avoiding the repeated analysis of automatic module dependencies.
- the pre-existing transitive readability cache is filled and used a bit more directly.

The enclosed test which uses 1_000 automatic modules is running in ~1s on my computer with this change; times out without it.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387377](https://bugs.openjdk.org/browse/JDK-8387377): Compilation is very slow when --module-path contains many Automatic Modules and ALL-MODULE-PATH is used (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31755/head:pull/31755` \
`$ git checkout pull/31755`

Update a local copy of the PR: \
`$ git checkout pull/31755` \
`$ git pull https://git.openjdk.org/jdk.git pull/31755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31755`

View PR using the GUI difftool: \
`$ git pr show -t 31755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31755.diff">https://git.openjdk.org/jdk/pull/31755.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31755#issuecomment-4867413845)
</details>
