### PR TITLE
8387638: Some compiler/vectorization/runner/* tests timed out in Driver mode

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java
@@ -141,17 +141,20 @@ public class VectorizationTestRunner {
         Object expected = null;
         Object actual = null;
 
-        // Temporarily disable the compiler and invoke the method to get reference
-        // result from the interpreter
-        Flags.WHITEBOX.setBooleanVMFlag("UseCompiler", false);
+        // Temporarily make the test method not compilable and invoke it to get the
+        // reference result from the interpreter.
+        Flags.WHITEBOX.makeMethodNotCompilable(method, CompLevel.ANY.getValue(), true);
+        Flags.WHITEBOX.makeMethodNotCompilable(method, CompLevel.ANY.getValue(), false);
         try {
             expected = method.invoke(this);
+            assert(Flags.WHITEBOX.getMethodCompilationLevel(method) == COMP_LEVEL_INTP);
         } catch (Exception e) {
             e.printStackTrace();
             fail("Exception is thrown in test method invocation (interpreter).");
+        } finally {
+            // Make the test method compilable again
+            Flags.WHITEBOX.clearMethodState(method);
         }
-        assert(Flags.WHITEBOX.getMethodCompilationLevel(method) == COMP_LEVEL_INTP);
-        Flags.WHITEBOX.setBooleanVMFlag("UseCompiler", true);
 
         // Compile the method and invoke it again
         long enqueueTime = System.currentTimeMillis();


### PR DESCRIPTION
After [JDK-8387334](https://bugs.openjdk.org/browse/JDK-8387334), some vectorization runner tests started to time out on Windows. The change modified `VectorizationTestRunner` to spawn a new VM to run correctness tests (in addition to the IR framework tests - yes, this should be consolidated / refactored at some point ...):

https://github.com/openjdk/jdk/blob/631b675d7949a0e6312d8d6f45e2515d53b12f05/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java#L75-L86

That child immediately sets `UseCompiler` to `false` before invoking the test method:

https://github.com/openjdk/jdk/blob/631b675d7949a0e6312d8d6f45e2515d53b12f05/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java#L144-L146

But since compiler threads initialize asynchronously, we then sometimes reach

https://github.com/openjdk/jdk/blob/631b675d7949a0e6312d8d6f45e2515d53b12f05/src/hotspot/share/opto/c2compiler.cpp#L95-L97

while `UseCompiler` is `false`. The VM interprets this as C2 runtime initialization failure, returns false and disables compilation forever:

https://github.com/openjdk/jdk/blob/631b675d7949a0e6312d8d6f45e2515d53b12f05/src/hotspot/share/compiler/compileBroker.cpp#L1560-L1564

Setting `UseCompiler` back to `true` afterward does not help to recover from this anymore. We are stuck in an endless loop of waiting for the method to compile:

https://github.com/openjdk/jdk/blob/631b675d7949a0e6312d8d6f45e2515d53b12f05/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java#L158-L161

The fix disables OSR and non-OSR compilation only for the test method, then restores its state before enqueuing the method for compilation. 

Unfortunately, I could never reproduce the issue. Analysis and fix are based on log files from the timeout handler when this failed a few times in our CI.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387638](https://bugs.openjdk.org/browse/JDK-8387638): Some compiler/vectorization/runner/* tests timed out in Driver mode (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31777/head:pull/31777` \
`$ git checkout pull/31777`

Update a local copy of the PR: \
`$ git checkout pull/31777` \
`$ git pull https://git.openjdk.org/jdk.git pull/31777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31777`

View PR using the GUI difftool: \
`$ git pr show -t 31777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31777.diff">https://git.openjdk.org/jdk/pull/31777.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31777#issuecomment-4890504017)
</details>
