### PR TITLE
8387973: CollectedHeap induced promotion failure handling should use Atomic

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,6 +282,8 @@ CollectedHeap::CollectedHeap() :
   _last_whole_heap_examined_time_ns(os::javaTimeNanos()),
   _total_collections(0),
   _total_full_collections(0),
+  NOT_PRODUCT(_promotion_failure_alot_count(0) COMMA)
+  NOT_PRODUCT(_promotion_failure_alot_gc_number(0) COMMA)
   _vmthread_cpu_time(0),
   _gc_cause(GCCause::_no_gc),
   _gc_lastcause(GCCause::_no_gc)
@@ -298,9 +300,6 @@ CollectedHeap::CollectedHeap() :
   const size_t elements_per_word = HeapWordSize / sizeof(jint);
   _filler_array_max_size = align_object_size(filler_array_hdr_size() +
                                              max_len / elements_per_word);
-
-  NOT_PRODUCT(_promotion_failure_alot_count = 0;)
-  NOT_PRODUCT(_promotion_failure_alot_gc_number = 0;)
 
   if (UsePerfData) {
     EXCEPTION_MARK;
@@ -622,35 +621,31 @@ size_t CollectedHeap::bootstrap_max_memory() const {
 
 #ifndef PRODUCT
 
-bool CollectedHeap::promotion_should_fail(volatile size_t* count) {
-  // Access to count is not atomic; the value does not have to be exact.
+bool CollectedHeap::promotion_should_fail() {
+  // Access to count is not atomic in any way - we can loose updates, overwrite never counts, etc;
+  // the value does not have to be exact.
   if (PromotionFailureALot) {
     const size_t gc_num = total_collections();
-    const size_t elapsed_gcs = gc_num - _promotion_failure_alot_gc_number;
+    const size_t elapsed_gcs = gc_num - _promotion_failure_alot_gc_number.load_relaxed();
     if (elapsed_gcs >= PromotionFailureALotInterval) {
-      // Test for unsigned arithmetic wrap-around.
-      if (++*count >= PromotionFailureALotCount) {
-        *count = 0;
+      // To avoid the base (x86-)costs for atomic RMW operations, use explicit load/store_relaxed() operations.
+      uintx new_count = _promotion_failure_alot_count.load_relaxed() + 1;
+      if (new_count >= PromotionFailureALotCount) {
+        _promotion_failure_alot_count.store_relaxed(0);
         return true;
+      } else {
+        _promotion_failure_alot_count.store_relaxed(new_count);
       }
     }
   }
   return false;
 }
 
-bool CollectedHeap::promotion_should_fail() {
-  return promotion_should_fail(&_promotion_failure_alot_count);
-}
-
-void CollectedHeap::reset_promotion_should_fail(volatile size_t* count) {
-  if (PromotionFailureALot) {
-    _promotion_failure_alot_gc_number = total_collections();
-    *count = 0;
-  }
-}
-
 void CollectedHeap::reset_promotion_should_fail() {
-  reset_promotion_should_fail(&_promotion_failure_alot_count);
+  if (PromotionFailureALot) {
+    _promotion_failure_alot_gc_number.store_relaxed(total_collections());
+    _promotion_failure_alot_count.store_relaxed(0);
+  }
 }
 
 #endif  // #ifndef PRODUCT

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -32,6 +32,7 @@
 #include "memory/metaspace.hpp"
 #include "memory/universe.hpp"
 #include "oops/stackChunkOop.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/perfDataTypes.hpp"
 #include "runtime/safepoint.hpp"
@@ -129,8 +130,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
 
   unsigned int _total_collections;          // ... started
   unsigned int _total_full_collections;     // ... started
-  NOT_PRODUCT(volatile size_t _promotion_failure_alot_count;)
-  NOT_PRODUCT(volatile size_t _promotion_failure_alot_gc_number;)
+  NOT_PRODUCT(Atomic<size_t> _promotion_failure_alot_count;)
+  NOT_PRODUCT(Atomic<size_t> _promotion_failure_alot_gc_number;)
 
   jlong _vmthread_cpu_time;
 
@@ -503,14 +504,11 @@ protected:
   // Non product verification and debugging.
 #ifndef PRODUCT
   // Support for PromotionFailureALot.  Return true if it's time to cause a
-  // promotion failure.  The no-argument version uses
-  // this->_promotion_failure_alot_count as the counter.
-  bool promotion_should_fail(volatile size_t* count);
+  // promotion failure.
   bool promotion_should_fail();
 
   // Reset the PromotionFailureALot counters.  Should be called at the end of a
   // GC in which promotion failure occurred.
-  void reset_promotion_should_fail(volatile size_t* count);
   void reset_promotion_should_fail();
 #endif  // #ifndef PRODUCT
 };


### PR DESCRIPTION
Hi all,

  please review this change that makes the volatiles used for promotion failure testing Atomic variables.

The change intentionally keeps the very loose "atomicity" guarantees the original change had; they would slow down this feature too much, making performance tests using it useless.

Some cleanup of unnecessary helpers has been applied.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387973](https://bugs.openjdk.org/browse/JDK-8387973): CollectedHeap induced promotion failure handling should use Atomic (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31830/head:pull/31830` \
`$ git checkout pull/31830`

Update a local copy of the PR: \
`$ git checkout pull/31830` \
`$ git pull https://git.openjdk.org/jdk.git pull/31830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31830`

View PR using the GUI difftool: \
`$ git pr show -t 31830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31830.diff">https://git.openjdk.org/jdk/pull/31830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31830#issuecomment-4915920122)
</details>
