### PR TITLE
8387704: java/nio/file/DirectoryStream/SecureDS.java failing with AccessDeniedException

### DIFF
--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -221,6 +221,7 @@ public class SecureDS {
                     assertEquals(permsFile, getPosixFilePermissions(file));
                 } catch (AccessDeniedException e) {
                     // Fails on older Linux systems without fchmodat AT_SYMLINK_NOFOLLOW support
+                    setPosixFilePermissions(file, permsFile);
                 }
 
                 // Test following link to file

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -216,8 +216,12 @@ public class SecureDS {
                 view = stream.getFileAttributeView(fileEntry, PosixFileAttributeView.class, NOFOLLOW_LINKS);
                 view.setPermissions(noperms);
                 assertEquals(noperms, getPosixFilePermissions(file));
-                view.setPermissions(permsFile);
-                assertEquals(permsFile, getPosixFilePermissions(file));
+                try {
+                    view.setPermissions(permsFile);
+                    assertEquals(permsFile, getPosixFilePermissions(file));
+                } catch (AccessDeniedException e) {
+                    // Fails on older Linux systems without fchmodat AT_SYMLINK_NOFOLLOW support
+                }
 
                 // Test following link to file
                 view = stream.getFileAttributeView(link, PosixFileAttributeView.class);


### PR DESCRIPTION
Linux systems without `fchmodat` `AT_SYMLINK_NOFOLLOW` support cannot change file permissions through `SecureDirectoryStream` that they don't have write permission to .


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387704](https://bugs.openjdk.org/browse/JDK-8387704): java/nio/file/DirectoryStream/SecureDS.java failing with AccessDeniedException (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31769/head:pull/31769` \
`$ git checkout pull/31769`

Update a local copy of the PR: \
`$ git checkout pull/31769` \
`$ git pull https://git.openjdk.org/jdk.git pull/31769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31769`

View PR using the GUI difftool: \
`$ git pr show -t 31769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31769.diff">https://git.openjdk.org/jdk/pull/31769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31769#issuecomment-4877073700)
</details>
