### PR TITLE
[PATCH] Avoid confusing AtomicReferenceArray.compareAndSet calls

### DIFF
--- a/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
+++ b/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
@@ -58,7 +58,7 @@ import java.util.spi.LocaleNameProvider;
 import sun.util.spi.CalendarProvider;
 
 /**
- * LocaleProviderdapter implementation for the Windows locale data.
+ * LocaleProviderAdapter implementation for the Windows locale data.
  *
  * @author Naoto Sato
  */
@@ -179,13 +179,13 @@ public class HostLocaleProviderAdapterImpl {
                 if (ref == null || (patterns = ref.get()) == null) {
                     String langtag = removeExtensions(locale).toLanguageTag();
                     patterns = new AtomicReferenceArray<>(4);
-                    patterns.compareAndSet(0, null, convertDateTimePattern(
+                    patterns.set(0, convertDateTimePattern(
                         getDateTimePattern(DateFormat.LONG, -1, langtag)));
-                    patterns.compareAndSet(1, null, convertDateTimePattern(
+                    patterns.set(1, convertDateTimePattern(
                         getDateTimePattern(DateFormat.SHORT, -1, langtag)));
-                    patterns.compareAndSet(2, null, convertDateTimePattern(
+                    patterns.set(2, convertDateTimePattern(
                         getDateTimePattern(-1, DateFormat.LONG, langtag)));
-                    patterns.compareAndSet(3, null, convertDateTimePattern(
+                    patterns.set(3, convertDateTimePattern(
                         getDateTimePattern(-1, DateFormat.SHORT, langtag)));
                     ref = new SoftReference<>(patterns);
                     dateFormatCache.put(locale, ref);
@@ -581,13 +581,13 @@ public class HostLocaleProviderAdapterImpl {
                 if (ref == null || (patterns = ref.get()) == null) {
                     String langtag = removeExtensions(locale).toLanguageTag();
                     patterns = new AtomicReferenceArray<>(4);
-                    patterns.compareAndSet(0, null, convertDateTimePattern(
+                    patterns.set(0, convertDateTimePattern(
                             getDateTimePattern(DateFormat.LONG, -1, langtag)));
-                    patterns.compareAndSet(1, null, convertDateTimePattern(
+                    patterns.set(1, convertDateTimePattern(
                             getDateTimePattern(DateFormat.SHORT, -1, langtag)));
-                    patterns.compareAndSet(2, null, convertDateTimePattern(
+                    patterns.set(2, convertDateTimePattern(
                             getDateTimePattern(-1, DateFormat.LONG, langtag)));
-                    patterns.compareAndSet(3, null, convertDateTimePattern(
+                    patterns.set(3, convertDateTimePattern(
                             getDateTimePattern(-1, DateFormat.SHORT, langtag)));
                     ref = new SoftReference<>(patterns);
                     dateFormatCache.put(locale, ref);


### PR DESCRIPTION
We just created a new AtomicReferenceArray and didn't leak it anywhere. There is no reason to use compareAndSet. Simple `set` is enough.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31804/head:pull/31804` \
`$ git checkout pull/31804`

Update a local copy of the PR: \
`$ git checkout pull/31804` \
`$ git pull https://git.openjdk.org/jdk.git pull/31804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31804`

View PR using the GUI difftool: \
`$ git pr show -t 31804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31804.diff">https://git.openjdk.org/jdk/pull/31804.diff</a>

</details>
