### PR TITLE
8386911: Crypto benchmark regressions after JDK-8384353

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ML_KEM.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ML_KEM.java
@@ -858,7 +858,7 @@ public final class ML_KEM {
                         allDone = false;
                         while (!allDone) {
                             allDone = true;
-                            parXof.squeezeBlock();
+                            parXof.squeezeBlock(parInd);
                             for (int k = 0; k < parInd; k++) {
                                 int parsedOfs = 0;
                                 int tmp;

--- a/src/java.base/share/classes/sun/security/provider/ML_DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/ML_DSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1184,7 +1184,7 @@ public class ML_DSA {
                         allDone = false;
                         while (!allDone) {
                             allDone = true;
-                            parXof.squeezeBlock();
+                            parXof.squeezeBlock(parInd);
                             for (int k = 0; k < parInd; k++) {
                                 int parsedOfs = 0;
                                 int tmp;

--- a/src/java.base/share/classes/sun/security/provider/SHA3Parallel.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA3Parallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,9 +80,28 @@ public class SHA3Parallel {
         }
     }
 
-    public int squeezeBlock() {
-        int retVal = quadKeccak(lanesArr[0], lanesArr[1], lanesArr[2], lanesArr[3]);
-        for (int i = 0; i < NRPAR; i++) {
+    public int squeezeBlock(int nr) throws InvalidAlgorithmParameterException {
+        int retVal = 0;
+        switch (nr) {
+            case 1:
+                // until we enable single keccak intrinsic, use the better
+                // doubleKeccak
+            case 2:
+                retVal = doubleKeccak(lanesArr[0], lanesArr[1]);
+                break;
+            case 3:
+                // until we enable single keccak intrinsic, use the better
+                // doubleKeccak/quadKeccak
+            case 4:
+                retVal = quadKeccak(lanesArr[0], lanesArr[1], lanesArr[2],
+                        lanesArr[3]);
+                break;
+            default:
+                throw new InvalidAlgorithmParameterException(
+                    "Bad parallel parameter.");
+        }
+
+        for (int i = 0; i < nr; i++) {
             l2bLittle(lanesArr[i], 0, buffers[i], 0, blockSize);
         }
         return retVal;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [58f118dd](https://github.com/openjdk/jdk/commit/58f118dd1c541a69b5c839609d026865a3365101) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Volodymyr Paprotski on 29 Jun 2026 and was reviewed by Weijun Wang and Shawn Emery.

Thanks!

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386911](https://bugs.openjdk.org/browse/JDK-8386911): Crypto benchmark regressions after JDK-8384353 (**Bug** - P2)


### Reviewers
 * [Shawn Emery](https://openjdk.org/census#semery) (@smemery - Author)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31796/head:pull/31796` \
`$ git checkout pull/31796`

Update a local copy of the PR: \
`$ git checkout pull/31796` \
`$ git pull https://git.openjdk.org/jdk.git pull/31796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31796`

View PR using the GUI difftool: \
`$ git pr show -t 31796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31796.diff">https://git.openjdk.org/jdk/pull/31796.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31796#issuecomment-4896180353)
</details>
