### PR TITLE
8387760: G1: Let G1ConcurrentMark::_chunks_in_chunk_list use the Atomic API

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -299,7 +299,7 @@ void G1CMMarkStack::add_chunk_to_list(Atomic<TaskQueueEntryChunk*>* list, TaskQu
 void G1CMMarkStack::add_chunk_to_chunk_list(TaskQueueEntryChunk* elem) {
   MutexLocker x(G1MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
   add_chunk_to_list(&_chunk_list, elem);
-  _chunks_in_chunk_list++;
+  _chunks_in_chunk_list.add_then_fetch(1u, memory_order_relaxed);
 }
 
 void G1CMMarkStack::add_chunk_to_free_list(TaskQueueEntryChunk* elem) {
@@ -319,7 +319,7 @@ G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::remove_chunk_from_chunk_list(
   MutexLocker x(G1MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
   TaskQueueEntryChunk* result = remove_chunk_from_list(&_chunk_list);
   if (result != nullptr) {
-    _chunks_in_chunk_list--;
+    _chunks_in_chunk_list.sub_then_fetch(1u, memory_order_relaxed);
   }
   return result;
 }
@@ -363,7 +363,7 @@ bool G1CMMarkStack::par_pop_chunk(G1TaskQueueEntry* ptr_arr) {
 }
 
 void G1CMMarkStack::set_empty() {
-  _chunks_in_chunk_list = 0;
+  _chunks_in_chunk_list.store_relaxed(0);
   _chunk_list.store_relaxed(nullptr);
   _free_list.store_relaxed(nullptr);
   _chunk_allocator.reset();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -213,8 +213,8 @@ private:
   Atomic<TaskQueueEntryChunk*> _free_list;  // Linked list of free chunks that can be allocated by users.
   char _pad1[DEFAULT_PADDING_SIZE - sizeof(TaskQueueEntryChunk*)];
   Atomic<TaskQueueEntryChunk*> _chunk_list; // List of chunks currently containing data.
-  volatile size_t _chunks_in_chunk_list;
-  char _pad2[DEFAULT_PADDING_SIZE - sizeof(TaskQueueEntryChunk*) - sizeof(size_t)];
+  Atomic<size_t> _chunks_in_chunk_list;
+  char _pad2[DEFAULT_PADDING_SIZE - sizeof(TaskQueueEntryChunk*) - sizeof(_chunks_in_chunk_list)];
 
   // Atomically add the given chunk to the list.
   void add_chunk_to_list(Atomic<TaskQueueEntryChunk*>* list, TaskQueueEntryChunk* elem);
@@ -265,7 +265,7 @@ private:
 
   // Return the approximate number of oops on this mark stack. Racy due to
   // unsynchronized access to _chunks_in_chunk_list.
-  size_t size() const { return _chunks_in_chunk_list * EntriesPerChunk; }
+  size_t size() const { return _chunks_in_chunk_list.load_relaxed() * EntriesPerChunk; }
 
   void set_empty();
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -93,7 +93,7 @@ inline void G1CMMarkStack::iterate(Fn fn) const {
 
   TaskQueueEntryChunk* cur = _chunk_list.load_relaxed();
   while (cur != nullptr) {
-    guarantee(num_chunks <= _chunks_in_chunk_list, "Found %zu oop chunks which is more than there should be", num_chunks);
+    guarantee(num_chunks <= _chunks_in_chunk_list.load_relaxed(), "Found %zu oop chunks which is more than there should be", num_chunks);
 
     for (size_t i = 0; i < EntriesPerChunk; ++i) {
       if (cur->data[i].is_null()) {


### PR DESCRIPTION
Hi all,

  please review this change that makes `G1ConcurrentMark::_chunks_in_chunk_list` use the `Atomic` API.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387760](https://bugs.openjdk.org/browse/JDK-8387760): G1: Let G1ConcurrentMark::_chunks_in_chunk_list use the Atomic API (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31784/head:pull/31784` \
`$ git checkout pull/31784`

Update a local copy of the PR: \
`$ git checkout pull/31784` \
`$ git pull https://git.openjdk.org/jdk.git pull/31784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31784`

View PR using the GUI difftool: \
`$ git pr show -t 31784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31784.diff">https://git.openjdk.org/jdk/pull/31784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31784#issuecomment-4893291423)
</details>
