### PR TITLE
8387414: Insufficient feature gate in vm_version_x86 for UseKyberIntrinsics

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_kyber.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_kyber.cpp
@@ -1108,15 +1108,14 @@ address generate_kyberBarrettReduce_avx512(StubGenerator *stubgen,
 void StubGenerator::generate_kyber_stubs() {
   // Generate Kyber intrinsics code
   if (UseKyberIntrinsics) {
-    if (VM_Version::supports_evex()) {
-      StubRoutines::_kyberNtt = generate_kyberNtt_avx512(this, _masm);
-      StubRoutines::_kyberInverseNtt = generate_kyberInverseNtt_avx512(this, _masm);
-      StubRoutines::_kyberNttMult = generate_kyberNttMult_avx512(this, _masm);
-      StubRoutines::_kyberAddPoly_2 = generate_kyberAddPoly_2_avx512(this, _masm);
-      StubRoutines::_kyberAddPoly_3 = generate_kyberAddPoly_3_avx512(this, _masm);
-      StubRoutines::_kyber12To16 = generate_kyber12To16_avx512(this, _masm);
-      StubRoutines::_kyberBarrettReduce = generate_kyberBarrettReduce_avx512(this, _masm);
-    }
+    assert(VM_Version::supports_avx512vlbw(), "must at least support AVX-512 VLBW");
+    StubRoutines::_kyberNtt = generate_kyberNtt_avx512(this, _masm);
+    StubRoutines::_kyberInverseNtt = generate_kyberInverseNtt_avx512(this, _masm);
+    StubRoutines::_kyberNttMult = generate_kyberNttMult_avx512(this, _masm);
+    StubRoutines::_kyberAddPoly_2 = generate_kyberAddPoly_2_avx512(this, _masm);
+    StubRoutines::_kyberAddPoly_3 = generate_kyberAddPoly_3_avx512(this, _masm);
+    StubRoutines::_kyber12To16 = generate_kyber12To16_avx512(this, _masm);
+    StubRoutines::_kyberBarrettReduce = generate_kyberBarrettReduce_avx512(this, _masm);
   }
 }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_kyber.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_kyber.cpp
@@ -1108,7 +1108,6 @@ address generate_kyberBarrettReduce_avx512(StubGenerator *stubgen,
 void StubGenerator::generate_kyber_stubs() {
   // Generate Kyber intrinsics code
   if (UseKyberIntrinsics) {
-    assert(VM_Version::supports_avx512vlbw(), "must at least support AVX-512 VLBW");
     StubRoutines::_kyberNtt = generate_kyberNtt_avx512(this, _masm);
     StubRoutines::_kyberInverseNtt = generate_kyberInverseNtt_avx512(this, _masm);
     StubRoutines::_kyberNttMult = generate_kyberNttMult_avx512(this, _masm);

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1270,7 +1270,7 @@ void VM_Version::get_processor_features() {
 
   // Kyber Intrinsics
   // Currently we only have them for AVX512
-  if (supports_evex() && supports_avx512bw()) {
+  if (supports_avx512vlbw()) {
     if (FLAG_IS_DEFAULT(UseKyberIntrinsics)) {
       UseKyberIntrinsics = true;
     }


### PR DESCRIPTION

Tidying up of an insufficient and redundant feature gate. BW implies EVEX so the latter check is not needed, but the Kyber fallback path requires VL as well which isn't checked. VBMI implies VL and BW though. Testing: T1-2

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387414](https://bugs.openjdk.org/browse/JDK-8387414): Insufficient feature gate in vm_version_x86 for UseKyberIntrinsics (**Bug** - P4)


### Reviewers
 * [Shawn Emery](https://openjdk.org/census#semery) (@smemery - Author)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31807/head:pull/31807` \
`$ git checkout pull/31807`

Update a local copy of the PR: \
`$ git checkout pull/31807` \
`$ git pull https://git.openjdk.org/jdk.git pull/31807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31807`

View PR using the GUI difftool: \
`$ git pr show -t 31807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31807.diff">https://git.openjdk.org/jdk/pull/31807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31807#issuecomment-4902791999)
</details>
