### PR TITLE
8387670: Clean up subclassing and DefWindowProc

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.cpp
@@ -41,10 +41,9 @@ void ComCtl32Util::InitLibraries() {
     m_bToolTipControlInitialized = ::InitCommonControlsEx(&iccex);
 }
 
-WNDPROC ComCtl32Util::SubclassHWND(HWND hwnd, WNDPROC _WindowProc) {
+void ComCtl32Util::SubclassHWND(HWND hwnd, WNDPROC _WindowProc) {
     const SUBCLASSPROC p = SharedWindowProc; // let compiler check type of SharedWindowProc
     ::SetWindowSubclass(hwnd, p, (UINT_PTR)_WindowProc, NULL); // _WindowProc is used as subclass ID
-    return NULL;
 }
 
 void ComCtl32Util::UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc) {

--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.cpp
@@ -47,12 +47,12 @@ WNDPROC ComCtl32Util::SubclassHWND(HWND hwnd, WNDPROC _WindowProc) {
     return NULL;
 }
 
-void ComCtl32Util::UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc, WNDPROC _DefWindowProc) {
+void ComCtl32Util::UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc) {
     const SUBCLASSPROC p = SharedWindowProc; // let compiler check type of SharedWindowProc
     ::RemoveWindowSubclass(hwnd, p, (UINT_PTR)_WindowProc); // _WindowProc is used as subclass ID
 }
 
-LRESULT ComCtl32Util::DefWindowProc(WNDPROC _DefWindowProc, HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+LRESULT ComCtl32Util::DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return ::DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
@@ -44,7 +44,7 @@ class ComCtl32Util
             return m_bToolTipControlInitialized;
         }
 
-        WNDPROC SubclassHWND(HWND hwnd, WNDPROC _WindowProc);
+        void SubclassHWND(HWND hwnd, WNDPROC _WindowProc);
         void UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc);
         LRESULT DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 

--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
@@ -45,7 +45,6 @@ class ComCtl32Util
         }
 
         WNDPROC SubclassHWND(HWND hwnd, WNDPROC _WindowProc);
-        // DefWindowProc is the same as returned from SubclassHWND
         void UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc);
         LRESULT DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 

--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ class ComCtl32Util
         WNDPROC SubclassHWND(HWND hwnd, WNDPROC _WindowProc);
         // DefWindowProc is the same as returned from SubclassHWND
         void UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc);
-        // DefWindowProc is the same as returned from SubclassHWND or NULL
         LRESULT DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
     private:

--- a/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
+++ b/src/java.desktop/windows/native/libawt/windows/ComCtl32Util.h
@@ -46,9 +46,9 @@ class ComCtl32Util
 
         WNDPROC SubclassHWND(HWND hwnd, WNDPROC _WindowProc);
         // DefWindowProc is the same as returned from SubclassHWND
-        void UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc, WNDPROC _DefWindowProc);
+        void UnsubclassHWND(HWND hwnd, WNDPROC _WindowProc);
         // DefWindowProc is the same as returned from SubclassHWND or NULL
-        LRESULT DefWindowProc(WNDPROC _DefWindowProc, HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+        LRESULT DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
     private:
         ComCtl32Util();

--- a/src/java.desktop/windows/native/libawt/windows/awt_Choice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Choice.cpp
@@ -89,7 +89,6 @@ namespace {
 
 AwtChoice::AwtChoice() {
     m_hList = NULL;
-    m_listDefWindowProc = NULL;
 }
 
 LPCTSTR AwtChoice::GetClassName() {
@@ -449,7 +448,7 @@ MsgRouting AwtChoice::WmNotify(UINT notifyCode)
             cbi.cbSize = sizeof(COMBOBOXINFO);
             ::GetComboBoxInfo(GetHWnd(), &cbi);
             m_hList = cbi.hwndList;
-            m_listDefWindowProc = ComCtl32Util::GetInstance().SubclassHWND(m_hList, ListWindowProc);
+            ComCtl32Util::GetInstance().SubclassHWND(m_hList, ListWindowProc);
             DASSERT(::GetWindowLongPtr(m_hList, GWLP_USERDATA) == NULL);
             ::SetWindowLongPtr(m_hList, GWLP_USERDATA, (LONG_PTR)this);
         }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Choice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Choice.cpp
@@ -97,8 +97,8 @@ LPCTSTR AwtChoice::GetClassName() {
 }
 
 void AwtChoice::Dispose() {
-    if (m_hList != NULL && m_listDefWindowProc != NULL) {
-        ComCtl32Util::GetInstance().UnsubclassHWND(m_hList, ListWindowProc, m_listDefWindowProc);
+    if (m_hList != NULL) {
+        ComCtl32Util::GetInstance().UnsubclassHWND(m_hList, ListWindowProc);
     }
     AwtComponent::Dispose();
 }
@@ -424,7 +424,7 @@ LRESULT CALLBACK AwtChoice::ListWindowProc(HWND hwnd, UINT message,
             }
         }
     }
-    return ComCtl32Util::GetInstance().DefWindowProc(NULL, hwnd, message, wParam, lParam);
+    return ComCtl32Util::GetInstance().DefWindowProc(hwnd, message, wParam, lParam);
 
     CATCH_BAD_ALLOC_RET(0);
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Choice.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Choice.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Choice.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Choice.h
@@ -93,7 +93,6 @@ private:
     int GetTotalHeight();
     static BOOL sm_isMouseMoveInList;
     HWND m_hList;
-    WNDPROC m_listDefWindowProc;
     static LRESULT CALLBACK ListWindowProc(HWND hwnd, UINT message,
                                            WPARAM wParam, LPARAM lParam);
 };

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -394,7 +394,7 @@ LRESULT CALLBACK AwtComponent::WndProc(HWND hWnd, UINT message,
     if (self == NULL || self->GetHWnd() != hWnd ||
         message == WM_UNDOCUMENTED_CLIENTSHUTDOWN) // handle log-off gracefully
     {
-        return ComCtl32Util::GetInstance().DefWindowProc(NULL, hWnd, message, wParam, lParam);
+        return ComCtl32Util::GetInstance().DefWindowProc(hWnd, message, wParam, lParam);
     } else {
         return self->WindowProc(message, wParam, lParam);
     }
@@ -694,7 +694,7 @@ void AwtComponent::UnsubclassHWND()
     if (!m_bSubclassed) {
         return;
     }
-    ComCtl32Util::GetInstance().UnsubclassHWND(GetHWnd(), WndProc, m_DefWindowProc);
+    ComCtl32Util::GetInstance().UnsubclassHWND(GetHWnd(), WndProc);
     m_bSubclassed = FALSE;
 }
 
@@ -1981,7 +1981,7 @@ LRESULT AwtComponent::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
  */
 LRESULT AwtComponent::DefWindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    return ComCtl32Util::GetInstance().DefWindowProc(m_DefWindowProc, GetHWnd(), msg, wParam, lParam);
+    return ComCtl32Util::GetInstance().DefWindowProc(GetHWnd(), msg, wParam, lParam);
 }
 
 /*

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -229,7 +229,6 @@ AwtComponent::AwtComponent()
     m_backgroundColorSet = FALSE;
     m_penForeground = NULL;
     m_brushBackground = NULL;
-    m_DefWindowProc = NULL;
     m_nextControlID = 1;
     m_childList = NULL;
     m_myControlID = 0;
@@ -683,7 +682,6 @@ void AwtComponent::SubclassHWND()
     }
     const WNDPROC wndproc = WndProc; // let compiler type check WndProc
     ComCtl32Util::GetInstance().SubclassHWND(GetHWnd(), wndproc);
-    m_DefWindowProc = NULL;
     m_bSubclassed = TRUE;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -682,7 +682,8 @@ void AwtComponent::SubclassHWND()
         return;
     }
     const WNDPROC wndproc = WndProc; // let compiler type check WndProc
-    m_DefWindowProc = ComCtl32Util::GetInstance().SubclassHWND(GetHWnd(), wndproc);
+    ComCtl32Util::GetInstance().SubclassHWND(GetHWnd(), wndproc);
+    m_DefWindowProc = NULL;
     m_bSubclassed = TRUE;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.h
@@ -780,7 +780,6 @@ private:
     AwtPen*  m_penForeground;
     AwtBrush* m_brushBackground;
 
-    WNDPROC  m_DefWindowProc;
     // counter for messages being processed by this component
     UINT     m_MessagesProcessing;
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -150,8 +150,7 @@ FileDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
             }
 
             // subclass dialog's parent to receive additional messages
-            WNDPROC lpfnWndProc = ComCtl32Util::GetInstance().SubclassHWND(parent,
-                                                                           FileDialogWndProc);
+            ComCtl32Util::GetInstance().SubclassHWND(parent, FileDialogWndProc);
             ::SetProp(parent, OpenFileNameProp, (void *)lParam);
 
             break;

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -152,8 +152,6 @@ FileDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
             // subclass dialog's parent to receive additional messages
             WNDPROC lpfnWndProc = ComCtl32Util::GetInstance().SubclassHWND(parent,
                                                                            FileDialogWndProc);
-            ::SetProp(parent, NativeDialogWndProcProp, reinterpret_cast<HANDLE>(lpfnWndProc));
-
             ::SetProp(parent, OpenFileNameProp, (void *)lParam);
 
             break;
@@ -167,7 +165,6 @@ FileDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
 
             ComCtl32Util::GetInstance().UnsubclassHWND(parent, FileDialogWndProc);
             ::RemoveProp(parent, ModalDialogPeerProp);
-            ::RemoveProp(parent, NativeDialogWndProcProp);
             ::RemoveProp(parent, OpenFileNameProp);
             break;
         }

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -111,9 +111,7 @@ LRESULT CALLBACK FileDialogWndProc(HWND hWnd, UINT message,
             return 0;
         }
     }
-
-    WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(hWnd, NativeDialogWndProcProp));
-    return ComCtl32Util::GetInstance().DefWindowProc(lpfnWndProc, hWnd, message, wParam, lParam);
+    return ComCtl32Util::GetInstance().DefWindowProc(hWnd, message, wParam, lParam);
 }
 
 static UINT_PTR CALLBACK
@@ -167,10 +165,7 @@ FileDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
                 ::ImmReleaseContext(hdlg, hIMC);
             }
 
-            WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(parent, NativeDialogWndProcProp));
-            ComCtl32Util::GetInstance().UnsubclassHWND(parent,
-                                                       FileDialogWndProc,
-                                                       lpfnWndProc);
+            ComCtl32Util::GetInstance().UnsubclassHWND(parent, FileDialogWndProc);
             ::RemoveProp(parent, ModalDialogPeerProp);
             ::RemoveProp(parent, NativeDialogWndProcProp);
             ::RemoveProp(parent, OpenFileNameProp);

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintDialog.cpp
@@ -98,8 +98,7 @@ PrintDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
             }
 
             // subclass dialog's parent to receive additional messages
-            WNDPROC lpfnWndProc = ComCtl32Util::GetInstance().SubclassHWND(hdlg,
-                                                                           PrintDialogWndProc);
+            ComCtl32Util::GetInstance().SubclassHWND(hdlg, PrintDialogWndProc);
             break;
         }
         case WM_DESTROY: {

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintDialog.cpp
@@ -64,9 +64,7 @@ LRESULT CALLBACK PrintDialogWndProc(HWND hWnd, UINT message,
             break;
         }
     }
-
-    WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(hWnd, NativeDialogWndProcProp));
-    return ComCtl32Util::GetInstance().DefWindowProc(lpfnWndProc, hWnd, message, wParam, lParam);
+    return ComCtl32Util::GetInstance().DefWindowProc(hWnd, message, wParam, lParam);
 }
 
 static UINT_PTR CALLBACK
@@ -107,10 +105,7 @@ PrintDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
         case WM_DESTROY: {
-            WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(hdlg, NativeDialogWndProcProp));
-            ComCtl32Util::GetInstance().UnsubclassHWND(hdlg,
-                                                       PrintDialogWndProc,
-                                                       lpfnWndProc);
+            ComCtl32Util::GetInstance().UnsubclassHWND(hdlg, PrintDialogWndProc);
             ::RemoveProp(hdlg, ModalDialogPeerProp);
             ::RemoveProp(hdlg, NativeDialogWndProcProp);
             break;

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,14 +100,11 @@ PrintDialogHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
             // subclass dialog's parent to receive additional messages
             WNDPROC lpfnWndProc = ComCtl32Util::GetInstance().SubclassHWND(hdlg,
                                                                            PrintDialogWndProc);
-            ::SetProp(hdlg, NativeDialogWndProcProp, reinterpret_cast<HANDLE>(lpfnWndProc));
-
             break;
         }
         case WM_DESTROY: {
             ComCtl32Util::GetInstance().UnsubclassHWND(hdlg, PrintDialogWndProc);
             ::RemoveProp(hdlg, ModalDialogPeerProp);
-            ::RemoveProp(hdlg, NativeDialogWndProcProp);
             break;
         }
     }

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -3205,7 +3205,7 @@ LRESULT CALLBACK PageDialogWndProc(HWND hWnd, UINT message,
     }
 
     WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(hWnd, NativeDialogWndProcProp));
-    return ComCtl32Util::GetInstance().DefWindowProc(lpfnWndProc, hWnd, message, wParam, lParam);
+    return ComCtl32Util::GetInstance().DefWindowProc(hWnd, message, wParam, lParam);
 }
 
 /**
@@ -3246,10 +3246,7 @@ static UINT CALLBACK pageDlgHook(HWND hDlg, UINT msg,
             break;
         }
         case WM_DESTROY: {
-            WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(hDlg, NativeDialogWndProcProp));
-            ComCtl32Util::GetInstance().UnsubclassHWND(hDlg,
-                                                       PageDialogWndProc,
-                                                       lpfnWndProc);
+            ComCtl32Util::GetInstance().UnsubclassHWND(hDlg, PageDialogWndProc);
             ::RemoveProp(hDlg, ModalDialogPeerProp);
             ::RemoveProp(hDlg, NativeDialogWndProcProp);
             break;

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -3237,8 +3237,7 @@ static UINT CALLBACK pageDlgHook(HWND hDlg, UINT msg,
             }
 
             // subclass dialog's parent to receive additional messages
-            WNDPROC lpfnWndProc = ComCtl32Util::GetInstance().SubclassHWND(hDlg,
-                                                                           PageDialogWndProc);
+            ComCtl32Util::GetInstance().SubclassHWND(hDlg, PageDialogWndProc);
             break;
         }
         case WM_DESTROY: {

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -3203,8 +3203,6 @@ LRESULT CALLBACK PageDialogWndProc(HWND hWnd, UINT message,
             break;
         }
     }
-
-    WNDPROC lpfnWndProc = (WNDPROC)(::GetProp(hWnd, NativeDialogWndProcProp));
     return ComCtl32Util::GetInstance().DefWindowProc(hWnd, message, wParam, lParam);
 }
 
@@ -3241,14 +3239,11 @@ static UINT CALLBACK pageDlgHook(HWND hDlg, UINT msg,
             // subclass dialog's parent to receive additional messages
             WNDPROC lpfnWndProc = ComCtl32Util::GetInstance().SubclassHWND(hDlg,
                                                                            PageDialogWndProc);
-            ::SetProp(hDlg, NativeDialogWndProcProp, reinterpret_cast<HANDLE>(lpfnWndProc));
-
             break;
         }
         case WM_DESTROY: {
             ComCtl32Util::GetInstance().UnsubclassHWND(hDlg, PageDialogWndProc);
             ::RemoveProp(hDlg, ModalDialogPeerProp);
-            ::RemoveProp(hDlg, NativeDialogWndProcProp);
             break;
         }
     }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@
 // property name tagging windows disabled by modality
 static LPCTSTR ModalBlockerProp = TEXT("SunAwtModalBlockerProp");
 static LPCTSTR ModalDialogPeerProp = TEXT("SunAwtModalDialogPeerProp");
-static LPCTSTR NativeDialogWndProcProp = TEXT("SunAwtNativeDialogWndProcProp");
 
 #ifndef WH_MOUSE_LL
 #define WH_MOUSE_LL 14


### PR DESCRIPTION
[JDK-8387298](https://bugs.openjdk.org/browse/JDK-8387298) removed the IS_WINXP macro, and the updated code in ComCtl32Util::UnsubclassHWND and ComCtl32Util::DefWindowProc doesn't use the _DefWindowProc parameter any more.

Thus, the _DefWindowProc parameter can be removed from these functions.

Removing these parameters requires updating all the usages of the functions, for example, in awt_Component.cpp, awt_Choice.cpp...

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387670](https://bugs.openjdk.org/browse/JDK-8387670): Clean up subclassing and DefWindowProc (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31814/head:pull/31814` \
`$ git checkout pull/31814`

Update a local copy of the PR: \
`$ git checkout pull/31814` \
`$ git pull https://git.openjdk.org/jdk.git pull/31814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31814`

View PR using the GUI difftool: \
`$ git pr show -t 31814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31814.diff">https://git.openjdk.org/jdk/pull/31814.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31814#issuecomment-4904926332)
</details>
