### PR TITLE
8388017: [aix] Narrow klass encoding protection region should be protected in mmap mode

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1897,7 +1897,11 @@ static bool checked_mprotect(char* addr, size_t size, int prot) {
     }
   }
 
-  assert(rc == true, "mprotect failed.");
+  if (!rc) {
+    // Reporting success via mprotect but failing to mprotect is a symptom of calling mprotect
+    // on SystemV-memory. It should not happen for mmap-mode.
+    assert(!g_multipage_support.can_use_64K_mmap_pages, "Should only happen in old-style shmat mode");
+  }
 
   return rc;
 }

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -334,15 +334,12 @@ void CompressedKlassPointers::print_mode(outputStream* st) {
   }
 }
 
-// On AIX, we cannot mprotect archive space or class space since they are reserved with SystemV shm.
-static constexpr bool can_mprotect_archive_space = NOT_AIX(true) AIX_ONLY(false);
-
 // Protect a zone a the start of the encoding range
 void CompressedKlassPointers::establish_protection_zone(address addr, size_t size) {
   assert(_protection_zone_size == 0, "just once");
   assert(addr == base(), "Protection zone not at start of encoding range?");
   assert(size > 0 && is_aligned(size, os::vm_page_size()), "Protection zone not page sized");
-  const bool rc = can_mprotect_archive_space && os::protect_memory((char*)addr, size, os::MEM_PROT_NONE, false);
+  const bool rc = os::protect_memory((char*)addr, size, os::MEM_PROT_NONE, false);
   log_info(metaspace)("%s Narrow Klass Protection zone " RANGEFMT,
       (rc ? "Established" : "FAILED to establish "),
       RANGEFMTARGS(addr, size));


### PR DESCRIPTION
Small AIX-only patch:

We protect the narrow Klass zero page to guard against accidental decoding of null narrowKlass. On all platforms but not on AIX, because mprotect would not work on the old-style System V shm we use as backing memory. But since we use mmap with 64K pages on newer AIX versions, this should work just fine.

Instead of conditionally enabling mprotect if mmap is used, which would have exposed these OS details to the generic code, I just removed the decades-old mprotect-failed assertion on AIX. I remember we added it very early in the AIX port to analyze a very specific problem, and then just never removed it. But it is sufficient to just return false on error, which matches what other platforms do for mprotect errors.

Since we no longer assert that mprotect silently fails. That is fine and we just use the (already existing) fallback path : report it, fill the zone with "P" as a consolation prize, and ignore it otherwise. On older machines, this is what continues to happen; on newer machines, mprotect will have worked and we will now have a protection zone established.

Tests: I tested this on AIX 7.2 (old-style SystemV), so the fallback path is tested. I have no newer machine.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388017](https://bugs.openjdk.org/browse/JDK-8388017): [aix] Narrow klass encoding protection region should be protected in mmap mode (**Enhancement** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31847/head:pull/31847` \
`$ git checkout pull/31847`

Update a local copy of the PR: \
`$ git checkout pull/31847` \
`$ git pull https://git.openjdk.org/jdk.git pull/31847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31847`

View PR using the GUI difftool: \
`$ git pr show -t 31847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31847.diff">https://git.openjdk.org/jdk/pull/31847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31847#issuecomment-4932602356)
</details>
