### PR TITLE
8388122: NMT: Remove unused comm_size variable from RegionsTree::visit_committed_regions

### DIFF
--- a/src/hotspot/share/nmt/regionsTree.inline.hpp
+++ b/src/hotspot/share/nmt/regionsTree.inline.hpp
@@ -32,7 +32,6 @@ template<typename F>
 void RegionsTree::visit_committed_regions(const VirtualMemoryRegion& rgn, F func) {
   position start = (position)rgn.base();
   size_t end = reinterpret_cast<size_t>(rgn.end()) + 1;
-  size_t comm_size = 0;
 
   NodeHelper prev;
   visit_range_in_order(start, end, [&](Node* node) {


### PR DESCRIPTION
Trivial removing dead code.

Test: build

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388122](https://bugs.openjdk.org/browse/JDK-8388122): NMT: Remove unused comm_size variable from RegionsTree::visit_committed_regions (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31876/head:pull/31876` \
`$ git checkout pull/31876`

Update a local copy of the PR: \
`$ git checkout pull/31876` \
`$ git pull https://git.openjdk.org/jdk.git pull/31876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31876`

View PR using the GUI difftool: \
`$ git pr show -t 31876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31876.diff">https://git.openjdk.org/jdk/pull/31876.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31876#issuecomment-4954823018)
</details>
