### PR TITLE
Fix typo in PrimitiveIterator.OfDouble trip message

### DIFF
--- a/src/java.base/share/classes/java/util/PrimitiveIterator.java
+++ b/src/java.base/share/classes/java/util/PrimitiveIterator.java
@@ -260,7 +260,7 @@ public interface PrimitiveIterator<T, T_CONS> extends Iterator<T> {
         @Override
         default Double next() {
             if (Tripwire.ENABLED)
-                Tripwire.trip(getClass(), "{0} calling PrimitiveIterator.OfDouble.nextLong()");
+                Tripwire.trip(getClass(), "{0} calling PrimitiveIterator.OfDouble.nextDouble()");
             return nextDouble();
         }
 


### PR DESCRIPTION
Simple typo. `OfDouble` calls `nextDouble` not `nextLong`, unlike what is incorrectly stated in the `Tripwire::trip` message.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31870/head:pull/31870` \
`$ git checkout pull/31870`

Update a local copy of the PR: \
`$ git checkout pull/31870` \
`$ git pull https://git.openjdk.org/jdk.git pull/31870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31870`

View PR using the GUI difftool: \
`$ git pr show -t 31870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31870.diff">https://git.openjdk.org/jdk/pull/31870.diff</a>

</details>
