### PR TITLE
8386322: Float16Vector.toString should render lane values using Float16.toString

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
@@ -3708,12 +3708,10 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
      *
      * The string is produced as if by a call to {@link
      * java.util.Arrays#toString(Object[]) Arrays.toString()},
-     * as appropriate to the {@link Float16} array whose elements are
-     * the lane values of this vector boxed as {@link Float16} values.
-     * Each lane is rendered by {@link Float16#toString(Float16)}, which
-     * produces a human-readable floating-point value and canonical text
-     * for special values (for example {@code "NaN"} and {@code "Infinity"})
-     * regardless of the underlying bit encoding.
+     * as appropriate to a {@code Float16} array whose elements
+     * are obtained by applying {@link Float16#shortBitsToFloat16(short)}
+     * to each element of the {@code short[]} array returned by
+     * {@link #toArray this.toArray()}.
      *
      * @return a string of the form {@code "[0,1,2...]"}
      * reporting the lane values of this vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
@@ -3707,9 +3707,13 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
      * in lane order.
      *
      * The string is produced as if by a call to {@link
-     * java.util.Arrays#toString(short[]) Arrays.toString()},
-     * as appropriate to the {@code short} array returned by
-     * {@link #toArray this.toArray()}.
+     * java.util.Arrays#toString(Object[]) Arrays.toString()},
+     * as appropriate to the {@link Float16} array whose elements are
+     * the lane values of this vector boxed as {@link Float16} values.
+     * Each lane is rendered by {@link Float16#toString(Float16)}, which
+     * produces a human-readable floating-point value and canonical text
+     * for special values (for example {@code "NaN"} and {@code "Infinity"})
+     * regardless of the underlying bit encoding.
      *
      * @return a string of the form {@code "[0,1,2...]"}
      * reporting the lane values of this vector
@@ -3718,8 +3722,10 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
     @ForceInline
     public final
     String toString() {
-        // now that toArray is strongly typed, we can define this
-        return Arrays.toString(toArray());
+        // Render the lanes as Float16 values; Float16.toString produces
+        // human-readable text and canonicalizes NaN, Infinity and -0.0
+        // independent of the underlying bit encoding.
+        return Arrays.toString(toFloat16Array());
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -5723,10 +5723,21 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
      * {@code "[0,1,2...]"}, reporting the lane values of this vector,
      * in lane order.
      *
+#if[FP16]
+     * The string is produced as if by a call to {@link
+     * java.util.Arrays#toString(Object[]) Arrays.toString()},
+     * as appropriate to the {@link Float16} array whose elements are
+     * the lane values of this vector boxed as {@link Float16} values.
+     * Each lane is rendered by {@link Float16#toString(Float16)}, which
+     * produces a human-readable floating-point value and canonical text
+     * for special values (for example {@code "NaN"} and {@code "Infinity"})
+     * regardless of the underlying bit encoding.
+#else[FP16]
      * The string is produced as if by a call to {@link
      * java.util.Arrays#toString($type$[]) Arrays.toString()},
      * as appropriate to the {@code $type$} array returned by
      * {@link #toArray this.toArray()}.
+#end[FP16]
      *
      * @return a string of the form {@code "[0,1,2...]"}
      * reporting the lane values of this vector
@@ -5735,8 +5746,15 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     @ForceInline
     public final
     String toString() {
+#if[FP16]
+        // Render the lanes as Float16 values; Float16.toString produces
+        // human-readable text and canonicalizes NaN, Infinity and -0.0
+        // independent of the underlying bit encoding.
+        return Arrays.toString(toFloat16Array());
+#else[FP16]
         // now that toArray is strongly typed, we can define this
         return Arrays.toString(toArray());
+#end[FP16]
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -5726,12 +5726,10 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
 #if[FP16]
      * The string is produced as if by a call to {@link
      * java.util.Arrays#toString(Object[]) Arrays.toString()},
-     * as appropriate to the {@link Float16} array whose elements are
-     * the lane values of this vector boxed as {@link Float16} values.
-     * Each lane is rendered by {@link Float16#toString(Float16)}, which
-     * produces a human-readable floating-point value and canonical text
-     * for special values (for example {@code "NaN"} and {@code "Infinity"})
-     * regardless of the underlying bit encoding.
+     * as appropriate to a {@code Float16} array whose elements
+     * are obtained by applying {@link Float16#shortBitsToFloat16(short)}
+     * to each element of the {@code short[]} array returned by
+     * {@link #toArray this.toArray()}.
 #else[FP16]
      * The string is produced as if by a call to {@link
      * java.util.Arrays#toString($type$[]) Arrays.toString()},

--- a/test/jdk/jdk/incubator/vector/Float16Vector128Tests.java
+++ b/test/jdk/jdk/incubator/vector/Float16Vector128Tests.java
@@ -5412,7 +5412,8 @@ public class Float16Vector128Tests extends AbstractVectorTest {
             String str = av.toString();
 
             short subarr[] = Arrays.copyOfRange(a, i, i + SPECIES.length());
-            Assert.assertTrue(str.equals(Arrays.toString(subarr)), "at index " + i + ", string should be = " + Arrays.toString(subarr) + ", but is = " + str);
+            String expectedStr = Arrays.toString(toFloat16Array(subarr));
+            Assert.assertTrue(str.equals(expectedStr), "at index " + i + ", string should be = " + expectedStr + ", but is = " + str);
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float16Vector256Tests.java
+++ b/test/jdk/jdk/incubator/vector/Float16Vector256Tests.java
@@ -5412,7 +5412,8 @@ public class Float16Vector256Tests extends AbstractVectorTest {
             String str = av.toString();
 
             short subarr[] = Arrays.copyOfRange(a, i, i + SPECIES.length());
-            Assert.assertTrue(str.equals(Arrays.toString(subarr)), "at index " + i + ", string should be = " + Arrays.toString(subarr) + ", but is = " + str);
+            String expectedStr = Arrays.toString(toFloat16Array(subarr));
+            Assert.assertTrue(str.equals(expectedStr), "at index " + i + ", string should be = " + expectedStr + ", but is = " + str);
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float16Vector512Tests.java
+++ b/test/jdk/jdk/incubator/vector/Float16Vector512Tests.java
@@ -5412,7 +5412,8 @@ public class Float16Vector512Tests extends AbstractVectorTest {
             String str = av.toString();
 
             short subarr[] = Arrays.copyOfRange(a, i, i + SPECIES.length());
-            Assert.assertTrue(str.equals(Arrays.toString(subarr)), "at index " + i + ", string should be = " + Arrays.toString(subarr) + ", but is = " + str);
+            String expectedStr = Arrays.toString(toFloat16Array(subarr));
+            Assert.assertTrue(str.equals(expectedStr), "at index " + i + ", string should be = " + expectedStr + ", but is = " + str);
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float16Vector64Tests.java
+++ b/test/jdk/jdk/incubator/vector/Float16Vector64Tests.java
@@ -5412,7 +5412,8 @@ public class Float16Vector64Tests extends AbstractVectorTest {
             String str = av.toString();
 
             short subarr[] = Arrays.copyOfRange(a, i, i + SPECIES.length());
-            Assert.assertTrue(str.equals(Arrays.toString(subarr)), "at index " + i + ", string should be = " + Arrays.toString(subarr) + ", but is = " + str);
+            String expectedStr = Arrays.toString(toFloat16Array(subarr));
+            Assert.assertTrue(str.equals(expectedStr), "at index " + i + ", string should be = " + expectedStr + ", but is = " + str);
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/Float16VectorMaxTests.java
+++ b/test/jdk/jdk/incubator/vector/Float16VectorMaxTests.java
@@ -5418,7 +5418,8 @@ public class Float16VectorMaxTests extends AbstractVectorTest {
             String str = av.toString();
 
             short subarr[] = Arrays.copyOfRange(a, i, i + SPECIES.length());
-            Assert.assertTrue(str.equals(Arrays.toString(subarr)), "at index " + i + ", string should be = " + Arrays.toString(subarr) + ", but is = " + str);
+            String expectedStr = Arrays.toString(toFloat16Array(subarr));
+            Assert.assertTrue(str.equals(expectedStr), "at index " + i + ", string should be = " + expectedStr + ", but is = " + str);
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-Miscellaneous.template
@@ -87,7 +87,12 @@
             String str = av.toString();
 
             $type$ subarr[] = Arrays.copyOfRange(a, i, i + SPECIES.length());
-            Assert.assertTrue(str.equals(Arrays.toString(subarr)), "at index " + i + ", string should be = " + Arrays.toString(subarr) + ", but is = " + str);
+#if[FP16]
+            String expectedStr = Arrays.toString(toFloat16Array(subarr));
+#else[FP16]
+            String expectedStr = Arrays.toString(subarr);
+#end[FP16]
+            Assert.assertTrue(str.equals(expectedStr), "at index " + i + ", string should be = " + expectedStr + ", but is = " + str);
         }
     }
 


### PR DESCRIPTION
Currently Float16Vector.toString prints raw short values from the backing storage, i.e. the IEEE 754 binary16 bit encodings. Patch uses Float16.toString routine to print the lane values in more user-friendly human-readable floating-point format.
In addition, the various bit representations of NaN are canonicalized so that such lanes are simply printed as "NaN". Float16.toString API renders each lane as a human-readable floating-point value and prints canonical text ("NaN",
"Infinity", "-0.0")

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8387954](https://bugs.openjdk.org/browse/JDK-8387954) to be approved
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8386322](https://bugs.openjdk.org/browse/JDK-8386322): Float16Vector.toString should render lane values using Float16.toString (**Enhancement** - P4)
 * [JDK-8387954](https://bugs.openjdk.org/browse/JDK-8387954): Float16Vector.toString should print values in human readable format (**CSR**)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31800/head:pull/31800` \
`$ git checkout pull/31800`

Update a local copy of the PR: \
`$ git checkout pull/31800` \
`$ git pull https://git.openjdk.org/jdk.git pull/31800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31800`

View PR using the GUI difftool: \
`$ git pr show -t 31800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31800.diff">https://git.openjdk.org/jdk/pull/31800.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31800#issuecomment-4900314829)
</details>
