### PR TITLE
8387961: Shenandoah: Rework marked objects loop prefetch 

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -45,6 +45,7 @@
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "gc/shenandoah/shenandoahHeapRegionSet.inline.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.inline.hpp"
+#include "gc/shenandoah/shenandoahPrefetch.inline.hpp"
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
 #include "gc/shenandoah/shenandoahWorkGroup.hpp"
 #include "oops/compressedOops.inline.hpp"
@@ -515,74 +516,35 @@ inline void ShenandoahHeap::marked_object_iterate(ShenandoahHeapRegion* region, 
 
 template<class T>
 inline void ShenandoahHeap::marked_object_iterate(ShenandoahHeapRegion* region, T* cl, HeapWord* limit) {
-  assert(! region->is_humongous_continuation(), "no humongous continuation regions here");
+  assert(!region->is_humongous_continuation(), "no humongous continuation regions here");
+  assert(limit <= region->top(), "sanity");
 
   ShenandoahMarkingContext* const ctx = marking_context();
 
   HeapWord* tams = ctx->top_at_mark_start(region);
-
-  size_t skip_bitmap_delta = 1;
-  HeapWord* start = region->bottom();
-  HeapWord* end = MIN2(tams, region->end());
-
-  // Step 1. Scan below the TAMS based on bitmap data.
   HeapWord* limit_bitmap = MIN2(limit, tams);
 
+  // Step 1. Scan below the TAMS based on bitmap data.
   // Try to scan the initial candidate. If the candidate is above the TAMS, it would
   // fail the subsequent "< limit_bitmap" checks, and fall through to Step 2.
-  HeapWord* cb = ctx->get_next_marked_addr(start, end);
+  HeapWord* cb = ctx->get_next_marked_addr(region->bottom(), limit_bitmap);
+  while (cb < limit_bitmap) {
+    assert (cb < tams,  "only objects below TAMS here: "  PTR_FORMAT " (" PTR_FORMAT ")", p2i(cb), p2i(tams));
+    assert (cb < limit, "only objects below limit here: " PTR_FORMAT " (" PTR_FORMAT ")", p2i(cb), p2i(limit));
+    oop obj = cast_to_oop(cb);
+    assert(oopDesc::is_oop(obj), "sanity");
+    assert(ctx->is_marked(obj), "object expected to be marked");
 
-  intx dist = ShenandoahMarkScanPrefetch;
-  if (dist > 0) {
-    // Batched scan that prefetches the oop data, anticipating the access to
-    // either header, oop field, or forwarding pointer. Not that we cannot
-    // touch anything in oop, while it still being prefetched to get enough
-    // time for prefetch to work. This is why we try to scan the bitmap linearly,
-    // disregarding the object size. However, since we know forwarding pointer
-    // precedes the object, we can skip over it. Once we cannot trust the bitmap,
-    // there is no point for prefetching the oop contents, as oop->size() will
-    // touch it prematurely.
-
-    // No variable-length arrays in standard C++, have enough slots to fit
-    // the prefetch distance.
-    static const int SLOT_COUNT = 256;
-    guarantee(dist <= SLOT_COUNT, "adjust slot count");
-    HeapWord* slots[SLOT_COUNT];
-
-    int avail;
-    do {
-      avail = 0;
-      for (int c = 0; (c < dist) && (cb < limit_bitmap); c++) {
-        Prefetch::read(cb, oopDesc::mark_offset_in_bytes());
-        slots[avail++] = cb;
-        cb += skip_bitmap_delta;
-        if (cb < limit_bitmap) {
-          cb = ctx->get_next_marked_addr(cb, limit_bitmap);
-        }
-      }
-
-      for (int c = 0; c < avail; c++) {
-        assert (slots[c] < tams,  "only objects below TAMS here: "  PTR_FORMAT " (" PTR_FORMAT ")", p2i(slots[c]), p2i(tams));
-        assert (slots[c] < limit, "only objects below limit here: " PTR_FORMAT " (" PTR_FORMAT ")", p2i(slots[c]), p2i(limit));
-        oop obj = cast_to_oop(slots[c]);
-        assert(oopDesc::is_oop(obj), "sanity");
-        assert(ctx->is_marked(obj), "object expected to be marked");
-        cl->do_object(obj);
-      }
-    } while (avail > 0);
-  } else {
-    while (cb < limit_bitmap) {
-      assert (cb < tams,  "only objects below TAMS here: "  PTR_FORMAT " (" PTR_FORMAT ")", p2i(cb), p2i(tams));
-      assert (cb < limit, "only objects below limit here: " PTR_FORMAT " (" PTR_FORMAT ")", p2i(cb), p2i(limit));
-      oop obj = cast_to_oop(cb);
-      assert(oopDesc::is_oop(obj), "sanity");
-      assert(ctx->is_marked(obj), "object expected to be marked");
-      cl->do_object(obj);
-      cb += skip_bitmap_delta;
-      if (cb < limit_bitmap) {
-        cb = ctx->get_next_marked_addr(cb, limit_bitmap);
-      }
+    // Compute the next object address and initiate prefetches for it,
+    // while we are processing current object.
+    constexpr size_t skip_bitmap_delta = 1;
+    cb += skip_bitmap_delta;
+    if (cb < limit_bitmap) {
+      cb = ctx->get_next_marked_addr(cb, limit_bitmap);
     }
+    ShenandoahPrefetch::prefetch(cast_to_oop(cb));
+
+    cl->do_object(obj);
   }
 
   // Step 2. Accurate size-based traversal, happens past the TAMS.
@@ -595,9 +557,13 @@ inline void ShenandoahHeap::marked_object_iterate(ShenandoahHeapRegion* region, 
     oop obj = cast_to_oop(cs);
     assert(oopDesc::is_oop(obj), "sanity");
     assert(ctx->is_marked(obj), "object expected to be marked");
-    size_t size = ShenandoahForwarding::size(obj);
+
+    // Compute the next object address and initiate prefetches for it,
+    // while we are processing current object.
+    cs += ShenandoahForwarding::size(obj);
+    ShenandoahPrefetch::prefetch(cast_to_oop(cs));
+
     cl->do_object(obj);
-    cs += size;
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -476,11 +476,6 @@
           "evacuated.")                                                     \
           range(0, 100)                                                     \
                                                                             \
-  product(intx, ShenandoahMarkScanPrefetch, 32, EXPERIMENTAL,               \
-          "How many objects to prefetch ahead when traversing mark bitmaps."\
-          "Set to 0 to disable prefetching.")                               \
-          range(0, 256)                                                     \
-                                                                            \
   product(uintx, ShenandoahMarkLoopStride, 1000, EXPERIMENTAL,              \
           "How many items to process during one marking iteration before "  \
           "checking for cancellation, yielding, etc. Larger values improve "\


### PR DESCRIPTION
`ShenandoahHeap::marked_object_iterate` is the kernel for traversing the marked objects for evacuation and update-refs. That code has has aged significantly, and can be optimized. The most promising work item there is reworking the prefetching in the style of [JDK-8387907](https://bugs.openjdk.org/browse/JDK-8387907). Despite the old comment, we _can_ actually prefetch the objects that we walk past the TAMS.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Ad-hoc evac/update-refs timing tests
 - [x] Regular testing pipelines

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387961](https://bugs.openjdk.org/browse/JDK-8387961): Shenandoah: Rework marked objects loop prefetch (**Enhancement** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31826/head:pull/31826` \
`$ git checkout pull/31826`

Update a local copy of the PR: \
`$ git checkout pull/31826` \
`$ git pull https://git.openjdk.org/jdk.git pull/31826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31826`

View PR using the GUI difftool: \
`$ git pr show -t 31826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31826.diff">https://git.openjdk.org/jdk/pull/31826.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31826#issuecomment-4913615447)
</details>
