### PR TITLE
8369020: Test compiler/intrinsics/TestLongUnsignedDivMod.java completed and timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
@@ -110,7 +110,6 @@ public class TestLongUnsignedDivMod {
     }
 
     @Test // needs to be run in (fast) debug mode
-    @Warmup(10000)
     @IR(counts = {IRNode.UDIV_L, ">= 1"}) // At least one UDivL node is generated if intrinsic is used
     public void testDivideUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
@@ -124,7 +123,6 @@ public class TestLongUnsignedDivMod {
     }
 
     @Test // needs to be run in (fast) debug mode
-    @Warmup(10000)
     @IR(counts = {IRNode.UMOD_L, ">= 1"}) // At least one UModL node is generated if intrinsic is used
     public void testRemainderUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
@@ -139,7 +137,6 @@ public class TestLongUnsignedDivMod {
 
 
     @Test // needs to be run in (fast) debug mode
-    @Warmup(10000)
     @IR(applyIfPlatform = {"x64", "true"},
         counts = {IRNode.UDIV_MOD_L, ">= 1"}) // At least one UDivModL node is generated if intrinsic is used
     public void testDivModUnsigned() {


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8369020](https://bugs.openjdk.org/browse/JDK-8369020): Test compiler/intrinsics/TestLongUnsignedDivMod.java completed and timed out (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31824/head:pull/31824` \
`$ git checkout pull/31824`

Update a local copy of the PR: \
`$ git checkout pull/31824` \
`$ git pull https://git.openjdk.org/jdk.git pull/31824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31824`

View PR using the GUI difftool: \
`$ git pr show -t 31824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31824.diff">https://git.openjdk.org/jdk/pull/31824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31824#issuecomment-4912090340)
</details>
