### PR TITLE
8358549: O(n²) time complexity in java.security.Provider.parseLegacy() method

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1084,13 +1084,14 @@ public abstract class Provider extends Properties {
                 String stdAlg = attrString.substring(0, i).intern();
                 String attrName = attrString.substring(i + 1);
                 // kill additional spaces
-                for (int pos = 0; pos < attrName.length(); pos++) {
+                int pos = 0;
+                for (; pos < attrName.length(); pos++) {
                     if (attrName.charAt(pos) != ' ') {
-                        if (pos > 0) {
-                            attrName = attrName.substring(pos);
-                        }
                         break;
                     }
+                }
+                if (pos > 0) {
+                    attrName = attrName.substring(pos);
                 }
 
                 attrName = attrName.intern();

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1084,9 +1084,15 @@ public abstract class Provider extends Properties {
                 String stdAlg = attrString.substring(0, i).intern();
                 String attrName = attrString.substring(i + 1);
                 // kill additional spaces
-                while (attrName.startsWith(" ")) {
-                    attrName = attrName.substring(1);
+                for (int pos = 0; pos < attrName.length(); pos++) {
+                    if (attrName.charAt(pos) != ' ') {
+                        if (pos > 0) {
+                            attrName = attrName.substring(pos);
+                        }
+                        break;
+                    }
                 }
+
                 attrName = attrName.intern();
                 ServiceKey stdKey = new ServiceKey(type, stdAlg, true);
                 Service stdService = legacyMap.get(stdKey);

--- a/test/jdk/java/security/Provider/SupportsParameter.java
+++ b/test/jdk/java/security/Provider/SupportsParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4911081 8130181
+ * @bug 4911081 8130181 8358549
  * @library /test/lib
  * @summary verify that Provider.Service.supportsParameter() works
  * @author Andreas Sterbenz
@@ -112,7 +112,9 @@ public class SupportsParameter {
             put("Signature.DSA0", "foo.DSA0");
 
             put("Signature.DSA", "foo.DSA");
-            put("Signature.DSA SupportedKeyClasses",
+            // Extra spaces between "Signature.DSA" and "SupportedKeyClasses"
+            // are used to verify that whitespace is trimmed.
+            put("Signature.DSA    SupportedKeyClasses",
                 "java.security.interfaces.DSAPublicKey" +
                 "|java.security.interfaces.DSAPrivateKey");
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8358549

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8358549](https://bugs.openjdk.org/browse/JDK-8358549): O(n²) time complexity in java.security.Provider.parseLegacy() method (**Enhancement** - P5)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) Review applies to [b11a1e20](https://git.openjdk.org/jdk/pull/31792/files/b11a1e2049c938cb452f8adfa7a5fe3cb2397c96)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31792/head:pull/31792` \
`$ git checkout pull/31792`

Update a local copy of the PR: \
`$ git checkout pull/31792` \
`$ git pull https://git.openjdk.org/jdk.git pull/31792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31792`

View PR using the GUI difftool: \
`$ git pr show -t 31792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31792.diff">https://git.openjdk.org/jdk/pull/31792.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31792#issuecomment-4894533489)
</details>
