### PR TITLE
8387793: test/jdk/java/nio/file/DirectoryStream/SecureDS.doSetPermissions tests absolute paths

### DIFF
--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -225,7 +225,7 @@ public class SecureDS {
                 }
 
                 // Test following link to file
-                view = stream.getFileAttributeView(link, PosixFileAttributeView.class);
+                view = stream.getFileAttributeView(linkEntry, PosixFileAttributeView.class);
                 view.setPermissions(noperms);
                 assertEquals(noperms, getPosixFilePermissions(file));
                 assertEquals(permsLink, getPosixFilePermissions(link, NOFOLLOW_LINKS));
@@ -234,7 +234,7 @@ public class SecureDS {
                 assertEquals(permsLink, getPosixFilePermissions(link, NOFOLLOW_LINKS));
 
                 // Test not following link to file
-                var linkView = stream.getFileAttributeView(link, PosixFileAttributeView.class, NOFOLLOW_LINKS);
+                var linkView = stream.getFileAttributeView(linkEntry, PosixFileAttributeView.class, NOFOLLOW_LINKS);
                 if (Platform.isLinux()) {
                     // Symbolic link permissions do not apply on Linux
                     assertThrows(IOException.class, () -> linkView.setPermissions(noperms));


### PR DESCRIPTION
Always pass a relative path to `SecureDirectoryStream.getFileAttributeView`.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387793](https://bugs.openjdk.org/browse/JDK-8387793): test/jdk/java/nio/file/DirectoryStream/SecureDS.doSetPermissions tests absolute paths (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31794/head:pull/31794` \
`$ git checkout pull/31794`

Update a local copy of the PR: \
`$ git checkout pull/31794` \
`$ git pull https://git.openjdk.org/jdk.git pull/31794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31794`

View PR using the GUI difftool: \
`$ git pr show -t 31794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31794.diff">https://git.openjdk.org/jdk/pull/31794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31794#issuecomment-4895936391)
</details>
