### PR TITLE
8387718: JVMTI GetLocal/SetLocal: slot bounds check overflows for long/double slots

### DIFF
--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -379,7 +379,7 @@ bool VM_BaseGetOrSetLocal::check_slot_type_lvt(javaVFrame* jvf) {
   if (!method->has_localvariable_table()) {
     // Just to check index boundaries.
     jint extra_slot = (_type == T_LONG || _type == T_DOUBLE) ? 1 : 0;
-    if (_index < 0 || _index + extra_slot >= method->max_locals()) {
+    if (_index < 0 || _index >= method->max_locals() - extra_slot) {
       _result = JVMTI_ERROR_INVALID_SLOT;
       return false;
     }
@@ -451,7 +451,7 @@ bool VM_BaseGetOrSetLocal::check_slot_type_no_lvt(javaVFrame* jvf) {
   Method* method = jvf->method();
   jint extra_slot = (_type == T_LONG || _type == T_DOUBLE) ? 1 : 0;
 
-  if (_index < 0 || _index + extra_slot >= method->max_locals()) {
+  if (_index < 0 || _index >= method->max_locals() - extra_slot) {
     _result = JVMTI_ERROR_INVALID_SLOT;
     return false;
   }

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387718
+ * @summary VM_GetOrSetLocal slot bounds check overflows for long/double slots,
+ *          allowing an out-of-bounds StackValueCollection access when slot == INT_MAX.
+ * @requires vm.jvmti
+ * @compile GetSetLocalSlotOverflow.java
+ * @run main/othervm/native -agentlib:GetSetLocalSlotOverflow GetSetLocalSlotOverflow
+ */
+
+/*
+ * Regression test / reproducer for the signed-overflow in
+ * VM_BaseGetOrSetLocal::check_slot_type_no_lvt (jvmtiImpl.cpp).
+ *
+ * For a T_LONG/T_DOUBLE access, the bounds check is
+ *     if (_index < 0 || _index + extra_slot >= method->max_locals())
+ * with extra_slot == 1. When the agent passes slot == INT_MAX, the
+ * sub-expression _index + extra_slot overflows to INT_MIN, which is < max_locals(),
+ * so the guard passes and the code goes on to index locals->at(INT_MAX).
+ *
+ * Expected (fixed) behavior: GetLocalLong/Double and SetLocalLong/Double with
+ * slot == INT_MAX return JVMTI_ERROR_INVALID_SLOT.
+ *
+ * On an unfixed VM this test does not merely fail: the out-of-bounds access
+ * crashes the VM (assertion failure in fastdebug, SIGSEGV / silent corruption
+ * in product). A clean PASS is only possible once the bounds check is fixed.
+ */
+
+public class GetSetLocalSlotOverflow {
+    private static final String agentLib = "GetSetLocalSlotOverflow";
+
+    // Invoked from runner(); the agent inspects the runner() frame at depth 1.
+    static native void testOverflow(Thread thread);
+    static native int getStatus();
+
+    public static void main(String[] args) throws Exception {
+        try {
+            System.loadLibrary(agentLib);
+        } catch (UnsatisfiedLinkError ex) {
+            System.err.println("Failed to load " + agentLib + " lib");
+            System.err.println("java.library.path: " + System.getProperty("java.library.path"));
+            throw ex;
+        }
+        runner();
+        int status = getStatus();
+        if (status != 0) {
+            throw new RuntimeException("Test GetSetLocalSlotOverflow failed with status: " + status);
+        }
+    }
+
+    // A non-native, non-static-receiver frame holding a few locals. The agent
+    // targets this frame (depth 1) with slot == INT_MAX. The actual local
+    // contents are irrelevant: the overflow happens in the slot bounds check,
+    // before any local is read.
+    public static void runner() {
+        long  l = 0xCAFEBABEL;
+        double d = 3.14d;
+        testOverflow(Thread.currentThread());
+        // Keep locals live across the native call.
+        if (l == 0 && d == 0) {
+            throw new AssertionError("unreachable");
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
@@ -50,31 +50,22 @@
  */
 
 public class GetSetLocalSlotOverflow {
-    private static final String agentLib = "GetSetLocalSlotOverflow";
 
     // Invoked from runner(); the agent inspects the runner() frame at depth 1.
     // Returns false if any accessor did not return JVMTI_ERROR_INVALID_SLOT.
     static native boolean testOverflow(Thread thread);
 
     public static void main(String[] args) throws Exception {
-        try {
-            System.loadLibrary(agentLib);
-        } catch (UnsatisfiedLinkError ex) {
-            System.err.println("Failed to load " + agentLib + " lib");
-            System.err.println("java.library.path: " + System.getProperty("java.library.path"));
-            throw ex;
-        }
         if (!runner()) {
             throw new RuntimeException("Test GetSetLocalSlotOverflow failed");
         }
     }
 
-    // A non-native, non-static-receiver frame holding a few locals. The agent
-    // targets this frame (depth 1) with slot == INT_MAX. The actual local
-    // contents are irrelevant: the overflow happens in the slot bounds check,
-    // before any local is read.
+    // A Java frame holding a few locals. The agent targets this frame (depth 1)
+    // with slot == INT_MAX. The actual local contents are irrelevant: the
+    // overflow happens in the slot bounds check, before any local is read.
     public static boolean runner() {
-        long  l = 0xCAFEBABEL;
+        long l = 0xCAFEBABEL;
         double d = 3.14d;
         boolean ok = testOverflow(Thread.currentThread());
         // Keep locals live across the native call.

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
@@ -53,8 +53,8 @@ public class GetSetLocalSlotOverflow {
     private static final String agentLib = "GetSetLocalSlotOverflow";
 
     // Invoked from runner(); the agent inspects the runner() frame at depth 1.
-    static native void testOverflow(Thread thread);
-    static native int getStatus();
+    // Returns false if any accessor did not return JVMTI_ERROR_INVALID_SLOT.
+    static native boolean testOverflow(Thread thread);
 
     public static void main(String[] args) throws Exception {
         try {
@@ -64,10 +64,8 @@ public class GetSetLocalSlotOverflow {
             System.err.println("java.library.path: " + System.getProperty("java.library.path"));
             throw ex;
         }
-        runner();
-        int status = getStatus();
-        if (status != 0) {
-            throw new RuntimeException("Test GetSetLocalSlotOverflow failed with status: " + status);
+        if (!runner()) {
+            throw new RuntimeException("Test GetSetLocalSlotOverflow failed");
         }
     }
 
@@ -75,13 +73,14 @@ public class GetSetLocalSlotOverflow {
     // targets this frame (depth 1) with slot == INT_MAX. The actual local
     // contents are irrelevant: the overflow happens in the slot bounds check,
     // before any local is read.
-    public static void runner() {
+    public static boolean runner() {
         long  l = 0xCAFEBABEL;
         double d = 3.14d;
-        testOverflow(Thread.currentThread());
+        boolean ok = testOverflow(Thread.currentThread());
         // Keep locals live across the native call.
         if (l == 0 && d == 0) {
             throw new AssertionError("unreachable");
         }
+        return ok;
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <limits.h>
+#include "jvmti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STATUS_PASSED 0
+#define STATUS_FAILED 2
+
+// The runner() frame at depth 1; INT_MAX makes (slot + extra_slot) overflow
+// for the long/double accessors.
+static const jint Depth = 1;
+static const jint OverflowSlot = INT_MAX; // 0x7fffffff
+
+static jint result = STATUS_PASSED;
+static jvmtiEnv *jvmti = nullptr;
+
+// Each access below MUST come back as JVMTI_ERROR_INVALID_SLOT. On an unfixed
+// VM the overflowing bounds check is bypassed and the subsequent
+// locals->at(INT_MAX) access crashes the VM before we ever see a return code.
+static void expect_invalid_slot(const char* what, jvmtiError err) {
+  if (err == JVMTI_ERROR_INVALID_SLOT) {
+    printf(" PASS: %s returned JVMTI_ERROR_INVALID_SLOT (%d) for slot=INT_MAX\n", what, err);
+  } else {
+    printf(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
+           what, err, JVMTI_ERROR_INVALID_SLOT);
+    result = STATUS_FAILED;
+  }
+}
+
+JNIEXPORT void JNICALL
+Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject thread) {
+  if (jvmti == nullptr) {
+    printf("JVMTI client was not properly loaded!\n");
+    result = STATUS_FAILED;
+    return;
+  }
+
+  jlong   lval = 0;
+  jdouble dval = 0;
+
+  // T_LONG / T_DOUBLE => extra_slot == 1 => INT_MAX + 1 overflows to INT_MIN.
+  expect_invalid_slot("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval));
+  expect_invalid_slot("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval));
+  expect_invalid_slot("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0));
+  expect_invalid_slot("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0));
+}
+
+JNIEXPORT jint JNICALL
+Java_GetSetLocalSlotOverflow_getStatus(JNIEnv *env, jclass cls) {
+  return result;
+}
+
+static jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res;
+  jvmtiError err;
+  static jvmtiCapabilities caps;
+
+  res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_9);
+  if (res != JNI_OK || jvmti == nullptr) {
+    printf("Wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+  caps.can_access_local_variables = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    printf("AddCapabilities: unexpected error: %d\n", err);
+    return JNI_ERR;
+  }
+  err = jvmti->GetCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    printf("GetCapabilities: unexpected error: %d\n", err);
+    return JNI_ERR;
+  }
+  if (!caps.can_access_local_variables) {
+    printf("Warning: Access to local variables is not implemented\n");
+    return JNI_ERR;
+  }
+  return JNI_OK;
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
@@ -29,51 +29,43 @@
 extern "C" {
 #endif
 
-#define STATUS_PASSED 0
-#define STATUS_FAILED 2
-
 // The runner() frame at depth 1; INT_MAX makes (slot + extra_slot) overflow
 // for the long/double accessors.
 static const jint Depth = 1;
 static const jint OverflowSlot = INT_MAX; // 0x7fffffff
 
-static jint result = STATUS_PASSED;
 static jvmtiEnv *jvmti = nullptr;
 
 // Each access below MUST come back as JVMTI_ERROR_INVALID_SLOT. On an unfixed
 // VM the overflowing bounds check is bypassed and the subsequent
 // locals->at(INT_MAX) access crashes the VM before we ever see a return code.
-static void expect_invalid_slot(const char* what, jvmtiError err) {
+static bool expect_invalid_slot(const char* what, jvmtiError err) {
   if (err == JVMTI_ERROR_INVALID_SLOT) {
     printf(" PASS: %s returned JVMTI_ERROR_INVALID_SLOT (%d) for slot=INT_MAX\n", what, err);
-  } else {
-    printf(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
-           what, err, JVMTI_ERROR_INVALID_SLOT);
-    result = STATUS_FAILED;
+    return true;
   }
+  printf(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
+         what, err, JVMTI_ERROR_INVALID_SLOT);
+  return false;
 }
 
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject thread) {
   if (jvmti == nullptr) {
     printf("JVMTI client was not properly loaded!\n");
-    result = STATUS_FAILED;
-    return;
+    return JNI_FALSE;
   }
 
   jlong   lval = 0;
   jdouble dval = 0;
 
   // T_LONG / T_DOUBLE => extra_slot == 1 => INT_MAX + 1 overflows to INT_MIN.
-  expect_invalid_slot("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval));
-  expect_invalid_slot("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval));
-  expect_invalid_slot("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0));
-  expect_invalid_slot("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0));
-}
-
-JNIEXPORT jint JNICALL
-Java_GetSetLocalSlotOverflow_getStatus(JNIEnv *env, jclass cls) {
-  return result;
+  bool ok = true;
+  ok &= expect_invalid_slot("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval));
+  ok &= expect_invalid_slot("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval));
+  ok &= expect_invalid_slot("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0));
+  ok &= expect_invalid_slot("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0));
+  return ok ? JNI_TRUE : JNI_FALSE;
 }
 
 static jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include "jvmti.h"
+#include "jvmti_common.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,10 +42,10 @@ static jvmtiEnv *jvmti = nullptr;
 // locals->at(INT_MAX) access crashes the VM before we ever see a return code.
 static bool expect_invalid_slot(const char* what, jvmtiError err) {
   if (err == JVMTI_ERROR_INVALID_SLOT) {
-    printf(" PASS: %s returned JVMTI_ERROR_INVALID_SLOT (%d) for slot=INT_MAX\n", what, err);
+    LOG(" PASS: %s returned JVMTI_ERROR_INVALID_SLOT (%d) for slot=INT_MAX\n", what, err);
     return true;
   }
-  printf(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
+  LOG(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
          what, err, JVMTI_ERROR_INVALID_SLOT);
   return false;
 }
@@ -52,7 +53,7 @@ static bool expect_invalid_slot(const char* what, jvmtiError err) {
 JNIEXPORT jboolean JNICALL
 Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject thread) {
   if (jvmti == nullptr) {
-    printf("JVMTI client was not properly loaded!\n");
+    LOG("JVMTI client was not properly loaded!\n");
     return JNI_FALSE;
   }
 
@@ -75,23 +76,23 @@ static jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
   res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_9);
   if (res != JNI_OK || jvmti == nullptr) {
-    printf("Wrong result of a valid call to GetEnv!\n");
+    LOG("Wrong result of a valid call to GetEnv!\n");
     return JNI_ERR;
   }
   caps.can_access_local_variables = 1;
 
   err = jvmti->AddCapabilities(&caps);
   if (err != JVMTI_ERROR_NONE) {
-    printf("AddCapabilities: unexpected error: %d\n", err);
+    LOG("AddCapabilities: unexpected error: %d\n", err);
     return JNI_ERR;
   }
   err = jvmti->GetCapabilities(&caps);
   if (err != JVMTI_ERROR_NONE) {
-    printf("GetCapabilities: unexpected error: %d\n", err);
+    LOG("GetCapabilities: unexpected error: %d\n", err);
     return JNI_ERR;
   }
   if (!caps.can_access_local_variables) {
-    printf("Warning: Access to local variables is not implemented\n");
+    LOG("Warning: Access to local variables is not implemented\n");
     return JNI_ERR;
   }
   return JNI_OK;


### PR DESCRIPTION
Found while auditing the JVMTI local-variable accessors.

`VM_BaseGetOrSetLocal` bounds-checks the requested slot before touching the frame's `StackValueCollection`. For a `long`/`double` the value spans two slots, so the check adds an `extra_slot` of 1: `_index + extra_slot >= method->max_locals()`. When an agent passes `slot == INT_MAX`, `_index + extra_slot` signed-overflows to `INT_MIN`, which is below `max_locals()`, so the guard is bypassed and we go on to index `locals->at(INT_MAX)` — out of bounds. That is an assertion failure in fastdebug and a SIGSEGV or silent corruption in product.

Doing the arithmetic on the other side (`_index >= method->max_locals() - extra_slot`) avoids the overflow. The same check appears in both `check_slot_type_lvt` and `check_slot_type_no_lvt`, so both are fixed.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `serviceability/jvmti/GetLocalVariable`
 - [ ] Regular testing pipelines

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387718](https://bugs.openjdk.org/browse/JDK-8387718): JVMTI GetLocal/SetLocal: slot bounds check overflows for long/double slots (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31772/head:pull/31772` \
`$ git checkout pull/31772`

Update a local copy of the PR: \
`$ git checkout pull/31772` \
`$ git pull https://git.openjdk.org/jdk.git pull/31772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31772`

View PR using the GUI difftool: \
`$ git pr show -t 31772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31772.diff">https://git.openjdk.org/jdk/pull/31772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31772#issuecomment-4880736063)
</details>
