### PR TITLE
8387865: ThisEscapeAnalyzer crashes for erroneous source code

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
@@ -873,11 +873,10 @@ public class ThisEscapeAnalyzer extends TreeScanner {
 
     @Override
     public void visitAssign(JCAssign tree) {
-        VarSymbol sym = (VarSymbol)TreeInfo.symbolFor(tree.lhs);
         scan(tree.lhs);
         refs.discardExprs(depth);
         scan(tree.rhs);
-        if (isParamOrVar(sym))
+        if (TreeInfo.symbolFor(tree.lhs) instanceof VarSymbol sym && isParamOrVar(sym))
             refs.replaceExprs(depth, ref -> new VarRef(sym, ref));
         else
             refs.discardExprs(depth);         // we don't track fields yet

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8301580 8322159 8333107 8332230 8338678 8351260 8366196 8372336 8373094 8384229
+ * @bug 8301580 8322159 8333107 8332230 8338678 8351260 8366196 8372336 8373094 8384229 8387865
  * @summary Verify error recovery w.r.t. Attr
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -858,6 +858,33 @@ public class AttrRecovery {
                 .outdir(out)
                 .run()
                 .writeAll();
+    }
+
+    @Test //JDK-8387865
+    public void testThisEscapeUnknownField() throws Exception {
+        String code = """
+                      public class C {
+                          public C() {
+                              this.unknown = unknown;
+                          }
+                      }
+                      """;
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev",
+                         "-XDshould-stop.at=WARN", "-Xlint:this-escape")
+                .sources(code)
+                .outdir(base)
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "C.java:3:13: compiler.err.cant.resolve: kindname.variable, unknown, , ",
+                "C.java:3:24: compiler.err.cant.resolve.location: kindname.variable, unknown, , , (compiler.misc.location: kindname.class, C, null)",
+                "2 errors"
+        );
+
+        assertEquals(expected, actual);
     }
 
     @BeforeEach


### PR DESCRIPTION
Having (an obviously erroneous) code like:
```
public class ThisEscapeCrash {
    public ThisEscapeCrash() {
        this.unknown = unknown;
    }
}
```

May lead to this javac crash:
```
$ javac -XDshould-stop.at=WARN -Xlint:this-escape -XDdev /tmp/ThisEscapeCrash.java
/tmp/ThisEscapeCrash.java:3: error: cannot find symbol
        this.unknown = unknown;
            ^
  symbol: variable unknown
/tmp/ThisEscapeCrash.java:3: error: cannot find symbol
        this.unknown = unknown;
                       ^
  symbol: variable unknown
  location: class ThisEscapeCrash
2 errors
An exception has occurred in the compiler (28-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.ClassCastException: class com.sun.tools.javac.code.Symbol$ClassSymbol cannot be cast to class com.sun.tools.javac.code.Symbol$VarSymbol (com.sun.tools.javac.code.Symbol$ClassSymbol and com.sun.tools.javac.code.Symbol$VarSymbol are in module jdk.compiler of loader 'app')
        at jdk.compiler/com.sun.tools.javac.comp.ThisEscapeAnalyzer.visitAssign(ThisEscapeAnalyzer.java:876)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCAssign.accept(JCTree.java:2130)
...
printing javac parameters to: /tmp/javac.20260707_132606.args
```

The reason is the unresolvable/erroneous symbols get represented as `ClassSymbol`s, not as `VarSymbol`s or `MethodSymbol`s. That's one limitation of the javac's model.

The proposal here is to check the `Symbol`'s type before casting by using the pattern matching.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387865](https://bugs.openjdk.org/browse/JDK-8387865): ThisEscapeAnalyzer crashes for erroneous source code (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31816/head:pull/31816` \
`$ git checkout pull/31816`

Update a local copy of the PR: \
`$ git checkout pull/31816` \
`$ git pull https://git.openjdk.org/jdk.git pull/31816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31816`

View PR using the GUI difftool: \
`$ git pr show -t 31816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31816.diff">https://git.openjdk.org/jdk/pull/31816.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31816#issuecomment-4905429802)
</details>
