### PR TITLE
8381565: FileDialogDropTargetTest.java fails: Unexpected exit from test [exit code: -1073740771]

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WFileDialogPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFileDialogPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,15 @@ final class WFileDialogPeer extends WWindowPeer implements FileDialogPeer {
     private WComponentPeer parent;
     private FilenameFilter fileFilter;
 
+    /*
+     * The file dialog runs a nested message loop while it is open.
+     * Allow only one native file dialog at a time to prevent reentrant
+     * GetOpenFileName/GetSaveFileName.
+     */
+    private static final Object showLock = new Object();
+    private volatile boolean isShowRequested;
+    private volatile boolean isShowFinished;
+
     private Vector<WWindowPeer> blockedWindows = new Vector<>();
 
     //Needed to fix 4152317
@@ -86,20 +95,51 @@ final class WFileDialogPeer extends WWindowPeer implements FileDialogPeer {
     private native void _dispose();
     @Override
     protected void disposeImpl() {
+        isShowRequested = false;
         WToolkit.targetDisposedPeer(target, this);
         _dispose();
     }
 
-    private native void _show();
+    private native boolean _show();
     private native void _hide();
 
     @Override
     public void show() {
-        new Thread(null, this::_show, "FileDialog", 0, false).start();
+        synchronized (this) {
+            isShowRequested = true;
+            isShowFinished = false;
+        }
+        new Thread(null, this::showFileDialog, "FileDialog", 0, false).start();
+    }
+
+    private void showFileDialog() {
+        synchronized (showLock) {
+            if (!isShowRequested || isDisposed()) {
+                return;
+            }
+            if (_show()) {
+                waitForShowFinished();
+            }
+            isShowRequested = false;
+        }
+    }
+
+    private synchronized void waitForShowFinished() {
+        while (!isShowFinished) {
+            try {
+                wait();
+            } catch (InterruptedException ignored) {}
+        }
+    }
+
+    private synchronized void showFinished() {
+        isShowFinished = true;
+        notifyAll();
     }
 
     @Override
     void hide() {
+        isShowRequested = false;
         _hide();
     }
 
@@ -115,6 +155,9 @@ final class WFileDialogPeer extends WWindowPeer implements FileDialogPeer {
             } else {
                 window.modalEnable((Dialog)target);
             }
+        }
+        if (hwnd != 0 && !isShowRequested) {
+            WToolkit.executeOnEventHandlerThread(target, this::_hide);
         }
     }
 
@@ -174,6 +217,7 @@ final class WFileDialogPeer extends WWindowPeer implements FileDialogPeer {
                  fileDialog.setVisible(false);
              }
         });
+        showFinished();
     } // handleSelected()
 
     // NOTE: This method is called by privileged threads.
@@ -191,6 +235,7 @@ final class WFileDialogPeer extends WWindowPeer implements FileDialogPeer {
                  fileDialog.setVisible(false);
              }
         });
+        showFinished();
     } // handleCancel()
 
     //This whole static block is a part of 4152317 fix

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -560,7 +560,7 @@ Java_sun_awt_windows_WFileDialogPeer_setFilterString(JNIEnv *env, jclass cls,
     CATCH_BAD_ALLOC;
 }
 
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_sun_awt_windows_WFileDialogPeer__1show(JNIEnv *env, jobject peer)
 {
     TRY;
@@ -574,9 +574,12 @@ Java_sun_awt_windows_WFileDialogPeer__1show(JNIEnv *env, jobject peer)
     if (!AwtToolkit::GetInstance().PostMessage(WM_AWT_INVOKE_METHOD,
                              (WPARAM)AwtFileDialog::Show, (LPARAM)peerGlobal)) {
         env->DeleteGlobalRef(peerGlobal);
+        return false;
     }
 
-    CATCH_BAD_ALLOC;
+    return true;
+
+    CATCH_BAD_ALLOC_RET(false);
 }
 
 JNIEXPORT void JNICALL

--- a/test/jdk/java/awt/dnd/FileDialogDropTargetTest.java
+++ b/test/jdk/java/awt/dnd/FileDialogDropTargetTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4411368 8381565
+ * @key headful
+ * @summary tests the app doesn't crash when a drop target registered
+ *           on a file dialog is unregistered
+ * @run main/othervm/timeout=120 -Dsun.awt.disableGtkFileDialogs=true FileDialogDropTargetTest
+ */
+
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+
+public class FileDialogDropTargetTest {
+    private static Robot robot;
+    private static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        frame = new Frame();
+
+        try {
+            test(10);
+            test(100);
+        } finally {
+            EventQueue.invokeAndWait(frame::dispose);
+        }
+
+        System.out.println("Test passed");
+    }
+
+    private static void test(int delay) {
+        System.out.printf("\nTesting FileDialogDropTarget with %d ms delay\n", delay);
+        for (int i = 0; i < 100; i++) {
+            final FileDialog fileDialog = new FileDialog(frame);
+
+            fileDialog.setDropTarget(new DropTarget(fileDialog,
+                    new DropTargetAdapter() {
+                        public void drop(DropTargetDropEvent dtde) {
+                        }
+                    }));
+            fileDialog.pack();
+
+            new Thread(() -> {
+                robot.delay(delay);
+                fileDialog.dispose();
+            }).start();
+
+            fileDialog.setVisible(true);
+        }
+
+        robot.waitForIdle();
+        robot.delay(1000);
+    }
+}


### PR DESCRIPTION


On Windows, java allows the next file dialog to start while the first native dialog is still cleaning up, so the AWT toolkit message loop re-enters `AwtFileDialog::Show`.

This can create a recursive native stack:

`GetOpenFileNameW -> AwtFileDialog::Show -> AwtToolkit::WndProc -> GetOpenFileNameW ...`

Eventually, the process can hit a `STATUS_STACK_OVERFLOW` (`0xc00000fd`) and then terminates with `STATUS_FATAL_USER_CALLBACK_EXCEPTION` (`0xc000041d`, or `-1073740771` as reported).

---

The fix is to allow only one native Windows file dialog at a time:

- The show thread now waits until the native dialog reports selected/cancelled before another dialog can enter native show.
- `_show` now reports whether posting the native show request succeeded.
- `dispose`/`hide` clears a pending show request.
- If a native dialog window appears after the java side has already cancelled the show request, it is hidden on the event handler thread.

---

This PR includes an open sourced test, with a slight modification.
The JDK-8381565 issue was discovered using this test, but it reproduces only on some machines.
A reduced 10 ms delay case was added to the test to improve reproducibility, while the original 100 ms delay from the JDK-4411368 test was retained.

`setDropTarget` is not relevant to this issue.

Testing looks good.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381565](https://bugs.openjdk.org/browse/JDK-8381565): FileDialogDropTargetTest.java fails: Unexpected exit from test [exit code: -1073740771] (**Bug** - P3)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31757/head:pull/31757` \
`$ git checkout pull/31757`

Update a local copy of the PR: \
`$ git checkout pull/31757` \
`$ git pull https://git.openjdk.org/jdk.git pull/31757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31757`

View PR using the GUI difftool: \
`$ git pr show -t 31757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31757.diff">https://git.openjdk.org/jdk/pull/31757.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31757#issuecomment-4868882829)
</details>
