### PR TITLE
8387977: The java manpage should describe the new main method variants

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -90,30 +90,36 @@ To launch a source-file program:
 
 ## Description
 
-The `java` command starts a Java application. It does this by starting the Java
-Virtual Machine (JVM), loading the specified class, and calling that
-class's `main()` method. The method must be declared `public` and `static`, it
-must not return any value, and it must accept a `String` array as a parameter.
-The method declaration has the following form:
+The `java` command launches a Java application. It does this by starting the Java
+Virtual Machine (JVM), loading the main class of the application, and calling
+that class's `main()` method.
 
->   `public static void main(String[] args)`
+By default, the first argument that isn't an option of the `java` command indicates
+the fully qualified name of the main class. If `-jar` is specified, then its
+argument is the name of the JAR file containing class and resource files for the
+application, and the main class is indicated by the `Main-Class` attribute in
+the manifest of the JAR file.
 
-In source-file mode, the `java` command can launch a class declared in a source
-file. See [Using Source-File Mode to Launch Source-Code Programs]
-for a description of using the source-file mode.
+Arguments after the main class name or the JAR file name are passed to
+the `main()` method. The `main()` method may be a static method or an instance
+method. It must accept either a `String` array as a parameter, or no parameters.
+It must not return any value, and must have `public`, `protected`, or package access.
+The method declaration typically has one of the following forms:
 
-> **Note:** You can use the `JDK_JAVA_OPTIONS` launcher environment variable to prepend its
-content to the actual command line of the `java` launcher. See [Using the
-JDK\_JAVA\_OPTIONS Launcher Environment Variable].
+>    `public static void main(String[] args)`
+>
+>    `void main(String[] args)`
+>
+>    `void main()`
 
-By default, the first argument that isn't an option of the `java` command is
-the fully qualified name of the class to be called. If `-jar` is specified,
-then its argument is the name of the JAR file containing class and resource
-files for the application. The startup class must be indicated by the
-`Main-Class` manifest header in its manifest file.
+In source-file mode, the `java` command can launch an application whose main class
+is provided as source code instead of a class file.
+See [Using Source-File Mode to Launch Source-Code Programs] for a description of
+using the source-file mode.
 
-Arguments after the class file name or the JAR file name are passed to the
-`main()` method.
+> **Note:** You can use the `JDK_JAVA_OPTIONS` launcher environment variable to
+prepend its content to the actual command line of the java launcher.
+See [Using the JDK\_JAVA\_OPTIONS Launcher Environment Variable].
 
 ### `javaw`
 

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -100,13 +100,16 @@ argument is the name of the JAR file containing class and resource files for the
 application, and the main class is indicated by the `Main-Class` attribute in
 the manifest of the JAR file.
 
-Arguments after the main class name or the JAR file name are passed to
-the `main()` method. The `main()` method may be a static method or an instance
-method. It must accept either a `String` array as a parameter, or no parameters.
-It must not return any value, and must have `public`, `protected`, or package access.
-The method declaration typically has one of the following forms:
+The `main()` method may be a static method or an instance method. It may
+declare a `String` array parameter for arguments passed to the `java`
+command after the main class name or the JAR file name; alternatively,
+it may declare no parameters. It must not return any value, and must
+have `public`, `protected`, or package access. The method declaration
+typically has one of the following forms:
 
 >    `public static void main(String[] args)`
+>
+>    `public static void main()`
 >
 >    `void main(String[] args)`
 >


### PR DESCRIPTION
The `java`' man page does not speak about the new forms of main method, this PR updates it to include these new forms, and also generally updates the text. This was noted and written by abuckley.

I am attaching images how the rendered man page looks in HTML and in a terminal:
<img width="2785" height="372" alt="html" src="https://github.com/user-attachments/assets/cd7c73c5-ab9c-4f80-848d-5ab0021317be" />
<img width="3184" height="398" alt="man" src="https://github.com/user-attachments/assets/b3668c4f-fcb9-4bef-8208-d007af43e2b1" />

/contributor add abuckley

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387977](https://bugs.openjdk.org/browse/JDK-8387977): The java manpage should describe the new main method variants (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Contributors
 * Alex Buckley `<abuckley@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31841/head:pull/31841` \
`$ git checkout pull/31841`

Update a local copy of the PR: \
`$ git checkout pull/31841` \
`$ git pull https://git.openjdk.org/jdk.git pull/31841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31841`

View PR using the GUI difftool: \
`$ git pr show -t 31841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31841.diff">https://git.openjdk.org/jdk/pull/31841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31841#issuecomment-4923921198)
</details>
