### PR TITLE
8386475: C2 x64: -XX:-UseBMI2Instructions is broken for AVX-512

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5872,7 +5872,7 @@ void MacroAssembler::xmm_clear_mem(Register base, Register cnt, Register rtmp, X
   // cnt - number of qwords (8-byte words).
   // base - start address, qword aligned.
   Label L_zero_64_bytes, L_loop, L_sloop, L_tail, L_end;
-  bool use64byteVector = (MaxVectorSize == 64) && (CopyAVX3Threshold == 0);
+  bool use64byteVector = (MaxVectorSize == 64) && (CopyAVX3Threshold == 0) && VM_Version::supports_bmi2();
   if (use64byteVector) {
     vpxor(xtmp, xtmp, xtmp, AVX_512bit);
   } else if (MaxVectorSize >= 32) {
@@ -5919,7 +5919,7 @@ void MacroAssembler::xmm_clear_mem(Register base, Register cnt, Register rtmp, X
   BIND(L_tail);
   addptr(cnt, 4);
   jccb(Assembler::lessEqual, L_end);
-  if (UseAVX > 2 && MaxVectorSize >= 32 && VM_Version::supports_avx512vl()) {
+  if (UseAVX > 2 && MaxVectorSize >= 32 && VM_Version::supports_avx512vl() && VM_Version::supports_bmi2()) {
     fill32_masked(3, base, 0, xtmp, mask, cnt, rtmp);
   } else {
     decrement(cnt);
@@ -6982,7 +6982,7 @@ void MacroAssembler::vectorized_mismatch(Register obja, Register objb, Register 
   xorq(result, result);
 
   if ((AVX3Threshold == 0) && (UseAVX > 2) &&
-      VM_Version::supports_avx512vlbw() && UseCountTrailingZerosInstruction) {
+      VM_Version::supports_avx512vlbw() && UseCountTrailingZerosInstruction && VM_Version::supports_bmi2()) {
     Label VECTOR64_LOOP, VECTOR64_NOT_EQUAL, VECTOR32_TAIL;
 
     cmpq(length, 64);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3069,7 +3069,7 @@ address StubGenerator::generate_base64_decodeBlock() {
 
   // If AVX512 VBMI not supported, just compile non-AVX code
   if(VM_Version::supports_avx512_vbmi() &&
-     VM_Version::supports_avx512bw()) {
+     VM_Version::supports_avx512bw() && VM_Version::supports_bmi2()) {
     __ cmpl(length, 31);     // 32-bytes is break-even for AVX-512
     __ jcc(Assembler::lessEqual, L_lastChunk);
 
@@ -4887,7 +4887,7 @@ void StubGenerator::generate_compiler_stubs() {
   StubRoutines::_data_cache_writeback = generate_data_cache_writeback();
   StubRoutines::_data_cache_writeback_sync = generate_data_cache_writeback_sync();
 
-  if ((UseAVX == 2) && EnableX86ECoreOpts && UseCountTrailingZerosInstruction) {
+  if ((UseAVX == 2) && EnableX86ECoreOpts && UseCountTrailingZerosInstruction && VM_Version::supports_bmi2()) {
     generate_string_indexof(StubRoutines::_string_indexof_array);
   }
 

--- a/test/hotspot/jtreg/compiler/cpuflags/TestUseBMI2Instructions.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestUseBMI2Instructions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8386475
+ * @summary Verify no assertions with -XX:+UseBMI2Instructions
+ * @requires os.simpleArch == "x64"
+ * @run main/othervm -XX:+UseBMI2Instructions ${test.main.class}
+ */
+
+/*
+ * @test
+ * @bug 8386475
+ * @summary Verify no assertions with -XX:-UseBMI2Instructions
+ * @requires os.simpleArch == "x64"
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,java.lang.CharacterDataLatin1::<clinit> -XX:+UnlockDiagnosticVMOptions -XX:CopyAVX3Threshold=0 -XX:-UseBMI2Instructions ${test.main.class}
+ */
+
+/*
+ * @test
+ * @bug 8386475
+ * @summary Verify no assertions when generating vectorizedMismatch stub with -XX:-UseBMI2Instructions
+ * @requires os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:AVX3Threshold=0 -XX:-UseBMI2Instructions ${test.main.class}
+ */
+
+/*
+ * @test
+ * @bug 8386475
+ * @summary Verify no assertions when generating string_indexof stub with -XX:-UseBMI2Instructions
+ * @requires os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseAVX=2 -XX:+EnableX86ECoreOpts -XX:-UseBMI2Instructions ${test.main.class}
+ */
+
+package compiler.cpuflags;
+
+public class TestUseBMI2Instructions {
+  public static void main(String args[]) {
+    // intentionally empty
+  }
+}


### PR DESCRIPTION
Backporting the fix for [JDK-8386475](https://bugs.openjdk.org/browse/JDK-8386475) to jdk27.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386475](https://bugs.openjdk.org/browse/JDK-8386475): C2 x64: -XX:-UseBMI2Instructions is broken for AVX-512 (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31849/head:pull/31849` \
`$ git checkout pull/31849`

Update a local copy of the PR: \
`$ git checkout pull/31849` \
`$ git pull https://git.openjdk.org/jdk.git pull/31849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31849`

View PR using the GUI difftool: \
`$ git pr show -t 31849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31849.diff">https://git.openjdk.org/jdk/pull/31849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31849#issuecomment-4925653150)
</details>
