### PR TITLE
8387769: GZIPInputStream tests should succeed with tryReadAheadAfterTrailer true and false

### DIFF
--- a/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
@@ -51,6 +51,12 @@ class GZIPInputStreamRead {
 
     private static final Random random = RandomFactory.getRandom();
 
+    // System property which configures whether GZIPInputStream skips the call to InputStream.available()
+    // when checking for additional GZIP members in a stream. Tests which specifically test the non-blocking
+    // behavior of 'jdk.util.gzip.tryReadAheadAfterTrailer=false' have to be skipped when the property
+    // is set to 'true'.
+    private static final boolean alwaysReadNextMember = Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
+
     /*
      * Generates GZIP content containing multiple members and then verifies
      * that using GZIPInputStream to decompress that content generates the correct
@@ -172,7 +178,9 @@ class GZIPInputStreamRead {
             while ((n = gzipIn.read(tmpBuf)) != -1) {
                 decompressedBaos.write(tmpBuf, 0, n);
             }
-            assertTrue(availableInvoked.get(), "InputStream.available() wasn't invoked");
+            if (!alwaysReadNextMember) {
+              assertTrue(availableInvoked.get(), "InputStream.available() wasn't invoked");
+            }
             final byte[] decompressed = decompressedBaos.toByteArray();
             // verify the decompressed content, it should represent the two GZIP members
             assertEquals(rawUncompressedMember1.length + rawUncompressedMember2.length,

--- a/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
@@ -24,6 +24,7 @@
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
@@ -45,17 +46,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @key randomness
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
+ * @modules java.base/java.util.zip:open
  * @run junit ${test.main.class}
  */
 class GZIPInputStreamRead {
 
     private static final Random random = RandomFactory.getRandom();
 
-    // System property which configures whether GZIPInputStream skips the call to InputStream.available()
-    // when checking for additional GZIP members in a stream. Tests which specifically test the non-blocking
-    // behavior of 'jdk.util.gzip.tryReadAheadAfterTrailer=false' have to be skipped when the property
-    // is set to 'true'.
-    private static final boolean alwaysReadNextMember = Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
+    // 'GZIPInputStream.alwaysReadNextMember' configures whether GZIPInputStream skips the call to
+    // 'InputStream.available()' when checking for additional GZIP members in a stream. Tests which
+    // specifically test the non-blocking behavior (i.e. for the 'alwaysReadNextMember=false' case)
+    // have to be skipped if 'GZIPInputStream.alwaysReadNextMember' is 'true'.
+    static boolean alwaysReadNextMember = false;
+    static {
+        try {
+            Field alwaysReadNextMemberField = GZIPInputStream.class.getDeclaredField("alwaysReadNextMember");
+            alwaysReadNextMemberField.setAccessible(true);
+            alwaysReadNextMember = alwaysReadNextMemberField.getBoolean(null);
+        } catch (Exception e) {
+            System.out.println("Warning: can't get value of 'GZIPInputStream.alwaysReadNextMember'");
+            e.printStackTrace(System.out);
+        }
+    }
 
     /*
      * Generates GZIP content containing multiple members and then verifies

--- a/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
@@ -76,6 +76,11 @@ class GZIPOverBlockingStreams {
     private static Server nonHttpServer;
     private static HttpServer httpServer;
 
+    // System property which configures whether GZIPInputStream skips the call to InputStream.available()
+    // when checking for additional GZIP members in a stream. Tests which specifically test the non-blocking
+    // behavior of 'jdk.util.gzip.tryReadAheadAfterTrailer=false' have to be skipped when the property
+    // is set to 'true'.
+    private static final boolean alwaysReadNextMember = Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
 
     @BeforeAll
     static void beforeAll() throws Exception {
@@ -119,7 +124,7 @@ class GZIPOverBlockingStreams {
     static List<Arguments> socketStreamTestArgs() {
         final List<Arguments> args = new ArrayList<>();
         final List<Integer> numMembers = numGZIPMembers();
-        for (boolean shouldCloseSocket : new boolean[]{true, false}) {
+        for (boolean shouldCloseSocket : new boolean[]{true, alwaysReadNextMember ? true : false}) {
             for (int n : numMembers) {
                 args.add(Arguments.of(n, shouldCloseSocket));
             }
@@ -166,7 +171,7 @@ class GZIPOverBlockingStreams {
     static List<Arguments> httpTestArgs() {
         final List<Arguments> args = new ArrayList<>();
         final List<Integer> numMembers = numGZIPMembers();
-        for (boolean chunkedOrNot : new boolean[]{true, false}) {
+        for (boolean chunkedOrNot : new boolean[]{alwaysReadNextMember ? false : true, false}) {
             for (int n : numMembers) {
                 args.add(Arguments.of(n, chunkedOrNot));
             }

--- a/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
@@ -27,6 +27,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -62,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @key randomness
  * @library /test/lib
  * @build jdk.test.lib.net.URIBuilder jdk.test.lib.RandomFactory
+ * @modules java.base/java.util.zip:open
  * @run junit GZIPOverBlockingStreams
  * @comment verify it behaves the same when jdk.util.gzip.tryReadAheadAfterTrailer system property
  *          is set to false
@@ -76,11 +78,21 @@ class GZIPOverBlockingStreams {
     private static Server nonHttpServer;
     private static HttpServer httpServer;
 
-    // System property which configures whether GZIPInputStream skips the call to InputStream.available()
-    // when checking for additional GZIP members in a stream. Tests which specifically test the non-blocking
-    // behavior of 'jdk.util.gzip.tryReadAheadAfterTrailer=false' have to be skipped when the property
-    // is set to 'true'.
-    private static final boolean alwaysReadNextMember = Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
+    // 'GZIPInputStream.alwaysReadNextMember' configures whether GZIPInputStream skips the call to
+    // 'InputStream.available()' when checking for additional GZIP members in a stream. Tests which
+    // specifically test the non-blocking behavior (i.e. for the 'alwaysReadNextMember=false' case)
+    // have to be skipped if 'GZIPInputStream.alwaysReadNextMember' is 'true'.
+    static boolean alwaysReadNextMember = false;
+    static {
+        try {
+            Field alwaysReadNextMemberField = GZIPInputStream.class.getDeclaredField("alwaysReadNextMember");
+            alwaysReadNextMemberField.setAccessible(true);
+            alwaysReadNextMember = alwaysReadNextMemberField.getBoolean(null);
+        } catch (Exception e) {
+            System.out.println("Warning: can't get value of 'GZIPInputStream.alwaysReadNextMember'");
+            e.printStackTrace(System.out);
+        }
+    }
 
     @BeforeAll
     static void beforeAll() throws Exception {


### PR DESCRIPTION
[JDK-8385924: GZIPInputStream.read() behaves differently on some Java versions](https://bugs.openjdk.org/browse/JDK-8385924) introduced the new system property `jdk.util.gzip.tryReadAheadAfterTrailer` which defaults to `false` and restores the behavior of `GZIPInputStream` when reading multi-member gzip streams to the before-JDK25 (and JDK 27+) state. When the property is set to `true`, GZIPInputStream will behave like in JDK 25.

Currently, some of the new `GZIPInputStream` JTreg tests which specifically test the non-blocking behavior of `GZIPInputStream` rely on the fact that `jdk.util.gzip.tryReadAheadAfterTrailer` is set to `false`.

We should make testing more resilient and allow testing with `jdk.util.gzip.tryReadAheadAfterTrailer=true` without errors or timeouts.

Tested with:
- `make test TEST=test/jdk/java/util/zip/GZIP JTREG="OPTIONS=-javaoption:-Djdk.util.gzip.tryReadAheadAfterTrailer=false"`
- `make test TEST=test/jdk/java/util/zip/GZIP JTREG="OPTIONS=-javaoption:-Djdk.util.gzip.tryReadAheadAfterTrailer=true"`


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387769](https://bugs.openjdk.org/browse/JDK-8387769): GZIPInputStream tests should succeed with tryReadAheadAfterTrailer true and false (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31790/head:pull/31790` \
`$ git checkout pull/31790`

Update a local copy of the PR: \
`$ git checkout pull/31790` \
`$ git pull https://git.openjdk.org/jdk.git pull/31790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31790`

View PR using the GUI difftool: \
`$ git pr show -t 31790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31790.diff">https://git.openjdk.org/jdk/pull/31790.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31790#issuecomment-4894025496)
</details>
