### PR TITLE
8387765: G1: Let G1HeapRegionType::_tag use the Atomic API

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegionType.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,7 @@ bool G1HeapRegionType::is_valid(Tag tag) {
 }
 
 const char* G1HeapRegionType::get_str() const {
-  hrt_assert_is_valid(_tag);
-  switch (_tag) {
+  switch (get()) {
     case FreeTag:               return "FREE";
     case EdenTag:               return "EDEN";
     case SurvTag:               return "SURV";
@@ -60,8 +59,7 @@ const char* G1HeapRegionType::get_str() const {
 }
 
 const char* G1HeapRegionType::get_short_str() const {
-  hrt_assert_is_valid(_tag);
-  switch (_tag) {
+  switch (get()) {
     case FreeTag:               return "F";
     case EdenTag:               return "E";
     case SurvTag:               return "S";
@@ -75,8 +73,7 @@ const char* G1HeapRegionType::get_short_str() const {
 }
 
 G1HeapRegionTraceType::Type G1HeapRegionType::get_trace_type() {
-  hrt_assert_is_valid(_tag);
-  switch (_tag) {
+  switch (get()) {
     case FreeTag:               return G1HeapRegionTraceType::Free;
     case EdenTag:               return G1HeapRegionTraceType::Eden;
     case SurvTag:               return G1HeapRegionTraceType::Survivor;

--- a/src/hotspot/share/gc/g1/g1HeapRegionType.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1HEAPREGIONTYPE_HPP
 
 #include "gc/g1/g1HeapRegionTraceType.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #define hrt_assert_is_valid(tag) \
@@ -34,7 +35,6 @@
 class G1HeapRegionType {
   friend class VMStructs;
 
-private:
   // We encode the value of the heap region type so the generation can be
   // determined quickly. The tag is split into two parts:
   //
@@ -73,20 +73,20 @@ private:
     OldTag                = OldMask
   } Tag;
 
-  volatile Tag _tag;
+  Atomic<Tag> _tag;
 
   static bool is_valid(Tag tag);
 
   Tag get() const {
-    hrt_assert_is_valid(_tag);
-    return _tag;
+    hrt_assert_is_valid(_tag.load_relaxed());
+    return _tag.load_relaxed();
   }
 
   // Sets the type to 'tag'.
   void set(Tag tag) {
     hrt_assert_is_valid(tag);
-    hrt_assert_is_valid(_tag);
-    _tag = tag;
+    hrt_assert_is_valid(_tag.load_relaxed());
+    _tag.store_relaxed(tag);
   }
 
   // Sets the type to 'tag', expecting the type to be 'before'. This
@@ -95,13 +95,12 @@ private:
   void set_from(Tag tag, Tag before) {
     hrt_assert_is_valid(tag);
     hrt_assert_is_valid(before);
-    hrt_assert_is_valid(_tag);
-    assert(_tag == before, "HR tag: %u, expected: %u new tag; %u", _tag, before, tag);
-    _tag = tag;
+    assert(get() == before, "HR tag: %u, expected: %u new tag; %u", get(), before, tag);
+    _tag.store_relaxed(tag);
   }
 
   // Private constructor used for static constants
-  G1HeapRegionType(Tag t) : _tag(t) { hrt_assert_is_valid(_tag); }
+  G1HeapRegionType(Tag t) : _tag(t) { hrt_assert_is_valid(t); }
 
 public:
   // Queries
@@ -159,7 +158,15 @@ public:
   const char* get_short_str() const;
   G1HeapRegionTraceType::Type get_trace_type();
 
-  G1HeapRegionType() : _tag(FreeTag) { hrt_assert_is_valid(_tag); }
+  G1HeapRegionType() : G1HeapRegionType(FreeTag) { }
+
+  G1HeapRegionType(const G1HeapRegionType& other) : G1HeapRegionType(other.get()) { }
+  G1HeapRegionType& operator=(const G1HeapRegionType& other) {
+    if (this != &other) {
+      set(other.get());
+    }
+    return *this;
+  }
 
   static const G1HeapRegionType Eden;
   static const G1HeapRegionType Survivor;

--- a/src/hotspot/share/gc/g1/g1HeapRegionType.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionType.hpp
@@ -78,8 +78,9 @@ class G1HeapRegionType {
   static bool is_valid(Tag tag);
 
   Tag get() const {
-    hrt_assert_is_valid(_tag.load_relaxed());
-    return _tag.load_relaxed();
+    Tag result = _tag.load_relaxed();
+    hrt_assert_is_valid(result);
+    return result;
   }
 
   // Sets the type to 'tag'.

--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
   nonstatic_field(G1HeapRegion, _end,            HeapWord* const)             \
   volatile_nonstatic_field(G1HeapRegion, _pinned_object_count, Atomic<size_t>)\
                                                                               \
-  nonstatic_field(G1HeapRegionType, _tag,   G1HeapRegionType::Tag volatile)   \
+  nonstatic_field(G1HeapRegionType, _tag,   Atomic<G1HeapRegionType::Tag>)    \
                                                                               \
                                                                               \
   nonstatic_field(G1HeapRegionTable, _base,             address)              \
@@ -104,6 +104,6 @@
   declare_toplevel_type(G1HeapRegion*)                                        \
   declare_toplevel_type(G1MonitoringSupport*)                                 \
                                                                               \
-  declare_integer_type(G1HeapRegionType::Tag volatile)
+  declare_integer_type(Atomic<G1HeapRegionType::Tag>)
 
 #endif // SHARE_GC_G1_VMSTRUCTS_G1_HPP


### PR DESCRIPTION
Hi all,

  please review this change that makes `G1HeapRegionType::_tag` use the `Atomic` API.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387765](https://bugs.openjdk.org/browse/JDK-8387765): G1: Let G1HeapRegionType::_tag use the Atomic API (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31788/head:pull/31788` \
`$ git checkout pull/31788`

Update a local copy of the PR: \
`$ git checkout pull/31788` \
`$ git pull https://git.openjdk.org/jdk.git pull/31788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31788`

View PR using the GUI difftool: \
`$ git pr show -t 31788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31788.diff">https://git.openjdk.org/jdk/pull/31788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31788#issuecomment-4893321960)
</details>
