### PR TITLE
8381880: Test compiler/c1/TestTooManyVirtualRegistersMain.java uses wrong class in CompileCommand

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestTooManyVirtualRegistersMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestTooManyVirtualRegistersMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,8 @@
  *          The test should bail out in C1.
  *
  * @compile TestTooManyVirtualRegisters.jasm
- * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,compiler.c1.TestExceptionBlockWithPredecessors::*
- *                   compiler.c1.TestTooManyVirtualRegistersMain
+ * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,compiler.c1.TestTooManyVirtualRegisters::*
+ *                   ${test.main.class}
  */
 
 package compiler.c1;


### PR DESCRIPTION
This is a clean backport of 16da917 from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit was authored by Manuel Hässig and reviewed by Christian Hagedorn and Aleksey Shipilëv.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8381880](https://bugs.openjdk.org/browse/JDK-8381880): Test compiler/c1/TestTooManyVirtualRegistersMain.java uses wrong class in CompileCommand (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31763/head:pull/31763` \
`$ git checkout pull/31763`

Update a local copy of the PR: \
`$ git checkout pull/31763` \
`$ git pull https://git.openjdk.org/jdk.git pull/31763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31763`

View PR using the GUI difftool: \
`$ git pr show -t 31763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31763.diff">https://git.openjdk.org/jdk/pull/31763.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31763#issuecomment-4873868178)
</details>
