### PR TITLE
8387991: Optimize execution of runtime/Thread/TestSpinPause.java

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
@@ -21,31 +21,103 @@
  * questions.
  */
 
+// Each SpinPause configuration has its own @test block so jtreg can run them
+// concurrently. Keep the blocks in sync when adding a new configuration.
+
 /**
- * @test TestSpinPause
+ * @test id=default
  * @summary JVM runtime can use SpinPause function for synchronized statements.
  *          Check different implementations of JVM SpinPause don't crash JVM.
- * @bug 8278241 8387991
+ * @bug 8278241
  * @library /test/lib
- *
  * @requires os.arch=="aarch64"
- *
  * @run main/othervm TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=none TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield -XX:OnSpinWaitInstCount=3 TestSpinPause
  * @run main/othervm -Xint TestSpinPause
+ * @run main/othervm -Xcomp TestSpinPause
+ */
+
+/**
+ * @test id=none
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=none TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=none TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=none TestSpinPause
+ */
+
+/**
+ * @test id=nop
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop TestSpinPause
+ */
+
+/**
+ * @test id=isb
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb TestSpinPause
+ */
+
+/**
+ * @test id=yield
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield TestSpinPause
+ */
+
+/**
+ * @test id=nop-count-10
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
+ */
+
+/**
+ * @test id=isb-count-3
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
+ */
+
+/**
+ * @test id=yield-count-3
+ * @summary JVM runtime can use SpinPause function for synchronized statements.
+ *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @bug 8278241
+ * @library /test/lib
+ * @requires os.arch=="aarch64"
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield -XX:OnSpinWaitInstCount=3 TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield -XX:OnSpinWaitInstCount=3 TestSpinPause
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield -XX:OnSpinWaitInstCount=3 TestSpinPause
  */
 
 public class TestSpinPause {

--- a/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
@@ -21,13 +21,9 @@
  * questions.
  */
 
-// Each SpinPause configuration has its own @test block so jtreg can run them
-// concurrently. Keep the blocks in sync when adding a new configuration.
-
-/**
+/*
  * @test id=default
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check the default SpinPause implementation for synchronized statements.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -36,10 +32,9 @@
  * @run main/othervm -Xcomp TestSpinPause
  */
 
-/**
+/*
  * @test id=none
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=none.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -48,10 +43,9 @@
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=none TestSpinPause
  */
 
-/**
+/*
  * @test id=nop
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=nop.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -60,10 +54,9 @@
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop TestSpinPause
  */
 
-/**
+/*
  * @test id=isb
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=isb.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -72,10 +65,9 @@
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb TestSpinPause
  */
 
-/**
+/*
  * @test id=yield
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=yield.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -84,10 +76,9 @@
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield TestSpinPause
  */
 
-/**
+/*
  * @test id=nop-count-10
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=nop and OnSpinWaitInstCount=10.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -96,10 +87,9 @@
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
  */
 
-/**
+/*
  * @test id=isb-count-3
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=isb and OnSpinWaitInstCount=3.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"
@@ -108,10 +98,9 @@
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
  */
 
-/**
+/*
  * @test id=yield-count-3
- * @summary JVM runtime can use SpinPause function for synchronized statements.
- *          Check different implementations of JVM SpinPause don't crash JVM.
+ * @summary Check SpinPause for synchronized statements with OnSpinWaitInst=yield and OnSpinWaitInstCount=3.
  * @bug 8278241
  * @library /test/lib
  * @requires os.arch=="aarch64"

--- a/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
@@ -25,7 +25,7 @@
  * @test TestSpinPause
  * @summary JVM runtime can use SpinPause function for synchronized statements.
  *          Check different implementations of JVM SpinPause don't crash JVM.
- * @bug 8278241
+ * @bug 8278241 8387991
  * @library /test/lib
  *
  * @requires os.arch=="aarch64"
@@ -46,14 +46,6 @@
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield -XX:OnSpinWaitInstCount=3 TestSpinPause
- * @run main/othervm -Xcomp TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=none TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=nop -XX:OnSpinWaitInstCount=10 TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=3 TestSpinPause
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:OnSpinWaitInst=yield -XX:OnSpinWaitInstCount=3 TestSpinPause
  */
 
 public class TestSpinPause {


### PR DESCRIPTION
As noted in https://bugs.openjdk.org/browse/JDK-8387991, runtime/Thread/TestSpinPause.java takes about 4 minutes 27 seconds in tier1. Its eight -Xcomp actions run sequentially, each taking roughly 30 seconds.

This patch removes the explicit -Xcomp actions while retaining the default and -Xint configurations, including all OnSpinWaitInst variants.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387991](https://bugs.openjdk.org/browse/JDK-8387991): Optimize execution of runtime/Thread/TestSpinPause.java (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31858/head:pull/31858` \
`$ git checkout pull/31858`

Update a local copy of the PR: \
`$ git checkout pull/31858` \
`$ git pull https://git.openjdk.org/jdk.git pull/31858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31858`

View PR using the GUI difftool: \
`$ git pr show -t 31858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31858.diff">https://git.openjdk.org/jdk/pull/31858.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31858#issuecomment-4931316216)
</details>
