### PR TITLE
8388035: RISC-V: Auto-enable Zfa extension features

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -103,7 +103,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZbb, false, DIAGNOSTIC, "Use Zbb instructions")               \
   product(bool, UseZbkb, false, EXPERIMENTAL, "Use Zbkb instructions")           \
   product(bool, UseZbs, false, DIAGNOSTIC, "Use Zbs instructions")               \
-  product(bool, UseZfa, false, EXPERIMENTAL, "Use Zfa instructions")             \
+  product(bool, UseZfa, false, DIAGNOSTIC, "Use Zfa instructions")               \
   product(bool, UseZfh, false, DIAGNOSTIC, "Use Zfh instructions")               \
   product(bool, UseZfhmin, false, DIAGNOSTIC, "Use Zfhmin instructions")         \
   product(bool, UseZacas, false, EXPERIMENTAL, "Use Zacas instructions")         \

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -215,11 +215,9 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBS)) {
     VM_Version::ext_Zbs.enable_feature();
   }
-#ifndef PRODUCT
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFA)) {
     VM_Version::ext_Zfa.enable_feature();
   }
-#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFH)) {
     VM_Version::ext_Zfh.enable_feature();
   }


### PR DESCRIPTION
Hi, I ran some tests on the SpacemiT Key Stone K3 (which features physical zfa hardware extensions). After enabling Zfa, the relevant JMH performance metrics improved significantly. So I propose to auto-enable this feature through hwprobe.

auto-enable this feature through hwprobe:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk/build/linux-riscv64-server-release/jdk/bin$ ./java -XX:+PrintFlagsFinal -version | grep UseZfa
     bool UseZfa                                   = true                              {ARCH diagnostic} {default}
openjdk version "28-internal" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zifeihan.jdk, mixed mode)
```

cpuinfo like this:
```
zifeihan@riscv-spacemitk3picoitx:~$ cat /proc/cpuinfo
processor	: 0
hart		: 0
model name	: Spacemit(R) X100
isa		: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
mmu		: sv39
mvendorid	: 0x710
marchid		: 0x8000000058000002
mimpid		: 0x33d8a600
hart isa	: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
```

kernel version like this:
```
zifeihan@riscv-spacemitk3picoitx:~$ uname -r
6.18.3-generic
zifeihan@riscv-spacemitk3picoitx:~$ uname -a
Linux riscv-spacemitk3picoitx 6.18.3-generic #1.0.0~rc2.4 SMP PREEMPT_DYNAMIC Thu Apr 16 11:50:58 CST 2026 riscv64 GNU/Linux
zifeihan@riscv-spacemitk3picoitx:~$ cat /etc/issue
Bianbu 4.0rc2 \n \l
```

### Testing (SpacemiT Key Stone K3)
- [x] tier1-3 tests (release)

jmh testing:
without this patch (SpacemiT Key Stone K3):
```
Benchmark                                       Mode  Cnt      Score    Error  Units
FpMinMaxIntrinsics.dMax                         avgt    5   5963.977 ±  8.339  ns/op
FpMinMaxIntrinsics.dMaxReduce                   avgt    5   1686.094 ±  1.396  ns/op
FpMinMaxIntrinsics.dMaxReduceGlobalAccumulator  avgt    5   2291.075 ±  1.062  ns/op
FpMinMaxIntrinsics.dMaxReduceInOuterLoop        avgt    5  12758.589 ± 23.060  ns/op
FpMinMaxIntrinsics.dMaxReduceNonCounted         avgt    5   2285.465 ±  0.679  ns/op
FpMinMaxIntrinsics.dMaxReducePartiallyUnrolled  avgt    5   1677.564 ±  1.138  ns/op
FpMinMaxIntrinsics.dMin                         avgt    5   6071.646 ±  1.639  ns/op
FpMinMaxIntrinsics.dMinReduce                   avgt    5   1687.090 ±  5.617  ns/op
FpMinMaxIntrinsics.dMinReduceGlobalAccumulator  avgt    5   2291.109 ±  0.383  ns/op
FpMinMaxIntrinsics.dMinReduceInOuterLoop        avgt    5  12773.045 ± 41.065  ns/op
FpMinMaxIntrinsics.dMinReduceNonCounted         avgt    5   2287.922 ± 18.289  ns/op
FpMinMaxIntrinsics.dMinReducePartiallyUnrolled  avgt    5   1680.154 ±  1.423  ns/op
FpMinMaxIntrinsics.fMax                         avgt    5   6023.560 ±  8.377  ns/op
FpMinMaxIntrinsics.fMaxReduce                   avgt    5    781.463 ±  6.747  ns/op
FpMinMaxIntrinsics.fMaxReduceGlobalAccumulator  avgt    5   2290.563 ±  1.308  ns/op
FpMinMaxIntrinsics.fMaxReduceInOuterLoop        avgt    5  12757.017 ±  4.227  ns/op
FpMinMaxIntrinsics.fMaxReduceNonCounted         avgt    5   2285.840 ±  0.995  ns/op
FpMinMaxIntrinsics.fMaxReducePartiallyUnrolled  avgt    5    773.987 ±  0.787  ns/op
FpMinMaxIntrinsics.fMin                         avgt    5   5964.782 ±  9.704  ns/op
FpMinMaxIntrinsics.fMinReduce                   avgt    5    780.069 ±  0.215  ns/op
FpMinMaxIntrinsics.fMinReduceGlobalAccumulator  avgt    5   2291.568 ±  1.563  ns/op
FpMinMaxIntrinsics.fMinReduceInOuterLoop        avgt    5  12759.729 ± 31.338  ns/op
FpMinMaxIntrinsics.fMinReduceNonCounted         avgt    5   2286.161 ±  2.443  ns/op
FpMinMaxIntrinsics.fMinReducePartiallyUnrolled  avgt    5    776.741 ±  0.518  ns/op
Finished running test 'micro:org.openjdk.bench.vm.compiler.FpMinMaxIntrinsics'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_org_openjdk_bench_vm_compiler_FpMinMaxIntrinsics

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:org.openjdk.bench.vm.compiler.FpMinMaxIntrinsics
                                                         1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'
```
with this patch (SpacemiT Key Stone K3)::
```
Benchmark                                       Mode  Cnt      Score      Error  Units
FpMinMaxIntrinsics.dMax                         avgt    5   4112.561 ±    2.544  ns/op
FpMinMaxIntrinsics.dMaxReduce                   avgt    5   1685.736 ±    0.619  ns/op
FpMinMaxIntrinsics.dMaxReduceGlobalAccumulator  avgt    5   1384.092 ±    0.427  ns/op
FpMinMaxIntrinsics.dMaxReduceInOuterLoop        avgt    5  12891.363 ± 3814.733  ns/op
FpMinMaxIntrinsics.dMaxReduceNonCounted         avgt    5   1383.136 ±    0.197  ns/op
FpMinMaxIntrinsics.dMaxReducePartiallyUnrolled  avgt    5   1668.166 ±    0.724  ns/op
FpMinMaxIntrinsics.dMin                         avgt    5   4202.201 ±    2.237  ns/op
FpMinMaxIntrinsics.dMinReduce                   avgt    5   1686.188 ±    0.524  ns/op
FpMinMaxIntrinsics.dMinReduceGlobalAccumulator  avgt    5   1384.168 ±    0.948  ns/op
FpMinMaxIntrinsics.dMinReduceInOuterLoop        avgt    5  11667.318 ± 1662.551  ns/op
FpMinMaxIntrinsics.dMinReduceNonCounted         avgt    5   1382.755 ±    2.866  ns/op
FpMinMaxIntrinsics.dMinReducePartiallyUnrolled  avgt    5   1673.804 ±    0.734  ns/op
FpMinMaxIntrinsics.fMax                         avgt    5   4105.915 ±   11.036  ns/op
FpMinMaxIntrinsics.fMaxReduce                   avgt    5    773.383 ±    2.430  ns/op
FpMinMaxIntrinsics.fMaxReduceGlobalAccumulator  avgt    5   1384.535 ±    0.196  ns/op
FpMinMaxIntrinsics.fMaxReduceInOuterLoop        avgt    5  11910.559 ±  526.084  ns/op
FpMinMaxIntrinsics.fMaxReduceNonCounted         avgt    5   1383.290 ±    1.693  ns/op
FpMinMaxIntrinsics.fMaxReducePartiallyUnrolled  avgt    5    767.537 ±    0.206  ns/op
FpMinMaxIntrinsics.fMin                         avgt    5   4015.520 ±    8.580  ns/op
FpMinMaxIntrinsics.fMinReduce                   avgt    5    773.001 ±    1.046  ns/op
FpMinMaxIntrinsics.fMinReduceGlobalAccumulator  avgt    5   1384.095 ±    0.375  ns/op
FpMinMaxIntrinsics.fMinReduceInOuterLoop        avgt    5  11625.496 ±  964.337  ns/op
FpMinMaxIntrinsics.fMinReduceNonCounted         avgt    5   1382.996 ±    0.710  ns/op
FpMinMaxIntrinsics.fMinReducePartiallyUnrolled  avgt    5    768.301 ±    1.575  ns/op
Finished running test 'micro:org.openjdk.bench.vm.compiler.FpMinMaxIntrinsics'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_org_openjdk_bench_vm_compiler_FpMinMaxIntrinsics

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:org.openjdk.bench.vm.compiler.FpMinMaxIntrinsics
                                                         1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'

```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388035](https://bugs.openjdk.org/browse/JDK-8388035): RISC-V: Auto-enable Zfa extension features (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31853/head:pull/31853` \
`$ git checkout pull/31853`

Update a local copy of the PR: \
`$ git checkout pull/31853` \
`$ git pull https://git.openjdk.org/jdk.git pull/31853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31853`

View PR using the GUI difftool: \
`$ git pr show -t 31853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31853.diff">https://git.openjdk.org/jdk/pull/31853.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31853#issuecomment-4927478603)
</details>
