### PR TITLE
8387764: G1: Let G1CollectedHeap::_summary_bytes_used use the Atomic API

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1761,12 +1761,11 @@ size_t G1CollectedHeap::unused_committed_regions_in_bytes() const {
 
 // Computes the sum of the storage used by the various regions.
 size_t G1CollectedHeap::used() const {
-  size_t result = _summary_bytes_used + _allocator->used_in_alloc_regions();
-  return result;
+  return used_unlocked() + _allocator->used_in_alloc_regions();
 }
 
 size_t G1CollectedHeap::used_unlocked() const {
-  return _summary_bytes_used;
+  return _summary_bytes_used.load_relaxed();
 }
 
 class SumUsedClosure: public G1HeapRegionClosure {
@@ -3024,18 +3023,18 @@ void G1CollectedHeap::prepare_region_for_full_compaction(G1HeapRegion* hr) {
 }
 
 void G1CollectedHeap::increase_used(size_t bytes) {
-  _summary_bytes_used += bytes;
+  _summary_bytes_used.add_then_fetch(bytes, memory_order_relaxed);
 }
 
 void G1CollectedHeap::decrease_used(size_t bytes) {
-  assert(_summary_bytes_used >= bytes,
+  assert(used_unlocked() >= bytes,
          "invariant: _summary_bytes_used: %zu should be >= bytes: %zu",
-         _summary_bytes_used, bytes);
-  _summary_bytes_used -= bytes;
+         used_unlocked(), bytes);
+  _summary_bytes_used.sub_then_fetch(bytes, memory_order_relaxed);
 }
 
 void G1CollectedHeap::set_used(size_t bytes) {
-  _summary_bytes_used = bytes;
+  _summary_bytes_used.store_relaxed(bytes);
 }
 
 class RebuildRegionSetsClosure : public G1HeapRegionClosure {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -243,7 +243,7 @@ private:
 
   // Outside of GC pauses, the number of bytes used in all regions other
   // than the current allocation region(s).
-  volatile size_t _summary_bytes_used;
+  Atomic<size_t> _summary_bytes_used;
 
   void increase_used(size_t bytes);
   void decrease_used(size_t bytes);

--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -55,7 +55,7 @@
                                                                               \
   nonstatic_field(G1HeapRegionManager, _regions,        G1HeapRegionTable)    \
                                                                               \
-  volatile_nonstatic_field(G1CollectedHeap, _summary_bytes_used, size_t)      \
+  volatile_nonstatic_field(G1CollectedHeap, _summary_bytes_used, Atomic<size_t>) \
   nonstatic_field(G1CollectedHeap, _hrm,                G1HeapRegionManager)  \
   nonstatic_field(G1CollectedHeap, _monitoring_support, G1MonitoringSupport*) \
   nonstatic_field(G1CollectedHeap, _old_set,            G1HeapRegionSetBase)  \

--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -42,7 +42,7 @@
   nonstatic_field(G1HeapRegion, _bottom,         HeapWord* const)             \
   nonstatic_field(G1HeapRegion, _top,            Atomic<HeapWord*>)           \
   nonstatic_field(G1HeapRegion, _end,            HeapWord* const)             \
-  volatile_nonstatic_field(G1HeapRegion, _pinned_object_count, Atomic<size_t>)\
+  nonstatic_field(G1HeapRegion, _pinned_object_count, Atomic<size_t>)         \
                                                                               \
   nonstatic_field(G1HeapRegionType, _tag,   G1HeapRegionType::Tag volatile)   \
                                                                               \
@@ -55,7 +55,7 @@
                                                                               \
   nonstatic_field(G1HeapRegionManager, _regions,        G1HeapRegionTable)    \
                                                                               \
-  volatile_nonstatic_field(G1CollectedHeap, _summary_bytes_used, Atomic<size_t>) \
+  nonstatic_field(G1CollectedHeap, _summary_bytes_used, Atomic<size_t>)       \
   nonstatic_field(G1CollectedHeap, _hrm,                G1HeapRegionManager)  \
   nonstatic_field(G1CollectedHeap, _monitoring_support, G1MonitoringSupport*) \
   nonstatic_field(G1CollectedHeap, _old_set,            G1HeapRegionSetBase)  \


### PR DESCRIPTION
Hi all,

  please review this change to make `G1CollectedHeap::_summary_bytes_used` use the `Atomic` API instead of volatile.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387764](https://bugs.openjdk.org/browse/JDK-8387764): G1: Let G1CollectedHeap::_summary_bytes_used use the Atomic API (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [ddf698ba](https://git.openjdk.org/jdk/pull/31786/files/ddf698ba019710362fb38115fa1edfdd784bffb3)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31786/head:pull/31786` \
`$ git checkout pull/31786`

Update a local copy of the PR: \
`$ git checkout pull/31786` \
`$ git pull https://git.openjdk.org/jdk.git pull/31786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31786`

View PR using the GUI difftool: \
`$ git pr show -t 31786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31786.diff">https://git.openjdk.org/jdk/pull/31786.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31786#issuecomment-4893326975)
</details>
