### PR TITLE
Update FileWriteEvent.java

### DIFF
--- a/src/java.base/share/classes/jdk/internal/event/FileWriteEvent.java
+++ b/src/java.base/share/classes/jdk/internal/event/FileWriteEvent.java
@@ -59,7 +59,7 @@ public final class FileWriteEvent extends Event {
      *
      * @param start  the start time
      * @param path  the path
-     * @param bytesRead  the number of bytes that were written, or -1 if the end of the file was reached
+     * @param bytesWritten  the number of bytes that were written
      */
     public static void offer(long start, String path, long bytesWritten) {
         long end = timestamp();


### PR DESCRIPTION
JFR: FileWriteEvent.offer javadoc has copy-pasted read semantics

PR description
FileWriteEvent.offer's @param tag for the bytesWritten parameter is named bytesRead and describes read-specific EOF se end of the file was reached"). This is leftover text copy-pasted from the sibling FileReadEvent.offer, whose bytesRead parameter really can be -1 to signal EOF (see FileReadEvent.java's endO PR description
FileWriteEvent.offer's @param tag for the bytesWritten parameter is named bytesRead and describes read-specific EOF semantics ("-1 if the end of the file was reached"). This is leftover text copy-pasted from the sibling FileReadEvent.offer, whose bytesRead p be -1 to signal EOF (see FileReadEvent.java's endOfFile field).

FileWriteEvent has no such concept: its callers in FileOutputStream (traceWrite, traceWriteBytes) initialize bytesWritten to 0, not -1, and there is no endOfFile field on the event. The
updated when FileWriteEvent was adapted from FileR

Fixed the @param name and description to match the actual parameter and its real semantics. No behavioral change, java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31760/head:pull/31760` \
`$ git checkout pull/31760`

Update a local copy of the PR: \
`$ git checkout pull/31760` \
`$ git pull https://git.openjdk.org/jdk.git pull/31760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31760`

View PR using the GUI difftool: \
`$ git pr show -t 31760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31760.diff">https://git.openjdk.org/jdk/pull/31760.diff</a>

</details>
