### PR TITLE
8387580: [S390x] OpenJDK build crashes with SIGSEGV in HashMap::resize()

### DIFF
--- a/src/hotspot/cpu/s390/templateTable_s390.cpp
+++ b/src/hotspot/cpu/s390/templateTable_s390.cpp
@@ -1055,7 +1055,7 @@ void TemplateTable::lstore() {
 void TemplateTable::fstore() {
   transition(ftos, vtos);
   locals_index(Z_R1_scratch);
-  __ freg2mem_opt(Z_ftos, faddress(_masm, Z_R1_scratch));
+  __ freg2mem_opt(Z_ftos, faddress(_masm, Z_R1_scratch), false);
 }
 
 void TemplateTable::dstore() {
@@ -3504,7 +3504,7 @@ void TemplateTable::fast_xaccess(TosState state) {
       __ verify_oop(Z_tos);
       break;
     case ftos:
-      __ mem2freg_opt(Z_ftos, field);
+      __ mem2freg_opt(Z_ftos, field, false);
       break;
     default:
       ShouldNotReachHere();


### PR DESCRIPTION
This PR changes `fstore` and `fast_xaccess` operations to generate float (4 byte) instructions on S390x. This resolves out of bound read and writes on float that causes a segmentation fault with Compact Object Headers enabled.

I have tried to create a jtreg test for the issue, but unfortunately the options I have came up with are either brittle (google test asserting machine code at the specific location), or overcomplicated (bytecode hacking to store float and read it out as a double) and do not test the read (fast_xaccess) issue. Would it be possible to get an advice on how to build the test?

Tier1 tests before the fix:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
>> jtreg:test/hotspot/jtreg:tier1                     3244  2716     5     0   523 <<
>> jtreg:test/jdk:tier1                               2594  2472     2     0   120 <<
   jtreg:test/langtools:tier1                         4732  4721     0     0    11
   jtreg:test/jaxp:tier1                                 0     0     0     0     0
   jtreg:test/lib-test:tier1                            38    38     0     0     0
==============================
TEST FAILURE
```

Tier1 tests after the fix:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
>> jtreg:test/hotspot/jtreg:tier1                     3244  2716     5     0   523 <<
>> jtreg:test/jdk:tier1                               2594  2471     3     0   120 <<
   jtreg:test/langtools:tier1                         4732  4721     0     0    11   
   jtreg:test/jaxp:tier1                                 0     0     0     0     0   
   jtreg:test/lib-test:tier1                            38    38     0     0     0   
==============================
TEST FAILURE
```
The new failure `jdk/java/lang/String/CompactString/MaxSizeUTF16String.java` is unrelated:
```
[05:03:32.430] STARTED    MaxSizeUTF16String::testMaxUTF8_UTF16Encode 'testMaxUTF8_UTF16Encode()'
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
	at java.base/java.lang.String.encodeUTF8_UTF16(String.java:1529)
	at java.base/java.lang.String.encodeUTF8(String.java:1462)
	at java.base/java.lang.String.encodeUTF8(String.java:1441)
	at java.base/java.lang.String.encode(String.java:893)
	at java.base/java.lang.String.getBytes(String.java:2077)
	at MaxSizeUTF16String.lambda$testMaxUTF8_UTF16Encode$0(MaxSizeUTF16String.java:146)
	at MaxSizeUTF16String$$Lambda/0x0000016601192400.execute(Unknown Source)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:53)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3128)
	at MaxSizeUTF16String.testMaxUTF8_UTF16Encode(MaxSizeUTF16String.java:146)
	at java.base/java.lang.invoke.LambdaForm$DMH/0x000001660118c000.invokeVirtual(LambdaForm$DMH)
	at java.base/java.lang.invoke.LambdaForm$MH/0x000001660118c800.invoke(LambdaForm$MH)
	at java.base/java.lang.invoke.Invokers$Holder.invokeExact_MT(Invokers$Holder)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(DirectMethodHandleAccessor.java:154)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:583)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:786)
	at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:514)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:161)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:152)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:91)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor$$Lambda/0x0000016601117800.apply(Unknown Source)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:112)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall$$Lambda/0x0000016601112000.apply(Unknown Source)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:94)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$$Lambda/0x0000016601183c00.apply(Unknown Source)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
```

The test passes on retry:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
                                                         1     1     0     0     0   
==============================
TEST SUCCESS
```
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387580](https://bugs.openjdk.org/browse/JDK-8387580): [S390x] OpenJDK build crashes with SIGSEGV in HashMap::resize() (**Bug** - P3)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Harshit Dhiman](https://openjdk.org/census#hdhiman) (@Harshit470250 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31819/head:pull/31819` \
`$ git checkout pull/31819`

Update a local copy of the PR: \
`$ git checkout pull/31819` \
`$ git pull https://git.openjdk.org/jdk.git pull/31819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31819`

View PR using the GUI difftool: \
`$ git pr show -t 31819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31819.diff">https://git.openjdk.org/jdk/pull/31819.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31819#issuecomment-4908956897)
</details>
