### PR TITLE
8388075: RISC-V: Auto-enable Zvbc extension features

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -118,7 +118,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use Zihintpause instructions")                                        \
   product(bool, UseZtso, false, EXPERIMENTAL, "Assume Ztso memory model")        \
   product(bool, UseZvbb, false, DIAGNOSTIC, "Use Zvbb instructions")             \
-  product(bool, UseZvbc, false, EXPERIMENTAL, "Use Zvbc instructions")           \
+  product(bool, UseZvbc, false, DIAGNOSTIC, "Use Zvbc instructions")             \
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
   product(bool, UseZvkg, false, DIAGNOSTIC, "Use Zvkg instructions")             \
   product(bool, UseZvkn, false, DIAGNOSTIC,                                      \

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -239,10 +239,10 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZTSO)) {
     VM_Version::ext_Ztso.enable_feature();
   }
+#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBC)) {
     VM_Version::ext_Zvbc.enable_feature();
   }
-#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBB)) {
     VM_Version::ext_Zvbb.enable_feature();
   }


### PR DESCRIPTION
Hi, I ran some tests on the SpacemiT Key Stone K3 (which features physical Zvbc hardware extensions). After enabling Zvbc, the relevant JMH performance metrics improved significantly. So I propose to auto-enable this feature through hwprobe.

auto-enable this feature through hwprobe:
```
zifeihan@riscv-spacemitk3picoitx:~/jdk/build/linux-riscv64-server-release/jdk/bin$ ./java -XX:+PrintFlagsFinal -version | grep UseZvbc
     bool UseZvbc                                  = true                              {ARCH diagnostic} {default}
openjdk version "28-internal" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zifeihan.jdk, mixed mode)

```

cpuinfo like this:
```
zifeihan@riscv-spacemitk3picoitx:~$ cat /proc/cpuinfo
processor	: 0
hart		: 0
model name	: Spacemit(R) X100
isa		: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
mmu		: sv39
mvendorid	: 0x710
marchid		: 0x8000000058000002
mimpid		: 0x33d8a600
hart isa	: rv64imafdcvh_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkt_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smstateen_ssaia_sscofpmf_sstc_svinval_svnapot_svpbmt_sdtrig
```

kernel version like this:
```
zifeihan@riscv-spacemitk3picoitx:~$ uname -r
6.18.3-generic
zifeihan@riscv-spacemitk3picoitx:~$ uname -a
Linux riscv-spacemitk3picoitx 6.18.3-generic #1.0.0~rc2.4 SMP PREEMPT_DYNAMIC Thu Apr 16 11:50:58 CST 2026 riscv64 GNU/Linux
zifeihan@riscv-spacemitk3picoitx:~$ cat /etc/issue
Bianbu 4.0rc2 \n \l
```

### Testing (SpacemiT Key Stone K3)
- [x] tier1-3 tests (release)

jmh testing:
without this patch (SpacemiT Key Stone K3):
```
Benchmark                    (count)   Mode  Cnt      Score    Error   Units
TestCRC32.testCRC32Update         64  thrpt   12  10057.523 ±  0.783  ops/ms
TestCRC32.testCRC32Update        128  thrpt   12   5449.713 ±  0.353  ops/ms
TestCRC32.testCRC32Update        256  thrpt   12   2906.332 ±  1.912  ops/ms
TestCRC32.testCRC32Update        512  thrpt   12   1496.518 ±  0.116  ops/ms
TestCRC32.testCRC32Update       2048  thrpt   12    457.293 ±  0.048  ops/ms
TestCRC32.testCRC32Update      16384  thrpt   12     61.339 ±  0.006  ops/ms
TestCRC32.testCRC32Update      65536  thrpt   12     15.338 ±  0.010  ops/ms
TestCRC32C.testCRC32CUpdate       64  thrpt   12  10135.697 ±  9.221  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt   12   6595.783 ± 32.884  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt   12   3873.301 ± 14.423  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt   12   2132.007 ±  4.856  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt   12    559.113 ±  0.136  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt   12     71.467 ±  0.029  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt   12     17.824 ±  0.010  ops/ms
Finished running test 'micro:org.openjdk.bench.java.util.TestCRC32'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_org_openjdk_bench_java_util_TestCRC32

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:org.openjdk.bench.java.util.TestCRC32           1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'

```
with this patch (SpacemiT Key Stone K3)::
```
Benchmark                    (count)   Mode  Cnt      Score    Error   Units
TestCRC32.testCRC32Update         64  thrpt   12  10006.359 ± 58.732  ops/ms
TestCRC32.testCRC32Update        128  thrpt   12   5448.468 ±  2.178  ops/ms
TestCRC32.testCRC32Update        256  thrpt   12   2907.767 ±  0.923  ops/ms
TestCRC32.testCRC32Update        512  thrpt   12   3564.267 ±  3.698  ops/ms
TestCRC32.testCRC32Update       2048  thrpt   12   1824.599 ±  0.185  ops/ms
TestCRC32.testCRC32Update      16384  thrpt   12    328.258 ±  0.087  ops/ms
TestCRC32.testCRC32Update      65536  thrpt   12     84.701 ±  1.973  ops/ms
TestCRC32C.testCRC32CUpdate       64  thrpt   12  10058.846 ± 65.353  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt   12   6588.618 ± 16.735  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt   12   3876.975 ±  6.573  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt   12   2129.257 ±  5.100  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt   12    559.549 ±  0.424  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt   12     71.422 ±  0.008  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt   12     17.788 ±  0.044  ops/ms
Finished running test 'micro:org.openjdk.bench.java.util.TestCRC32'
Test report is stored in build/linux-riscv64-server-release/test-results/micro_org_openjdk_bench_java_util_TestCRC32

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:org.openjdk.bench.java.util.TestCRC32           1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-riscv64-server-release'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388075](https://bugs.openjdk.org/browse/JDK-8388075): RISC-V: Auto-enable Zvbc extension features (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31862/head:pull/31862` \
`$ git checkout pull/31862`

Update a local copy of the PR: \
`$ git checkout pull/31862` \
`$ git pull https://git.openjdk.org/jdk.git pull/31862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31862`

View PR using the GUI difftool: \
`$ git pr show -t 31862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31862.diff">https://git.openjdk.org/jdk/pull/31862.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31862#issuecomment-4936138022)
</details>
