### PR TITLE
8375572: stuck method references should consider free vars in the target type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -1273,6 +1273,17 @@ public class DeferredAttr extends JCTree.Visitor {
                 stuckVars.addAll(freeArgVars);
                 depVars.addAll(inferenceContext.freeVarsIn(descType.getReturnType()));
                 depVars.addAll(inferenceContext.freeVarsIn(descType.getThrownTypes()));
+                /* if pt has any type arguments which happen to be free vars, and hasn't been accounted
+                 * for, should be included as stuck vars since the deferred check calls
+                 * findDescriptorType(asInstType(pt))
+                 */
+                Set<Type> stuckAndDepVars = new LinkedHashSet<>(stuckVars);
+                stuckAndDepVars.addAll(depVars);
+                for (Type v : inferenceContext.freeVarsIn(pt.getTypeArguments())) {
+                    if (!stuckAndDepVars.contains(v)) {
+                        stuckVars.add(v);
+                    }
+                }
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -1278,10 +1278,12 @@ public class DeferredAttr extends JCTree.Visitor {
                  * findDescriptorType(asInstType(pt)) and we can get a partial type if not all free vars
                  * in the target type have been instantiated
                  */
-                Set<Type> stuckAndDepVars = new LinkedHashSet<>(stuckVars);
-                stuckAndDepVars.addAll(depVars);
+                List<Type> freeInDescriptor = inferenceContext.freeVarsIn(
+                        descType.getParameterTypes()
+                                .appendList(descType.getThrownTypes())
+                                .prepend(descType.getReturnType()));
                 for (Type v : inferenceContext.freeVarsIn(pt.getTypeArguments())) {
-                    if (!stuckAndDepVars.contains(v)) {
+                    if (!freeInDescriptor.contains(v)) {
                         stuckVars.add(v);
                     }
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -1274,8 +1274,9 @@ public class DeferredAttr extends JCTree.Visitor {
                 depVars.addAll(inferenceContext.freeVarsIn(descType.getReturnType()));
                 depVars.addAll(inferenceContext.freeVarsIn(descType.getThrownTypes()));
                 /* if pt has any type arguments which happen to be free vars, and hasn't been accounted
-                 * for, should be included as stuck vars since the deferred check calls
-                 * findDescriptorType(asInstType(pt))
+                 * for, they should be included as stuck vars since the deferred check calls
+                 * findDescriptorType(asInstType(pt)) and we can get a partial type if not all free vars
+                 * in the target type have been instantiated
                  */
                 Set<Type> stuckAndDepVars = new LinkedHashSet<>(stuckVars);
                 stuckAndDepVars.addAll(depVars);

--- a/test/langtools/tools/javac/lambda/methodReference/MethodRefStuck3.java
+++ b/test/langtools/tools/javac/lambda/methodReference/MethodRefStuck3.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8375572
+ * @summary stuck method references should consider free vars in the target type
+ * @compile MethodRefStuck3.java
+ */
+
+class MethodRefStuck3 {
+    interface Interface<A> {
+        interface Factory<A extends Interface<B>,B> {
+            Interface<B> create(B obj);
+        }
+    }
+
+    record Klass(String value, int otherValue) implements Interface<String> {
+        public Klass(String thing) {
+            this(thing, -1);
+        }
+    }
+
+    interface InterfaceB<A extends Interface<B>,B> {}
+
+    record KlassB<A extends Interface<B>,B>(Class<A> cls, Interface.Factory<A,B> factory) implements InterfaceB<A,B> {}
+
+    private interface InterfaceC<A extends Interface<B>,B> {
+        InterfaceB<A,B> getInterfaceB();
+    }
+
+    private static class KlassC implements InterfaceC<Klass,String> {
+        @Override
+        public InterfaceB<Klass, String> getInterfaceB() {
+            return new KlassB<>(Klass.class, Klass::new);
+        }
+    }
+}


### PR DESCRIPTION
Please review this fix related to inexact method references. In this case a test case like:

```
class MethodRefStuck3 {
    interface Interface<A> {
        interface Factory<A extends Interface<B>,B> {
            Interface<B> create(B obj);
        }
    }

    record Klass(String value, int otherValue) implements Interface<String> {
        public Klass(String thing) {
            this(thing, -1);
        }
    }

    interface InterfaceB<A extends Interface<B>,B> {}

    record KlassB<A extends Interface<B>,B>(Class<A> cls, Interface.Factory<A,B> factory) implements InterfaceB<A,B> {}

    private interface InterfaceC<A extends Interface<B>,B> {
        InterfaceB<A,B> getInterfaceB();
    }

    private static class KlassC implements InterfaceC<Klass,String> {
        @Override
        public InterfaceB<Klass, String> getInterfaceB() {
            return new KlassB<>(Klass.class, Klass::new);
        }
    }
}
```
is being rejected by javac. The issue here is that method reference Klass::new is overloaded so not considered during overload resolution, considered stuck. But the issue here is that the target type of this method reference has one free variable that javac is not accounting for, waiting until it is instantiated. So by the time javac considers that the method reference is unstuck and proceeds to check it, the the target type still has type variables that hasn't been instantiated and thus the check fails and the compilation fails. In this particular case the target type has one type argument that is not accounted for. The proposed fix is to add type arguments in the target type to the stuck variables to avoid this issue.

TIA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8375572: stuck method references should consider free vars in the target type`

### Issue
 * [JDK-8375572](https://bugs.openjdk.org/browse/JDK-8375572): stuck method references should consider free vars in the target type (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31865/head:pull/31865` \
`$ git checkout pull/31865`

Update a local copy of the PR: \
`$ git checkout pull/31865` \
`$ git pull https://git.openjdk.org/jdk.git pull/31865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31865`

View PR using the GUI difftool: \
`$ git pr show -t 31865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31865.diff">https://git.openjdk.org/jdk/pull/31865.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31865#issuecomment-4938787700)
</details>
