### PR TITLE
8365575: AOT cache should include classes verified using "fail over" verification

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -222,9 +222,9 @@ bool Verifier::verify(InstanceKlass* klass, bool should_verify_class, TRAPS) {
     split_verifier.verify_class(THREAD);
     exception_name = split_verifier.result();
 
-    // If dumping {classic, final} static archive, don't bother to run the old verifier, as
+    // If dumping classic static archive, don't bother to run the old verifier, as
     // the class will be excluded from the archive anyway.
-    bool can_failover = !(CDSConfig::is_dumping_classic_static_archive() || CDSConfig::is_dumping_final_static_archive()) &&
+    bool can_failover = !(CDSConfig::is_dumping_classic_static_archive()) &&
       klass->major_version() < NOFAILOVER_MAJOR_VERSION;
 
     if (can_failover && !HAS_PENDING_EXCEPTION &&  // Split verifier doesn't set PENDING_EXCEPTION for failure
@@ -233,9 +233,9 @@ bool Verifier::verify(InstanceKlass* klass, bool should_verify_class, TRAPS) {
       log_info(verification)("Fail over class verification to old verifier for: %s", klass->external_name());
       log_info(class, init)("Fail over class verification to old verifier for: %s", klass->external_name());
 #if INCLUDE_CDS
-      // Exclude any classes that are verified with the old verifier, as the old verifier
-      // doesn't call SystemDictionaryShared::add_verification_constraint()
-      if (CDSConfig::is_dumping_archive()) {
+      // Exclude any classes that are verified with the old verifier when the verification constraints
+      // cannot be preserved.
+      if (CDSConfig::is_dumping_archive() && !CDSConfig::is_preserving_verification_constraints()) {
         SystemDictionaryShared::log_exclusion(klass, "Verified with old verifier");
         SystemDictionaryShared::set_excluded(klass);
       }
@@ -244,6 +244,10 @@ bool Verifier::verify(InstanceKlass* klass, bool should_verify_class, TRAPS) {
       exception_message = message_buffer;
       exception_name = inference_verify(
         klass, message_buffer, message_buffer_len, THREAD);
+
+      if (exception_name == nullptr && !HAS_PENDING_EXCEPTION) {
+        klass->set_verification_failed_over();
+      }
     }
     if (exception_name != nullptr) {
       exception_message = split_verifier.exception_message();

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -246,7 +246,7 @@ bool Verifier::verify(InstanceKlass* klass, bool should_verify_class, TRAPS) {
         klass, message_buffer, message_buffer_len, THREAD);
 
       if (exception_name == nullptr && !HAS_PENDING_EXCEPTION) {
-        klass->set_verification_failed_over();
+        klass->set_fail_over_verified();
       }
     }
     if (exception_name != nullptr) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2913,10 +2913,10 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
   }
 
   if (CDSConfig::is_dumping_final_static_archive() && fail_over_verified()) {
-    // This is a "new" class but was verified with the old verifier in the training run, which had
-     // -XX:+AOTClassLinking. However, we are now in the assembly run with -XX:-AOTClassLinking.
-     // As SystemDictionaryShared::check_verification_constraints() does not support this case,
-     // we must exclude this class.
+    // This is a class with version >50 but was verified with the old verifier in the training run,
+    // which had -XX:+AOTClassLinking. However, we are now in the assembly run with -XX:-AOTClassLinking.
+    // As SystemDictionaryShared::check_verification_constraints() does not support this case,
+    // we must exclude this class.
     assert(!CDSConfig::is_dumping_aot_linked_classes(), "must be");
     return false;
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2912,10 +2912,11 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
     return false;
   }
 
-  if (CDSConfig::is_dumping_final_static_archive() && verification_failed_over()) {
-    // This class failed over to the old verifier during a training run using AOTClassLinking so
-    // it was archived in the config file. An assembly run without AOTClassLinking needs to exclude
-    // this class.
+  if (CDSConfig::is_dumping_final_static_archive() && fail_over_verified()) {
+    // This is a "new" class but was verified with the old verifier in the training run, which had
+     // -XX:+AOTClassLinking. However, we are now in the assembly run with -XX:-AOTClassLinking.
+     // As SystemDictionaryShared::check_verification_constraints() does not support this case,
+     // we must exclude this class.
     assert(!CDSConfig::is_dumping_aot_linked_classes(), "must be");
     return false;
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2911,6 +2911,15 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
     // SystemDictionaryShared::check_verification_constraints() will not work for this class.
     return false;
   }
+
+  if (CDSConfig::is_dumping_final_static_archive() && verification_failed_over()) {
+    // This class failed over to the old verifier during a training run using AOTClassLinking so
+    // it was archived in the config file. An assembly run without AOTClassLinking needs to exclude
+    // this class.
+    assert(!CDSConfig::is_dumping_aot_linked_classes(), "must be");
+    return false;
+  }
+
   if (super() != nullptr && !super()->can_be_verified_at_dumptime()) {
     return false;
   }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -339,8 +339,8 @@ class InstanceKlass: public Klass {
   bool has_localvariable_table() const     { return _misc_flags.has_localvariable_table(); }
   void set_has_localvariable_table(bool b) { _misc_flags.set_has_localvariable_table(b); }
 
-  bool verification_failed_over() const { return _misc_flags.verification_failed_over(); }
-  void set_verification_failed_over() { _misc_flags.set_verification_failed_over(true); }
+  bool fail_over_verified() const { return _misc_flags.fail_over_verified(); }
+  void set_fail_over_verified() { _misc_flags.set_fail_over_verified(true); }
 
   // field sizes
   int nonstatic_field_size() const         { return _nonstatic_field_size; }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -339,6 +339,9 @@ class InstanceKlass: public Klass {
   bool has_localvariable_table() const     { return _misc_flags.has_localvariable_table(); }
   void set_has_localvariable_table(bool b) { _misc_flags.set_has_localvariable_table(b); }
 
+  bool verification_failed_over() const { return _misc_flags.verification_failed_over(); }
+  void set_verification_failed_over() { _misc_flags.set_verification_failed_over(true); }
+
   // field sizes
   int nonstatic_field_size() const         { return _nonstatic_field_size; }
   void set_nonstatic_field_size(int size)  { _nonstatic_field_size = size; }

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -54,7 +54,7 @@ class InstanceKlassFlags {
     flag(has_miranda_methods                , 1 << 12) /* True if this class has miranda methods in it's vtable */ \
     flag(has_final_method                   , 1 << 13) /* True if klass has final method */ \
     flag(trust_final_fields                 , 1 << 14) /* All instance final fields in this class should be trusted */ \
-    flag(verification_failed_over           , 1 << 15) /* class failed split verification but passed inference verification */ \
+    flag(fail_over_verified           , 1 << 15) /* class failed split verification but passed inference verification */ \
     /* end of list */
 
 #define IK_FLAGS_ENUM_NAME(name, value)    _misc_##name = value,

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -54,6 +54,7 @@ class InstanceKlassFlags {
     flag(has_miranda_methods                , 1 << 12) /* True if this class has miranda methods in it's vtable */ \
     flag(has_final_method                   , 1 << 13) /* True if klass has final method */ \
     flag(trust_final_fields                 , 1 << 14) /* All instance final fields in this class should be trusted */ \
+    flag(verification_failed_over           , 1 << 15) /* class failed split verification but passed inference verification */ \
     /* end of list */
 
 #define IK_FLAGS_ENUM_NAME(name, value)    _misc_##name = value,

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/VerifierFailOver.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/VerifierFailOver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @bug 8365575
  * @summary Sanity test for AOTCache
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib
@@ -33,24 +34,72 @@
  * @run driver VerifierFailOver
  */
 
+import jdk.test.lib.cds.CDSAppTester;
 import jdk.test.lib.cds.SimpleCDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class VerifierFailOver {
+
+    static final String mainClass = VerifierFailOverApp.class.getName();
+    static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+
     public static void main(String... args) throws Exception {
         SimpleCDSAppTester.of("VerifierFailOver")
             .addVmArgs("-Xlog:aot,aot+class=debug")
             .classpath("app.jar")
             .appCommandLine("VerifierFailOverApp")
             .setTrainingChecker((OutputAnalyzer out) -> {
-                    out.shouldContain("Skipping VerifierFailOver_Helper: Verified with old verifier");
+                    out.shouldMatch("class.* klasses.* VerifierFailOver_Helper");
                 })
             .setAssemblyChecker((OutputAnalyzer out) -> {
-                    // classes verified with fail-over mode should not be cached.
-                    out.shouldMatch("class.* klasses.* VerifierFailOverApp");
-                    out.shouldNotMatch("class.* klasses.* VerifierFailOver_Helper");
+                    // Classes verified with fail-over can be cached if AOTClassLinking is on
+                    out.shouldMatch("class.* klasses.* VerifierFailOverApp aot-linked");
+                    out.shouldMatch("class.* klasses.* VerifierFailOver_Helper aot-linked");
                 })
             .runAOTWorkflow();
+
+
+        // When running an assembly run without AOTClassLinking, any classes verified with
+        // fail-over need to be excluded.
+        Tester t = new Tester();
+        t.runAOTWorkflow();
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return appJar;
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            if (runMode == RunMode.ASSEMBLY) {
+                return new String[] {"-XX:-AOTClassLinking", "-Xlog:aot,aot+class=debug"};
+            } else {
+                return new String[] { "-Xlog:aot,aot+class=debug" };
+            }
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] { mainClass };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode)  throws Exception {
+            if (runMode == RunMode.TRAINING) {
+                out.shouldMatch("class.* klasses.* VerifierFailOver_Helper");
+            } else if (runMode == RunMode.ASSEMBLY) {
+                out.shouldContain("Skipping VerifierFailOver_Helper: Old class has been linked");
+                out.shouldMatch("class.* klasses.* VerifierFailOverApp");
+                out.shouldNotMatch("class.* klasses.* VerifierFailOver_Helper");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Classes that succeed inference verification are able to be archived in AOT after [JDK-8317269](https://bugs.openjdk.org/browse/JDK-8317269) but "fail-over" classes, which refers to classes that fail split verification but can pass inference verification. were excluded. This patch allows these "fail-over" classes to be archived so long as AOTClassLinking is used. Verified with tier 1-5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8365575](https://bugs.openjdk.org/browse/JDK-8365575): AOT cache should include classes verified using "fail over" verification (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31857/head:pull/31857` \
`$ git checkout pull/31857`

Update a local copy of the PR: \
`$ git checkout pull/31857` \
`$ git pull https://git.openjdk.org/jdk.git pull/31857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31857`

View PR using the GUI difftool: \
`$ git pr show -t 31857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31857.diff">https://git.openjdk.org/jdk/pull/31857.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31857#issuecomment-4930034679)
</details>
