### PR TITLE
8387702: Linux/clang: enable linktime-gc on libjvm.so too, when it is configured

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -81,6 +81,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       fi
 
       if test "x$ENABLE_LINKTIME_GC" = xtrue; then
+        BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,--gc-sections -Wl,--undefined=_ZTV8Metadata"
         BASIC_LDFLAGS_JDK_ONLY="$BASIC_LDFLAGS_JDK_ONLY -Wl,--gc-sections"
       fi
     fi


### PR DESCRIPTION
Linux/gcc currently enables linktime-gc on libjvm.so, when it is configured for the build.
Linux/clang enables it (when configured) so far only for the JDK libs. This should be changed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387702](https://bugs.openjdk.org/browse/JDK-8387702): Linux/clang: enable linktime-gc on libjvm.so too, when it is configured (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31765/head:pull/31765` \
`$ git checkout pull/31765`

Update a local copy of the PR: \
`$ git checkout pull/31765` \
`$ git pull https://git.openjdk.org/jdk.git pull/31765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31765`

View PR using the GUI difftool: \
`$ git pr show -t 31765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31765.diff">https://git.openjdk.org/jdk/pull/31765.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31765#issuecomment-4875197159)
</details>
