### PR TITLE
8387876: Remove psapi lib

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
   if test "x$OPENJDK_TARGET_OS" = xwindows; then
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS kernel32.lib user32.lib gdi32.lib winspool.lib \
         comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib powrprof.lib uuid.lib \
-        ws2_32.lib winmm.lib version.lib psapi.lib"
+        ws2_32.lib winmm.lib version.lib"
   fi
   LIB_SETUP_JVM_LIBS(BUILD)
   LIB_SETUP_JVM_LIBS(TARGET)

--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT, \
     OPTIMIZATION := HIGH, \
     JDK_LIBS := java.base:libjava java.base:libjvm, \
     LIBS_aix := -lperfstat, \
-    LIBS_windows := advapi32.lib psapi.lib, \
+    LIBS_windows := advapi32.lib, \
 ))
 
 TARGETS += $(BUILD_LIBMANAGEMENT)

--- a/make/modules/jdk.attach/Lib.gmk
+++ b/make/modules/jdk.attach/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,20 +31,12 @@ include LibCommon.gmk
 ## Build libattach
 ################################################################################
 
-ifeq ($(call isTargetOs, windows), true)
-  # In (at least) VS2013 and later, -DPSAPI_VERSION=1 is needed to generate
-  # a binary that is compatible with windows versions older than 7/2008R2.
-  # See MSDN documentation for GetProcessMemoryInfo for more information.
-  LIBATTACH_CFLAGS := -DPSAPI_VERSION=1
-endif
-
 $(eval $(call SetupJdkLibrary, BUILD_LIBATTACH, \
     NAME := attach, \
     OPTIMIZATION := LOW, \
-    CFLAGS := $(LIBATTACH_CFLAGS), \
     CFLAGS_windows := -Gy, \
     JDK_LIBS := java.base:libjava, \
-    LIBS_windows := advapi32.lib psapi.lib, \
+    LIBS_windows := advapi32.lib, \
 ))
 
 TARGETS += $(BUILD_LIBATTACH)

--- a/make/modules/jdk.management/Lib.gmk
+++ b/make/modules/jdk.management/Lib.gmk
@@ -31,21 +31,13 @@ include LibCommon.gmk
 ## Build libmanagement_ext
 ################################################################################
 
-ifeq ($(call isTargetOs, windows), true)
-  # In (at least) VS2013 and later, -DPSAPI_VERSION=1 is needed to generate
-  # a binary that is compatible with windows versions older than 7/2008R2.
-  # See MSDN documentation for GetProcessMemoryInfo for more information.
-  LIBMANAGEMENT_EXT_CFLAGS := -DPSAPI_VERSION=1
-endif
-
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT_EXT, \
     NAME := management_ext, \
     OPTIMIZATION := HIGH, \
     DISABLED_WARNINGS_clang_UnixOperatingSystem.c := format-nonliteral, \
-    CFLAGS := $(LIBMANAGEMENT_EXT_CFLAGS), \
     JDK_LIBS := java.base:libjava java.base:libjvm, \
     LIBS_aix := -lperfstat, \
-    LIBS_windows := advapi32.lib psapi.lib, \
+    LIBS_windows := advapi32.lib, \
 ))
 
 TARGETS += $(BUILD_LIBMANAGEMENT_EXT)


### PR DESCRIPTION
Currently we still link the jvm lib on Windows with psapi.
But this seems to be unnecessary these days.
If we want to use the older API, we can compile with -DPSAPI_VERSION=1 and link psapi; but this is not done for hotspot.
(btw it's done for some jdk libs :

https://github.com/openjdk/jdk/blob/6e5bfcc6450512b4b974ed4afa067547552a0847/make/modules/jdk.attach/Lib.gmk#L35
https://github.com/openjdk/jdk/blob/6e5bfcc6450512b4b974ed4afa067547552a0847/make/modules/jdk.management/Lib.gmk#L35

but not in the hotspot build).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387876](https://bugs.openjdk.org/browse/JDK-8387876): Remove psapi lib (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31846/head:pull/31846` \
`$ git checkout pull/31846`

Update a local copy of the PR: \
`$ git checkout pull/31846` \
`$ git pull https://git.openjdk.org/jdk.git pull/31846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31846`

View PR using the GUI difftool: \
`$ git pr show -t 31846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31846.diff">https://git.openjdk.org/jdk/pull/31846.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31846#issuecomment-4925310838)
</details>
