### PR TITLE
8387874: Timeout when running test BulkCipherDisabledAlgorithms

### DIFF
--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -31,15 +31,16 @@
  *          /javax/net/ssl/templates
  */
 
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import javax.net.ssl.*;
-
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 import jdk.test.lib.process.Proc;
-
-import java.security.NoSuchAlgorithmException;
 
 /*
  * Each test case is executed in a separate JVM because

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -31,7 +31,7 @@
  *          /javax/net/ssl/TLSCommon
  *          /javax/net/ssl/templates
  * @run main/othervm/timeout=480 BulkCipherDisabledAlgorithms visibility
- * @run main/othervm/timeout=480 BulkCipherDisabledAlgorithms handshake
+ * @run main/othervm BulkCipherDisabledAlgorithms handshake
  */
 
 import java.util.ArrayList;

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -100,7 +100,6 @@ public class BulkCipherDisabledAlgorithms {
             String suiteName = suite.name();
             String bulk = extractBulkCipher(suiteName);
 
-            tests.add(new String[] { suiteName, suiteName, "disabled" });
             tests.add(new String[] { suiteName, bulk, "disabled" });
 
             for (CipherSuite other : suites) {

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8387124
- * @summary Test TLS cipher suite disabling via jdk.tls.disabledAlgorithms
- *          using both cipher suite names and bulk cipher components.
+ * @summary Verify that disabling bulk cipher algorithms in
+ *          jdk.tls.disabledAlgorithms disables associated TLS cipher suites.
  * @library /test/lib
  *          /javax/net/ssl/TLSCommon
  *          /javax/net/ssl/templates
@@ -51,22 +51,26 @@ public class BulkCipherDisabledAlgorithms {
 
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            List<String[]> tests = buildTests();
+            // Sanity check: all enabled cipher suites should work before
+            // applying any jdk.tls.disabledAlgorithms restrictions.
+            testAllCipherSuitesEnabled();
+
+            // Verify that disabling a bulk cipher algorithm disables cipher
+            // suites that use that algorithm.
+            List<String[]> tests = buildCipherSuitesDisabled();
 
             for (String[] test : tests) {
                 String suite = test[0];
-                String disabled = test[1];
-                String expected = test[2];
+                String bulkCipher = test[1];
 
                 System.out.println("=================================================");
                 System.out.println("Testing: suite=" + suite +
-                        ", disabled=" + disabled +
-                        ", expected=" + expected);
+                        ", bulkCipher=" + bulkCipher);
 
                 Proc p = Proc.create(
                         BulkCipherDisabledAlgorithms.class.getName())
-                        .args(suite, expected)
-                        .secprop("jdk.tls.disabledAlgorithms", disabled)
+                        .args(suite)
+                        .secprop("jdk.tls.disabledAlgorithms", bulkCipher)
                         .inheritIO();
 
                 p.start().waitFor(0);
@@ -77,10 +81,18 @@ public class BulkCipherDisabledAlgorithms {
         }
 
         String suite = args[0];
-        String expected = args[1];
-        boolean expectedDisabled = "disabled".equals(expected);
 
-        testHandshake(suite, expectedDisabled);
+        testCipherSuiteDisabled(suite);
+
+        testHandshake(suite, true);
+    }
+
+    private static void testAllCipherSuitesEnabled() throws Exception {
+        CipherSuite[] suites = getCipherSuites();
+
+        for (CipherSuite suite : suites) {
+            testHandshake(suite.name(), false);
+        }
     }
 
     private static CipherSuite[] getCipherSuites() throws NoSuchAlgorithmException {
@@ -92,32 +104,15 @@ public class BulkCipherDisabledAlgorithms {
                 .toArray(CipherSuite[]::new);
     }
 
-    private static List<String[]> buildTests() throws NoSuchAlgorithmException {
+    private static List<String[]> buildCipherSuitesDisabled() throws NoSuchAlgorithmException {
         List<String[]> tests = new ArrayList<>();
         CipherSuite[] suites = getCipherSuites();
 
         for (CipherSuite suite : suites) {
             String suiteName = suite.name();
-            String bulk = extractBulkCipher(suiteName);
+            String bulkCipher = extractBulkCipher(suiteName);
 
-            tests.add(new String[] { suiteName, bulk, "disabled" });
-
-            for (CipherSuite other : suites) {
-                // Negative test case: disable a different bulk cipher than the one
-                // used by the current suite. This ensures that the suite remains
-                // enabled and a successful TLS handshake can still be negotiated.
-                if (other == suite) {
-                    continue;
-                }
-
-                String otherBulk = extractBulkCipher(other.name());
-
-                if (!bulk.equals(otherBulk)
-                        && !suiteName.contains(otherBulk)) {
-                    tests.add(new String[] { suiteName, otherBulk, "enabled" });
-                    break;
-                }
-            }
+            tests.add(new String[] { suiteName, bulkCipher });
         }
 
         return tests;
@@ -141,37 +136,47 @@ public class BulkCipherDisabledAlgorithms {
         }
     }
 
-    private static void testHandshake(String suite, boolean expectedDisabled) throws Exception {
+    private static void testCipherSuiteDisabled(String suite) throws NoSuchAlgorithmException {
+        boolean visible = Arrays.asList(getCipherSuites())
+                .contains(CipherSuite.cipherSuite(suite));
+
+        if (visible) {
+            throw new RuntimeException(
+                    "Cipher suite '" + suite + "' visible but expected to be disabled");
+        }
+    }
+
+    private static void testHandshake(String cipherSuite, boolean expectedDisabled) throws Exception {
         try {
-            new TLSHandshakeTest(suite).run();
+            new TLSHandshakeTest(cipherSuite).run();
 
             if (expectedDisabled) {
                 throw new RuntimeException(
-                        "Handshake succeeded but should fail: " + suite);
+                        "Handshake succeeded but should fail: " + cipherSuite);
             }
         } catch (SSLHandshakeException e) {
             if (!expectedDisabled) {
                 throw new RuntimeException(
-                        "Handshake failed unexpectedly: " + suite, e);
+                        "Handshake failed unexpectedly: " + cipherSuite, e);
             }
         }
     }
 
     private static class TLSHandshakeTest extends SSLSocketTemplate {
-        private final String suite;
+        private final String cipherSuite;
 
-        TLSHandshakeTest(String suite) {
-            this.suite = suite;
+        TLSHandshakeTest(String cipherSuite) {
+            this.cipherSuite = cipherSuite;
         }
 
         @Override
         protected void configureClientSocket(SSLSocket socket) {
-            socket.setEnabledCipherSuites(new String[] { suite });
+            socket.setEnabledCipherSuites(new String[] { cipherSuite });
         }
 
         @Override
         protected void configureServerSocket(SSLServerSocket socket) {
-            socket.setEnabledCipherSuites(new String[] { suite });
+            socket.setEnabledCipherSuites(new String[] { cipherSuite });
         }
     }
 }

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -30,8 +30,8 @@
  * @library /test/lib
  *          /javax/net/ssl/TLSCommon
  *          /javax/net/ssl/templates
- * @run main/othervm/timeout=2400 BulkCipherDisabledAlgorithms visibility
- * @run main/othervm/timeout=2400 BulkCipherDisabledAlgorithms handshake
+ * @run main/othervm/timeout=480 BulkCipherDisabledAlgorithms visibility
+ * @run main/othervm/timeout=480 BulkCipherDisabledAlgorithms handshake
  */
 
 import java.util.ArrayList;

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -24,14 +24,11 @@
 /*
  * @test
  * @bug 8387124
- * @summary Test TLS cipher suite disabling via jdk.tls.disabledAlgorithms,
- *          including matching on bulk cipher components, covering both
- *          visibility and handshake behavior.
+ * @summary Test TLS cipher suite disabling via jdk.tls.disabledAlgorithms
+ *          using both cipher suite names and bulk cipher components.
  * @library /test/lib
  *          /javax/net/ssl/TLSCommon
  *          /javax/net/ssl/templates
- * @run main/othervm/timeout=480 BulkCipherDisabledAlgorithms visibility
- * @run main/othervm BulkCipherDisabledAlgorithms handshake
  */
 
 import java.util.ArrayList;
@@ -43,21 +40,17 @@ import javax.net.ssl.*;
 import jdk.test.lib.process.Proc;
 
 import java.security.NoSuchAlgorithmException;
-import java.security.Security;
 
+/*
+ * Each test case is executed in a separate JVM because
+ * jdk.tls.disabledAlgorithms is evaluated during JSSE initialization and
+ * cannot be reliably reconfigured within the same VM.
+ */
 public class BulkCipherDisabledAlgorithms {
 
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            throw new RuntimeException("Missing mode argument");
-        }
-
-        String mode = args[0];
-        boolean isVisibilityTest = "visibility".equals(mode);
-        boolean isHandshakeTest = "handshake".equals(mode);
-
-        if (args.length == 1) {
-            List<String[]> tests = buildTests(isVisibilityTest);
+            List<String[]> tests = buildTests();
 
             for (String[] test : tests) {
                 String suite = test[0];
@@ -65,14 +58,13 @@ public class BulkCipherDisabledAlgorithms {
                 String expected = test[2];
 
                 System.out.println("=================================================");
-                System.out.println("Testing: " + mode +
-                        ", suite=" + suite +
+                System.out.println("Testing: suite=" + suite +
                         ", disabled=" + disabled +
                         ", expected=" + expected);
 
                 Proc p = Proc.create(
                         BulkCipherDisabledAlgorithms.class.getName())
-                        .args(mode, suite, expected)
+                        .args(suite, expected)
                         .secprop("jdk.tls.disabledAlgorithms", disabled)
                         .inheritIO();
 
@@ -83,44 +75,25 @@ public class BulkCipherDisabledAlgorithms {
             return;
         }
 
-        String suite = args[1];
-        String expected = args[2];
+        String suite = args[0];
+        String expected = args[1];
         boolean expectedDisabled = "disabled".equals(expected);
 
-        if (isVisibilityTest) {
-            testCipherSuiteVisibility(suite, expectedDisabled);
-        }
-
-        if (isHandshakeTest) {
-            testHandshake(suite, expectedDisabled);
-        }
+        testHandshake(suite, expectedDisabled);
     }
 
-    // Returns cipher suites for testing.
-    // - true: use all supported suites (independent of disabledAlgorithms)
-    // - false: use default enabled suites (candidates for handshake)
-    private static CipherSuite[] getCipherSuites(boolean useSupportedSuites)
-            throws NoSuchAlgorithmException {
+    private static CipherSuite[] getCipherSuites() throws NoSuchAlgorithmException {
         SSLEngine engine = SSLContext.getDefault().createSSLEngine();
-        String[] suites = useSupportedSuites
-                ? engine.getSupportedCipherSuites()
-                : engine.getEnabledCipherSuites();
-
+        String[] suites = engine.getEnabledCipherSuites();
         return Arrays.stream(suites)
                 .map(CipherSuite::cipherSuite)
                 .filter(cs -> cs != CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
                 .toArray(CipherSuite[]::new);
     }
 
-    private static List<String[]> buildTests(boolean useSupportedSuites)
-            throws NoSuchAlgorithmException {
-        if (useSupportedSuites) {
-            // disabledAlgorithms limits supported suites; clear to list all
-            Security.setProperty("jdk.tls.disabledAlgorithms", "");
-        }
-
+    private static List<String[]> buildTests() throws NoSuchAlgorithmException {
         List<String[]> tests = new ArrayList<>();
-        CipherSuite[] suites = getCipherSuites(useSupportedSuites);
+        CipherSuite[] suites = getCipherSuites();
 
         for (CipherSuite suite : suites) {
             String suiteName = suite.name();
@@ -165,20 +138,6 @@ public class BulkCipherDisabledAlgorithms {
             int first = suite.indexOf('_');
             int last = suite.lastIndexOf('_');
             return suite.substring(first + 1, last);
-        }
-    }
-
-    private static void testCipherSuiteVisibility(String suite, boolean expectedDisabled)
-            throws NoSuchAlgorithmException {
-        boolean visible = Arrays.asList(getCipherSuites(true))
-                .contains(CipherSuite.cipherSuite(suite));
-
-        if (!expectedDisabled && !visible) {
-            throw new RuntimeException(
-                    "Cipher suite '" + suite + "' not visible but expected to be enabled");
-        } else if (expectedDisabled && visible) {
-            throw new RuntimeException(
-                    "Cipher suite '" + suite + "' visible but expected to be disabled");
         }
     }
 

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -34,12 +34,16 @@
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
+
 import jdk.test.lib.process.Proc;
 
 /*
@@ -57,20 +61,19 @@ public class BulkCipherDisabledAlgorithms {
 
             // Verify that disabling a bulk cipher algorithm disables cipher
             // suites that use that algorithm.
-            List<String[]> tests = buildCipherSuitesDisabled();
+            Map<String, List<String>> cipherSuitesByBulkCipher = groupCipherSuitesByBulkCipher();
 
-            for (String[] test : tests) {
-                String suite = test[0];
-                String bulkCipher = test[1];
+            for (Map.Entry<String, List<String>> entry : cipherSuitesByBulkCipher.entrySet()) {
+                String disabledBulkCipher = entry.getKey();
+                List<String> disabledCipherSuites = entry.getValue();
 
-                System.out.println("=================================================");
-                System.out.println("Testing: suite=" + suite +
-                        ", bulkCipher=" + bulkCipher);
-
+                // Verify that all cipher suites associated with the disabled
+                // bulk cipher become unavailable.
                 Proc p = Proc.create(
                         BulkCipherDisabledAlgorithms.class.getName())
-                        .args(suite)
-                        .secprop("jdk.tls.disabledAlgorithms", bulkCipher)
+                        .args(disabledBulkCipher,
+                                String.join(",", disabledCipherSuites))
+                        .secprop("jdk.tls.disabledAlgorithms", disabledBulkCipher)
                         .inheritIO();
 
                 p.start().waitFor(0);
@@ -80,11 +83,17 @@ public class BulkCipherDisabledAlgorithms {
             return;
         }
 
-        String suite = args[0];
+        String disabledBulkCipher = args[0];
+        List<String> disabledCipherSuites = Arrays.asList(args[1].split(","));
 
-        testCipherSuiteDisabled(suite);
+        for (String disabledCipherSuite : disabledCipherSuites) {
+            System.out.println("=================================================");
+            System.out.println("Testing: suite=" + disabledCipherSuite +
+                    ", disabled bulk cipher=" + disabledBulkCipher);
 
-        testHandshake(suite, true);
+            testCipherSuiteDisabled(disabledCipherSuite);
+            testHandshake(disabledCipherSuite, true);
+        }
     }
 
     private static void testAllCipherSuitesEnabled() throws Exception {
@@ -104,18 +113,24 @@ public class BulkCipherDisabledAlgorithms {
                 .toArray(CipherSuite[]::new);
     }
 
-    private static List<String[]> buildCipherSuitesDisabled() throws NoSuchAlgorithmException {
-        List<String[]> tests = new ArrayList<>();
+    private static Map<String, List<String>> groupCipherSuitesByBulkCipher() throws NoSuchAlgorithmException {
+        Map<String, List<String>> cipherSuitesByBulkCipher = new LinkedHashMap<>();
         CipherSuite[] suites = getCipherSuites();
 
         for (CipherSuite suite : suites) {
             String suiteName = suite.name();
             String bulkCipher = extractBulkCipher(suiteName);
+            List<String> suitesForBulk = cipherSuitesByBulkCipher.get(bulkCipher);
 
-            tests.add(new String[] { suiteName, bulkCipher });
+            if (suitesForBulk == null) {
+                suitesForBulk = new ArrayList<>();
+                cipherSuitesByBulkCipher.put(bulkCipher, suitesForBulk);
+            }
+
+            suitesForBulk.add(suiteName);
         }
 
-        return tests;
+        return cipherSuitesByBulkCipher;
     }
 
     /**

--- a/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/BulkCipherDisabledAlgorithms.java
@@ -30,8 +30,8 @@
  * @library /test/lib
  *          /javax/net/ssl/TLSCommon
  *          /javax/net/ssl/templates
- * @run main/othervm BulkCipherDisabledAlgorithms visibility
- * @run main/othervm BulkCipherDisabledAlgorithms handshake
+ * @run main/othervm/timeout=2400 BulkCipherDisabledAlgorithms visibility
+ * @run main/othervm/timeout=2400 BulkCipherDisabledAlgorithms handshake
  */
 
 import java.util.ArrayList;

--- a/test/jdk/sun/security/ssl/SSLAlgorithmDecomposer/BulkCipherDecomposition.java
+++ b/test/jdk/sun/security/ssl/SSLAlgorithmDecomposer/BulkCipherDecomposition.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
@@ -83,25 +82,19 @@ public class BulkCipherDecomposition {
         }
     }
 
-    private static CipherSuite[] getCipherSuites() throws NoSuchAlgorithmException {
+    private static String[] getCipherSuites() throws NoSuchAlgorithmException {
         SSLEngine engine = SSLContext.getDefault().createSSLEngine();
         return Arrays.stream(engine.getSupportedCipherSuites())
                 .map(CipherSuite::cipherSuite)
                 .filter(cs -> cs != CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
-                .toArray(CipherSuite[]::new);
-    }
-
-    private static List<String> buildTests() throws NoSuchAlgorithmException {
-        // disabledAlgorithms limits supported suites; clear to list all
-        Security.setProperty("jdk.tls.disabledAlgorithms", "");
-        List<String> tests = new ArrayList<>();
-        for (CipherSuite suite : getCipherSuites()) {
-            tests.add(suite.name());
-        }
-        return tests;
+                .map(CipherSuite::name)
+                .toArray(String[]::new);
     }
 
     public static void main(String[] args) throws Exception {
+        // disabledAlgorithms limits supported suites; clear to list all
+        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+
         Class<?> c = Class.forName("sun.security.ssl.SSLAlgorithmDecomposer");
         var ctor = c.getDeclaredConstructor();
         ctor.setAccessible(true);
@@ -109,7 +102,7 @@ public class BulkCipherDecomposition {
         Method decomposeMethod = c.getDeclaredMethod("decompose", String.class);
         decomposeMethod.setAccessible(true);
 
-        for (String suite : buildTests()) {
+        for (String suite : getCipherSuites()) {
             testDecomposition(instance, decomposeMethod, suite);
         }
 

--- a/test/jdk/sun/security/ssl/SSLAlgorithmDecomposer/BulkCipherDecomposition.java
+++ b/test/jdk/sun/security/ssl/SSLAlgorithmDecomposer/BulkCipherDecomposition.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387124
+ * @summary Verify SSLAlgorithmDecomposer bulk cipher decomposition
+ * @library /javax/net/ssl/TLSCommon
+ * @run main/othervm
+ *      --add-opens java.base/sun.security.ssl=ALL-UNNAMED
+ *      BulkCipherDecomposition
+ */
+
+import java.lang.reflect.Method;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+public class BulkCipherDecomposition {
+
+    private static void testDecomposition(Object instance, Method decomposeMethod, String suite)
+            throws Exception {
+        @SuppressWarnings("unchecked")
+        Set<String> result = (Set<String>) decomposeMethod.invoke(instance, suite);
+
+        String expectedBulk = extractBulkCipher(suite);
+
+        System.out.println("=================================================");
+        System.out.println("Testing suite   : " + suite);
+        System.out.println("Expected bulk   : " + expectedBulk);
+        System.out.println("Decomposition   : " + result);
+
+        if (!result.contains(expectedBulk)) {
+            throw new RuntimeException(
+                    "Missing bulk cipher decomposition\n" +
+                            "Suite: " + suite + "\n" +
+                            "Expected: " + expectedBulk + "\n" +
+                            "Actual: " + result);
+        }
+    }
+
+    /**
+     * Separator used in TLS cipher suite names to mark the start of
+     * the bulk cipher component (e.g. TLS_RSA_WITH_AES_128_CBC_SHA).
+     */
+    private static final String WITH = "_WITH_";
+
+    private static String extractBulkCipher(String suite) {
+        if (suite.contains(WITH)) {
+            String after = suite.substring(suite.indexOf(WITH) + WITH.length());
+            int last = after.lastIndexOf('_');
+            return after.substring(0, last);
+        } else {
+            int first = suite.indexOf('_');
+            int last = suite.lastIndexOf('_');
+            return suite.substring(first + 1, last);
+        }
+    }
+
+    private static CipherSuite[] getCipherSuites() throws NoSuchAlgorithmException {
+        SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+        return Arrays.stream(engine.getSupportedCipherSuites())
+                .map(CipherSuite::cipherSuite)
+                .filter(cs -> cs != CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
+                .toArray(CipherSuite[]::new);
+    }
+
+    private static List<String> buildTests() throws NoSuchAlgorithmException {
+        // disabledAlgorithms limits supported suites; clear to list all
+        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        List<String> tests = new ArrayList<>();
+        for (CipherSuite suite : getCipherSuites()) {
+            tests.add(suite.name());
+        }
+        return tests;
+    }
+
+    public static void main(String[] args) throws Exception {
+        Class<?> c = Class.forName("sun.security.ssl.SSLAlgorithmDecomposer");
+        var ctor = c.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        Object instance = ctor.newInstance();
+        Method decomposeMethod = c.getDeclaredMethod("decompose", String.class);
+        decomposeMethod.setAccessible(true);
+
+        for (String suite : buildTests()) {
+            testDecomposition(instance, decomposeMethod, suite);
+        }
+
+        System.out.println("PASS");
+    }
+}

--- a/test/jdk/sun/security/ssl/SSLAlgorithmDecomposer/BulkCipherDecomposition.java
+++ b/test/jdk/sun/security/ssl/SSLAlgorithmDecomposer/BulkCipherDecomposition.java
@@ -34,9 +34,7 @@
 import java.lang.reflect.Method;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8387124

The test times out. This change increases the timeout based on the relative
execution time of DisabledAlgorithms.java.

Execution times on my system:
  DisabledAlgorithms.java            ~11 s (timeout = 480)
  BulkCipherDisabledAlgorithms.java  ~53 s

Using the same ratio would result in a timeout of approximately 2300 seconds.
To avoid setting such a high value, the timeout was reduced and set to 1200,
which should still provide sufficient margin.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387874](https://bugs.openjdk.org/browse/JDK-8387874): Timeout when running test BulkCipherDisabledAlgorithms (**Bug** - P5)


### Reviewers
 * [Artur Barashev](https://openjdk.org/census#abarashev) (@artur-oracle - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31812/head:pull/31812` \
`$ git checkout pull/31812`

Update a local copy of the PR: \
`$ git checkout pull/31812` \
`$ git pull https://git.openjdk.org/jdk.git pull/31812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31812`

View PR using the GUI difftool: \
`$ git pr show -t 31812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31812.diff">https://git.openjdk.org/jdk/pull/31812.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31812#issuecomment-4904878053)
</details>
