### PR TITLE
8387758: Oop verification wrong in StubGenerator::generate_generic_copy

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2568,7 +2568,7 @@ class StubGenerator: public StubCodeGenerator {
     __ movw(scratch_length, length);        // length (elements count, 32-bits value)
     __ tbnz(scratch_length, 31, L_failed);  // i.e. sign bit set
 
-    __ load_klass(scratch_src_klass, src);
+    __ load_narrow_klass(scratch_src_klass, src);
 #ifdef ASSERT
     //  assert(src->klass() != nullptr);
     {
@@ -2583,6 +2583,7 @@ class StubGenerator: public StubCodeGenerator {
       BLOCK_COMMENT("} assert klasses not null done");
     }
 #endif
+    __ decode_klass_not_null(scratch_src_klass, scratch_src_klass);
 
     // Load layout helper (32-bits)
     //

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1889,7 +1889,7 @@ class StubGenerator: public StubCodeGenerator {
     __ sext(scratch_length, length, 32); // length (elements count, 32-bits value)
     __ bltz(scratch_length, L_failed);
 
-    __ load_klass(scratch_src_klass, src);
+    __ load_narrow_klass(scratch_src_klass, src);
 #ifdef ASSERT
     {
       BLOCK_COMMENT("assert klasses not null {");
@@ -1903,6 +1903,7 @@ class StubGenerator: public StubCodeGenerator {
       BLOCK_COMMENT("} assert klasses not null done");
     }
 #endif
+    __ decode_klass_not_null(scratch_src_klass, t0);
 
     // Load layout helper (32-bits)
     //

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -3560,13 +3560,13 @@ address StubGenerator::generate_generic_copy(address byte_copy_entry, address sh
   __ testl(r11_length, r11_length);
   __ jccb(Assembler::negative, L_failed_0);
 
-  __ load_klass(r10_src_klass, src, rklass_tmp);
+  __ load_narrow_klass(r10_src_klass, src);
 #ifdef ASSERT
   //  assert(src->klass() != nullptr);
   {
     BLOCK_COMMENT("assert klasses not null {");
     Label L1, L2;
-    __ testptr(r10_src_klass, r10_src_klass);
+    __ testl(r10_src_klass, r10_src_klass);
     __ jcc(Assembler::notZero, L2);   // it is broken if klass is null
     __ bind(L1);
     __ stop("broken null klass");
@@ -3577,6 +3577,7 @@ address StubGenerator::generate_generic_copy(address byte_copy_entry, address sh
     BLOCK_COMMENT("} assert klasses not null done");
   }
 #endif
+  __ decode_klass_not_null(r10_src_klass, rklass_tmp);
 
   // Load layout helper (32-bits)
   //


### PR DESCRIPTION
Same issue as in [JDK-8387660](https://bugs.openjdk.org/browse/JDK-8387660) (decoding a narrow Klass without null check, then comparing it to NULL, which fails if narrowKlass encoding base != NULL), but in generate_generic_copy on aarch64, riscv and x86.

Tested: hotspot tier1+2 on Linux x64 and MacOS aarch64

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387758](https://bugs.openjdk.org/browse/JDK-8387758): Oop verification wrong in StubGenerator::generate_generic_copy (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31787/head:pull/31787` \
`$ git checkout pull/31787`

Update a local copy of the PR: \
`$ git checkout pull/31787` \
`$ git pull https://git.openjdk.org/jdk.git pull/31787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31787`

View PR using the GUI difftool: \
`$ git pr show -t 31787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31787.diff">https://git.openjdk.org/jdk/pull/31787.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31787#issuecomment-4893943001)
</details>
