### PR TITLE
8272194: java.sql.Date::toLocalDate() broken for dates before 1 A.D.

### DIFF
--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -636,18 +636,6 @@ public class Date
 
     /**
      * Returns a value that is the result of subtracting 1900 from the
-     * normalized year that contains or begins with the instant in time
-     * represented by this {@code Date} object, as interpreted in the local
-     * time zone.
-     *
-     * @return  the normalized year represented by this date, minus 1900.
-     */
-    protected int getNormalizedYear() {
-        return normalize().getNormalizedYear() - 1900;
-    }
-
-    /**
-     * Returns a value that is the result of subtracting 1900 from the
      * year that contains or begins with the instant in time represented
      * by this {@code Date} object, as interpreted in the local
      * time zone.

--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -636,6 +636,18 @@ public class Date
 
     /**
      * Returns a value that is the result of subtracting 1900 from the
+     * normalized year that contains or begins with the instant in time
+     * represented by this {@code Date} object, as interpreted in the local
+     * time zone.
+     *
+     * @return  the normalized year represented by this date, minus 1900.
+     */
+    protected int getNormalizedYear() {
+        return normalize().getNormalizedYear() - 1900;
+    }
+
+    /**
+     * Returns a value that is the result of subtracting 1900 from the
      * year that contains or begins with the instant in time represented
      * by this {@code Date} object, as interpreted in the local
      * time zone.

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -276,6 +276,17 @@ public class Date extends java.util.Date {
     static final long serialVersionUID = 1511598038487230103L;
 
     /**
+     * The epoch millisecond value of 0002-01-01T00:00:00.000 at UTC in
+     * the Julian-Gregorian hybrid calendar system.
+     * We cannot use 1st January 1AD as different timezones could possibly
+     * offset the date back into BC, thus resulting in the incorrect BC year.
+     * While a one year margin is considerably larger than any possible
+     * timezone offset, it gives us a comfortable distance while still
+     * providing a faster code path for almost 1970 years.
+     */
+    private static final long TWO_AD_AT_UTC_EPOCH_MILLIS = -62104233600000L;
+
+    /**
      * Obtains an instance of {@code Date} from a {@link LocalDate} object
      * with the same year, month and day of month value as the given
      * {@code LocalDate}.
@@ -307,9 +318,10 @@ public class Date extends java.util.Date {
         // of the date in order to find the correct year.
         // However, deriving a new calendar is a relatively expensive operation
         // that we would ideally avoid if possible.
-        // Given that we can comfortably state that any dates after the unix epoch
-        // are AD, we can use a much faster local date derivation for these dates.
-        if (getTime() >= 0) {
+        // Given that we can comfortably state that any dates on or after
+        // 0002-01-01 are AD, we can use a much faster local date derivation
+        // for these dates.
+        if (getTime() >= TWO_AD_AT_UTC_EPOCH_MILLIS) {
             return LocalDate.of(getYear() + 1900, getMonth() + 1, getDate());
         }
         final GregorianCalendar calendar = new GregorianCalendar();

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -313,29 +313,40 @@ public class Date extends java.util.Date {
      */
     @SuppressWarnings("deprecation")
     public LocalDate toLocalDate() {
-        // The underlying date does not expose any direct way of determining if
-        // the year is a BC year. As a result, we need to rederive the calendar
-        // of the date in order to find the correct year.
+        return LocalDate.of(
+            toProlepticYear(getYear() + 1900, getTime()),
+            getMonth() + 1,
+            getDate());
+    }
+
+    /**
+     * Converts an era-relative calendar year into the correct proleptic year.
+     * <p>
+     * The milliseconds is required to determine if the given year is a BC or AD year.
+     *
+     * @param year the era-relative calendar year.
+     * @param millis the epoch millisecond represented by the date with the given year
+     * used to determine the calendar era.
+     * @return the proleptic year corresponding to {@code year} and {@code millis}
+     */
+    static int toProlepticYear(int year, long millis) {
+        // We need to determine the era of the year using the given millis.
         // However, deriving a new calendar is a relatively expensive operation
         // that we would ideally avoid if possible.
         // Given that we can comfortably state that any dates on or after
-        // 0002-01-01 are AD, we can use a much faster local date derivation
-        // for these dates.
-        if (getTime() >= TWO_AD_AT_UTC_EPOCH_MILLIS) {
-            return LocalDate.of(getYear() + 1900, getMonth() + 1, getDate());
+        // 0002-01-01 are AD, we only need to test dates earlier than this cutoff.
+        if (millis < TWO_AD_AT_UTC_EPOCH_MILLIS) {
+            final GregorianCalendar calendar = new GregorianCalendar();
+            calendar.setTimeInMillis(millis);
+            if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+                // Adjust the BC date into a negative astronomical date.
+                // As there is no year 0 in the Gregorian calendar
+                // we also have to adjust the BC year by 1.
+                // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
+                year = 1 - year;
+            }
         }
-        final GregorianCalendar calendar = new GregorianCalendar();
-        calendar.setTime(this);
-
-        int year = getYear() + 1900;
-        if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
-            // Adjust the BC date into a negative astronomical date.
-            // As there is no year 0 in the Gregorian calendar
-            // we also have to adjust the BC year by 1.
-            // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
-            year = 1 - year;
-        }
-        return LocalDate.of(year, getMonth() + 1, getDate());
+        return year;
     }
 
    /**

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -327,15 +327,13 @@ public class Date extends java.util.Date {
         final GregorianCalendar calendar = new GregorianCalendar();
         calendar.setTime(this);
 
-        final int year;
+        int year = getYear() + 1900;
         if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
             // Adjust the BC date into a negative astronomical date.
             // As there is no year 0 in the Gregorian calendar
             // we also have to adjust the BC year by 1.
             // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
-            year = 1 - calendar.get(Calendar.YEAR);
-        } else {
-            year = getYear() + 1900;
+            year = 1 - year;
         }
         return LocalDate.of(year, getMonth() + 1, getDate());
     }

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -335,7 +335,7 @@ public class Date extends java.util.Date {
             // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
             year = 1 - calendar.get(Calendar.YEAR);
         } else {
-            year = calendar.get(Calendar.YEAR);
+            year = getYear() + 1900;
         }
         return LocalDate.of(year, getMonth() + 1, getDate());
     }

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -300,7 +300,18 @@ public class Date extends java.util.Date {
      *
      * @since 1.8
      */
+    @SuppressWarnings("deprecation")
     public LocalDate toLocalDate() {
+        // The underlying date does not expose any direct way of determining if
+        // the year is a BC year. As a result, we need to rederive the calendar
+        // of the date in order to find the correct year.
+        // However, deriving a new calendar is a relatively expensive operation
+        // that we would ideally avoid if possible.
+        // Given that we can comfortably state that any dates after the unix epoch
+        // are AD, we can use a much faster local date derivation for these dates.
+        if (getTime() >= 0) {
+            return LocalDate.of(getYear() + 1900, getMonth() + 1, getDate());
+        }
         final GregorianCalendar calendar = new GregorianCalendar();
         calendar.setTime(this);
 

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -314,7 +314,7 @@ public class Date extends java.util.Date {
     @SuppressWarnings("deprecation")
     public LocalDate toLocalDate() {
         return LocalDate.of(
-            toProlepticYear(getYear() + 1900, getTime()),
+            toGregorianProlepticYear(getYear() + 1900, getTime()),
             getMonth() + 1,
             getDate());
     }
@@ -329,7 +329,7 @@ public class Date extends java.util.Date {
      * used to determine the calendar era.
      * @return the proleptic year corresponding to {@code year} and {@code millis}
      */
-    static int toProlepticYear(int year, long millis) {
+    static int toGregorianProlepticYear(int year, long millis) {
         // We need to determine the era of the year using the given millis.
         // However, deriving a new calendar is a relatively expensive operation
         // that we would ideally avoid if possible.

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -300,7 +300,7 @@ public class Date extends java.util.Date {
      */
     @SuppressWarnings("deprecation")
     public LocalDate toLocalDate() {
-        return LocalDate.of(getYear() + 1900, getMonth() + 1, getDate());
+        return LocalDate.of(getNormalizedYear() + 1900, getMonth() + 1, getDate());
     }
 
    /**

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -317,8 +317,8 @@ public class Date extends java.util.Date {
 
         final int year;
         if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
-            // Ajdust the BC date into a negative astronomical date.
-            // As there is no year 0 in the proleptic Gregorian calendar
+            // Adjust the BC date into a negative astronomical date.
+            // As there is no year 0 in the Gregorian calendar
             // we also have to adjust the BC year by 1.
             // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
             year = 1 - calendar.get(Calendar.YEAR);

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -27,6 +27,8 @@ package java.sql;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 /**
  * <P>A thin wrapper around a millisecond value that allows
@@ -298,9 +300,21 @@ public class Date extends java.util.Date {
      *
      * @since 1.8
      */
-    @SuppressWarnings("deprecation")
     public LocalDate toLocalDate() {
-        return LocalDate.of(getNormalizedYear() + 1900, getMonth() + 1, getDate());
+        final GregorianCalendar calendar = new GregorianCalendar();
+        calendar.setTime(this);
+
+        final int year;
+        if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+            // Ajdust the BC date into a negative astronomical date.
+            // As there is no year 0 in the proleptic Gregorian calendar
+            // we also have to adjust the BC year by 1.
+            // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
+            year = 1 - calendar.get(Calendar.YEAR);
+        } else {
+            year = calendar.get(Calendar.YEAR);
+        }
+        return LocalDate.of(year, calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
     }
 
    /**

--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -325,7 +325,7 @@ public class Date extends java.util.Date {
         } else {
             year = calendar.get(Calendar.YEAR);
         }
-        return LocalDate.of(year, calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
+        return LocalDate.of(year, getMonth() + 1, getDate());
     }
 
    /**

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -540,8 +540,8 @@ public class Timestamp extends java.util.Date {
 
         final int year;
         if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
-            // Ajdust the BC date into a negative astronomical date.
-            // As there is no year 0 in the proleptic Gregorian calendar
+            // Adjust the BC date into a negative astronomical date.
+            // As there is no year 0 in the Gregorian calendar
             // we also have to adjust the BC year by 1.
             // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
             year = 1 - calendar.get(Calendar.YEAR);

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -485,6 +485,17 @@ public class Timestamp extends java.util.Date {
     private static final int MILLIS_PER_SECOND = 1000;
 
     /**
+     * The epoch millisecond value of 0002-01-01T00:00:00.000 at UTC in
+     * the Julian-Gregorian hybrid calendar system.
+     * We cannot use 1st January 1AD as different timezones could possibly
+     * offset the date back into BC, thus resulting in the incorrect BC year.
+     * While a one year margin is considerably larger than any possible
+     * timezone offset, it gives us a comfortable distance while still
+     * providing a faster code path for almost 1970 years.
+     */
+    private static final long TWO_AD_AT_UTC_EPOCH_MILLIS = -62104233600000L;
+
+    /**
      * Obtains an instance of {@code Timestamp} from a {@code LocalDateTime}
      * object, with the same year, month, day of month, hours, minutes,
      * seconds and nanos date-time value as the provided {@code LocalDateTime}.
@@ -524,9 +535,10 @@ public class Timestamp extends java.util.Date {
         // of the date in order to find the correct year.
         // However, deriving a new calendar is a relatively expensive operation
         // that we would ideally avoid if possible.
-        // Given that we can comfortably state that any dates after the unix epoch
-        // are AD, we can use a much faster local date time derivation for these dates.
-        if (getTime() >= 0) {
+        // Given that we can comfortably state that any dates on or after
+        // 0002-01-01 are AD, we can use a much faster local date time
+        // derivation for these dates.
+        if (getTime() >= TWO_AD_AT_UTC_EPOCH_MILLIS) {
             return LocalDateTime.of(getYear() + 1900,
                                     getMonth() + 1,
                                     getDate(),

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -27,8 +27,6 @@ package java.sql;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 
 /**
  * <P>A thin wrapper around {@code java.util.Date} that allows
@@ -485,17 +483,6 @@ public class Timestamp extends java.util.Date {
     private static final int MILLIS_PER_SECOND = 1000;
 
     /**
-     * The epoch millisecond value of 0002-01-01T00:00:00.000 at UTC in
-     * the Julian-Gregorian hybrid calendar system.
-     * We cannot use 1st January 1AD as different timezones could possibly
-     * offset the date back into BC, thus resulting in the incorrect BC year.
-     * While a one year margin is considerably larger than any possible
-     * timezone offset, it gives us a comfortable distance while still
-     * providing a faster code path for almost 1970 years.
-     */
-    private static final long TWO_AD_AT_UTC_EPOCH_MILLIS = -62104233600000L;
-
-    /**
      * Obtains an instance of {@code Timestamp} from a {@code LocalDateTime}
      * object, with the same year, month, day of month, hours, minutes,
      * seconds and nanos date-time value as the provided {@code LocalDateTime}.
@@ -530,41 +517,14 @@ public class Timestamp extends java.util.Date {
      */
     @SuppressWarnings("deprecation")
     public LocalDateTime toLocalDateTime() {
-        // The underlying date does not expose any direct way of determining if
-        // the year is a BC year. As a result, we need to rederive the calendar
-        // of the date in order to find the correct year.
-        // However, deriving a new calendar is a relatively expensive operation
-        // that we would ideally avoid if possible.
-        // Given that we can comfortably state that any dates on or after
-        // 0002-01-01 are AD, we can use a much faster local date time
-        // derivation for these dates.
-        if (getTime() >= TWO_AD_AT_UTC_EPOCH_MILLIS) {
-            return LocalDateTime.of(getYear() + 1900,
-                                    getMonth() + 1,
-                                    getDate(),
-                                    getHours(),
-                                    getMinutes(),
-                                    getSeconds(),
-                                    getNanos());
-        }
-        final GregorianCalendar calendar = new GregorianCalendar();
-        calendar.setTime(this);
-
-        int year = getYear() + 1900;
-        if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
-            // Adjust the BC date into a negative astronomical date.
-            // As there is no year 0 in the Gregorian calendar
-            // we also have to adjust the BC year by 1.
-            // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
-            year = 1 - year;
-        }
-        return LocalDateTime.of(year,
-                                getMonth() + 1,
-                                getDate(),
-                                getHours(),
-                                getMinutes(),
-                                getSeconds(),
-                                getNanos());
+        return LocalDateTime.of(
+            Date.toProlepticYear(getYear() + 1900, getTime()),
+            getMonth() + 1,
+            getDate(),
+            getHours(),
+            getMinutes(),
+            getSeconds(),
+            getNanos());
     }
 
     /**

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -518,7 +518,7 @@ public class Timestamp extends java.util.Date {
     @SuppressWarnings("deprecation")
     public LocalDateTime toLocalDateTime() {
         return LocalDateTime.of(
-            Date.toProlepticYear(getYear() + 1900, getTime()),
+            Date.toGregorianProlepticYear(getYear() + 1900, getTime()),
             getMonth() + 1,
             getDate(),
             getHours(),

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -27,6 +27,8 @@ package java.sql;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 /**
  * <P>A thin wrapper around {@code java.util.Date} that allows
@@ -515,15 +517,27 @@ public class Timestamp extends java.util.Date {
      * @return a {@code LocalDateTime} object representing the same date-time value
      * @since 1.8
      */
-    @SuppressWarnings("deprecation")
     public LocalDateTime toLocalDateTime() {
-        return LocalDateTime.of(getNormalizedYear() + 1900,
-                                getMonth() + 1,
-                                getDate(),
-                                getHours(),
-                                getMinutes(),
-                                getSeconds(),
-                                getNanos());
+        final GregorianCalendar calendar = new GregorianCalendar();
+        calendar.setTime(this);
+
+        final int year;
+        if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+            // Ajdust the BC date into a negative astronomical date.
+            // As there is no year 0 in the proleptic Gregorian calendar
+            // we also have to adjust the BC year by 1.
+            // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
+            year = 1 - calendar.get(Calendar.YEAR);
+        } else {
+            year = calendar.get(Calendar.YEAR);
+        }
+        return LocalDateTime.of(year,
+                                calendar.get(Calendar.MONTH) + 1,
+                                calendar.get(Calendar.DAY_OF_MONTH),
+                                calendar.get(Calendar.HOUR_OF_DAY),
+                                calendar.get(Calendar.MINUTE),
+                                calendar.get(Calendar.SECOND),
+                                getNanos()); // We have to use nanos here as the calendar does not support nano precision
     }
 
     /**

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -558,7 +558,7 @@ public class Timestamp extends java.util.Date {
             // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
             year = 1 - calendar.get(Calendar.YEAR);
         } else {
-            year = calendar.get(Calendar.YEAR);
+            year = getYear() + 1900;
         }
         return LocalDateTime.of(year,
                                 getMonth() + 1,

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -549,11 +549,11 @@ public class Timestamp extends java.util.Date {
             year = calendar.get(Calendar.YEAR);
         }
         return LocalDateTime.of(year,
-                                calendar.get(Calendar.MONTH) + 1,
-                                calendar.get(Calendar.DAY_OF_MONTH),
-                                calendar.get(Calendar.HOUR_OF_DAY),
-                                calendar.get(Calendar.MINUTE),
-                                calendar.get(Calendar.SECOND),
+                                getMonth() + 1,
+                                getDate(),
+                                getHours(),
+                                getMinutes(),
+                                getSeconds(),
                                 getNanos()); // We have to use nanos here as the calendar does not support nano precision
     }
 

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -564,7 +564,7 @@ public class Timestamp extends java.util.Date {
                                 getHours(),
                                 getMinutes(),
                                 getSeconds(),
-                                getNanos()); // We have to use nanos here as the calendar does not support nano precision
+                                getNanos());
     }
 
     /**

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -550,15 +550,13 @@ public class Timestamp extends java.util.Date {
         final GregorianCalendar calendar = new GregorianCalendar();
         calendar.setTime(this);
 
-        final int year;
+        int year = getYear() + 1900;
         if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
             // Adjust the BC date into a negative astronomical date.
             // As there is no year 0 in the Gregorian calendar
             // we also have to adjust the BC year by 1.
             // 1 BC becomes year 0, 2 BC becomes year -1 and so on.
-            year = 1 - calendar.get(Calendar.YEAR);
-        } else {
-            year = getYear() + 1900;
+            year = 1 - year;
         }
         return LocalDateTime.of(year,
                                 getMonth() + 1,

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -517,7 +517,24 @@ public class Timestamp extends java.util.Date {
      * @return a {@code LocalDateTime} object representing the same date-time value
      * @since 1.8
      */
+    @SuppressWarnings("deprecation")
     public LocalDateTime toLocalDateTime() {
+        // The underlying date does not expose any direct way of determining if
+        // the year is a BC year. As a result, we need to rederive the calendar
+        // of the date in order to find the correct year.
+        // However, deriving a new calendar is a relatively expensive operation
+        // that we would ideally avoid if possible.
+        // Given that we can comfortably state that any dates after the unix epoch
+        // are AD, we can use a much faster local date time derivation for these dates.
+        if (getTime() >= 0) {
+            return LocalDateTime.of(getYear() + 1900,
+                                    getMonth() + 1,
+                                    getDate(),
+                                    getHours(),
+                                    getMinutes(),
+                                    getSeconds(),
+                                    getNanos());
+        }
         final GregorianCalendar calendar = new GregorianCalendar();
         calendar.setTime(this);
 

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -517,7 +517,7 @@ public class Timestamp extends java.util.Date {
      */
     @SuppressWarnings("deprecation")
     public LocalDateTime toLocalDateTime() {
-        return LocalDateTime.of(getYear() + 1900,
+        return LocalDateTime.of(getNormalizedYear() + 1900,
                                 getMonth() + 1,
                                 getDate(),
                                 getHours(),

--- a/test/jdk/java/sql/test/sql/DateTests.java
+++ b/test/jdk/java/sql/test/sql/DateTests.java
@@ -24,6 +24,7 @@ package sql;
 
 import java.sql.Date;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -328,16 +329,23 @@ public class DateTests extends BaseTest {
     }
 
     /*
-     * Validate that Date.valueOf and Date.toLocalDate yield the expected results for dates with negative years.
+     * Validate that Date.valueOf and Date.toLocalDate yield the expected results for dates with BC years.
+     * Ensures that the fix for 8272194 has not regressed.
      */
     @Test
     public void test27() {
-        LocalDate ld1 = LocalDate.of(-4, 1, 1);
-        Date d1 = Date.valueOf(ld1);
-        LocalDate ld2 = d1.toLocalDate();
-        assertTrue(ld1.equals(ld2), "Error ld1 != ld2");
-        Date d2 = Date.valueOf(ld1);
-        assertTrue(d1.equals(d2), "Error d1 != d2");
+        List<LocalDate> bcLocalDates = List.of(
+            LocalDate.of(0, 1, 1),
+            LocalDate.of(-4, 9, 8),
+            LocalDate.of(-1000, 3, 22)
+        );
+        for (LocalDate bcLocalDate : bcLocalDates) {
+            Date bcDate = Date.valueOf(bcLocalDate);
+            // Previously, getYear() of a LocalDate created from a Date always returned a positive year, even if it was BC.
+            assertTrue(bcDate.toLocalDate().getYear() <= 0, "Expected a BC year.");
+            assertEquals(bcDate.toLocalDate(), bcLocalDate, "The LocalDate created from the Date does not match the original BC LocalDate.");
+            assertEquals(Date.valueOf(bcDate.toLocalDate()), bcDate, "The BC Date did not yield the expected result on a round trip Date / LocalDate conversion.");
+        }
     }
 
     /*

--- a/test/jdk/java/sql/test/sql/DateTests.java
+++ b/test/jdk/java/sql/test/sql/DateTests.java
@@ -342,6 +342,18 @@ public class DateTests extends BaseTest {
     }
 
     /*
+     * Ensure that LocalDate conversion of AD dates close to the BC check threshold
+     * behave as expected.
+     */
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("datesAroundBcCheckThreshold")
+    public void test28(LocalDate localDate) {
+        Date date = Date.valueOf(localDate);
+        assertEquals(localDate, date.toLocalDate(), "The LocalDate created from the Date does not match the original LocalDate.");
+        assertEquals(date, Date.valueOf(date.toLocalDate()), "The Date did not yield the expected result on a round trip Date / LocalDate conversion.");
+    }
+
+    /*
      * DataProvider used to provide Date which are not valid and are used
      * to validate that an IllegalArgumentException will be thrown from the
      * valueOf method
@@ -397,6 +409,22 @@ public class DateTests extends BaseTest {
             LocalDate.of(0, 1, 1),
             LocalDate.of(-4, 9, 8),
             LocalDate.of(-1000, 3, 22)
+        );
+    }
+
+    /*
+     * DataProvider used to provide LocalDate values immediately surrounding
+     * the BC check threshold used internally by Date.toLocalDate().
+     */
+    private Stream<LocalDate> datesAroundBcCheckThreshold() {
+        return Stream.of(
+            LocalDate.of(1, 12, 1),
+            LocalDate.of(1, 12, 30),
+            LocalDate.of(1, 12, 31),
+            LocalDate.of(2, 1, 1),
+            LocalDate.of(2, 1, 2),
+            LocalDate.of(2, 1, 3),
+            LocalDate.of(2, 2, 1)
         );
     }
 }

--- a/test/jdk/java/sql/test/sql/DateTests.java
+++ b/test/jdk/java/sql/test/sql/DateTests.java
@@ -331,7 +331,7 @@ public class DateTests extends BaseTest {
      * Validate that Date.valueOf and Date.toLocalDate yield the expected results for dates with BC years.
      * Ensures that the fix for 8272194 has not regressed.
      */
-    @ParameterizedTest(autoCloseArguments = false)
+    @ParameterizedTest
     @MethodSource("bcLocalDates")
     public void test27(LocalDate bcLocalDate) {
         Date bcDate = Date.valueOf(bcLocalDate);
@@ -345,7 +345,7 @@ public class DateTests extends BaseTest {
      * Ensure that LocalDate conversion of AD dates close to the BC check threshold
      * behave as expected.
      */
-    @ParameterizedTest(autoCloseArguments = false)
+    @ParameterizedTest
     @MethodSource("datesAroundBcCheckThreshold")
     public void test28(LocalDate localDate) {
         Date date = Date.valueOf(localDate);

--- a/test/jdk/java/sql/test/sql/DateTests.java
+++ b/test/jdk/java/sql/test/sql/DateTests.java
@@ -24,7 +24,6 @@ package sql;
 
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -332,20 +331,14 @@ public class DateTests extends BaseTest {
      * Validate that Date.valueOf and Date.toLocalDate yield the expected results for dates with BC years.
      * Ensures that the fix for 8272194 has not regressed.
      */
-    @Test
-    public void test27() {
-        List<LocalDate> bcLocalDates = List.of(
-            LocalDate.of(0, 1, 1),
-            LocalDate.of(-4, 9, 8),
-            LocalDate.of(-1000, 3, 22)
-        );
-        for (LocalDate bcLocalDate : bcLocalDates) {
-            Date bcDate = Date.valueOf(bcLocalDate);
-            // Previously, getYear() of a LocalDate created from a Date always returned a positive year, even if it was BC.
-            assertTrue(bcDate.toLocalDate().getYear() <= 0, "Expected a BC year.");
-            assertEquals(bcDate.toLocalDate(), bcLocalDate, "The LocalDate created from the Date does not match the original BC LocalDate.");
-            assertEquals(Date.valueOf(bcDate.toLocalDate()), bcDate, "The BC Date did not yield the expected result on a round trip Date / LocalDate conversion.");
-        }
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("bcLocalDates")
+    public void test27(LocalDate bcLocalDate) {
+        Date bcDate = Date.valueOf(bcLocalDate);
+        // Previously, getYear() of a LocalDate created from a Date always returned a positive year, even if it was BC.
+        assertTrue(bcDate.toLocalDate().getYear() <= 0, "Expected a BC year.");
+        assertEquals(bcLocalDate, bcDate.toLocalDate(), "The LocalDate created from the Date does not match the original BC LocalDate.");
+        assertEquals(bcDate, Date.valueOf(bcDate.toLocalDate()), "The BC Date did not yield the expected result on a round trip Date / LocalDate conversion.");
     }
 
     /*
@@ -391,6 +384,19 @@ public class DateTests extends BaseTest {
             Arguments.of("2009-01-8", "2009-01-08"),
             Arguments.of("2009-1-01", "2009-01-01"),
             Arguments.of("2009-1-1", "2009-01-01")
+        );
+    }
+
+    /*
+     * DataProvider used to provide BC LocalDate values, used to validate that
+     * Date.valueOf and Date.toLocalDate yield the expected results for dates
+     * with BC years.
+     */
+    private Stream<LocalDate> bcLocalDates() {
+        return Stream.of(
+            LocalDate.of(0, 1, 1),
+            LocalDate.of(-4, 9, 8),
+            LocalDate.of(-1000, 3, 22)
         );
     }
 }

--- a/test/jdk/java/sql/test/sql/DateTests.java
+++ b/test/jdk/java/sql/test/sql/DateTests.java
@@ -328,6 +328,19 @@ public class DateTests extends BaseTest {
     }
 
     /*
+     * Validate that Date.valueOf and Date.toLocalDate yield the expected results for dates with negative years.
+     */
+    @Test
+    public void test27() {
+        LocalDate ld1 = LocalDate.of(-4, 1, 1);
+        Date d1 = Date.valueOf(ld1);
+        LocalDate ld2 = d1.toLocalDate();
+        assertTrue(ld1.equals(ld2), "Error ld1 != ld2");
+        Date d2 = Date.valueOf(ld1);
+        assertTrue(d1.equals(d2), "Error d1 != d2");
+    }
+
+    /*
      * DataProvider used to provide Date which are not valid and are used
      * to validate that an IllegalArgumentException will be thrown from the
      * valueOf method

--- a/test/jdk/java/sql/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/test/sql/TimestampTests.java
@@ -714,6 +714,19 @@ public class TimestampTests extends BaseTest {
     }
 
     /*
+     * Validate that Timestamp.valueOf and Timestamp.toLocalDateTime yield the expected results for dates with negative years.
+     */
+    @Test
+    public void test56() throws Exception {
+        LocalDateTime ldt1 = LocalDateTime.of(-4, 1, 1, 0, 0);
+        Timestamp ts1 = Timestamp.valueOf(ldt1);
+        LocalDateTime ldt2 = ts1.toLocalDateTime();
+        assertTrue(ldt1.equals(ldt2), "Error ldt1 != ldt2");
+        Timestamp ts2 = Timestamp.valueOf(ldt2);
+        assertTrue(ts1.equals(ts2), "Error ts1 != ts2");
+    }
+
+    /*
      * DataProvider used to provide Timestamps which are not valid and are used
      * to validate that an IllegalArgumentException will be thrown from the
      * valueOf method

--- a/test/jdk/java/sql/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/test/sql/TimestampTests.java
@@ -717,7 +717,7 @@ public class TimestampTests extends BaseTest {
      * Validate that Timestamp.valueOf and Timestamp.toLocalDateTime yield the expected results for dates with BC years.
      * Ensures that the fix for 8272194 has not regressed.
      */
-    @ParameterizedTest(autoCloseArguments = false)
+    @ParameterizedTest
     @MethodSource("bcLocalDateTimes")
     public void test56(LocalDateTime bcLocalDateTime) throws Exception {
         Timestamp bcTimestamp = Timestamp.valueOf(bcLocalDateTime);
@@ -731,7 +731,7 @@ public class TimestampTests extends BaseTest {
      * Ensure that LocalDateTime conversion of AD dates close to the BC check threshold
      * behave as expected.
      */
-    @ParameterizedTest(autoCloseArguments = false)
+    @ParameterizedTest
     @MethodSource("dateTimesAroundBcCheckThreshold")
     public void test57(LocalDateTime localDateTime) {
         Timestamp timestamp = Timestamp.valueOf(localDateTime);

--- a/test/jdk/java/sql/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/test/sql/TimestampTests.java
@@ -728,6 +728,18 @@ public class TimestampTests extends BaseTest {
     }
 
     /*
+     * Ensure that LocalDateTime conversion of AD dates close to the BC check threshold
+     * behave as expected.
+     */
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("dateTimesAroundBcCheckThreshold")
+    public void test57(LocalDateTime localDateTime) {
+        Timestamp timestamp = Timestamp.valueOf(localDateTime);
+        assertEquals(localDateTime, timestamp.toLocalDateTime(), "The LocalDateTime created from the Timestamp does not match the original LocalDateTime.");
+        assertEquals(timestamp, Timestamp.valueOf(timestamp.toLocalDateTime()), "The Timestamp did not yield the expected result on a round trip Timestamp / LocalDateTime conversion.");
+    }
+
+    /*
      * DataProvider used to provide Timestamps which are not valid and are used
      * to validate that an IllegalArgumentException will be thrown from the
      * valueOf method
@@ -866,6 +878,23 @@ public class TimestampTests extends BaseTest {
             LocalDateTime.of(0, 1, 1, 0, 0, 0, 0),
             LocalDateTime.of(-4, 9, 8, 23, 11, 59, 999_999_999),
             LocalDateTime.of(-1000, 3, 22, 8, 30, 20, 0)
+        );
+    }
+
+    /*
+     * DataProvider used to provide LocalDateTime values immediately
+     * surrounding the BC check threshold used internally by
+     * Timestamp.toLocalDateTime().
+     */
+    private Stream<LocalDateTime> dateTimesAroundBcCheckThreshold() {
+        return Stream.of(
+            LocalDateTime.of(1, 12, 1, 6, 15, 45, 500_000_000),
+            LocalDateTime.of(1, 12, 30, 12, 30, 0, 250_000_000),
+            LocalDateTime.of(1, 12, 31, 23, 59, 59, 999_999_999),
+            LocalDateTime.of(2, 1, 1, 0, 0, 0, 0),
+            LocalDateTime.of(2, 1, 2, 8, 20, 10, 750_750_750),
+            LocalDateTime.of(2, 1, 3, 16, 40, 20, 100_000_000),
+            LocalDateTime.of(2, 2, 1, 18, 45, 30, 123_000_000)
         );
     }
 }

--- a/test/jdk/java/sql/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/test/sql/TimestampTests.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Calendar;
+import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
@@ -714,16 +715,23 @@ public class TimestampTests extends BaseTest {
     }
 
     /*
-     * Validate that Timestamp.valueOf and Timestamp.toLocalDateTime yield the expected results for dates with negative years.
+     * Validate that Timestamp.valueOf and Timestamp.toLocalDateTime yield the expected results for dates with BC years.
+     * Ensures that the fix for 8272194 has not regressed.
      */
     @Test
     public void test56() throws Exception {
-        LocalDateTime ldt1 = LocalDateTime.of(-4, 1, 1, 0, 0);
-        Timestamp ts1 = Timestamp.valueOf(ldt1);
-        LocalDateTime ldt2 = ts1.toLocalDateTime();
-        assertTrue(ldt1.equals(ldt2), "Error ldt1 != ldt2");
-        Timestamp ts2 = Timestamp.valueOf(ldt2);
-        assertTrue(ts1.equals(ts2), "Error ts1 != ts2");
+        List<LocalDateTime> bcLocalDateTimes = List.of(
+            LocalDateTime.of(0, 1, 1, 0, 0, 0, 0),
+            LocalDateTime.of(-4, 9, 8, 23, 11, 59, 999_999_999),
+            LocalDateTime.of(-1000, 3, 22, 8, 30, 20, 0)
+        );
+        for (LocalDateTime bcLocalDateTime : bcLocalDateTimes) {
+            Timestamp bcTimestamp = Timestamp.valueOf(bcLocalDateTime);
+            // Previously, getYear() of a LocalDateTime created from a Timestamp always returned a positive year, even if it was BC.
+            assertTrue(bcTimestamp.toLocalDateTime().getYear() <= 0, "Expected a BC year.");
+            assertEquals(bcTimestamp.toLocalDateTime(), bcLocalDateTime, "The LocalDateTime created from the Timestamp does not match the original BC LocalDateTime.");
+            assertEquals(Timestamp.valueOf(bcTimestamp.toLocalDateTime()), bcTimestamp, "The BC Timestamp did not yield the expected result on a round trip Timestamp / LocalDateTime conversion.");
+        }
     }
 
     /*

--- a/test/jdk/java/sql/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/test/sql/TimestampTests.java
@@ -29,7 +29,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Calendar;
-import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
@@ -718,20 +717,14 @@ public class TimestampTests extends BaseTest {
      * Validate that Timestamp.valueOf and Timestamp.toLocalDateTime yield the expected results for dates with BC years.
      * Ensures that the fix for 8272194 has not regressed.
      */
-    @Test
-    public void test56() throws Exception {
-        List<LocalDateTime> bcLocalDateTimes = List.of(
-            LocalDateTime.of(0, 1, 1, 0, 0, 0, 0),
-            LocalDateTime.of(-4, 9, 8, 23, 11, 59, 999_999_999),
-            LocalDateTime.of(-1000, 3, 22, 8, 30, 20, 0)
-        );
-        for (LocalDateTime bcLocalDateTime : bcLocalDateTimes) {
-            Timestamp bcTimestamp = Timestamp.valueOf(bcLocalDateTime);
-            // Previously, getYear() of a LocalDateTime created from a Timestamp always returned a positive year, even if it was BC.
-            assertTrue(bcTimestamp.toLocalDateTime().getYear() <= 0, "Expected a BC year.");
-            assertEquals(bcTimestamp.toLocalDateTime(), bcLocalDateTime, "The LocalDateTime created from the Timestamp does not match the original BC LocalDateTime.");
-            assertEquals(Timestamp.valueOf(bcTimestamp.toLocalDateTime()), bcTimestamp, "The BC Timestamp did not yield the expected result on a round trip Timestamp / LocalDateTime conversion.");
-        }
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("bcLocalDateTimes")
+    public void test56(LocalDateTime bcLocalDateTime) throws Exception {
+        Timestamp bcTimestamp = Timestamp.valueOf(bcLocalDateTime);
+        // Previously, getYear() of a LocalDateTime created from a Timestamp always returned a positive year, even if it was BC.
+        assertTrue(bcTimestamp.toLocalDateTime().getYear() <= 0, "Expected a BC year.");
+        assertEquals(bcLocalDateTime, bcTimestamp.toLocalDateTime(), "The LocalDateTime created from the Timestamp does not match the original BC LocalDateTime.");
+        assertEquals(bcTimestamp, Timestamp.valueOf(bcTimestamp.toLocalDateTime()), "The BC Timestamp did not yield the expected result on a round trip Timestamp / LocalDateTime conversion.");
     }
 
     /*
@@ -860,6 +853,19 @@ public class TimestampTests extends BaseTest {
             Arguments.of("1996-12-10 12:26:19.012345678", 12345678),
             Arguments.of("1996-12-10 12:26:19.0", 0),
             Arguments.of("1996-12-10 12:26:19.01230", 12300000)
+        );
+    }
+
+    /*
+     * DataProvider used to provide BC LocalDateTime values, used to validate
+     * that Timestamp.valueOf and Timestamp.toLocalDateTime yield the expected
+     * results for dates with BC years.
+     */
+    private Stream<LocalDateTime> bcLocalDateTimes() {
+        return Stream.of(
+            LocalDateTime.of(0, 1, 1, 0, 0, 0, 0),
+            LocalDateTime.of(-4, 9, 8, 23, 11, 59, 999_999_999),
+            LocalDateTime.of(-1000, 3, 22, 8, 30, 20, 0)
         );
     }
 }


### PR DESCRIPTION
Also covers: [8249280](https://bugs.openjdk.org/browse/JDK-8249280)

I will first give a quick summary of the problem.
Put simply, the `LocalDate` form of the `java.sql.Date` is derived using the `getYear` method of `java.util.Date`. This in turn returns the year of the normalised internal calendar.
However, the internal calendar `getYear` has an extra layer of complexity.
The calendar has an additional era field, which captures BC/AD.
`getYear` therefore just returns the year _of that era_.
For example, the year 6BC and the year 6AD both return `getYear` as 6.

**This means that for BC dates, our `LocalDate` conversion loses the sign of the year.**

This leads to additional problems down the line, as the year 1BC is for calculations sake is considered to be year 0 (and 2BC us considered year -1 and so on). As a result, the various leap year calculations are WRONG for these years, causing year format validation failures in situations like marshalling/unmarshalling the dates with a DB.

There are two seemingly obvious fixes here, however I will attempt to explain why I did not proceed with them.

Firstly, it seems sensible is to derive the `LocalDate` from an `Instant` created from the millisecond representation of the `Date`. After all, why we are having to use the deprecated `getYear`, `getMonth` and `getDay` methods anyway?
The answer lies in [8061577](https://bugs.openjdk.org/browse/JDK-8061577).
The underlying millisecond representation between `java.time.Instant` and `java.util.Date` is fundamentally different. Read that ticket for a greater explanation.
Ultimately though, it means that the for older dates, the only real way to bridge between the two calendar systems is to use these year/month/day methods.

This is where the second possible solution appears.
The underlying calendar representation that `java.util.Date` uses actually does have a year method which gives you the correctly signed year, that being `getNormalizedYear`.
In fact, `java.util.Date` uses the setter counterpart `setNormalizedYear` is its `setYear` method.
Given this, it seems natural that `getYear` should similarly call `getNormalizedYear`.
I think this would be my ideal solution, however I recognise that `get`Year only returning a positive year is very long standing behaviour. Given how widely spread `java.util.Date` is, I felt it was perhaps better not to rock the boat too much.

I have therefore taken the decision to add an equivalent `getNormalizedYear` method to `java.util.Date`.
This is the simplest way to expose the real inner year of the date to `java.sql.Date` and `java.sql.Timestamp`.
This fixes the negative year issue in the LocalDate conversion in an incredibly low impact way, and without altering long standing `java.util.Date` behaviour.
I chose to make the method `protected` to prevent unwanted consumption of the method. However, I did not make it `Deprecated` like the other accessor methods which perhaps I should have done.

Let me know what you think.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8272194: java.sql.Date::toLocalDate() broken for dates before 1 A.D.`

### Issue
 * [JDK-8272194](https://bugs.openjdk.org/browse/JDK-8272194): java.sql.Date::toLocalDate() broken for dates before 1 A.D. (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31808/head:pull/31808` \
`$ git checkout pull/31808`

Update a local copy of the PR: \
`$ git checkout pull/31808` \
`$ git pull https://git.openjdk.org/jdk.git pull/31808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31808`

View PR using the GUI difftool: \
`$ git pr show -t 31808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31808.diff">https://git.openjdk.org/jdk/pull/31808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31808#issuecomment-4903705786)
</details>
