### PR TITLE
8383563: Record pattern inference fails when inferred type arguments are same as formals

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -683,7 +683,13 @@ public class Infer {
 
         //step 1:
         List<Type> expressionTypes = List.nil();
-        List<Type> params = patternTypeSymbol.type.allparams();
+
+        // replace tvars in generic pattern type P<A1, ... An> with
+        // fresh tvars A1', ..., An' so that occurrences of A1, ..., An
+        // in the expression type are not confused with inference tvars
+        List<Type> declaredParams = patternTypeSymbol.type.allparams();
+        List<Type> params = types.newInstances(declaredParams);
+        Type patternType = types.subst(patternTypeSymbol.type, declaredParams, params);
         List<Type> capturedWildcards = List.nil();
         List<Type> todo = List.of(expressionType);
         while (todo.nonEmpty()) {
@@ -713,8 +719,8 @@ public class Infer {
         }
         //add synthetic captured ivars
         InferenceContext c = new InferenceContext(this, params);
-        Type patternType = c.asUndetVar(patternTypeSymbol.type);
-        List<Type> exprTypes = expressionTypes.map(t -> c.asUndetVar(t));
+        Type undetPatternType = c.asUndetVar(patternType);
+        List<Type> exprTypes = expressionTypes.map(c::asUndetVar);
 
         capturedWildcards.forEach(s -> ((UndetVar) c.asUndetVar(s)).setNormal());
 
@@ -723,9 +729,9 @@ public class Infer {
             for (Type exprType : exprTypes) {
                 if (exprType.isParameterized()) {
                     Type patternAsExpression =
-                            types.asSuper(patternType, exprType.tsym);
+                            types.asSuper(undetPatternType, exprType.tsym);
                     if (patternAsExpression == null ||
-                        !types.isSameType(patternAsExpression, exprType)) {
+                            !types.isSameType(patternAsExpression, exprType)) {
                         return null;
                     }
                 }
@@ -736,7 +742,7 @@ public class Infer {
             //step 3:
             List<Type> freshVars = instantiatePatternVars(params, c);
 
-            Type substituted = c.asInstType(patternTypeSymbol.type);
+            Type substituted = c.asInstType(patternType);
 
             //step 4:
             return types.upward(substituted, freshVars);

--- a/test/langtools/tools/javac/patterns/GenericRecordDeconstructionPattern.java
+++ b/test/langtools/tools/javac/patterns/GenericRecordDeconstructionPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,8 @@ public class GenericRecordDeconstructionPattern {
         testInference3();
         assertEquals(1, runIfSuperBound(new Box<>(new StringBuilder())));
         assertEquals(1, runIfSuperBound(new Box<>(0)));
+        assertEquals(1, new PairBox<String, Integer>("", 0)
+                .selfSuperInference(new PairBox<>("x", 1)));
     }
 
     void runTest(Function<Box<String>, Integer> test) {
@@ -122,6 +124,18 @@ public class GenericRecordDeconstructionPattern {
 
     sealed interface I<T> {}
     record Box<V>(V v) implements I<V> {
+    }
+
+    interface PairI<A, B> {}
+    record PairBox<A, B>(A a, B b) implements PairI<A, B> {
+        int selfSuperInference(PairI<A, B> p) {
+            if (p instanceof PairBox(var a, var b)) {
+                A aa = a;
+                B bb = b;
+                return 1;
+            }
+            return -1;
+        }
     }
 
     void assertEquals(Object expected, Object actual) {


### PR DESCRIPTION
The code for record pattern type inference has a flaw: when we infer a generic type for a record pattern `P(...)`, we end up using `P`'s declared type variables as inference variables.
This is problematic, because client code might also refer to such type variables, for instance in a case like this:

```
record Foo<X>(X x) {
   switch (this) ... case Foo(...)
}
```

In this case the type of the selector expression is `Foo<X>`, which uses the same `X` we use for pattern inference. This confusion generates spurious errors, as the compiler end up inferring the wrong types.

The solution is to note that we have a similar problem for (recursive) generic method calls:

```
<X> m(Foo<X> foo) { ... m(foo); ... }
```

To handle these cases, javac creates a _fresh copy_ of the declared type variables, and use such copies as inference vars. This is done in `Resolve::rawInstantiate`.

This PR applies the same treatment to `Infer::instantiatePatternType`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8383563](https://bugs.openjdk.org/browse/JDK-8383563): Record pattern inference fails when inferred type arguments are same as formals (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31861/head:pull/31861` \
`$ git checkout pull/31861`

Update a local copy of the PR: \
`$ git checkout pull/31861` \
`$ git pull https://git.openjdk.org/jdk.git pull/31861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31861`

View PR using the GUI difftool: \
`$ git pr show -t 31861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31861.diff">https://git.openjdk.org/jdk/pull/31861.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31861#issuecomment-4962817179)
</details>
