### PR TITLE
8387697: Avoid using os::Linux::query_accurate_process_memory_info in JFR

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2860,39 +2860,14 @@ void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
 
 #if INCLUDE_JFR
 
-// hwm (high water mark) in K for the VM RSS
-static long jfr_rss_hwm_k = -1;
-
-static void send_resident_set_size_event(ssize_t size, ssize_t peak) {
-  EventResidentSetSize event;
-  event.set_size(size * K);
-  event.set_peak(peak * K);
-  event.commit();
-}
-
 void os::jfr_report_memory_info() {
-  os::Linux::accurate_meminfo_t accurate_info;
-  if (os::Linux::query_accurate_process_memory_info(&accurate_info) && accurate_info.rss != -1) {
-    // unfortunately the smaps_rollup/accurate_info contains no hwm (high water mark) for RSS
-    struct rusage ru;
-    if (getrusage(RUSAGE_SELF, &ru) == 0) {
-      if (ru.ru_maxrss > jfr_rss_hwm_k) {
-        jfr_rss_hwm_k = ru.ru_maxrss;
-      }
-    }
-
-    // do not allow larger current RSS than hwm
-    if (accurate_info.rss > jfr_rss_hwm_k) {
-      jfr_rss_hwm_k = accurate_info.rss;
-    }
-
-    send_resident_set_size_event(accurate_info.rss, jfr_rss_hwm_k);
-    return;
-  }
-
   os::Linux::meminfo_t info;
   if (os::Linux::query_process_memory_info(&info)) {
-    send_resident_set_size_event(info.vmrss, info.vmhwm);
+    // Send the RSS JFR event
+    EventResidentSetSize event;
+    event.set_size(info.vmrss * K);
+    event.set_peak(info.vmhwm * K);
+    event.commit();
   } else {
     // Log a warning
     static bool first_warning = true;


### PR DESCRIPTION
Using os::Linux::query_accurate_process_memory_info might be too costly.
See the discussion (comments) here : [JDK-8385892](https://bugs.openjdk.org/browse/JDK-8385892) and https://gitlab.com/gitlab-com/gl-infra/production-engineering/-/work_items/10966 .

Revert "8385892: TestResidentSetSizeEvent fails with RuntimeException: Should be non-zero: expected 0 > 0" .
This reverts commit d3d67ece7cf1885a30d46707a5c0a450510f037f.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387697](https://bugs.openjdk.org/browse/JDK-8387697): Avoid using os::Linux::query_accurate_process_memory_info in JFR (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31766/head:pull/31766` \
`$ git checkout pull/31766`

Update a local copy of the PR: \
`$ git checkout pull/31766` \
`$ git pull https://git.openjdk.org/jdk.git pull/31766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31766`

View PR using the GUI difftool: \
`$ git pr show -t 31766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31766.diff">https://git.openjdk.org/jdk/pull/31766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31766#issuecomment-4875258745)
</details>
