### PR TITLE
8388080: Increase static size of some stubs for APX code

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.hpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.hpp
@@ -27,7 +27,7 @@
 
 // Adapters
 enum /* platform_dependent_constants */ {
-  adapter_code_size = 6000 DEBUG_ONLY(+ 6000)
+  adapter_code_size = 12000 DEBUG_ONLY(+ 6000)
 };
 
 // Additional helper methods for MethodHandles code generation:

--- a/src/hotspot/cpu/x86/methodHandles_x86.hpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.hpp
@@ -27,7 +27,7 @@
 
 // Adapters
 enum /* platform_dependent_constants */ {
-  adapter_code_size = 12000 DEBUG_ONLY(+ 6000)
+  adapter_code_size = 8000 DEBUG_ONLY(+ 6000)
 };
 
 // Additional helper methods for MethodHandles code generation:

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3452,7 +3452,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
   };
 
   const char* name = SharedRuntime::stub_name(StubId::shared_jfr_write_checkpoint_id);
-  CodeBuffer code(name, 1024 + (UseAPX ? 64 : 0), 64);
+  CodeBuffer code(name, 1024 + (UseAPX ? 1024 : 0), 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3452,7 +3452,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
   };
 
   const char* name = SharedRuntime::stub_name(StubId::shared_jfr_write_checkpoint_id);
-  CodeBuffer code(name, 1024, 64);
+  CodeBuffer code(name, 1024 + (UseAPX ? 64 : 0), 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();
 


### PR DESCRIPTION
Some APX code sequences are larger in bytes, and register save/restore sequences are larger to account for more registers.

This caused a few jtreg test failures in release and fastdebug runs. Primarily in cases involving APX+Shenandoah+[AOT].

Bug only affects x86 systems that support the new APX instructions, running with UseAPX.

Draft status: retesting in progress
---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388080](https://bugs.openjdk.org/browse/JDK-8388080): Increase static size of some stubs for APX code (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31867/head:pull/31867` \
`$ git checkout pull/31867`

Update a local copy of the PR: \
`$ git checkout pull/31867` \
`$ git pull https://git.openjdk.org/jdk.git pull/31867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31867`

View PR using the GUI difftool: \
`$ git pr show -t 31867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31867.diff">https://git.openjdk.org/jdk/pull/31867.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31867#issuecomment-4960051452)
</details>
