### PR TITLE
8388117: [s390x] is_z_illtrap should recognise all forms

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -3280,7 +3280,7 @@ class Assembler : public AbstractAssembler {
     return is_z_nop(* (short *) x);
   }
   static bool is_z_illtrap(address x) {
-    return *(uint16_t*)x == 0u;
+    return *(uint8_t*)x == 0u;
   }
   static bool is_z_br(long x) {
     return is_z_bcr(x) && ((x & 0x00f0) == 0x00f0);

--- a/test/hotspot/gtest/s390/test_assembler_s390.cpp
+++ b/test/hotspot/gtest/s390/test_assembler_s390.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, IBM Corporation. and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#if defined(S390) && !defined(ZERO)
+
+#include "asm/assembler.hpp"
+#include "asm/assembler.inline.hpp"
+#include "unittest.hpp"
+
+// ---------------------------------------------------------------------------
+// Tests for Assembler::is_z_illtrap
+//
+// The three emitter forms and what they write into memory (big-endian):
+//
+//   z_illtrap()                -> 0x00 0x00   (id == 0)
+//   z_illtrap(int id)          -> 0x00 <id>   (e.g. 0x00 0xba)
+//   z_illtrap_eyecatcher(...)  -> ends with z_illtrap(xpattern) -> 0x00 <xp>
+//
+// All forms share: high byte (first byte in memory) == 0x00.
+// is_z_illtrap must recognise all of them, not just 0x0000.
+// ---------------------------------------------------------------------------
+
+TEST(AssemblerS390, is_z_illtrap_no_id) {
+  // z_illtrap() emits 0x0000 — must be detected.
+  uint8_t buf[] = { 0x00, 0x00 };
+  EXPECT_TRUE(Assembler::is_z_illtrap((address)buf))
+      << "z_illtrap() (0x0000) must be recognised as illtrap";
+}
+
+TEST(AssemblerS390, is_z_illtrap_with_id) {
+  // z_illtrap(id) emits 0x00<id> — must also be detected.
+  // Tests a representative set of ids actually used in the source.
+  const uint8_t ids[] = { 0x22, 0x55, 0x66, 0x99, 0xba, 0xd1, 0xd2, 0xee };
+  for (uint8_t id : ids) {
+    uint8_t buf[] = { 0x00, id };
+    EXPECT_TRUE(Assembler::is_z_illtrap((address)buf))
+        << "z_illtrap(0x" << std::hex << (int)id << ") must be recognised as illtrap";
+  }
+}
+
+TEST(AssemblerS390, is_z_illtrap_false_positive) {
+  // A non-zero high byte must NOT be recognised as an illtrap.
+  uint8_t buf[] = { 0x47, 0x00 };  // BCR 0,0  (a NOP — not an illtrap)
+  EXPECT_FALSE(Assembler::is_z_illtrap((address)buf))
+      << "BCR 0,0 (0x4700) must not be recognised as illtrap";
+}
+
+#endif // S390 && !ZERO
+

--- a/test/hotspot/gtest/s390/test_assembler_s390.cpp
+++ b/test/hotspot/gtest/s390/test_assembler_s390.cpp
@@ -60,9 +60,9 @@ TEST(AssemblerS390, is_z_illtrap_with_id) {
 
 TEST(AssemblerS390, is_z_illtrap_false_positive) {
   // A non-zero high byte must NOT be recognised as an illtrap.
-  uint8_t buf[] = { 0x47, 0x00 };  // BCR 0,0  (a NOP — not an illtrap)
+  uint8_t buf[] = { 0x07, 0x00 };  // BCR 0,0  (a NOP — not an illtrap)
   EXPECT_FALSE(Assembler::is_z_illtrap((address)buf))
-      << "BCR 0,0 (0x4700) must not be recognised as illtrap";
+      << "BCR 0,0 (0x0700) must not be recognised as illtrap";
 }
 
 #endif // S390 && !ZERO


### PR DESCRIPTION
Address the comment: https://github.com/openjdk/jdk/pull/31441#discussion_r3552166911 

See the JBS and testcase to understand the issue;

Before 
```
[  FAILED  ] AssemblerS390.is_z_illtrap_with_id (0 ms)
[ RUN      ] AssemblerS390.is_z_illtrap_false_positive
[       OK ] AssemblerS390.is_z_illtrap_false_positive (0 ms)
[----------] 3 tests from AssemblerS390 (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] AssemblerS390.is_z_illtrap_with_id

```

with the fix: 

```
Note: Google Test filter = AssemblerS390*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from AssemblerS390
[ RUN      ] AssemblerS390.is_z_illtrap_no_id
[       OK ] AssemblerS390.is_z_illtrap_no_id (0 ms)
[ RUN      ] AssemblerS390.is_z_illtrap_with_id
[       OK ] AssemblerS390.is_z_illtrap_with_id (0 ms)
[ RUN      ] AssemblerS390.is_z_illtrap_false_positive
[       OK ] AssemblerS390.is_z_illtrap_false_positive (0 ms)
[----------] 3 tests from AssemblerS390 (0 ms total)
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388117](https://bugs.openjdk.org/browse/JDK-8388117): [s390x] is_z_illtrap should recognise all forms (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Harshit Dhiman](https://openjdk.org/census#hdhiman) (@Harshit470250 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31871/head:pull/31871` \
`$ git checkout pull/31871`

Update a local copy of the PR: \
`$ git checkout pull/31871` \
`$ git pull https://git.openjdk.org/jdk.git pull/31871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31871`

View PR using the GUI difftool: \
`$ git pr show -t 31871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31871.diff">https://git.openjdk.org/jdk/pull/31871.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31871#issuecomment-4943707831)
</details>
