### PR TITLE
8388008: AArch64: data race accessing CodeHeap::high in CodeCache::max_distance_to_non_nmethod

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1182,8 +1182,8 @@ size_t CodeCache::max_distance_to_non_nmethod() {
     CodeHeap* blob = get_code_heap(CodeBlobType::NonNMethod);
     // the max distance is minimized by placing the NonNMethod segment
     // in between MethodProfiled and MethodNonProfiled segments
-    size_t dist1 = (size_t)blob->high() - (size_t)_low_bound;
-    size_t dist2 = (size_t)_high_bound - (size_t)blob->low();
+    size_t dist1 = (size_t)blob->high_boundary() - (size_t)_low_bound;
+    size_t dist2 = (size_t)_high_bound - (size_t)blob->low_boundary();
     return dist1 > dist2 ? dist1 : dist2;
   }
 }


### PR DESCRIPTION
This PR fixes the data race in `CodeCache::max_distance_to_non_nmethod`: using `CodeHeap::high` without any synchronization. The fix is to use `CodeHeap::high_boundary` instead.

Tested fastdebug/release builds:
- [x] tier1: passed

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388008](https://bugs.openjdk.org/browse/JDK-8388008): AArch64: data race accessing CodeHeap::high in CodeCache::max_distance_to_non_nmethod (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Boris Ulasevich](https://openjdk.org/census#bulasevich) (@bulasevich - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31848/head:pull/31848` \
`$ git checkout pull/31848`

Update a local copy of the PR: \
`$ git checkout pull/31848` \
`$ git pull https://git.openjdk.org/jdk.git pull/31848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31848`

View PR using the GUI difftool: \
`$ git pr show -t 31848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31848.diff">https://git.openjdk.org/jdk/pull/31848.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31848#issuecomment-4925383388)
</details>
