### PR TITLE
8387693: Remove unused method

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
@@ -1165,24 +1165,6 @@ public class BasicProgressBarUI extends ProgressBarUI {
         return repaintInterval;
     }
 
-    /**
-     * Returns the number of milliseconds per animation cycle.
-     * This value is meaningful
-     * only if the progress bar is in indeterminate mode.
-     * The cycle time is used by the default indeterminate progress bar
-     * painting code when determining
-     * how far to move the bouncing box per frame.
-     * The cycle time is specified by
-     * the "ProgressBar.cycleTime" UI default
-     * and adjusted, if necessary,
-     * by the initIndeterminateDefaults method.
-     *
-     * @return  the cycle time, in milliseconds
-     */
-    private int getCycleTime() {
-        return cycleTime;
-    }
-
     private int initCycleTime() {
         cycleTime = DefaultLookup.getInt(progressBar, this,
                 "ProgressBar.cycleTime", 3000);


### PR DESCRIPTION
getCycleTime private method is unused in BasicProgressBarUI which can be removed 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387693](https://bugs.openjdk.org/browse/JDK-8387693): Remove unused method (**Enhancement** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31761/head:pull/31761` \
`$ git checkout pull/31761`

Update a local copy of the PR: \
`$ git checkout pull/31761` \
`$ git pull https://git.openjdk.org/jdk.git pull/31761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31761`

View PR using the GUI difftool: \
`$ git pr show -t 31761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31761.diff">https://git.openjdk.org/jdk/pull/31761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31761#issuecomment-4873383312)
</details>
