### PR TITLE
8387996: Remove reference to -d64 from serviceability tool manpages

### DIFF
--- a/src/jdk.jcmd/share/man/jinfo.md
+++ b/src/jdk.jcmd/share/man/jinfo.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,10 +50,7 @@ jinfo - generate Java configuration information for a specified Java process
 
 The `jinfo` command prints Java configuration information for a specified Java
 process. The configuration information includes Java system properties and JVM
-command-line flags. If the specified process is running on a 64-bit JVM, then
-you might need to specify the `-J-d64` option, for example:
-
->   `jinfo -J-d64 -sysprops` *pid*
+command-line flags.
 
 This command is unsupported and might not be available in future releases of
 the JDK. In Windows Systems where `dbgeng.dll` is not present, the Debugging

--- a/src/jdk.jcmd/share/man/jstack.md
+++ b/src/jdk.jcmd/share/man/jstack.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,7 @@ The `jstack` command prints Java stack traces of Java threads for a specified
 Java process. For each Java frame, the full class name, method name, byte code
 index (BCI), and line number, when available, are printed. C++ mangled names
 aren't demangled. To demangle C++ names, the output of this command can be
-piped to `c++filt`. When the specified process is running on a 64-bit JVM, you
-might need to specify the `-J-d64` option, for example: `jstack -J-d64` *pid*.
+piped to `c++filt`.
 
 **Note:**
 


### PR DESCRIPTION
As noted in https://bugs.openjdk.org/browse/JDK-8387996, the `jinfo` and
`jstack` man pages still recommend using the `-J-d64` option when attaching
to a 64-bit JVM.

The `-d64` option has not been available since JDK 10. This patch removes
the obsolete guidance from both man pages.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387996](https://bugs.openjdk.org/browse/JDK-8387996): Remove reference to -d64 from serviceability tool manpages (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31872/head:pull/31872` \
`$ git checkout pull/31872`

Update a local copy of the PR: \
`$ git checkout pull/31872` \
`$ git pull https://git.openjdk.org/jdk.git pull/31872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31872`

View PR using the GUI difftool: \
`$ git pr show -t 31872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31872.diff">https://git.openjdk.org/jdk/pull/31872.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31872#issuecomment-4950162038)
</details>
