### PR TITLE
8387747: Enable long vector multiply IR tests for RISC-V

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMulLongToSignedUnsignedInt.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMulLongToSignedUnsignedInt.java
@@ -89,7 +89,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.AND_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -119,7 +119,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.AND_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -147,7 +147,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.AND_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -176,7 +176,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     // Case 5: Mask = 0xFFFF_FFFFL (exactly uint max, boundary valid case).
     @Test
     @IR(counts = {IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.X86_VMULUDQ_REG, " >0 "},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -205,7 +205,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     // Case 6: Small mask (0xFFFFL), clearly fits in uint.
     @Test
     @IR(counts = {IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.X86_VMULUDQ_REG, " >0 "},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -235,7 +235,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.MUL_VL, " >0 ",
                   IRNode.URSHIFT_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.X86_VMULUDQ_REG, " >0 "},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -265,7 +265,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.AND_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -297,7 +297,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @IR(counts = {IRNode.URSHIFT_VL, " >0 ",
                   IRNode.AND_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx", "true"})
@@ -327,7 +327,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.AND_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx512f", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512f", "true", "sve", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx512f", "true"})
@@ -359,7 +359,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.URSHIFT_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx512f", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512f", "true", "sve", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULUDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx512f", "true"})
@@ -391,7 +391,7 @@ public class TestVectorMulLongToSignedUnsignedInt {
     @Test
     @IR(counts = {IRNode.RSHIFT_VL, " >0 ",
                   IRNode.MUL_VL, " >0 "},
-        applyIfCPUFeatureOr = {"avx512f", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx512f", "true", "sve", "true", "rvv", "true"})
     @IR(failOn = {IRNode.X86_VMULDQ_REG},
         phase = CompilePhase.MATCHING,
         applyIfCPUFeature = {"avx512f", "true"})

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
@@ -107,7 +107,8 @@ public class VectorMultiplyOpt {
     }
 
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.AND_VL, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.AND_VL, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuludq", " >0 "}, phase = CompilePhase.FINAL_CODE, applyIfCPUFeature = {"avx", "true"})
     @IR(counts = {"vmulL_uint_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -135,7 +136,8 @@ public class VectorMultiplyOpt {
     }
 
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.AND_VL, " >0 ", IRNode.URSHIFT_VL, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.AND_VL, " >0 ", IRNode.URSHIFT_VL, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuludq", " >0 "}, phase = CompilePhase.FINAL_CODE, applyIfCPUFeature = {"avx", "true"})
     @IR(counts = {"vmulL_uint_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -163,7 +165,8 @@ public class VectorMultiplyOpt {
     }
 
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.URSHIFT_VL, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.URSHIFT_VL, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuludq", " >0 "}, phase = CompilePhase.FINAL_CODE, applyIfCPUFeature = {"avx", "true"})
     @IR(counts = {"vmulL_uint_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -191,7 +194,8 @@ public class VectorMultiplyOpt {
     }
 
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.URSHIFT_VL, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.URSHIFT_VL, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuludq", " >0 "}, applyIfCPUFeature = {"avx", "true"}, phase = CompilePhase.FINAL_CODE)
     @IR(counts = {"vmulL_uint_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -219,7 +223,8 @@ public class VectorMultiplyOpt {
     }
 
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.VECTOR_CAST_I2L, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.VECTOR_CAST_I2L, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuldq", " >0 "}, applyIfCPUFeature = {"avx", "true"}, phase = CompilePhase.FINAL_CODE)
     @IR(counts = {"vmulL_int_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -250,7 +255,8 @@ public class VectorMultiplyOpt {
 
 
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.RSHIFT_VL, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.RSHIFT_VL, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuldq", " >0 "}, applyIfCPUFeature = {"avx", "true"}, phase = CompilePhase.FINAL_CODE)
     @IR(counts = {"vmulL_int_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -280,7 +286,8 @@ public class VectorMultiplyOpt {
     // Same-operand multiplication (v * v) where v has zero-extended high bits.
     // On NEON this should map to the dedicated rule that emits a single xtn.
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.AND_VL, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.AND_VL, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuludq", " >0 "}, phase = CompilePhase.FINAL_CODE, applyIfCPUFeature = {"avx", "true"})
     @IR(counts = {"vmulL_uint_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})
@@ -309,7 +316,8 @@ public class VectorMultiplyOpt {
     // Same-operand multiplication (v * v) where v has sign-extended high bits.
     // On NEON this should map to the dedicated rule that emits a single xtn.
     @Test
-    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.VECTOR_CAST_I2L, " >0 "}, applyIfCPUFeature = {"avx", "true"})
+    @IR(counts = {IRNode.MUL_VL, " >0 ", IRNode.VECTOR_CAST_I2L, " >0 "},
+        applyIfCPUFeatureOr = {"avx", "true", "rvv", "true"})
     @IR(counts = {"vmuldq", " >0 "}, applyIfCPUFeature = {"avx", "true"}, phase = CompilePhase.FINAL_CODE)
     @IR(counts = {"vmulL_int_sve2", " >0 "}, phase = CompilePhase.FINAL_CODE,
         applyIfCPUFeature = {"sve2", "true"})


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

These IR tests check long vector multiplication patterns where operands fit signed or unsigned int ranges. This enables the MulVL IR checks for RISC-V when RVV is available.

Testing: run the same test using fastdebug build on linux-riscv64 (SG2044).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387747](https://bugs.openjdk.org/browse/JDK-8387747): Enable long vector multiply IR tests for RISC-V (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31779/head:pull/31779` \
`$ git checkout pull/31779`

Update a local copy of the PR: \
`$ git checkout pull/31779` \
`$ git pull https://git.openjdk.org/jdk.git pull/31779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31779`

View PR using the GUI difftool: \
`$ git pr show -t 31779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31779.diff">https://git.openjdk.org/jdk/pull/31779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31779#issuecomment-4891174469)
</details>
