### PR TITLE
8387675: IS_WINVISTA macro is obsolete

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsEnvironment.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsEnvironment.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsEnvironment.java
@@ -255,11 +255,4 @@ public final class Win32GraphicsEnvironment extends SunGraphicsEnvironment {
     private static void dwmCompositionChanged(boolean enabled) {
         isDWMCompositionEnabled = enabled;
     }
-
-    /**
-     * Used to find out if the OS is Windows Vista or later.
-     *
-     * @return {@code true} if the OS is Vista or later, {@code false} otherwise
-     */
-    public static native boolean isVistaOS();
 }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WComponentPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WComponentPeer.java
@@ -1082,16 +1082,10 @@ public abstract class WComponentPeer extends WObjectPeer
      */
     public boolean isAccelCapable() {
         if (!isAccelCapable ||
-            !isContainingTopLevelAccelCapable((Component)target))
-        {
+            !isContainingTopLevelAccelCapable((Component)target)) {
             return false;
         }
-
-        boolean isTranslucent =
-            SunToolkit.isContainingTopLevelTranslucent((Component)target);
-        // D3D/OGL and translucent windows interacted poorly in Windows XP;
-        // these problems are no longer present in Vista
-        return !isTranslucent || Win32GraphicsEnvironment.isVistaOS();
+        return true;
     }
 
     /**

--- a/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
@@ -683,16 +683,6 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
             throw new IllegalArgumentException(
                 "The value of opacity should be in the range [0.0f .. 1.0f].");
         }
-
-        if (((this.opacity == 1.0f && opacity <  1.0f) ||
-             (this.opacity <  1.0f && opacity == 1.0f)) &&
-            !Win32GraphicsEnvironment.isVistaOS())
-        {
-            // non-Vista OS: only replace the surface data if opacity status
-            // changed (see WComponentPeer.isAccelCapable() for more)
-            replaceSurfaceDataRecursively((Component)getTarget());
-        }
-
         this.opacity = opacity;
 
         final int maxOpacity = 0xff;
@@ -734,14 +724,6 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
             }
         }
 
-        boolean isVistaOS = Win32GraphicsEnvironment.isVistaOS();
-
-        if (this.isOpaque != isOpaque && !isVistaOS) {
-            // non-Vista OS: only replace the surface data if the opacity
-            // status changed (see WComponentPeer.isAccelCapable() for more)
-            replaceSurfaceDataRecursively(target);
-        }
-
         synchronized (getStateLock()) {
             this.isOpaque = isOpaque;
             setOpaqueImpl(isOpaque);
@@ -756,16 +738,14 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
             }
         }
 
-        if (isVistaOS) {
-            // On Vista: setting the window non-opaque makes the window look
-            // rectangular, though still catching the mouse clicks within
-            // its shape only. To restore the correct visual appearance
-            // of the window (i.e. w/ the correct shape) we have to reset
-            // the shape.
-            Shape shape = target.getShape();
-            if (shape != null) {
-                target.setShape(shape);
-            }
+        // On Vista: setting the window non-opaque makes the window look
+        // rectangular, though still catching the mouse clicks within
+        // its shape only. To restore the correct visual appearance
+        // of the window (i.e. w/ the correct shape) we have to reset
+        // the shape.
+        Shape shape = target.getShape();
+        if (shape != null) {
+            target.setShape(shape);
         }
 
         if (target.isVisible()) {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
@@ -738,7 +738,7 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
             }
         }
 
-        // On Vista: setting the window non-opaque makes the window look
+        // Since Vista: setting the window non-opaque makes the window look
         // rectangular, though still catching the mouse clicks within
         // its shape only. To restore the correct visual appearance
         // of the window (i.e. w/ the correct shape) we have to reset

--- a/src/java.desktop/windows/native/libawt/java2d/windows/WindowsFlags.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/windows/WindowsFlags.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/java2d/windows/WindowsFlags.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/windows/WindowsFlags.cpp
@@ -88,8 +88,7 @@ void GetFlagValues(JNIEnv *env, jclass wFlagsClass)
     }
     useD3D = d3dEnabled;
     forceD3DUsage = d3dSet;
-    setHighDPIAware =
-        (IS_WINVISTA && GetStaticBoolean(env, wFlagsClass, "setHighDPIAware"));
+    setHighDPIAware = GetStaticBoolean(env, wFlagsClass, "setHighDPIAware");
     JNU_CHECK_EXCEPTION(env);
 
     J2dTraceLn(J2D_TRACE_INFO, "WindowsFlags (native):");

--- a/src/java.desktop/windows/native/libawt/windows/awt.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt.h
@@ -154,12 +154,8 @@ typedef AwtObject* PDATA;
                                                      JNI_TRUE)
 /*  /NEW JNI */
 
-/*
- * IS_WINVISTA returns TRUE on Vista
- */
-#define IS_WINVISTA (LOBYTE(LOWORD(::GetVersion())) >= 6)
 #define IS_WIN8 (                                                              \
-    (IS_WINVISTA && (HIBYTE(LOWORD(::GetVersion())) >= 2)) ||                  \
+    (LOBYTE(LOWORD(::GetVersion())) == 6 && (HIBYTE(LOWORD(::GetVersion())) >= 2)) ||  \
     (LOBYTE(LOWORD(::GetVersion())) > 6))
 
 #define IS_WINVER_ATLEAST(maj, min) \

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -272,20 +272,8 @@ void AwtDesktopProperties::GetNonClientParameters() {
     // general window properties
     //
     NONCLIENTMETRICS    ncmetrics;
+    ncmetrics.cbSize = sizeof(ncmetrics);
 
-    // Fix for 6944516: specify correct size for ncmetrics on WIN2K/XP
-    // Microsoft recommend to subtract the size of  'iPaddedBorderWidth' field
-    // when running on XP. However this can't be referenced at compile time
-    // with the older SDK, so there use 'lfMessageFont' plus its size.
-    if (!IS_WINVISTA) {
-#if defined(_MSC_VER)
-        ncmetrics.cbSize = offsetof(NONCLIENTMETRICS, iPaddedBorderWidth);
-#else
-        ncmetrics.cbSize = offsetof(NONCLIENTMETRICS,lfMessageFont) + sizeof(LOGFONT);
-#endif
-    } else {
-        ncmetrics.cbSize = sizeof(ncmetrics);
-    }
     VERIFY( SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncmetrics.cbSize, &ncmetrics, FALSE) );
 
     float invScaleX;

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
@@ -395,9 +395,7 @@ AwtMenuItem::DrawSelf(DRAWITEMSTRUCT& drawInfo)
     //draw check mark
     int checkWidth = ::GetSystemMetrics(SM_CXMENUCHECK);
     // Workaround for CR#6401956
-    if (IS_WINVISTA) {
-        AdjustCheckWidth(checkWidth);
-    }
+    AdjustCheckWidth(checkWidth);
 
     if (IsCheckbox()) {
         // means that target is a java.awt.CheckboxMenuItem
@@ -558,9 +556,7 @@ void AwtMenuItem::MeasureSelf(HDC hDC, MEASUREITEMSTRUCT& measureInfo)
     if (!IsTopMenu()) {
         int checkWidth = ::GetSystemMetrics(SM_CXMENUCHECK);
         // Workaround for CR#6401956
-        if (IS_WINVISTA) {
-            AdjustCheckWidth(checkWidth);
-        }
+        AdjustCheckWidth(checkWidth);
         measureInfo.itemWidth += checkWidth;
 
         // Add in shortcut width, if one exists.

--- a/src/java.desktop/windows/native/libawt/windows/awt_TextArea.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TextArea.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_TextArea.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TextArea.cpp
@@ -78,7 +78,7 @@ void AwtTextArea::EditSetSel(CHARRANGE &cr) {
     SendMessage(EM_EXSETSEL, 0, reinterpret_cast<LPARAM>(&cr));
     SendMessage(EM_HIDESELECTION, TRUE, TRUE);
     // 6417581: force expected drawing
-    if (IS_WINVISTA && cr.cpMin == cr.cpMax) {
+    if (cr.cpMin == cr.cpMax) {
         ::InvalidateRect(GetHWnd(), NULL, TRUE);
     }
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_TextField.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TextField.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_TextField.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TextField.cpp
@@ -55,7 +55,7 @@ void AwtTextField::EditSetSel(CHARRANGE &cr) {
     SendMessage(EM_EXSETSEL, 0, reinterpret_cast<LPARAM>(&cr));
 
     // 6417581: force expected drawing
-    if (IS_WINVISTA && cr.cpMin == cr.cpMax) {
+    if (cr.cpMin == cr.cpMax) {
         ::InvalidateRect(GetHWnd(), NULL, TRUE);
     }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -93,7 +93,6 @@ void DWMResetCompositionEnabled() {
  * Returns true if dwm composition is enabled, false if dwm composition is disabled.
  */
 BOOL DWMIsCompositionEnabled() {
-    // cheaper to check than whether it's vista or not
     if (dwmIsCompositionEnabled != DWM_COMP_UNDEFINED) {
         return (BOOL)dwmIsCompositionEnabled;
     }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -90,12 +90,13 @@ void DWMResetCompositionEnabled() {
 }
 
 /**
- * Returns true if dwm composition is enabled, false if dwm composition is disabled.
+ * Returns true if DWM composition is enabled, false if DWM composition is disabled.
  */
 BOOL DWMIsCompositionEnabled() {
     if (dwmIsCompositionEnabled != DWM_COMP_UNDEFINED) {
         return (BOOL)dwmIsCompositionEnabled;
     }
+
     BOOL bRes = FALSE;
 
     try {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -90,20 +90,13 @@ void DWMResetCompositionEnabled() {
 }
 
 /**
- * Returns true if dwm composition is enabled, false if it is not applicable
- * (if the OS is not Vista) or dwm composition is disabled.
+ * Returns true if dwm composition is enabled, false if dwm composition is disabled.
  */
 BOOL DWMIsCompositionEnabled() {
     // cheaper to check than whether it's vista or not
     if (dwmIsCompositionEnabled != DWM_COMP_UNDEFINED) {
         return (BOOL)dwmIsCompositionEnabled;
     }
-
-    if (!IS_WINVISTA) {
-        dwmIsCompositionEnabled = FALSE;
-        return FALSE;
-    }
-
     BOOL bRes = FALSE;
 
     try {
@@ -337,13 +330,3 @@ Java_sun_awt_Win32GraphicsEnvironment_getYResolution(JNIEnv *env, jobject wge)
     CATCH_BAD_ALLOC_RET(0);
 }
 
-/*
- * Class:     sun_awt_Win32GraphicsEnvironment
- * Method:    isVistaOS
- * Signature: ()Z
- */
-JNIEXPORT jboolean JNICALL Java_sun_awt_Win32GraphicsEnvironment_isVistaOS
-  (JNIEnv *env, jclass wgeclass)
-{
-    return IS_WINVISTA;
-}


### PR DESCRIPTION
The IS_WINVISTA macro is obsolete these days, because we run on higher Windows versions as a minimum requirement.
Same is true for the isVistaOS() method.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387675](https://bugs.openjdk.org/browse/JDK-8387675): IS_WINVISTA macro is obsolete (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [e1c0d718](https://git.openjdk.org/jdk/pull/31762/files/e1c0d7186734868abf2f7c6b305c09b85fa8edbd)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [1b5e4986](https://git.openjdk.org/jdk/pull/31762/files/1b5e4986da7194d823ed5b40319f1b99a63e41b2)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31762/head:pull/31762` \
`$ git checkout pull/31762`

Update a local copy of the PR: \
`$ git checkout pull/31762` \
`$ git pull https://git.openjdk.org/jdk.git pull/31762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31762`

View PR using the GUI difftool: \
`$ git pr show -t 31762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31762.diff">https://git.openjdk.org/jdk/pull/31762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31762#issuecomment-4873822909)
</details>
