### PR TITLE
[PATCH] Use String.replace instead of regexp-based replaceAll

### DIFF
--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,7 +247,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
         if (rgn == null && !id.startsWith("Etc") && !id.startsWith("SystemV")) {
             int slash = id.lastIndexOf('/');
             if (slash > 0) {
-                rgn = id.substring(slash + 1).replaceAll("_", " ");
+                rgn = id.substring(slash + 1).replace("_", " ");
             }
         }
 

--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ public final class InternalLocaleBuilder {
             this.variant = "";
         } else {
             // normalize separators to "_"
-            String var = variant.replaceAll(LanguageTag.SEP, BaseLocale.SEP);
+            String var = variant.replace(LanguageTag.SEP, BaseLocale.SEP);
             int errIdx = checkVariants(var, BaseLocale.SEP);
             if (errIdx != -1) {
                 throw new LocaleSyntaxException("Ill-formed variant: " + variant, errIdx);
@@ -143,7 +143,7 @@ public final class InternalLocaleBuilder {
         } else {
             if (type.length() != 0) {
                 // normalize separator to "-"
-                String tp = type.replaceAll(BaseLocale.SEP, LanguageTag.SEP);
+                String tp = type.replace(BaseLocale.SEP, LanguageTag.SEP);
                 // validate
                 StringTokenIterator itr = new StringTokenIterator(tp, LanguageTag.SEP);
                 while (!itr.isDone()) {
@@ -190,7 +190,7 @@ public final class InternalLocaleBuilder {
             }
         } else {
             // validate value
-            String val = value.replaceAll(BaseLocale.SEP, LanguageTag.SEP);
+            String val = value.replace(BaseLocale.SEP, LanguageTag.SEP);
             StringTokenIterator itr = new StringTokenIterator(val, LanguageTag.SEP);
             while (!itr.isDone()) {
                 String s = itr.current();
@@ -227,7 +227,7 @@ public final class InternalLocaleBuilder {
             clearExtensions();
             return this;
         }
-        subtags = subtags.replaceAll(BaseLocale.SEP, LanguageTag.SEP);
+        subtags = subtags.replace(BaseLocale.SEP, LanguageTag.SEP);
         StringTokenIterator itr = new StringTokenIterator(subtags, LanguageTag.SEP);
 
         List<String> extensions = null;
@@ -514,8 +514,8 @@ public final class InternalLocaleBuilder {
                     if (sb.length() != 0) {
                         sb.append(BaseLocale.SEP);
                     }
-                    sb.append(privuse.substring(privVarStart).replaceAll(LanguageTag.SEP,
-                                                                         BaseLocale.SEP));
+                    sb.append(privuse.substring(privVarStart).replace(LanguageTag.SEP,
+                                                                      BaseLocale.SEP));
                     variant = sb.toString();
                 }
             }

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -517,7 +517,7 @@ public class LocaleResources {
                 pattern = switch (Objects.requireNonNull(dateTimePattern)) {
                     case "{1} {0}" -> datePattern + " " + timePattern;
                     case "{0} {1}" -> timePattern + " " + datePattern;
-                    default -> MessageFormat.format(dateTimePattern.replaceAll("'", "''"), timePattern, datePattern);
+                    default -> MessageFormat.format(dateTimePattern.replace("'", "''"), timePattern, datePattern);
                 };
             } else {
                 pattern = timePattern;
@@ -633,7 +633,7 @@ public class LocaleResources {
                     default -> 3;
                 };
                 var dateTimePattern = getDateTimePattern(null, "DateTimePatterns", style, calType);
-                matched = MessageFormat.format(dateTimePattern.replaceAll("'", "''"), timeMatched, dateMatched);
+                matched = MessageFormat.format(dateTimePattern.replace("'", "''"), timeMatched, dateMatched);
             }
         }
 

--- a/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
+++ b/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
@@ -58,7 +58,7 @@ import java.util.spi.LocaleNameProvider;
 import sun.util.spi.CalendarProvider;
 
 /**
- * LocaleProviderdapter implementation for the Windows locale data.
+ * LocaleProviderAdapter implementation for the Windows locale data.
  *
  * @author Naoto Sato
  */
@@ -714,10 +714,10 @@ public class HostLocaleProviderAdapterImpl {
     }
 
     private static String convertDateTimePattern(String winPattern) {
-        String ret = winPattern.replaceAll("dddd", "EEEE");
-        ret = ret.replaceAll("ddd", "EEE");
-        ret = ret.replaceAll("tt", "a");
-        ret = ret.replaceAll("g", "GG");
+        String ret = winPattern.replace("dddd", "EEEE");
+        ret = ret.replace("ddd", "EEE");
+        ret = ret.replace("tt", "a");
+        ret = ret.replace("g", "GG");
         return ret;
     }
 


### PR DESCRIPTION
String.replaceAll uses regexp inside it (Pattern). We don't need to parse/generate regexp for simple replace.
It improves performance (a bit) and makes code a bit shorter.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31782/head:pull/31782` \
`$ git checkout pull/31782`

Update a local copy of the PR: \
`$ git checkout pull/31782` \
`$ git pull https://git.openjdk.org/jdk.git pull/31782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31782`

View PR using the GUI difftool: \
`$ git pr show -t 31782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31782.diff">https://git.openjdk.org/jdk/pull/31782.diff</a>

</details>
