### PR TITLE
8386872: Test gc/shenandoah/generational/TestOldGrowthTriggers still fails intermittently

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -112,6 +112,8 @@ public class TestOldGrowthTriggers {
                 "-XX:ShenandoahMinOldGenGrowthRemainingHeapPercent=100",
                 "-XX:ShenandoahGuaranteedYoungGCInterval=0",
                 "-XX:ShenandoahGuaranteedOldGCInterval=0",
+                "-XX:ShenandoahGenerationalMinTenuringAge=2",
+                "-XX:ShenandoahGenerationalMaxTenuringAge=2",
                 "-XX:-UseCompactObjectHeaders"
         );
 
@@ -129,6 +131,8 @@ public class TestOldGrowthTriggers {
                 "-XX:ShenandoahMinOldGenGrowthRemainingHeapPercent=100",
                 "-XX:ShenandoahGuaranteedYoungGCInterval=0",
                 "-XX:ShenandoahGuaranteedOldGCInterval=0",
+                "-XX:ShenandoahGenerationalMinTenuringAge=2",
+                "-XX:ShenandoahGenerationalMaxTenuringAge=2",
                 "-XX:+UseCompactObjectHeaders"
         );
     }

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -41,7 +41,9 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestOldGrowthTriggers {
 
     public static void makeOldAllocations() {
-        // Expect most of the BitSet entries placed into array to be promoted, and most will eventually become garbage within old
+        // Keep the majority of BitSet entries (5/8, 960) long-lived so they promote and grow old generation
+        // well past the old GC trigger threshold. A smaller long-lived set can fall just short and only
+        // intermittently trigger an old GC, so don't reduce the array size or the promoted fraction.
 
         final int ArraySize = 1536;  // 1536 entries (1024 + 512)
         final int RefillIterations = 128;
@@ -57,8 +59,8 @@ public class TestOldGrowthTriggers {
                 int replaceIndex = i;
                 int deriveIndex = i-1;
 
-                // 3/8 of entries are replaced each pass to trigger young gcs.
-                // The other 5/8 entries are never touched, so they age each cycle.
+                // 3/8 entries are replaced each pass to trigger young gcs.
+                // 5/8 entries are never touched, so they age each cycle.
                 switch (i & 0x7) {
                     case 0,1 -> {
                         // creates new BitSet, releases old BitSet,

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -43,7 +43,7 @@ public class TestOldGrowthTriggers {
     public static void makeOldAllocations() {
         // Expect most of the BitSet entries placed into array to be promoted, and most will eventually become garbage within old
 
-        final int ArraySize = 1024;  // 1K entries
+        final int ArraySize = 1536;  // 1536 entries (1024 + 512)
         final int RefillIterations = 128;
         BitSet[] array = new BitSet[ArraySize];
 
@@ -57,8 +57,10 @@ public class TestOldGrowthTriggers {
                 int replaceIndex = i;
                 int deriveIndex = i-1;
 
+                // 3/8 of entries are replaced each pass to trigger young gcs.
+                // The other 5/8 entries are never touched, so they age each cycle.
                 switch (i & 0x7) {
-                    case 0,1,2 -> {
+                    case 0,1 -> {
                         // creates new BitSet, releases old BitSet,
                         // create ephemeral data while computing
                         BitSet result = (BitSet) array[deriveIndex].clone();
@@ -67,12 +69,12 @@ public class TestOldGrowthTriggers {
                         }
                         array[replaceIndex] = result;
                     }
-                    case 3,4 -> {
+                    case 2 -> {
                         // creates new BitSet, releases old BitSet
                         BitSet result = (BitSet) array[deriveIndex].clone();
                         array[replaceIndex] = result;
                     }
-                    case 5,6,7 -> {
+                    default -> {
                         // do nothing, let all objects in the array age to increase pressure on old generation
                     }
                 }


### PR DESCRIPTION
After looking at the gc log of the failed test, I noticed that the old gen usage never grows beyond the threshold that triggers an old gc. The solution is to close this gap by enlarging the array and keeping the majority of its entries long lived, so they age and get promoted into old gen.

### Testing
`gc/shenandoah/generational/TestOldGrowthTriggers.java` ran 100x on `linux-x86_64-server-fastdebug`
 `gc/shenandoah/generational/TestOldGrowthTriggers.java` with `-XX:ShenandoahGenerationalMinTenuringAge=15` ran 100x 

Original test will fail intermittently with `-XX:ShenandoahGenerationalMinTenuringAge=15`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386872](https://bugs.openjdk.org/browse/JDK-8386872): Test gc/shenandoah/generational/TestOldGrowthTriggers still fails intermittently (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role) Review applies to [871a463f](https://git.openjdk.org/jdk/pull/31834/files/871a463ffc4c99744ac4fd496c7b1307fd6c4169)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31834/head:pull/31834` \
`$ git checkout pull/31834`

Update a local copy of the PR: \
`$ git checkout pull/31834` \
`$ git pull https://git.openjdk.org/jdk.git pull/31834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31834`

View PR using the GUI difftool: \
`$ git pr show -t 31834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31834.diff">https://git.openjdk.org/jdk/pull/31834.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31834#issuecomment-4919015849)
</details>
