### PR TITLE
8378719: CompiledDirectCall::set_to_interpreted() fails with guarantee(chk == -1 || chk == 0) failed: Field too big for insn

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1198,8 +1198,12 @@ class HandlerImpl {
   static int emit_deopt_handler(C2_MacroAssembler* masm);
 
   static uint size_deopt_handler() {
-    // count one branch instruction and one far call instruction sequence
-    return NativeInstruction::instruction_size + MacroAssembler::far_codestub_branch_size();
+    bool use_far_branch = MacroAssembler::target_needs_far_branch(SharedRuntime::deopt_blob()->unpack());
+    // far: adrp, add, blr; near: bl
+    uint target_branch_instructions = use_far_branch ? 3 : 1;
+    // target branch + one branch instruction
+    uint deopt_handler_instructions = target_branch_instructions + 1;
+    return deopt_handler_instructions * NativeInstruction::instruction_size;
   }
 };
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -622,20 +622,18 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
   }
 }
 
-static inline bool target_needs_far_branch(address addr) {
+bool MacroAssembler::target_needs_far_branch(address addr) {
   if (AOTCodeCache::is_on_for_dump()) {
     return true;
   }
-  // codecache size <= 128M
-  if (!MacroAssembler::far_branches()) {
+  if (!far_branches()) {
     return false;
   }
-  // codecache size > 240M
-  if (MacroAssembler::codestub_branch_needs_far_jump()) {
-    return true;
+  if (CodeCache::is_non_nmethod(addr) &&
+      CodeCache::max_distance_to_non_nmethod() <= branch_range) {
+    return false;
   }
-  // codecache size: 128M..240M
-  return !CodeCache::is_non_nmethod(addr);
+  return true;
 }
 
 void MacroAssembler::far_call(Address entry, Register tmp) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1320,15 +1320,16 @@ public:
   static bool far_branches() {
     return ReservedCodeCacheSize > branch_range;
   }
-
-  // Check if branches to the non nmethod section require a far jump
+  // Check if the static call stub branch needs a far jump.
   static bool codestub_branch_needs_far_jump() {
     if (AOTCodeCache::is_on_for_dump()) {
-      // To calculate far_codestub_branch_size correctly.
+      // To calculate static_call_stub_size correctly.
       return true;
     }
-    return CodeCache::max_distance_to_non_nmethod() > branch_range;
+    return far_branches();
   }
+  // Check if a branch to the given address needs a far jump.
+  static bool target_needs_far_branch(address addr);
 
   // Emit a direct call/jump if the entry address will always be in range,
   // otherwise a far call/jump.
@@ -1340,17 +1341,9 @@ public:
   // In the case of a far call/jump, the entry address is put in the tmp register.
   // The tmp register is invalidated.
   //
-  // Far_jump returns the amount of the emitted code.
   void far_call(Address entry, Register tmp = rscratch1);
+  // Far_jump returns the amount of the emitted code.
   int far_jump(Address entry, Register tmp = rscratch1);
-
-  static int far_codestub_branch_size() {
-    if (codestub_branch_needs_far_jump()) {
-      return 3 * 4;  // adrp, add, br
-    } else {
-      return 4;
-    }
-  }
 
   // Emit the CompiledIC call idiom
   address ic_call(address entry, jint method_index = 0);

--- a/test/hotspot/jtreg/compiler/codecache/TestNonNMethodHeapOverflow.java
+++ b/test/hotspot/jtreg/compiler/codecache/TestNonNMethodHeapOverflow.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8378719
+ * @summary Reproduces a RuntimeStub::resolve_static_call_blob pd_patch_instruction_size guarantee
+ *          - forces adapters to be allocated outside the NonNMethod heap
+ *          - puts c2i adapter and compiled method at 128+ MB distance
+ * @requires vm.flagless
+ * @requires os.arch == "aarch64"
+ * @requires vm.debug == false
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+UnlockExperimentalVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   -XX:ReservedCodeCacheSize=240M
+ *                   -XX:NonNMethodCodeHeapSize=8M
+ *                   -XX:ProfiledCodeHeapSize=116M
+ *                   -XX:NonProfiledCodeHeapSize=116M
+ *                   -XX:CodeCacheMinBlockLength=1
+ *                   -XX:CodeCacheSegmentSize=128
+ *                   -XX:-UseCodeCacheFlushing
+ *                   -XX:CompileCommand=dontinline,compiler.codecache.TestNonNMethodHeapOverflowTarget::a
+ *                   -XX:CompileCommand=exclude,compiler.codecache.TestNonNMethodHeapOverflowTarget::a
+ *                   -XX:CompileCommand=compileonly,compiler.codecache.TestNonNMethodHeapOverflowTarget::b
+ *                   compiler.codecache.TestNonNMethodHeapOverflow
+ */
+
+package compiler.codecache;
+
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.whitebox.code.BlobType;
+import jdk.test.whitebox.code.CodeBlob;
+import jdk.test.whitebox.code.NMethod;
+
+import java.lang.reflect.Method;
+
+public class TestNonNMethodHeapOverflow {
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final int HEAP_BLOCK_HEADER_SIZE = 8;
+
+    public static void main(String[] args) throws Exception {
+        WB.lockCompilation();
+
+        BlobType blobType;
+        int blobSize = 1024;
+        int allocSize = blobSize - HEAP_BLOCK_HEADER_SIZE;
+        // fill the NonNMethod heap
+        do {
+            long addr = WB.allocateCodeBlob(allocSize, BlobType.NonNMethod.id);
+            if (addr == 0) {
+                throw new RuntimeException("Failed to allocate in BlobType.NonNMethod");
+            }
+            blobType = CodeBlob.getCodeBlob(addr).code_blob_type;
+        } while (blobType == BlobType.NonNMethod);
+
+        if (blobType != BlobType.MethodNonProfiled) {
+            throw new RuntimeException("NonNMethod->NonProfiled fallback mechanism was changed? Need to update the test");
+        }
+
+        long heapSize = BlobType.MethodNonProfiled.getSize();
+        int allocated = 0;
+        // fill the first half of NonProfiled heap
+        while (allocated < heapSize / 2) {
+            long addr = WB.allocateCodeBlob(allocSize, BlobType.MethodNonProfiled.id);
+            if (addr == 0) {
+                throw new RuntimeException("Failed to allocate in MethodNonProfiled");
+            }
+            allocated += blobSize;
+        }
+
+        WB.unlockCompilation();
+
+        // loading triggers i2c/c2i adapter generation; NonNMethod heap is full, adapters go into a middle of NonProfiled heap
+        Class<?> c = Class.forName("compiler.codecache.TestNonNMethodHeapOverflowTarget");
+        Method methodB = c.getDeclaredMethod("b");
+        methodB.invoke(null);
+
+        // compile b() at level 2 so the nmethod goes into the beginning of Profiled heap
+        int compLevel = 2;
+        WB.enqueueMethodForCompilation(methodB, compLevel);
+        while (WB.isMethodQueuedForCompilation(methodB)) {
+            Thread.sleep(100);
+        }
+        if (WB.getMethodCompilationLevel(methodB) != compLevel) {
+            throw new IllegalStateException("b() is not compiled at the compilation level " + compLevel +
+                                            ". Got: " + WB.getMethodCompilationLevel(methodB));
+        }
+
+        // The distance from the static call stub in nmethod to the c2i adapter exceeds 128MB (AArch64 near-branch range):
+        //
+        //  |        Profiled                | NonNMethod |       NonProfiled              |
+        //   -------------------------------- ------------ --------------------------------
+        //  |[nmethod]                       |############|################[c2i]           |
+
+        NMethod nm = NMethod.get(methodB, false);
+        System.out.println("b() at 0x" + Long.toHexString(nm.address) + " heap=" + nm.code_blob_type);
+        if (nm.code_blob_type != BlobType.MethodProfiled) {
+            throw new RuntimeException("b() is expected to be in MethodProfiled heap, got: " + nm.code_blob_type);
+        }
+
+        // invoke compiled b(): triggers resolve_static_call_blob to patch the static call stub
+        // in nmethod to point to the c2i adapter for a()
+        methodB.invoke(null);
+    }
+}
+
+class TestNonNMethodHeapOverflowTarget {
+    static float a(float f1, double d1, long l1, int i1, float f2, double d2) {
+        return f1;
+    }
+    static float b() {
+        return a(1.0f, 2.0, 3L, 4, 5.0f, 6.0);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1911bd77](https://github.com/openjdk/jdk/commit/1911bd7782e075f01eca7578c07d3f805c41c21d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Boris Ulasevich on 8 Jul 2026 and was reviewed by Evgeny Astigeevich and Dean Long.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8378719](https://bugs.openjdk.org/browse/JDK-8378719): CompiledDirectCall::set_to_interpreted() fails with guarantee(chk == -1 || chk == 0) failed: Field too big for insn (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31878/head:pull/31878` \
`$ git checkout pull/31878`

Update a local copy of the PR: \
`$ git checkout pull/31878` \
`$ git pull https://git.openjdk.org/jdk.git pull/31878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31878`

View PR using the GUI difftool: \
`$ git pr show -t 31878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31878.diff">https://git.openjdk.org/jdk/pull/31878.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31878#issuecomment-4955384296)
</details>
