### PR TITLE
8385945: Deprecate the CompilationMode flag

### DIFF
--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -273,7 +273,7 @@
           "mode if posssible")                                              \
                                                                             \
   product(ccstr, CompilationMode, "default",                                \
-          "Compilation modes: "                                             \
+          "(Deprecated) Compilation modes: "                                \
           "default: normal tiered compilation; "                            \
           "quick-only: C1-only mode; "                                      \
           "high-only: C2-only mode.")                                       \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -529,6 +529,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "CompilationMode",              JDK_Version::jdk(28), JDK_Version::jdk(29), JDK_Version::jdk(30)},
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
   { "InitiatingHeapOccupancyPercent", JDK_Version::jdk(27),  JDK_Version::jdk(28), JDK_Version::jdk(29) },

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,7 @@ public class VMDeprecatedOptions {
             // { <flag name> , <expected default value> }
             // deprecated non-alias flags:
             {"AllowRedefinitionToAddDeleteMethods", "true"},
+            {"CompilationMode", "default"},
 
             // deprecated alias flags (see also aliased_jvm_flags):
             {"CreateMinidumpOnCrash", "false"}


### PR DESCRIPTION
This is a simple PR to deprecate the `CompilationMode` flag. With the removal of JVMCI and the `high-only-quick-internal` compilation mode, all uses of `CompilationMode` are better served by other flags.

Testing:
 - [x] Github Actions
 - [x] tier1,tier2,tier3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))
- \[x\] Change requires CSR request [JDK-8385947](https://bugs.openjdk.org/browse/JDK-8385947) to be approved

### Issues
 * [JDK-8385945](https://bugs.openjdk.org/browse/JDK-8385945): Deprecate the CompilationMode flag (**Sub-task** - P4)
 * [JDK-8385947](https://bugs.openjdk.org/browse/JDK-8385947): Deprecate the CompilationMode flag (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31831/head:pull/31831` \
`$ git checkout pull/31831`

Update a local copy of the PR: \
`$ git checkout pull/31831` \
`$ git pull https://git.openjdk.org/jdk.git pull/31831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31831`

View PR using the GUI difftool: \
`$ git pr show -t 31831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31831.diff">https://git.openjdk.org/jdk/pull/31831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31831#issuecomment-4916269922)
</details>
