### PR TITLE
8388922: RISC-V: Use check_klass_subtype_slow_path in C1 arraycopy subtype check

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
@@ -224,11 +224,7 @@ void LIR_Assembler::arraycopy_type_check(Register src, Register src_pos, Registe
     __ load_klass(dst, dst);
     __ check_klass_subtype_fast_path(src, dst, tmp, &cont, &slow, nullptr);
 
-    PUSH(src, dst);
-    __ far_call(RuntimeAddress(Runtime1::entry_for(StubId::c1_slow_subtype_check_id)));
-    POP(src, dst);
-    __ bnez(dst, cont);
-
+    __ check_klass_subtype_slow_path(src, dst, tmp, noreg, &cont, &slow);
     __ bind(slow);
     POP(src, dst);
 


### PR DESCRIPTION
Three sites in c1_LIRAssembler_riscv.cpp were previously converted from far_call to check_klass_subtype_slow_path for the subtype check inline macro, but a fourth site in c1_LIRAssembler_arraycopy_riscv.cpp was missed.
This remaining site still uses the old far_call pattern. Update it to use check_klass_subtype_slow_path for consistency with the other three.

Testing:
  - hotspot jtreg compiler/c1: all pass
  - hotspot jtreg compiler/types: all pass
  - hotspot jtreg compiler/arraycopy: all pass

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388922](https://bugs.openjdk.org/browse/JDK-8388922): RISC-V: Use check_klass_subtype_slow_path in C1 arraycopy subtype check (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31764/head:pull/31764` \
`$ git checkout pull/31764`

Update a local copy of the PR: \
`$ git checkout pull/31764` \
`$ git pull https://git.openjdk.org/jdk.git pull/31764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31764`

View PR using the GUI difftool: \
`$ git pr show -t 31764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31764.diff">https://git.openjdk.org/jdk/pull/31764.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31764#issuecomment-5521904353)
</details>
