### PR TITLE
8387754: G1: Let Eden/SurvivorRegions use Atomic instead of volatile

### DIFF
--- a/src/hotspot/share/gc/g1/g1EdenRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EdenRegions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,15 @@
 
 #include "gc/g1/g1HeapRegion.hpp"
 #include "gc/g1/g1RegionsOnNodes.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/debug.hpp"
 
 class G1EdenRegions {
-private:
-  uint    _length;
+  uint _length;
   // Sum of used bytes from all retired eden regions.
   // I.e. updated when mutator regions are retired.
-  volatile size_t _used_bytes;
+  Atomic<size_t> _used_bytes;
   G1RegionsOnNodes  _regions_on_node;
 
 public:
@@ -49,17 +49,17 @@ public:
 
   void clear() {
     _length = 0;
-    _used_bytes = 0;
+    _used_bytes.store_relaxed(0);
     _regions_on_node.clear();
   }
 
   uint length() const { return _length; }
   uint regions_on_node(uint node_index) const { return _regions_on_node.count(node_index); }
 
-  size_t used_bytes() const { return _used_bytes; }
+  size_t used_bytes() const { return _used_bytes.load_relaxed(); }
 
   void add_used_bytes(size_t used_bytes) {
-    _used_bytes += used_bytes;
+    _used_bytes.add_then_fetch(used_bytes, memory_order_relaxed);
   }
 };
 

--- a/src/hotspot/share/gc/g1/g1RegionsOnNodes.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionsOnNodes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 #include "gc/g1/g1RegionsOnNodes.hpp"
 
 G1RegionsOnNodes::G1RegionsOnNodes() : _count_per_node(nullptr), _numa(G1NUMA::numa()) {
-  _count_per_node = NEW_C_HEAP_ARRAY(uint, _numa->num_active_nodes(), mtGC);
+  _count_per_node = NEW_C_HEAP_ARRAY(Atomic<uint>, _numa->num_active_nodes(), mtGC);
   clear();
 }
 
@@ -40,16 +40,14 @@ void G1RegionsOnNodes::add(G1HeapRegion* hr) {
 
   // Update only if the node index is valid.
   if (node_index < _numa->num_active_nodes()) {
-    *(_count_per_node + node_index) += 1;
+    _count_per_node[node_index].add_then_fetch(1u, memory_order_relaxed);
   }
 }
 
 void G1RegionsOnNodes::clear() {
-  for (uint i = 0; i < _numa->num_active_nodes(); i++) {
-    _count_per_node[i] = 0;
-  }
+  ::new (_count_per_node) Atomic<uint>[_numa->num_active_nodes()]{};
 }
 
 uint G1RegionsOnNodes::count(uint node_index) const {
-  return _count_per_node[node_index];
+  return _count_per_node[node_index].load_relaxed();
 }

--- a/src/hotspot/share/gc/g1/g1RegionsOnNodes.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionsOnNodes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,14 @@
 #define SHARE_VM_GC_G1_G1REGIONS_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 
 class G1NUMA;
 class G1HeapRegion;
 
 // Contains per node index region count
 class G1RegionsOnNodes : public StackObj {
-  volatile uint* _count_per_node;
+  Atomic<uint>*  _count_per_node;
   G1NUMA*        _numa;
 
 public:

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,10 +55,10 @@ void G1SurvivorRegions::convert_to_eden() {
 
 void G1SurvivorRegions::clear() {
   _regions.clear();
-  _used_bytes = 0;
+  _used_bytes.store_relaxed(0);
   _regions_on_node.clear();
 }
 
 void G1SurvivorRegions::add_used_bytes(size_t used_bytes) {
-  _used_bytes += used_bytes;
+  _used_bytes.add_then_fetch(used_bytes, memory_order_relaxed);
 }

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1SURVIVORREGIONS_HPP
 
 #include "gc/g1/g1RegionsOnNodes.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/growableArray.hpp"
 
@@ -36,7 +37,7 @@ class G1HeapRegion;
 // Set of current survivor regions.
 class G1SurvivorRegions {
   GrowableArray<G1HeapRegion*> _regions;
-  volatile size_t _used_bytes;
+  Atomic<size_t> _used_bytes;
   G1RegionsOnNodes _regions_on_node;
 
 public:
@@ -56,7 +57,7 @@ public:
   }
 
   // Used bytes of all survivor regions.
-  size_t used_bytes() const { return _used_bytes; }
+  size_t used_bytes() const { return _used_bytes.load_relaxed(); }
 
   void add_used_bytes(size_t used_bytes);
 };


### PR DESCRIPTION
Hi all,

  please review this change to make several volatiles in the `G1Eden/SurvivorRegions` area use `Atomic` API instead of volatile.

There is potentially opportunity to merge `G1Eden/SurivorRegions`, but I consider this out of scope.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387754](https://bugs.openjdk.org/browse/JDK-8387754): G1: Let Eden/SurvivorRegions use Atomic instead of volatile (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31781/head:pull/31781` \
`$ git checkout pull/31781`

Update a local copy of the PR: \
`$ git checkout pull/31781` \
`$ git pull https://git.openjdk.org/jdk.git pull/31781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31781`

View PR using the GUI difftool: \
`$ git pr show -t 31781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31781.diff">https://git.openjdk.org/jdk/pull/31781.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31781#issuecomment-4893288220)
</details>
