### PR TITLE
8359758: O(n²) time complexity in sun.security.util.LocalizedMessage.getNonlocalized

### DIFF
--- a/src/java.base/share/classes/sun/security/util/LocalizedMessage.java
+++ b/src/java.base/share/classes/sun/security/util/LocalizedMessage.java
@@ -120,13 +120,14 @@ public class LocalizedMessage {
                 //   that exception class may not be loaded yet
                 throw new RuntimeException("Unmatched braces");
             }
-            String indexStr = value.substring(leftBraceIndex + 1, rightBraceIndex);
             try {
-                int index = Integer.parseInt(indexStr);
+                int index = Integer.parseInt(value, leftBraceIndex + 1,
+                        rightBraceIndex, 10);
                 sb.append(arguments[index]);
             } catch (NumberFormatException e) {
                 // argument index is not an integer
-                throw new RuntimeException("not an integer: " + indexStr);
+                throw new RuntimeException("not an integer: " +
+                        value.substring(leftBraceIndex + 1, rightBraceIndex));
             }
 
             pos = rightBraceIndex + 1;

--- a/src/java.base/share/classes/sun/security/util/LocalizedMessage.java
+++ b/src/java.base/share/classes/sun/security/util/LocalizedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,22 +106,21 @@ public class LocalizedMessage {
         // Classes like StringTokenizer may not be loaded, so parsing
         //   is performed with String methods
         StringBuilder sb = new StringBuilder();
-        int nextBraceIndex;
-        while ((nextBraceIndex = value.indexOf('{')) >= 0) {
+        int pos = 0;
+        int leftBraceIndex;
+        while ((leftBraceIndex = value.indexOf('{', pos)) >= 0) {
 
-            String firstPart = value.substring(0, nextBraceIndex);
-            sb.append(firstPart);
-            value = value.substring(nextBraceIndex + 1);
+            sb.append(value, pos, leftBraceIndex);
 
             // look for closing brace and argument index
-            nextBraceIndex = value.indexOf('}');
-            if (nextBraceIndex < 0) {
+            int rightBraceIndex = value.indexOf('}', leftBraceIndex + 1);
+            if (rightBraceIndex < 0) {
                 // no closing brace
                 // MessageFormat would throw IllegalArgumentException, but
                 //   that exception class may not be loaded yet
                 throw new RuntimeException("Unmatched braces");
             }
-            String indexStr = value.substring(0, nextBraceIndex);
+            String indexStr = value.substring(leftBraceIndex + 1, rightBraceIndex);
             try {
                 int index = Integer.parseInt(indexStr);
                 sb.append(arguments[index]);
@@ -129,9 +128,10 @@ public class LocalizedMessage {
                 // argument index is not an integer
                 throw new RuntimeException("not an integer: " + indexStr);
             }
-            value = value.substring(nextBraceIndex + 1);
+
+            pos = rightBraceIndex + 1;
         }
-        sb.append(value);
+        sb.append(value, pos, value.length());
         return sb.toString();
     }
 


### PR DESCRIPTION
[JDK-8359758](https://bugs.openjdk.org/browse/JDK-8359758)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8359758](https://bugs.openjdk.org/browse/JDK-8359758): O(n²) time complexity in sun.security.util.LocalizedMessage.getNonlocalized (**Enhancement** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Artur Barashev](https://openjdk.org/census#abarashev) (@artur-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31789/head:pull/31789` \
`$ git checkout pull/31789`

Update a local copy of the PR: \
`$ git checkout pull/31789` \
`$ git pull https://git.openjdk.org/jdk.git pull/31789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31789`

View PR using the GUI difftool: \
`$ git pr show -t 31789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31789.diff">https://git.openjdk.org/jdk/pull/31789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31789#issuecomment-4893991178)
</details>
