### PR TITLE
8388001: Test java/awt/Frame/PackTwiceTest.java fails because the frame title is displayed as 'PackTwiceTest TestFrame' instead of 'TestFrame'

### DIFF
--- a/test/jdk/java/awt/Frame/PackTwiceTest.java
+++ b/test/jdk/java/awt/Frame/PackTwiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.awt.TextField;
 public class PackTwiceTest {
     public static void main(String[] args) throws Exception {
         String INSTRUCTIONS = """
-                1. You would see a Frame titled 'TestFrame'
+                1. You would see a Frame titled 'PackTwiceTest TestFrame'
                 2. The Frame displays a text as below:
                     'I am a lengthy sentence...can you see me?'
                 3. If you can see the full text without resizing the frame


### PR DESCRIPTION
Fixed the test instruction to match the actual test frame title from 'TestFrame' to 'PackTwiceTest TestFrame'




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388001](https://bugs.openjdk.org/browse/JDK-8388001): Test java/awt/Frame/PackTwiceTest.java fails because the frame title is displayed as 'PackTwiceTest TestFrame' instead of 'TestFrame' (**Bug** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31854/head:pull/31854` \
`$ git checkout pull/31854`

Update a local copy of the PR: \
`$ git checkout pull/31854` \
`$ git pull https://git.openjdk.org/jdk.git pull/31854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31854`

View PR using the GUI difftool: \
`$ git pr show -t 31854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31854.diff">https://git.openjdk.org/jdk/pull/31854.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31854#issuecomment-4937181635)
</details>
