### PR TITLE
8373487: Out-of-bounds access in AlignmentGapAccess test

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -68,8 +68,6 @@ compiler/intrinsics/TestReturnOopSetForJFRWriteCheckpoint.java 8286300 linux-s39
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 generic-aarch64
 
-compiler/unsafe/AlignmentGapAccess.java 8373487 generic-all
-
 compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java 8387392 windows-aarch64
 
 #############################################################################

--- a/test/hotspot/jtreg/compiler/unsafe/AlignmentGapAccess.java
+++ b/test/hotspot/jtreg/compiler/unsafe/AlignmentGapAccess.java
@@ -38,17 +38,22 @@ public class AlignmentGapAccess {
 
     static class A           { int  fa; }
     static class B extends A { byte fb; }
+    static class C extends B { int  fc; }
 
     static final long FA_OFFSET = UNSAFE.objectFieldOffset(A.class, "fa");
     static final long FB_OFFSET = UNSAFE.objectFieldOffset(B.class, "fb");
+    static final long FC_OFFSET = UNSAFE.objectFieldOffset(C.class, "fc");
 
     static int test(B obj) {
         return UNSAFE.getInt(obj, FB_OFFSET + 1);
     }
 
     public static void main(String[] args) {
+        System.out.printf("Layout: +%d: fa; +%d: fb; +%d: fc\n",
+                          FA_OFFSET, FB_OFFSET, FC_OFFSET);
+
         for (int i = 0; i < 20_000; i++) {
-            test(new B());
+            test(new C());
         }
         System.out.println("TEST PASSED");
     }


### PR DESCRIPTION
The test performs an unsafe access which is partially beyond object boundaries. Accessing memory outside an object is problematic and can cause crashes. Proposed fix introduces extra field, so the unsafe access is reliably in-bounds now. 

Testing: hs-tier1 - hs-tier4

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8373487](https://bugs.openjdk.org/browse/JDK-8373487): Out-of-bounds access in AlignmentGapAccess test (**Bug** - P4)(⚠️ The fixVersion in this issue is [27] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31799/head:pull/31799` \
`$ git checkout pull/31799`

Update a local copy of the PR: \
`$ git checkout pull/31799` \
`$ git pull https://git.openjdk.org/jdk.git pull/31799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31799`

View PR using the GUI difftool: \
`$ git pr show -t 31799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31799.diff">https://git.openjdk.org/jdk/pull/31799.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31799#issuecomment-4906742125)
</details>
