### PR TITLE
8374452: [17u] TestUseSHA512IntrinsicsOptionOnUnsupportedCPU failed with java.lang.AssertionError 

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
@@ -23,10 +23,11 @@
 
 /**
  * @test
- * @bug 8035968
+ * @bug 8035968 8374452
  * @summary Verify UseSHA512Intrinsics option processing on unsupported CPU.
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires !(os.arch == "aarch64" & vm.cpu.features ~= ".*sha512.*")
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
On aarch64 machines with SHA-512 hardware support (e.g. Graviton3+), `UseSHA512Intrinsics` is correctly set to `true` by the VM based on CPU features. However, the test's runtime predicate (`IntrinsicPredicates.isSHA512IntrinsicAvailable()`) returns `false` because the WhiteBox `isIntrinsicAvailable` check does not agree with the VM flag. This causes the "OnUnsupportedCPU" test to run instead of skip, hitting the assertion.

The fix adds a `@requires` guard to skip the test on aarch64 when `sha512` is present in `vm.cpu.features`.

Ran all SHA intrinsic tests on linux-x64 — no regressions (22 passed).
Tested on linux-aarch64 (Graviton3, c7g instance with sha512 CPU feature):
  - Without fix: FAILED (AssertionError: UseSHA512Intrinsics expected false but was true)
  - With fix: test correctly skipped (did not meet platform requirements)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8374452](https://bugs.openjdk.org/browse/JDK-8374452): [17u] TestUseSHA512IntrinsicsOptionOnUnsupportedCPU failed with java.lang.AssertionError (**Bug** - P4)(⚠️ The fixVersion in this issue is [17-pool-oracle] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.)


### Reviewers without OpenJDK IDs
 * @cindylhiam01-jpg (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31835/head:pull/31835` \
`$ git checkout pull/31835`

Update a local copy of the PR: \
`$ git checkout pull/31835` \
`$ git pull https://git.openjdk.org/jdk.git pull/31835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31835`

View PR using the GUI difftool: \
`$ git pr show -t 31835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31835.diff">https://git.openjdk.org/jdk/pull/31835.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31835#issuecomment-4919941343)
</details>
