### PR TITLE
8387860: G1: G1ConcurrentMark padding should use variables instead of types

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -144,7 +144,7 @@ private:
     Atomic<TaskQueueEntryChunk*>* _buckets;
     char _pad0[DEFAULT_PADDING_SIZE];
     Atomic<size_t> _size;
-    char _pad4[DEFAULT_PADDING_SIZE - sizeof(size_t)];
+    char _pad4[DEFAULT_PADDING_SIZE - sizeof(_size)];
 
     size_t bucket_size(size_t bucket) {
       return (bucket == 0) ?
@@ -211,10 +211,10 @@ private:
 
   char _pad0[DEFAULT_PADDING_SIZE];
   Atomic<TaskQueueEntryChunk*> _free_list;  // Linked list of free chunks that can be allocated by users.
-  char _pad1[DEFAULT_PADDING_SIZE - sizeof(TaskQueueEntryChunk*)];
+  char _pad1[DEFAULT_PADDING_SIZE - sizeof(_free_list)];
   Atomic<TaskQueueEntryChunk*> _chunk_list; // List of chunks currently containing data.
   Atomic<size_t> _chunks_in_chunk_list;
-  char _pad2[DEFAULT_PADDING_SIZE - sizeof(TaskQueueEntryChunk*) - sizeof(_chunks_in_chunk_list)];
+  char _pad2[DEFAULT_PADDING_SIZE - sizeof(_chunk_list) - sizeof(_chunks_in_chunk_list)];
 
   // Atomically add the given chunk to the list.
   void add_chunk_to_list(Atomic<TaskQueueEntryChunk*>* list, TaskQueueEntryChunk* elem);


### PR DESCRIPTION
Hi all,

  please review this change that changes padding calculation to use member names, not member types, to avoid future problems with type changes in that area.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387860](https://bugs.openjdk.org/browse/JDK-8387860): G1: G1ConcurrentMark padding should use variables instead of types (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31844/head:pull/31844` \
`$ git checkout pull/31844`

Update a local copy of the PR: \
`$ git checkout pull/31844` \
`$ git pull https://git.openjdk.org/jdk.git pull/31844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31844`

View PR using the GUI difftool: \
`$ git pr show -t 31844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31844.diff">https://git.openjdk.org/jdk/pull/31844.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31844#issuecomment-4924559164)
</details>
