### PR TITLE
8387640: vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq001/TestDescription.java fails intermittently

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,9 +219,11 @@ public class thrstartreq001 {
                                 log.display("EventListener: following JDI event occured: "
                                     + event.toString());
                         }
-                        if (isConnected) {
-                            eventSet.resume();
-                        }
+                        eventSet.resume();
+                        // Even if isConnected has been set false, we need to continue consuming
+                        // events until there are no more. So do a continue here rather than
+                        // allowing continuing to be conditional on isConnected below.
+                        continue;
                     }
                 } while (isConnected);
             } catch (InterruptedException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq001.java
@@ -201,7 +201,7 @@ public class thrstartreq001 {
 
         public void run() {
             try {
-                do {
+                while (true) {
                     EventSet eventSet = vm.eventQueue().remove(1000);
                     if (eventSet != null) { // there is not a timeout
                         EventIterator it = eventSet.eventIterator();
@@ -225,7 +225,9 @@ public class thrstartreq001 {
                         // allowing continuing to be conditional on isConnected below.
                         continue;
                     }
-                } while (isConnected);
+                    if (!isConnected)
+                        break;
+                }
             } catch (InterruptedException e) {
                 tot_res = FAILED;
                 log.complain("FAILURE in EventListener: caught unexpected "


### PR DESCRIPTION
The test wasn't consuming all ThreadStartEvents, meaning that eventSet.resume() wasn't called, which left threads suspended, which meant the debuggee never exited, which caused the debugger to timeout waiting for it to exit. Updated EventListener to ignore the `isConnected` flag until there are no more events.

The issue turned up about 1 in every 25000 runs. I ran about 75000 times with the fix without any issues.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387640](https://bugs.openjdk.org/browse/JDK-8387640): vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq001/TestDescription.java fails intermittently (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31756/head:pull/31756` \
`$ git checkout pull/31756`

Update a local copy of the PR: \
`$ git checkout pull/31756` \
`$ git pull https://git.openjdk.org/jdk.git pull/31756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31756`

View PR using the GUI difftool: \
`$ git pr show -t 31756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31756.diff">https://git.openjdk.org/jdk/pull/31756.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31756#issuecomment-4868119301)
</details>
