### PR TITLE
8382841: Revert annotation parsing changes from libgraal

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -77,14 +77,14 @@ public class AnnotationParser {
      * Like {@link #parseAnnotations(byte[], sun.reflect.ConstantPool, Class)}
      * with an additional parameter {@code selectAnnotationClasses} which selects the
      * annotation types to parse (other than selected are quickly skipped).<p>
-     * This method is used to parse select meta annotations in the construction
+     * This method is only used to parse select meta annotations in the construction
      * phase of {@link AnnotationType} instances to prevent infinite recursion.
      *
      * @param selectAnnotationClasses an array of annotation types to select when parsing
      */
     @SafeVarargs
     @SuppressWarnings("varargs") // selectAnnotationClasses is used safely
-    public static Map<Class<? extends Annotation>, Annotation> parseSelectAnnotations(
+    static Map<Class<? extends Annotation>, Annotation> parseSelectAnnotations(
                 byte[] rawAnnotations,
                 ConstantPool constPool,
                 Class<?> container,


### PR DESCRIPTION
As noted in https://bugs.openjdk.org/browse/JDK-8382841, JVMCI added annotation access helpers for the libgraal annotation API.

The memberValues accessors were already removed by JDK-8382582, but AnnotationParser.parseSelectAnnotations was still left public even though its only remaining caller is AnnotationType in the same package.

This patch makes parseSelectAnnotations package-private again and restores the original comment describing its package-internal use.

Testing:
- `make CONF=windows-x86_64-server-release CONF_CHECK=ignore java.base`
- `make CONF=windows-x86_64-server-release CONF_CHECK=ignore test TEST="test/jdk/java/lang/annotation"`
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8382841](https://bugs.openjdk.org/browse/JDK-8382841): Revert annotation parsing changes from libgraal (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31851/head:pull/31851` \
`$ git checkout pull/31851`

Update a local copy of the PR: \
`$ git checkout pull/31851` \
`$ git pull https://git.openjdk.org/jdk.git pull/31851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31851`

View PR using the GUI difftool: \
`$ git pr show -t 31851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31851.diff">https://git.openjdk.org/jdk/pull/31851.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31851#issuecomment-4927265117)
</details>
