### PR TITLE
8388072: Linux/AArch64 PAC-RET: assert(top.pc() == *(address*)(sp - frame::sender_sp_ret_address_offset())) failed

### DIFF
--- a/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
@@ -216,7 +216,7 @@ inline intptr_t* AnchorMark::anchor_mark_set_pd() {
       // We need to move up return pc and fp. They will be read next in
       // set_anchor() and set as _last_Java_pc and _last_Java_fp respectively.
       ContinuationHelper::patch_return_address_at(&_last_sp_from_frame[-1],
-        _top_frame.pc());
+                                                  _top_frame.pc());
       _last_sp_from_frame[-2] = (intptr_t)_top_frame.fp();
     }
     _is_interpreted = true;
@@ -342,7 +342,7 @@ inline intptr_t* ThawBase::push_cleanup_continuation() {
 
   // We only need to set the return pc. rfp will be restored back in gen_continuation_enter().
   ContinuationHelper::patch_return_address_at(&sp[-1],
-    ContinuationEntry::cleanup_pc());
+                                              ContinuationEntry::cleanup_pc());
   return sp;
 }
 
@@ -352,7 +352,7 @@ inline intptr_t* ThawBase::push_preempt_adapter() {
 
   // We only need to set the return pc. rfp will be restored back in generate_cont_preempt_stub().
   ContinuationHelper::patch_return_address_at(&sp[-1],
-    StubRoutines::cont_preempt_stub());
+                                              StubRoutines::cont_preempt_stub());
   return sp;
 }
 

--- a/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,8 @@ inline intptr_t* AnchorMark::anchor_mark_set_pd() {
     if (sp != _last_sp_from_frame) {
       // We need to move up return pc and fp. They will be read next in
       // set_anchor() and set as _last_Java_pc and _last_Java_fp respectively.
-      _last_sp_from_frame[-1] = (intptr_t)_top_frame.pc();
+      ContinuationHelper::patch_return_address_at(&_last_sp_from_frame[-1],
+        _top_frame.pc());
       _last_sp_from_frame[-2] = (intptr_t)_top_frame.fp();
     }
     _is_interpreted = true;
@@ -230,7 +231,7 @@ inline void AnchorMark::anchor_mark_clear_pd() {
     _top_frame.interpreter_frame_set_last_sp(_last_sp_from_frame);
     intptr_t* sp = _top_frame.sp();
     if (sp != _last_sp_from_frame) {
-      sp[-1] = (intptr_t)_top_frame.pc();
+      ContinuationHelper::patch_return_address_at(&sp[-1], _top_frame.pc());
     }
   }
 }
@@ -340,7 +341,8 @@ inline intptr_t* ThawBase::push_cleanup_continuation() {
   intptr_t* sp = enterSpecial.sp();
 
   // We only need to set the return pc. rfp will be restored back in gen_continuation_enter().
-  sp[-1] = (intptr_t)ContinuationEntry::cleanup_pc();
+  ContinuationHelper::patch_return_address_at(&sp[-1],
+    ContinuationEntry::cleanup_pc());
   return sp;
 }
 
@@ -349,7 +351,8 @@ inline intptr_t* ThawBase::push_preempt_adapter() {
   intptr_t* sp = enterSpecial.sp();
 
   // We only need to set the return pc. rfp will be restored back in generate_cont_preempt_stub().
-  sp[-1] = (intptr_t)StubRoutines::cont_preempt_stub();
+  ContinuationHelper::patch_return_address_at(&sp[-1],
+    StubRoutines::cont_preempt_stub());
   return sp;
 }
 

--- a/src/hotspot/cpu/aarch64/continuationHelper_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationHelper_aarch64.inline.hpp
@@ -48,7 +48,7 @@ static inline void patch_return_pc_with_preempt_stub(frame& f) {
     // compiled method so that the target returns to the preempt cleanup stub.
     intptr_t* caller_sp = f.sp() + f.cb()->frame_size();
     ContinuationHelper::patch_return_address_at(&caller_sp[-1],
-      StubRoutines::cont_preempt_stub());
+                                                StubRoutines::cont_preempt_stub());
   } else {
     // The target will check for preemption once it returns to the interpreter
     // or the native wrapper code and will manually jump to the preempt stub.

--- a/src/hotspot/cpu/aarch64/continuationHelper_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationHelper_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ static inline void patch_return_pc_with_preempt_stub(frame& f) {
     // Instead, we will patch the return from the runtime stub back to the
     // compiled method so that the target returns to the preempt cleanup stub.
     intptr_t* caller_sp = f.sp() + f.cb()->frame_size();
-    caller_sp[-1] = (intptr_t)StubRoutines::cont_preempt_stub();
+    ContinuationHelper::patch_return_address_at(&caller_sp[-1],
+      StubRoutines::cont_preempt_stub());
   } else {
     // The target will check for preemption once it returns to the interpreter
     // or the native wrapper code and will manually jump to the preempt stub.

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -3246,8 +3246,6 @@ static void log_frames(JavaThread* thread) {
 
 static void log_frames_after_thaw(JavaThread* thread, ContinuationWrapper& cont, intptr_t* sp) {
   intptr_t* sp0 = sp;
-  address pc0 = *(address*)(sp - frame::sender_sp_ret_address_offset());
-
   bool preempted = false;
   stackChunkOop tail = cont.tail();
   if (tail != nullptr && tail->preempted()) {

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2636,7 +2636,7 @@ void ThawBase::clear_bitmap_bits(address start, address end) {
 
 intptr_t* ThawBase::handle_preempted_continuation(intptr_t* sp, Continuation::preempt_kind preempt_kind, bool fast_case) {
   frame top(sp);
-  assert(top.pc() == *(address*)(sp - frame::sender_sp_ret_address_offset()), "");
+  assert(top.pc() == ContinuationHelper::return_address_at(sp - frame::sender_sp_ret_address_offset()), "");
   DEBUG_ONLY(verify_frame_kind(top, preempt_kind);)
   NOT_PRODUCT(int64_t tid = _thread->monitor_owner_id();)
 


### PR DESCRIPTION
We got this debug assert failure for ~500 jtreg test cases on Linux AArch64 with PAC feature (Neoverse-V1 in my local test). The root cause is a bad comparison between a raw return address and a PAC-signed LR from the stack slot. The fix is trivial, i.e. using helper `ContinuationHelper::return_address_at()` to strip the PAC code in high bits.

After fixing this assert failure, we encountered a further failure.

```c
  guarantee(pauth_ptr_is_raw(ret_addr), "Return address did not authenticate");
```

The root cause is that JDK-8338383 and JDK-8369238 added virtual-thread preemption/thaw paths that write return addresses into saved-LR stack slots using raw code pointers in several sites. Later, PAC-aware code reads or returns through those slots and authentication fails. In this patch, we use helper `ContinuationHelper::patch_return_address_at()` to sign the return address.

Test: Ran `hotspot jdk langtools` on Neoverse-V1 and Neoverse-V2 with the following test configs and didn't find new failures.

- test config 1: build JDK with `--enable-branch-protection` and run test with the default option
- test config 2: build JDK with `--enable-branch-protection` and run test with `-XX:UseBranchProtection=standard` option


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388072](https://bugs.openjdk.org/browse/JDK-8388072): Linux/AArch64 PAC-RET: assert(top.pc() == *(address*)(sp - frame::sender_sp_ret_address_offset())) failed (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) Review applies to [3125b6a0](https://git.openjdk.org/jdk/pull/31877/files/3125b6a0dd3e6e715bd414b990ce523e63bc4184)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31877/head:pull/31877` \
`$ git checkout pull/31877`

Update a local copy of the PR: \
`$ git checkout pull/31877` \
`$ git pull https://git.openjdk.org/jdk.git pull/31877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31877`

View PR using the GUI difftool: \
`$ git pr show -t 31877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31877.diff">https://git.openjdk.org/jdk/pull/31877.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31877#issuecomment-4954835375)
</details>
