### PR TITLE
Arrays

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5934,11 +5934,18 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   // then we align it down. This is valid because the new
   // offset will always be the klass which is the same
   // for type arrays.
-  int start_offset = align_down(length_offset, BytesPerWord);
-  int extra_length = base_offset - start_offset;
-  assert(start_offset == length_offset || start_offset == klass_offset,
-         "start offset must be 8-byte-aligned or be the klass offset");
-  assert(base_offset != start_offset, "must include the length field");
+  int start_offset;
+  int extra_length;
+  if (length_offset + BytesPerInt != base_offset) {
+    // Don't compare the alignment gap
+    start_offset = base_offset;
+    extra_length = 0;
+  } else {
+    start_offset = align_down(length_offset, BytesPerWord);
+    extra_length = base_offset - start_offset;
+  }
+  assert(is_aligned(start_offset, BytesPerWord),
+         "start offset must be 8-byte-aligned");
   extra_length = extra_length / elem_size; // We count in elements, not bytes.
   int stubBytesThreshold = 3 * 64 + (UseSIMDForArrayEquals ? 0 : 16);
 

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -216,6 +216,7 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
   _obj_alignment = ObjectAlignmentInBytes;
   _compact_strings = CompactStrings;
   _compact_headers = UseCompactObjectHeaders;
+  _align_array_elements = AlignArrayElements;
 #if INCLUDE_CDS_JAVA_HEAP
   if (CDSConfig::is_dumping_heap()) {
     _object_streaming_mode = HeapShared::is_writing_streaming_mode();
@@ -286,6 +287,7 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- narrow_oop_shift                          %d", _narrow_oop_shift);
   st->print_cr("- compact_strings:                          %d", _compact_strings);
   st->print_cr("- compact_headers:                          %d", _compact_headers);
+  st->print_cr("- align_array_elements:                     %d", _align_array_elements);
   st->print_cr("- max_heap_size:                            %zu", _max_heap_size);
   st->print_cr("- narrow_oop_mode:                          %d", _narrow_oop_mode);
   st->print_cr("- compressed_oops:                          %d", _compressed_oops);
@@ -1929,6 +1931,14 @@ bool FileMapHeader::validate() {
                      " does not equal the current UseCompactObjectHeaders setting (%s).", file_type, file_type,
                      _compact_headers          ? "enabled" : "disabled",
                      UseCompactObjectHeaders   ? "enabled" : "disabled");
+    return false;
+  }
+
+  if (align_array_elements() != AlignArrayElements) {
+    aot_log_warning(aot)("Unable to use %s.\nThe %s's AlignArrayElements setting (%s)"
+                     " does not equal the current AlignArrayElements setting (%s).", file_type, file_type,
+                     _align_array_elements ? "enabled" : "disabled",
+                     AlignArrayElements    ? "enabled" : "disabled");
     return false;
   }
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -116,6 +116,7 @@ private:
   int    _narrow_oop_shift;                       // compressed oop encoding shift
   bool   _compact_strings;                        // value of CompactStrings
   bool   _compact_headers;                        // value of UseCompactObjectHeaders
+  bool   _align_array_elements;                   // value of AlignArrayElements
   uintx  _max_heap_size;                          // java max heap size during dumping
   CompressedOops::Mode _narrow_oop_mode;          // compressed oop encoding mode
   bool    _object_streaming_mode;                 // dump was created for object streaming
@@ -187,6 +188,7 @@ public:
   int narrow_oop_shift()                   const { return _narrow_oop_shift; }
   bool compact_strings()                   const { return _compact_strings; }
   bool compact_headers()                   const { return _compact_headers; }
+  bool align_array_elements()              const { return _align_array_elements; }
   uintx max_heap_size()                    const { return _max_heap_size; }
   CompressedOops::Mode narrow_oop_mode()   const { return _narrow_oop_mode; }
   char* cloned_vtables()                   const { return decode<char*>(_cloned_vtables); }

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -398,15 +398,14 @@ oop ObjArrayAllocator::initialize(HeapWord* mem) const {
   assert(_length >= 0, "length should be non-negative");
   if (_do_zero) {
     mem_clear(mem);
-    mem_zap_start_padding(mem);
     mem_zap_end_padding(mem);
   }
+  mem_zero_start_padding(mem);
   arrayOopDesc::set_length(mem, _length);
   return finish(mem);
 }
 
-#ifndef PRODUCT
-void ObjArrayAllocator::mem_zap_start_padding(HeapWord* mem) const {
+void ObjArrayAllocator::mem_zero_start_padding(HeapWord* mem) const {
   const BasicType element_type = ArrayKlass::cast(_klass)->element_type();
   const size_t base_offset_in_bytes = arrayOopDesc::base_offset_in_bytes(element_type);
   const size_t header_size_in_bytes = arrayOopDesc::header_size_in_bytes();
@@ -416,10 +415,11 @@ void ObjArrayAllocator::mem_zap_start_padding(HeapWord* mem) const {
 
   if (header_end < base) {
     const size_t padding_in_bytes = base - header_end;
-    Copy::fill_to_bytes(header_end, padding_in_bytes, heapPaddingByteVal);
+    Copy::fill_to_bytes(header_end, padding_in_bytes, 0);
   }
 }
 
+#ifndef PRODUCT
 void ObjArrayAllocator::mem_zap_end_padding(HeapWord* mem) const {
   const size_t length_in_bytes = static_cast<size_t>(_length) << ArrayKlass::cast(_klass)->log2_element_size();
   const BasicType element_type = ArrayKlass::cast(_klass)->element_type();

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ protected:
   const int  _length;
   const bool _do_zero;
 
-  void mem_zap_start_padding(HeapWord* mem) const PRODUCT_RETURN;
+  void mem_zero_start_padding(HeapWord* mem) const;
   void mem_zap_end_padding(HeapWord* mem) const PRODUCT_RETURN;
 
 public:

--- a/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,6 +72,8 @@ oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
   assert(_length >= 0, "length should be non-negative");
   arrayOopDesc::set_length(mem, _length);
 
+  mem_zero_start_padding(mem);
+
   // Keep the array alive across safepoints through an invisible
   // root. Invisible roots are not visited by the heap iterator
   // and the marking logic will not attempt to follow its elements.
@@ -142,8 +144,6 @@ oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
     }
     return true;
   };
-
-  mem_zap_start_padding(mem);
 
   if (!initialize_memory()) {
     // Re-color with 11 remset bits if we got intercepted by a GC safepoint

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -54,7 +54,7 @@ private:
   }
 
   // Given a type, return true if elements of that type must be aligned to 64-bit.
-  static bool element_type_should_be_aligned(BasicType type) {
+  static bool first_element_should_be_aligned_to_long(BasicType type) {
 #ifdef _LP64
     if (type == T_OBJECT || type == T_ARRAY) {
       return !UseCompressedOops;
@@ -69,6 +69,9 @@ private:
   // This is not equivalent to sizeof(arrayOopDesc) which should not appear in the code.
   static int header_size_in_bytes() {
     int hs = length_offset_in_bytes() + (int)sizeof(int);
+    if (AlignArrayElements) {
+      hs = align_up(hs, BytesPerWord);
+    }
 #ifdef ASSERT
     // make sure it isn't called before UseCompressedOops is initialized.
     static int arrayoopdesc_hs = 0;
@@ -88,7 +91,7 @@ private:
   // Returns the offset of the first element.
   static int base_offset_in_bytes(BasicType type) {
     int hs = header_size_in_bytes();
-    return element_type_should_be_aligned(type) ? align_up(hs, BytesPerLong) : hs;
+    return first_element_should_be_aligned_to_long(type) ? align_up(hs, BytesPerLong) : hs;
   }
 
   // Returns the address of the first element. The elements in the array will not

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1384,7 +1384,7 @@ const TypePtr *Compile::flatten_alias_type( const TypePtr *tj ) const {
   }
   if( ta && is_known_inst ) {
     if ( offset != Type::OffsetBot &&
-         offset > arrayOopDesc::length_offset_in_bytes() ) {
+         offset >= arrayOopDesc::base_offset_in_bytes(T_BYTE) ) {
       offset = Type::OffsetBot; // Flatten constant access into array body only
       tj = ta = ta->
               remove_speculative()->

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1855,7 +1855,8 @@ PhaseMacroExpand::initialize_object(AllocateNode* alloc,
 
   // Array length
   if (length != nullptr) {         // Arrays need length field
-    rawmem = make_store_raw(control, rawmem, object, arrayOopDesc::length_offset_in_bytes(), length, T_INT);
+    const int length_offset = arrayOopDesc::length_offset_in_bytes();
+    rawmem = make_store_raw(control, rawmem, object, length_offset, length, T_INT);
     // conservatively small header size:
     header_size = arrayOopDesc::base_offset_in_bytes(T_BYTE);
     if (_igvn.type(klass_node)->isa_aryklassptr()) {   // we know the exact header size in most cases:
@@ -1864,6 +1865,13 @@ PhaseMacroExpand::initialize_object(AllocateNode* alloc,
         elem = T_OBJECT;
       }
       header_size = Klass::layout_helper_header_size(Klass::array_layout_helper(elem));
+    }
+
+    const int header_end = length_offset + BytesPerInt;
+    if (header_end < header_size) {
+      assert(header_size - header_end == BytesPerInt, "unexpected array alignment gap");
+      rawmem = make_store_raw(control, rawmem, object,
+                              header_end, _igvn.intcon(0), T_INT);
     }
   }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1991,6 +1991,11 @@ const int ObjectAlignmentInBytes = 8;
           "Minimal number of elements in a sorted collection to prefer"     \
           "binary search over simple linear search." )                      \
                                                                             \
+  product(bool, AlignArrayElements, true,                                   \
+          "Align the first element of arrays to long boundary"              \
+          " which can use more footprint but improves performance for "     \
+          " vectorization and intrinsics.")                                 \
+                                                                            \
 
 // end of RUNTIME_FLAGS
 

--- a/test/hotspot/gtest/oops/test_arrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_arrayOop.cpp
@@ -81,33 +81,21 @@ TEST_VM(arrayOopDesc, narrowOop) {
 
 TEST_VM(arrayOopDesc, base_offset) {
 #ifdef _LP64
-  if (UseCompactObjectHeaders) {
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 12);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    12);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   12);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_CHAR),    12);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_INT),     12);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_FLOAT),   12);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_LONG),    16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_DOUBLE),  16);
-    if (UseCompressedOops) {
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), 12);
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  12);
-    } else {
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), 16);
-      EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  16);
-    }
+  int start_offset = (UseCompactObjectHeaders && !AlignArrayElements) ? 12 : 16;
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), start_offset);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    start_offset);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   start_offset);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_CHAR),    start_offset);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_INT),     start_offset);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_FLOAT),   start_offset);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_LONG),    16);
+  EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_DOUBLE),  16);
+  if (UseCompressedOops) {
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), start_offset);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  start_offset);
   } else {
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_CHAR),    16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_INT),     16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_FLOAT),   16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_LONG),    16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_DOUBLE),  16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT),  16);
-    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),   16);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT), 16);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),  16);
   }
 #else
   EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 12);

--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -27,30 +27,38 @@
 
 TEST_VM(objArrayOop, osize) {
   static const struct {
-    int objal; bool coops; bool coh; int result;
+    int objal; bool coops; bool coh; bool aae; int result;
   } x[] = {
-//    ObjAligInB, UseCoops, UseCOH, object size in heap words
+//    ObjAligInB, UseCoops, UseCOH, AlignArrayElements, object size in heap words
 #ifdef _LP64
-    { 8,          false, false,   3 },  // 16 byte header, 8 byte oops
-    { 8,          true,  false,   3 },  // 16 byte header, 4 byte oops
-    { 8,          false, true,    3 },  // 12 byte header, 8 byte oops
-    { 8,          true,  true,    2 },  // 12 byte header, 4 byte oops
-    { 16,         false, false,   4 },  // 16 byte header, 8 byte oops, 16-byte align
-    { 16,         true,  false,   4 },  // 16 byte header, 4 byte oops, 16-byte align
-    { 16,         false, true,    4 },  // 12 byte header, 8 byte oops, 16-byte align
-    { 16,         true,  true,    2 },  // 12 byte header, 4 byte oops, 16-byte align
-    { 256,        false, false,  32 }, // 16 byte header, 8 byte oops, 256-byte align
-    { 256,        true,  false,  32 }, // 16 byte header, 4 byte oops, 256-byte align
-    { 256,        false, true,   32 }, // 12 byte header, 8 byte oops, 256-byte align
-    { 256,        true,  true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
+    { 8,          false, false, true,  3 },  // 16 byte header, 8 byte oops
+    { 8,          true,  false, true,  3 },  // 16 byte header, 4 byte oops
+    { 8,          false, true,  false, 3 },  // 12 byte header, 8 byte oops
+    { 8,          false, true,  true,  3 },  // 16 byte header, 8 byte oops
+    { 8,          true,  true,  false, 2 },  // 12 byte header, 4 byte oops
+    { 8,          true,  true,  true,  3 },  // 16 byte header, 4 byte oops
+
+    { 16,         false, false, true,  4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,  false, true,  4 },  // 16 byte header, 4 byte oops, 16-byte align
+    { 16,         false, true,  false, 4 },  // 12 byte header, 8 byte oops, 16-byte align
+    { 16,         false, true,  true,  4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,  true,  false, 2 },  // 12 byte header, 4 byte oops, 16-byte align
+    { 16,         true,  true,  true,  3 },  // 16 byte header, 4 byte oops, 16-byte align
+
+    { 256,        false, false,  true, 32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,  false,  true, 32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 256,        false, true,   false, 32 }, // 12 byte header, 8 byte oops, 256-byte align
+    { 256,        false, true,   true,  32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,  true,   false, 32 }, // 12 byte header, 4 byte oops, 256-byte align
+    { 256,        true,  true,   true,  32 }, // 16 byte header, 4 byte oops, 256-byte align
 #else
-    { 8,          false, false,   4 }, // 12 byte header, 4 byte oops, wordsize 4
+    { 8,          false, false,  true, 4 }, // 12 byte header, 4 byte oops, wordsize 4
 #endif
-    { -1,         false, false,  -1 }
+    { -1,         false, false,  true, -1 }
   };
   for (int i = 0; x[i].result != -1; i++) {
     if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].coops == UseCompressedOops &&
-        x[i].coh == UseCompactObjectHeaders) {
+        x[i].coh == UseCompactObjectHeaders && x[i].aae == AlignArrayElements) {
       EXPECT_EQ(objArrayOopDesc::object_size(1), (size_t)x[i].result);
     }
   }

--- a/test/hotspot/jtreg/gtest/ObjArrayTests.java
+++ b/test/hotspot/jtreg/gtest/ObjArrayTests.java
@@ -57,3 +57,35 @@
  *          java.xml
  * @run main/native GTestWrapper --gtest_filter=objArrayOop -XX:-UseCompressedOops -XX:ObjAlignmentInBytes=256
  */
+
+/* @test id=nocoh-noalign
+ * @summary Run object array size tests with compressed oops
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=objArrayOop -XX:-UseCompactObjectHeaders -XX:-AlignArrayElements
+ */
+
+/* @test id=coh-noalign
+ * @summary Run object array size tests with compressed oops
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=objArrayOop -XX:+UseCompactObjectHeaders -XX:-AlignArrayElements
+ */
+
+/* @test id=nocoh-align
+ * @summary Run object array size tests with compressed oops
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=objArrayOop -XX:-UseCompactObjectHeaders -XX:+AlignArrayElements
+ */
+
+/* @test id=coh-align
+ * @summary Run object array size tests with compressed oops
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=objArrayOop -XX:+UseCompactObjectHeaders -XX:+AlignArrayElements
+ */


### PR DESCRIPTION
This is a broken change to align first array element on 8 byte boundaries to test performance for https://bugs.openjdk.org/browse/JDK-8386990.  C2 is unhappy with the alignment gap between the end of the length field and the beginning of the first element of an array when the array element doesn't require this alignment.
Also generates different IR code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31820/head:pull/31820` \
`$ git checkout pull/31820`

Update a local copy of the PR: \
`$ git checkout pull/31820` \
`$ git pull https://git.openjdk.org/jdk.git pull/31820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31820`

View PR using the GUI difftool: \
`$ git pr show -t 31820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31820.diff">https://git.openjdk.org/jdk/pull/31820.diff</a>

</details>
