### PR TITLE
8387467: ZGC: Use shared thread-local _nmethod_disarmed_guard_value

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ BarrierSet::BarrierSet(BarrierSetAssembler* barrier_set_assembler,
 
 void BarrierSet::on_thread_attach(Thread* thread) {
   BarrierSetNMethod* bs_nm = barrier_set_nmethod();
-  thread->set_nmethod_disarmed_guard_value(bs_nm->disarmed_guard_value());
+  bs_nm->set_thread_disarmed_guard_value(thread);
 }
 
 // Called from init.cpp

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -135,6 +135,10 @@ ByteSize BarrierSetNMethod::thread_disarmed_guard_value_offset() const {
   return Thread::nmethod_disarmed_guard_value_offset();
 }
 
+void BarrierSetNMethod::set_thread_disarmed_guard_value(Thread* thread) {
+  thread->set_nmethod_disarmed_guard_value(disarmed_guard_value());
+}
+
 class BarrierSetNMethodArmClosure : public ThreadClosure {
 private:
   int _disarmed_guard_value;

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.hpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.hpp
@@ -54,8 +54,10 @@ public:
   bool supports_entry_barrier(nmethod* nm);
 
   virtual bool nmethod_entry_barrier(nmethod* nm);
-  virtual ByteSize thread_disarmed_guard_value_offset() const;
   virtual int* disarmed_guard_value_address() const;
+
+  ByteSize thread_disarmed_guard_value_offset() const;
+  void set_thread_disarmed_guard_value(Thread* thread);
 
   int disarmed_guard_value() const;
 

--- a/src/hotspot/share/gc/shared/gcThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shared/gcThreadLocalData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,6 @@
 // should consider placing frequently accessed fields first in
 // T, so that field offsets relative to Thread are small, which
 // often allows for a more compact instruction encoding.
-typedef uint64_t GCThreadLocalData[40]; // 320 bytes
+typedef uint64_t GCThreadLocalData[39]; // 312 bytes
 
 #endif // SHARE_GC_SHARED_GCTHREADLOCALDATA_HPP

--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -251,13 +251,14 @@ void ZBarrierSet::on_thread_destroy(Thread* thread) {
 }
 
 void ZBarrierSet::on_thread_attach(Thread* thread) {
+  BarrierSet::on_thread_attach(thread);
+
   // Set thread local masks
   ZThreadLocalData::set_load_bad_mask(thread, ZPointerLoadBadMask);
   ZThreadLocalData::set_load_good_mask(thread, ZPointerLoadGoodMask);
   ZThreadLocalData::set_mark_bad_mask(thread, ZPointerMarkBadMask);
   ZThreadLocalData::set_store_bad_mask(thread, ZPointerStoreBadMask);
   ZThreadLocalData::set_store_good_mask(thread, ZPointerStoreGoodMask);
-  ZThreadLocalData::set_nmethod_disarmed(thread, ZPointerStoreGoodMask);
   if (thread->is_Java_thread()) {
     JavaThread* const jt = JavaThread::cast(thread);
     StackWatermark* const watermark = new ZStackWatermark(jt);

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zNMethod.hpp"
 #include "gc/z/zResurrection.inline.hpp"
-#include "gc/z/zThreadLocalData.hpp"
 #include "gc/z/zUncoloredRoot.inline.hpp"
 #include "logging/log.hpp"
 #include "runtime/icache.hpp"
@@ -96,10 +95,6 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
 
 int* ZBarrierSetNMethod::disarmed_guard_value_address() const {
   return (int*)ZPointerStoreGoodMaskLowOrderBitsAddr;
-}
-
-ByteSize ZBarrierSetNMethod::thread_disarmed_guard_value_offset() const {
-  return ZThreadLocalData::nmethod_disarmed_offset();
 }
 
 oop ZBarrierSetNMethod::oop_load_no_keepalive(const nmethod* nm, int index) {

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ protected:
 public:
   uintptr_t color(nmethod* nm);
 
-  virtual ByteSize thread_disarmed_guard_value_offset() const;
   virtual int* disarmed_guard_value_address() const;
 
   virtual oop oop_load_no_keepalive(const nmethod* nm, int index);

--- a/src/hotspot/share/gc/z/zStackWatermark.cpp
+++ b/src/hotspot/share/gc/z/zStackWatermark.cpp
@@ -23,6 +23,7 @@
 
 #include "gc/z/zAddress.hpp"
 #include "gc/z/zBarrier.inline.hpp"
+#include "gc/z/zBarrierSet.hpp"
 #include "gc/z/zGeneration.inline.hpp"
 #include "gc/z/zStackWatermark.hpp"
 #include "gc/z/zStoreBarrierBuffer.hpp"
@@ -189,7 +190,9 @@ void ZStackWatermark::start_processing_impl(void* context) {
   ZThreadLocalData::set_mark_bad_mask(_jt, ZPointerMarkBadMask);
   ZThreadLocalData::set_store_bad_mask(_jt, ZPointerStoreBadMask);
   ZThreadLocalData::set_store_good_mask(_jt, ZPointerStoreGoodMask);
-  _jt->set_nmethod_disarmed_guard_value(*ZPointerStoreGoodMaskLowOrderBitsAddr);
+
+  // Update thread-local nmethod disarmed guard value
+  BarrierSet::barrier_set()->barrier_set_nmethod()->set_thread_disarmed_guard_value(_jt);
 
   // Retire TLAB
   if (ZGeneration::young()->is_phase_mark() || ZGeneration::old()->is_phase_mark()) {

--- a/src/hotspot/share/gc/z/zStackWatermark.cpp
+++ b/src/hotspot/share/gc/z/zStackWatermark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ void ZStackWatermark::start_processing_impl(void* context) {
   ZThreadLocalData::set_mark_bad_mask(_jt, ZPointerMarkBadMask);
   ZThreadLocalData::set_store_bad_mask(_jt, ZPointerStoreBadMask);
   ZThreadLocalData::set_store_good_mask(_jt, ZPointerStoreGoodMask);
-  ZThreadLocalData::set_nmethod_disarmed(_jt, ZPointerStoreGoodMask);
+  _jt->set_nmethod_disarmed_guard_value(*ZPointerStoreGoodMaskLowOrderBitsAddr);
 
   // Retire TLAB
   if (ZGeneration::young()->is_phase_mark() || ZGeneration::old()->is_phase_mark()) {

--- a/src/hotspot/share/gc/z/zThreadLocalData.hpp
+++ b/src/hotspot/share/gc/z/zThreadLocalData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ private:
   uintptr_t              _mark_bad_mask;
   uintptr_t              _store_good_mask;
   uintptr_t              _store_bad_mask;
-  uintptr_t              _nmethod_disarmed;
   ZStoreBarrierBuffer*   _store_barrier_buffer;
   ZMarkThreadLocalStacks _mark_stacks[2];
   zaddress_unsafe*       _invisible_root;
@@ -50,7 +49,6 @@ private:
       _mark_bad_mask(0),
       _store_good_mask(0),
       _store_bad_mask(0),
-      _nmethod_disarmed(0),
       _store_barrier_buffer(new ZStoreBarrierBuffer()),
       _mark_stacks(),
       _invisible_root(nullptr) {}
@@ -92,10 +90,6 @@ public:
     data(thread)->_store_good_mask = mask;
   }
 
-  static void set_nmethod_disarmed(Thread* thread, uintptr_t value) {
-    data(thread)->_nmethod_disarmed = value;
-  }
-
   static ZMarkThreadLocalStacks* mark_stacks(Thread* thread, ZGenerationId id) {
     return &data(thread)->_mark_stacks[(int)id];
   }
@@ -132,10 +126,6 @@ public:
 
   static ByteSize store_good_mask_offset() {
     return Thread::gc_data_offset() + byte_offset_of(ZThreadLocalData, _store_good_mask);
-  }
-
-  static ByteSize nmethod_disarmed_offset() {
-    return Thread::gc_data_offset() + byte_offset_of(ZThreadLocalData, _nmethod_disarmed);
   }
 
   static ByteSize store_barrier_buffer_offset() {


### PR DESCRIPTION
As noted in https://bugs.openjdk.org/browse/JDK-8387467, ZGC stores its
thread-local disarmed nmethod guard value separately in
`ZThreadLocalData::_nmethod_disarmed`, even though `Thread` already provides
`_nmethod_disarmed_guard_value` for this purpose.

This patch makes ZGC use the shared `Thread` field. It removes the duplicate
field and offset accessor, uses the common barrier-set initialization when
attaching threads, and updates the shared guard during stack-watermark
processing.

Testing:
- `make CONF=windows-x86_64-server-fastdebug hotspot`
- `make CONF=windows-x86_64-server-fastdebug test TEST="test/hotspot/jtreg/gc/z"`
- `jtreg -jdk:build/windows-x86_64-server-fastdebug/images/jdk test/hotspot/jtreg/gc/TestCodeCacheUnload.java#z`
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387467](https://bugs.openjdk.org/browse/JDK-8387467): ZGC: Use shared thread-local _nmethod_disarmed_guard_value (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31873/head:pull/31873` \
`$ git checkout pull/31873`

Update a local copy of the PR: \
`$ git checkout pull/31873` \
`$ git pull https://git.openjdk.org/jdk.git pull/31873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31873`

View PR using the GUI difftool: \
`$ git pr show -t 31873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31873.diff">https://git.openjdk.org/jdk/pull/31873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31873#issuecomment-4950303623)
</details>
