### PR TITLE
8387411: C2: assert((in_vt->isa_pvectmask() == nullptr) == (vt->isa_pvectmask() == nullptr)) failed: Both BVectMask, or both NVectMask, or both PVectMask

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -2308,7 +2308,13 @@ Node* VectorUnboxNode::Ideal(PhaseGVN* phase, bool can_reshape) {
         if (is_vector_mask) {
           // VectorUnbox (VectorBox vmask) ==> VectorMaskCast vmask
           const TypeVect* vmask_type = TypeVect::makemask(out_vt->element_basic_type(), out_vt->length());
-          return new VectorMaskCastNode(value, vmask_type);
+          const TypeVect* value_type = value->bottom_type()->is_vect();
+          // Very rarely, profiling can give us output types that are not
+          // compatible with the input type, where one is PVectMask and
+          // the other not. Such a path should be unreachable anyway.
+          if ((value_type->isa_pvectmask() == nullptr) == (vmask_type->isa_pvectmask() == nullptr)) {
+            return new VectorMaskCastNode(value, vmask_type);
+          }
         } else {
           // Vector type mismatch is only supported for masks, but sometimes it happens in pathological cases.
         }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskUnboxingTypeMismatch.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskUnboxingTypeMismatch.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.*;
+
+/*
+ * @test id=vanilla
+ * @bug 8387411
+ * @modules jdk.incubator.vector
+ *
+ * @run driver ${test.main.class}
+ */
+
+/*
+ * @test id=KNL
+ * @bug 8387411
+ * @modules jdk.incubator.vector
+ *
+ * @run main/othervm -Xbatch
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+public class TestMaskUnboxingTypeMismatch {
+
+    public static Object pollute() {
+        VectorMask<Integer> intMask = VectorMask.fromLong(IntVector.SPECIES_512, 1L);
+        // Profile "andNot" with I512.
+        return intMask.andNot(intMask);
+    }
+
+    public static Object test() {
+        var v0 = ByteVector.broadcast(ByteVector.SPECIES_128, (byte)7);
+        var v1 = VectorMask.fromLong(ByteVector.SPECIES_128, 1L);
+        var v2 = VectorMask.fromLong(ByteVector.SPECIES_128, 2L);
+        // Use "andNot" with B128.
+        // We can get some boxing of B128 mask, which is later unboxed
+        // as profiled I512, which is impossible. When trying to insert
+        // an VectorMaskCast in VectorUnboxNode::Ideal, we hit an assert,
+        // because with UseKNLSetting, B128 mask is a NVectMask, and I512
+        // a PVectMask.
+        var v3 = v1.andNot(v2);
+        var v4 = v0.lanewise(VectorOperators.UMAX, (byte)42, v3);
+        return v4;
+    }
+
+    public static void main(String[] args) {
+        // Sufficient repetitions to get some profiling.
+        for (int i = 0; i < 10_000; i++) {
+            pollute();
+        }
+        // Sufficient repetitions to get compilation.
+        for (int i = 0; i < 50_000; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [05c93a1d](https://github.com/openjdk/jdk/commit/05c93a1dbb0d6f9c4da10d5a7d924a64408d40d2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Emanuel Peter on 9 Jul 2026 and was reviewed by Christian Hagedorn, Tobias Hartmann and Vladimir Ivanov.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387411](https://bugs.openjdk.org/browse/JDK-8387411): C2: assert((in_vt-&gt;isa_pvectmask() == nullptr) == (vt-&gt;isa_pvectmask() == nullptr)) failed: Both BVectMask, or both NVectMask, or both PVectMask (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31837/head:pull/31837` \
`$ git checkout pull/31837`

Update a local copy of the PR: \
`$ git checkout pull/31837` \
`$ git pull https://git.openjdk.org/jdk.git pull/31837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31837`

View PR using the GUI difftool: \
`$ git pr show -t 31837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31837.diff">https://git.openjdk.org/jdk/pull/31837.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31837#issuecomment-4921862102)
</details>
