### PR TITLE
8387856: G1: Fix passing G1ParScanThreadState and worker_id in methods

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentRefineThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefineThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ class G1ConcurrentRefineThread: public ConcurrentGCThread {
 
   Monitor _notifier;
   bool _requested_active;
-
-  uint _worker_id;
 
   G1ConcurrentRefine* _cr;
 

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -52,12 +52,11 @@ public:
 class G1AdjustRegionClosure : public G1HeapRegionClosure {
   G1FullCollector* _collector;
   G1CMBitMap* _bitmap;
-  uint _worker_id;
- public:
-  G1AdjustRegionClosure(G1FullCollector* collector, uint worker_id) :
+
+public:
+  G1AdjustRegionClosure(G1FullCollector* collector) :
     _collector(collector),
-    _bitmap(collector->mark_bitmap()),
-    _worker_id(worker_id) { }
+    _bitmap(collector->mark_bitmap()) { }
 
   bool do_heap_region(G1HeapRegion* r) {
     G1AdjustClosure cl(_collector);
@@ -103,7 +102,7 @@ void G1FullGCAdjustTask::work(uint worker_id) {
   _root_processor.process_all_roots(&_adjust, &adjust_cld, &adjust_code);
 
   // Now adjust pointers region by region
-  G1AdjustRegionClosure blk(collector(), worker_id);
+  G1AdjustRegionClosure blk(collector());
   G1CollectedHeap::heap()->heap_region_par_iterate_from_worker_offset(&blk, &_hrclaimer, worker_id);
   log_task("Adjust task", worker_id, start);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -40,7 +40,7 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _bitmap(collector->mark_bitmap()),
     _task_queue(),
     _partial_array_splitter(collector->partial_array_state_manager(), collector->workers()),
-    _mark_closure(worker_id, this, ClassLoaderData::_claim_stw_fullgc_mark, G1CollectedHeap::heap()->ref_processor_stw()),
+    _mark_closure(this, ClassLoaderData::_claim_stw_fullgc_mark, G1CollectedHeap::heap()->ref_processor_stw()),
     _stack_closure(this),
     _cld_closure(mark_closure(), ClassLoaderData::_claim_stw_fullgc_mark),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,13 +60,11 @@ public:
 
 class G1MarkAndPushClosure : public ClaimMetadataVisitingOopIterateClosure {
   G1FullGCMarker* _marker;
-  uint _worker_id;
 
 public:
-  G1MarkAndPushClosure(uint worker_id, G1FullGCMarker* marker, int claim, ReferenceDiscoverer* ref) :
+  G1MarkAndPushClosure(G1FullGCMarker* marker, int claim, ReferenceDiscoverer* ref) :
     ClaimMetadataVisitingOopIterateClosure(claim, ref),
-    _marker(marker),
-    _worker_id(worker_id) { }
+    _marker(marker) { }
 
   template <class T> inline void do_oop_work(T* p);
   virtual void do_oop(oop* p);

--- a/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ class G1EvacPhaseTimesTracker : public G1GCParPhaseTimesTracker {
 
   G1EvacPhaseWithTrimTimeTracker _trim_tracker;
 public:
-  G1EvacPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1ParScanThreadState* pss, G1GCPhaseTimes::GCParPhases phase, uint worker_id);
+  G1EvacPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1ParScanThreadState* par_scan_state, G1GCPhaseTimes::GCParPhases phase);
   virtual ~G1EvacPhaseTimesTracker();
 };
 

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -581,14 +581,14 @@ const char* G1GCPhaseTimes::phase_name(GCParPhases phase) {
   return phase_times->_gc_par_phases[phase]->short_name();
 }
 
-G1EvacPhaseWithTrimTimeTracker::G1EvacPhaseWithTrimTimeTracker(G1ParScanThreadState* pss, Tickspan& total_time, Tickspan& trim_time) :
-  _pss(pss),
+G1EvacPhaseWithTrimTimeTracker::G1EvacPhaseWithTrimTimeTracker(G1ParScanThreadState* par_scan_state, Tickspan& total_time, Tickspan& trim_time) :
+  _par_scan_state(par_scan_state),
   _start(Ticks::now()),
   _total_time(total_time),
   _trim_time(trim_time),
   _stopped(false) {
 
-  assert(_pss->trim_ticks().value() == 0, "Possibly remaining trim ticks left over from previous use");
+  assert(_par_scan_state->trim_ticks().value() == 0, "Possibly remaining trim ticks left over from previous use");
 }
 
 G1EvacPhaseWithTrimTimeTracker::~G1EvacPhaseWithTrimTimeTracker() {
@@ -599,9 +599,9 @@ G1EvacPhaseWithTrimTimeTracker::~G1EvacPhaseWithTrimTimeTracker() {
 
 void G1EvacPhaseWithTrimTimeTracker::stop() {
   assert(!_stopped, "Should only be called once");
-  _total_time += (Ticks::now() - _start) - _pss->trim_ticks();
-  _trim_time += _pss->trim_ticks();
-  _pss->reset_trim_ticks();
+  _total_time += (Ticks::now() - _start) - _par_scan_state->trim_ticks();
+  _trim_time += _par_scan_state->trim_ticks();
+  _par_scan_state->reset_trim_ticks();
   _stopped = true;
 }
 
@@ -625,9 +625,8 @@ G1GCParPhaseTimesTracker::~G1GCParPhaseTimesTracker() {
 
 G1EvacPhaseTimesTracker::G1EvacPhaseTimesTracker(G1GCPhaseTimes* phase_times,
                                                  G1ParScanThreadState* pss,
-                                                 G1GCPhaseTimes::GCParPhases phase,
-                                                 uint worker_id) :
-  G1GCParPhaseTimesTracker(phase_times, phase, worker_id),
+                                                 G1GCPhaseTimes::GCParPhases phase) :
+  G1GCParPhaseTimesTracker(phase_times, phase, pss->worker_id()),
   _total_time(),
   _trim_time(),
   _trim_tracker(pss, _total_time, _trim_time) {

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -413,7 +413,7 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 };
 
 class G1EvacPhaseWithTrimTimeTracker : public StackObj {
-  G1ParScanThreadState* _pss;
+  G1ParScanThreadState* _par_scan_state;
   Ticks _start;
 
   Tickspan& _total_time;
@@ -421,7 +421,7 @@ class G1EvacPhaseWithTrimTimeTracker : public StackObj {
 
   bool _stopped;
 public:
-  G1EvacPhaseWithTrimTimeTracker(G1ParScanThreadState* pss, Tickspan& total_time, Tickspan& trim_time);
+  G1EvacPhaseWithTrimTimeTracker(G1ParScanThreadState* par_scan_state, Tickspan& total_time, Tickspan& trim_time);
   ~G1EvacPhaseWithTrimTimeTracker();
 
   void stop();

--- a/src/hotspot/share/gc/g1/g1NMethodClosure.cpp
+++ b/src/hotspot/share/gc/g1/g1NMethodClosure.cpp
@@ -28,10 +28,16 @@
 #include "gc/g1/g1HeapRegion.hpp"
 #include "gc/g1/g1HeapRegionRemSet.inline.hpp"
 #include "gc/g1/g1NMethodClosure.hpp"
+#include "gc/g1/g1ParScanThreadState.inline.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/oop.inline.hpp"
+
+G1NMethodClosure::G1NMethodClosure(OopClosure* oc, bool strong, G1ParScanThreadState* par_scan_state) :
+  _oc(oc, par_scan_state),
+  _marking_oc(par_scan_state->worker_id()),
+  _strong(strong) { }
 
 template <typename T>
 void G1NMethodClosure::HeapRegionGatheringOopClosure::do_oop_work(T* p) {
@@ -65,17 +71,17 @@ void G1NMethodClosure::HeapRegionGatheringOopClosure::do_oop_work(T* p) {
   }
 }
 
-G1NMethodClosure::HeapRegionGatheringOopClosure::HeapRegionGatheringOopClosure(OopClosure* oc, G1ParScanThreadState* pss) :
+G1NMethodClosure::HeapRegionGatheringOopClosure::HeapRegionGatheringOopClosure(OopClosure* oc, G1ParScanThreadState* par_scan_state) :
   _g1h(G1CollectedHeap::heap()),
   _work(oc),
-  _pss(pss),
+  _par_scan_state(par_scan_state),
   _nm(nullptr),
   _affected_regions(5) {
 }
 
 void G1NMethodClosure::HeapRegionGatheringOopClosure::add_to_remsets() {
   while (!_affected_regions.is_empty()) {
-    _pss->remember_nmethod_into_region(_affected_regions.pop(), _nm);
+    _par_scan_state->remember_nmethod_into_region(_affected_regions.pop(), _nm);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1NMethodClosure.hpp
+++ b/src/hotspot/share/gc/g1/g1NMethodClosure.hpp
@@ -38,7 +38,7 @@ class G1NMethodClosure : public NMethodClosure {
   class HeapRegionGatheringOopClosure : public OopClosure {
     G1CollectedHeap* _g1h;
     OopClosure* _work;
-    G1ParScanThreadState* _pss;
+    G1ParScanThreadState* _par_scan_state;
 
     nmethod* _nm;
     GrowableArrayCHeap<G1HeapRegion*, mtGC> _affected_regions;
@@ -47,7 +47,7 @@ class G1NMethodClosure : public NMethodClosure {
     void do_oop_work(T* p);
 
   public:
-    HeapRegionGatheringOopClosure(OopClosure* oc, G1ParScanThreadState* pss);
+    HeapRegionGatheringOopClosure(OopClosure* oc, G1ParScanThreadState* par_scan_state);
     ~HeapRegionGatheringOopClosure() = default;
 
     void do_oop(oop* o);
@@ -81,8 +81,7 @@ class G1NMethodClosure : public NMethodClosure {
 
   bool _strong;
 public:
-  G1NMethodClosure(uint worker_id, OopClosure* oc, bool strong, G1ParScanThreadState* pss) :
-    _oc(oc, pss), _marking_oc(worker_id), _strong(strong) { }
+  G1NMethodClosure(OopClosure* oc, bool strong, G1ParScanThreadState* par_scan_state);
 
   void do_evacuation_and_fixup(nmethod* nm);
   void do_marking(nmethod* nm);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -679,17 +679,17 @@ void G1ParScanThreadStateSet::par_iterate_nmethod_regions_to_add(G1HeapRegionClo
 }
 
 void G1ParScanThreadStateSet::record_unused_optional_region(G1HeapRegion* hr) {
-  for (uint worker_index = 0; worker_index < _num_workers; ++worker_index) {
-    G1ParScanThreadState* pss = _states[worker_index];
+  for (uint worker_id = 0; worker_id < _num_workers; ++worker_id) {
+    G1ParScanThreadState* pss = _states[worker_id];
     assert(pss != nullptr, "must be initialized");
 
     size_t used_memory = pss->oops_into_optional_region(hr)->used_memory();
-    _g1h->phase_times()->record_or_add_thread_work_item(G1GCPhaseTimes::OptScanHR, worker_index, used_memory, G1GCPhaseTimes::ScanHRUsedMemory);
+    _g1h->phase_times()->record_or_add_thread_work_item(G1GCPhaseTimes::OptScanHR, worker_id, used_memory, G1GCPhaseTimes::ScanHRUsedMemory);
   }
 }
 
-void G1ParScanThreadState::record_evacuation_failed_region(G1HeapRegion* r, uint worker_id, bool cause_pinned) {
-  if (_evac_failure_regions->record(worker_id, r->hrm_index(), cause_pinned)) {
+void G1ParScanThreadState::record_evacuation_failed_region(G1HeapRegion* r, bool cause_pinned) {
+  if (_evac_failure_regions->record(worker_id(), r->hrm_index(), cause_pinned)) {
     G1HeapRegionPrinter::evac_failure(r);
   }
 }
@@ -703,7 +703,7 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, Kla
     // Forward-to-self succeeded. We are the "owner" of the object.
     G1HeapRegion* r = _g1h->heap_region_containing(old);
 
-    record_evacuation_failed_region(r, _worker_id, cause_pinned);
+    record_evacuation_failed_region(r, cause_pinned);
 
     // Mark the failing object in the marking bitmap and later use the bitmap to handle
     // evacuation failure recovery.

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -250,7 +250,7 @@ public:
   Tickspan trim_ticks() const;
   void reset_trim_ticks();
 
-  void record_evacuation_failed_region(G1HeapRegion* r, uint worker_id, bool cause_pinned);
+  void record_evacuation_failed_region(G1HeapRegion* r, bool cause_pinned);
   // An attempt to evacuate "obj" has failed; take necessary steps.
   oop handle_evacuation_failure_par(oop obj, markWord m, Klass* klass, G1HeapRegionAttr attr, size_t word_sz, bool cause_pinned);
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -398,13 +398,9 @@ class G1ScanHRForRegionClosure : public G1HeapRegionClosure {
   G1CollectedHeap* _g1h;
   G1CardTable* _ct;
 
-  G1ParScanThreadState* _pss;
-
   G1RemSetScanState* _scan_state;
 
-  G1GCPhaseTimes::GCParPhases _phase;
-
-  uint   _worker_id;
+  G1ParScanThreadState* _pss;
 
   size_t _cards_pending;
   size_t _cards_empty;
@@ -493,15 +489,11 @@ class G1ScanHRForRegionClosure : public G1HeapRegionClosure {
 public:
   G1ScanHRForRegionClosure(G1RemSetScanState* scan_state,
                            G1ParScanThreadState* pss,
-                           uint worker_id,
-                           G1GCPhaseTimes::GCParPhases phase,
                            bool remember_already_scanned_cards) :
     _g1h(G1CollectedHeap::heap()),
     _ct(_g1h->card_table()),
-    _pss(pss),
     _scan_state(scan_state),
-    _phase(phase),
-    _worker_id(worker_id),
+    _pss(pss),
     _cards_pending(0),
     _cards_empty(0),
     _cards_scanned(0),
@@ -540,12 +532,13 @@ public:
 };
 
 void G1RemSet::scan_heap_roots(G1ParScanThreadState* pss,
-                               uint worker_id,
                                G1GCPhaseTimes::GCParPhases scan_phase,
                                G1GCPhaseTimes::GCParPhases objcopy_phase,
                                bool remember_already_scanned_cards) {
+  uint worker_id = pss->worker_id();
+
   EventGCPhaseParallel event;
-  G1ScanHRForRegionClosure cl(_scan_state, pss, worker_id, scan_phase, remember_already_scanned_cards);
+  G1ScanHRForRegionClosure cl(_scan_state, pss, remember_already_scanned_cards);
   _scan_state->iterate_dirty_regions_from(&cl, worker_id);
 
   event.commit(GCId::current(), worker_id, G1GCPhaseTimes::phase_name(scan_phase));
@@ -587,19 +580,12 @@ public:
 // increment to fix up non-card related roots.
 class G1ScanCodeRootsClosure : public G1HeapRegionClosure {
   G1ParScanThreadState* _pss;
-  G1RemSetScanState* _scan_state;
-
-  uint _worker_id;
 
   size_t _code_roots_scanned;
 
 public:
-  G1ScanCodeRootsClosure(G1RemSetScanState* scan_state,
-                         G1ParScanThreadState* pss,
-                         uint worker_id) :
+  G1ScanCodeRootsClosure(G1ParScanThreadState* pss) :
     _pss(pss),
-    _scan_state(scan_state),
-    _worker_id(worker_id),
     _code_roots_scanned(0) { }
 
   bool do_heap_region(G1HeapRegion* r) {
@@ -614,7 +600,6 @@ public:
 };
 
 void G1RemSet::scan_collection_set_code_roots(G1ParScanThreadState* pss,
-                                              uint worker_id,
                                               G1GCPhaseTimes::GCParPhases coderoots_phase,
                                               G1GCPhaseTimes::GCParPhases objcopy_phase) {
   EventGCPhaseParallel event;
@@ -622,10 +607,11 @@ void G1RemSet::scan_collection_set_code_roots(G1ParScanThreadState* pss,
   Tickspan code_root_trim_partially_time;
 
   G1GCPhaseTimes* p = _g1h->phase_times();
+  uint worker_id = pss->worker_id();
   {
     G1EvacPhaseWithTrimTimeTracker timer(pss, code_root_scan_time, code_root_trim_partially_time);
 
-    G1ScanCodeRootsClosure cl(_scan_state, pss, worker_id);
+    G1ScanCodeRootsClosure cl(pss);
     // Code roots work distribution occurs inside the iteration method. So scan all collection
     // set regions for all threads.
     _g1h->collection_set_iterate_increment_from(&cl, worker_id);
@@ -644,10 +630,6 @@ void G1RemSet::scan_collection_set_code_roots(G1ParScanThreadState* pss,
 class G1ScanOptionalRemSetRootsClosure : public G1HeapRegionClosure {
   G1ParScanThreadState* _pss;
 
-  uint _worker_id;
-
-  G1GCPhaseTimes::GCParPhases _scan_phase;
-
   size_t _opt_roots_scanned;
 
   size_t _opt_refs_scanned;
@@ -663,12 +645,8 @@ class G1ScanOptionalRemSetRootsClosure : public G1HeapRegionClosure {
   }
 
 public:
-  G1ScanOptionalRemSetRootsClosure(G1ParScanThreadState* pss,
-                                   uint worker_id,
-                                   G1GCPhaseTimes::GCParPhases scan_phase) :
+  G1ScanOptionalRemSetRootsClosure(G1ParScanThreadState* pss) :
     _pss(pss),
-    _worker_id(worker_id),
-    _scan_phase(scan_phase),
     _opt_roots_scanned(0),
     _opt_refs_scanned(0),
     _opt_refs_memory_used(0) { }
@@ -686,7 +664,6 @@ public:
 };
 
 void G1RemSet::scan_collection_set_optional_roots(G1ParScanThreadState* pss,
-                                                  uint worker_id,
                                                   G1GCPhaseTimes::GCParPhases scan_phase,
                                                   G1GCPhaseTimes::GCParPhases objcopy_phase) {
   assert(scan_phase == G1GCPhaseTimes::OptScanHR, "must be");
@@ -699,7 +676,8 @@ void G1RemSet::scan_collection_set_optional_roots(G1ParScanThreadState* pss,
 
   G1GCPhaseTimes* p = _g1h->phase_times();
 
-  G1ScanOptionalRemSetRootsClosure cl(pss, worker_id, scan_phase);
+  G1ScanOptionalRemSetRootsClosure cl(pss);
+  uint worker_id = pss->worker_id();
   // The individual references for the optional remembered set are per-worker, so every worker
   // always need to scan all regions (no claimer).
   _g1h->collection_set_iterate_increment_from(&cl, worker_id);

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,6 @@ public:
   // Scan all cards in the non-collection set regions that potentially contain
   // references into the current whole collection set.
   void scan_heap_roots(G1ParScanThreadState* pss,
-                       uint worker_id,
                        G1GCPhaseTimes::GCParPhases scan_phase,
                        G1GCPhaseTimes::GCParPhases objcopy_phase,
                        bool remember_already_scanned_cards);
@@ -109,12 +108,10 @@ public:
   // Do work for regions in the current increment of the collection set, scanning
   // non-card based (heap) roots.
   void scan_collection_set_code_roots(G1ParScanThreadState* pss,
-                                      uint worker_id,
                                       G1GCPhaseTimes::GCParPhases coderoots_phase,
                                       G1GCPhaseTimes::GCParPhases objcopy_phase);
 
   void scan_collection_set_optional_roots(G1ParScanThreadState* pss,
-                                          uint worker_id,
                                           G1GCPhaseTimes::GCParPhases scan_phase,
                                           G1GCPhaseTimes::GCParPhases objcopy_phase);
 

--- a/src/hotspot/share/gc/g1/g1RootProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.cpp
@@ -52,12 +52,13 @@ G1RootProcessor::G1RootProcessor(G1CollectedHeap* g1h, bool is_parallel) :
     _threads_claim_token_scope(),
     _is_parallel(is_parallel) {}
 
-void G1RootProcessor::evacuate_roots(G1ParScanThreadState* pss, uint worker_id) {
+void G1RootProcessor::evacuate_roots(G1ParScanThreadState* pss) {
   G1GCPhaseTimes* phase_times = _g1h->phase_times();
 
-  G1EvacPhaseTimesTracker timer(phase_times, pss, G1GCPhaseTimes::ExtRootScan, worker_id);
+  G1EvacPhaseTimesTracker timer(phase_times, pss, G1GCPhaseTimes::ExtRootScan);
 
   G1EvacuationRootClosures* closures = pss->closures();
+  uint worker_id = pss->worker_id();
   process_java_roots(closures, phase_times, worker_id);
 
   process_vm_roots(closures, phase_times, worker_id);

--- a/src/hotspot/share/gc/g1/g1RootProcessor.hpp
+++ b/src/hotspot/share/gc/g1/g1RootProcessor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public:
   // Apply correct closures from pss to the strongly and weakly reachable roots in the system
   // in a single pass.
   // Record and report timing measurements for sub phases using worker_id.
-  void evacuate_roots(G1ParScanThreadState* pss, uint worker_id);
+  void evacuate_roots(G1ParScanThreadState* pss);
 
   // Apply oops, clds and blobs to all strongly reachable roots in the system
   void process_strong_roots(OopClosure* oops,

--- a/src/hotspot/share/gc/g1/g1SharedClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1SharedClosures.hpp
@@ -55,7 +55,7 @@ public:
     _oops_in_cld(g1h, pss),
     _oops_in_nmethod(g1h, pss),
     _clds(&_oops_in_cld, process_only_dirty),
-    _nmethods(pss->worker_id(), &_oops_in_nmethod, should_mark, pss) {}
+    _nmethods(&_oops_in_nmethod, should_mark, pss) {}
 };
 
 #endif // SHARE_GC_G1_G1SHAREDCLOSURES_HPP

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -577,7 +577,6 @@ class G1ParEvacuateFollowersClosure : public VoidClosure {
   void start_term_time() { _term_attempts++; _start_term = os::elapsedTime(); }
   void end_term_time() { _term_time += (os::elapsedTime() - _start_term); }
 
-  G1CollectedHeap*              _g1h;
   G1ParScanThreadState*         _par_scan_state;
   G1ScannerTasksQueueSet*       _queues;
   TaskTerminator*               _terminator;
@@ -589,22 +588,20 @@ class G1ParEvacuateFollowersClosure : public VoidClosure {
 
   inline bool offer_termination() {
     EventGCPhaseParallel event;
-    G1ParScanThreadState* const pss = par_scan_state();
     start_term_time();
     const bool res = (terminator() == nullptr) ? true : terminator()->offer_termination();
     end_term_time();
-    event.commit(GCId::current(), pss->worker_id(), G1GCPhaseTimes::phase_name(G1GCPhaseTimes::Termination));
+    event.commit(GCId::current(), par_scan_state()->worker_id(), G1GCPhaseTimes::phase_name(G1GCPhaseTimes::Termination));
     return res;
   }
 
 public:
-  G1ParEvacuateFollowersClosure(G1CollectedHeap* g1h,
-                                G1ParScanThreadState* par_scan_state,
+  G1ParEvacuateFollowersClosure(G1ParScanThreadState* par_scan_state,
                                 G1ScannerTasksQueueSet* queues,
                                 TaskTerminator* terminator,
                                 G1GCPhaseTimes::GCParPhases phase)
     : _start_term(0.0), _term_time(0.0), _term_attempts(0),
-      _g1h(g1h), _par_scan_state(par_scan_state),
+      _par_scan_state(par_scan_state),
       _queues(queues), _terminator(terminator), _phase(phase) {}
 
   void do_void() {
@@ -629,23 +626,22 @@ class G1EvacuateRegionsBaseTask : public WorkerTask {
   // regions as there is no guarantee that there is a reference reachable by
   // Java code (i.e. only by native code) that adds it to the evacuation failed
   // regions.
-  void record_pinned_regions(G1ParScanThreadState* pss, uint worker_id) {
+  void record_pinned_regions(G1ParScanThreadState* pss) {
     class RecordPinnedRegionClosure : public G1HeapRegionClosure {
       G1ParScanThreadState* _pss;
-      uint _worker_id;
 
     public:
-      RecordPinnedRegionClosure(G1ParScanThreadState* pss, uint worker_id) : _pss(pss), _worker_id(worker_id) { }
+      RecordPinnedRegionClosure(G1ParScanThreadState* pss) : _pss(pss) { }
 
       bool do_heap_region(G1HeapRegion* r) {
         if (r->has_pinned_objects()) {
-          _pss->record_evacuation_failed_region(r, _worker_id, true /* cause_pinned */);
+          _pss->record_evacuation_failed_region(r, true /* cause_pinned */);
         }
         return false;
       }
-    } cl(pss, worker_id);
+    } cl(pss);
 
-    _g1h->collection_set_iterate_increment_from(&cl, worker_id);
+    _g1h->collection_set_iterate_increment_from(&cl, pss->worker_id());
   }
 
 protected:
@@ -656,18 +652,18 @@ protected:
   TaskTerminator _terminator;
 
   void evacuate_live_objects(G1ParScanThreadState* pss,
-                             uint worker_id,
                              G1GCPhaseTimes::GCParPhases objcopy_phase,
                              G1GCPhaseTimes::GCParPhases termination_phase) {
     G1GCPhaseTimes* p = _g1h->phase_times();
 
     Ticks start = Ticks::now();
-    G1ParEvacuateFollowersClosure cl(_g1h, pss, _task_queues, &_terminator, objcopy_phase);
+    G1ParEvacuateFollowersClosure cl(pss, _task_queues, &_terminator, objcopy_phase);
     cl.do_void();
 
     assert(pss->queue_is_empty(), "should be empty");
 
     Tickspan evac_time = (Ticks::now() - start);
+    uint worker_id = pss->worker_id();
     p->record_or_add_time_secs(objcopy_phase, worker_id, evac_time.seconds() - cl.term_time());
 
     if (termination_phase == G1GCPhaseTimes::Termination) {
@@ -686,9 +682,9 @@ protected:
 
   virtual void end_work(uint worker_id) { }
 
-  virtual void scan_roots(G1ParScanThreadState* pss, uint worker_id) = 0;
+  virtual void scan_roots(G1ParScanThreadState* pss) = 0;
 
-  virtual void evacuate_live_objects(G1ParScanThreadState* pss, uint worker_id) = 0;
+  virtual void evacuate_live_objects(G1ParScanThreadState* pss) = 0;
 
 private:
   Atomic<bool> _pinned_regions_recorded;
@@ -716,10 +712,10 @@ public:
       pss->set_ref_discoverer(_g1h->ref_processor_stw());
 
       if (_pinned_regions_recorded.compare_set(false, true)) {
-        record_pinned_regions(pss, worker_id);
+        record_pinned_regions(pss);
       }
-      scan_roots(pss, worker_id);
-      evacuate_live_objects(pss, worker_id);
+      scan_roots(pss);
+      evacuate_live_objects(pss);
     }
 
     end_work(worker_id);
@@ -730,29 +726,26 @@ class G1EvacuateRegionsTask : public G1EvacuateRegionsBaseTask {
   G1RootProcessor* _root_processor;
   bool _has_optional_evacuation_work;
 
-  void scan_roots(G1ParScanThreadState* pss, uint worker_id) {
-    _root_processor->evacuate_roots(pss, worker_id);
-    _g1h->rem_set()->scan_heap_roots(pss, worker_id, G1GCPhaseTimes::ScanHR, G1GCPhaseTimes::ObjCopy, _has_optional_evacuation_work);
-    _g1h->rem_set()->scan_collection_set_code_roots(pss, worker_id, G1GCPhaseTimes::CodeRoots, G1GCPhaseTimes::ObjCopy);
+  void scan_roots(G1ParScanThreadState* pss) {
+    _root_processor->evacuate_roots(pss);
+    _g1h->rem_set()->scan_heap_roots(pss, G1GCPhaseTimes::ScanHR, G1GCPhaseTimes::ObjCopy, _has_optional_evacuation_work);
+    _g1h->rem_set()->scan_collection_set_code_roots(pss, G1GCPhaseTimes::CodeRoots, G1GCPhaseTimes::ObjCopy);
     // There are no optional roots to scan right now.
 #ifdef ASSERT
     class VerifyOptionalCollectionSetRootsEmptyClosure : public G1HeapRegionClosure {
-      G1ParScanThreadState* _pss;
-
     public:
-      VerifyOptionalCollectionSetRootsEmptyClosure(G1ParScanThreadState* pss) : _pss(pss) { }
 
       bool do_heap_region(G1HeapRegion* r) override {
         assert(!r->has_index_in_opt_cset(), "must be");
         return false;
       }
-    } cl(pss);
-    _g1h->collection_set_iterate_increment_from(&cl, worker_id);
+    } cl;
+    _g1h->collection_set_iterate_increment_from(&cl, pss->worker_id());
 #endif
   }
 
-  void evacuate_live_objects(G1ParScanThreadState* pss, uint worker_id) {
-    G1EvacuateRegionsBaseTask::evacuate_live_objects(pss, worker_id, G1GCPhaseTimes::ObjCopy, G1GCPhaseTimes::Termination);
+  void evacuate_live_objects(G1ParScanThreadState* pss) {
+    G1EvacuateRegionsBaseTask::evacuate_live_objects(pss, G1GCPhaseTimes::ObjCopy, G1GCPhaseTimes::Termination);
   }
 
   void start_work(uint worker_id) {
@@ -764,8 +757,7 @@ class G1EvacuateRegionsTask : public G1EvacuateRegionsBaseTask {
   }
 
 public:
-  G1EvacuateRegionsTask(G1CollectedHeap* g1h,
-                        G1ParScanThreadStateSet* per_thread_states,
+  G1EvacuateRegionsTask(G1ParScanThreadStateSet* per_thread_states,
                         G1ScannerTasksQueueSet* task_queues,
                         G1RootProcessor* root_processor,
                         uint num_workers,
@@ -788,8 +780,7 @@ void G1YoungCollector::evacuate_initial_collection_set(G1ParScanThreadStateSet* 
   Ticks start_processing = Ticks::now();
   {
     G1RootProcessor root_processor(_g1h, num_workers > 1 /* is_parallel */);
-    G1EvacuateRegionsTask g1_par_task(_g1h,
-                                      per_thread_states,
+    G1EvacuateRegionsTask g1_par_task(per_thread_states,
                                       task_queues(),
                                       &root_processor,
                                       num_workers,
@@ -811,14 +802,14 @@ void G1YoungCollector::evacuate_initial_collection_set(G1ParScanThreadStateSet* 
 
 class G1EvacuateOptionalRegionsTask : public G1EvacuateRegionsBaseTask {
 
-  void scan_roots(G1ParScanThreadState* pss, uint worker_id) {
-    _g1h->rem_set()->scan_heap_roots(pss, worker_id, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::OptObjCopy, true /* remember_already_scanned_cards */);
-    _g1h->rem_set()->scan_collection_set_code_roots(pss, worker_id, G1GCPhaseTimes::OptCodeRoots, G1GCPhaseTimes::OptObjCopy);
-    _g1h->rem_set()->scan_collection_set_optional_roots(pss, worker_id, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::ObjCopy);
+  void scan_roots(G1ParScanThreadState* pss) {
+    _g1h->rem_set()->scan_heap_roots(pss, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::OptObjCopy, true /* remember_already_scanned_cards */);
+    _g1h->rem_set()->scan_collection_set_code_roots(pss, G1GCPhaseTimes::OptCodeRoots, G1GCPhaseTimes::OptObjCopy);
+    _g1h->rem_set()->scan_collection_set_optional_roots(pss, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::ObjCopy);
   }
 
-  void evacuate_live_objects(G1ParScanThreadState* pss, uint worker_id) {
-    G1EvacuateRegionsBaseTask::evacuate_live_objects(pss, worker_id, G1GCPhaseTimes::OptObjCopy, G1GCPhaseTimes::OptTermination);
+  void evacuate_live_objects(G1ParScanThreadState* pss) {
+    G1EvacuateRegionsBaseTask::evacuate_live_objects(pss, G1GCPhaseTimes::OptObjCopy, G1GCPhaseTimes::OptTermination);
   }
 
 public:
@@ -979,7 +970,7 @@ public:
     G1STWIsAliveClosure is_alive(&_g1h);
     G1CopyingKeepAliveClosure keep_alive(&_g1h, pss);
     G1EnqueueDiscoveredFieldClosure enqueue(&_g1h, pss);
-    G1ParEvacuateFollowersClosure complete_gc(&_g1h, pss, &_task_queues, _tm == RefProcThreadModel::Single ? nullptr : &_terminator, G1GCPhaseTimes::ObjCopy);
+    G1ParEvacuateFollowersClosure complete_gc(pss, &_task_queues, _tm == RefProcThreadModel::Single ? nullptr : &_terminator, G1GCPhaseTimes::ObjCopy);
     _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &enqueue, &complete_gc);
 
     // We have completed copying any necessary live referent objects.


### PR DESCRIPTION
Hi all,

  please review this cleanup that removes redundant passing of both `G1ParScanThreadState` and a `worker-id` in signatures. Further it removes some stale `worker-id` class members that are unused except for assigning them during construction time.
Finally, some dead code in touched methods has been removed.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387856](https://bugs.openjdk.org/browse/JDK-8387856): G1: Fix passing G1ParScanThreadState and worker_id in methods (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31840/head:pull/31840` \
`$ git checkout pull/31840`

Update a local copy of the PR: \
`$ git checkout pull/31840` \
`$ git pull https://git.openjdk.org/jdk.git pull/31840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31840`

View PR using the GUI difftool: \
`$ git pr show -t 31840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31840.diff">https://git.openjdk.org/jdk/pull/31840.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31840#issuecomment-4923746848)
</details>
