### PR TITLE
8386953: sun/security/ssl/CertificateCompression/CompressedCertMsgCache.java failing

### DIFF
--- a/test/jdk/sun/security/ssl/CertificateCompression/CompressedCertMsgCache.java
+++ b/test/jdk/sun/security/ssl/CertificateCompression/CompressedCertMsgCache.java
@@ -46,7 +46,7 @@ import jdk.test.lib.security.CertificateBuilder;
 
 /*
  * @test
- * @bug 8372526 8386953
+ * @bug 8372526
  * @summary Check CompressedCertificate message cache.
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util

--- a/test/jdk/sun/security/ssl/CertificateCompression/CompressedCertMsgCache.java
+++ b/test/jdk/sun/security/ssl/CertificateCompression/CompressedCertMsgCache.java
@@ -46,13 +46,13 @@ import jdk.test.lib.security.CertificateBuilder;
 
 /*
  * @test
- * @bug 8372526
+ * @bug 8372526 8386953
  * @summary Check CompressedCertificate message cache.
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util
  * @library /javax/net/ssl/templates
  *          /test/lib
- * @run main/othervm CompressedCertMsgCache
+ * @run main/othervm -Djdk.tls.server.newSessionTicketCount=0 CompressedCertMsgCache
  */
 
 public class CompressedCertMsgCache extends SSLSocketTemplate {


### PR DESCRIPTION
Sometimes OS assigns the same server port to 2 test runs out of 3, thus causing TLS session resumption (so no certificate is being sent by the server). Disable NewSessionTicket being sent by the server to remove any chance of such condition and avoid the test flakiness.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386953](https://bugs.openjdk.org/browse/JDK-8386953): sun/security/ssl/CertificateCompression/CompressedCertMsgCache.java failing (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31811/head:pull/31811` \
`$ git checkout pull/31811`

Update a local copy of the PR: \
`$ git checkout pull/31811` \
`$ git pull https://git.openjdk.org/jdk.git pull/31811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31811`

View PR using the GUI difftool: \
`$ git pr show -t 31811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31811.diff">https://git.openjdk.org/jdk/pull/31811.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31811#issuecomment-4904561748)
</details>
