### PR TITLE
8388120: [s390x] c2: c_return_value is redundant

### DIFF
--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -2617,21 +2617,6 @@ frame %{
   // stack slot.
   return_addr(REG Z_R14);
 
-  // Location of native (C/C++) and interpreter return values. This
-  // is specified to be the same as Java. In the 32-bit VM, long
-  // values are actually returned from native calls in O0:O1 and
-  // returned to the interpreter in I0:I1. The copying to and from
-  // the register pairs is done by the appropriate call and epilog
-  // opcodes. This simplifies the register allocator.
-  //
-  // Use register pair for c return value.
-  c_return_value %{
-    assert(ideal_reg >= Op_RegI && ideal_reg <= Op_RegL, "only return normal values");
-    static int typeToRegLo[Op_RegL+1] = { 0, 0, Z_R2_num, Z_R2_num, Z_R2_num, Z_F0_num, Z_F0_num, Z_R2_num };
-    static int typeToRegHi[Op_RegL+1] = { 0, 0, OptoReg::Bad, OptoReg::Bad, Z_R2_H_num, OptoReg::Bad, Z_F0_H_num, Z_R2_H_num };
-    return OptoRegPair(typeToRegHi[ideal_reg], typeToRegLo[ideal_reg]);
-  %}
-
   // Use register pair for return value.
   // Location of compiled Java return values. Same as C
   return_value %{

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -2621,9 +2621,27 @@ frame %{
   // Location of compiled Java return values. Same as C
   return_value %{
     assert(ideal_reg >= Op_RegI && ideal_reg <= Op_RegL, "only return normal values");
-    static int typeToRegLo[Op_RegL+1] = { 0, 0, Z_R2_num, Z_R2_num, Z_R2_num, Z_F0_num, Z_F0_num, Z_R2_num };
-    static int typeToRegHi[Op_RegL+1] = { 0, 0, OptoReg::Bad, OptoReg::Bad, Z_R2_H_num, OptoReg::Bad, Z_F0_H_num, Z_R2_H_num };
-    return OptoRegPair(typeToRegHi[ideal_reg], typeToRegLo[ideal_reg]);
+    static const int lo[Op_RegL + 1] = {
+      0,
+      0,
+      Z_R2_num,     // Op_RegN
+      Z_R2_num,     // Op_RegI
+      Z_R2_num,     // Op_RegP
+      Z_F0_num,     // Op_RegF
+      Z_F0_num,     // Op_RegD
+      Z_R2_num      // Op_RegL
+    };
+    static const int hi[Op_RegL + 1] = {
+      0,
+      0,
+      OptoReg::Bad, // Op_RegN
+      OptoReg::Bad, // Op_RegI
+      Z_R2_H_num,   // Op_RegP
+      OptoReg::Bad, // Op_RegF
+      Z_F0_H_num,   // Op_RegD
+      Z_R2_H_num    // Op_RegL
+    };
+    return OptoRegPair(hi[ideal_reg], lo[ideal_reg]);
   %}
 %}
 


### PR DESCRIPTION
The s390x `c_return_value` definition is identical to `return_value`. When
`c_return_value` is omitted, ADLC automatically uses `return_value` for native
calls.

This patch removes the redundant definition and an outdated SPARC-specific
comment describing O0/O1 and I0/I1 return registers.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388120](https://bugs.openjdk.org/browse/JDK-8388120): [s390x] c2: c_return_value is redundant (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31875/head:pull/31875` \
`$ git checkout pull/31875`

Update a local copy of the PR: \
`$ git checkout pull/31875` \
`$ git pull https://git.openjdk.org/jdk.git pull/31875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31875`

View PR using the GUI difftool: \
`$ git pr show -t 31875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31875.diff">https://git.openjdk.org/jdk/pull/31875.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31875#issuecomment-4954440509)
</details>
