### PR TITLE
8387795: Remove hard coded set of locales in LocaleData

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Formatter;
 import java.util.HashSet;
 import java.util.HashMap;
@@ -39,6 +40,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
+import static java.util.ResourceBundle.Control;
 
 class ResourceBundleGenerator implements BundleGenerator {
     // preferred timezones - keeping compatibility with JDK1.1 3 letter abbreviations
@@ -69,6 +71,9 @@ class ResourceBundleGenerator implements BundleGenerator {
     // For duplicated values
     private static final String META_VALUE_PREFIX = "metaValue_";
 
+    // locales in the base module
+    private final Set<Locale> baseModuleLocales = new HashSet<>();
+
     @Override
     public void generateBundle(String packageName, String baseName, String localeID,
                                Map<String, ?> map, BundleType type) throws IOException {
@@ -80,8 +85,15 @@ class ResourceBundleGenerator implements BundleGenerator {
             return;
         }
 
-        // Assume that non-base resources go into jdk.localedata
-        if (!CLDRConverter.isBaseModule) {
+        if (CLDRConverter.isBaseModule) {
+            if (!localeID.equals("root")) {
+                baseModuleLocales.addAll(
+                    Control.getControl(Control.FORMAT_DEFAULT)
+                        .getCandidateLocales("",
+                            Locale.forLanguageTag(CLDRConverter.toLanguageTag(localeID))));
+            }
+        } else {
+            // Assume that non-base resources go into jdk.localedata
             dirName = dirName + File.separator + "ext";
             packageName = packageName + ".ext";
         }
@@ -284,6 +296,7 @@ class ResourceBundleGenerator implements BundleGenerator {
                 import java.util.HashMap;
                 import java.util.Locale;
                 import java.util.Map;
+                import java.util.Set;
                 import sun.util.locale.provider.LocaleDataMetaInfo;
                 import sun.util.locale.provider.LocaleProviderAdapter;
 
@@ -296,6 +309,7 @@ class ResourceBundleGenerator implements BundleGenerator {
                 out.printf("""
                         private static final Map<Locale, String[]> parentLocalesMap = HashMap.newHashMap(%d);
                         private static final Map<String, String> languageAliasMap = HashMap.newHashMap(%d);
+                        private static final Set<Locale> baseModuleLocales;
                         static final boolean nonlikelyScript = %s; // package access from CLDRLocaleProviderAdapter
 
                         static {
@@ -322,7 +336,23 @@ class ResourceBundleGenerator implements BundleGenerator {
                 CLDRConverter.handlerSupplMeta.getLanguageAliasData().forEach((key, value) -> {
                     out.printf("        languageAliasMap.put(\"%s\", \"%s\");\n", CLDRConverter.escape(key), CLDRConverter.escape(value));
                 });
-                out.printf("    }\n\n");
+                out.println();
+
+                // for baseModuleLocales
+                out.printf("        baseModuleLocales = Set.of(\n");
+                out.printf("            %s",
+                    baseModuleLocales.stream()
+                        .map(Locale::toLanguageTag)
+                        .sorted(Comparator.comparing(l -> l.equals("und") ? "" : l))
+                        .map(l -> switch(l) {
+                                case "und"   -> "Locale.ROOT";
+                                case "en"    -> "Locale.ENGLISH";
+                                case "en-US" -> "Locale.US";
+                                default      -> "Locale.forLanguageTag(\"" + l + "\")";
+                            })
+                        .collect(Collectors.joining(",\n            ")));
+                out.printf("\n        );");
+                out.println("\n    }\n");
 
                 // end of static initializer block.
 
@@ -389,6 +419,10 @@ class ResourceBundleGenerator implements BundleGenerator {
 
                     public Map<Locale, String[]> parentLocales() {
                         return parentLocalesMap;
+                    }
+
+                    public Set<Locale> baseModuleLocales() {
+                        return baseModuleLocales;
                     }
 
                     // package access from CLDRLocaleProviderAdapter

--- a/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,6 +286,11 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
         return Locale.ROOT.equals(locale)
                 || langtags.contains(locale.stripExtensions().toLanguageTag())
                 || langtags.contains(getEquivalentLoc(locale).toLanguageTag());
+    }
+
+    @Override
+    public Set<Locale> baseModuleLocales() {
+        return baseMetaInfo.baseModuleLocales();
     }
 
     /**

--- a/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
@@ -288,7 +288,6 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
                 || langtags.contains(getEquivalentLoc(locale).toLanguageTag());
     }
 
-    @Override
     public Set<Locale> baseModuleLocales() {
         return baseMetaInfo.baseModuleLocales();
     }

--- a/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
@@ -488,4 +488,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
                    "th-TH-TH".equals(oldname) ||
                    "no-NO-NY".equals(oldname);
     }
+
+    @Override
+    public Set<Locale> baseModuleLocales() {
+        return Set.of(Locale.ROOT);
+    }
 }

--- a/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
@@ -489,7 +489,6 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
                    "no-NO-NY".equals(oldname);
     }
 
-    @Override
     public Set<Locale> baseModuleLocales() {
         return Set.of(Locale.ROOT);
     }

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -300,14 +300,6 @@ public abstract class LocaleProviderAdapter {
         return false;
     }
 
-    /**
-     * Returns the locales whose resource bundles are resolved from
-     * the java.base module for this adapter.
-     */
-    public Set<Locale> baseModuleLocales() {
-        return Set.of();
-    }
-
     public static Locale[] toLocaleArray(Set<String> tags) {
         return tags.stream()
             .map(t -> switch (t) {

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -300,6 +300,14 @@ public abstract class LocaleProviderAdapter {
         return false;
     }
 
+    /**
+     * Returns the locales whose resource bundles are resolved from
+     * the java.base module for this adapter.
+     */
+    public Set<Locale> baseModuleLocales() {
+        return Set.of();
+    }
+
     public static Locale[] toLocaleArray(Set<String> tags) {
         return tags.stream()
             .map(t -> switch (t) {

--- a/src/java.base/share/classes/sun/util/locale/provider/ResourceBundleBasedAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/ResourceBundleBasedAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package sun.util.locale.provider;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+
 import sun.util.resources.LocaleData;
 
 /**
@@ -40,5 +42,11 @@ public interface ResourceBundleBasedAdapter {
     /**
      * candidate locales customization
      */
-    public List<Locale> getCandidateLocales(String baseName, Locale locale);
+    List<Locale> getCandidateLocales(String baseName, Locale locale);
+
+    /**
+     * Returns the locales whose resource bundles are resolved from
+     * the java.base module for this adapter.
+     */
+    Set<Locale> baseModuleLocales();
 }

--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -180,8 +180,6 @@ public class LocaleData {
 
     private static class LocaleDataStrategy implements Bundles.Strategy {
         private static final LocaleDataStrategy INSTANCE = new LocaleDataStrategy();
-        private static final Set<Locale> JAVA_BASE_LOCALES =
-            LocaleProviderAdapter.getResourceBundleBased().baseModuleLocales();
 
         private LocaleDataStrategy() {
         }
@@ -225,14 +223,17 @@ public class LocaleData {
             return candidates;
         }
 
-        boolean inJavaBaseModule(Locale locale) {
-            return JAVA_BASE_LOCALES.contains(locale);
+        boolean inJavaBaseModule(String baseName, Locale locale) {
+            var adapter = baseName.contains(DOTCLDR) ?
+                    LocaleProviderAdapter.forType(CLDR) :
+                    LocaleProviderAdapter.forType(JRE);
+            return adapter.baseModuleLocales().contains(locale);
         }
 
         @Override
         public String toBundleName(String baseName, Locale locale) {
             String newBaseName = baseName;
-            if (!inJavaBaseModule(locale)) {
+            if (!inJavaBaseModule(baseName, locale)) {
                 if (baseName.startsWith(JRE.getUtilResourcesPackage())
                         || baseName.startsWith(JRE.getTextResourcesPackage())) {
                     // Assume the lengths are the same.
@@ -252,7 +253,7 @@ public class LocaleData {
         @Override
         public Class<? extends ResourceBundleProvider> getResourceBundleProviderType(String baseName,
                                                                                      Locale locale) {
-            return inJavaBaseModule(locale) ?
+            return inJavaBaseModule(baseName, locale) ?
                         null : LocaleDataResourceBundleProvider.class;
         }
     }

--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,9 +180,8 @@ public class LocaleData {
 
     private static class LocaleDataStrategy implements Bundles.Strategy {
         private static final LocaleDataStrategy INSTANCE = new LocaleDataStrategy();
-        // TODO: avoid hard-coded Locales
-        private static final Set<Locale> JAVA_BASE_LOCALES
-            = Set.of(Locale.ROOT, Locale.ENGLISH, Locale.US, Locale.of("en", "US", "POSIX"));
+        private static final Set<Locale> JAVA_BASE_LOCALES =
+            LocaleProviderAdapter.getResourceBundleBased().baseModuleLocales();
 
         private LocaleDataStrategy() {
         }
@@ -226,14 +225,14 @@ public class LocaleData {
             return candidates;
         }
 
-        boolean inJavaBaseModule(String baseName, Locale locale) {
+        boolean inJavaBaseModule(Locale locale) {
             return JAVA_BASE_LOCALES.contains(locale);
         }
 
         @Override
         public String toBundleName(String baseName, Locale locale) {
             String newBaseName = baseName;
-            if (!inJavaBaseModule(baseName, locale)) {
+            if (!inJavaBaseModule(locale)) {
                 if (baseName.startsWith(JRE.getUtilResourcesPackage())
                         || baseName.startsWith(JRE.getTextResourcesPackage())) {
                     // Assume the lengths are the same.
@@ -253,7 +252,7 @@ public class LocaleData {
         @Override
         public Class<? extends ResourceBundleProvider> getResourceBundleProviderType(String baseName,
                                                                                      Locale locale) {
-            return inJavaBaseModule(baseName, locale) ?
+            return inJavaBaseModule(locale) ?
                         null : LocaleDataResourceBundleProvider.class;
         }
     }

--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.spi.ResourceBundleProvider;
 import sun.util.locale.provider.JRELocaleProviderAdapter;
@@ -199,10 +198,8 @@ public class LocaleData {
             String key = baseName + '-' + locale.toLanguageTag();
             List<Locale> candidates = CANDIDATES_MAP.get(key);
             if (candidates == null) {
-                LocaleProviderAdapter adapter = getAdapter(baseName);
-                candidates = adapter instanceof ResourceBundleBasedAdapter rbba ?
-                    rbba.getCandidateLocales(baseName, locale) :
-                    defaultControl.getCandidateLocales(baseName, locale);
+                var adapter = getAdapter(baseName);
+                candidates = adapter.getCandidateLocales(baseName, locale);
 
                 // Weed out Locales which are known to have no resource bundles
                 int lastDot = baseName.lastIndexOf('.');
@@ -226,10 +223,10 @@ public class LocaleData {
             return getAdapter(baseName).baseModuleLocales().contains(locale);
         }
 
-        private static LocaleProviderAdapter getAdapter(String baseName) {
-            return baseName.contains(DOTCLDR) ?
+        private static ResourceBundleBasedAdapter getAdapter(String baseName) {
+            return (ResourceBundleBasedAdapter)(baseName.contains(DOTCLDR) ?
                 LocaleProviderAdapter.forType(CLDR) :
-                LocaleProviderAdapter.forType(JRE);
+                LocaleProviderAdapter.forType(JRE));
         }
 
         @Override

--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -199,8 +199,7 @@ public class LocaleData {
             String key = baseName + '-' + locale.toLanguageTag();
             List<Locale> candidates = CANDIDATES_MAP.get(key);
             if (candidates == null) {
-                LocaleProviderAdapter.Type type = baseName.contains(DOTCLDR) ? CLDR : JRE;
-                LocaleProviderAdapter adapter = LocaleProviderAdapter.forType(type);
+                LocaleProviderAdapter adapter = getAdapter(baseName);
                 candidates = adapter instanceof ResourceBundleBasedAdapter rbba ?
                     rbba.getCandidateLocales(baseName, locale) :
                     defaultControl.getCandidateLocales(baseName, locale);
@@ -224,10 +223,13 @@ public class LocaleData {
         }
 
         boolean inJavaBaseModule(String baseName, Locale locale) {
-            var adapter = baseName.contains(DOTCLDR) ?
-                    LocaleProviderAdapter.forType(CLDR) :
-                    LocaleProviderAdapter.forType(JRE);
-            return adapter.baseModuleLocales().contains(locale);
+            return getAdapter(baseName).baseModuleLocales().contains(locale);
+        }
+
+        private static LocaleProviderAdapter getAdapter(String baseName) {
+            return baseName.contains(DOTCLDR) ?
+                LocaleProviderAdapter.forType(CLDR) :
+                LocaleProviderAdapter.forType(JRE);
         }
 
         @Override


### PR DESCRIPTION
The `LocaleData` class currently hard-codes the set of locales whose resource bundles reside in the `java.base` module. This change generates that set at build time from the CLDR source XML for the CLDR locale provider. Other locale providers now provide the appropriate set based on their own resource bundles.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387795](https://bugs.openjdk.org/browse/JDK-8387795): Remove hard coded set of locales in LocaleData (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31822/head:pull/31822` \
`$ git checkout pull/31822`

Update a local copy of the PR: \
`$ git checkout pull/31822` \
`$ git pull https://git.openjdk.org/jdk.git pull/31822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31822`

View PR using the GUI difftool: \
`$ git pr show -t 31822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31822.diff">https://git.openjdk.org/jdk/pull/31822.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31822#issuecomment-4910244962)
</details>
