### PR TITLE
8198549: Desktop.setOpenURIHandler() only receives event if application is already launched

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -44,7 +44,7 @@
 #define PREFERENCES_TAG  42
 
 // Custom event that is emitted by AWT to let libraries like JavaFX awtEmbeddedEvent
-// know that it is ready to receive embedded events. Until this event is 
+// know that it is ready to receive embedded events. Until this event is
 // emitted libraries should buffer the already received events.
 static NSString* awtEmbeddedEventReady = @"AWTEmbeddedEventReady";
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -43,6 +43,11 @@
 // The following is a AWT convention?
 #define PREFERENCES_TAG  42
 
+// Custom event that is emitted by AWT to let libraries like JavaFX awtEmbeddedEvent
+// know that it is ready to receive embedded events. Until this event is 
+// emitted libraries should buffer the already received events.
+static NSString* awtEmbeddedEventReady = @"AWTEmbeddedEventReady";
+
 // Custom event that is provided by AWT to allow libraries like
 // JavaFX to forward native events to AWT even if AWT runs in
 // embedded mode.
@@ -135,7 +140,9 @@ AWT_ASSERT_APPKIT_THREAD;
         // Register embedded event listener
         NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
         Class clz = [ApplicationDelegate class];
+
         [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:awtEmbeddedEvent object:nil];
+        [ctr postNotificationName:awtEmbeddedEventReady object:nil userInfo:nil];
     }
 
     checked = YES;


### PR DESCRIPTION
# Problem description

When You create a JavaFX native application with *jpackage* for macOS You will run into an issue when trying to handle URIs. When Your application isn’t running and You have it registered for handling certain types of URIs it won’t receive the first URI. 

## Here is a simple example: 

If You have a JavaFX application that handles URIs for example of the form *openurifx://your-content* and You have it installed with *jpackage* for macOS and now You try to handle an URI by running the following command: 

``` open openurifx://hello-world ``` 

The application will open, but it won’t receive the above URI. If You call the same command after the application is already running, everything will work fine and the application will receive the URI.

# Problem cause

The cause of the problem is that when You build a JavaFX application and want to handle URIs You will have to combine JavaFX and AWT as AWT provides the URI handling capabilities. So the startup process is as follows:

1. JavaFX is initialized
2. JavaFX forwards the URI event to AWT
3. AWT is initialized 
4. AWT is ready to handle URI events from JavaFX

The issue is that the URI event is delivered before AWT can handle it and therefore is simple dropped. That’s why later URIs will be received and are handled properly. 

# Fix

The fix is that JavaFX will wait until it receives a ready event from AWT so JavaFX knows that AWT is able to handle events now. After that it will forward all buffered URIs and therefore everything will be handled correctly. This means that the fix involves both the JFX and JDK repositories and needs to be integrated in both. 

**Note**: In the case that a user has only a fix for the JFX part the URIs won’t be delivered at all, but there won’t be any error. This means that JavaFX applications won’t be able to handle any URIs so it might be an idea to add an environment variable to tell JavaFX to not wait for an AWT ready event. Then the first URI event would be lost, but at least all the following events would be handled properly.

# Tests

To test the error and the fix You can clone this repository: https://github.com/pabulaner/openurifx and checkout the branch *first-url*. There You will find a README.md with further instructions.

PR inside JFX: https://github.com/openjdk/jfx/pull/2203

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8198549](https://bugs.openjdk.org/browse/JDK-8198549): Desktop.setOpenURIHandler() only receives event if application is already launched (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31791/head:pull/31791` \
`$ git checkout pull/31791`

Update a local copy of the PR: \
`$ git checkout pull/31791` \
`$ git pull https://git.openjdk.org/jdk.git pull/31791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31791`

View PR using the GUI difftool: \
`$ git pr show -t 31791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31791.diff">https://git.openjdk.org/jdk/pull/31791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31791#issuecomment-4894563984)
</details>
