### PR TITLE
8387578: Test sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java failed: Existing session was used: FAIL

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8206929 8333857
+ * @bug 8206929 8333857 8387578
  * @summary ensure that server only resumes a session if certain properties
  *    of the session are compatible with the new connection
  * @modules java.base/sun.security.x509
@@ -93,6 +93,9 @@ public class ResumeChecksServer extends SSLContextTemplate {
         System.err.println("firstSession.getCreationTime() = " +
             firstSession.getCreationTime());
 
+        // Sleep 100ms between 2 connections to avoid test flakiness.
+        Thread.sleep(100);
+
         long secondStartTime = System.currentTimeMillis();
         secondSession = c.test();
 
@@ -128,7 +131,8 @@ public class ResumeChecksServer extends SSLContextTemplate {
         case SIGNATURE_SCHEME:
         case LOCAL_CERTS:
             // fail if a new session is not created
-            if (secondSession.getCreationTime() < secondStartTime) {
+            if (secondSession.getCreationTime() ==
+                    firstSession.getCreationTime()) {
                 throw new AssertionError("Existing session was used: FAIL");
             }
             System.out.println("secondSession not resumed: PASS");

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8206929 8333857 8387578
+ * @bug 8206929 8333857
  * @summary ensure that server only resumes a session if certain properties
  *    of the session are compatible with the new connection
  * @modules java.base/sun.security.x509


### PR DESCRIPTION
A few changes to avoid test flakiness.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387578](https://bugs.openjdk.org/browse/JDK-8387578): Test sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java failed: Existing session was used: FAIL (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31813/head:pull/31813` \
`$ git checkout pull/31813`

Update a local copy of the PR: \
`$ git checkout pull/31813` \
`$ git pull https://git.openjdk.org/jdk.git pull/31813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31813`

View PR using the GUI difftool: \
`$ git pr show -t 31813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31813.diff">https://git.openjdk.org/jdk/pull/31813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31813#issuecomment-4904893102)
</details>
